### PR TITLE
HDDS-11878. Use CommandSpec to find top-level command

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -105,7 +105,6 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
     throw new MissingSubcommandException(cmd);
   }
 
-  @Override
   public OzoneConfiguration createOzoneConfiguration() {
     OzoneConfiguration ozoneConf = new OzoneConfiguration();
     if (configurationPath != null) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -119,6 +119,7 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
     return ozoneConf;
   }
 
+  @Override
   public OzoneConfiguration getOzoneConf() {
     if (conf == null) {
       conf = createOzoneConfiguration();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericParentCommand.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericParentCommand.java
@@ -25,7 +25,5 @@ public interface GenericParentCommand {
 
   boolean isVerbose();
 
-  OzoneConfiguration createOzoneConfiguration();
-
   OzoneConfiguration getOzoneConf();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericParentCommand.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericParentCommand.java
@@ -25,5 +25,6 @@ public interface GenericParentCommand {
 
   boolean isVerbose();
 
+  /** Returns a cached configuration, i.e. it is created only once, subsequent calls return the same instance. */
   OzoneConfiguration getOzoneConf();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericParentCommand.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericParentCommand.java
@@ -26,4 +26,6 @@ public interface GenericParentCommand {
   boolean isVerbose();
 
   OzoneConfiguration createOzoneConfiguration();
+
+  OzoneConfiguration getOzoneConf();
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
@@ -24,7 +24,7 @@ import static picocli.CommandLine.Spec.Target.MIXEE;
 
 /** Base functionality for all Ozone CLI mixins. */
 @CommandLine.Command
-public abstract class AbstractMixin implements GenericParentCommand {
+public abstract class AbstractMixin {
 
   @CommandLine.Spec(MIXEE)
   private CommandLine.Model.CommandSpec spec;
@@ -37,18 +37,11 @@ public abstract class AbstractMixin implements GenericParentCommand {
     return (GenericParentCommand) spec.root().userObject();
   }
 
-  @Override
-  public boolean isVerbose() {
-    return rootCommand().isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
+  protected OzoneConfiguration createOzoneConfiguration() {
     return rootCommand().createOzoneConfiguration();
   }
 
-  @Override
-  public OzoneConfiguration getOzoneConf() {
+  protected OzoneConfiguration getOzoneConf() {
     return rootCommand().getOzoneConf();
   }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
@@ -37,10 +37,6 @@ public abstract class AbstractMixin {
     return (GenericParentCommand) spec.root().userObject();
   }
 
-  protected OzoneConfiguration createOzoneConfiguration() {
-    return rootCommand().createOzoneConfiguration();
-  }
-
   protected OzoneConfiguration getOzoneConf() {
     return rootCommand().getOzoneConf();
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.cli;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import picocli.CommandLine;
+
+import static picocli.CommandLine.Spec.Target.MIXEE;
+
+/** Base functionality for all Ozone CLI mixins. */
+@CommandLine.Command
+public abstract class AbstractMixin implements GenericParentCommand {
+
+  @CommandLine.Spec(MIXEE)
+  private CommandLine.Model.CommandSpec spec;
+
+  protected CommandLine.Model.CommandSpec spec() {
+    return spec;
+  }
+
+  protected GenericParentCommand rootCommand() {
+    return (GenericParentCommand) spec.root().userObject();
+  }
+
+  @Override
+  public boolean isVerbose() {
+    return rootCommand().isVerbose();
+  }
+
+  @Override
+  public OzoneConfiguration createOzoneConfiguration() {
+    return rootCommand().createOzoneConfiguration();
+  }
+
+  @Override
+  public OzoneConfiguration getOzoneConf() {
+    return rootCommand().getOzoneConf();
+  }
+
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractMixin.java
@@ -34,7 +34,7 @@ public abstract class AbstractMixin {
   }
 
   protected GenericParentCommand rootCommand() {
-    return (GenericParentCommand) spec.root().userObject();
+    return AbstractSubcommand.findRootCommand(spec);
   }
 
   protected OzoneConfiguration getOzoneConf() {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -45,10 +45,6 @@ public abstract class AbstractSubcommand {
     return rootCommand().isVerbose();
   }
 
-  public OzoneConfiguration createOzoneConfiguration() {
-    return rootCommand().createOzoneConfiguration();
-  }
-
   protected OzoneConfiguration getOzoneConf() {
     return rootCommand().getOzoneConf();
   }
@@ -61,11 +57,6 @@ public abstract class AbstractSubcommand {
     @Override
     public boolean isVerbose() {
       return false;
-    }
-
-    @Override
-    public OzoneConfiguration createOzoneConfiguration() {
-      return new OzoneConfiguration();
     }
 
     @Override

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.cli;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import picocli.CommandLine;
+
+/** Base functionality for all Ozone subcommands. */
+@CommandLine.Command(
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+public abstract class AbstractSubcommand implements GenericParentCommand {
+
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  protected CommandLine.Model.CommandSpec spec() {
+    return spec;
+  }
+
+  protected GenericParentCommand rootCommand() {
+    return (GenericParentCommand) spec.root().userObject();
+  }
+
+  @Override
+  public boolean isVerbose() {
+    final GenericParentCommand root = rootCommand();
+    // 'this' could be root in unit test, where subcommand is created without parents
+    return root != this && root.isVerbose();
+  }
+
+  @Override
+  public OzoneConfiguration createOzoneConfiguration() {
+    final GenericParentCommand root = rootCommand();
+    // 'this' could be root in unit test, where subcommand is created without parents
+    return root != this ? root.createOzoneConfiguration() : new OzoneConfiguration();
+  }
+
+  @Override
+  public OzoneConfiguration getOzoneConf() {
+    final GenericParentCommand root = rootCommand();
+    // 'this' could be root in unit test, where subcommand is created without parents
+    return root != this ? root.getOzoneConf() : new OzoneConfiguration();
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -18,7 +18,10 @@
 package org.apache.hadoop.hdds.cli;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.ratis.util.MemoizedSupplier;
 import picocli.CommandLine;
+
+import java.util.function.Supplier;
 
 /** Base functionality for all Ozone subcommands. */
 @CommandLine.Command(
@@ -30,11 +33,18 @@ public abstract class AbstractSubcommand {
   @CommandLine.Spec
   private CommandLine.Model.CommandSpec spec;
 
+  private final Supplier<GenericParentCommand> rootSupplier =
+      MemoizedSupplier.valueOf(this::findRootCommand);
+
   protected CommandLine.Model.CommandSpec spec() {
     return spec;
   }
 
   protected GenericParentCommand rootCommand() {
+    return rootSupplier.get();
+  }
+
+  private GenericParentCommand findRootCommand() {
     Object root = spec.root().userObject();
     return root instanceof GenericParentCommand
         ? (GenericParentCommand) root

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -34,17 +34,19 @@ public abstract class AbstractSubcommand {
   private CommandLine.Model.CommandSpec spec;
 
   private final Supplier<GenericParentCommand> rootSupplier =
-      MemoizedSupplier.valueOf(this::findRootCommand);
+      MemoizedSupplier.valueOf(() -> findRootCommand(spec));
 
   protected CommandLine.Model.CommandSpec spec() {
     return spec;
   }
 
+  /** Get the Ozone object annotated with {@link CommandLine.Command}) that was used to run this command.
+   * Usually this is some subclass of {@link GenericCli}, but in unit tests it could be any subcommand. */
   protected GenericParentCommand rootCommand() {
     return rootSupplier.get();
   }
 
-  private GenericParentCommand findRootCommand() {
+  static GenericParentCommand findRootCommand(CommandLine.Model.CommandSpec spec) {
     Object root = spec.root().userObject();
     return root instanceof GenericParentCommand
         ? (GenericParentCommand) root

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -57,6 +57,7 @@ public abstract class AbstractSubcommand {
     return rootCommand().isVerbose();
   }
 
+  /** @see GenericParentCommand#getOzoneConf() */
   protected OzoneConfiguration getOzoneConf() {
     return rootCommand().getOzoneConf();
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -46,13 +46,6 @@ public abstract class AbstractSubcommand {
     return rootSupplier.get();
   }
 
-  static GenericParentCommand findRootCommand(CommandLine.Model.CommandSpec spec) {
-    Object root = spec.root().userObject();
-    return root instanceof GenericParentCommand
-        ? (GenericParentCommand) root
-        : new NoParentCommand();
-  }
-
   protected boolean isVerbose() {
     return rootCommand().isVerbose();
   }
@@ -60,6 +53,13 @@ public abstract class AbstractSubcommand {
   /** @see GenericParentCommand#getOzoneConf() */
   protected OzoneConfiguration getOzoneConf() {
     return rootCommand().getOzoneConf();
+  }
+
+  static GenericParentCommand findRootCommand(CommandLine.Model.CommandSpec spec) {
+    Object root = spec.root().userObject();
+    return root instanceof GenericParentCommand
+        ? (GenericParentCommand) root
+        : new NoParentCommand();
   }
 
   /** No-op implementation for unit tests, which may bypass creation of GenericCli object. */

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
@@ -49,7 +49,7 @@ public class ScmOption extends AbstractMixin {
   private String scmServiceId;
 
   public ScmClient createScmClient() throws IOException {
-    OzoneConfiguration conf = createOzoneConfiguration();
+    OzoneConfiguration conf = getOzoneConf();
     checkAndSetSCMAddressArg(conf);
 
     return new ContainerOperationClient(conf);
@@ -85,7 +85,7 @@ public class ScmOption extends AbstractMixin {
 
   public SCMSecurityProtocol createScmSecurityClient() {
     try {
-      return getScmSecurityClient(createOzoneConfiguration());
+      return getScmSecurityClient(getOzoneConf());
     } catch (IOException ex) {
       throw new IllegalArgumentException(
           "Can't create SCM Security client", ex);

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.scm.cli;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.HddsUtils;
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
+import org.apache.hadoop.hdds.cli.AbstractMixin;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -33,15 +33,11 @@ import java.io.IOException;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClient;
-import static picocli.CommandLine.Spec.Target.MIXEE;
 
 /**
  * Defines command-line option for SCM address.
  */
-public class ScmOption {
-
-  @CommandLine.Spec(MIXEE)
-  private CommandLine.Model.CommandSpec spec;
+public class ScmOption extends AbstractMixin {
 
   @CommandLine.Option(names = {"--scm"},
       description = "The destination scm (host:port)")
@@ -53,9 +49,7 @@ public class ScmOption {
   private String scmServiceId;
 
   public ScmClient createScmClient() throws IOException {
-    GenericParentCommand parent = (GenericParentCommand)
-        spec.root().userObject();
-    OzoneConfiguration conf = parent.createOzoneConfiguration();
+    OzoneConfiguration conf = createOzoneConfiguration();
     checkAndSetSCMAddressArg(conf);
 
     return new ContainerOperationClient(conf);
@@ -91,13 +85,10 @@ public class ScmOption {
 
   public SCMSecurityProtocol createScmSecurityClient() {
     try {
-      GenericParentCommand parent = (GenericParentCommand)
-          spec.root().userObject();
-      return getScmSecurityClient(parent.createOzoneConfiguration());
+      return getScmSecurityClient(createOzoneConfiguration());
     } catch (IOException ex) {
       throw new IllegalArgumentException(
           "Can't create SCM Security client", ex);
     }
   }
-
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmSubcommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.cli;
 
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
 
@@ -26,7 +27,7 @@ import java.util.concurrent.Callable;
 /**
  * Base class for admin commands that connect via SCM client.
  */
-public abstract class ScmSubcommand implements Callable<Void> {
+public abstract class ScmSubcommand extends AbstractSubcommand implements Callable<Void> {
 
   @CommandLine.Mixin
   private ScmOption scmOption;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerCommands.java
@@ -22,11 +22,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
@@ -52,16 +50,9 @@ public class ContainerCommands implements Callable<Void>, AdminSubcommand {
   @Spec
   private CommandSpec spec;
 
-  @ParentCommand
-  private OzoneAdmin parent;
-
   @Override
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  public OzoneAdmin getParent() {
-    return parent;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -27,7 +27,6 @@ import java.time.Instant;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -47,9 +46,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Parameters;
-import picocli.CommandLine.Spec;
 
 /**
  * This is the handler that process container info command.
@@ -60,9 +57,6 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class InfoSubcommand extends ScmSubcommand {
-
-  @Spec
-  private CommandSpec spec;
 
   @CommandLine.Option(names = { "--json" },
       defaultValue = "false",
@@ -181,10 +175,7 @@ public class InfoSubcommand extends ScmSubcommand {
     } else {
       // Print container report info.
       System.out.printf("Container id: %s%n", containerID);
-      boolean verbose = spec != null
-          && spec.root().userObject() instanceof GenericParentCommand
-          && ((GenericParentCommand) spec.root().userObject()).isVerbose();
-      if (verbose) {
+      if (isVerbose()) {
         System.out.printf("Pipeline Info: %s%n", container.getPipeline());
       } else {
         System.out.printf("Pipeline id: %s%n", container.getPipeline().getId().getId());

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 
@@ -82,9 +81,6 @@ public class ListSubcommand extends ScmSubcommand {
 
   private static final ObjectWriter WRITER;
 
-  @ParentCommand
-  private ContainerCommands parent;
-
   static {
     ObjectMapper mapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
@@ -116,7 +112,7 @@ public class ListSubcommand extends ScmSubcommand {
           replication, new OzoneConfiguration());
     }
 
-    int maxCountAllowed = parent.getParent().getOzoneConf()
+    int maxCountAllowed = getOzoneConf()
         .getInt(ScmConfigKeys.OZONE_SCM_CONTAINER_LIST_MAX_COUNT,
             ScmConfigKeys.OZONE_SCM_CONTAINER_LIST_MAX_COUNT_DEFAULT);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -66,10 +66,6 @@ public class NSSummaryAdmin implements AdminSubcommand {
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
 
-  public OzoneAdmin getParent() {
-    return parent;
-  }
-
   private boolean isObjectStoreBucket(OzoneBucket bucket, ObjectStore objectStore) {
     boolean enableFileSystemPaths = getOzoneConfig()
         .getBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.debug.container;
 
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
@@ -39,14 +40,14 @@ import java.util.concurrent.Callable;
     name = "inspect",
     description
         = "Check the metadata of all container replicas on this datanode.")
-public class InspectSubcommand implements Callable<Void> {
+public class InspectSubcommand extends AbstractSubcommand implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private ContainerCommands parent;
 
   @Override
   public Void call() throws IOException {
-    final OzoneConfiguration conf = parent.getOzoneConf();
+    final OzoneConfiguration conf = getOzoneConf();
     parent.loadContainersFromVolumes();
 
     final KeyValueContainerMetadataInspector inspector

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonReplicationOptions.java
@@ -22,13 +22,11 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.shell.ReplicationOptions;
+import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Spec;
 
 import java.util.Optional;
-
-import static picocli.CommandLine.Spec.Target.MIXEE;
 
 /**
  * Options for specifying replication config for Freon.
@@ -38,9 +36,6 @@ public class FreonReplicationOptions extends ReplicationOptions {
   private static final String FACTOR_OPT = "--factor";
 
   private ReplicationFactor factor;
-
-  @Spec(MIXEE)
-  private CommandSpec spec;
 
   @Option(names = { "-F", FACTOR_OPT },
       description = "[deprecated] Replication factor (ONE, THREE)",
@@ -70,10 +65,13 @@ public class FreonReplicationOptions extends ReplicationOptions {
    */
   @Override
   public Optional<ReplicationConfig> fromParams(ConfigurationSource conf) {
-    if (spec != null && spec.commandLine().getParseResult() != null &&
-            spec.commandLine().getParseResult().hasMatchedOption(FACTOR_OPT)) {
-      return Optional.of(ReplicationConfig.fromTypeAndFactor(
-          ReplicationType.RATIS, factor));
+    CommandSpec spec = spec();
+    if (spec != null) {
+      CommandLine.ParseResult parseResult = spec.commandLine().getParseResult();
+      if (parseResult != null && parseResult.hasMatchedOption(FACTOR_OPT)) {
+        return Optional.of(ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.RATIS, factor));
+      }
     }
 
     return super.fromParams(conf);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonReplicationOptions.java
@@ -22,11 +22,13 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.shell.ReplicationOptions;
-import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
 
 import java.util.Optional;
+
+import static picocli.CommandLine.Spec.Target.MIXEE;
 
 /**
  * Options for specifying replication config for Freon.
@@ -36,6 +38,9 @@ public class FreonReplicationOptions extends ReplicationOptions {
   private static final String FACTOR_OPT = "--factor";
 
   private ReplicationFactor factor;
+
+  @Spec(MIXEE)
+  private CommandSpec spec;
 
   @Option(names = { "-F", FACTOR_OPT },
       description = "[deprecated] Replication factor (ONE, THREE)",
@@ -65,13 +70,10 @@ public class FreonReplicationOptions extends ReplicationOptions {
    */
   @Override
   public Optional<ReplicationConfig> fromParams(ConfigurationSource conf) {
-    CommandSpec spec = spec();
-    if (spec != null) {
-      CommandLine.ParseResult parseResult = spec.commandLine().getParseResult();
-      if (parseResult != null && parseResult.hasMatchedOption(FACTOR_OPT)) {
-        return Optional.of(ReplicationConfig.fromTypeAndFactor(
-            ReplicationType.RATIS, factor));
-      }
+    if (spec != null && spec.commandLine().getParseResult() != null &&
+            spec.commandLine().getParseResult().hasMatchedOption(FACTOR_OPT)) {
+      return Optional.of(ReplicationConfig.fromTypeAndFactor(
+          ReplicationType.RATIS, factor));
     }
 
     return super.fromParams(conf);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaRepair.java
@@ -113,8 +113,4 @@ public class QuotaRepair implements Callable<Void>, RepairSubcommand {
   public UserGroupInformation getUser() throws IOException {
     return UserGroupInformation.getCurrentUser();
   }
-
-  protected OzoneRepair getParent() {
-    return parent;
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaStatus.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaStatus.java
@@ -64,8 +64,4 @@ public class QuotaStatus implements Callable<Void>  {
     System.out.println(ozoneManagerClient.getQuotaRepairStatus());
     return null;
   }
-
-  protected QuotaRepair getParent() {
-    return parent;
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
@@ -84,9 +84,4 @@ public class QuotaTrigger implements Callable<Void>  {
     }
     return null;
   }
-
-  protected QuotaRepair getParent() {
-    return parent;
-  }
-
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -64,7 +64,7 @@ public abstract class Handler extends AbstractSubcommand implements Callable<Voi
 
   @Override
   public Void call() throws Exception {
-    conf = createOzoneConfiguration();
+    conf = getOzoneConf();
 
     if (!isApplicable()) {
       return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -24,8 +24,7 @@ import java.util.Iterator;
 import java.util.concurrent.Callable;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
-import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.JsonUtils;
 
@@ -34,35 +33,16 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Base class for shell commands that connect via Ozone client.
  */
-@Command(mixinStandardHelpOptions = true,
-    versionProvider = HddsVersionProvider.class)
 @SuppressWarnings("squid:S106") // CLI
-public abstract class Handler implements Callable<Void> {
+public abstract class Handler extends AbstractSubcommand implements Callable<Void> {
 
   protected static final Logger LOG = LoggerFactory.getLogger(Handler.class);
 
   private OzoneConfiguration conf;
-
-  @ParentCommand
-  private GenericParentCommand parent;
-
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
-  public boolean isVerbose() {
-    return parent.isVerbose();
-  }
-
-  public OzoneConfiguration createOzoneConfiguration() {
-    return parent.createOzoneConfiguration();
-  }
 
   protected OzoneAddress getAddress() throws OzoneClientException {
     return new OzoneAddress();
@@ -111,7 +91,7 @@ public abstract class Handler implements Callable<Void> {
     if (!enabled) {
       err().printf("Error: '%s' operation works only when security is " +
           "enabled. To enable security set ozone.security.enabled to " +
-          "true.%n", spec.qualifiedName().trim());
+          "true.%n", spec().qualifiedName().trim());
     }
     return enabled;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ReplicationOptions.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.fs.ozone.OzoneClientUtils;
-import org.apache.hadoop.hdds.cli.AbstractMixin;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -33,7 +32,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
  * Common options for specifying replication config: specialized for
  * Ozone Shell and Freon commands.
  */
-public abstract class ReplicationOptions extends AbstractMixin {
+public abstract class ReplicationOptions {
 
   protected static final String REPLICATION_DESCRIPTION =
       "Replication definition. Valid values are replication"

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ReplicationOptions.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.fs.ozone.OzoneClientUtils;
+import org.apache.hadoop.hdds.cli.AbstractMixin;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -32,7 +33,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
  * Common options for specifying replication config: specialized for
  * Ozone Shell and Freon commands.
  */
-public abstract class ReplicationOptions {
+public abstract class ReplicationOptions extends AbstractMixin {
 
   protected static final String REPLICATION_DESCRIPTION =
       "Replication definition. Valid values are replication"

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.shell.bucket;
 
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -52,7 +50,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class BucketCommands implements GenericParentCommand, Callable<Void> {
+public class BucketCommands implements Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -61,15 +59,5 @@ public class BucketCommands implements GenericParentCommand, Callable<Void> {
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("bucket"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.shell.keys;
 
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -52,8 +50,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class KeyCommands
-    implements GenericParentCommand, Callable<Void> {
+public class KeyCommands implements Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -62,15 +59,5 @@ public class KeyCommands
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("key"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixCommands.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.shell.prefix;
 
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -42,7 +40,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class PrefixCommands implements GenericParentCommand, Callable<Void> {
+public class PrefixCommands implements Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -51,15 +49,5 @@ public class PrefixCommands implements GenericParentCommand, Callable<Void> {
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("prefix"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.shell.snapshot;
 
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -45,7 +43,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class SnapshotCommands implements GenericParentCommand, Callable<Void> {
+public class SnapshotCommands implements Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -54,15 +52,5 @@ public class SnapshotCommands implements GenericParentCommand, Callable<Void> {
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("snapshot"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantUserCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantUserCommands.java
@@ -17,10 +17,8 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 import picocli.CommandLine;
 
@@ -43,8 +41,7 @@ import java.util.concurrent.Callable;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class TenantUserCommands implements
-    GenericParentCommand, Callable<Void> {
+public class TenantUserCommands implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private Shell shell;
@@ -53,15 +50,5 @@ public class TenantUserCommands implements
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("user"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenCommands.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.shell.token;
 
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -42,8 +40,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class TokenCommands
-    implements GenericParentCommand, Callable<Void> {
+public class TokenCommands implements Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -52,15 +49,5 @@ public class TokenCommands
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("token"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.shell.volume;
 
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -50,7 +48,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class VolumeCommands implements GenericParentCommand, Callable<Void> {
+public class VolumeCommands implements Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -59,15 +57,5 @@ public class VolumeCommands implements GenericParentCommand, Callable<Void> {
   public Void call() throws Exception {
     throw new MissingSubcommandException(
         this.shell.getCmd().getSubcommands().get("volume"));
-  }
-
-  @Override
-  public boolean isVerbose() {
-    return shell.isVerbose();
-  }
-
-  @Override
-  public OzoneConfiguration createOzoneConfiguration() {
-    return shell.createOzoneConfiguration();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem

`GenericParentCommand` provides a way to access `GenericCli` methods from sub-subcommands.  However, its usage is tedious and comes with boilerplate code that needs to:

- implement `GenericParentCommand`
- define methods manually
- define member variable for `@ParentCommand` (injected by picocli)

Adding new methods to `GenericParentCommand` becomes harder the more implementations we have.  The interface needs to be implemented on all sub-command levels.
Currently only very few implementations exists.  Some subcommands access top-level command via similar parent chain, but without implementing `GenericParentCommand`.

### Solution

Picocli keeps track of the command hierarchy and allows accessing the top-level command directly via `CommandSpec`.

Changes in this PR:

- Introduce new `AbstractSubcommand`/`AbstractMixin` base classes.  Subcommands/mixins that want to access the top-level command can do so easily by extending it.
- Remove boilerplate implementation of `GenericParentCommand`.
- Remove parent chains where it is only used to access the top-level command.

Accessing the top-level command directly makes it easier to reorganize subcommands, add them to different parents, or even multiple parents at different levels.

https://issues.apache.org/jira/browse/HDDS-11878

## How was this patch tested?

Tested some of the commands changed, that they still reflect the `--verbose` flag:

```
$ ozone sh --verbose volume info /vol1
Volume Name : vol1
VOLUME_NOT_FOUND org.apache.hadoop.ozone.om.exceptions.OMException: Volume vol1 is not found
	at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.handleError(OzoneManagerProtocolClientSideTranslatorPB.java:763)
	at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.getVolumeInfo(OzoneManagerProtocolClientSideTranslatorPB.java:462)
	at org.apache.hadoop.ozone.client.rpc.RpcClient.getVolumeDetails(RpcClient.java:498)
```

```
$ ozone admin container info 1
Container id: 1
Pipeline id: 9dc28c7f-4e45-4a3b-8d87-ce8b1d788e86
...

$ ozone admin --verbose container info 1
Container id: 1
Pipeline Info: Pipeline[ Id: 9dc28c7f-4e45-4a3b-8d87-ce8b1d788e86, Nodes: 5b43e396-c1e8-4ab0-907a-1988d8ae3ff7(ozone-datanode-1.ozone_default/172.17.0.8) ReplicaIndex: 0f40dd8b8-bf0d-4e71-b3b7-6f99cedbf786(ozone-datanode-3.ozone_default/172.17.0.9) ReplicaIndex: 0d930ec97-4ffd-4d49-8177-96430fc508ae(ozone-datanode-2.ozone_default/172.17.0.2) ReplicaIndex: 0, ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:5b43e396-c1e8-4ab0-907a-1988d8ae3ff7, CreationTimestamp2024-12-13T21:28:06.443Z[UTC]]
...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12428823594