### PR TITLE
HDDS-11877. Enable Maven cache for more checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
-        if: ${{ !contains('author,bats,docs', matrix.check) }}
+        if: ${{ !contains('author,bats', matrix.check) }}
       - name: Download Ratis repo
         if: ${{ inputs.ratis_args != '' }}
         uses: actions/download-artifact@v4
@@ -343,6 +343,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-info.outputs.sha }}
+      - name: Cache for maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@v4
         with:
@@ -486,6 +495,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-info.outputs.sha }}
+      - name: Cache for maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@v4
         with:
@@ -530,6 +548,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-info.outputs.sha }}
+      - name: Cache for maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Summary: Add Maven cache in CI for more checks, which use Maven only for reading Ozone version from `pom.xml`.

Background:

Acceptance check intermittently seems to be [stuck](https://github.com/apache/ozone/actions/runs/12198919237/job/34037623484#step:5:1) before executing any tests:

```
Fri, 06 Dec 2024 14:42:43 GMT Run pushd hadoop-ozone/dist/target/ozone-*
Fri, 06 Dec 2024 14:42:43 GMT   pushd hadoop-ozone/dist/target/ozone-*
Fri, 06 Dec 2024 14:42:43 GMT   sudo mkdir .aws && sudo chmod 777 .aws && sudo chown 1000 .aws
Fri, 06 Dec 2024 14:42:43 GMT   popd
Fri, 06 Dec 2024 14:42:43 GMT   ./hadoop-ozone/dev-support/checks/acceptance.sh
Fri, 06 Dec 2024 14:42:43 GMT   shell: /usr/bin/bash -e {0}
Fri, 06 Dec 2024 14:42:43 GMT   env:
Fri, 06 Dec 2024 14:42:43 GMT     ...
Fri, 06 Dec 2024 14:42:43 GMT ~/work/ozone/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT ~/work/ozone/ozone
Fri, 06 Dec 2024 14:42:43 GMT ~/work/ozone/ozone
Fri, 06 Dec 2024 16:10:56 GMT Error: The operation was canceled.
```

With `set -x` we can see it is [executing](https://github.com/adoroszlai/ozone/actions/runs/12202954381/job/34045955438#step:5:42) Maven:

```
++ mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false
Error: The operation was canceled.
```

It is downloading artifacts, which can sometimes be painfully slow (see also HDDS-11872).

Even in the "normal" case this single Maven command takes [almost 1 minute](https://github.com/adoroszlai/ozone/actions/runs/12210172399/job/34065941115#step:3:830) vs. [less than 2 seconds](https://github.com/adoroszlai/ozone/actions/runs/12210176044/job/34065948974#step:4:154) when artifacts are available in local repo:

```
# no cache
[INFO] Total time:  53.632 s
```

```
# with cache
[INFO] Total time:  1.817 s
```

https://issues.apache.org/jira/browse/HDDS-11877

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/12210195782