### PR TITLE
HDDS-11949. Update Recon OM Sync default configs

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3323,7 +3323,7 @@
   </property>
   <property>
     <name>ozone.recon.om.snapshot.task.interval.delay</name>
-    <value>10m</value>
+    <value>5s</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
       Interval in MINUTES by Recon to request OM DB Snapshot.
@@ -3339,7 +3339,7 @@
   </property>
   <property>
     <name>recon.om.delta.update.limit</name>
-    <value>2000</value>
+    <value>50000</value>
     <tag>OZONE, RECON</tag>
     <description>
       Recon each time get a limited delta updates from OM.
@@ -3360,7 +3360,7 @@
   </property>
   <property>
     <name>recon.om.delta.update.loop.limit</name>
-    <value>10</value>
+    <value>50</value>
     <tag>OZONE, RECON</tag>
     <description>
       The sync between Recon and OM consists of several small

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -85,7 +85,7 @@ public final class  ReconServerConfigKeys {
   public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY =
       "ozone.recon.om.snapshot.task.interval.delay";
   public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT
-      = "10m";
+      = "5s";
   @Deprecated
   public static final String RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY =
       "recon.om.snapshot.task.interval.delay";
@@ -98,10 +98,10 @@ public final class  ReconServerConfigKeys {
 
   public static final String RECON_OM_DELTA_UPDATE_LIMIT =
       "recon.om.delta.update.limit";
-  public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFUALT = 2000;
+  public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT = 50000;
   public static final String RECON_OM_DELTA_UPDATE_LOOP_LIMIT =
       "recon.om.delta.update.loop.limit";
-  public static final int RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFUALT = 10;
+  public static final int RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFAULT = 50;
 
   public static final String OZONE_RECON_TASK_THREAD_COUNT_KEY =
       "ozone.recon.task.thread.count";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -91,9 +91,9 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT_DEFUALT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LOOP_LIMIT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFUALT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconUtils.convertNumericToSymbolic;
 import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.LEADER;
 
@@ -178,10 +178,10 @@ public class OzoneManagerServiceProviderImpl
         .OZONE_OM_HTTPS_ADDRESS_KEY);
 
     long deltaUpdateLimits = configuration.getLong(RECON_OM_DELTA_UPDATE_LIMIT,
-        RECON_OM_DELTA_UPDATE_LIMIT_DEFUALT);
+        RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT);
     int deltaUpdateLoopLimits = configuration.getInt(
         RECON_OM_DELTA_UPDATE_LOOP_LIMIT,
-        RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFUALT);
+        RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFAULT);
 
     omSnapshotDBParentDir = reconUtils.getReconDbDir(configuration,
         OZONE_RECON_OM_SNAPSHOT_DB_DIR);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to update Recon OM Sync default configs values.

Default configs for recon om sync are recommended based on recent performance test and evaluation of recon om sync process and underlying tasks execution speed.

`Recommended configs default values:`

```
ozone.recon.om.snapshot.task.interval.delay -> 5s
recon.om.delta.update.limit -> 50000
recon.om.delta.update.loop.limit -> 50
```
Above are recommended and default configs for high write TPS workload in the range of approx 5k to achieve near real time sync between Recon and OM data.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11949

## How was this patch tested?
Tested manually with existing Junit test cases.
