### PR TITLE
HDDS-11908. Snapshot diff DAG traversal should not skip node based on prefix presence

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -938,10 +938,6 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     Preconditions.checkArgument(sameFiles.isEmpty(), "Set must be empty");
     Preconditions.checkArgument(differentFiles.isEmpty(), "Set must be empty");
 
-    // Use source snapshot's table prefix. At this point Source and target's
-    // table prefix should be same.
-    Map<String, String> columnFamilyToPrefixMap = src.getTablePrefixes();
-
     for (String fileName : srcSnapFiles) {
       if (destSnapFiles.contains(fileName)) {
         LOG.debug("Source '{}' and destination '{}' share the same SST '{}'",

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ozone.rocksdiff;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
@@ -113,4 +115,35 @@ public final class RocksDiffUtils {
   }
 
 
+  @VisibleForTesting
+  static boolean shouldSkipNode(CompactionNode node,
+                                Map<String, String> columnFamilyToPrefixMap) {
+    // This is for backward compatibility. Before the compaction log table
+    // migration, startKey, endKey and columnFamily information is not persisted
+    // in compaction log files.
+    // Also for the scenario when there is an exception in reading SST files
+    // for the file node.
+    if (node.getStartKey() == null || node.getEndKey() == null ||
+        node.getColumnFamily() == null) {
+      LOG.debug("Compaction node with fileName: {} doesn't have startKey, " +
+          "endKey and columnFamily details.", node.getFileName());
+      return false;
+    }
+
+    if (MapUtils.isEmpty(columnFamilyToPrefixMap)) {
+      LOG.debug("Provided columnFamilyToPrefixMap is null or empty.");
+      return false;
+    }
+
+    if (!columnFamilyToPrefixMap.containsKey(node.getColumnFamily())) {
+      LOG.debug("SstFile node: {} is for columnFamily: {} while filter map " +
+              "contains columnFamilies: {}.", node.getFileName(),
+          node.getColumnFamily(), columnFamilyToPrefixMap.keySet());
+      return true;
+    }
+
+    String keyPrefix = columnFamilyToPrefixMap.get(node.getColumnFamily());
+    return !isKeyWithPrefixPresent(keyPrefix, node.getStartKey(),
+        node.getEndKey());
+  }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1794,7 +1794,7 @@ public class TestRocksDBCheckpointDiffer {
         .getCompactionNodeMap().values().stream()
         .sorted(Comparator.comparing(CompactionNode::getFileName))
         .map(node ->
-            rocksDBCheckpointDiffer.shouldSkipNode(node,
+            RocksDiffUtils.shouldSkipNode(node,
                 columnFamilyToPrefixMap))
         .collect(Collectors.toList());
 
@@ -1831,7 +1831,7 @@ public class TestRocksDBCheckpointDiffer {
 
     rocksDBCheckpointDiffer.loadAllCompactionLogs();
 
-    assertEquals(expectedResponse, rocksDBCheckpointDiffer.shouldSkipNode(node,
+    assertEquals(expectedResponse, RocksDiffUtils.shouldSkipNode(node,
         columnFamilyToPrefixMap));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshot diff DAG traversal should not skip node based on prefix presence. 

Consider the case 

Snap1 has 1, 2, 3 files

Say 1,4 compacted to => 5

And 5, 6 => 7

Snap 2 has 7, 2, 3 file.

Now diff b/w Snap1 & Snap2 would be in 4 & 6 sst files.

Consider 1 had +k & 4 had -k

Now 5 would have neither of these files.

But as per this condition:
https://github.com/apache/ozone/blob/b11b80707d4e6721c06966936ad87063ec107da6/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L1009-L1016 traversal on would skip node 5 thus traversal would never reach 1,4. We should not have this optmization check. This would end up not using the compaction even though it is not there.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11908

## How was this patch tested?
Unit tests
