### PR TITLE
HDDS-11914. Snapshot diff should not filter SST Files based by reading SST file reader

### DIFF
--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
@@ -41,12 +41,6 @@ import java.util.stream.Collectors;
 public class ManagedRocksDB extends ManagedObject<RocksDB> {
   public static final Class<RocksDB> ORIGINAL_CLASS = RocksDB.class;
   public static final int NOT_FOUND = RocksDB.NOT_FOUND;
-  /**
-   * SST file extension. Must be lower case.
-   * Used to trim the file extension when writing compaction entries to the log
-   * to save space.
-   */
-  public static final String SST_FILE_EXTENSION = ".sst";
 
   static final Logger LOG = LoggerFactory.getLogger(ManagedRocksDB.class);
 
@@ -113,8 +107,7 @@ public class ManagedRocksDB extends ManagedObject<RocksDB> {
   }
 
   public static Map<String, LiveFileMetaData> getLiveMetadataForSSTFiles(RocksDB db) {
-    return db.getLiveFilesMetaData().stream()
-        .filter(liveFileMetaData -> liveFileMetaData.fileName().endsWith(SST_FILE_EXTENSION)).collect(
+    return db.getLiveFilesMetaData().stream().collect(
             Collectors.toMap(liveFileMetaData -> FilenameUtils.getBaseName(liveFileMetaData.fileName()),
                 liveFileMetaData -> liveFileMetaData));
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
@@ -20,7 +20,9 @@ package org.apache.ozone.compaction.log;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.rocksdb.LiveFileMetaData;
 
 import java.util.Objects;
 
@@ -125,6 +127,16 @@ public final class CompactionFileInfo {
 
     public Builder setColumnFamily(String columnFamily) {
       this.columnFamily = columnFamily;
+      return this;
+    }
+
+    public Builder setValues(LiveFileMetaData fileMetaData) {
+      if (fileMetaData != null) {
+        String columnFamilyName = StringUtils.bytes2String(fileMetaData.columnFamilyName());
+        String startRangeValue = StringUtils.bytes2String(fileMetaData.smallestKey());
+        String endRangeValue = StringUtils.bytes2String(fileMetaData.largestKey());
+        this.setColumnFamily(columnFamilyName).setStartRange(startRangeValue).setEndRange(endRangeValue);
+      }
       return this;
     }
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/CompactionNode.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/CompactionNode.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ozone.rocksdiff;
 
+import org.apache.ozone.compaction.log.CompactionFileInfo;
+
 /**
  * Node in the compaction DAG that represents an SST file.
  */
@@ -46,6 +48,11 @@ public class CompactionNode {
     this.startKey = startKey;
     this.endKey = endKey;
     this.columnFamily = columnFamily;
+  }
+
+  public CompactionNode(CompactionFileInfo compactionFileInfo) {
+    this(compactionFileInfo.getFileName(), -1, -1, compactionFileInfo.getStartKey(),
+        compactionFileInfo.getEndKey(), compactionFileInfo.getColumnFamily());
   }
 
   @Override

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -490,7 +490,14 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
         builder = new CompactionLogEntry.Builder(trxId,
             System.currentTimeMillis(),
             inputFileCompactions.keySet().stream()
-                .map(inputFile -> inflightCompactions.getOrDefault(inputFile, inputFileCompactions.get(inputFile)))
+                .map(inputFile -> {
+                  if (!inflightCompactions.containsKey(inputFile)) {
+                    LOG.warn("Input file not found in inflightCompactionsMap : {} which should have been added on " +
+                            "compactionBeginListener.",
+                        inputFile);
+                  }
+                  return inflightCompactions.getOrDefault(inputFile, inputFileCompactions.get(inputFile));
+                })
                 .collect(Collectors.toList()),
             new ArrayList<>(toFileInfoList(compactionJobInfo.outputFiles(), db).values()));
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -580,8 +580,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   private long getSSTFileSummary(String filename)
       throws RocksDBException, FileNotFoundException {
 
-    if (!filename.endsWith(ManagedRocksDB.SST_FILE_EXTENSION)) {
-      filename += ManagedRocksDB.SST_FILE_EXTENSION;
+    if (!filename.endsWith(SST_FILE_EXTENSION)) {
+      filename += SST_FILE_EXTENSION;
     }
 
     try (ManagedOptions option = new ManagedOptions();
@@ -599,8 +599,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
 
   private String getAbsoluteSstFilePath(String filename)
       throws FileNotFoundException {
-    if (!filename.endsWith(ManagedRocksDB.SST_FILE_EXTENSION)) {
-      filename += ManagedRocksDB.SST_FILE_EXTENSION;
+    if (!filename.endsWith(SST_FILE_EXTENSION)) {
+      filename += SST_FILE_EXTENSION;
     }
     File sstFile = new File(sstBackupDir + filename);
     File sstFileInActiveDB = new File(activeDBLocationStr + filename);
@@ -623,7 +623,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       LOG.error(errorMsg);
       throw new RuntimeException(errorMsg);
     }
-    if (!filename.endsWith(ManagedRocksDB.SST_FILE_EXTENSION)) {
+    if (!filename.endsWith(SST_FILE_EXTENSION)) {
       final String errorMsg = String.format(
           "Invalid extension of file: '%s'. Expected '%s'",
           filename, SST_FILE_EXTENSION_LENGTH);
@@ -793,7 +793,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
 
     // Try to locate the SST in the backup dir first
     final Path sstPathInBackupDir = Paths.get(sstBackupDir,
-        sstFilenameWithoutExtension + ManagedRocksDB.SST_FILE_EXTENSION);
+        sstFilenameWithoutExtension + SST_FILE_EXTENSION);
     if (Files.exists(sstPathInBackupDir)) {
       return sstPathInBackupDir.toString();
     }
@@ -803,7 +803,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     // src DB directory or destDB directory
     for (String dbPath : dbPaths) {
       final Path sstPathInDBDir = Paths.get(dbPath,
-          sstFilenameWithoutExtension + ManagedRocksDB.SST_FILE_EXTENSION);
+          sstFilenameWithoutExtension + SST_FILE_EXTENSION);
       if (Files.exists(sstPathInDBDir)) {
         return sstPathInDBDir.toString();
       }
@@ -838,7 +838,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
             sst -> {
               String sstFullPath = getSSTFullPath(sst, src.getDbPath(), dest.getDbPath());
               Path link = Paths.get(sstFilesDirForSnapDiffJob,
-                  sst + ManagedRocksDB.SST_FILE_EXTENSION);
+                  sst + SST_FILE_EXTENSION);
               Path srcFile = Paths.get(sstFullPath);
               createLink(link, srcFile);
               return link.toString();
@@ -1231,7 +1231,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   private void removeSstFiles(Set<String> sstFileNodes) {
     for (String sstFileNode: sstFileNodes) {
       File file =
-          new File(sstBackupDir + "/" + sstFileNode + ManagedRocksDB.SST_FILE_EXTENSION);
+          new File(sstBackupDir + "/" + sstFileNode + SST_FILE_EXTENSION);
       try {
         Files.deleteIfExists(file.toPath());
       } catch (IOException exception) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -143,8 +143,14 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   private static final String COMPACTION_LOG_ENTRY_INPUT_OUTPUT_FILES_DELIMITER
       = ":";
 
+  /**
+   * SST file extension. Must be lower case.
+   * Used to trim the file extension when writing compaction entries to the log
+   * to save space.
+   */
+  static final String SST_FILE_EXTENSION = ".sst";
   public static final int SST_FILE_EXTENSION_LENGTH =
-      ManagedRocksDB.SST_FILE_EXTENSION.length();
+      SST_FILE_EXTENSION.length();
 
   private static final int LONG_MAX_STR_LEN =
       String.valueOf(Long.MAX_VALUE).length();

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -90,10 +90,8 @@ public final class RocksDiffUtils {
       String filename = FilenameUtils.getBaseName(fileIterator.next());
       while (!preExistingCompactionNodes.containsKey(filename) && !liveFileMetaDataMap.containsKey(filename)
           && dbIdx < dbs.length) {
-        while (dbIdx < dbs.length) {
-          liveFileMetaDataMap.putAll(dbs[dbIdx].getLiveMetadataForSSTFiles());
-          dbIdx += 1;
-        }
+        liveFileMetaDataMap.putAll(dbs[dbIdx].getLiveMetadataForSSTFiles());
+        dbIdx += 1;
       }
       CompactionNode compactionNode = preExistingCompactionNodes.get(filename);
       if (compactionNode == null) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -17,22 +17,20 @@
  */
 package org.apache.ozone.rocksdiff;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
-import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
-import org.apache.hadoop.hdds.utils.db.managed.ManagedSstFileReader;
-import org.apache.hadoop.hdds.utils.db.managed.ManagedSstFileReaderIterator;
-import org.rocksdb.TableProperties;
-import org.rocksdb.RocksDBException;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.ozone.compaction.log.CompactionFileInfo;
+import org.rocksdb.LiveFileMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 
 /**
@@ -73,44 +71,38 @@ public final class RocksDiffUtils {
   }
 
   public static void filterRelevantSstFiles(Set<String> inputFiles,
-      Map<String, String> tableToPrefixMap) throws IOException {
+                                            Map<String, String> tableToPrefixMap,
+                                            ManagedRocksDB... dbs) {
+    filterRelevantSstFiles(inputFiles, tableToPrefixMap, Collections.emptyMap(), dbs);
+  }
+
+  /**
+   * Filter sst files based on prefixes.
+   */
+  public static void filterRelevantSstFiles(Set<String> inputFiles,
+                                            Map<String, String> tableToPrefixMap,
+                                            Map<String, CompactionNode> preExistingCompactionNodes,
+                                            ManagedRocksDB... dbs) {
+    Map<String, LiveFileMetaData> liveFileMetaDataMap = new HashMap<>();
+    int dbIdx = 0;
     for (Iterator<String> fileIterator =
          inputFiles.iterator(); fileIterator.hasNext();) {
-      String filepath = fileIterator.next();
-      if (!RocksDiffUtils.doesSstFileContainKeyRange(filepath,
-          tableToPrefixMap)) {
+      String filename = FilenameUtils.getBaseName(fileIterator.next());
+      while (!preExistingCompactionNodes.containsKey(filename) && !liveFileMetaDataMap.containsKey(filename)
+          && dbIdx < dbs.length) {
+        while (dbIdx < dbs.length) {
+          liveFileMetaDataMap.putAll(dbs[dbIdx].getLiveMetadataForSSTFiles());
+          dbIdx += 1;
+        }
+      }
+      CompactionNode compactionNode = preExistingCompactionNodes.get(filename);
+      if (compactionNode == null) {
+        compactionNode = new CompactionNode(new CompactionFileInfo.Builder(filename)
+            .setValues(liveFileMetaDataMap.get(filename)).build());
+      }
+      if (RocksDBCheckpointDiffer.shouldSkipNode(compactionNode, tableToPrefixMap)) {
         fileIterator.remove();
       }
     }
   }
-
-  public static boolean doesSstFileContainKeyRange(String filepath,
-      Map<String, String> tableToPrefixMap) throws IOException {
-
-    try (
-        ManagedOptions options = new ManagedOptions();
-        ManagedSstFileReader sstFileReader = new ManagedSstFileReader(options)) {
-      sstFileReader.open(filepath);
-      TableProperties properties = sstFileReader.getTableProperties();
-      String tableName = new String(properties.getColumnFamilyName(), UTF_8);
-      if (tableToPrefixMap.containsKey(tableName)) {
-        String prefix = tableToPrefixMap.get(tableName);
-
-        try (
-            ManagedReadOptions readOptions = new ManagedReadOptions();
-            ManagedSstFileReaderIterator iterator = ManagedSstFileReaderIterator.managed(
-                sstFileReader.newIterator(readOptions))) {
-          iterator.get().seek(prefix.getBytes(UTF_8));
-          String seekResultKey = new String(iterator.get().key(), UTF_8);
-          return seekResultKey.startsWith(prefix);
-        }
-      }
-      return false;
-    } catch (RocksDBException e) {
-      LOG.error("Failed to read SST File ", e);
-      throw new IOException(e);
-    }
-  }
-
-
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -95,7 +95,7 @@ import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COLUMN_FAMILIES
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COMPACTION_LOG_FILE_NAME_SUFFIX;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_DAG_LIVE_NODES;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_READ_ALL_DB_KEYS;
-import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB.SST_FILE_EXTENSION;
+import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.SST_FILE_EXTENSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -70,6 +70,7 @@ import org.apache.ozone.compaction.log.CompactionLogEntry;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.NodeComparator;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -94,7 +95,7 @@ import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COLUMN_FAMILIES
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COMPACTION_LOG_FILE_NAME_SUFFIX;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_DAG_LIVE_NODES;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_READ_ALL_DB_KEYS;
-import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.SST_FILE_EXTENSION;
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB.SST_FILE_EXTENSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -539,7 +540,12 @@ public class TestRocksDBCheckpointDiffer {
               "000017.sst", "000019.sst", "000021.sst", "000023.sst",
           "000024.sst", "000026.sst", "000029.sst"));
     }
-
+    rocksDBCheckpointDiffer.getForwardCompactionDAG().nodes().stream().forEach(compactionNode -> {
+      Assertions.assertNotNull(compactionNode.getStartKey());
+      Assertions.assertNotNull(compactionNode.getEndKey());
+    });
+    GenericTestUtils.waitFor(() -> rocksDBCheckpointDiffer.getInflightCompactions().isEmpty(), 1000,
+        10000);
     if (LOG.isDebugEnabled()) {
       rocksDBCheckpointDiffer.dumpCompactionNodeTable();
     }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDiffUtils.java
@@ -18,10 +18,32 @@
 
 package org.apache.ozone.rocksdiff;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.assertj.core.util.Sets;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.rocksdb.LiveFileMetaData;
+import org.rocksdb.RocksDB;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Class to test RocksDiffUtils.
@@ -53,5 +75,104 @@ public class TestRocksDiffUtils {
         "/volume/bucket/",
         "/volume/bucket/key-1",
         "/volume/bucket2/key-97"));
+  }
+
+  public static Stream<Arguments> values() {
+    return Stream.of(
+        arguments("validColumnFamily", "invalidColumnFamily", "a", "d", "b", "f"),
+        arguments("validColumnFamily", "invalidColumnFamily", "a", "d", "e", "f"),
+        arguments("validColumnFamily", "invalidColumnFamily", "a", "d", "a", "f"),
+        arguments("validColumnFamily", "validColumnFamily", "a", "d", "e", "g"),
+        arguments("validColumnFamily", "validColumnFamily", "e", "g", "a", "d"),
+        arguments("validColumnFamily", "validColumnFamily", "b", "b", "e", "g"),
+        arguments("validColumnFamily", "validColumnFamily", "a", "d", "e", "e")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("values")
+  public void testFilterRelevantSstFilesWithPreExistingCompactionInfo(String validSSTColumnFamilyName,
+                                                                      String invalidColumnFamilyName,
+                                                                      String validSSTFileStartRange,
+                                                                      String validSSTFileEndRange,
+                                                                      String invalidSSTFileStartRange,
+                                                                      String invalidSSTFileEndRange) {
+    try (MockedStatic<RocksDiffUtils> mockedHandler = Mockito.mockStatic(RocksDiffUtils.class,
+        Mockito.CALLS_REAL_METHODS)) {
+      mockedHandler.when(() -> RocksDiffUtils.constructBucketKey(anyString())).thenAnswer(i -> i.getArgument(0));
+      String validSstFile = "filePath/validSSTFile.sst";
+      String invalidSstFile = "filePath/invalidSSTFile.sst";
+      String untrackedSstFile = "filePath/untrackedSSTFile.sst";
+      String expectedPrefix = String.valueOf((char)(((int)validSSTFileEndRange.charAt(0) +
+          validSSTFileStartRange.charAt(0)) / 2));
+      Set<String> sstFile = Sets.newTreeSet(validSstFile, invalidSstFile, untrackedSstFile);
+      RocksDiffUtils.filterRelevantSstFiles(sstFile, ImmutableMap.of(validSSTColumnFamilyName, expectedPrefix),
+          ImmutableMap.of("validSSTFile", new CompactionNode(validSstFile, 0, 0, validSSTFileStartRange,
+                  validSSTFileEndRange, validSSTColumnFamilyName), "invalidSSTFile",
+              new CompactionNode(invalidSstFile, 0, 0, invalidSSTFileStartRange,
+                  invalidSSTFileEndRange, invalidColumnFamilyName)));
+      Assertions.assertEquals(Sets.newTreeSet(validSstFile, untrackedSstFile), sstFile);
+    }
+
+  }
+
+  private LiveFileMetaData getMockedLiveFileMetadata(String columnFamilyName, String startRange,
+                                                     String endRange,
+                                                     String name) {
+    LiveFileMetaData liveFileMetaData = Mockito.mock(LiveFileMetaData.class);
+    Mockito.when(liveFileMetaData.largestKey()).thenReturn(endRange.getBytes(StandardCharsets.UTF_8));
+    Mockito.when(liveFileMetaData.columnFamilyName()).thenReturn(columnFamilyName.getBytes(StandardCharsets.UTF_8));
+    Mockito.when(liveFileMetaData.smallestKey()).thenReturn(startRange.getBytes(StandardCharsets.UTF_8));
+    Mockito.when(liveFileMetaData.fileName()).thenReturn("basePath/" + name + ".sst");
+    return liveFileMetaData;
+  }
+
+  @ParameterizedTest
+  @MethodSource("values")
+  public void testFilterRelevantSstFilesFromDB(String validSSTColumnFamilyName,
+                                               String invalidColumnFamilyName,
+                                               String validSSTFileStartRange,
+                                               String validSSTFileEndRange,
+                                               String invalidSSTFileStartRange,
+                                               String invalidSSTFileEndRange) {
+    try (MockedStatic<RocksDiffUtils> mockedHandler = Mockito.mockStatic(RocksDiffUtils.class,
+        Mockito.CALLS_REAL_METHODS)) {
+      mockedHandler.when(() -> RocksDiffUtils.constructBucketKey(anyString())).thenAnswer(i -> i.getArgument(0));
+      for (int numberOfDBs = 1; numberOfDBs < 10; numberOfDBs++) {
+        String validSstFile = "filePath/validSSTFile.sst";
+        String invalidSstFile = "filePath/invalidSSTFile.sst";
+        String untrackedSstFile = "filePath/untrackedSSTFile.sst";
+        int expectedDBKeyIndex = numberOfDBs / 2;
+        ManagedRocksDB[] rocksDBs =
+            IntStream.range(0, numberOfDBs).mapToObj(i -> Mockito.mock(ManagedRocksDB.class))
+                .collect(Collectors.toList()).toArray(new ManagedRocksDB[numberOfDBs]);
+        for (int i = 0; i < numberOfDBs; i++) {
+          ManagedRocksDB managedRocksDB = rocksDBs[i];
+          RocksDB mockedRocksDB = Mockito.mock(RocksDB.class);
+          Mockito.when(managedRocksDB.get()).thenReturn(mockedRocksDB);
+          if (i == expectedDBKeyIndex) {
+            LiveFileMetaData validLiveFileMetaData = getMockedLiveFileMetadata(validSSTColumnFamilyName,
+                validSSTFileStartRange, validSSTFileEndRange, "validSSTFile");
+            LiveFileMetaData invalidLiveFileMetaData = getMockedLiveFileMetadata(invalidColumnFamilyName,
+                invalidSSTFileStartRange, invalidSSTFileEndRange, "invalidSSTFile");
+            List<LiveFileMetaData> liveFileMetaDatas = Arrays.asList(validLiveFileMetaData, invalidLiveFileMetaData);
+            Mockito.when(mockedRocksDB.getLiveFilesMetaData()).thenReturn(liveFileMetaDatas);
+          } else {
+            Mockito.when(mockedRocksDB.getLiveFilesMetaData()).thenReturn(Collections.emptyList());
+          }
+          Mockito.when(managedRocksDB.getLiveMetadataForSSTFiles())
+              .thenAnswer(invocation -> ManagedRocksDB.getLiveMetadataForSSTFiles(mockedRocksDB));
+        }
+
+        String expectedPrefix = String.valueOf((char)(((int)validSSTFileEndRange.charAt(0) +
+            validSSTFileStartRange.charAt(0)) / 2));
+        Set<String> sstFile = Sets.newTreeSet(validSstFile, invalidSstFile, untrackedSstFile);
+        RocksDiffUtils.filterRelevantSstFiles(sstFile, ImmutableMap.of(validSSTColumnFamilyName, expectedPrefix),
+            Collections.emptyMap(), rocksDBs);
+        Assertions.assertEquals(Sets.newTreeSet(validSstFile, untrackedSstFile), sstFile);
+      }
+
+    }
+
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1032,8 +1032,10 @@ public class SnapshotDiffManager implements AutoCloseable {
     // tombstone is not loaded.
     // TODO: [SNAPSHOT] Update Rocksdb SSTFileIterator to read tombstone
     if (skipNativeDiff || !isNativeLibsLoaded) {
-      deltaFiles.addAll(getSSTFileListForSnapshot(fromSnapshot,
-          tablesToLookUp));
+      Set<String> inputFiles = getSSTFileListForSnapshot(fromSnapshot, tablesToLookUp);
+      ManagedRocksDB fromDB = ((RDBStore)fromSnapshot.getMetadataManager().getStore()).getDb().getManagedRocksDb();
+      RocksDiffUtils.filterRelevantSstFiles(inputFiles, tablePrefixes, fromDB);
+      deltaFiles.addAll(inputFiles);
     }
     addToObjectIdMap(fsTable, tsTable, deltaFiles,
         !skipNativeDiff && isNativeLibsLoaded,
@@ -1155,21 +1157,16 @@ public class SnapshotDiffManager implements AutoCloseable {
         LOG.warn("RocksDBCheckpointDiffer is not available, falling back to" +
                 " slow path");
       }
-
-      Set<String> fromSnapshotFiles =
-          RdbUtil.getSSTFilesForComparison(
-              ((RDBStore)fromSnapshot.getMetadataManager().getStore())
-                  .getDb().getManagedRocksDb(),
-              tablesToLookUp);
-      Set<String> toSnapshotFiles =
-          RdbUtil.getSSTFilesForComparison(
-              ((RDBStore)toSnapshot.getMetadataManager().getStore()).getDb()
-                  .getManagedRocksDb(),
-              tablesToLookUp);
+      ManagedRocksDB fromDB = ((RDBStore)fromSnapshot.getMetadataManager().getStore())
+          .getDb().getManagedRocksDb();
+      ManagedRocksDB toDB = ((RDBStore)fromSnapshot.getMetadataManager().getStore())
+          .getDb().getManagedRocksDb();
+      Set<String> fromSnapshotFiles = RdbUtil.getSSTFilesForComparison(fromDB, tablesToLookUp);
+      Set<String> toSnapshotFiles = RdbUtil.getSSTFilesForComparison(toDB, tablesToLookUp);
 
       deltaFiles.addAll(fromSnapshotFiles);
       deltaFiles.addAll(toSnapshotFiles);
-      RocksDiffUtils.filterRelevantSstFiles(deltaFiles, tablePrefixes);
+      RocksDiffUtils.filterRelevantSstFiles(deltaFiles, tablePrefixes, fromDB, toDB);
     }
 
     return deltaFiles;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1159,10 +1159,10 @@ public class SnapshotDiffManager implements AutoCloseable {
       }
       ManagedRocksDB fromDB = ((RDBStore)fromSnapshot.getMetadataManager().getStore())
           .getDb().getManagedRocksDb();
-      ManagedRocksDB toDB = ((RDBStore)fromSnapshot.getMetadataManager().getStore())
+      ManagedRocksDB toDB = ((RDBStore)toSnapshot.getMetadataManager().getStore())
           .getDb().getManagedRocksDb();
-      Set<String> fromSnapshotFiles = RdbUtil.getSSTFilesForComparison(fromDB, tablesToLookUp);
-      Set<String> toSnapshotFiles = RdbUtil.getSSTFilesForComparison(toDB, tablesToLookUp);
+      Set<String> fromSnapshotFiles = getSSTFileListForSnapshot(fromSnapshot, tablesToLookUp);
+      Set<String> toSnapshotFiles = getSSTFileListForSnapshot(toSnapshot, tablesToLookUp);
 
       deltaFiles.addAll(fromSnapshotFiles);
       deltaFiles.addAll(toSnapshotFiles);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -92,7 +92,6 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -476,7 +475,8 @@ public class TestSnapshotDiffManager {
           });
 
       mockedRocksDiffUtils.when(() ->
-              RocksDiffUtils.filterRelevantSstFiles(anySet(), anyMap()))
+              RocksDiffUtils.filterRelevantSstFiles(anySet(), anyMap(), anyMap(), any(ManagedRocksDB.class),
+                  any(ManagedRocksDB.class)))
           .thenAnswer((Answer<Void>) invocationOnMock -> {
             invocationOnMock.getArgument(0, Set.class).stream()
                 .findAny().ifPresent(val -> {
@@ -543,7 +543,8 @@ public class TestSnapshotDiffManager {
           });
 
       mockedRocksDiffUtils.when(() ->
-              RocksDiffUtils.filterRelevantSstFiles(anySet(), anyMap()))
+              RocksDiffUtils.filterRelevantSstFiles(anySet(), anyMap(), anyMap(), any(ManagedRocksDB.class),
+                  any(ManagedRocksDB.class)))
           .thenAnswer((Answer<Void>) invocationOnMock -> {
             invocationOnMock.getArgument(0, Set.class).stream()
                 .findAny().ifPresent(val -> {
@@ -560,7 +561,7 @@ public class TestSnapshotDiffManager {
       when(snapshotInfoTable.get(SnapshotInfo.getTableKey(VOLUME_NAME, BUCKET_NAME, snap2.toString())))
           .thenReturn(getSnapshotInfoInstance(VOLUME_NAME, BUCKET_NAME, snap2.toString(), snap2));
 
-      doThrow(new FileNotFoundException("File not found exception."))
+      doThrow(new RuntimeException("File not found exception."))
           .when(differ)
           .getSSTDiffListWithFullPath(
               any(DifferSnapshotInfo.class),


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshot diff should not filter SST Files based by reading SST file reader and instead should rely on rocksdb's liveMetadataFile which also includes tombstone entries. 

When creating dag compaction log as well, key ranges should also look at liveMetadataFile.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11914

## How was this patch tested?
Existing Unit tests and adding more