### PR TITLE
HDDS-11909. Intermittent timeout building Hadoop in s3a test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   # Minimum required Java version for running Ozone is defined in pom.xml (javac.version).
   TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
+  MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml --show-version
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   HADOOP_IMAGE: ghcr.io/apache/hadoop
   OZONE_IMAGE: ghcr.io/apache/ozone

--- a/dev-support/ci/maven-settings.xml
+++ b/dev-support/ci/maven-settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>block-snapshots1</id>
+      <mirrorOf>apache.snapshots</mirrorOf>
+      <name>Block access to Apache Snapshots</name>
+      <url>https://repository.apache.org/snapshots</url>
+      <blocked>true</blocked>
+    </mirror>
+    <mirror>
+      <id>block-snapshots2</id>
+      <mirrorOf>apache.snapshots.https</mirrorOf>
+      <name>Block access to Apache Snapshots</name>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <blocked>true</blocked>
+    </mirror>
+  </mirrors>
+</settings>

--- a/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
@@ -98,7 +98,7 @@ EOF
   # - ITestS3AContractDistCp: HDDS-10616
   # - ITestS3AContractMkdirWithCreatePerf: HDDS-11662
   # - ITestS3AContractRename: HDDS-10665
-  mvn -B -V --fail-never --no-transfer-progress \
+  mvn ${MAVEN_ARGS:-} --fail-never \
     -Dtest='ITestS3AContract*, ITestS3ACommitterMRJob, !ITestS3AContractBulkDelete, !ITestS3AContractCreate#testOverwrite*EmptyDirectory[*], !ITestS3AContractDistCp, !ITestS3AContractMkdirWithCreatePerf, !ITestS3AContractRename' \
     clean test
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

_acceptance (s3a)_ runs some Hadoop AWS contract tests using Ozone as the object store.  Hadoop POM defines Apache snapshots repo without disabling it for release artifacts.  This is fixed in HADOOP-19360, but not yet released.

This PR adds a workaround for HADOOP-19360 in Ozone, to disable access to snapshot repos while compiling and running Hadoop tests.  This is achieved by defining mirrors with `blocked=true` in Maven settings (see [MNG-7117](https://issues.apache.org/jira/browse/MNG-7117)).

The option `--no-transfer-progress` is removed so that we can see dependency downloads.  It can be restored once we are sure that this round of problems with the Maven repo is over.

https://issues.apache.org/jira/browse/HDDS-11909

## How was this patch tested?

1. Downloaded and extracted Hadoop 3.4.1 sources
2. Compiled `hadoop-aws` pointing local Maven repo to an empty directory (to ensure dependencies are fetched from remote repo)
3. Verified that no dependencies are downloaded from `repository.apache.org`

```
$ curl -LOSs https://dlcdn.apache.org/hadoop/common/hadoop-3.4.1/hadoop-3.4.1-src.tar.gz
$ tar zxf hadoop-3.4.1-src.tar.gz
$ cd hadoop-3.4.1-src/hadoop-tools/hadoop-aws

$ mvn --settings ${OZONE_DIR}/dev-support/ci/maven-settings.xml \
    -Dmaven.repo.local=$(pwd)/.m2 \
    --log-file maven.log \
    --batch-mode -DskipTests clean package

$ grep BUILD maven.log 
[INFO] BUILD SUCCESS

$ grep -c repository.apache.org maven.log
0
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12273977320