### PR TITLE
HDDS-11830. Subcommands should not extend GenericCli

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.admin.nssummary;
 
 import org.apache.hadoop.fs.ozone.OzoneClientUtils;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
@@ -63,21 +62,12 @@ import static org.apache.hadoop.hdds.server.http.HttpServer2.HTTP_SCHEME;
         FileSizeDistSubCommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class NSSummaryAdmin extends GenericCli implements AdminSubcommand {
+public class NSSummaryAdmin implements AdminSubcommand {
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
   public OzoneAdmin getParent() {
     return parent;
-  }
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
   }
 
   private boolean isObjectStoreBucket(OzoneBucket bucket, ObjectStore objectStore) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.admin.om;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
@@ -38,8 +37,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import org.apache.ratis.protocol.ClientId;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 import java.util.Collection;
 
@@ -64,22 +61,13 @@ import java.util.Collection;
         FetchKeySubCommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class OMAdmin extends GenericCli implements AdminSubcommand {
+public class OMAdmin implements AdminSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
 
-  @Spec
-  private CommandSpec spec;
-
   public OzoneAdmin getParent() {
     return parent;
-  }
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
   }
 
   public ClientProtocol createClient(String omServiceId) throws Exception {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ScmAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ScmAdmin.java
@@ -17,14 +17,11 @@
  */
 package org.apache.hadoop.ozone.admin.scm;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Subcommand for admin operations related to SCM.
@@ -44,21 +41,12 @@ import picocli.CommandLine.Spec;
         RotateKeySubCommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class ScmAdmin extends GenericCli implements AdminSubcommand {
+public class ScmAdmin implements AdminSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
 
-  @Spec
-  private CommandSpec spec;
-
   public OzoneAdmin getParent() {
     return parent;
-  }
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/segmentparser/RatisLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/segmentparser/RatisLogParser.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.debug.segmentparser;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 
@@ -39,9 +38,5 @@ import picocli.CommandLine;
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 @MetaInfServices(DebugSubcommand.class)
-public class RatisLogParser extends GenericCli implements DebugSubcommand {
-
-  public static void main(String[] args) {
-    new RatisLogParser().run(args);
-  }
+public class RatisLogParser implements DebugSubcommand {
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Subcommands should not extend `GenericCli`, it is required only for top-level commands.

https://issues.apache.org/jira/browse/HDDS-11830

## How was this patch tested?

- Verified that parent commands (`ozone admin` and `ozone debug`) display these subcommands in their help.
- Verified that the subcommands show help when invoked without options.

```
$ cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT

$ bin/ozone admin
Incomplete command
Usage: ozone admin [-hV] [--verbose] [-conf=<configurationPath>]
                   [-D=<String=String>]... [COMMAND]
Developer tools for Ozone Admin operations
      -conf=<configurationPath>

  -D, --set=<String=String>

  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
      --verbose   More verbose output. Show the stack trace of the errors.
Commands:
  ...
  namespace           Namespace Summary specific admin operations
  om                  Ozone Manager specific admin operations
  ...
  scm                 Ozone Storage Container Manager specific admin operations

$ bin/ozone admin namespace
Missing required subcommand
Usage: ozone admin namespace [-hV] [COMMAND]
Namespace Summary specific admin operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  summary  Get entity type and object counts for a path request.
  du       Get disk usage for a path request.
  quota    Get quota usage for a path request.
  dist     Get file size distribution for a path request.

$ bin/ozone admin om
Missing required subcommand
Usage: ozone admin om [-hV] [COMMAND]
Ozone Manager specific admin operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  finalizeupgrade                           Finalizes Ozone Manager's metadata
                                              changes and enables new features
                                              after a software upgrade.
                                            It is possible to specify the
                                              service ID for an HA environment,
                                              or the Ozone manager host in a
                                              non-HA environment, if none
                                              provided the default from
                                              configuration is being used if
                                              not ambiguous.
...

$ bin/ozone admin scm
Missing required subcommand
Usage: ozone admin scm [-hV] [COMMAND]
Ozone Storage Container Manager specific admin operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  roles               List all SCMs, their respective Ratis server roles and
                        RaftPeerIds
  finalizeupgrade     Finalize SCM Upgrade
  finalizationstatus  Finalization SCM Status
  transfer            Manually transfer the raft leadership to the target node.
  deletedBlocksTxn    SCM deleted blocks transaction specific operations
  decommission        Decommission SCM <scmid>.  Includes removing from ratis
                        ring and removing its certificate from certStore
  rotate              CLI command to force generate new keys (rotate)

$ bin/ozone debug          
Incomplete command
Usage: ozone debug [-hV] [--verbose] [-conf=<configurationPath>]
                   [-D=<String=String>]... [COMMAND]
Developer tools for Ozone Debug operations
      -conf=<configurationPath>

  -D, --set=<String=String>

  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
      --verbose   More verbose output. Show the stack trace of the errors.
Commands:
  ...
  ratislogparser             Shell of printing Ratis Log in understandable text

$ bin/ozone debug ratislogparser
Missing required subcommand
Usage: ozone debug ratislogparser [-hV] [COMMAND]
Shell of printing Ratis Log in understandable text
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  datanode  dump datanode segment file
  generic   dump generic ratis segment file
  om        dump om ratis segment file
  scm       dump scm ratis segment file
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12205055763