### PR TITLE
HDDS-11957. Make breadcrumb scrollable for long path names in DiskUsage page

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duBreadcrumbNav/duBreadcrumbNav.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duBreadcrumbNav/duBreadcrumbNav.tsx
@@ -106,15 +106,15 @@ const DUBreadcrumbNav: React.FC<File> = ({
     //Push a new input to allow passing a path
     menuItems.push(
       <Menu.Item
-        key={`${lastPath}-search`}>
+        key={`${lastPath}-search`}
+        style={{ width: '100%'}}>
         <Input.Search
           placeholder='Enter Path'
           onSearch={handleSearch}
           onClick={(e) => {
             //Prevent menu close on click
             e.stopPropagation();
-          }}
-          style={{ width: 160}}/>
+          }} />
       </Menu.Item>
     )
     return (
@@ -162,11 +162,13 @@ const DUBreadcrumbNav: React.FC<File> = ({
   }
 
   return (
-    <Breadcrumb
-      separator={<CaretRightOutlined style={{ fontSize: '12px'}}/>}
+    <div id='breadcrumb-container'>
+      <Breadcrumb
+      separator={'/'}
       className='breadcrumb-nav'>
       {generateBreadCrumbs()}
     </Breadcrumb>
+    </div>
   )
 }
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duBreadcrumbNav/duBreadcrumbNav.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duBreadcrumbNav/duBreadcrumbNav.tsx
@@ -21,7 +21,7 @@ import React, { useState } from 'react';
 import { DUSubpath } from '@/v2/types/diskUsage.types';
 import { Breadcrumb, Menu, Input } from 'antd';
 import { MenuProps } from 'antd/es/menu';
-import { CaretDownOutlined, CaretRightOutlined, HomeFilled } from '@ant-design/icons';
+import { CaretDownOutlined, HomeFilled } from '@ant-design/icons';
 
 
 type File = {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.less
@@ -28,15 +28,24 @@
 .content-div {
   min-height: unset;
 
-  .breadcrumb-nav {
-    font-size: 0.9vw;
-    margin: 0px 0px 8px 8px;
-    .breadcrumb-nav-item {
-      background: transparent;
-      border: none !important;
-      cursor: pointer;
-      color: @primary-color;
-      
+  #breadcrumb-container {
+    overflow-y: hidden;
+    overflow-x: scroll;
+    padding: 0px 8px 16px 8px;
+    margin-bottom: 10px;
+    width: 100%;
+    height: 20%;
+
+    .breadcrumb-nav {
+      font-size: 0.9vw;
+      width: 85vw;
+      .breadcrumb-nav-item {
+        background: transparent;
+        border: none !important;
+        cursor: pointer;
+        color: @primary-color;
+        
+      }
     }
   }
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.less
@@ -30,15 +30,15 @@
 
   #breadcrumb-container {
     overflow-y: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
     padding: 0px 8px 16px 8px;
     margin-bottom: 10px;
-    width: 100%;
+    width: 83vw;
     height: 20%;
 
     .breadcrumb-nav {
       font-size: 0.9vw;
-      width: 85vw;
+      width: max-content;
       .breadcrumb-nav-item {
         background: transparent;
         border: none !important;


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11957. Make breadcrumb scrollable for long path names in DiskUsage page

Please describe your PR in detail:
* We use a breadcrumb to show the current path for which we are displaying the DU data
* When the path is long it causes the text to wrap to next line which is not ideal behaviour for a breadcrumb.
* This PR removes the wrapping behaviour and overflows to scroll instead.
* **Minor change**: The breadcrumb separators are changed to a `/` (slash) to follow path separator conventions instead of a right arrow

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11957

## How was this patch tested?
Patch was tested manually.

https://github.com/user-attachments/assets/f6cc61ed-1a66-444d-8246-7d2f335d6584