### PR TITLE
HDDS-11934. Split compat suite to old/new

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:compat
-
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
@@ -114,12 +112,3 @@ test_cross_compatibility() {
 }
 
 create_results_dir
-
-# current cluster with various clients
-COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} test_cross_compatibility ${old_versions} ${current_version}
-
-# old cluster with clients: same version and current version
-for cluster_version in ${old_versions}; do
-  export OZONE_VERSION=${cluster_version}
-  COMPOSE_FILE=old-cluster.yaml:clients.yaml test_cross_compatibility ${cluster_version} ${current_version}
-done

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test-new.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test-new.sh
@@ -15,21 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:misc
+#suite:compat-new
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
-export SECURITY_ENABLED=false
-export OZONE_REPLICATION_FACTOR=1
+# shellcheck source=hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+source "${COMPOSE_DIR}/lib.sh"
 
-# shellcheck source=/dev/null
-source "$COMPOSE_DIR/../testlib.sh"
-
-start_docker_env ${OZONE_REPLICATION_FACTOR}
-
-execute_robot_test datanode compatibility/dn.robot
-execute_robot_test om compatibility/om.robot
-execute_robot_test recon compatibility/recon.robot
-execute_robot_test scm compatibility/scm.robot
-execute_robot_test datanode compatibility/dn-one-rocksdb.robot
+# current cluster with various clients
+COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} test_cross_compatibility ${old_versions} ${current_version}

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test-old.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test-old.sh
@@ -15,21 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:misc
+#suite:compat-old
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
-export SECURITY_ENABLED=false
-export OZONE_REPLICATION_FACTOR=1
+# shellcheck source=hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+source "${COMPOSE_DIR}/lib.sh"
 
-# shellcheck source=/dev/null
-source "$COMPOSE_DIR/../testlib.sh"
-
-start_docker_env ${OZONE_REPLICATION_FACTOR}
-
-execute_robot_test datanode compatibility/dn.robot
-execute_robot_test om compatibility/om.robot
-execute_robot_test recon compatibility/recon.robot
-execute_robot_test scm compatibility/scm.robot
-execute_robot_test datanode compatibility/dn-one-rocksdb.robot
+# old cluster with clients: same version and current version
+for cluster_version in ${old_versions}; do
+  export OZONE_VERSION=${cluster_version}
+  COMPOSE_FILE=old-cluster.yaml:clients.yaml test_cross_compatibility ${cluster_version} ${current_version}
+done


### PR DESCRIPTION
## What changes were proposed in this pull request?

`xcompat` test is now one of the longest, due to increasing coverage.  This change splits it into two suites based on cluster version: `compat-new` for cluster running current code, and `compat-old` for testing current client with various old cluster versions.

https://issues.apache.org/jira/browse/HDDS-11934

## How was this patch tested?

CI:
- `test-old.sh`: https://github.com/adoroszlai/ozone/actions/runs/12327584447/job/34409960056
- `test-new.sh`: https://github.com/adoroszlai/ozone/actions/runs/12327584447/job/34409959998
- `compatibility` Robot tests: https://github.com/adoroszlai/ozone/actions/runs/12327584447/job/34409960208#step:6:24