### PR TITLE
HDDS-11889. Include Maven dependencies for hdds-rocks-native in cache

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Fetch dependencies
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: mvn --batch-mode --no-transfer-progress --show-version -Pgo-offline -Pdist clean verify
+        run: mvn --batch-mode --no-transfer-progress --show-version -Pgo-offline -Pdist -Drocks_tools_native clean verify
 
       - name: Delete Ozone jars from repo
         if: steps.restore-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What changes were proposed in this pull request?

`native` check intermittently times out at:

```
[INFO] --- properties-maven-plugin:1.2.1:read-project-properties (read-property-from-file) @ hdds-rocks-native ---
Error: The operation was canceled.
```

With `--debug` we can it's downloading dependencies:

```
[INFO] --- properties-maven-plugin:1.2.1:read-project-properties (read-property-from-file) @ hdds-rocks-native ---
[DEBUG] Resolving artifact org.apache.maven:maven-core:pom:3.9.9 from [apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots, default, releases+snapshots), central (https://repo.maven.apache.org/maven2, default, releases)]
[DEBUG] Using transporter WagonTransporter with priority -1.0 for https://repository.apache.org/content/repositories/snapshots
[DEBUG] Using connector BasicRepositoryConnector with priority 0.0 for https://repository.apache.org/content/repositories/snapshots
[INFO] Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/org/apache/maven/maven-core/3.9.9/maven-core-3.9.9.pom
```

This change enables native build in `populate-cache` workflow, to make sure the dependencies of `hdds-rocks-native` are included in the cache.  This reduces downloads required for `native` check in CI runs.

https://issues.apache.org/jira/browse/HDDS-11889

## How was this patch tested?

Manually triggered `populate-cache`:
https://github.com/adoroszlai/ozone/actions/runs/12237865938

Verified `maven-core-3.9.9` is included:
https://github.com/adoroszlai/ozone/actions/runs/12237865938/job/34134588872#step:10:3379