### PR TITLE
HDDS-11367. Improve ozone balancing status command output. Fix flaky.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
@@ -177,9 +177,7 @@ Verify Container Balancer for RATIS/EC containers
 
     Run Balancer Verbose Status
 
-    Sleep                   40000ms
-
-    Run Balancer Verbose History Status
+    Wait Until Keyword Succeeds    40sec    5sec   Run Balancer Verbose History Status
 
     Wait Finish Of Balancing
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Minor improvements to command output:
1. job task time consumption
2. iteration time consumption
3. unfinished iteration shouldn't be in iteration history section
4. show data units, even it less than gb show it in mb

## What is the link to the Apache JIRA
[HDDS-11367](https://issues.apache.org/jira/browse/HDDS-11367)

## How was this patch tested?
Tested by robot test
