### PR TITLE
HDDS-11915. Netty OpenSsl not available on arm64

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -30,7 +30,7 @@
     <downloadSources>true</downloadSources>
     <docker.ozone.image>apache/ozone</docker.ozone.image>
     <docker.ozone.image.flavor>-rocky</docker.ozone.image.flavor> <!-- suffix appended to Ozone version to get Docker image version -->
-    <docker.ozone-runner.version>20241119-1-jdk21</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20241212-1-jdk21</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20241129-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `ozone-runner` to the version that comes with `libcrypt.so.1` on `arm64`, too.  This is to fix:

```
UnsatisfiedLinkError: /tmp/liborg_apache_ratis_thirdparty_netty_tcnative_linux_aarch_6412907517136400085340.so: libcrypt.so.1: cannot open shared object file: No such file or directory
```

https://issues.apache.org/jira/browse/HDDS-11915

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12300562062