### PR TITLE
HDDS-11869. Enable OM Ratis in TestOzoneDelegationTokenSecretManager

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -257,6 +257,10 @@ public class TestOzoneDelegationTokenSecretManager {
     Token<OzoneTokenIdentifier> token = secretManager.createToken(TEST_USER,
         TEST_USER,
         TEST_USER);
+    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
+        readProtoBuf(token.getIdentifier());
+    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
+    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
     Thread.sleep(10 * 5);
 
     if (restartSecretManager) {
@@ -264,6 +268,8 @@ public class TestOzoneDelegationTokenSecretManager {
     }
 
     long renewalTime = secretManager.renewToken(token, TEST_USER.toString());
+    secretManager.updateToken(token, OzoneTokenIdentifier.
+        readProtoBuf(token.getIdentifier()), expiryTime);
     assertThat(renewalTime).isGreaterThan(0);
   }
 
@@ -354,6 +360,10 @@ public class TestOzoneDelegationTokenSecretManager {
     secretManager.start(certificateClient);
     Token<OzoneTokenIdentifier> token = secretManager.createToken(TEST_USER,
         TEST_USER, TEST_USER);
+    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
+        readProtoBuf(token.getIdentifier());
+    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
+    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
     secretManager.cancelToken(token, TEST_USER.toString());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -59,7 +59,6 @@ import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
 
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -132,14 +131,6 @@ public class TestOzoneDelegationTokenSecretManager {
 
   private OzoneConfiguration createNewTestPath() throws IOException {
     OzoneConfiguration config = new OzoneConfiguration();
-    // When ratis is enabled, tokens are not updated to the store directly by
-    // OzoneDelegationTokenSecretManager. Tokens are updated via Ratis
-    // through the DoubleBuffer. Hence, to test
-    // OzoneDelegationTokenSecretManager, we should disable OM Ratis.
-    // TODO: Once HA and non-HA code paths are merged in
-    //  OzoneDelegationTokenSecretManager, this test should be updated to
-    //  test both ratis enabled and disabled case.
-    config.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, true);
     File newFolder = folder.toFile();
     if (!newFolder.exists()) {
       assertTrue(newFolder.mkdirs());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -265,8 +265,7 @@ public class TestOzoneDelegationTokenSecretManager {
     }
 
     long renewalTime = secretManager.renewToken(token, TEST_USER.toString());
-    secretManager.updateToken(token, OzoneTokenIdentifier.
-        readProtoBuf(token.getIdentifier()), expiryTime);
+    addToTokenStore(token);
     assertThat(renewalTime).isGreaterThan(0);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -257,10 +257,7 @@ public class TestOzoneDelegationTokenSecretManager {
     Token<OzoneTokenIdentifier> token = secretManager.createToken(TEST_USER,
         TEST_USER,
         TEST_USER);
-    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
-        readProtoBuf(token.getIdentifier());
-    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
-    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
+    addToTokenStore(token);
     Thread.sleep(10 * 5);
 
     if (restartSecretManager) {
@@ -293,10 +290,7 @@ public class TestOzoneDelegationTokenSecretManager {
     secretManager.start(certificateClient);
     Token<OzoneTokenIdentifier> token = secretManager.createToken(TEST_USER,
         TEST_USER, TEST_USER);
-    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
-        readProtoBuf(token.getIdentifier());
-    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
-    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
+    addToTokenStore(token);
     AccessControlException exception =
         assertThrows(AccessControlException.class,
             () -> secretManager.renewToken(token, "rougeUser"));
@@ -364,10 +358,7 @@ public class TestOzoneDelegationTokenSecretManager {
     secretManager.start(certificateClient);
     Token<OzoneTokenIdentifier> token = secretManager.createToken(TEST_USER,
         TEST_USER, TEST_USER);
-    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
-        readProtoBuf(token.getIdentifier());
-    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
-    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
+    addToTokenStore(token);
     secretManager.cancelToken(token, TEST_USER.toString());
   }
 
@@ -525,5 +516,12 @@ public class TestOzoneDelegationTokenSecretManager {
         .setOmServiceId(OzoneConsts.OM_SERVICE_ID_DEFAULT)
         .setSecretKeyClient(secretKeyClient)
         .build();
+  }
+
+  private void addToTokenStore(Token<OzoneTokenIdentifier> token) throws IOException {
+    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
+        readProtoBuf(token.getIdentifier());
+    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
+    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -139,7 +139,7 @@ public class TestOzoneDelegationTokenSecretManager {
     // TODO: Once HA and non-HA code paths are merged in
     //  OzoneDelegationTokenSecretManager, this test should be updated to
     //  test both ratis enabled and disabled case.
-    config.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
+    config.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, true);
     File newFolder = folder.toFile();
     if (!newFolder.exists()) {
       assertTrue(newFolder.mkdirs());
@@ -293,6 +293,10 @@ public class TestOzoneDelegationTokenSecretManager {
     secretManager.start(certificateClient);
     Token<OzoneTokenIdentifier> token = secretManager.createToken(TEST_USER,
         TEST_USER, TEST_USER);
+    OzoneTokenIdentifier ozoneTokenIdentifier = OzoneTokenIdentifier.
+        readProtoBuf(token.getIdentifier());
+    long renewDate = secretManager.updateToken(token, ozoneTokenIdentifier, expiryTime);
+    om.getMetadataManager().getDelegationTokenTable().put(ozoneTokenIdentifier, renewDate);
     AccessControlException exception =
         assertThrows(AccessControlException.class,
             () -> secretManager.renewToken(token, "rougeUser"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix tests to renew/cancel TestOzoneDelegationTokenSecretManager with OM Ratis enabled.
In ratis, create/renew token doesn't add token to store until `validateAndUpdateCache`.
Add `addToTokenStore` to the tests.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11869

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/12396367209
