### PR TITLE
HDDS-11846. [Recon] Recon Schema version_number column is always set as -1.

### DIFF
--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
@@ -24,8 +24,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.function.BiPredicate;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -95,4 +98,23 @@ public final class SqlDbUtils {
         LOG.info("{} table already exists, skipping creation.", tableName);
         return true;
       };
+
+  /**
+   * Utility method to list all user-defined tables in the database.
+   *
+   * @param connection The database connection to use.
+   * @return A list of table names (user-defined tables only).
+   * @throws SQLException If there is an issue accessing the database metadata.
+   */
+  public static List<String> listAllTables(Connection connection) throws SQLException {
+    List<String> tableNames = new ArrayList<>();
+    try (ResultSet resultSet = connection.getMetaData().getTables(null, null, null, new String[]{"TABLE"})) {
+      while (resultSet.next()) {
+        String tableName = resultSet.getString("TABLE_NAME");
+        tableNames.add(tableName);
+      }
+    }
+    LOG.debug("Found {} user-defined tables in the database: {}", tableNames.size(), tableNames);
+    return tableNames;
+  }
 }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
@@ -58,17 +58,13 @@ public class SchemaVersionTableDefinition implements ReconSchemaDefinition {
 
       if (!TABLE_EXISTS_CHECK.test(conn, SCHEMA_VERSION_TABLE_NAME)) {
         // If the RECON_SCHEMA_VERSION table does not exist, check for other tables
+        // to identify if it is a fresh install
         boolean isFreshInstall = checkForFreshInstall(conn);
-
-        // Create the RECON_SCHEMA_VERSION table
         createSchemaVersionTable();
 
         if (isFreshInstall) {
           // Fresh install: Set the SLV to the latest version
           insertInitialSLV(conn, latestSLV);
-        } else {
-          // Upgrade scenario: Set the SLV to -1 to trigger all upgrade actions
-          insertInitialSLV(conn, -1);
         }
       }
     }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
@@ -91,17 +91,19 @@ public class SchemaVersionTableDefinition implements ReconSchemaDefinition {
    */
   private void insertInitialSLV(DSLContext dslContext, int slv) {
     dslContext.insertInto(DSL.table(SCHEMA_VERSION_TABLE_NAME))
-        .columns(DSL.field(name("version_number")), DSL.field(name("applied_on")))
+        .columns(DSL.field(name("version_number")),
+            DSL.field(name("applied_on")))
         .values(slv, DSL.currentTimestamp())
         .execute();
     LOG.info("Inserted initial SLV '{}' into SchemaVersion table.", slv);
   }
 
   /**
-     * Set the latest SLV.
-     * @param slv The latest Software Layout Version.
-     */
-    public void setLatestSLV(int slv) {
-      this.latestSLV = slv;
-    }
+   * Set the latest SLV.
+   *
+   * @param slv The latest Software Layout Version.
+   */
+  public void setLatestSLV(int slv) {
+    this.latestSLV = slv;
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.hadoop.ozone.recon.upgrade.ReconLayoutFeature;
-import org.apache.hadoop.ozone.recon.upgrade.ReconLayoutVersionManager;
 import org.hadoop.ozone.recon.schema.ReconSchemaDefinition;
 import org.hadoop.ozone.recon.schema.SchemaVersionTableDefinition;
 import org.slf4j.Logger;
@@ -31,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
-import org.apache.hadoop.ozone.recon.ReconUtils;
 
 /**
  * Class used to create Recon SQL tables.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
@@ -19,7 +19,8 @@
 package org.apache.hadoop.ozone.recon;
 
 import java.sql.SQLException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.hadoop.ozone.recon.upgrade.ReconLayoutFeature;
 import org.apache.hadoop.ozone.recon.upgrade.ReconLayoutVersionManager;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import org.apache.hadoop.ozone.recon.ReconUtils;
 
 /**
  * Class used to create Recon SQL tables.
@@ -87,9 +89,6 @@ public class ReconSchemaManager {
    * @return The latest SLV.
    */
   private int calculateLatestSLV() {
-    return Arrays.stream(ReconLayoutFeature.values())
-        .mapToInt(ReconLayoutFeature::getVersion)
-        .max()
-        .orElse(0);
+    return ReconLayoutFeature.determineSLV();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.recon.upgrade;
 
 import org.reflections.Reflections;
 
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Optional;
 import java.util.Set;
@@ -90,6 +91,17 @@ public enum ReconLayoutFeature {
         throw new RuntimeException("Failed to register upgrade action: " + actionClass.getSimpleName(), e);
       }
     }
+  }
+
+  /**
+   * Determines the Software Layout Version (SLV) based on the latest feature version.
+   * @return The Software Layout Version (SLV).
+   */
+  public static int determineSLV() {
+    return Arrays.stream(ReconLayoutFeature.values())
+        .mapToInt(ReconLayoutFeature::getVersion)
+        .max()
+        .orElse(0); // Default to 0 if no features are defined
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutVersionManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutVersionManager.java
@@ -70,10 +70,7 @@ public class ReconLayoutVersionManager {
    * @return The Software Layout Version (SLV).
    */
   private int determineSLV() {
-    return Arrays.stream(ReconLayoutFeature.values())
-        .mapToInt(ReconLayoutFeature::getVersion)
-        .max()
-        .orElse(0); // Default to 0 if no features are defined
+    return ReconLayoutFeature.determineSLV();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutVersionManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutVersionManager.java
@@ -70,7 +70,10 @@ public class ReconLayoutVersionManager {
    * @return The Software Layout Version (SLV).
    */
   private int determineSLV() {
-    return ReconLayoutFeature.determineSLV();
+    return Arrays.stream(ReconLayoutFeature.values())
+        .mapToInt(ReconLayoutFeature::getVersion)
+        .max()
+        .orElse(0);
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -126,6 +126,10 @@ public class AbstractReconSqlDBTest {
     return injector.getInstance(DataSource.class).getConnection();
   }
 
+  protected DataSource getDataSource() {
+    return injector.getInstance(DataSource.class);
+  }
+
   protected DSLContext getDslContext() {
     return dslContext;
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestSchemaVersionTableDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestSchemaVersionTableDefinition.java
@@ -26,9 +26,7 @@ import static org.hadoop.ozone.recon.schema.SchemaVersionTableDefinition.SCHEMA_
 import static org.hadoop.ozone.recon.schema.StatsSchemaDefinition.GLOBAL_STATS_TABLE_NAME;
 import static org.jooq.impl.DSL.name;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -43,7 +41,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.recon.ReconContext;
 import org.apache.hadoop.ozone.recon.ReconSchemaVersionTableManager;
-import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.upgrade.ReconLayoutVersionManager;
 import org.hadoop.ozone.recon.schema.SchemaVersionTableDefinition;
 import org.jooq.DSLContext;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestSchemaVersionTableDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestSchemaVersionTableDefinition.java
@@ -19,9 +19,16 @@
 
 package org.apache.hadoop.ozone.recon.persistence;
 
+import static org.hadoop.ozone.recon.codegen.SqlDbUtils.TABLE_EXISTS_CHECK;
+import static org.hadoop.ozone.recon.codegen.SqlDbUtils.listAllTables;
+import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME;
 import static org.hadoop.ozone.recon.schema.SchemaVersionTableDefinition.SCHEMA_VERSION_TABLE_NAME;
+import static org.hadoop.ozone.recon.schema.StatsSchemaDefinition.GLOBAL_STATS_TABLE_NAME;
 import static org.jooq.impl.DSL.name;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -34,9 +41,15 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.recon.ReconContext;
+import org.apache.hadoop.ozone.recon.ReconSchemaVersionTableManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
+import org.apache.hadoop.ozone.recon.upgrade.ReconLayoutVersionManager;
+import org.hadoop.ozone.recon.schema.SchemaVersionTableDefinition;
 import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -120,4 +133,170 @@ public class TestSchemaVersionTableDefinition extends AbstractReconSqlDBTest {
     int count = dslContext.fetchCount(DSL.table(SCHEMA_VERSION_TABLE_NAME));
     assertEquals(0, count, "The table should be empty after deletion.");
   }
+
+  /**
+   * Scenario:
+   * - A fresh installation of the cluster, where no tables exist initially.
+   * - All tables, including the schema version table, are created during initialization.
+   *
+   * Expected Outcome:
+   * - The schema version table is created during initialization.
+   * - The MLV is set to the latest SLV (Software Layout Version), indicating the schema is up-to-date.
+   * - No upgrade actions are triggered as all tables are already at the latest version.
+   */
+  @Test
+  public void testFreshInstallScenario() throws Exception {
+    Connection connection = getConnection();
+
+    // Ensure no tables exist initially, simulating a fresh installation
+    dropAllTables(connection);
+
+    // Initialize the schema
+    SchemaVersionTableDefinition schemaVersionTable = new SchemaVersionTableDefinition(getDataSource());
+    schemaVersionTable.setLatestSLV(3); // Assuming the latest SLV = 3
+    schemaVersionTable.initializeSchema();
+
+    // Verify that the SchemaVersionTable is created
+    boolean tableExists = TABLE_EXISTS_CHECK.test(connection, SCHEMA_VERSION_TABLE_NAME);
+    assertEquals(true, tableExists, "The Schema Version Table should be created.");
+
+    // Initialize ReconSchemaVersionTableManager and ReconLayoutVersionManager
+    ReconSchemaVersionTableManager schemaVersionTableManager = new ReconSchemaVersionTableManager(getDataSource());
+    ReconLayoutVersionManager layoutVersionManager =
+        new ReconLayoutVersionManager(schemaVersionTableManager, mock(ReconContext.class));
+
+    // Fetch and verify the current MLV
+    int mlv = layoutVersionManager.getCurrentMLV();
+    assertEquals(3, mlv, "For a fresh install, MLV should be set to the latest SLV value.");
+  }
+
+  /**
+   * Scenario:
+   * - The cluster was running without a schema version framework in an older version.
+   * - After the upgrade, the schema version table is introduced while other tables already exist.
+   *
+   * Expected Outcome:
+   * - The schema version table is created during initialization.
+   * - The MLV is set to -1, indicating the starting point of the schema version framework.
+   * - Ensures only necessary upgrades are executed, avoiding redundant updates.
+   */
+  @Test
+  public void testPreUpgradedClusterScenario() throws Exception {
+    Connection connection = getConnection();
+
+    // Simulate the cluster by creating other tables but not the schema version table
+    dropTable(connection, SCHEMA_VERSION_TABLE_NAME);
+    if (listAllTables(connection).isEmpty()) {
+      createTable(connection, GLOBAL_STATS_TABLE_NAME);
+      createTable(connection, UNHEALTHY_CONTAINERS_TABLE_NAME);
+    }
+
+    // Initialize the schema
+    SchemaVersionTableDefinition schemaVersionTable = new SchemaVersionTableDefinition(getDataSource());
+    schemaVersionTable.initializeSchema();
+
+    // Verify SchemaVersionTable is created
+    boolean tableExists = TABLE_EXISTS_CHECK.test(connection, SCHEMA_VERSION_TABLE_NAME);
+    assertEquals(true, tableExists, "The Schema Version Table should be created.");
+
+    // Initialize ReconSchemaVersionTableManager and ReconLayoutVersionManager
+    ReconSchemaVersionTableManager schemaVersionTableManager = new ReconSchemaVersionTableManager(getDataSource());
+    ReconLayoutVersionManager layoutVersionManager =
+        new ReconLayoutVersionManager(schemaVersionTableManager, mock(ReconContext.class));
+
+    // Fetch and verify the current MLV
+    int mlv = layoutVersionManager.getCurrentMLV();
+    assertEquals(-1, mlv, "For a pre-upgraded cluster, MLV should be set to -1.");
+  }
+
+  /***
+   * Scenario:
+   * - This simulates a cluster where the schema version table already exists,
+   *   indicating the schema version framework is in place.
+   * - The schema version table contains a previously finalized Metadata Layout Version (MLV).
+   *
+   * Expected Outcome:
+   * - The MLV stored in the schema version table (2) is correctly read by the ReconLayoutVersionManager.
+   * - The MLV is retained and not overridden by the SLV value (3) during schema initialization.
+   * - This ensures no unnecessary upgrades are triggered and the existing MLV remains consistent.
+   */
+  @Test
+  public void testUpgradedClusterScenario() throws Exception {
+    Connection connection = getConnection();
+
+    // Simulate a cluster with an existing schema version framework
+    dropAllTables(connection); // Ensure no previous data exists
+    if (listAllTables(connection).isEmpty()) {
+      // Create necessary tables to simulate the cluster state
+      createTable(connection, GLOBAL_STATS_TABLE_NAME);
+      createTable(connection, UNHEALTHY_CONTAINERS_TABLE_NAME);
+
+      // Create the schema version table
+      DSLContext dslContext = DSL.using(connection);
+      dslContext.createTableIfNotExists(SCHEMA_VERSION_TABLE_NAME)
+          .column("version_number", SQLDataType.INTEGER.nullable(false))
+          .column("applied_on", SQLDataType.TIMESTAMP.defaultValue(DSL.currentTimestamp()))
+          .execute();
+    }
+
+    // Insert a single existing MLV (e.g., version 2) into the Schema Version Table
+    DSLContext dslContext = DSL.using(connection);
+    dslContext.insertInto(DSL.table(SCHEMA_VERSION_TABLE_NAME))
+        .columns(DSL.field(name("version_number")),
+            DSL.field(name("applied_on")))
+        .values(2, new Timestamp(System.currentTimeMillis()))
+        .execute();
+
+    // Initialize the schema
+    SchemaVersionTableDefinition schemaVersionTable = new SchemaVersionTableDefinition(getDataSource());
+    schemaVersionTable.setLatestSLV(3); // Assuming the latest SLV = 3
+    schemaVersionTable.initializeSchema();
+
+    // Initialize managers to interact with schema version framework
+    ReconSchemaVersionTableManager schemaVersionTableManager = new ReconSchemaVersionTableManager(getDataSource());
+    ReconLayoutVersionManager layoutVersionManager =
+        new ReconLayoutVersionManager(schemaVersionTableManager, mock(ReconContext.class));
+
+    // Fetch and verify the current MLV stored in the database
+    int mlv = layoutVersionManager.getCurrentMLV();
+
+    // Assert that the MLV stored in the DB is retained and not overridden by the SLV value
+    // when running initializeSchema() before upgrade takes place
+    assertEquals(2, mlv, "For a cluster with an existing schema version framework, " +
+        "the MLV should match the value stored in the DB.");
+  }
+
+  /**
+   * Utility method to create a mock table.
+   */
+  private void createTable(Connection connection, String tableName) throws SQLException {
+    DSLContext dslContext = DSL.using(connection);
+    dslContext.createTableIfNotExists(tableName)
+        .column("id", SQLDataType.INTEGER.nullable(false))
+        .column("data", SQLDataType.VARCHAR(255))
+        .execute();
+  }
+
+  /**
+   * Utility method to drop all tables (simulating a fresh environment).
+   */
+  private void dropAllTables(Connection connection) throws SQLException {
+    DSLContext dslContext = DSL.using(connection);
+    List<String> tableNames = listAllTables(connection);
+    if (tableNames.isEmpty()) {
+      return;
+    }
+    for (String tableName : tableNames) {
+      dslContext.dropTableIfExists(tableName).execute();
+    }
+  }
+
+  /**
+   * Utility method to drop one table.
+   */
+  private void dropTable(Connection connection, String tableName) throws SQLException {
+    DSLContext dslContext = DSL.using(connection);
+    dslContext.dropTableIfExists(tableName).execute();
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
### We fixed code to make sure the three scenarios below, work correctly :- 

#### **Scenario 1: Fresh Install**
- **What Happens Now:**
  - During a fresh install, all tables, including the schema version table, are created for the first time.
  - When the schema version table is created, it is initialized with the latest SLV (Software Layout Version), indicating that the schema is already at the latest state.
  - The Recon Layout Version Manager will detect this value, and no upgrade actions will be triggered since the metadata of all tables is already up-to-date.

#### **Scenario 2: Upgrade from a Cluster Without Schema Version Framework**
- **What Happens Now:**
  - In clusters being upgraded where the schema version framework was not present previously:
    - The schema version table is newly created while other tables already exist.
    - The MLV (Metadata Layout Version) is initialized to `-1`, indicating the starting point of the upgrade framework.
  - Only the necessary upgrade actions are executed to bring the schema from the pre-upgrade state to the latest SLV. 
  - This ensures no redundant upgrades are applied, and the cluster is transitioned smoothly.

#### **Scenario 3: Upgrade from a Cluster with an Existing Schema Version Framework**
- **What Happens Now:**
  - In clusters where the schema version framework is already present:
    - The schema version table exists and contains the current MLV.
    - The Recon Layout Version Manager reads the MLV from the schema version table and compares it with the SLV.
    - Upgrade actions for versions between the MLV and SLV are executed sequentially to ensure the schema is brought to the latest state.
  - Since the schema version table is already present, there are no redundant or skipped upgrades.

### **Key Improvements:**
1. Redundant upgrades are avoided in fresh installs by initializing the schema version table with the latest SLV.
2. Pre-upgraded clusters without the schema version framework are correctly identified, and upgrades are applied only where necessary.
3. Clusters with an existing schema version framework continue to work as expected, ensuring seamless transitions across versions. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11846

## How was this patch tested?
Manually Tested
