### PR TITLE
HDDS-11860. Improve BufferUtils.writeFully.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -58,9 +58,9 @@ public class CodecBuffer implements UncheckedAutoCloseable {
   private static class Factory {
     private static volatile BiFunction<ByteBuf, Object, CodecBuffer> constructor
         = CodecBuffer::new;
-    static void set(BiFunction<ByteBuf, Object, CodecBuffer> f) {
+    static void set(BiFunction<ByteBuf, Object, CodecBuffer> f, String name) {
       constructor = f;
-      LOG.info("Successfully set constructor to " + f);
+      LOG.info("Successfully set constructor to {}: {}", name, f);
     }
 
     static CodecBuffer newCodecBuffer(ByteBuf buf) {
@@ -89,7 +89,7 @@ public class CodecBuffer implements UncheckedAutoCloseable {
    * Note that there is a severe performance penalty for leak detection.
    */
   public static void enableLeakDetection() {
-    Factory.set(LeakDetector::newCodecBuffer);
+    Factory.set(LeakDetector::newCodecBuffer, "LeakDetector::newCodecBuffer");
   }
 
   /** The size of a buffer. */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
@@ -248,10 +248,7 @@ public class ChunkBufferImplWithByteBufferList implements ChunkBuffer {
 
   @Override
   public long writeTo(GatheringByteChannel channel) throws IOException {
-    long written = 0;
-    for (ByteBuffer buf : buffers) {
-      written += BufferUtils.writeFully(channel, buf);
-    }
+    final long written = BufferUtils.writeFully(channel, buffers);
     findCurrent();
     return written;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
@@ -280,11 +280,7 @@ final class IncrementalChunkBuffer implements ChunkBuffer {
 
   @Override
   public long writeTo(GatheringByteChannel channel) throws IOException {
-    long written = 0;
-    for (ByteBuffer buf : buffers) {
-      written += BufferUtils.writeFully(channel, buf);
-    }
-    return written;
+    return BufferUtils.writeFully(channel, buffers);
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -26,11 +26,15 @@ import java.nio.channels.GatheringByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for buffers.
  */
 public final class BufferUtils {
+  public static final Logger LOG = LoggerFactory.getLogger(BufferUtils.class);
+
   private static final ByteBuffer[] EMPTY_BYTE_BUFFER_ARRAY = {};
 
   /** Utility classes should not be constructed. **/
@@ -161,10 +165,19 @@ public final class BufferUtils {
   }
 
   public static long writeFully(GatheringByteChannel ch, ByteBuffer[] buffers) throws IOException {
+    if (LOG.isDebugEnabled()) {
+      for (int i = 0; i < buffers.length; i++) {
+        LOG.debug("buffer[{}]: remaining={}", i, buffers[i].remaining());
+      }
+    }
+
     long written = 0;
     for (int i = 0; i < buffers.length; i++) {
       while (buffers[i].remaining() > 0) {
         final long n = ch.write(buffers, i, buffers.length - i);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("buffer[{}]: remaining={}, written={}", i, buffers[i].remaining(), n);
+        }
         if (n < 0) {
           throw new IllegalStateException("GatheringByteChannel.write returns " + n + " < 0 for " + ch);
         }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -31,6 +31,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
  * Utilities for buffers.
  */
 public final class BufferUtils {
+  private static final ByteBuffer[] EMPTY_BYTE_BUFFER_ARRAY = {};
 
   /** Utility classes should not be constructed. **/
   private BufferUtils() {
@@ -147,10 +148,28 @@ public final class BufferUtils {
     long written = 0;
     while (bb.remaining() > 0) {
       int n = ch.write(bb);
-      if (n <= 0) {
-        throw new IllegalStateException("no bytes written");
+      if (n < 0) {
+        throw new IllegalStateException("GatheringByteChannel.write returns " + n + " < 0 for " + ch);
       }
       written += n;
+    }
+    return written;
+  }
+
+  public static long writeFully(GatheringByteChannel ch, List<ByteBuffer> buffers) throws IOException {
+    return BufferUtils.writeFully(ch, buffers.toArray(EMPTY_BYTE_BUFFER_ARRAY));
+  }
+
+  public static long writeFully(GatheringByteChannel ch, ByteBuffer[] buffers) throws IOException {
+    long written = 0;
+    for(int i = 0; i < buffers.length; i++) {
+      while (buffers[i].remaining() > 0) {
+        final long n = ch.write(buffers, i, buffers.length - i);
+        if (n < 0) {
+          throw new IllegalStateException("GatheringByteChannel.write returns " + n + " < 0 for " + ch);
+        }
+        written += n;
+      }
     }
     return written;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -162,7 +162,7 @@ public final class BufferUtils {
 
   public static long writeFully(GatheringByteChannel ch, ByteBuffer[] buffers) throws IOException {
     long written = 0;
-    for(int i = 0; i < buffers.length; i++) {
+    for (int i = 0; i < buffers.length; i++) {
       while (buffers[i].remaining() > 0) {
         final long n = ch.write(buffers, i, buffers.length - i);
         if (n < 0) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/MockGatheringChannel.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/MockGatheringChannel.java
@@ -61,7 +61,7 @@ public class MockGatheringChannel implements GatheringByteChannel {
 
     long written = 0;
     for (int i = offset; i < srcs.length; i++) {
-      for(final ByteBuffer src = srcs[i]; src.hasRemaining(); ) {
+      for (final ByteBuffer src = srcs[i]; src.hasRemaining();) {
         final long n = partialLength - written;  // write at most n bytes
         assertThat(n).isGreaterThanOrEqualTo(0);
         if (n == 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Pass `byte[]` to `GatheringByteChannel.write(..)`.
- Check `< 0` instead of `<= 0`.

## What is the link to the Apache JIRA

HDDS-11860

## How was this patch tested?

By existing tests.