### PR TITLE
HDDS-11807. Make callId different for each request in openKeyCleanupService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
@@ -78,7 +78,6 @@ public class OpenKeyCleanupService extends BackgroundService {
   private final Duration leaseThreshold;
   private final int cleanupLimitPerTask;
   private final AtomicLong submittedOpenKeyCount;
-  private final AtomicLong runCount;
   private final AtomicLong callId;
   private final AtomicBoolean suspended;
 
@@ -114,19 +113,18 @@ public class OpenKeyCleanupService extends BackgroundService {
         OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_LIMIT_PER_TASK_DEFAULT);
 
     this.submittedOpenKeyCount = new AtomicLong(0);
-    this.runCount = new AtomicLong(0);
     this.callId = new AtomicLong(0);
     this.suspended = new AtomicBoolean(false);
   }
 
   /**
-   * Returns the number of times this Background service has run.
+   * Returns the number of times this Background service has called OM for delete/commit keys.
    *
    * @return Long, run count.
    */
   @VisibleForTesting
   public long getRunCount() {
-    return runCount.get();
+    return  callId.get();
   }
 
   /**
@@ -192,7 +190,6 @@ public class OpenKeyCleanupService extends BackgroundService {
       if (!shouldRun()) {
         return BackgroundTaskResult.EmptyTaskResult.newResult();
       }
-      runCount.incrementAndGet();
       long startTime = Time.monotonicNow();
       final ExpiredOpenKeys expiredOpenKeys;
       try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
@@ -79,7 +79,7 @@ public class OpenKeyCleanupService extends BackgroundService {
   private final int cleanupLimitPerTask;
   private final AtomicLong submittedOpenKeyCount;
   private final AtomicLong runCount;
-  private final AtomicLong callIdCount;
+  private final AtomicLong callId;
   private final AtomicBoolean suspended;
 
   public OpenKeyCleanupService(long interval, TimeUnit unit, long timeout,
@@ -115,7 +115,7 @@ public class OpenKeyCleanupService extends BackgroundService {
 
     this.submittedOpenKeyCount = new AtomicLong(0);
     this.runCount = new AtomicLong(0);
-    this.callIdCount = new AtomicLong(0);
+    this.callId = new AtomicLong(0);
     this.suspended = new AtomicBoolean(false);
   }
 
@@ -269,7 +269,7 @@ public class OpenKeyCleanupService extends BackgroundService {
 
     private OMResponse submitRequest(OMRequest omRequest) {
       try {
-        return OzoneManagerRatisUtils.submitRequest(ozoneManager, omRequest, clientId, callIdCount.incrementAndGet());
+        return OzoneManagerRatisUtils.submitRequest(ozoneManager, omRequest, clientId, callId.incrementAndGet());
       } catch (ServiceException e) {
         LOG.error("Open key " + omRequest.getCmdType()
             + " request failed. Will retry at next run.", e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
@@ -118,16 +118,6 @@ public class OpenKeyCleanupService extends BackgroundService {
   }
 
   /**
-   * Returns the number of times this Background service has called OM for delete/commit keys.
-   *
-   * @return Long, run count.
-   */
-  @VisibleForTesting
-  public long getRunCount() {
-    return  callId.get();
-  }
-
-  /**
    * Suspend the service (for testing).
    */
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -166,8 +166,7 @@ class TestOpenKeyCleanupService {
     // wait for submitted tasks to complete
     Thread.sleep(SERVICE_INTERVAL);
     final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
-    final long oldrunCount = openKeyCleanupService.getRunCount();
-    LOG.info("oldkeyCount={}, oldrunCount={}", oldkeyCount, oldrunCount);
+    LOG.info("oldkeyCount={}", oldkeyCount);
 
     final OMMetrics metrics = om.getMetrics();
     long numKeyHSyncs = metrics.getNumKeyHSyncs();
@@ -329,8 +328,7 @@ class TestOpenKeyCleanupService {
     // wait for submitted tasks to complete
     Thread.sleep(SERVICE_INTERVAL);
     final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
-    final long oldrunCount = openKeyCleanupService.getRunCount();
-    LOG.info("oldMpuKeyCount={}, oldMpuRunCount={}", oldkeyCount, oldrunCount);
+    LOG.info("oldMpuKeyCount={}", oldkeyCount);
 
     final OMMetrics metrics = om.getMetrics();
     long numKeyHSyncs = metrics.getNumKeyHSyncs();
@@ -389,8 +387,7 @@ class TestOpenKeyCleanupService {
     // wait for submitted tasks to complete
     Thread.sleep(SERVICE_INTERVAL);
     final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
-    final long oldrunCount = openKeyCleanupService.getRunCount();
-    LOG.info("oldMpuKeyCount={}, oldMpuRunCount={}", oldkeyCount, oldrunCount);
+    LOG.info("oldMpuKeyCount={},", oldkeyCount);
 
     final OMMetrics metrics = om.getMetrics();
     long numOpenKeysCleaned = metrics.getNumOpenKeysCleaned();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -189,9 +189,6 @@ class TestOpenKeyCleanupService {
     GenericTestUtils.waitFor(
         () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= oldkeyCount + keyCount,
         SERVICE_INTERVAL, WAIT_TIME);
-    GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
-        SERVICE_INTERVAL, WAIT_TIME);
 
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
     waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED);
@@ -353,13 +350,8 @@ class TestOpenKeyCleanupService {
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     openKeyCleanupService.resume();
-
-    GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
-        SERVICE_INTERVAL, WAIT_TIME);
-
-    // wait for requests to complete
-    Thread.sleep(SERVICE_INTERVAL);
+    // wait for openKeyCleanupService to complete at least once
+    Thread.sleep(SERVICE_INTERVAL * 2);
 
     // No expired open keys fetched
     assertEquals(openKeyCleanupService.getSubmittedOpenKeyCount(), oldkeyCount);
@@ -422,9 +414,6 @@ class TestOpenKeyCleanupService {
 
     GenericTestUtils.waitFor(
         () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= oldkeyCount + partCount,
-        SERVICE_INTERVAL, WAIT_TIME);
-    GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
         SERVICE_INTERVAL, WAIT_TIME);
 
     // No expired MPU parts fetched


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis may reject request when callId and clientId is same for different request(Assume it as a replay). To avoid such replay issue we need to ensure callId is different for different requests sent from openKeyCleanupService in each interval.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11807

## How was this patch tested?

New integration test
