### PR TITLE
HDDS-11961. Improve existing repair tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.ozone.repair.om;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -35,9 +35,9 @@ import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.repair.OzoneRepair;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -45,33 +45,40 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * FSORepairTool test cases.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestFSORepairTool {
+
   public static final Logger LOG = LoggerFactory.getLogger(TestFSORepairTool.class);
-  private static final ByteArrayOutputStream OUT = new ByteArrayOutputStream();
-  private static final ByteArrayOutputStream ERR = new ByteArrayOutputStream();
-  private static final PrintStream OLD_OUT = System.out;
-  private static final PrintStream OLD_ERR = System.err;
-  private static final String DEFAULT_ENCODING = UTF_8.name();
+  private static final int ORDER_DRY_RUN = 1;
+  //private static final int ORDER_REPAIR_SOME = 2; // TODO add test case
+  private static final int ORDER_REPAIR_ALL = 3;
+  private static final int ORDER_REPAIR_ALL_AGAIN = 4;
+  private static final int ORDER_RESTART_OM = 5;
+
   private static MiniOzoneCluster cluster;
   private static FileSystem fs;
   private static OzoneClient client;
@@ -81,6 +88,9 @@ public class TestFSORepairTool {
   private static FSORepairTool.Report vol2Report;
   private static FSORepairTool.Report fullReport;
   private static FSORepairTool.Report emptyReport;
+
+  private GenericTestUtils.PrintStreamCapturer out;
+  private GenericTestUtils.PrintStreamCapturer err;
 
   @BeforeAll
   public static void setup() throws Exception {
@@ -137,81 +147,73 @@ public class TestFSORepairTool {
 
   @BeforeEach
   public void init() throws Exception {
-    System.setOut(new PrintStream(OUT, false, DEFAULT_ENCODING));
-    System.setErr(new PrintStream(ERR, false, DEFAULT_ENCODING));
+    out = GenericTestUtils.captureOut();
+    err = GenericTestUtils.captureErr();
   }
 
   @AfterEach
   public void clean() throws Exception {
     // reset stream after each unit test
-    OUT.reset();
-    ERR.reset();
-
-    // restore system streams
-    System.setOut(OLD_OUT);
-    System.setErr(OLD_ERR);
+    IOUtils.closeQuietly(out, err);
   }
 
   @AfterAll
   public static void reset() throws IOException {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-    if (client != null) {
-      client.close();
-    }
-    IOUtils.closeQuietly(fs);
+    IOUtils.closeQuietly(fs, client, cluster);
   }
 
   /**
    * Test to check a connected tree with one bucket.
    * The output remains the same in debug and repair mode as the tree is connected.
-   * @throws Exception
    */
-  @Order(1)
-  @Test
-  public void testConnectedTreeOneBucket() throws Exception {
+  @Order(ORDER_DRY_RUN)
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testConnectedTreeOneBucket(boolean dryRun) {
     String expectedOutput = serializeReport(vol1Report);
 
     // Test the connected tree in debug mode.
-    String[] args = new String[] {"om", "fso-tree", "--db", dbPath, "-v", "/vol1", "-b", "bucket1"};
-    int exitCode = cmd.execute(args);
-    assertEquals(0, exitCode);
+    int exitCode = execute(dryRun, "-v", "/vol1", "-b", "bucket1");
+    assertEquals(0, exitCode, err.getOutput());
 
-    String cliOutput = OUT.toString(DEFAULT_ENCODING);
+    String cliOutput = out.getOutput();
     String reportOutput = extractRelevantSection(cliOutput);
-    Assertions.assertEquals(expectedOutput, reportOutput);
+    assertEquals(expectedOutput, reportOutput);
+  }
 
-    OUT.reset();
-    ERR.reset();
+  private int repair(String... args) {
+    return execute(false, args);
+  }
 
-    // Running again in repair mode should give same results since the tree is connected.
-    String[] args1 = new String[] {"om", "fso-tree", "--db", dbPath, "--repair", "-v", "/vol1", "-b", "bucket1"};
-    int exitCode1 = cmd.execute(args1);
-    assertEquals(0, exitCode1);
+  private int dryRun(String... args) {
+    return execute(true, args);
+  }
 
-    String cliOutput1 = OUT.toString(DEFAULT_ENCODING);
-    String reportOutput1 = extractRelevantSection(cliOutput1);
-    Assertions.assertEquals(expectedOutput, reportOutput1);
+  private int execute(boolean dryRun, String... args) {
+    List<String> argList = new ArrayList<>(Arrays.asList("om", "fso-tree", "--db", dbPath));
+    if (!dryRun) {
+      argList.add("--repair");
+    }
+    argList.addAll(Arrays.asList(args));
+
+    return cmd.execute(argList.toArray(new String[0]));
   }
 
   /**
    * Test to verify the file size of the tree.
-   * @throws Exception
    */
-  @Order(2)
+  @Order(ORDER_DRY_RUN)
   @Test
-  public void testReportedDataSize() throws Exception {
+  public void testReportedDataSize() {
     String expectedOutput = serializeReport(vol2Report);
 
-    String[] args = new String[] {"om", "fso-tree", "--db", dbPath, "-v", "/vol2"};
-    int exitCode = cmd.execute(args);
+    int exitCode = dryRun("-v", "/vol2");
     assertEquals(0, exitCode);
 
-    String cliOutput = OUT.toString(DEFAULT_ENCODING);
+    String cliOutput = out.getOutput();
     String reportOutput = extractRelevantSection(cliOutput);
 
-    Assertions.assertEquals(expectedOutput, reportOutput);
+    assertEquals(expectedOutput, reportOutput);
   }
 
   /**
@@ -222,132 +224,127 @@ public class TestFSORepairTool {
    * - Non-existent volume.
    * - Using a bucket filter without specifying a volume.
    */
-  @Order(3)
+  @Order(ORDER_DRY_RUN)
   @Test
-  public void testVolumeAndBucketFilter() throws Exception {
+  public void testVolumeFilter() {
+    String expectedOutput1 = serializeReport(vol1Report);
+
     // When volume filter is passed
-    String[] args1 = new String[]{"om", "fso-tree", "--db", dbPath, "--volume", "/vol1"};
-    int exitCode1 = cmd.execute(args1);
+    int exitCode1 = dryRun("--volume", "/vol1");
     assertEquals(0, exitCode1);
 
-    String cliOutput1 = OUT.toString(DEFAULT_ENCODING);
+    String cliOutput1 = out.getOutput();
     String reportOutput1 = extractRelevantSection(cliOutput1);
-    String expectedOutput1 = serializeReport(vol1Report);
-    Assertions.assertEquals(expectedOutput1, reportOutput1);
+    assertEquals(expectedOutput1, reportOutput1);
+  }
 
-    OUT.reset();
-    ERR.reset();
+  @Order(ORDER_DRY_RUN)
+  @Test
+  public void testVolumeAndBucketFilter() {
+    String expectedOutput2 = serializeReport(vol1Report);
 
     // When both volume and bucket filters are passed
-    String[] args2 = new String[]{"om", "fso-tree", "--db", dbPath, "--volume", "/vol1",
-        "--bucket", "bucket1"};
-    int exitCode2 = cmd.execute(args2);
+    int exitCode2 = dryRun("--volume", "/vol1", "--bucket", "bucket1");
     assertEquals(0, exitCode2);
 
-    String cliOutput2 = OUT.toString(DEFAULT_ENCODING);
+    String cliOutput2 = out.getOutput();
     String reportOutput2 = extractRelevantSection(cliOutput2);
-    String expectedOutput2 = serializeReport(vol1Report);
-    Assertions.assertEquals(expectedOutput2, reportOutput2);
+    assertEquals(expectedOutput2, reportOutput2);
+  }
 
-    OUT.reset();
-    ERR.reset();
-
+  @Order(ORDER_DRY_RUN)
+  @Test
+  public void testNonExistentBucket() {
     // When a non-existent bucket filter is passed
-    String[] args3 = new String[]{"om", "fso-tree", "--db", dbPath, "--volume", "/vol1",
-        "--bucket", "bucket3"};
-    int exitCode3 = cmd.execute(args3);
-    assertEquals(0, exitCode3);
-    String cliOutput3 = OUT.toString(DEFAULT_ENCODING);
-    Assertions.assertTrue(cliOutput3.contains("Bucket 'bucket3' does not exist in volume '/vol1'."));
+    int exitCode = dryRun("--volume", "/vol1", "--bucket", "bucket3");
+    assertEquals(0, exitCode);
+    String cliOutput = out.getOutput();
+    assertThat(cliOutput).contains("Bucket 'bucket3' does not exist in volume '/vol1'.");
+  }
 
-    OUT.reset();
-    ERR.reset();
-
+  @Order(ORDER_DRY_RUN)
+  @Test
+  public void testNonExistentVolume() {
     // When a non-existent volume filter is passed
-    String[] args4 = new String[]{"om", "fso-tree", "--db", dbPath, "--volume", "/vol5"};
-    int exitCode4 = cmd.execute(args4);
-    assertEquals(0, exitCode4);
-    String cliOutput4 = OUT.toString(DEFAULT_ENCODING);
-    Assertions.assertTrue(cliOutput4.contains("Volume '/vol5' does not exist."));
+    int exitCode = dryRun("--volume", "/vol5");
+    assertEquals(0, exitCode);
+    String cliOutput = out.getOutput();
+    assertThat(cliOutput).contains("Volume '/vol5' does not exist.");
+  }
 
-    OUT.reset();
-    ERR.reset();
-
+  @Order(ORDER_DRY_RUN)
+  @Test
+  public void testBucketFilterWithoutVolume() {
     // When bucket filter is passed without the volume filter.
-    String[] args5 = new String[]{"om", "fso-tree", "--db", dbPath, "--bucket", "bucket1"};
-    int exitCode5 = cmd.execute(args5);
-    assertEquals(0, exitCode5);
-    String cliOutput5 = OUT.toString(DEFAULT_ENCODING);
-    Assertions.assertTrue(cliOutput5.contains("--bucket flag cannot be used without specifying --volume."));
+    int exitCode = dryRun("--bucket", "bucket1");
+    assertEquals(0, exitCode);
+    String cliOutput = out.getOutput();
+    assertThat(cliOutput).contains("--bucket flag cannot be used without specifying --volume.");
   }
 
   /**
    * Test to verify that non-fso buckets, such as legacy and obs, are skipped during the process.
-   * @throws Exception
    */
-  @Order(4)
+  @Order(ORDER_DRY_RUN)
   @Test
-  public void testNonFSOBucketsSkipped() throws Exception {
-    String[] args = new String[] {"om", "fso-tree", "--db", dbPath};
-    int exitCode = cmd.execute(args);
+  public void testNonFSOBucketsSkipped() {
+    int exitCode = dryRun();
     assertEquals(0, exitCode);
 
-    String cliOutput = OUT.toString(DEFAULT_ENCODING);
-    Assertions.assertTrue(cliOutput.contains("Skipping non-FSO bucket /vol1/obs-bucket"));
-    Assertions.assertTrue(cliOutput.contains("Skipping non-FSO bucket /vol1/legacy-bucket"));
+    String cliOutput = out.getOutput();
+    assertThat(cliOutput).contains("Skipping non-FSO bucket /vol1/obs-bucket");
+    assertThat(cliOutput).contains("Skipping non-FSO bucket /vol1/legacy-bucket");
   }
 
   /**
    * If no file is present inside a vol/bucket, the report statistics should be zero.
-   * @throws Exception
    */
-  @Order(5)
+  @Order(ORDER_DRY_RUN)
   @Test
-  public void testEmptyFileTrees() throws Exception {
+  public void testEmptyFileTrees() {
     String expectedOutput = serializeReport(emptyReport);
 
     // Run on an empty volume and bucket
-    String[] args = new String[] {"om", "fso-tree", "--db", dbPath, "-v", "/vol-empty", "-b", "bucket-empty"};
-    int exitCode = cmd.execute(args);
+    int exitCode = dryRun("-v", "/vol-empty", "-b", "bucket-empty");
     assertEquals(0, exitCode);
 
-    String cliOutput = OUT.toString(DEFAULT_ENCODING);
+    String cliOutput = out.getOutput();
     String reportOutput = extractRelevantSection(cliOutput);
-    Assertions.assertEquals(expectedOutput, reportOutput);
+    assertEquals(expectedOutput, reportOutput);
   }
 
   /**
    * Test in repair mode. This test ensures that:
    * - The initial repair correctly resolves unreferenced objects.
    * - Subsequent repair runs do not find any unreferenced objects to process.
-   * @throws Exception
    */
-  @Order(6)
+  @Order(ORDER_REPAIR_ALL)
   @Test
-  public void testMultipleBucketsAndVolumes() throws Exception {
+  public void testMultipleBucketsAndVolumes() {
     String expectedOutput = serializeReport(fullReport);
 
-    String[] args = new String[] {"om", "fso-tree", "--db", dbPath, "--repair"};
-    int exitCode = cmd.execute(args);
+    int exitCode = repair();
     assertEquals(0, exitCode);
 
-    String cliOutput = OUT.toString(DEFAULT_ENCODING);
+    String cliOutput = out.getOutput();
     String reportOutput = extractRelevantSection(cliOutput);
-    Assertions.assertEquals(expectedOutput, reportOutput);
-    Assertions.assertTrue(cliOutput.contains("Unreferenced:\n\tDirectories: 1\n\tFiles: 3\n\tBytes: 30"));
+    assertEquals(expectedOutput, reportOutput);
+    assertThat(cliOutput).contains("Unreferenced:\n\tDirectories: 1\n\tFiles: 3\n\tBytes: 30");
+  }
 
-    String[] args1 = new String[] {"om", "fso-tree", "--db", dbPath, "--repair"};
-    int exitCode1 = cmd.execute(args1);
-    assertEquals(0, exitCode1);
-    String cliOutput1 = OUT.toString(DEFAULT_ENCODING);
-    Assertions.assertTrue(cliOutput1.contains("Unreferenced:\n\tDirectories: 0\n\tFiles: 0\n\tBytes: 0"));
+  @Order(ORDER_REPAIR_ALL_AGAIN)
+  @Test
+  public void repairAllAgain() {
+    int exitCode = repair();
+    assertEquals(0, exitCode);
+    String cliOutput = out.getOutput();
+    assertThat(cliOutput).contains("Unreferenced:\n\tDirectories: 0\n\tFiles: 0\n\tBytes: 0");
   }
 
   /**
    * Validate cluster state after OM restart by checking the tables.
-   * @throws Exception
    */
-  @Order(7)
+  @Order(ORDER_RESTART_OM)
   @Test
   public void validateClusterAfterRestart() throws Exception {
     cluster.getOzoneManager().restart();
@@ -469,13 +466,13 @@ public class TestFSORepairTool {
     Path dir3 = new Path(bucketPath, "dir3");
     Path file4 = new Path(bucketPath, "file4");
 
-    Assertions.assertTrue(fs.exists(dir1));
-    Assertions.assertTrue(fs.exists(dir2));
-    Assertions.assertTrue(fs.exists(dir3));
-    Assertions.assertTrue(fs.exists(file1));
-    Assertions.assertTrue(fs.exists(file2));
-    Assertions.assertTrue(fs.exists(file3));
-    Assertions.assertTrue(fs.exists(file4));
+    assertTrue(fs.exists(dir1));
+    assertTrue(fs.exists(dir2));
+    assertTrue(fs.exists(dir3));
+    assertTrue(fs.exists(file1));
+    assertTrue(fs.exists(file2));
+    assertTrue(fs.exists(file3));
+    assertTrue(fs.exists(file4));
   }
 
   /**
@@ -530,12 +527,12 @@ public class TestFSORepairTool {
     Path dir3 = new Path(bucketPath, "dir3");
     Path file4 = new Path(bucketPath, "file4");
 
-    Assertions.assertFalse(fs.exists(dir1));
-    Assertions.assertFalse(fs.exists(dir2));
-    Assertions.assertTrue(fs.exists(dir3));
-    Assertions.assertFalse(fs.exists(file1));
-    Assertions.assertFalse(fs.exists(file2));
-    Assertions.assertFalse(fs.exists(file3));
-    Assertions.assertTrue(fs.exists(file4));
+    assertFalse(fs.exists(dir1));
+    assertFalse(fs.exists(dir2));
+    assertTrue(fs.exists(dir3));
+    assertFalse(fs.exists(file1));
+    assertFalse(fs.exists(file2));
+    assertFalse(fs.exists(file3));
+    assertTrue(fs.exists(file4));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -172,7 +172,6 @@ public class TestFSORepairTool {
   void testConnectedTreeOneBucket(boolean dryRun) {
     String expectedOutput = serializeReport(vol1Report);
 
-    // Test the connected tree in debug mode.
     int exitCode = execute(dryRun, "-v", "/vol1", "-b", "bucket1");
     assertEquals(0, exitCode, err.getOutput());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -180,24 +180,6 @@ public class TestFSORepairTool {
     assertEquals(expectedOutput, reportOutput);
   }
 
-  private int repair(String... args) {
-    return execute(false, args);
-  }
-
-  private int dryRun(String... args) {
-    return execute(true, args);
-  }
-
-  private int execute(boolean dryRun, String... args) {
-    List<String> argList = new ArrayList<>(Arrays.asList("om", "fso-tree", "--db", dbPath));
-    if (!dryRun) {
-      argList.add("--repair");
-    }
-    argList.addAll(Arrays.asList(args));
-
-    return cmd.execute(argList.toArray(new String[0]));
-  }
-
   /**
    * Test to verify the file size of the tree.
    */
@@ -356,6 +338,24 @@ public class TestFSORepairTool {
     assertEquals(1, countTableEntries(cluster.getOzoneManager().getMetadataManager().getDeletedDirTable()));
     // 3 files are unreferenced and moved to the deletedTable during repair mode.
     assertEquals(3, countTableEntries(cluster.getOzoneManager().getMetadataManager().getDeletedTable()));
+  }
+
+  private int repair(String... args) {
+    return execute(false, args);
+  }
+
+  private int dryRun(String... args) {
+    return execute(true, args);
+  }
+
+  private int execute(boolean dryRun, String... args) {
+    List<String> argList = new ArrayList<>(Arrays.asList("om", "fso-tree", "--db", dbPath));
+    if (!dryRun) {
+      argList.add("--repair");
+    }
+    argList.addAll(Arrays.asList(args));
+
+    return cmd.execute(argList.toArray(new String[0]));
   }
 
   private <K, V> int countTableEntries(Table<K, V> table) throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,22 +18,21 @@
 package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.debug.ldb.RDBParser;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.debug.OzoneDebug;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.repair.OzoneRepair;
-import org.apache.hadoop.ozone.repair.ldb.RDBRepair;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,18 +40,14 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Test Ozone Repair shell.
  */
 public class TestOzoneRepairShell {
 
-  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
-  private static final PrintStream OLD_OUT = System.out;
-  private static final PrintStream OLD_ERR = System.err;
-  private static final String DEFAULT_ENCODING = UTF_8.name();
+  private GenericTestUtils.PrintStreamCapturer out;
+  private GenericTestUtils.PrintStreamCapturer err;
   private static MiniOzoneCluster cluster = null;
   private static OzoneConfiguration conf = null;
 
@@ -67,24 +62,24 @@ public class TestOzoneRepairShell {
 
   @BeforeEach
   public void setup() throws Exception {
-    System.setOut(new PrintStream(out, false, DEFAULT_ENCODING));
-    System.setErr(new PrintStream(err, false, DEFAULT_ENCODING));
+    out = GenericTestUtils.captureOut();
+    err = GenericTestUtils.captureErr();
   }
 
   @AfterEach
   public void reset() {
     // reset stream after each unit test
-    out.reset();
-    err.reset();
+    IOUtils.closeQuietly(out, err);
+  }
 
-    // restore system streams
-    System.setOut(OLD_OUT);
-    System.setErr(OLD_ERR);
+  @AfterAll
+  static void cleanup() {
+    IOUtils.closeQuietly(cluster);
   }
 
   @Test
   public void testUpdateTransactionInfoTable() throws Exception {
-    CommandLine cmd = new CommandLine(new RDBRepair());
+    CommandLine cmd = new OzoneRepair().getCmd();
     String dbPath = new File(OMStorage.getOmDbDir(conf) + "/" + OM_DB_NAME).getPath();
 
     cluster.getOzoneManager().stop();
@@ -94,35 +89,33 @@ public class TestOzoneRepairShell {
 
     String testTerm = "1111";
     String testIndex = "1111";
-    String[] args =
-        new String[] {"--db=" + dbPath, "update-transaction", "--term", testTerm, "--index", testIndex};
-    int exitCode = cmd.execute(args);
-    assertEquals(0, exitCode);
-    assertThat(out.toString(DEFAULT_ENCODING)).contains(
-        "The original highest transaction Info was " +
-            String.format("(t:%s, i:%s)", originalHighestTermIndex[0], originalHighestTermIndex[1]));
-    assertThat(out.toString(DEFAULT_ENCODING)).contains(
-        String.format("The highest transaction info has been updated to: (t:%s, i:%s)",
-        testTerm, testIndex));
+    int exitCode = cmd.execute("ldb", "--db", dbPath, "update-transaction", "--term", testTerm, "--index", testIndex);
+    assertEquals(0, exitCode, err);
+    assertThat(out.get())
+        .contains(
+            "The original highest transaction Info was " +
+                String.format("(t:%s, i:%s)", originalHighestTermIndex[0], originalHighestTermIndex[1]),
+            String.format("The highest transaction info has been updated to: (t:%s, i:%s)", testTerm, testIndex)
+        );
 
     String cmdOut2 = scanTransactionInfoTable(dbPath);
     assertThat(cmdOut2).contains(testTerm + "#" + testIndex);
 
-    cmd.execute("--db=" + dbPath, "update-transaction", "--term",
+    cmd.execute("ldb", "--db", dbPath, "update-transaction", "--term",
         originalHighestTermIndex[0], "--index", originalHighestTermIndex[1]);
     cluster.getOzoneManager().restart();
-    cluster.newClient().getObjectStore().createVolume("vol1");
+    try (OzoneClient ozoneClient = cluster.newClient()) {
+      ozoneClient.getObjectStore().createVolume("vol1");
+    }
   }
 
-  private String scanTransactionInfoTable(String dbPath) throws Exception {
-    CommandLine cmdDBScanner = new CommandLine(new RDBParser());
-    String[] argsDBScanner =
-        new String[] {"--db=" + dbPath, "scan", "--column_family", "transactionInfoTable"};
-    cmdDBScanner.execute(argsDBScanner);
-    return out.toString(DEFAULT_ENCODING);
+  private String scanTransactionInfoTable(String dbPath) {
+    CommandLine debugCmd = new OzoneDebug().getCmd();
+    debugCmd.execute("ldb", "--db", dbPath, "scan", "--column_family", "transactionInfoTable");
+    return out.get();
   }
 
-  private String[] parseScanOutput(String output) throws IOException {
+  private String[] parseScanOutput(String output) {
     Pattern pattern = Pattern.compile(TRANSACTION_INFO_TABLE_TERM_INDEX_PATTERN);
     Matcher matcher = pattern.matcher(output);
     if (matcher.find()) {
@@ -135,19 +128,16 @@ public class TestOzoneRepairShell {
   public void testQuotaRepair() throws Exception {
     CommandLine cmd = new OzoneRepair().getCmd();
 
-    String[] args = new String[] {"quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
-    int exitCode = cmd.execute(args);
-    assertEquals(0, exitCode, err::toString);
-    args = new String[] {"quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
-    exitCode = cmd.execute(args);
-    assertEquals(0, exitCode);
+    int exitCode = cmd.execute("quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+    assertEquals(0, exitCode, err);
+    exitCode = cmd.execute("quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+    assertEquals(0, exitCode, err);
     GenericTestUtils.waitFor(() -> {
       out.reset();
       // verify quota trigger is completed having non-zero lastRunFinishedTime
-      String[] targs = new String[]{"quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
-      cmd.execute(targs);
+      cmd.execute("quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
       try {
-        return !out.toString(DEFAULT_ENCODING).contains("\"lastRunFinishedTime\":\"\"");
+        return out.get().contains("\"lastRunFinishedTime\":\"\"");
       } catch (Exception ex) {
         // do nothing
       }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestTransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestTransactionInfoRepair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,25 +17,26 @@
  */
 package org.apache.hadoop.ozone.repair.ldb;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
-import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.debug.RocksDBUtils;
+import org.apache.hadoop.ozone.repair.OzoneRepair;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import picocli.CommandLine;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.function.Supplier;
-
+import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TRANSACTION_INFO_TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
@@ -43,8 +44,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests TransactionInfoRepair.
@@ -55,31 +54,38 @@ public class TestTransactionInfoRepair {
   private static final String DB_PATH = "testDBPath";
   private static final long TEST_TERM = 1;
   private static final long TEST_INDEX = 1;
+  private GenericTestUtils.PrintStreamCapturer out;
+  private GenericTestUtils.PrintStreamCapturer err;
 
-  @Test
-  public void testUpdateTransactionInfoTableSuccessful() throws Exception {
-    ManagedRocksDB mdb = mockRockDB();
-    try (GenericTestUtils.SystemOutCapturer outCapturer = new GenericTestUtils.SystemOutCapturer()) {
-      testCommand(mdb, mock(ColumnFamilyHandle.class), () -> {
-        try {
-          return outCapturer.getOutput();
-        } catch (UnsupportedEncodingException e) {
-          throw new RuntimeException(e);
-        }
-      }, new String[]{String.format("The original highest transaction Info was (t:%s, i:%s)",
-          TEST_TERM, TEST_INDEX),
-              String.format("The highest transaction info has been updated to: (t:%s, i:%s)",
-                  TEST_TERM, TEST_INDEX)});
-    }
+  @BeforeEach
+  void setup() {
+    out = GenericTestUtils.captureOut();
+    err = GenericTestUtils.captureErr();
+  }
+
+  @AfterEach
+  void cleanup() {
+    IOUtils.closeQuietly(out, err);
   }
 
   @Test
-  public void testCommandWhenTableNotInDBForGivenPath() throws Exception {
+  public void testUpdateTransactionInfoTableSuccessful() {
     ManagedRocksDB mdb = mockRockDB();
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-        () -> testCommand(mdb, null, null, new String[]{""}));
-    assertThat(exception.getMessage()).contains(TRANSACTION_INFO_TABLE +
-        " is not in a column family in DB for the given path");
+    testCommand(mdb, mock(ColumnFamilyHandle.class));
+
+    assertThat(out.getOutput())
+        .contains(
+            String.format("The original highest transaction Info was (t:%s, i:%s)", TEST_TERM, TEST_INDEX),
+            String.format("The highest transaction info has been updated to: (t:%s, i:%s)", TEST_TERM, TEST_INDEX)
+        );
+  }
+
+  @Test
+  public void testCommandWhenTableNotInDBForGivenPath() {
+    ManagedRocksDB mdb = mockRockDB();
+    testCommand(mdb, null);
+    assertThat(err.getOutput())
+        .contains(TRANSACTION_INFO_TABLE + " is not in a column family in DB for the given path");
   }
 
   @Test
@@ -87,53 +93,45 @@ public class TestTransactionInfoRepair {
     ManagedRocksDB mdb = mockRockDB();
     RocksDB rdb = mdb.get();
 
+    ColumnFamilyHandle mock = mock(ColumnFamilyHandle.class);
     doThrow(RocksDBException.class).when(rdb)
-        .put(any(ColumnFamilyHandle.class), any(byte[].class), any(byte[].class));
+        .put(eq(mock), any(byte[].class), any(byte[].class));
 
-    IOException exception = assertThrows(IOException.class,
-        () -> testCommand(mdb, mock(ColumnFamilyHandle.class), null, new String[]{""}));
-    assertThat(exception.getMessage()).contains("Failed to update RocksDB.");
-    assertThat(exception.getCause()).isInstanceOf(RocksDBException.class);
+    testCommand(mdb, mock);
+
+    assertThat(err.getOutput())
+        .contains("Failed to update RocksDB.");
   }
 
 
-  private void testCommand(ManagedRocksDB mdb, ColumnFamilyHandle columnFamilyHandle, Supplier<String> capturer,
-                           String[] messages) throws Exception {
+  private void testCommand(ManagedRocksDB mdb, ColumnFamilyHandle columnFamilyHandle) {
     try (MockedStatic<ManagedRocksDB> mocked = mockStatic(ManagedRocksDB.class);
          MockedStatic<RocksDBUtils> mockUtil = mockStatic(RocksDBUtils.class)) {
       mocked.when(() -> ManagedRocksDB.open(anyString(), anyList(), anyList())).thenReturn(mdb);
       mockUtil.when(() -> RocksDBUtils.getColumnFamilyHandle(anyString(), anyList()))
           .thenReturn(columnFamilyHandle);
-      mockUtil.when(() ->
-          RocksDBUtils.getValue(any(ManagedRocksDB.class), any(ColumnFamilyHandle.class), anyString(),
-              any(Codec.class))).thenReturn(mock(TransactionInfo.class));
 
-      mockTransactionInfo(mockUtil);
+      mockUtil.when(() -> RocksDBUtils.getValue(eq(mdb), eq(columnFamilyHandle), eq(TRANSACTION_INFO_KEY),
+              eq(TransactionInfo.getCodec())))
+          .thenReturn(mock(TransactionInfo.class));
 
-      TransactionInfoRepair cmd = spy(TransactionInfoRepair.class);
-      RDBRepair rdbRepair = mock(RDBRepair.class);
-      when(rdbRepair.getDbPath()).thenReturn(DB_PATH);
-      when(cmd.getParent()).thenReturn(rdbRepair);
-      cmd.setHighestTransactionTerm(TEST_TERM);
-      cmd.setHighestTransactionIndex(TEST_INDEX);
+      mockUtil.when(() -> RocksDBUtils.getValue(eq(mdb), eq(columnFamilyHandle), eq(TRANSACTION_INFO_KEY),
+              eq(TransactionInfo.getCodec())))
+          .thenReturn(mock(TransactionInfo.class));
 
-      cmd.call();
-      for (String message : messages) {
-        assertThat(capturer.get()).contains(message);
-      }
+      TransactionInfo transactionInfo2 = TransactionInfo.valueOf(TermIndex.valueOf(TEST_TERM, TEST_INDEX));
+      mockUtil.when(() -> RocksDBUtils.getValue(eq(mdb), eq(columnFamilyHandle), eq(TRANSACTION_INFO_KEY),
+              eq(TransactionInfo.getCodec())))
+          .thenReturn(transactionInfo2);
+
+      CommandLine cli = new OzoneRepair().getCmd();
+      cli.execute(
+          "ldb",
+          "--db", DB_PATH,
+          "update-transaction",
+          "--term", String.valueOf(TEST_TERM),
+          "--index", String.valueOf(TEST_INDEX));
     }
-  }
-
-  private void mockTransactionInfo(MockedStatic<RocksDBUtils> mockUtil) {
-    mockUtil.when(() ->
-        RocksDBUtils.getValue(any(ManagedRocksDB.class), any(ColumnFamilyHandle.class), anyString(),
-            any(Codec.class))).thenReturn(mock(TransactionInfo.class));
-
-    TransactionInfo transactionInfo2 = mock(TransactionInfo.class);
-    doReturn(TermIndex.valueOf(TEST_TERM, TEST_INDEX)).when(transactionInfo2).getTermIndex();
-    mockUtil.when(() ->
-        RocksDBUtils.getValue(any(ManagedRocksDB.class), any(ColumnFamilyHandle.class), anyString(),
-            any(Codec.class))).thenReturn(transactionInfo2);
   }
 
   private ManagedRocksDB mockRockDB() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Code cleanup in `TestFSORepairTool`, `TestOzoneRepairShell`, and `TestTransactionInfoRepair`.

- `TestOzoneRepairShell` should shutdown cluster, close client.
- Reduce mocking.
- Test `ozone repair`, not subcommands.
- Less strict ordering of test cases in `TestFSORepairTool`.
- Reduce duplication by extracting method for executing `ozone repair om fso-tree` with/without `--repair` flag.
- Use static import for assertions.
- Use `assertThat` instead of `assertTrue` where applicable, for better failure message.
- Improve usability of `SystemOutCapturer`, `SystemErrCapturer` and reduce duplication.

https://issues.apache.org/jira/browse/HDDS-11961

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/12399956746