### PR TITLE
HDDS-7990. Add acceptance test to validate HA Proxy with secure Ozone S3 deployment

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/s3-haproxy-secure.yaml
+++ b/hadoop-ozone/dist/src/main/compose/common/s3-haproxy-secure.yaml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+x-s3-worker:
+  &s3-worker
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
+  volumes:
+    - ../..:/opt/hadoop
+    - ../_keytabs:/etc/security/keytabs
+    - ./krb5.conf:/etc/krb5.conf
+  env_file:
+    - docker-config
+  command: ["ozone","s3g", "-Dozone.om.transport.class=${OZONE_S3_OM_TRANSPORT:-org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory}"]
+
+services:
+  s3g:
+    image: haproxy:lts-alpine
+    hostname: s3g
+    dns_search: .
+    volumes:
+      - ../..:/opt/hadoop
+      - ../common/s3-haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
+    ports:
+      - 9878:9878
+    command: ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+  s3g1:
+    <<: *s3-worker
+    hostname: s3g1
+    dns_search: .
+    ports:
+      - 9879:9878
+  s3g2:
+
+    <<: *s3-worker
+    hostname: s3g2
+    dns_search: .
+    ports:
+      - 9880:9878
+  s3g3:
+    <<: *s3-worker
+    hostname: s3g3
+    dns_search: .
+    ports:
+      - 9881:9878

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
     command: ["ozone","s3g"]
   recon:
     <<: *common-config
+    hostname: recon
     ports:
       - 9888:9888
     environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-haproxy-s3g.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-haproxy-s3g.sh
@@ -24,6 +24,7 @@ export COMPOSE_DIR
 source "$COMPOSE_DIR/../testlib.sh"
 
 export SECURITY_ENABLED=true
+export COMPOSE_FILE=docker-compose.yaml:../common/s3-haproxy-secure.yaml
 
 : ${OZONE_BUCKET_KEY_NAME:=key1}
 
@@ -33,11 +34,7 @@ execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
 execute_robot_test scm kinit.robot
 
-execute_robot_test scm basic
-
 execute_robot_test scm security
-
-execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-ofs-bucket ozonefs/ozonefs.robot
 
 ## Exclude virtual-host tests. This is tested separately as it requires additional config.
 exclude="--exclude virtual-host"
@@ -48,21 +45,4 @@ for bucket in encrypted; do
   exclude="--exclude virtual-host --exclude no-bucket-type"
 done
 
-#expects 4 pipelines, should be run before
-#admincli which creates STANDALONE pipeline
-execute_robot_test scm recon
-
-execute_robot_test scm admincli
 execute_robot_test scm spnego
-execute_robot_test scm snapshot/snapshot-acls.robot
-
-execute_robot_test scm httpfs
-
-# test replication
-docker-compose up -d --scale datanode=2
-execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
-docker-compose up -d --scale datanode=3
-execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
-
-#test public key and certificate recovery
-source "$COMPOSE_DIR/public-key-cert-recovery-test.sh"

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-haproxy-s3g.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-haproxy-s3g.sh
@@ -39,7 +39,7 @@ execute_robot_test scm security
 ## Exclude virtual-host tests. This is tested separately as it requires additional config.
 exclude="--exclude virtual-host"
 for bucket in encrypted; do
-  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
+  execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
   # some tests are independent of the bucket type, only need to be run once
   ## Exclude virtual-host.robot
   exclude="--exclude virtual-host --exclude no-bucket-type"

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -24,6 +24,7 @@ export COMPOSE_DIR
 source "$COMPOSE_DIR/../testlib.sh"
 
 export SECURITY_ENABLED=true
+export COMPOSE_FILE=docker-compose.yaml:../common/s3-haproxy-secure.yaml
 
 : ${OZONE_BUCKET_KEY_NAME:=key1}
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -238,7 +238,7 @@ Create key with custom etag metadata and expect it won't conflict with ETag resp
     ${file_md5_checksum}                    Execute                             md5sum /tmp/small_file | awk '{print $1}'
                                             Execute AWSS3CliDebug               cp --metadata "ETag=custom-etag-value" /tmp/small_file s3://${BUCKET}/test_file
     ${result}                               Execute AWSS3CliDebug               cp s3://${BUCKET}/test_file /tmp/test_file_downloaded
-    ${match}    ${ETag}     ${etagCustom}   Should Match Regexp                 ${result}    HEAD /${BUCKET}/test_file\ .*?Response headers.*?ETag':\ '"(.*?)"'.*?x-amz-meta-etag':\ '(.*?)'     flags=DOTALL
+    ${match}    ${ETag}     ${etagCustom}   Should Match Regexp                 ${result}    HEAD /${BUCKET}/test_file\ .*?Response headers.*?ETag':\ '"(.*?)"'.*?x-amz-meta-etag':\ '(.*?)'     flags=DOTALL | IGNORECASE
                                             Should Be Equal As Strings          ${ETag}     ${file_md5_checksum}
                                             Should BE Equal As Strings          ${etagCustom}       custom-etag-value
                                             Should Not Be Equal As Strings      ${ETag}     ${etagCustom}
@@ -262,9 +262,9 @@ Create key twice with different content and expect different ETags
                                 Execute                    head -c 1MiB </dev/urandom > /tmp/file1
                                 Execute                    head -c 1MiB </dev/urandom > /tmp/file2
     ${file1UploadResult}        Execute AWSS3CliDebug      cp /tmp/file1 s3://${BUCKET}/test_key_to_check_etag_differences
-    ${match}    ${etag1}        Should Match Regexp        ${file1UploadResult}     PUT /${BUCKET}/test_key_to_check_etag_differences\ .*?Response headers.*?ETag':\ '"(.*?)"'    flags=DOTALL
+    ${match}    ${etag1}        Should Match Regexp        ${file1UploadResult}     PUT /${BUCKET}/test_key_to_check_etag_differences\ .*?Response headers.*?ETag':\ '"(.*?)"'    flags=DOTALL | IGNORECASE
     ${file2UploadResult}        Execute AWSS3CliDebug      cp /tmp/file2 s3://${BUCKET}/test_key_to_check_etag_differences
-    ${match}    ${etag2}        Should Match Regexp        ${file2UploadResult}     PUT /${BUCKET}/test_key_to_check_etag_differences\ .*?Response headers.*?ETag':\ '"(.*?)"'    flags=DOTALL
+    ${match}    ${etag2}        Should Match Regexp        ${file2UploadResult}     PUT /${BUCKET}/test_key_to_check_etag_differences\ .*?Response headers.*?ETag':\ '"(.*?)"'    flags=DOTALL | IGNORECASE
                                 Should Not Be Equal As Strings  ${etag1}    ${etag2}
                                 # clean up
                                 Execute AWSS3Cli           rm s3://${BUCKET}/test_key_to_check_etag_differences


### PR DESCRIPTION
Please describe your PR in detail:
This PR:
1. Adds the docker compose setup where multiple secured S3 gateways sit behind HAProxy, a reverse-proxy.
2. Runs acceptance test for this secured S3 setup.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7990
https://issues.apache.org/jira/browse/HDDS-12028

## How was this patch tested?
CI: 
~~https://github.com/ptlrs/ozone/actions/runs/12282892948~~
~~https://github.com/ptlrs/ozone/actions/runs/12302743602~~
~~https://github.com/ptlrs/ozone/actions/runs/12302743602~~
~~https://github.com/ptlrs/ozone/actions/runs/12656507658~~
https://github.com/ptlrs/ozone/actions/runs/12659812384