### PR TITLE
HDDS-11873. Skip old-only xcompat read tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -98,6 +98,14 @@ test_cross_compatibility() {
 
   for client_version in "$@"; do
     for data_version in $(echo "$client_version" "$cluster_version" "$current_version" | xargs -n1 | sort -u); do
+
+      # do not test old-only scenario
+      if [[ "${cluster_version}" != "${current_version}" ]] \
+        && [[ "${client_version}" != "${current_version}" ]] \
+        && [[ "${data_version}" != "${current_version}" ]]; then
+        continue
+      fi
+
       client _read ${data_version}
     done
   done


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cluster/client/data combinations where all versions are "old" can be skipped, since no new code is exercised:

```
xcompat-cluster-1.1.0-client-1.1.0-read-1.1.0 :: Read Compatibility           
xcompat-cluster-1.2.1-client-1.2.1-read-1.2.1 :: Read Compatibility           
...
```

https://issues.apache.org/jira/browse/HDDS-11873

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12199003296/job/34034385847