### PR TITLE
HDDS-11833. Return NotImplemented for S3 put-object-acl request.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -139,7 +139,7 @@ public class TestMultipartObjectGet {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     Response response = REST.put(BUCKET, KEY, content.length(),
-        partNumber, uploadID, null, body);
+        partNumber, uploadID, null, null, body);
     assertEquals(200, response.getStatus());
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/audit/S3GAction.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/audit/S3GAction.java
@@ -51,7 +51,8 @@ public enum S3GAction implements AuditAction {
   REVOKE_SECRET,
   GET_OBJECT_TAGGING,
   PUT_OBJECT_TAGGING,
-  DELETE_OBJECT_TAGGING;
+  DELETE_OBJECT_TAGGING,
+  PUT_OBJECT_ACL;
 
   @Override
   public String getAction() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -121,6 +121,7 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIREC
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ENTITY_TOO_SMALL;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NOT_IMPLEMENTED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_UPLOAD;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
@@ -222,6 +223,7 @@ public class ObjectEndpoint extends EndpointBase {
       @QueryParam("partNumber")  int partNumber,
       @QueryParam("uploadId") @DefaultValue("") String uploadID,
       @QueryParam("tagging") String taggingMarker,
+      @QueryParam("acl") String aclMarker,
       final InputStream body) throws IOException, OS3Exception {
     long startNanos = Time.monotonicNowNanos();
     S3GAction s3GAction = S3GAction.CREATE_KEY;
@@ -231,6 +233,10 @@ public class ObjectEndpoint extends EndpointBase {
     String copyHeader = null, storageType = null;
     DigestInputStream digestInputStream = null;
     try {
+      if (aclMarker != null) {
+        s3GAction = S3GAction.PUT_OBJECT_ACL;
+        throw newError(NOT_IMPLEMENTED, keyPath);
+      }
       OzoneVolume volume = getVolume();
       if (taggingMarker != null) {
         s3GAction = S3GAction.PUT_OBJECT_TAGGING;
@@ -369,7 +375,9 @@ public class ObjectEndpoint extends EndpointBase {
     } catch (Exception ex) {
       auditSuccess = false;
       auditWriteFailure(s3GAction, ex);
-      if (taggingMarker != null) {
+      if (aclMarker != null) {
+        getMetrics().updatePutObjectAclFailureStats(startNanos);
+      } else if (taggingMarker != null) {
         getMetrics().updatePutObjectTaggingFailureStats(startNanos);
       } else if (copyHeader != null) {
         getMetrics().updateCopyObjectFailureStats(startNanos);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
@@ -101,6 +101,8 @@ public final class S3GatewayMetrics implements Closeable, MetricsSource {
   private @Metric MutableCounterLong putObjectTaggingFailure;
   private @Metric MutableCounterLong deleteObjectTaggingSuccess;
   private @Metric MutableCounterLong deleteObjectTaggingFailure;
+  private @Metric MutableCounterLong putObjectAclSuccess;
+  private @Metric MutableCounterLong putObjectAclFailure;
 
   // S3 Gateway Latency Metrics
   // BucketEndpoint
@@ -270,6 +272,14 @@ public final class S3GatewayMetrics implements Closeable, MetricsSource {
   @Metric(about = "Latency for failing to delete object tagging of a key in nanoseconds")
   private PerformanceMetrics deleteObjectTaggingFailureLatencyNs;
 
+  @Metric(about = "Latency for successfully setting an S3 object ACL " +
+      "in nanoseconds")
+  private PerformanceMetrics putObjectAclSuccessLatencyNs;
+
+  @Metric(about = "Latency for failing to set an S3 object ACL " +
+      "in nanoseconds")
+  private PerformanceMetrics putObjectAclFailureLatencyNs;
+
   private final Map<String, PerformanceMetrics> performanceMetrics;
 
   /**
@@ -411,6 +421,8 @@ public final class S3GatewayMetrics implements Closeable, MetricsSource {
     deleteObjectTaggingSuccessLatencyNs.snapshot(recordBuilder, true);
     deleteObjectTaggingFailure.snapshot(recordBuilder, true);
     deleteObjectTaggingFailureLatencyNs.snapshot(recordBuilder, true);
+    putObjectAclSuccess.snapshot(recordBuilder, true);
+    putObjectAclFailure.snapshot(recordBuilder, true);
   }
 
   // INC and UPDATE
@@ -660,6 +672,16 @@ public final class S3GatewayMetrics implements Closeable, MetricsSource {
   public void updateDeleteObjectTaggingFailureStats(long startNanos) {
     this.deleteObjectTaggingFailure.incr();
     this.deleteObjectTaggingFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updatePutObjectAclSuccessStats(long startNanos) {
+    this.putObjectAclSuccess.incr();
+    this.putObjectAclSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updatePutObjectAclFailureStats(long startNanos) {
+    this.putObjectAclFailure.incr();
+    this.putObjectAclFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
   }
 
   // GET

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
@@ -77,17 +77,17 @@ public class TestListParts {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 
     response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        content.length(), 2, uploadID, null, body);
+        content.length(), 2, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 
     response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        content.length(), 3, uploadID, null, body);
+        content.length(), 3, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -109,7 +109,7 @@ public class TestMultipartUploadComplete {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     Response response = REST.put(OzoneConsts.S3_BUCKET, key, content.length(),
-        partNumber, uploadID, null, body);
+        partNumber, uploadID, null, null, body);
     assertEquals(200, response.getStatus());
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
     Part part = new Part();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -330,7 +330,7 @@ public class TestMultipartUploadWithCopy {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     Response response = REST.put(OzoneConsts.S3_BUCKET, key, content.length(),
-        partNumber, uploadID, null, body);
+        partNumber, uploadID, null, null, body);
     assertEquals(200, response.getStatus());
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
     Part part = new Part();
@@ -375,7 +375,7 @@ public class TestMultipartUploadWithCopy {
 
     ByteArrayInputStream body = new ByteArrayInputStream("".getBytes(UTF_8));
     Response response = REST.put(OzoneConsts.S3_BUCKET, key, 0, partNumber,
-        uploadID, null, body);
+        uploadID, null, null, body);
     assertEquals(200, response.getStatus());
 
     CopyPartResult result = (CopyPartResult) response.getEntity();
@@ -402,7 +402,7 @@ public class TestMultipartUploadWithCopy {
         OzoneConsts.S3_BUCKET + "/" + EXISTING_KEY);
     additionalHeaders.put(COPY_SOURCE_HEADER_RANGE, "bytes=0-3");
     setHeaders(additionalHeaders);
-    REST.put(OzoneConsts.S3_BUCKET, KEY, 0, 1, uploadID, null, body);
+    REST.put(OzoneConsts.S3_BUCKET, KEY, 0, 1, uploadID, null, null, body);
     OzoneMultipartUploadPartListParts parts =
         CLIENT.getObjectStore().getS3Bucket(OzoneConsts.S3_BUCKET)
         .listParts(KEY, uploadID, 0, 100);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -95,11 +95,11 @@ public class TestObjectGet {
 
     ByteArrayInputStream body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     rest.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-        1, null, null, body);
+        1, null, null, null, body);
     // Create a key with object tags
     when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
     rest.put(BUCKET_NAME, KEY_WITH_TAG, CONTENT.length(),
-        1, null, null, body);
+        1, null, null, null, body);
 
     context = mock(ContainerRequestContext.class);
     when(context.getUriInfo()).thenReturn(mock(UriInfo.class));

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -157,7 +157,7 @@ class TestObjectPut {
     bucket.setReplicationConfig(replication);
 
     //WHEN
-    Response response = objectEndpoint.put(BUCKET_NAME, KEY_NAME, length, 1, null, null, body);
+    Response response = objectEndpoint.put(BUCKET_NAME, KEY_NAME, length, 1, null, null, null, body);
 
     //THEN
     assertEquals(200, response.getStatus());
@@ -184,7 +184,7 @@ class TestObjectPut {
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     long dataSize = CONTENT.length();
 
-    objectEndpoint.put(BUCKET_NAME, KEY_NAME, dataSize, 0, null, null,  body);
+    objectEndpoint.put(BUCKET_NAME, KEY_NAME, dataSize, 0, null, null, null, body);
     assertEquals(dataSize, getKeyDataSize());
   }
 
@@ -202,7 +202,7 @@ class TestObjectPut {
     when(headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER))
         .thenReturn("15");
     objectEndpoint.put(BUCKET_NAME, KEY_NAME, chunkedContent.length(), 0, null, null,
-        new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
+        null, new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
     assertEquals(15, getKeyDataSize());
   }
 
@@ -216,7 +216,7 @@ class TestObjectPut {
     objectEndpoint.setHeaders(headersWithTags);
 
     Response response = objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-        1, null, null, body);
+        1, null, null, null, body);
 
     assertEquals(200, response.getStatus());
 
@@ -239,7 +239,7 @@ class TestObjectPut {
 
     try {
       objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-          1, null, null, body);
+          1, null, null, null, body);
       fail("request with invalid query param should fail");
     } catch (OS3Exception ex) {
       assertEquals(INVALID_TAG.getCode(), ex.getCode());
@@ -257,7 +257,7 @@ class TestObjectPut {
     objectEndpoint.setHeaders(headersWithDuplicateTagKey);
     try {
       objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-          1, null, null, body);
+          1, null, null, null, body);
       fail("request with duplicate tag key should fail");
     } catch (OS3Exception ex) {
       assertEquals(INVALID_TAG.getCode(), ex.getCode());
@@ -276,7 +276,7 @@ class TestObjectPut {
     objectEndpoint.setHeaders(headersWithLongTagKey);
     try {
       objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-          1, null, null, body);
+          1, null, null, null, body);
       fail("request with tag key exceeding the length limit should fail");
     } catch (OS3Exception ex) {
       assertEquals(INVALID_TAG.getCode(), ex.getCode());
@@ -295,7 +295,7 @@ class TestObjectPut {
     when(headersWithLongTagValue.getHeaderString(TAG_HEADER)).thenReturn("tag1=" + longTagValue);
     try {
       objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-          1, null, null, body);
+          1, null, null, null, body);
       fail("request with tag value exceeding the length limit should fail");
     } catch (OS3Exception ex) {
       assertEquals(INVALID_TAG.getCode(), ex.getCode());
@@ -320,7 +320,7 @@ class TestObjectPut {
     objectEndpoint.setHeaders(headersWithTooManyTags);
     try {
       objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),
-          1, null, null, body);
+          1, null, null, null, body);
       fail("request with number of tags exceeding limit should fail");
     } catch (OS3Exception ex) {
       assertEquals(INVALID_TAG.getCode(), ex.getCode());
@@ -349,7 +349,7 @@ class TestObjectPut {
 
     //WHEN
     Response response = objectEndpoint.put(BUCKET_NAME, KEY_NAME,
-        chunkedContent.length(), 1, null, null,
+        chunkedContent.length(), 1, null, null, null,
         new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
 
     //THEN
@@ -378,7 +378,7 @@ class TestObjectPut {
           new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
       try {
         objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT
-            .length(), 1, null, null, body);
+            .length(), 1, null, null, null, body);
         fail("Should throw IOException");
       } catch (IOException ignored) {
         // Verify that the message digest is reset so that the instance can be reused for the
@@ -403,7 +403,7 @@ class TestObjectPut {
     when(headers.getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER)).thenReturn("COPY");
 
     Response response = objectEndpoint.put(BUCKET_NAME, KEY_NAME,
-        CONTENT.length(), 1, null, null, body);
+        CONTENT.length(), 1, null, null, null, body);
 
     OzoneInputStream ozoneInputStream = clientStub.getObjectStore()
         .getS3Bucket(BUCKET_NAME)
@@ -429,7 +429,7 @@ class TestObjectPut {
         BUCKET_NAME + "/" + urlEncode(KEY_NAME));
 
     response = objectEndpoint.put(DEST_BUCKET_NAME, DEST_KEY, CONTENT.length(), 1,
-        null, null, body);
+        null, null, null, body);
 
     // Check destination key and response
     ozoneInputStream = clientStub.getObjectStore().getS3Bucket(DEST_BUCKET_NAME)
@@ -459,7 +459,7 @@ class TestObjectPut {
     metadataHeaders.remove(CUSTOM_METADATA_HEADER_PREFIX + "custom-key-2");
 
     response = objectEndpoint.put(DEST_BUCKET_NAME, DEST_KEY, CONTENT.length(), 1,
-        null, null, body);
+        null, null, null, body);
 
     ozoneInputStream = clientStub.getObjectStore().getS3Bucket(DEST_BUCKET_NAME)
         .readKey(DEST_KEY);
@@ -486,7 +486,7 @@ class TestObjectPut {
     // wrong copy metadata directive
     when(headers.getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER)).thenReturn("INVALID");
     OS3Exception e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(
-            DEST_BUCKET_NAME, DEST_KEY, CONTENT.length(), 1, null, null, body),
+            DEST_BUCKET_NAME, DEST_KEY, CONTENT.length(), 1, null, null, null, body),
         "test copy object failed");
     assertThat(e.getHttpCode()).isEqualTo(400);
     assertThat(e.getCode()).isEqualTo("InvalidArgument");
@@ -496,7 +496,7 @@ class TestObjectPut {
 
     // source and dest same
     e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(
-            BUCKET_NAME, KEY_NAME, CONTENT.length(), 1, null, null, body),
+            BUCKET_NAME, KEY_NAME, CONTENT.length(), 1, null, null, null, body),
         "test copy object failed");
     assertThat(e.getErrorMessage()).contains("This copy request is illegal");
 
@@ -504,28 +504,28 @@ class TestObjectPut {
     when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
         NO_SUCH_BUCKET + "/"  + urlEncode(KEY_NAME));
     e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(DEST_BUCKET_NAME,
-        DEST_KEY, CONTENT.length(), 1, null, null, body), "test copy object failed");
+        DEST_KEY, CONTENT.length(), 1, null, null, null, body), "test copy object failed");
     assertThat(e.getCode()).contains("NoSuchBucket");
 
     // dest bucket not found
     when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
         BUCKET_NAME + "/" + urlEncode(KEY_NAME));
     e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(NO_SUCH_BUCKET,
-        DEST_KEY, CONTENT.length(), 1, null, null, body), "test copy object failed");
+        DEST_KEY, CONTENT.length(), 1, null, null, null, body), "test copy object failed");
     assertThat(e.getCode()).contains("NoSuchBucket");
 
     //Both source and dest bucket not found
     when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
         NO_SUCH_BUCKET + "/" + urlEncode(KEY_NAME));
     e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(NO_SUCH_BUCKET,
-        DEST_KEY, CONTENT.length(), 1, null, null, body), "test copy object failed");
+        DEST_KEY, CONTENT.length(), 1, null, null, null, body), "test copy object failed");
     assertThat(e.getCode()).contains("NoSuchBucket");
 
     // source key not found
     when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
         BUCKET_NAME + "/" + urlEncode(NO_SUCH_BUCKET));
     e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(
-        "nonexistent", KEY_NAME, CONTENT.length(), 1, null, null, body),
+        "nonexistent", KEY_NAME, CONTENT.length(), 1, null, null, null, body),
         "test copy object failed");
     assertThat(e.getCode()).contains("NoSuchBucket");
   }
@@ -537,7 +537,7 @@ class TestObjectPut {
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
 
     Response response = objectEndpoint.put(BUCKET_NAME, KEY_NAME,
-        CONTENT.length(), 1, null, null, body);
+        CONTENT.length(), 1, null, null, null, body);
 
     OzoneInputStream ozoneInputStream = clientStub.getObjectStore()
         .getS3Bucket(BUCKET_NAME)
@@ -564,7 +564,7 @@ class TestObjectPut {
 
       try {
         objectEndpoint.put(DEST_BUCKET_NAME, DEST_KEY, CONTENT.length(), 1,
-            null, null, body);
+            null, null, null, body);
         fail("Should throw IOException");
       } catch (IOException ignored) {
         // Verify that the message digest is reset so that the instance can be reused for the
@@ -586,7 +586,7 @@ class TestObjectPut {
     String sourceKeyName = "sourceKey";
 
     Response putResponse = objectEndpoint.put(BUCKET_NAME, sourceKeyName,
-        CONTENT.length(), 1, null, null, body);
+        CONTENT.length(), 1, null, null, null, body);
     OzoneKeyDetails keyDetails =
         clientStub.getObjectStore().getS3Bucket(BUCKET_NAME).getKey(sourceKeyName);
 
@@ -603,7 +603,7 @@ class TestObjectPut {
         BUCKET_NAME  + "/" + urlEncode(sourceKeyName));
 
     objectEndpoint.setHeaders(headersForCopy);
-    Response copyResponse = objectEndpoint.put(DEST_BUCKET_NAME, destKey, CONTENT.length(), 1, null, null, body);
+    Response copyResponse = objectEndpoint.put(DEST_BUCKET_NAME, destKey, CONTENT.length(), 1, null, null, null, body);
 
     OzoneKeyDetails destKeyDetails = clientStub.getObjectStore()
         .getS3Bucket(DEST_BUCKET_NAME).getKey(destKey);
@@ -622,7 +622,7 @@ class TestObjectPut {
 
     // With x-amz-tagging-directive = COPY with a different x-amz-tagging
     when(headersForCopy.getHeaderString(TAG_HEADER)).thenReturn("tag3=value3");
-    copyResponse = objectEndpoint.put(DEST_BUCKET_NAME, destKey, CONTENT.length(), 1, null, null, body);
+    copyResponse = objectEndpoint.put(DEST_BUCKET_NAME, destKey, CONTENT.length(), 1, null, null, null, body);
     assertEquals(200, copyResponse.getStatus());
 
     destKeyDetails = clientStub.getObjectStore()
@@ -637,7 +637,7 @@ class TestObjectPut {
 
     // Copy object with x-amz-tagging-directive = REPLACE
     when(headersForCopy.getHeaderString(TAG_DIRECTIVE_HEADER)).thenReturn("REPLACE");
-    copyResponse = objectEndpoint.put(DEST_BUCKET_NAME, destKey, CONTENT.length(), 1, null, null, body);
+    copyResponse = objectEndpoint.put(DEST_BUCKET_NAME, destKey, CONTENT.length(), 1, null, null, null, body);
     assertEquals(200, copyResponse.getStatus());
 
     destKeyDetails = clientStub.getObjectStore()
@@ -659,7 +659,7 @@ class TestObjectPut {
     HttpHeaders headersForCopy = Mockito.mock(HttpHeaders.class);
     when(headersForCopy.getHeaderString(TAG_DIRECTIVE_HEADER)).thenReturn("INVALID");
     try {
-      objectEndpoint.put(DEST_BUCKET_NAME, "somekey", CONTENT.length(), 1, null, null, body);
+      objectEndpoint.put(DEST_BUCKET_NAME, "somekey", CONTENT.length(), 1, null, null, null, body);
     } catch (OS3Exception ex) {
       assertEquals(INVALID_ARGUMENT.getCode(), ex.getCode());
       assertThat(ex.getErrorMessage()).contains("The tagging copy directive specified is invalid");
@@ -674,7 +674,7 @@ class TestObjectPut {
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("random");
 
     OS3Exception e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(
-        BUCKET_NAME, KEY_NAME, CONTENT.length(), 1, null, null, body));
+        BUCKET_NAME, KEY_NAME, CONTENT.length(), 1, null, null, null, body));
     assertEquals(S3ErrorTable.INVALID_ARGUMENT.getErrorMessage(),
         e.getErrorMessage());
     assertEquals("random", e.getResource());
@@ -687,7 +687,7 @@ class TestObjectPut {
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("");
 
     objectEndpoint.put(BUCKET_NAME, KEY_NAME, CONTENT
-            .length(), 1, null, null, body);
+            .length(), 1, null, null, null, body);
     OzoneKeyDetails key =
         clientStub.getObjectStore().getS3Bucket(BUCKET_NAME)
             .getKey(KEY_NAME);
@@ -706,7 +706,7 @@ class TestObjectPut {
 
     // WHEN
     try (Response response = objectEndpoint.put(fsoBucket.getName(), path,
-        0L, 0, "", null,  null)) {
+        0L, 0, "", null,  null, null)) {
       assertEquals(HttpStatus.SC_OK, response.getStatus());
     }
 
@@ -721,12 +721,12 @@ class TestObjectPut {
     final String path = "key";
     final ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
-    objectEndpoint.put(FSO_BUCKET_NAME, path, CONTENT.length(), 0, "", null, body);
+    objectEndpoint.put(FSO_BUCKET_NAME, path, CONTENT.length(), 0, "", null, null, body);
 
     // WHEN
     final OS3Exception exception = assertThrows(OS3Exception.class,
         () -> objectEndpoint
-            .put(FSO_BUCKET_NAME, path + "/", 0, 0, "", null, null)
+            .put(FSO_BUCKET_NAME, path + "/", 0, 0, "", null, null, null)
             .close());
 
     // THEN
@@ -741,7 +741,7 @@ class TestObjectPut {
     ByteArrayInputStream body = new ByteArrayInputStream(emptyString.getBytes(UTF_8));
     objectEndpoint.setHeaders(headersWithTags);
 
-    Response putResponse = objectEndpoint.put(BUCKET_NAME, KEY_NAME, emptyString.length(), 1, null, null, body);
+    Response putResponse = objectEndpoint.put(BUCKET_NAME, KEY_NAME, emptyString.length(), 1, null, null, null, body);
     assertEquals(200, putResponse.getStatus());
     OzoneKeyDetails keyDetails = clientStub.getObjectStore().getS3Bucket(BUCKET_NAME).getKey(KEY_NAME);
     assertEquals(0, keyDetails.getDataSize());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingDelete.java
@@ -83,7 +83,7 @@ public class TestObjectTaggingDelete {
     // Create a key with object tags
     Mockito.when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
     rest.put(BUCKET_NAME, KEY_WITH_TAG, CONTENT.length(),
-        1, null, null, body);
+        1, null, null, null, body);
 
 
     context = Mockito.mock(ContainerRequestContext.class);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingGet.java
@@ -70,7 +70,7 @@ public class TestObjectTaggingGet {
     // Create a key with object tags
     Mockito.when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
     rest.put(BUCKET_NAME, KEY_WITH_TAG, CONTENT.length(),
-        1, null, null, body);
+        1, null, null, null, body);
 
 
     ContainerRequestContext context = Mockito.mock(ContainerRequestContext.class);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingPut.java
@@ -84,13 +84,13 @@ public class TestObjectTaggingPut {
         new ByteArrayInputStream("".getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
 
-    objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null, null, body);
+    objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null, null, null, body);
   }
 
   @Test
   public void testPutObjectTaggingWithEmptyBody() throws Exception {
     try {
-      objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null, "",
+      objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null, "", null,
           null);
       fail();
     } catch (OS3Exception ex) {
@@ -101,8 +101,8 @@ public class TestObjectTaggingPut {
 
   @Test
   public void testPutValidObjectTagging() throws Exception {
-    assertEquals(HTTP_OK, objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1,
-        null, "", twoTags()).getStatus());
+    assertEquals(HTTP_OK, objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null,
+         "", null, twoTags()).getStatus());
     OzoneKeyDetails keyDetails =
         clientStub.getObjectStore().getS3Bucket(BUCKET_NAME).getKey(KEY_NAME);
     assertEquals(2, keyDetails.getTags().size());
@@ -123,7 +123,7 @@ public class TestObjectTaggingPut {
   private void testInvalidObjectTagging(Supplier<InputStream> inputStream,
                                         int expectedHttpCode, String expectedErrorCode) throws Exception {
     try {
-      objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null, "",
+      objectEndpoint.put(BUCKET_NAME, KEY_NAME, 0, 1, null, "", null,
           inputStream.get());
       fail("Expected an OS3Exception to be thrown");
     } catch (OS3Exception ex) {
@@ -136,7 +136,7 @@ public class TestObjectTaggingPut {
   public void testPutObjectTaggingNoKeyFound() throws Exception {
     try {
       objectEndpoint.put(BUCKET_NAME, "nonexistent", 0, 1,
-          null, "", twoTags());
+          null, "", null, twoTags());
       fail("Expected an OS3Exception to be thrown");
     } catch (OS3Exception ex) {
       assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
@@ -148,7 +148,7 @@ public class TestObjectTaggingPut {
   public void testPutObjectTaggingNoBucketFound() throws Exception {
     try {
       objectEndpoint.put("nonexistent", "nonexistent", 0, 1,
-          null, "", twoTags());
+          null, "", null, twoTags());
       fail("Expected an OS3Exception to be thrown");
     } catch (OS3Exception ex) {
       assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
@@ -177,7 +177,8 @@ public class TestObjectTaggingPut {
         ResultCodes.NOT_SUPPORTED_OPERATION)).when(mockBucket).putObjectTagging("dir/", twoTagsMap);
 
     try {
-      endpoint.put("fsoBucket", "dir/", 0, 1, null, "", twoTags());
+      endpoint.put("fsoBucket", "dir/", 0, 1, null, "",
+          null, twoTags());
       fail("Expected an OS3Exception to be thrown");
     } catch (OS3Exception ex) {
       assertEquals(HTTP_NOT_IMPLEMENTED, ex.getHttpCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -100,7 +100,7 @@ public class TestPartUpload {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 
@@ -122,7 +122,7 @@ public class TestPartUpload {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 
@@ -131,7 +131,7 @@ public class TestPartUpload {
     // Upload part again with same part Number, the ETag should be changed.
     content = "Multipart Upload Changed";
     response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
     assertNotEquals(eTag, response.getHeaderString(OzoneConsts.ETAG));
 
@@ -145,7 +145,7 @@ public class TestPartUpload {
       ByteArrayInputStream body =
           new ByteArrayInputStream(content.getBytes(UTF_8));
       REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY, content.length(), 1,
-          "random", null, body);
+          "random", null, null, body);
     });
     assertEquals("NoSuchUpload", ex.getCode());
     assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
@@ -179,7 +179,7 @@ public class TestPartUpload {
     long contentLength = chunkedContent.length();
 
     objectEndpoint.put(OzoneConsts.S3_BUCKET, keyName, contentLength, 1,
-        uploadID, null, new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
+        uploadID, null, null, new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
     assertContentLength(uploadID, keyName, 15);
   }
 
@@ -202,7 +202,7 @@ public class TestPartUpload {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     REST.put(OzoneConsts.S3_BUCKET, keyName,
-        contentLength, 1, uploadID, null, body);
+        contentLength, 1, uploadID, null, null, body);
     assertContentLength(uploadID, keyName, content.length());
   }
 
@@ -243,7 +243,7 @@ public class TestPartUpload {
           new ByteArrayInputStream(content.getBytes(UTF_8));
       try {
         objectEndpoint.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-            content.length(), 1, uploadID, null, body);
+            content.length(), 1, uploadID, null, null, body);
         fail("Should throw IOException");
       } catch (IOException ignored) {
         // Verify that the message digest is reset so that the instance can be reused for the

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUploadWithStream.java
@@ -94,7 +94,7 @@ public class TestPartUploadWithStream {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     response = REST.put(S3BUCKET, S3KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 
@@ -115,7 +115,7 @@ public class TestPartUploadWithStream {
     ByteArrayInputStream body =
         new ByteArrayInputStream(content.getBytes(UTF_8));
     response = REST.put(S3BUCKET, S3KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
 
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
 
@@ -124,7 +124,7 @@ public class TestPartUploadWithStream {
     // Upload part again with same part Number, the ETag should be changed.
     content = "Multipart Upload Changed";
     response = REST.put(S3BUCKET, S3KEY,
-        content.length(), 1, uploadID, null, body);
+        content.length(), 1, uploadID, null, null, body);
     assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
     assertNotEquals(eTag, response.getHeaderString(OzoneConsts.ETAG));
 
@@ -137,7 +137,7 @@ public class TestPartUploadWithStream {
       ByteArrayInputStream body =
           new ByteArrayInputStream(content.getBytes(UTF_8));
       REST.put(S3BUCKET, S3KEY, content.length(), 1,
-          "random", null, body);
+          "random", null, null, body);
     });
     assertEquals("NoSuchUpload", ex.getCode());
     assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -263,7 +263,7 @@ public class TestPermissionCheck {
     objectEndpoint.setOzoneConfiguration(conf);
 
     OS3Exception e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(
-        "bucketName", "keyPath", 1024, 0, null, null,
+        "bucketName", "keyPath", 1024, 0, null, null, null,
         new ByteArrayInputStream(new byte[]{})));
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
   }
@@ -324,7 +324,7 @@ public class TestPermissionCheck {
 
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         objectEndpoint.put("bucketName", "keyPath", 0, 1,
-            null, "", tagInput));
+            null, "", null, tagInput));
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
 
     e = assertThrows(OS3Exception.class, () ->

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
@@ -106,7 +106,7 @@ public class TestUploadWithStream {
     byte[] keyContent = S3_COPY_EXISTING_KEY_CONTENT.getBytes(UTF_8);
     ByteArrayInputStream body =
         new ByteArrayInputStream(keyContent);
-    Response response = REST.put(S3BUCKET, S3KEY, 0, 0, null, null, body);
+    Response response = REST.put(S3BUCKET, S3KEY, 0, 0, null, null, null, body);
 
     assertEquals(200, response.getStatus());
   }
@@ -140,7 +140,7 @@ public class TestUploadWithStream {
         .forEach((k, v) -> when(headers.getHeaderString(k)).thenReturn(v));
     REST.setHeaders(headers);
 
-    Response response = REST.put(S3BUCKET, S3KEY, 0, 0, null, null, null);
+    Response response = REST.put(S3BUCKET, S3KEY, 0, 0, null, null, null, null);
 
     assertEquals(200, response.getStatus());
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -310,7 +310,7 @@ public class TestS3GatewayMetrics {
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     // Create the file
     keyEndpoint.put(bucketName, keyName, CONTENT
-        .length(), 1, null, null, body);
+        .length(), 1, null, null, null, body);
     body.close();
     long curMetric = metrics.getCreateKeySuccess();
     assertEquals(1L, curMetric - oriMetric);
@@ -322,7 +322,8 @@ public class TestS3GatewayMetrics {
 
     // Create the file in a bucket that does not exist
     OS3Exception e = assertThrows(OS3Exception.class, () -> keyEndpoint.put(
-        "unknownBucket", keyName, CONTENT.length(), 1, null, null, null));
+        "unknownBucket", keyName, CONTENT.length(), 1, null, null,
+        null, null));
     assertEquals(S3ErrorTable.NO_SUCH_BUCKET.getCode(), e.getCode());
     long curMetric = metrics.getCreateKeyFailure();
     assertEquals(1L, curMetric - oriMetric);
@@ -358,7 +359,7 @@ public class TestS3GatewayMetrics {
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     // Create the file
     keyEndpoint.put(bucketName, keyName, CONTENT
-        .length(), 1, null, null, body);
+        .length(), 1, null, null, null, body);
     // GET the key from the bucket
     Response response = keyEndpoint.get(bucketName, keyName, 0, null, 0, null, null);
     StreamingOutput stream = (StreamingOutput) response.getEntity();
@@ -466,7 +467,7 @@ public class TestS3GatewayMetrics {
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     keyEndpoint.put(bucketName, keyName, CONTENT.length(),
-        1, uploadID, null, body);
+        1, uploadID, null, null, body);
     long curMetric = metrics.getCreateMultipartKeySuccess();
     assertEquals(1L, curMetric - oriMetric);
   }
@@ -475,7 +476,7 @@ public class TestS3GatewayMetrics {
   public void testCreateMultipartKeyFailure() throws Exception {
     long oriMetric = metrics.getCreateMultipartKeyFailure();
     OS3Exception e = assertThrows(OS3Exception.class, () -> keyEndpoint.put(
-        bucketName, keyName, CONTENT.length(), 1, "randomId", null, null));
+        bucketName, keyName, CONTENT.length(), 1, "randomId", null, null, null));
     assertEquals(S3ErrorTable.NO_SUCH_UPLOAD.getCode(), e.getCode());
     long curMetric = metrics.getCreateMultipartKeyFailure();
     assertEquals(1L, curMetric - oriMetric);
@@ -522,14 +523,14 @@ public class TestS3GatewayMetrics {
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
 
     keyEndpoint.put(bucketName, keyName,
-        CONTENT.length(), 1, null, null, body);
+        CONTENT.length(), 1, null, null, null, body);
 
     // Add copy header, and then call put
     when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
         bucketName + "/" + urlEncode(keyName));
 
     keyEndpoint.put(destBucket, destKey, CONTENT.length(), 1,
-        null, null, body);
+        null, null, null, body);
     long curMetric = metrics.getCopyObjectSuccess();
     assertEquals(1L, curMetric - oriMetric);
 
@@ -538,7 +539,7 @@ public class TestS3GatewayMetrics {
     // source and dest same
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("");
     OS3Exception e = assertThrows(OS3Exception.class, () -> keyEndpoint.put(
-        bucketName, keyName, CONTENT.length(), 1, null, null, body),
+        bucketName, keyName, CONTENT.length(), 1, null, null, null, body),
         "Test for CopyObjectMetric failed");
     assertThat(e.getErrorMessage()).contains("This copy request is illegal");
     curMetric = metrics.getCopyObjectFailure();
@@ -553,11 +554,11 @@ public class TestS3GatewayMetrics {
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     // Create the file
     keyEndpoint.put(bucketName, keyName, CONTENT
-        .length(), 1, null, null, body);
+        .length(), 1, null, null, null, body);
     body.close();
 
     // Put object tagging
-    keyEndpoint.put(bucketName, keyName, 0, 1, null, "", getPutTaggingBody());
+    keyEndpoint.put(bucketName, keyName, 0, 1, null, "", null, getPutTaggingBody());
 
     long curMetric = metrics.getPutObjectTaggingSuccess();
     assertEquals(1L, curMetric - oriMetric);
@@ -569,7 +570,8 @@ public class TestS3GatewayMetrics {
 
     // Put object tagging for nonexistent key
     OS3Exception ex = assertThrows(OS3Exception.class, () ->
-        keyEndpoint.put(bucketName, "nonexistent", 0, 1, null, "", getPutTaggingBody())
+        keyEndpoint.put(bucketName, "nonexistent", 0, 1, null, "",
+            null, getPutTaggingBody())
     );
     assertEquals(S3ErrorTable.NO_SUCH_KEY.getCode(), ex.getCode());
 
@@ -585,11 +587,11 @@ public class TestS3GatewayMetrics {
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     keyEndpoint.put(bucketName, keyName, CONTENT
-        .length(), 1, null, null, body);
+        .length(), 1, null, null, null, body);
     body.close();
 
     // Put object tagging
-    keyEndpoint.put(bucketName, keyName, 0, 1, null, "", getPutTaggingBody());
+    keyEndpoint.put(bucketName, keyName, 0, 1, null, "", null, getPutTaggingBody());
 
     // Get object tagging
     keyEndpoint.get(bucketName, keyName, 0,
@@ -620,11 +622,11 @@ public class TestS3GatewayMetrics {
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     keyEndpoint.put(bucketName, keyName, CONTENT
-        .length(), 1, null, null, body);
+        .length(), 1, null, null, null, body);
     body.close();
 
     // Put object tagging
-    keyEndpoint.put(bucketName, keyName, 0, 1, null, "", getPutTaggingBody());
+    keyEndpoint.put(bucketName, keyName, 0, 1, null, "", null, getPutTaggingBody());
 
     // Delete object tagging
     keyEndpoint.delete(bucketName, keyName, null, "");


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 Object ACL requests has not been implemented in Ozone due to possible conflicts with the existing ACL model. Therefore, S3 put-object-acl request is processed as a normal put-object request. This causes object ACL requests to overwrite the current object, which is unexpected.

We need to explicitly throw NotImplemented for put-object-acl requests to prevent misuse.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11833

## How was this patch tested?

Integration test.
