### PR TITLE
HDDS-11893. Fix full snapshot diff fallback logic because of DAG pruning

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -27,6 +27,7 @@ import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -825,15 +826,15 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
    *         e.g. ["/path/to/sstBackupDir/000050.sst",
    *               "/path/to/sstBackupDir/000060.sst"]
    */
-  public synchronized List<String> getSSTDiffListWithFullPath(
+  public synchronized Optional<List<String>> getSSTDiffListWithFullPath(
       DifferSnapshotInfo src,
       DifferSnapshotInfo dest,
       String sstFilesDirForSnapDiffJob
   ) throws IOException {
 
-    List<String> sstDiffList = getSSTDiffList(src, dest);
+    Optional<List<String>> sstDiffList = getSSTDiffList(src, dest);
 
-    return sstDiffList.stream()
+    return sstDiffList.map(diffList -> diffList.stream()
         .map(
             sst -> {
               String sstFullPath = getSSTFullPath(sst, src.getDbPath());
@@ -843,7 +844,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
               createLink(link, srcFile);
               return link.toString();
             })
-        .collect(Collectors.toList());
+        .collect(Collectors.toList()));
   }
 
   /**
@@ -857,10 +858,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
    * @param dest destination snapshot
    * @return A list of SST files without extension. e.g. ["000050", "000060"]
    */
-  public synchronized List<String> getSSTDiffList(
-      DifferSnapshotInfo src,
-      DifferSnapshotInfo dest
-  ) throws IOException {
+  public synchronized Optional<List<String>> getSSTDiffList(DifferSnapshotInfo src,
+                                                            DifferSnapshotInfo dest) throws IOException {
 
     // TODO: Reject or swap if dest is taken after src, once snapshot chain
     //  integration is done.
@@ -898,8 +897,13 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       filterRelevantSstFilesFullPath(fwdDAGDifferentFiles,
           src.getTablePrefixes());
     }
-
-    return new ArrayList<>(fwdDAGDifferentFiles);
+    // Check if the DAG traversal was able to reach all the destination SST files.
+    for (String destSnapFile : destSnapFiles) {
+      if (!fwdDAGSameFiles.contains(destSnapFile) || !fwdDAGDifferentFiles.contains(destSnapFile)) {
+        return Optional.empty();
+      }
+    }
+    return Optional.of(new ArrayList<>(fwdDAGDifferentFiles));
   }
 
   /**

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -641,7 +641,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
    * @param rocksDB open rocksDB instance.
    * @return a list of SST files (without extension) in the DB.
    */
-  public HashSet<String> readRocksDBLiveFiles(ManagedRocksDB rocksDB) {
+  public Set<String> readRocksDBLiveFiles(ManagedRocksDB rocksDB) {
     HashSet<String> liveFiles = new HashSet<>();
 
     final List<String> cfs = Arrays.asList(
@@ -893,15 +893,16 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       LOG.debug("{}", logSB);
     }
 
+    // Check if the DAG traversal was able to reach all the destination SST files.
+    for (String destSnapFile : destSnapFiles) {
+      if (!fwdDAGSameFiles.contains(destSnapFile) && !fwdDAGDifferentFiles.contains(destSnapFile)) {
+        return Optional.empty();
+      }
+    }
+
     if (src.getTablePrefixes() != null && !src.getTablePrefixes().isEmpty()) {
       filterRelevantSstFilesFullPath(fwdDAGDifferentFiles,
           src.getTablePrefixes());
-    }
-    // Check if the DAG traversal was able to reach all the destination SST files.
-    for (String destSnapFile : destSnapFiles) {
-      if (!fwdDAGSameFiles.contains(destSnapFile) || !fwdDAGDifferentFiles.contains(destSnapFile)) {
-        return Optional.empty();
-      }
     }
     return Optional.of(new ArrayList<>(fwdDAGDifferentFiles));
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -587,7 +587,7 @@ public class TestRocksDBCheckpointDiffer {
     int index = 0;
     for (DifferSnapshotInfo snap : snapshots) {
       // Returns a list of SST files to be fed into RocksDiff
-      List<String> sstDiffList = differ.getSSTDiffList(src, snap);
+      List<String> sstDiffList = differ.getSSTDiffList(src, snap).orElse(Collections.emptyList());
       LOG.info("SST diff list from '{}' to '{}': {}",
           src.getDbPath(), snap.getDbPath(), sstDiffList);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -231,7 +232,7 @@ public class TestOMSnapshotDAG {
     final File checkpointSnap2 = new File(snap2.getDbPath());
     GenericTestUtils.waitFor(checkpointSnap2::exists, 2000, 20000);
 
-    List<String> sstDiffList21 = differ.getSSTDiffList(snap2, snap1);
+    List<String> sstDiffList21 = differ.getSSTDiffList(snap2, snap1).orElse(Collections.emptyList());
     LOG.debug("Got diff list: {}", sstDiffList21);
 
     // Delete 1000 keys, take a 3rd snapshot, and do another diff
@@ -250,13 +251,13 @@ public class TestOMSnapshotDAG {
     final File checkpointSnap3 = new File(snap3.getDbPath());
     GenericTestUtils.waitFor(checkpointSnap3::exists, 2000, 20000);
 
-    List<String> sstDiffList32 = differ.getSSTDiffList(snap3, snap2);
+    List<String> sstDiffList32 = differ.getSSTDiffList(snap3, snap2).orElse(Collections.emptyList());
 
     // snap3-snap1 diff result is a combination of snap3-snap2 and snap2-snap1
-    List<String> sstDiffList31 = differ.getSSTDiffList(snap3, snap1);
+    List<String> sstDiffList31 = differ.getSSTDiffList(snap3, snap1).orElse(Collections.emptyList());
 
     // Same snapshot. Result should be empty list
-    List<String> sstDiffList22 = differ.getSSTDiffList(snap2, snap2);
+    List<String> sstDiffList22 = differ.getSSTDiffList(snap2, snap2).orElse(Collections.emptyList());
     assertThat(sstDiffList22).isEmpty();
     snapDB1.close();
     snapDB2.close();
@@ -282,13 +283,13 @@ public class TestOMSnapshotDAG {
         volumeName, bucketName, "snap3",
         ((RDBStore) snapDB3.get()
             .getMetadataManager().getStore()).getDb().getManagedRocksDb());
-    List<String> sstDiffList21Run2 = differ.getSSTDiffList(snap2, snap1);
+    List<String> sstDiffList21Run2 = differ.getSSTDiffList(snap2, snap1).orElse(Collections.emptyList());
     assertEquals(sstDiffList21, sstDiffList21Run2);
 
-    List<String> sstDiffList32Run2 = differ.getSSTDiffList(snap3, snap2);
+    List<String> sstDiffList32Run2 = differ.getSSTDiffList(snap3, snap2).orElse(Collections.emptyList());
     assertEquals(sstDiffList32, sstDiffList32Run2);
 
-    List<String> sstDiffList31Run2 = differ.getSSTDiffList(snap3, snap1);
+    List<String> sstDiffList31Run2 = differ.getSSTDiffList(snap3, snap1).orElse(Collections.emptyList());
     assertEquals(sstDiffList31, sstDiffList31Run2);
     snapDB1.close();
     snapDB2.close();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1125,7 +1125,7 @@ public class SnapshotDiffManager implements AutoCloseable {
                             String diffDir)
       throws IOException {
     // TODO: [SNAPSHOT] Refactor the parameter list
-    final Set<String> deltaFiles = new HashSet<>();
+    Optional<Set<String>> deltaFiles = Optional.empty();
 
     // Check if compaction DAG is available, use that if so
     if (differ != null && fsInfo != null && tsInfo != null && !useFullDiff) {
@@ -1139,18 +1139,14 @@ public class SnapshotDiffManager implements AutoCloseable {
 
       LOG.debug("Calling RocksDBCheckpointDiffer");
       try {
-        Optional<List<String>> sstDiffList = differ.getSSTDiffListWithFullPath(toDSI,
-            fromDSI, diffDir);
-        if (sstDiffList.isPresent()) {
-          deltaFiles.addAll(sstDiffList.get());
-        }
+        deltaFiles = differ.getSSTDiffListWithFullPath(toDSI, fromDSI, diffDir).map(HashSet::new);
       } catch (Exception exception) {
         LOG.warn("Failed to get SST diff file using RocksDBCheckpointDiffer. " +
             "It will fallback to full diff now.", exception);
       }
     }
 
-    if (useFullDiff || deltaFiles.isEmpty()) {
+    if (useFullDiff || !deltaFiles.isPresent()) {
       // If compaction DAG is not available (already cleaned up), fall back to
       //  the slower approach.
       if (!useFullDiff) {
@@ -1168,13 +1164,16 @@ public class SnapshotDiffManager implements AutoCloseable {
               ((RDBStore)toSnapshot.getMetadataManager().getStore()).getDb()
                   .getManagedRocksDb(),
               tablesToLookUp);
-
-      deltaFiles.addAll(fromSnapshotFiles);
-      deltaFiles.addAll(toSnapshotFiles);
-      RocksDiffUtils.filterRelevantSstFiles(deltaFiles, tablePrefixes);
+      Set<String> diffFiles = new HashSet<>();
+      diffFiles.addAll(fromSnapshotFiles);
+      diffFiles.addAll(toSnapshotFiles);
+      RocksDiffUtils.filterRelevantSstFiles(diffFiles, tablePrefixes);
+      deltaFiles = Optional.of(diffFiles);
     }
 
-    return deltaFiles;
+    return deltaFiles.orElseThrow(() ->
+        new IOException("Error getting diff files b/w " + fromSnapshot.getSnapshotTableKey() + " and " +
+            toSnapshot.getSnapshotTableKey()));
   }
 
   private void validateEstimatedKeyChangesAreInLimits(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1139,9 +1139,11 @@ public class SnapshotDiffManager implements AutoCloseable {
 
       LOG.debug("Calling RocksDBCheckpointDiffer");
       try {
-        List<String> sstDiffList = differ.getSSTDiffListWithFullPath(toDSI,
+        Optional<List<String>> sstDiffList = differ.getSSTDiffListWithFullPath(toDSI,
             fromDSI, diffDir);
-        deltaFiles.addAll(sstDiffList);
+        if (sstDiffList.isPresent()) {
+          deltaFiles.addAll(sstDiffList.get());
+        }
       } catch (Exception exception) {
         LOG.warn("Failed to get SST diff file using RocksDBCheckpointDiffer. " +
             "It will fallback to full diff now.", exception);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -429,7 +429,7 @@ public class TestSnapshotDiffManager {
         any(DifferSnapshotInfo.class),
         any(DifferSnapshotInfo.class),
         eq(diffDir))
-    ).thenReturn(Lists.newArrayList(randomStrings));
+    ).thenReturn(Optional.of(Lists.newArrayList(randomStrings)));
 
     ReferenceCounted<OmSnapshot> rcFromSnapshot =
         omSnapshotManager.getActiveSnapshot(VOLUME_NAME, BUCKET_NAME, snap1.toString());
@@ -497,7 +497,7 @@ public class TestSnapshotDiffManager {
             any(DifferSnapshotInfo.class),
             any(DifferSnapshotInfo.class),
             anyString()))
-            .thenReturn(Collections.emptyList());
+            .thenReturn(Optional.ofNullable(Collections.emptyList()));
       }
 
       ReferenceCounted<OmSnapshot> rcFromSnapshot =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -82,6 +82,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -411,7 +412,7 @@ public class TestSnapshotDiffManager {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {1, 2, 5, 10, 100, 1000, 10000})
+  @ValueSource(ints = {0, 1, 2, 5, 10, 100, 1000, 10000})
   public void testGetDeltaFilesWithDag(int numberOfFiles) throws IOException {
     UUID snap1 = UUID.randomUUID();
     UUID snap2 = UUID.randomUUID();
@@ -441,14 +442,20 @@ public class TestSnapshotDiffManager {
     SnapshotInfo fromSnapshotInfo = getMockedSnapshotInfo(snap1);
     SnapshotInfo toSnapshotInfo = getMockedSnapshotInfo(snap2);
     when(jobTableIterator.isValid()).thenReturn(false);
-    Set<String> deltaFiles = snapshotDiffManager.getDeltaFiles(
-        fromSnapshot,
-        toSnapshot,
-        Arrays.asList("cf1", "cf2"), fromSnapshotInfo,
-        toSnapshotInfo, false,
-        Collections.emptyMap(), diffDir);
-    assertEquals(randomStrings, deltaFiles);
-
+    try (MockedStatic<RdbUtil> mockedRdbUtil = Mockito.mockStatic(RdbUtil.class, Mockito.CALLS_REAL_METHODS);
+         MockedStatic<RocksDiffUtils> mockedRocksDiffUtils = Mockito.mockStatic(RocksDiffUtils.class,
+             Mockito.CALLS_REAL_METHODS)) {
+      mockedRdbUtil.when(() -> RdbUtil.getSSTFilesForComparison(any(), any()))
+          .thenReturn(Collections.singleton(RandomStringUtils.randomAlphabetic(10)));
+      mockedRocksDiffUtils.when(() -> RocksDiffUtils.filterRelevantSstFiles(any(), any())).thenAnswer(i -> null);
+      Set<String> deltaFiles = snapshotDiffManager.getDeltaFiles(
+          fromSnapshot,
+          toSnapshot,
+          Arrays.asList("cf1", "cf2"), fromSnapshotInfo,
+          toSnapshotInfo, false,
+          Collections.emptyMap(), diffDir);
+      assertEquals(randomStrings, deltaFiles);
+    }
     rcFromSnapshot.close();
     rcToSnapshot.close();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshot diff currently doesn't fallback to full snapdiff if DAG has been pruned and rather returns the partial delta sst file list which could lead to wrong snapshot diff result. 

Instead we need to check if all the sst files of source snapshots have been visited as part of the dag traversal.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11893
## How was this patch tested?
Adding unit tests & integration tests
