### PR TITLE
HDDS-11843. Enhance DataNodeSafeModeRule to Use Pipeline DN List.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -116,6 +116,14 @@ public final class HddsConfigKeys {
   public static final double
       HDDS_SCM_SAFEMODE_ONE_NODE_REPORTED_PIPELINE_PCT_DEFAULT = 0.90;
 
+  public static final String HDDS_SCM_SAFEMODE_REPORTED_DATANODE_PCT =
+      "hdds.scm.safemode.reported.datanode.pct";
+  public static final double HDDS_SCM_SAFEMODE_REPORTED_DATANODE_PCT_DEFAULT = 0.10;
+
+  public static final String HDDS_SCM_SAFEMODE_DATANODE_USE_PIPELINE_ENABLED =
+      "hdds.scm.safemode.datanode.use.pipeline.enabled";
+  public static final boolean HDDS_SCM_SAFEMODE_DATANODE_USE_PIPELINE_ENABLED_DEFAULT = false;
+
   // This configuration setting is used as a fallback location by all
   // Ozone/HDDS services for their metadata. It is useful as a single
   // config point for test/PoC clusters.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1703,6 +1703,25 @@
   </property>
 
   <property>
+    <name>hdds.scm.safemode.datanode.use.pipeline.enabled</name>
+    <value>false</value>
+    <tag>HDDS,SCM,OPERATION</tag>
+    <description>
+      In the DataNodeSafeModeRule,
+      the registered DN is validated based on the DN list stored in the Pipeline.
+    </description>
+  </property>
+
+  <property>
+    <name>hdds.scm.safemode.reported.datanode.pct</name>
+    <value>0.10</value>
+    <tag>HDDS,SCM,OPERATION</tag>
+    <description>
+      Percentage of successfully reported datanodes.
+    </description>
+  </property>
+
+  <property>
     <name>hdds.container.action.max.limit</name>
     <value>20</value>
     <tag>DATANODE</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
@@ -17,16 +17,30 @@
  */
 package org.apache.hadoop.hdds.scm.safemode;
 
-import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer.NodeRegistrationContainerReport;
 
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.server.events.TypedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_DATANODE_USE_PIPELINE_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_DATANODE_USE_PIPELINE_ENABLED_DEFAULT;
 
 /**
  * Class defining Safe mode exit criteria according to number of DataNodes
@@ -35,20 +49,49 @@ import org.apache.hadoop.hdds.server.events.TypedEvent;
 public class DataNodeSafeModeRule extends
     SafeModeExitRule<NodeRegistrationContainerReport> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DataNodeSafeModeRule.class);
+
   // Min DataNodes required to exit safe mode.
   private int requiredDns;
   private int registeredDns = 0;
   // Set to track registered DataNodes.
   private HashSet<UUID> registeredDnSet;
 
+  // These are a set of new variables used for DN registration in Pipeline mode.
+  private boolean usePipeline;
+  private PipelineManager pipelineManager;
+  private double dnReportedPercent;
+  private Map<UUID, String> unRegisteredDn = new HashMap<>();
+
   public DataNodeSafeModeRule(String ruleName, EventQueue eventQueue,
       ConfigurationSource conf,
-      SCMSafeModeManager manager) {
+      SCMSafeModeManager manager, PipelineManager pipelineManager) {
     super(manager, ruleName, eventQueue);
-    requiredDns = conf.getInt(
+
+    // The original strategy allows the user to set a minimum number of DNs to
+    // ensure that the registered DNs in safe mode meet the expected quantity.
+    this.requiredDns = conf.getInt(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE,
         HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE_DEFAULT);
-    registeredDnSet = new HashSet<>(requiredDns * 2);
+    this.registeredDnSet = new HashSet<>(requiredDns * 2);
+
+    // This is our newly added strategy,
+    // which allows obtaining the DN list from the Pipeline list and calculates the
+    // required number of DNs based on the configured ratio.
+    this.usePipeline = conf.getBoolean(HDDS_SCM_SAFEMODE_DATANODE_USE_PIPELINE_ENABLED,
+        HDDS_SCM_SAFEMODE_DATANODE_USE_PIPELINE_ENABLED_DEFAULT);
+    if (this.usePipeline) {
+      this.pipelineManager = pipelineManager;
+      this.dnReportedPercent = conf.getDouble(
+          HddsConfigKeys.HDDS_SCM_SAFEMODE_REPORTED_DATANODE_PCT,
+          HddsConfigKeys.HDDS_SCM_SAFEMODE_REPORTED_DATANODE_PCT_DEFAULT);
+      Preconditions.checkArgument((dnReportedPercent >= 0.0 && dnReportedPercent <= 1.0),
+          HddsConfigKeys.HDDS_SCM_SAFEMODE_REPORTED_DATANODE_PCT  +
+          " value should be >= 0.0 and <= 1.0");
+    }
+
+    initializeRule();
   }
 
   @Override
@@ -63,35 +106,83 @@ public class DataNodeSafeModeRule extends
 
   @Override
   protected void process(NodeRegistrationContainerReport reportsProto) {
+    UUID dnUUID = reportsProto.getDatanodeDetails().getUuid();
 
-    registeredDnSet.add(reportsProto.getDatanodeDetails().getUuid());
+    // If a DN is registered for the first time
+    // (as it is possible for the DN to be registered multiple times),
+    // we will write the UUID of this DN into the `registeredDnSet` and
+    // remove it from the unregistered list.
+    registeredDnSet.add(dnUUID);
     registeredDns = registeredDnSet.size();
-
-    if (scmInSafeMode()) {
-      SCMSafeModeManager.getLogger().info(
-          "SCM in safe mode. {} DataNodes registered, {} required.",
-          registeredDns, requiredDns);
+    if (registeredDnSet.contains(dnUUID)) {
+      unRegisteredDn.remove(dnUUID);
     }
 
+    // Print the DN registration logs.
+    if (scmInSafeMode()) {
+      SCMSafeModeManager.getLogger().debug(
+          "SCM in safe mode. {} DataNodes registered, {} required.", registeredDns, requiredDns);
+    }
   }
 
   @Override
   protected void cleanup() {
     registeredDnSet.clear();
+    unRegisteredDn.clear();
   }
 
   @Override
   public String getStatusText() {
-    return String
-        .format("registered datanodes (=%d) >= required datanodes (=%d)",
-            this.registeredDns, this.requiredDns);
-  }
+    // If it is in Pipeline mode, we will attempt to print the unregistered DNs.
+    if (this.usePipeline) {
+      String status = String
+          .format("Registered DataNodes (=%d) >= Required DataNodes (=%d)",
+          this.registeredDns, this.requiredDns);
 
+      // Retrieve the list of unregistered DNs.
+      List<String> unRegisteredDnHostNames = unRegisteredDn.values()
+          .stream()
+          .limit(SAMPLE_DN_DISPLAY_LIMIT)
+          .collect(Collectors.toList());
+
+      // We will concatenate the information of unregistered DNs and then display it.
+      if (!unRegisteredDnHostNames.isEmpty()) {
+        String sampleDNText = "Unregistered DN : " + unRegisteredDnHostNames;
+        status = status.concat("\n").concat(sampleDNText);
+      }
+
+      return status;
+    }
+    return "";
+  }
 
   @Override
   public void refresh(boolean forceRefresh) {
-    // Do nothing.
-    // As for this rule, there is nothing we read from SCM DB state and
-    // validate it.
+    initializeRule();
+  }
+
+  private void initializeRule() {
+    if (usePipeline) {
+      // We will attempt to retrieve the entire DN list here,
+      // as the Pipeline only exists within the list of active DNs.
+      Set<UUID> pipeLineDnSet = new HashSet<>();
+      if (this.pipelineManager != null) {
+        List<Pipeline> pipelines = this.pipelineManager.getPipelines();
+        pipelines.forEach(pipeline -> {
+          List<DatanodeDetails> nodes = pipeline.getNodes();
+          for (DatanodeDetails node : nodes) {
+            pipeLineDnSet.add(node.getUuid());
+            // If the registeredDnSet does not contain this DN,
+            // we will place this DN in the unRegisteredDn.
+            if (!this.registeredDnSet.contains(node.getUuid())) {
+              this.unRegisteredDn.put(node.getUuid(), node.getHostName());
+            }
+          }
+        });
+        this.requiredDns = (int) Math.ceil(dnReportedPercent * pipeLineDnSet.size());
+        LOG.info("Total DataNodes is {} / RequiredDataNodes is {}, Reported Datanode count is {}.",
+            pipeLineDnSet.size(), requiredDns, registeredDns);
+      }
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -130,7 +130,7 @@ public class SCMSafeModeManager implements SafeModeManager {
           new ContainerSafeModeRule(CONT_EXIT_RULE, eventQueue, config,
               allContainers,  containerManager, this);
       DataNodeSafeModeRule dataNodeSafeModeRule =
-          new DataNodeSafeModeRule(DN_EXIT_RULE, eventQueue, config, this);
+          new DataNodeSafeModeRule(DN_EXIT_RULE, eventQueue, config, this, pipelineManager);
       exitRules.put(CONT_EXIT_RULE, containerSafeModeRule);
       exitRules.put(DN_EXIT_RULE, dataNodeSafeModeRule);
       preCheckRules.add(DN_EXIT_RULE);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
@@ -40,6 +40,7 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
   private final String ruleName;
   protected static final int SAMPLE_CONTAINER_DISPLAY_LIMIT = 5;
   protected static final int SAMPLE_PIPELINE_DISPLAY_LIMIT = 5;
+  protected static final int SAMPLE_DN_DISPLAY_LIMIT = 5;
 
   public SafeModeExitRule(SCMSafeModeManager safeModeManager,
       String ruleName, EventQueue eventQueue) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -226,8 +226,8 @@ public class TestSCMSafeModeManager {
   @ParameterizedTest
   @CsvSource(value = {"100,0.9,false", "0.9,200,false", "0.9,0.1,true"})
   public void testHealthyPipelinePercentWithIncorrectValue(double healthyPercent,
-                                                           double oneReplicaPercent,
-                                                           boolean overrideScmSafeModeThresholdPct) throws Exception {
+      double oneReplicaPercent,
+      boolean overrideScmSafeModeThresholdPct) throws Exception {
     OzoneConfiguration conf = createConf(healthyPercent, oneReplicaPercent);
     if (overrideScmSafeModeThresholdPct) {
       conf.setDouble(HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT, -1.0);


### PR DESCRIPTION
## What changes were proposed in this pull request?

> Background

We enhanced the `DataNodeSafeModeRule` to validate the registered DN based on the DN list stored in the Pipeline.

Currently, the `DataNodeSafeModeRule` in SCM requires users to manually configure the number of DataNodes in the cluster using the setting `hdds.scm.safemode.min.datanode`, with a default value of `1`. If not configured, this value defaults to `1`. However, since clusters are frequently scaled and the number of active DataNodes is uncertain, relying on a fixed value to determine whether SafeMode conditions are met is not reliable.

To address this issue, we propose a new rule: 
allowing `DataNodeSafeModeRule` to retrieve the DataNode list from the registered Pipeline and use a configurable ratio to dynamically calculate the required number of DataNodes. This will provide a more accurate way to determine when the system can exit SafeMode.

> The usage of the new rules

- The following configurations need to be set simultaneously:

Configuration 1: Enable Pipeline Rule.

```
<property>
    <name>hdds.scm.safemode.datanode.use.pipeline.enabled</name>
    <value>true</value>
</property>
```

Configuration 2: Enable Pipeline Rule.

```
<property>
    <name>hdds.scm.safemode.reported.datanode.pct</name>
    <value>0.1</value>
</property>
```

> Execution Flow of the New Rule

- We will use the DN list from the Pipeline as the total list of DataNodes to be registered.
- The total DN list will determine the required DataNodes for registration based on the `hdds.scm.safemode.reported.datanode.pct` value.
- Once DataNodes continuously report and the number of registered DataNodes reaches the calculated threshold, the DataNodeSafeModeRule will exit automatically.
- At the same time, we will list 5 DataNodes that have not been registered, in order to facilitate troubleshooting of DataNodes that failed to register.

> Final Result Display

![image](https://github.com/user-attachments/assets/c00fcf21-7ff7-4786-ab1e-5c4196a17f8d)


## What is the link to the Apache JIRA

JIRA: HDDS-11843. Enhance DataNodeSafeModeRule to Use Pipeline DN List.

## How was this patch tested?

Manual Testing.
