### PR TITLE
HDDS-11963. Unify client version and layout version under one interface to accomodate in the request validator framework

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hdds;
 
-import org.apache.hadoop.ozone.Version;
+import org.apache.hadoop.ozone.Versioned;
 
 /**
  * Base type for component version enums.
  */
-public interface ComponentVersion extends Version {
+public interface ComponentVersion extends Versioned {
 
   /**
    * Returns the description of the version enum value.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone;
 import org.apache.hadoop.hdds.ComponentVersion;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Map;
 
 import static java.util.function.Function.identity;
@@ -75,8 +76,8 @@ public enum ClientVersion implements ComponentVersion {
   }
 
   private static ClientVersion latest() {
-    ClientVersion[] versions = ClientVersion.values();
-    return versions[versions.length - 2];
+    return Arrays.stream(ClientVersion.values())
+        .max(Comparator.comparingInt(ComponentVersion::toProtoValue)).orElse(null);
   }
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/Version.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/Version.java
@@ -15,30 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hdds;
+package org.apache.hadoop.ozone;
 
-import org.apache.hadoop.ozone.Version;
 
 /**
- * Base type for component version enums.
+ * Base class defining the version in the entire system.
  */
-public interface ComponentVersion extends Version {
-
-  /**
-   * Returns the description of the version enum value.
-   * @return the description of the version enum value.
-   */
-  String description();
-
-  /**
-   * Returns the value that represents the enum in a protocol message
-   * transferred over the wire.
-   * @return the version associated with the enum value.
-   */
-  int toProtoValue();
-
-  @Override
-  default int version() {
-    return toProtoValue();
-  }
+public interface Version {
+  int version();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/Versioned.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/Versioned.java
@@ -21,6 +21,6 @@ package org.apache.hadoop.ozone;
 /**
  * Base class defining the version in the entire system.
  */
-public interface Version {
+public interface Versioned {
   int version();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/LayoutFeature.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/LayoutFeature.java
@@ -18,14 +18,14 @@
 
 package org.apache.hadoop.ozone.upgrade;
 
-import org.apache.hadoop.ozone.Version;
+import org.apache.hadoop.ozone.Versioned;
 
 import java.util.Optional;
 
 /**
  * Generic Layout feature interface for Ozone.
  */
-public interface LayoutFeature extends Version {
+public interface LayoutFeature extends Versioned {
   String name();
 
   int layoutVersion();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/LayoutFeature.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/LayoutFeature.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.ozone.upgrade;
 
+import org.apache.hadoop.ozone.Version;
+
 import java.util.Optional;
 
 /**
  * Generic Layout feature interface for Ozone.
  */
-public interface LayoutFeature {
+public interface LayoutFeature extends Version {
   String name();
 
   int layoutVersion();
@@ -46,6 +48,11 @@ public interface LayoutFeature {
     }
 
     void execute(T arg) throws Exception;
+  }
+
+  @Override
+  default int version() {
+    return this.layoutVersion();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/VersionExtractor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/VersionExtractor.java
@@ -17,7 +17,7 @@
 package org.apache.hadoop.ozone.om.request.validation;
 
 import org.apache.hadoop.ozone.ClientVersion;
-import org.apache.hadoop.ozone.Version;
+import org.apache.hadoop.ozone.Versioned;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
@@ -31,7 +31,7 @@ public enum VersionExtractor {
    */
   LAYOUT_VERSION_EXTRACTOR {
     @Override
-    public Version extractVersion(OMRequest req, ValidationContext ctx) {
+    public Versioned extractVersion(OMRequest req, ValidationContext ctx) {
       LayoutVersionManager layoutVersionManager = ctx.versionManager();
       return ctx.versionManager().getFeature(layoutVersionManager.getMetadataLayoutVersion());
     }
@@ -47,7 +47,7 @@ public enum VersionExtractor {
    */
   CLIENT_VERSION_EXTRACTOR {
     @Override
-    public Version extractVersion(OMRequest req, ValidationContext ctx) {
+    public Versioned extractVersion(OMRequest req, ValidationContext ctx) {
       return req.getVersion() > ClientVersion.CURRENT_VERSION ?
           ClientVersion.FUTURE_VERSION : ClientVersion.fromProtoValue(req.getVersion());
     }
@@ -58,6 +58,6 @@ public enum VersionExtractor {
     }
   };
 
-  public abstract Version extractVersion(OMRequest req, ValidationContext ctx);
-  public abstract Class<? extends Version> getVersionClass();
+  public abstract Versioned extractVersion(OMRequest req, ValidationContext ctx);
+  public abstract Class<? extends Versioned> getVersionClass();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/VersionExtractor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/VersionExtractor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.request.validation;
+
+import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.Version;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
+
+/**
+ * Class to extract version out of OM request.
+ */
+public enum VersionExtractor {
+  /**
+   * Extracts current metadata layout version.
+   */
+  LAYOUT_VERSION_EXTRACTOR {
+    @Override
+    public Version extractVersion(OMRequest req, ValidationContext ctx) {
+      LayoutVersionManager layoutVersionManager = ctx.versionManager();
+      return ctx.versionManager().getFeature(layoutVersionManager.getMetadataLayoutVersion());
+    }
+
+    @Override
+    public Class<OMLayoutFeature> getVersionClass() {
+      return OMLayoutFeature.class;
+    }
+  },
+
+  /**
+   * Extracts client version from the OMRequests.
+   */
+  CLIENT_VERSION_EXTRACTOR {
+    @Override
+    public Version extractVersion(OMRequest req, ValidationContext ctx) {
+      return req.getVersion() > ClientVersion.CURRENT_VERSION ?
+          ClientVersion.FUTURE_VERSION : ClientVersion.fromProtoValue(req.getVersion());
+    }
+
+    @Override
+    public Class<ClientVersion> getVersionClass() {
+      return ClientVersion.class;
+    }
+  };
+
+  public abstract Version extractVersion(OMRequest req, ValidationContext ctx);
+  public abstract Class<? extends Version> getVersionClass();
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestVersionExtractor.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestVersionExtractor.java
@@ -1,0 +1,58 @@
+package org.apache.hadoop.ozone.om.request.validation;
+
+import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.Version;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestVersionExtractor {
+
+  private static Stream<Arguments> layoutValues() {
+    return Arrays.stream(OMLayoutFeature.values()).map(Arguments::of);
+  }
+
+  private static Stream<Arguments> clientVersionValues() {
+    return Stream.of(
+        Arrays.stream(ClientVersion.values())
+            .map(clientVersion -> Arguments.of(clientVersion, clientVersion.version())),
+        IntStream.range(1, 10)
+            .mapToObj(delta -> Arguments.of(ClientVersion.FUTURE_VERSION, ClientVersion.CURRENT_VERSION + delta))
+        ).flatMap(Function.identity());
+  }
+
+  @ParameterizedTest
+  @MethodSource("layoutValues")
+  void testLayoutVersionExtractor(OMLayoutFeature layoutVersionValue) throws OMException {
+    ValidationContext context = mock(ValidationContext.class);
+    LayoutVersionManager layoutVersionManager = new OMLayoutVersionManager(layoutVersionValue.version());
+    when(context.versionManager()).thenReturn(layoutVersionManager);
+    Version version = VersionExtractor.LAYOUT_VERSION_EXTRACTOR.extractVersion(null, context);
+    assertEquals(layoutVersionValue, version);
+    assertEquals(OMLayoutFeature.class, VersionExtractor.LAYOUT_VERSION_EXTRACTOR.getVersionClass());
+  }
+
+  @ParameterizedTest
+  @MethodSource("clientVersionValues")
+  void testClientVersionExtractor(ClientVersion expectedClientVersion, int clientVersion) {
+    OMRequest request = mock(OMRequest.class);
+    when(request.getVersion()).thenReturn(clientVersion);
+    Version version = VersionExtractor.CLIENT_VERSION_EXTRACTOR.extractVersion(request, null);
+    assertEquals(expectedClientVersion, version);
+    assertEquals(ClientVersion.class, VersionExtractor.CLIENT_VERSION_EXTRACTOR.getVersionClass());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestVersionExtractor.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestVersionExtractor.java
@@ -24,22 +24,14 @@ import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class TestVersionExtractor {
-
-  private static Stream<Arguments> futureClientVersionValues() {
-    return IntStream.range(1, 10).mapToObj(delta -> Arguments.of(ClientVersion.CURRENT_VERSION + delta));
-  }
 
   @ParameterizedTest
   @EnumSource(OMLayoutFeature.class)
@@ -63,10 +55,10 @@ class TestVersionExtractor {
   }
 
   @ParameterizedTest
-  @MethodSource("futureClientVersionValues")
-  void testClientVersionExtractorForFutureValues(int clientVersion) {
+  @ValueSource(ints = {1, 2, 5, 10, 1000, 10000})
+  void testClientVersionExtractorForFutureValues(int futureVersion) {
     OMRequest request = mock(OMRequest.class);
-    when(request.getVersion()).thenReturn(clientVersion);
+    when(request.getVersion()).thenReturn(ClientVersion.CURRENT_VERSION + futureVersion);
     Versioned version = VersionExtractor.CLIENT_VERSION_EXTRACTOR.extractVersion(request, null);
     assertEquals(ClientVersion.FUTURE_VERSION, version);
     assertEquals(ClientVersion.class, VersionExtractor.CLIENT_VERSION_EXTRACTOR.getVersionClass());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestVersionExtractor.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestVersionExtractor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.ozone.om.request.validation;
 
 import org.apache.hadoop.ozone.ClientVersion;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently LayoutVersion & ClientVersion classes don't have a common base class even though they represent some sort version in the overall system. We should unify both these classes under one single interface which would help us perform some set of operations on the common base class in the request validator framework.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11963

## How was this patch tested?
Added new unit tests & existing unit tests 