### PR TITLE
HDDS-11779. Add DN metrics to show deletion progress

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -46,9 +46,6 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The number of failed delete blocks.")
   private MutableCounterLong failureCount;
 
-  @Metric(about = "The number of delete block transaction processed.")
-  private MutableCounterLong processedTransactionCount;
-
   @Metric(about = "The number of out of order delete block transaction.")
   private MutableCounterLong outOfOrderDeleteBlockTransactionCount;
 
@@ -79,16 +76,11 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The total number of transactions which failed due to container lock wait timeout.")
   private MutableGaugeLong totalLockTimeoutTransactionCount;
 
-  @Metric(about = "The total number of deletion commands received.")
-  private MutableGaugeLong totalCommandsReceived;
+  @Metric(about = "The number of delete block transactions successful.")
+  private MutableCounterLong processedTransactionSuccessCount;
 
-  @Metric(about = "The total number of deletion commands that were discarded " +
-      "due to the queue being full.")
-  private MutableGaugeLong totalCommandsDiscarded;
-
-  @Metric(about = "The total number of deletion transactions that were discarded " +
-      "due to the transaction being a duplicate.")
-  private MutableGaugeLong totalTransactionsDiscarded;
+  @Metric(about = "The number of delete block transactions failed.")
+  private MutableGaugeLong processedTransactionFailCount;
 
   private BlockDeletingServiceMetrics() {
   }
@@ -124,8 +116,12 @@ public final class BlockDeletingServiceMetrics {
     this.failureCount.incr();
   }
 
-  public void incrProcessedTransactionCount(long count) {
-    processedTransactionCount.incr(count);
+  public void incrProcessedTransactionSuccessCount(long count) {
+    processedTransactionSuccessCount.incr(count);
+  }
+
+  public void incrProcessedTransactionFailCount(long count) {
+    processedTransactionFailCount.incr(count);
   }
 
   public void incrReceivedTransactionCount(long count) {
@@ -164,18 +160,6 @@ public final class BlockDeletingServiceMetrics {
     totalLockTimeoutTransactionCount.incr();
   }
 
-  public void incrTotalCommandsReceived(long delta) {
-    this.totalCommandsReceived.incr(delta);
-  }
-
-  public void incrTotalCommandsDiscarded(long delta) {
-    this.totalCommandsDiscarded.incr(delta);
-  }
-
-  public void incrTotalTransactionsDiscarded(long delta) {
-    this.totalTransactionsDiscarded.incr(delta);
-  }
-
   public long getSuccessCount() {
     return successCount.value();
   }
@@ -212,24 +196,16 @@ public final class BlockDeletingServiceMetrics {
     return totalLockTimeoutTransactionCount.value();
   }
 
-  public long getProcessedTransactionCount() {
-    return processedTransactionCount.value();
-  }
-
   public long getReceivedTransactionCount() {
     return receivedTransactionCount.value();
   }
 
-  public long getTotalCommandsReceived() {
-    return totalCommandsReceived.value();
+  public long getProcessedTransactionSuccessCount() {
+    return processedTransactionSuccessCount.value();
   }
 
-  public long getTotalCommandsDiscarded() {
-    return totalCommandsDiscarded.value();
-  }
-
-  public long getTotalTransactionsDiscarded() {
-    return totalTransactionsDiscarded.value();
+  public long getProcessedTransactionFailCount() {
+    return processedTransactionFailCount.value();
   }
 
   @Override
@@ -250,8 +226,10 @@ public final class BlockDeletingServiceMetrics {
             + receivedTransactionCount.value()).append("\t")
         .append("receivedRetryTransactionCount = "
             + receivedRetryTransactionCount.value()).append("\t")
-        .append("processedTransactionCount = "
-            + processedTransactionCount.value()).append("\t")
+        .append("processedTransactionSuccessCount = "
+            + processedTransactionSuccessCount.value()).append("\t")
+        .append("processedTransactionFailCount = "
+            + processedTransactionFailCount.value()).append("\t")
         .append("receivedContainerCount = "
             + receivedContainerCount.value()).append("\t")
         .append("receivedBlockCount = "
@@ -259,13 +237,7 @@ public final class BlockDeletingServiceMetrics {
         .append("markedBlockCount = "
             + markedBlockCount.value()).append("\t")
         .append("totalLockTimeoutTransactionCount = "
-            + totalLockTimeoutTransactionCount.value()).append("\t")
-        .append("totalCommandsReceived = "
-            + totalCommandsReceived.value()).append("\t")
-        .append("totalCommandsDiscarded = "
-            + totalCommandsDiscarded.value()).append("\t")
-        .append("totalTransactionsDiscarded = "
-            + totalTransactionsDiscarded.value()).append("\t");
+            + totalLockTimeoutTransactionCount.value()).append("\t");
     return buffer.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -196,10 +196,6 @@ public final class BlockDeletingServiceMetrics {
     return totalLockTimeoutTransactionCount.value();
   }
 
-  public long getReceivedTransactionCount() {
-    return receivedTransactionCount.value();
-  }
-
   public long getProcessedTransactionSuccessCount() {
     return processedTransactionSuccessCount.value();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -46,6 +46,9 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The number of failed delete blocks.")
   private MutableCounterLong failureCount;
 
+  @Metric(about = "The number of delete block transaction processed.")
+  private MutableCounterLong processedTransactionCount;
+
   @Metric(about = "The number of out of order delete block transaction.")
   private MutableCounterLong outOfOrderDeleteBlockTransactionCount;
 
@@ -55,8 +58,7 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The total number of DeleteBlockTransaction received")
   private MutableCounterLong receivedTransactionCount;
 
-  @Metric(about = "The total number of DeleteBlockTransaction" +
-      " that is a retry Transaction")
+  @Metric(about = "The total number of DeleteBlockTransaction that is a retry Transaction")
   private MutableCounterLong receivedRetryTransactionCount;
 
   @Metric(about = "The total number of Container received to be processed")
@@ -74,9 +76,19 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The total number of Container chosen to be deleted.")
   private MutableGaugeLong totalContainerChosenCount;
 
-  @Metric(about = "The total number of transactions which failed due" +
-      " to container lock wait timeout.")
+  @Metric(about = "The total number of transactions which failed due to container lock wait timeout.")
   private MutableGaugeLong totalLockTimeoutTransactionCount;
+
+  @Metric(about = "The total number of deletion commands received.")
+  private MutableGaugeLong totalCommandsReceived;
+
+  @Metric(about = "The total number of deletion commands that were discarded " +
+      "due to the queue being full.")
+  private MutableGaugeLong totalCommandsDiscarded;
+
+  @Metric(about = "The total number of deletion transactions that were discarded " +
+      "due to the transaction being a duplicate.")
+  private MutableGaugeLong totalTransactionsDiscarded;
 
   private BlockDeletingServiceMetrics() {
   }
@@ -110,6 +122,10 @@ public final class BlockDeletingServiceMetrics {
 
   public void incrFailureCount() {
     this.failureCount.incr();
+  }
+
+  public void incrProcessedTransactionCount(long count) {
+    processedTransactionCount.incr(count);
   }
 
   public void incrReceivedTransactionCount(long count) {
@@ -148,6 +164,18 @@ public final class BlockDeletingServiceMetrics {
     totalLockTimeoutTransactionCount.incr();
   }
 
+  public void incrTotalCommandsReceived(long delta) {
+    this.totalCommandsReceived.incr(delta);
+  }
+
+  public void incrTotalCommandsDiscarded(long delta) {
+    this.totalCommandsDiscarded.incr(delta);
+  }
+
+  public void incrTotalTransactionsDiscarded(long delta) {
+    this.totalTransactionsDiscarded.incr(delta);
+  }
+
   public long getSuccessCount() {
     return successCount.value();
   }
@@ -184,6 +212,26 @@ public final class BlockDeletingServiceMetrics {
     return totalLockTimeoutTransactionCount.value();
   }
 
+  public long getProcessedTransactionCount() {
+    return processedTransactionCount.value();
+  }
+
+  public long getReceivedTransactionCount() {
+    return receivedTransactionCount.value();
+  }
+
+  public long getTotalCommandsReceived() {
+    return totalCommandsReceived.value();
+  }
+
+  public long getTotalCommandsDiscarded() {
+    return totalCommandsDiscarded.value();
+  }
+
+  public long getTotalTransactionsDiscarded() {
+    return totalTransactionsDiscarded.value();
+  }
+
   @Override
   public String toString() {
     StringBuffer buffer = new StringBuffer();
@@ -202,6 +250,8 @@ public final class BlockDeletingServiceMetrics {
             + receivedTransactionCount.value()).append("\t")
         .append("receivedRetryTransactionCount = "
             + receivedRetryTransactionCount.value()).append("\t")
+        .append("processedTransactionCount = "
+            + processedTransactionCount.value()).append("\t")
         .append("receivedContainerCount = "
             + receivedContainerCount.value()).append("\t")
         .append("receivedBlockCount = "
@@ -209,7 +259,13 @@ public final class BlockDeletingServiceMetrics {
         .append("markedBlockCount = "
             + markedBlockCount.value()).append("\t")
         .append("totalLockTimeoutTransactionCount = "
-            + totalLockTimeoutTransactionCount.value()).append("\t");
+            + totalLockTimeoutTransactionCount.value()).append("\t")
+        .append("totalCommandsReceived = "
+            + totalCommandsReceived.value()).append("\t")
+        .append("totalCommandsDiscarded = "
+            + totalCommandsDiscarded.value()).append("\t")
+        .append("totalTransactionsDiscarded = "
+            + totalTransactionsDiscarded.value()).append("\t");
     return buffer.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -144,6 +144,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         container, context, connectionManager);
     try {
       deleteCommandQueues.add(cmd);
+      blockDeleteMetrics.incrTotalCommandsReceived(1);
     } catch (IllegalStateException e) {
       String dnId = context.getParent().getDatanodeDetails().getUuidString();
       Consumer<CommandStatus> updateFailure = (cmdStatus) -> {
@@ -157,6 +158,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       };
       updateCommandStatus(cmd.getContext(), cmd.getCmd(), updateFailure, LOG);
       LOG.warn("Command is discarded because of the command queue is full");
+      blockDeleteMetrics.incrTotalCommandsDiscarded(1);
     }
   }
 
@@ -462,6 +464,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       Future<DeleteBlockTransactionExecutionResult> future =
           executor.submit(new ProcessTransactionTask(tx));
       futures.add(future);
+      blockDeleteMetrics.incrProcessedTransactionCount(1);
     }
     return futures;
   }
@@ -650,6 +653,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
           containerData.getDeleteTransactionId()));
     } else if (delTX.getTxID() == containerData.getDeleteTransactionId()) {
       duplicate = true;
+      metrics.incrTotalTransactionsDiscarded(1);
       LOG.info(String.format("Delete blocks with txID %d for containerId: %d"
               + " is retried.", delTX.getTxID(), containerId));
     } else {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -331,6 +331,9 @@ public class TestDeleteBlocksCommandHandler {
         assertEquals(cmdStatus.getProtoBufMessage().getBlockDeletionAck().getResultsCount(), 0);
       }
     }
+    blockDeleteMetrics = handler.getBlockDeleteMetrics();
+    assertEquals(5, blockDeleteMetrics.getTotalCommandsReceived());
+    assertEquals(2, blockDeleteMetrics.getTotalCommandsDiscarded());
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -367,6 +370,7 @@ public class TestDeleteBlocksCommandHandler {
     assertTrue(results3.get(0).getSuccess());
     assertEquals(0,
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
+    assertEquals(1, blockDeleteMetrics.getTotalTransactionsDiscarded());
     // Duplicate cmd content will not be persisted.
     assertEquals(2,
         ((KeyValueContainerData) container.getContainerData()).getNumPendingDeletionBlocks());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -331,7 +331,6 @@ public class TestDeleteBlocksCommandHandler {
         assertEquals(cmdStatus.getProtoBufMessage().getBlockDeletionAck().getResultsCount(), 0);
       }
     }
-    blockDeleteMetrics = handler.getBlockDeleteMetrics();
   }
 
   @ContainerTestVersionInfo.ContainerTest

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -332,8 +332,6 @@ public class TestDeleteBlocksCommandHandler {
       }
     }
     blockDeleteMetrics = handler.getBlockDeleteMetrics();
-    assertEquals(5, blockDeleteMetrics.getTotalCommandsReceived());
-    assertEquals(2, blockDeleteMetrics.getTotalCommandsDiscarded());
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -370,7 +368,6 @@ public class TestDeleteBlocksCommandHandler {
     assertTrue(results3.get(0).getSuccess());
     assertEquals(0,
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
-    assertEquals(1, blockDeleteMetrics.getTotalTransactionsDiscarded());
     // Duplicate cmd content will not be persisted.
     assertEquals(2,
         ((KeyValueContainerData) container.getContainerData()).getNumPendingDeletionBlocks());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the following metrics for datanode w.r.t. deletion:
- Total no. of delete transactions processed
- Total no. of delete transactions skipped for deletion
- Total no. of delete commands received in DN
- Total no. of delete commands discarded in DN due to queue being full

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11779

## How was this patch tested?

Tested manually