### PR TITLE
HDDS-5045. Create acceptance test for using rclone with s3 protocol

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -30,7 +30,7 @@
     <downloadSources>true</downloadSources>
     <docker.ozone.image>apache/ozone</docker.ozone.image>
     <docker.ozone.image.flavor>-rocky</docker.ozone.image.flavor> <!-- suffix appended to Ozone version to get Docker image version -->
-    <docker.ozone-runner.version>20241212-1-jdk21</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20241216-1-jdk21</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20241129-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
     <sort.skip>true</sort.skip>

--- a/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
@@ -43,4 +43,4 @@ Rclone Client Test
     Set Environment Variable   RCLONE_CONFIG    ${RCLONE_CONFIG_PATH}
     Set Environment Variable   RCLONE_VERBOSE   ${RCLONE_VERBOSE_LEVEL}
     ${result} =     Execute    rclone config create ${RCLONE_CONFIG_NAME} s3 env_auth=true provider=Other endpoint=${ENDPOINT_URL}
-    ${result} =     Execute    rclone copy ./compose ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}
+    ${result} =     Execute    rclone copy /opt/hadoop/smoketest ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
@@ -29,13 +29,18 @@ ${RCLONE_CONFIG_NAME}       ozone
 ${RCLONE_CONFIG_PATH}       /tmp/rclone.conf
 ${RCLONE_VERBOSE_LEVEL}     2
 
-*** Test Cases ***
+*** Keywords ***
+#   Export access key and secret to the environment
+Setup aws credentials
+    ${accessKey} =      Execute     aws configure get aws_access_key_id
+    ${secret} =         Execute     aws configure get aws_secret_access_key
+    Set Environment Variable        AWS_SECRET_ACCESS_KEY  ${secret}
+    Set Environment Variable        AWS_ACCESS_KEY_ID  ${accessKey}
 
+*** Test Cases ***
 Rclone Client Test
-    [Setup]    Setup v2 headers
+    [Setup]    Setup aws credentials
     Set Environment Variable   RCLONE_CONFIG    ${RCLONE_CONFIG_PATH}
     Set Environment Variable   RCLONE_VERBOSE   ${RCLONE_VERBOSE_LEVEL}
     ${result} =     Execute    rclone config create ${RCLONE_CONFIG_NAME} s3 env_auth=true provider=Other endpoint=${ENDPOINT_URL}
-    ${result} =     Execute    rclone copy . ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}
-                    Execute    cat ${RCLONE_CONFIG_PATH}
-                    Execute    env | grep RCLONE
+    ${result} =     Execute    rclone copy ./compose ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
@@ -26,11 +26,12 @@ ${ENDPOINT_URL}        http://s3g:9878
 ${S3_VOLUME}           s3v
 ${BUCKET}              generated
 ${RCLONE_CONFIG_NAME}  ozone
-
+${RCLONE_CONFIG_PATH}  /tmp/rclone.conf
 
 *** Test Cases ***
 
 Rclone Client Test
     [Setup]    Setup v2 headers
+    Set Environment Variable   RCLONE_CONFIG  ${RCLONE_CONFIG_PATH}
     ${result} =    Execute    rclone config create ${RCLONE_CONFIG_NAME} s3 env_auth=true provider=Other endpoint=${ENDPOINT_URL}
     ${result} =    Execute    rclone copy . ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       S3 gateway test with rclone client
+Library             OperatingSystem
+Library             BuiltIn
+Resource            ./commonawslib.robot
+Test Timeout        15 minutes
+Suite Setup         Setup s3 tests
+
+*** Variables ***
+${ENDPOINT_URL}        http://s3g:9878
+${S3_VOLUME}           s3v
+${BUCKET}              generated
+${RCLONE_CONFIG_NAME}  ozone
+
+
+*** Test Cases ***
+
+Rclone Client Test
+    [Setup]    Setup v2 headers
+    ${result} =    Execute    rclone config create ${RCLONE_CONFIG_NAME} s3 env_auth=true provider=Other endpoint=${ENDPOINT_URL}
+    ${result} =    Execute    rclone copy . ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/rclone.robot
@@ -22,16 +22,20 @@ Test Timeout        15 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***
-${ENDPOINT_URL}        http://s3g:9878
-${S3_VOLUME}           s3v
-${BUCKET}              generated
-${RCLONE_CONFIG_NAME}  ozone
-${RCLONE_CONFIG_PATH}  /tmp/rclone.conf
+${ENDPOINT_URL}             http://s3g:9878
+${S3_VOLUME}                s3v
+${BUCKET}                   generated
+${RCLONE_CONFIG_NAME}       ozone
+${RCLONE_CONFIG_PATH}       /tmp/rclone.conf
+${RCLONE_VERBOSE_LEVEL}     2
 
 *** Test Cases ***
 
 Rclone Client Test
     [Setup]    Setup v2 headers
-    Set Environment Variable   RCLONE_CONFIG  ${RCLONE_CONFIG_PATH}
-    ${result} =    Execute    rclone config create ${RCLONE_CONFIG_NAME} s3 env_auth=true provider=Other endpoint=${ENDPOINT_URL}
-    ${result} =    Execute    rclone copy . ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}
+    Set Environment Variable   RCLONE_CONFIG    ${RCLONE_CONFIG_PATH}
+    Set Environment Variable   RCLONE_VERBOSE   ${RCLONE_VERBOSE_LEVEL}
+    ${result} =     Execute    rclone config create ${RCLONE_CONFIG_NAME} s3 env_auth=true provider=Other endpoint=${ENDPOINT_URL}
+    ${result} =     Execute    rclone copy . ${RCLONE_CONFIG_NAME}:/${S3_VOLUME}/${BUCKET}
+                    Execute    cat ${RCLONE_CONFIG_PATH}
+                    Execute    env | grep RCLONE


### PR DESCRIPTION
Please describe your PR in detail:
This PR adds a robot test to validate the [rclone](https://rclone.org/s3/) tool with ozone
This PR depends on https://github.com/apache/ozone-docker-runner/pull/37 to install the rclone tool to the docker runner image

Although the default path to the rclone config works when running the robot test on the local machine, we explicitly use the `/tmp` dir to save the rclone config file as the default path is not writable when using the Github CI. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5045

## How was this patch tested?

Tested locally by running the robot test

~~CI will fail until https://github.com/apache/ozone-docker-runner/pull/37 is merged~~
CI: 
~~https://github.com/ptlrs/ozone/actions/runs/12306745127~~
~~https://github.com/ptlrs/ozone/actions/runs/12358744782~~
~~https://github.com/ptlrs/ozone/actions/runs/12628265823~~
~~https://github.com/ptlrs/ozone/actions/runs/12637768640~~
~~https://github.com/ptlrs/ozone/actions/runs/12656460230~~
https://github.com/ptlrs/ozone/actions/runs/12657589951
