### PR TITLE
HDDS-11885. Download Hadoop for S3A test from mirrors if available

### DIFF
--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -161,7 +161,7 @@ download_hadoop_aws() {
   if [[ ! -e "${dir}" ]] || [[ ! -d "${dir}"/src/test/resources ]]; then
     mkdir -p "${dir}"
     if [[ ! -f "${dir}.tar.gz" ]]; then
-      local url="https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}-src.tar.gz"
+      local url="https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}-src.tar.gz"
       echo "Downloading Hadoop from ${url}"
       curl -LSs --fail -o "${dir}.tar.gz" "$url" || return 1
     fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

_acceptance (s3a)_ downloads Hadoop source tarball for running contract tests.  Currently it uses `archive.apache.org` directly.  This PR changes the URL to use `closer.lua`, which checks mirrors first.

https://issues.apache.org/jira/browse/HDDS-11885

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/12232729746/job/34120102070#step:6:21