### PR TITLE
HDDS-11950. Enable sortpom in dev-support module.

### DIFF
--- a/dev-support/pom.xml
+++ b/dev-support/pom.xml
@@ -12,28 +12,25 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>ozone-main</artifactId>
     <groupId>org.apache.ozone</groupId>
+    <artifactId>ozone-main</artifactId>
     <version>2.0.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
   <artifactId>ozone-dev-support</artifactId>
-  <description>Helper module for sharing resources among projects</description>
   <name>Apache Ozone Dev Support</name>
+  <description>Helper module for sharing resources among projects</description>
 
   <properties>
     <failIfNoTests>false</failIfNoTests>
-    <sort.skip>true</sort.skip>
   </properties>
   <build>
     <resources>
       <resource>
-        <directory>${project.build.directory}/extra-resources</directory>
         <targetPath>META-INF</targetPath>
+        <directory>${project.build.directory}/extra-resources</directory>
         <includes>
           <include>LICENSE.txt</include>
           <include>NOTICE.txt</include>
@@ -55,10 +52,10 @@
         <executions>
           <execution>
             <id>copy-resources</id>
-            <phase>validate</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
+            <phase>validate</phase>
             <configuration>
               <outputDirectory>${project.build.directory}/extra-resources</outputDirectory>
               <resources>
@@ -78,14 +75,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <resourcesDirectory>${project.build.outputDirectory}</resourcesDirectory>
           <includes>
@@ -93,6 +82,14 @@
             <include>META-INF/NOTICE.txt</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enable sortpom in dev-support module.

[Sortpom](https://github.com/Ekryd/sortpom/) plugin was added as part of #7555.
This PR enables the plugin for dev-support module.
It also sorts the pom of  dev-support module.

## What is the link to the Apache JIRA

HDDS-11950

## How was this patch tested?
Manually tested by adding out of order property.

Out of order Property
```
[INFO] --- sortpom:3.0.1:verify (default) @ ozone-dev-support ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/dev-support/pom.xml
[ERROR] The line 27 is not considered sorted, should be '    <failIfNoTests>false</failIfNoTests>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/dev-support/pom.xml is not sorted
```
