### PR TITLE
HDDS-11731. ContainerSafeModeRule Refactor.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -71,6 +72,8 @@ public interface ContainerManager extends Closeable {
    */
   List<ContainerInfo> getContainers(ContainerID startID, int count);
 
+
+  List<ContainerInfo> getContainers(ReplicationType type);
 
   /**
    * Returns all the containers which are in the specified state.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
@@ -145,6 +146,12 @@ public class ContainerManagerImpl implements ContainerManager {
         .getContainer(id))
         .orElseThrow(() -> new ContainerNotFoundException("Container with id " +
             id + " not found."));
+  }
+
+
+  @Override
+  public List<ContainerInfo> getContainers(ReplicationType type) {
+    return toContainers(containerStateManager.getContainerIDs(type));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -23,6 +23,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
@@ -113,6 +114,12 @@ public interface ContainerStateManager {
    *
    */
   Set<ContainerID> getContainerIDs(LifeCycleState state);
+
+
+  /**
+   * Returns the IDs of the Containers whose ReplicationType matches the given type.
+   */
+  Set<ContainerID> getContainerIDs(ReplicationType type);
 
   /**
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -34,6 +34,7 @@ import com.google.common.util.concurrent.Striped;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
@@ -284,6 +285,13 @@ public final class ContainerStateManagerImpl
   public Set<ContainerID> getContainerIDs(final LifeCycleState state) {
     try (AutoCloseableLock ignored = readLock()) {
       return containers.getContainerIDsByState(state);
+    }
+  }
+
+  @Override
+  public Set<ContainerID> getContainerIDs(final ReplicationType type) {
+    try (AutoCloseableLock ignored = readLock()) {
+      return containers.getContainerIDsByType(type);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -316,7 +316,7 @@ public class ContainerStateMap {
    * @param type - Replication type -- StandAlone, Ratis etc.
    * @return NavigableSet
    */
-  NavigableSet<ContainerID> getContainerIDsByType(final ReplicationType type) {
+  public NavigableSet<ContainerID> getContainerIDsByType(final ReplicationType type) {
     Preconditions.checkNotNull(type);
     return typeMap.getCollection(type);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -141,13 +141,13 @@ public class ContainerSafeModeRule extends
   }
 
   @VisibleForTesting
-  public synchronized double getCurrentContainerThreshold() {
+  public double getCurrentContainerThreshold() {
     return ratisMaxContainer == 0 ? 1 :
         (ratisContainerWithMinReplicas.doubleValue() / ratisMaxContainer);
   }
 
   @VisibleForTesting
-  public synchronized double getCurrentECContainerThreshold() {
+  public double getCurrentECContainerThreshold() {
     return ecMaxContainer == 0 ? 1 :
         (ecContainerWithMinReplicas.doubleValue() / ecMaxContainer);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -112,14 +112,10 @@ public class ContainerSafeModeRule extends
     final List<ContainerInfo> containers = containerManager.getContainers(
         ReplicationType.RATIS);
 
-    final Set<ContainerID> containerIDs = containers.parallelStream()
-        .filter(this::isClosed).map(ContainerInfo::containerID)
-        .collect(Collectors.toSet());
-
-    final long missingContainerCount = containerIDs.parallelStream()
-        .filter(this::isMissing).count();
-
-    return missingContainerCount == 0;
+    return containers.stream()
+        .filter(this::isClosed)
+        .map(ContainerInfo::containerID)
+        .noneMatch(this::isMissing);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,11 +27,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -48,54 +48,52 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT;
+
 /**
  * Class defining Safe mode exit criteria for Containers.
  */
 public class ContainerSafeModeRule extends
     SafeModeExitRule<NodeRegistrationContainerReport> {
 
-  public static final Logger LOG =
-      LoggerFactory.getLogger(ContainerSafeModeRule.class);
+  public static final Logger LOG = LoggerFactory.getLogger(ContainerSafeModeRule.class);
+  private final ContainerManager containerManager;
   // Required cutoff % for containers with at least 1 reported replica.
-  private double safeModeCutoff;
+  private final double safeModeCutoff;
   // Containers read from scm db (excluding containers in ALLOCATED state).
-  private Set<Long> ratisContainers;
-  private Set<Long> ecContainers;
-  private Map<Long, Set<UUID>> ecContainerDNsMap;
+  private final Set<Long> ratisContainers;
+  private final Set<Long> ecContainers;
+  private final Map<Long, Set<UUID>> ecContainerDNsMap;
+  private final AtomicLong ratisContainerWithMinReplicas = new AtomicLong(0);
+  private final AtomicLong ecContainerWithMinReplicas = new AtomicLong(0);
+
   private double ratisMaxContainer;
   private double ecMaxContainer;
-  private AtomicLong ratisContainerWithMinReplicas = new AtomicLong(0);
-  private AtomicLong ecContainerWithMinReplicas = new AtomicLong(0);
-  private final ContainerManager containerManager;
 
-  public ContainerSafeModeRule(String ruleName, EventQueue eventQueue,
-                               ConfigurationSource conf,
-                               ContainerManager containerManager, SCMSafeModeManager manager) {
-    this(ruleName, eventQueue, conf, containerManager.getContainers(), containerManager, manager);
-  }
-
-  public ContainerSafeModeRule(String ruleName, EventQueue eventQueue,
-             ConfigurationSource conf,
-             List<ContainerInfo> containers,
-             ContainerManager containerManager, SCMSafeModeManager manager) {
+  public ContainerSafeModeRule(final String ruleName,
+                               final EventQueue eventQueue,
+                               final ConfigurationSource conf,
+                               final ContainerManager containerManager,
+                               final SCMSafeModeManager manager) {
     super(manager, ruleName, eventQueue);
+    this.safeModeCutoff = getSafeModeCutoff(conf);
     this.containerManager = containerManager;
-    safeModeCutoff = conf.getDouble(
-        HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT,
-        HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT);
-
-    Preconditions.checkArgument(
-        (safeModeCutoff >= 0.0 && safeModeCutoff <= 1.0),
-        HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT  +
-            " value should be >= 0.0 and <= 1.0");
-
-    ratisContainers = new HashSet<>();
-    ecContainers = new HashSet<>();
-    ecContainerDNsMap = new ConcurrentHashMap<>();
-
-    initializeRule(containers);
+    this.ratisContainers = new HashSet<>();
+    this.ecContainers = new HashSet<>();
+    this.ecContainerDNsMap = new ConcurrentHashMap<>();
+    initializeRule();
   }
 
+
+  private static double getSafeModeCutoff(ConfigurationSource conf) {
+    final double cutoff = conf.getDouble(HDDS_SCM_SAFEMODE_THRESHOLD_PCT,
+        HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT);
+    Preconditions.checkArgument((cutoff >= 0.0 && cutoff <= 1.0),
+        HDDS_SCM_SAFEMODE_THRESHOLD_PCT  +
+            " value should be >= 0.0 and <= 1.0");
+    return cutoff;
+  }
 
   @Override
   protected TypedEvent<NodeRegistrationContainerReport> getEventType() {
@@ -104,45 +102,63 @@ public class ContainerSafeModeRule extends
 
   @Override
   protected synchronized boolean validate() {
-    return (getCurrentContainerThreshold() >= safeModeCutoff) &&
-        (getCurrentECContainerThreshold() >= safeModeCutoff);
+    if (validateBasedOnReportProcessing()) {
+      return (getCurrentContainerThreshold() >= safeModeCutoff) &&
+          (getCurrentECContainerThreshold() >= safeModeCutoff);
+    }
+
+    // TODO: Split ContainerSafeModeRule into RatisContainerSafeModeRule and
+    //   ECContainerSafeModeRule
+    final List<ContainerInfo> containers = containerManager.getContainers(
+        ReplicationType.RATIS);
+
+    final Set<ContainerID> containerIDs = containers.parallelStream()
+        .filter(this::isClosed).map(ContainerInfo::containerID)
+        .collect(Collectors.toSet());
+
+    final long missingContainerCount = containerIDs.parallelStream()
+        .filter(this::isMissing).count();
+
+    return missingContainerCount == 0;
+  }
+
+  /**
+   * Checks if the container has any replica.
+   */
+  private boolean isMissing(ContainerID id) {
+    try {
+      return containerManager.getContainerReplicas(id).isEmpty();
+    } catch (ContainerNotFoundException ex) {
+      /*
+       * This should never happen, in case this happens the container
+       * somehow got removed from SCM.
+       * Safemode rule doesn't have to log/fix this. We will just exclude this
+       * from the rule validation.
+       */
+      return false;
+
+    }
   }
 
   @VisibleForTesting
   public synchronized double getCurrentContainerThreshold() {
-    if (ratisMaxContainer == 0) {
-      return 1;
-    }
-    return (ratisContainerWithMinReplicas.doubleValue() / ratisMaxContainer);
+    return ratisMaxContainer == 0 ? 1 :
+        (ratisContainerWithMinReplicas.doubleValue() / ratisMaxContainer);
   }
 
   @VisibleForTesting
   public synchronized double getCurrentECContainerThreshold() {
-    if (ecMaxContainer == 0) {
-      return 1;
-    }
-    return (ecContainerWithMinReplicas.doubleValue() / ecMaxContainer);
+    return ecMaxContainer == 0 ? 1 :
+        (ecContainerWithMinReplicas.doubleValue() / ecMaxContainer);
   }
 
-  private synchronized double getEcMaxContainer() {
-    if (ecMaxContainer == 0) {
-      return 1;
-    }
-    return ecMaxContainer;
-  }
 
-  private synchronized double getRatisMaxContainer() {
-    if (ratisMaxContainer == 0) {
-      return 1;
-    }
-    return ratisMaxContainer;
-  }
-
+  // TODO: Report processing logic will be removed in future. HDDS-11958.
   @Override
   protected synchronized void process(
-      NodeRegistrationContainerReport reportsProto) {
-    DatanodeDetails datanodeDetails = reportsProto.getDatanodeDetails();
-    UUID datanodeUUID = datanodeDetails.getUuid();
+      final NodeRegistrationContainerReport reportsProto) {
+    final DatanodeDetails datanodeDetails = reportsProto.getDatanodeDetails();
+    final UUID datanodeUUID = datanodeDetails.getUuid();
     StorageContainerDatanodeProtocolProtos.ContainerReportsProto report = reportsProto.getReport();
 
     report.getReportsList().forEach(c -> {
@@ -166,9 +182,7 @@ public class ContainerSafeModeRule extends
       SCMSafeModeManager.getLogger().info(
           "SCM in safe mode. {} % containers [Ratis] have at least one"
           + " reported replica, {} % containers [EC] have at N reported replica.",
-          ((ratisContainerWithMinReplicas.doubleValue() / getRatisMaxContainer()) * 100),
-          ((ecContainerWithMinReplicas.doubleValue() / getEcMaxContainer()) * 100)
-      );
+          getCurrentContainerThreshold() * 100, getCurrentECContainerThreshold() * 100);
     }
   }
 
@@ -246,8 +260,8 @@ public class ContainerSafeModeRule extends
     String status = String.format(
         "%1.2f%% of [Ratis] Containers(%s / %s) with at least one reported replica (=%1.2f) >= " +
         "safeModeCutoff (=%1.2f);",
-        (ratisContainerWithMinReplicas.doubleValue() / getRatisMaxContainer()) * 100,
-        ratisContainerWithMinReplicas, (long) getRatisMaxContainer(),
+        getCurrentContainerThreshold() * 100,
+        ratisContainerWithMinReplicas, (long) ratisMaxContainer,
         getCurrentContainerThreshold(), this.safeModeCutoff);
 
     Set<Long> sampleRatisContainers = ratisContainers.stream().
@@ -264,8 +278,8 @@ public class ContainerSafeModeRule extends
     String ecStatus = String.format(
         "%1.2f%% of [EC] Containers(%s / %s) with at least N reported replica (=%1.2f) >= " +
         "safeModeCutoff (=%1.2f);",
-        (ecContainerWithMinReplicas.doubleValue() / getEcMaxContainer()) * 100,
-        ecContainerWithMinReplicas, (long) getEcMaxContainer(),
+        getCurrentECContainerThreshold() * 100,
+        ecContainerWithMinReplicas, (long) ecMaxContainer,
         getCurrentECContainerThreshold(), this.safeModeCutoff);
     status = status.concat("\n").concat(ecStatus);
 
@@ -295,25 +309,19 @@ public class ContainerSafeModeRule extends
 
   @Override
   public synchronized void refresh(boolean forceRefresh) {
-    List<ContainerInfo> containers = containerManager.getContainers();
-    if (forceRefresh) {
-      initializeRule(containers);
-    } else {
-      if (!validate()) {
-        initializeRule(containers);
-      }
+    if (forceRefresh || !validate()) {
+      initializeRule();
     }
   }
 
-  private boolean checkContainerState(LifeCycleState state) {
-    if (state == LifeCycleState.QUASI_CLOSED || state == LifeCycleState.CLOSED) {
-      return true;
-    }
-    return false;
+  private boolean isClosed(ContainerInfo container) {
+    final LifeCycleState state = container.getState();
+    return state == LifeCycleState.QUASI_CLOSED ||
+        state == LifeCycleState.CLOSED;
   }
 
-  private void initializeRule(List<ContainerInfo> containers) {
-
+  private void initializeRule() {
+    final List<ContainerInfo> containers = containerManager.getContainers();
     // Clean up the related data in the map.
     ratisContainers.clear();
     ecContainers.clear();
@@ -325,10 +333,9 @@ public class ContainerSafeModeRule extends
       // created by the client. We are not considering these containers for
       // now. These containers can be handled by tracking pipelines.
 
-      LifeCycleState containerState = container.getState();
       HddsProtos.ReplicationType replicationType = container.getReplicationType();
 
-      if (checkContainerState(containerState) && container.getNumberOfKeys() > 0) {
+      if (isClosed(container) && container.getNumberOfKeys() > 0) {
         // If it's of type Ratis
         if (replicationType.equals(HddsProtos.ReplicationType.RATIS)) {
           ratisContainers.add(container.getContainerID());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.safemode;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -105,7 +104,6 @@ public class SCMSafeModeManager implements SafeModeManager {
   private Set<String> validatedPreCheckRules = new HashSet<>(1);
 
   private final EventQueue eventPublisher;
-  private final PipelineManager pipelineManager;
   private final SCMServiceManager serviceManager;
   private final SCMContext scmContext;
 
@@ -114,12 +112,10 @@ public class SCMSafeModeManager implements SafeModeManager {
 
   // TODO: Remove allContainers argument. (HDDS-11795)
   public SCMSafeModeManager(ConfigurationSource conf,
-             List<ContainerInfo> allContainers,
              ContainerManager containerManager, PipelineManager pipelineManager,
              EventQueue eventQueue, SCMServiceManager serviceManager,
              SCMContext scmContext) {
     this.config = conf;
-    this.pipelineManager = pipelineManager;
     this.eventPublisher = eventQueue;
     this.serviceManager = serviceManager;
     this.scmContext = scmContext;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
@@ -41,11 +41,23 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
   protected static final int SAMPLE_CONTAINER_DISPLAY_LIMIT = 5;
   protected static final int SAMPLE_PIPELINE_DISPLAY_LIMIT = 5;
 
+  // TODO: Report processing logic will be removed in future. HDDS-11958.
+  //   This flag is to add new code without breaking Safemode logic until we have HDDS-11958.
+  private boolean validateBasedOnReportProcessing = true;
+
   public SafeModeExitRule(SCMSafeModeManager safeModeManager,
       String ruleName, EventQueue eventQueue) {
     this.safeModeManager = safeModeManager;
     this.ruleName = ruleName;
     eventQueue.addHandler(getEventType(), this);
+  }
+
+  public void setValidateBasedOnReportProcessing(boolean newValue) {
+    validateBasedOnReportProcessing = newValue;
+  }
+
+  protected boolean validateBasedOnReportProcessing() {
+    return validateBasedOnReportProcessing;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -847,8 +847,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       scmSafeModeManager = configurator.getScmSafeModeManager();
     } else {
       scmSafeModeManager = new SCMSafeModeManager(conf,
-          containerManager.getContainers(), containerManager,
-          pipelineManager, eventQueue, serviceManager, scmContext);
+         containerManager, pipelineManager, eventQueue,
+          serviceManager, scmContext);
     }
 
     scmDecommissionManager = new NodeDecommissionManager(conf, scmNodeManager, containerManager,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -847,7 +847,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       scmSafeModeManager = configurator.getScmSafeModeManager();
     } else {
       scmSafeModeManager = new SCMSafeModeManager(conf,
-         containerManager, pipelineManager, eventQueue,
+          containerManager, pipelineManager, eventQueue,
           serviceManager, scmContext);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -162,8 +162,7 @@ public class TestBlockManager {
             new ContainerReplicaPendingOps(
                 Clock.system(ZoneId.systemDefault())));
     SCMSafeModeManager safeModeManager = new SCMSafeModeManager(conf,
-        containerManager.getContainers(), containerManager,
-        pipelineManager, eventQueue, serviceManager, scmContext) {
+        containerManager, pipelineManager, eventQueue, serviceManager, scmContext) {
       @Override
       public void emitSafeModeStatus() {
         // skip

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -358,7 +358,7 @@ public class TestPipelineManagerImpl {
   public void testPipelineReport() throws Exception {
     try (PipelineManagerImpl pipelineManager = createPipelineManager(true)) {
       SCMSafeModeManager scmSafeModeManager =
-          new SCMSafeModeManager(conf, new ArrayList<>(),
+          new SCMSafeModeManager(conf,
               mock(ContainerManager.class), pipelineManager,
               new EventQueue(), serviceManager, scmContext);
       Pipeline pipeline = pipelineManager
@@ -469,7 +469,7 @@ public class TestPipelineManagerImpl {
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(new OzoneConfiguration(), new ArrayList<>(),
+        new SCMSafeModeManager(new OzoneConfiguration(),
             mock(ContainerManager.class), pipelineManager, new EventQueue(),
             serviceManager, scmContext);
     PipelineReportHandler pipelineReportHandler =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -99,7 +99,7 @@ public class TestHealthyPipelineSafeModeRule {
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, containerManager, pipelineManager, eventQueue,
+          config, containerManager, pipelineManager, eventQueue,
           serviceManager, scmContext);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =
@@ -179,7 +179,7 @@ public class TestHealthyPipelineSafeModeRule {
       MockRatisPipelineProvider.markPipelineHealthy(pipeline3);
 
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, containerManager, pipelineManager, eventQueue,
+          config, containerManager, pipelineManager, eventQueue,
           serviceManager, scmContext);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =
@@ -275,7 +275,7 @@ public class TestHealthyPipelineSafeModeRule {
       MockRatisPipelineProvider.markPipelineHealthy(pipeline3);
 
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, containerManager, pipelineManager, eventQueue,
+          config, containerManager, pipelineManager, eventQueue,
           serviceManager, scmContext);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -120,7 +120,7 @@ public class TestOneReplicaPipelineSafeModeRule {
         HddsProtos.ReplicationFactor.ONE);
 
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(ozoneConfiguration, containers, containerManager,
+        new SCMSafeModeManager(ozoneConfiguration, containerManager,
             pipelineManager, eventQueue, serviceManager, scmContext);
 
     rule = scmSafeModeManager.getOneReplicaPipelineSafeModeRule();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -136,7 +136,7 @@ public class TestSCMSafeModeManager {
     ContainerManager containerManager = mock(ContainerManager.class);
     when(containerManager.getContainers()).thenReturn(containers);
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, containerManager, null, queue,
+        config, containerManager, null, queue,
         serviceManager, scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
@@ -175,7 +175,7 @@ public class TestSCMSafeModeManager {
     ContainerManager containerManager = mock(ContainerManager.class);
     when(containerManager.getContainers()).thenReturn(containers);
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, containerManager, null, queue,
+        config, containerManager, null, queue,
         serviceManager, scmContext);
 
     long cutOff = (long) Math.ceil(numContainers * config.getDouble(
@@ -244,7 +244,7 @@ public class TestSCMSafeModeManager {
     ContainerManager containerManager = mock(ContainerManager.class);
     when(containerManager.getContainers()).thenReturn(containers);
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-        () -> new SCMSafeModeManager(conf, containers, containerManager,
+        () -> new SCMSafeModeManager(conf, containerManager,
             pipelineManager, queue, serviceManager, scmContext));
     assertThat(exception).hasMessageEndingWith("value should be >= 0.0 and <= 1.0");
   }
@@ -311,7 +311,7 @@ public class TestSCMSafeModeManager {
     when(containerManager.getContainers()).thenReturn(containers);
 
     scmSafeModeManager = new SCMSafeModeManager(
-        conf, containers, containerManager, pipelineManager, queue, serviceManager,
+        conf, containerManager, pipelineManager, queue, serviceManager,
         scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
@@ -447,7 +447,7 @@ public class TestSCMSafeModeManager {
     ContainerManager containerManager = mock(ContainerManager.class);
     when(containerManager.getContainers()).thenReturn(containers);
     scmSafeModeManager = new SCMSafeModeManager(
-        conf, containers, containerManager, pipelineManager, queue, serviceManager,
+        conf, containerManager, pipelineManager, queue, serviceManager,
         scmContext);
     assertFalse(scmSafeModeManager.getInSafeMode());
   }
@@ -489,7 +489,7 @@ public class TestSCMSafeModeManager {
     when(containerManager.getContainers()).thenReturn(containers);
 
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, containerManager, null, queue, serviceManager, scmContext);
+        config, containerManager, null, queue, serviceManager, scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
 
@@ -565,7 +565,7 @@ public class TestSCMSafeModeManager {
         new ContainerReplicaPendingOps(Clock.system(ZoneId.systemDefault())));
 
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, containerManager, pipelineManager, queue, serviceManager, scmContext);
+        config, containerManager, pipelineManager, queue, serviceManager, scmContext);
     assertTrue(scmSafeModeManager.getInSafeMode());
 
     // Only 20 containers are involved in the calculation,
@@ -588,7 +588,7 @@ public class TestSCMSafeModeManager {
     ContainerManager containerManager = mock(ContainerManager.class);
     when(containerManager.getContainers()).thenReturn(containers);
     scmSafeModeManager = new SCMSafeModeManager(
-        conf, containers, containerManager, null, queue,
+        conf, containerManager, null, queue,
         serviceManager, scmContext);
 
     // Assert SCM is in Safe mode.
@@ -702,7 +702,7 @@ public class TestSCMSafeModeManager {
       when(containerManager.getContainers()).thenReturn(containers);
 
       scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, containerManager, pipelineManager, queue, serviceManager,
+          config, containerManager, pipelineManager, queue, serviceManager,
           scmContext);
 
       SCMDatanodeProtocolServer.NodeRegistrationContainerReport nodeRegistrationContainerReport =
@@ -757,7 +757,7 @@ public class TestSCMSafeModeManager {
     when(containerManager.getContainers()).thenReturn(containers);
 
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, containerManager, pipelineManager, queue, serviceManager,
+        config, containerManager, pipelineManager, queue, serviceManager,
         scmContext);
 
     // Assert SCM is in Safe mode.


### PR DESCRIPTION
## What changes were proposed in this pull request?
ContainerSafeModeRule Refactor

Currently, the Safemode Rule validation is driven by processing of reports sent by Datanodes, this is unnecessary and this also introduces additional complexity as the `ContainerSafeModeRule` is maintaining the same information that the `ContainerManager` is maintaining.

Since the information about `Containers` are maintained at two different places, this can go out of sync and introduce bugs into `ContainerSafeModeRule` logic. (eg: [HDDS-5263](https://issues.apache.org/jira/browse/HDDS-5263))

We will move to a simpler model where `ContainerSafeModeRule` will not care about report processing but check `ContainerManager` to validate the rule.

This is part-1 of the change where we introduce logic to use `ContainerManager` for rule validation, this new logic is disabled by default (using `validateBasedOnReportProcessing` flag). The new logic will be enabled once all the `SafeModeRules` are updated with new logic.

## What is the link to the Apache JIRA

HDDS-11731

## How was this patch tested?

Existing unit and acceptance tests.

Additional unit test will be added in [HDDS-12000](https://issues.apache.org/jira/browse/HDDS-12000)
