### PR TITLE
HDDS-11945. Improve startup message for ozone repair commands

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
@@ -31,7 +31,7 @@ import java.util.Scanner;
  * Ozone Repair Command line tool.
  */
 @CommandLine.Command(name = "ozone repair",
-    description = "Operational tool to repair Ozone",
+    description = "Repair is an advanced operation and the nodes being repaired should be stopped while it is running",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class OzoneRepair extends GenericCli implements ExtensibleParentCommand {
@@ -46,6 +46,10 @@ public class OzoneRepair extends GenericCli implements ExtensibleParentCommand {
 
   @Override
   public int execute(String[] argv) {
+    if (argv.length == 0 || argv[0].equals("--help") || argv[0].equals("-h")) {
+      return super.execute(argv);
+    }
+
     String currentUser = getSystemUserName();
     if (!("y".equalsIgnoreCase(getConsoleReadLineWithFormat(currentUser)))) {
       System.out.println("Aborting command.");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
@@ -31,7 +31,8 @@ import java.util.Scanner;
  * Ozone Repair Command line tool.
  */
 @CommandLine.Command(name = "ozone repair",
-    description = "Repair is an advanced operation and the nodes being repaired should be stopped while it is running",
+    description = "Repair is an advanced operation and the nodes being repaired " +
+        "should be stopped while it is running.",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class OzoneRepair extends GenericCli implements ExtensibleParentCommand {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
@@ -31,8 +31,8 @@ import java.util.Scanner;
  * Ozone Repair Command line tool.
  */
 @CommandLine.Command(name = "ozone repair",
-    description = "Repair is an advanced operation and the nodes being repaired " +
-        "should be stopped while it is running.",
+    description = "Advanced tool to repair Ozone. The nodes being repaired " +
+        "must be stopped before the tool is run.",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class OzoneRepair extends GenericCli implements ExtensibleParentCommand {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -67,7 +67,7 @@ public class TestOzoneRepair {
     OzoneRepair ozoneRepair = new OzoneRepair();
     System.setIn(new ByteArrayInputStream("N".getBytes(DEFAULT_ENCODING)));
 
-    int res = ozoneRepair.execute(new String[]{});
+    int res = ozoneRepair.execute(new String[]{"om", "fso-tree"});
     assertEquals(1, res);
     assertThat(out.toString(DEFAULT_ENCODING)).contains("Aborting command.");
     // prompt should contain the current user name as well
@@ -79,10 +79,19 @@ public class TestOzoneRepair {
     OzoneRepair ozoneRepair = new OzoneRepair();
     System.setIn(new ByteArrayInputStream("y".getBytes(DEFAULT_ENCODING)));
 
-    ozoneRepair.execute(new String[]{});
+    ozoneRepair.execute(new String[]{"om", "fso-tree"});
     assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_USER);
     // prompt should contain the current user name as well
     assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
+  }
+
+  @Test
+  void testOzoneRepairSkipsPromptWhenNoSubcommandProvided() throws Exception {
+    OzoneRepair ozoneRepair = new OzoneRepair();
+
+    // when no argument is passed, prompt should not be displayed
+    ozoneRepair.execute(new String[]{});
+    assertThat(err.toString(DEFAULT_ENCODING)).doesNotContain("ATTENTION: Running as user " + OZONE_USER);
   }
 
 }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -94,4 +94,16 @@ public class TestOzoneRepair {
     assertThat(err.toString(DEFAULT_ENCODING)).doesNotContain("ATTENTION: Running as user " + OZONE_USER);
   }
 
+  @Test
+  void testOzoneRepairSkipsPromptWhenHelpFlagProvided() throws Exception {
+    OzoneRepair ozoneRepair = new OzoneRepair();
+
+    // when --help or -h flag is passed, prompt should not be displayed
+    ozoneRepair.execute(new String[]{"--help"});
+    assertThat(err.toString(DEFAULT_ENCODING)).doesNotContain("ATTENTION: Running as user " + OZONE_USER);
+
+    ozoneRepair.execute(new String[]{"-h"});
+    assertThat(err.toString(DEFAULT_ENCODING)).doesNotContain("ATTENTION: Running as user " + OZONE_USER);
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Skip the warning prompt when invoked without arguments or with help flags (`--help` or `-h`). The prompt is now displayed only if the command is about to execute an operation.
- Update the help message to emphasize that repair is an advanced operation requiring nodes to be stopped while it runs.

## What is the link to the Apache JIRA
[HDDS-11945](https://issues.apache.org/jira/browse/HDDS-11945)

## How was this patch tested?
Tested the patch locally.

Before
```
bash-5.1$ ozone repair --help | -h
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Usage: ozone repair [-hV] [--verbose] [-conf=<configurationPath>]
                    [-D=<String=String>]... [COMMAND]
Operational tool to repair Ozone
      -conf=<configurationPath>

  -D, --set=<String=String>

  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
      --verbose   More verbose output. Show the stack trace of the errors.
Commands:
  cert-recover  Recover Deleted SCM Certificate from RocksDB
  ldb           Operational tool to repair RocksDB table.
  om            Operational tool to repair OM.
  quota         Operational tool to repair quota in OM DB.

```

After
```
bash-5.1$ ozone repair --help | -h
Usage: ozone repair [-hV] [--verbose] [-conf=<configurationPath>]
                    [-D=<String=String>]... [COMMAND]
Repair is an advanced operation and the nodes being repaired should be stopped
while it is running
      -conf=<configurationPath>

  -D, --set=<String=String>

  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
      --verbose   More verbose output. Show the stack trace of the errors.
Commands:
  cert-recover  Recover Deleted SCM Certificate from RocksDB
  ldb           Operational tool to repair RocksDB table.
  om            Operational tool to repair OM.
  quota         Operational tool to repair quota in OM DB.
```

Warning prompt should be displayed only when execution takes place.
```
bash-5.1$ ozone repair om fso-tree --db /data/metadata/om.db
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
FSO Repair Tool is running in debug mode .....
```

