### PR TITLE
HDDS-11964. Allow ozone sh bucket create to take obs and fso as options.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -68,7 +68,7 @@ File Can Be Deleted
 FSO Bucket Can Be Created and Used
     Pass Execution If    '${CLIENT_VERSION}' < '${FSO_VERSION}'    Client does not support FSO
     Pass Execution If    '${CLUSTER_VERSION}' < '${FSO_VERSION}'   Cluster does not support FSO
-    Execute    ozone sh bucket create --layout fso /vol1/fso-bucket-${CLIENT_VERSION}
+    Execute    ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /vol1/fso-bucket-${CLIENT_VERSION}
     Execute    ozone fs -mkdir -p ofs://om/vol1/fso-bucket-${CLIENT_VERSION}/dir/subdir
     Execute    ozone fs -put ${TESTFILE} ofs://om/vol1/fso-bucket-${CLIENT_VERSION}/dir/subdir/file
 

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -68,7 +68,7 @@ File Can Be Deleted
 FSO Bucket Can Be Created and Used
     Pass Execution If    '${CLIENT_VERSION}' < '${FSO_VERSION}'    Client does not support FSO
     Pass Execution If    '${CLUSTER_VERSION}' < '${FSO_VERSION}'   Cluster does not support FSO
-    Execute    ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /vol1/fso-bucket-${CLIENT_VERSION}
+    Execute    ozone sh bucket create --layout fso /vol1/fso-bucket-${CLIENT_VERSION}
     Execute    ozone fs -mkdir -p ofs://om/vol1/fso-bucket-${CLIENT_VERSION}/dir/subdir
     Execute    ozone fs -put ${TESTFILE} ofs://om/vol1/fso-bucket-${CLIENT_VERSION}/dir/subdir/file
 

--- a/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
@@ -32,7 +32,7 @@ Create volume
     ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --namespace-quota 100
                     Should not contain  ${result}       Failed
 Create bucket
-                    Execute             ozone sh bucket create /${volume}/${bucket} --space-quota 1TB --layout FILE_SYSTEM_OPTIMIZED
+                    Execute             ozone sh bucket create /${volume}/${bucket} --space-quota 1TB --layout fso
 
 *** Test Cases ***
 Create test volume, bucket and key

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-ldb.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-ldb.robot
@@ -31,7 +31,7 @@ ${TESTFILE}         testfile
 Write keys
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user     testuser     testuser.keytab
     Execute             ozone sh volume create ${VOLUME}
-    Execute             ozone sh bucket create ${VOLUME}/${BUCKET} -l OBJECT_STORE
+    Execute             ozone sh bucket create ${VOLUME}/${BUCKET} -l obs
     Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE}1 bs=100 count=10
     Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}1 ${TEMP_DIR}/${TESTFILE}1
     Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE}2 bs=100 count=15

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -66,17 +66,17 @@ public class CreateBucketHandler extends BucketHandler {
         return null;
       }
       switch (value) {
-        case "fso":
-          return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-        case "obs":
-          return BucketLayout.OBJECT_STORE;
-        default:
-          for (BucketLayout candidate : BucketLayout.values()) {
-            if (candidate.name().equalsIgnoreCase(value)) {
-              return candidate;
-            }
+      case "fso":
+        return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+      case "obs":
+        return BucketLayout.OBJECT_STORE;
+      default:
+        for (BucketLayout candidate : BucketLayout.values()) {
+          if (candidate.name().equalsIgnoreCase(value)) {
+            return candidate;
           }
-          throw new IllegalArgumentException("Unknown bucket layout: " + value);
+        }
+        throw new IllegalArgumentException("Unknown bucket layout: " + value);
       }
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -59,11 +59,31 @@ public class CreateBucketHandler extends BucketHandler {
               " user if not specified")
   private String ownerName;
 
-  enum AllowedBucketLayouts { FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY }
+  enum AllowedBucketLayouts {
+    FILE_SYSTEM_OPTIMIZED,
+    fso,
+    OBJECT_STORE,
+    obs,
+    LEGACY;
+
+    public static AllowedBucketLayouts fromString(String value) {
+      if (value.equals("FILE_SYSTEM_OPTIMIZED") || value.equalsIgnoreCase("fso")) {
+        return FILE_SYSTEM_OPTIMIZED;
+      }
+      if (value.equals("OBJECT_STORE") || value.equalsIgnoreCase("obs")) {
+        return OBJECT_STORE;
+      }
+      if (value.equals("LEGACY") || value.equalsIgnoreCase("legacy")) {
+        return LEGACY;
+      }
+      return valueOf(value); // throws IllegalArgumentException if not mapped to an enum, better than returning null
+    }
+  }
 
   @Option(names = { "--layout", "-l" },
-      description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}")
-  private AllowedBucketLayouts allowedBucketLayout;
+      description = "Allowed Bucket Layouts: fso (for file system optimized buckets FILE_SYSTEM_OPTIMIZED), " +
+          "obs (for object store optimized OBJECT_STORE) and legacy (LEGACY is Deprecated)")
+  private String allowedBucketLayout;
 
   @CommandLine.Mixin
   private ShellReplicationOptions replication;
@@ -87,7 +107,7 @@ public class CreateBucketHandler extends BucketHandler {
             .setVersioning(false).setOwner(ownerName);
     if (allowedBucketLayout != null) {
       BucketLayout bucketLayout =
-          BucketLayout.fromString(allowedBucketLayout.toString());
+          BucketLayout.fromString(AllowedBucketLayouts.fromString(allowedBucketLayout).toString());
       bb.setBucketLayout(bucketLayout);
     }
     // TODO: New Client talking to old server, will it create a LEGACY bucket?

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -82,8 +82,8 @@ public class CreateBucketHandler extends BucketHandler {
   }
 
   @Option(names = { "--layout", "-l" }, converter = LayoutConverter.class,
-      description = "Allowed Bucket Layouts: fso (for file system optimized buckets FILE_SYSTEM_OPTIMIZED), " +
-          "obs (for object store optimized OBJECT_STORE) and legacy (LEGACY is Deprecated)")
+          description = "Allowed Bucket Layouts: fso (for file system optimized buckets FILE_SYSTEM_OPTIMIZED), " +
+                  "obs (for object store optimized OBJECT_STORE) and legacy (LEGACY is Deprecated)")
   private BucketLayout allowedBucketLayout;
 
   @CommandLine.Mixin


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, one must use the enum used in the code to define the layout in the `ozone sh` command (`OBJECT_STORE` or `FILE_SYSTEM_OPTIMIZED`). This could be more helpful.
Adding the more commonly used terms `obs` and `fso` to the CLI.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11964

## How was this patch tested?

Some of the existing robot tests have been updated to use the new options.
