### PR TITLE
HDDS-11926. Use "name" in bucket info JSON for links, same as regular buckets

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
@@ -53,7 +53,7 @@ public class InfoBucketHandler extends BucketHandler {
    */
   public static class LinkBucket {
     private String volumeName;
-    private String bucketName;
+    private String name;
     private String sourceVolume;
     private String sourceBucket;
     private Instant creationTime;
@@ -63,7 +63,7 @@ public class InfoBucketHandler extends BucketHandler {
 
     LinkBucket(OzoneBucket ozoneBucket) {
       this.volumeName = ozoneBucket.getVolumeName();
-      this.bucketName = ozoneBucket.getName();
+      this.name = ozoneBucket.getName();
       this.sourceVolume = ozoneBucket.getSourceVolume();
       this.sourceBucket = ozoneBucket.getSourceBucket();
       this.creationTime = ozoneBucket.getCreationTime();
@@ -76,8 +76,8 @@ public class InfoBucketHandler extends BucketHandler {
       return volumeName;
     }
 
-    public String getBucketName() {
-      return bucketName;
+    public String getName() {
+      return name;
     }
 
     public String getSourceVolume() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the bucket-name for bucket info/ls for linked buckets from **_bucketName_** to **_name_**, to keep it consistent with source buckets info/ls output

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11926

## How was this patch tested?

Tested manually on docker -
```
bash-5.1$ ozone sh volume create vol1
bash-5.1$ ozone sh bucket create vol1/buck1
bash-5.1$ ozone sh bucket link vol1/buck1 vol1/linkbuck1
bash-5.1$ ozone sh bucket ls vol1
[ {
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "buck1",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2024-12-16T05:18:18.730Z",
  "modificationTime" : "2024-12-16T05:18:18.730Z",
  "sourcePathExist" : true,
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "hadoop",
  "link" : false
}, {
  "volumeName" : "vol1",
  "name" : "linkbuck1",
  "sourceVolume" : "vol1",
  "sourceBucket" : "buck1",
  "creationTime" : "2024-12-16T05:18:30.212Z",
  "modificationTime" : "2024-12-16T05:18:30.212Z",
  "owner" : "hadoop",
  "link" : true
} ]
bash-5.1$ ozone sh bucket info vol1/linkbuck1
{
  "volumeName" : "vol1",
  "name" : "linkbuck1",
  "sourceVolume" : "vol1",
  "sourceBucket" : "buck1",
  "creationTime" : "2024-12-16T05:18:30.212Z",
  "modificationTime" : "2024-12-16T05:18:30.212Z",
  "owner" : "hadoop",
  "link" : true
}
```
