### PR TITLE
HDDS-11882. Do not create aggregate BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1974,7 +1974,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>makeAggregateBom</goal>
+                  <goal>makeBom</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change switches from `makeAggregateBom` to `makeBom`, which only affects the BOM built for the root module.

Description from [CycloneDX](https://github.com/CycloneDX/cyclonedx-maven-plugin/tree/master?tab=readme-ov-file#goals):

> * `makeBom`: creates a BOM for each Maven module with its dependencies,
> * `makeAggregateBom`: creates an aggregate BOM at build root (with dependencies from the whole multi-modules build), and eventually a BOM for each module,

It is a workaround for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/410, which causes unnecessary attempts to download Ozone snapshot artifacts from repository.apache.org.

https://issues.apache.org/jira/browse/HDDS-11882

## How was this patch tested?

```
mvn -B -DskipTests -Dskip.installnodenpm -Dskip.npx -DskipShade \
    --log-file build.log \
    -Pdist clean package

grep -c 'Downloading.*repository.apache.org.*org/apache/ozone' build.log
```

- on `master`: 81
- with this fix: 0

https://github.com/adoroszlai/ozone/actions/runs/12221790282