### PR TITLE
HDDS-11870. Fix TestHSync overwrite cases for OM Ratis enabled

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -181,7 +181,7 @@ public class TestHSync {
   public static void init() throws Exception {
     final BucketLayout layout = BUCKET_LAYOUT;
 
-    CONF.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
+    CONF.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, true);
     CONF.set(OZONE_DEFAULT_BUCKET_LAYOUT, layout.name());
     CONF.setBoolean(OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED, true);
     CONF.setBoolean("ozone.client.hbase.enhancements.allowed", true);
@@ -1426,9 +1426,12 @@ public class TestHSync {
       outputStream2.hsync();
       outputStream2.close();
       assertEquals(data1.length() + data2.length(), metrics.getDataCommittedBytes());
+      // wait until double buffer flush
+      cluster.getOzoneManager().awaitDoubleBufferFlush();
 
       Map<String, OmKeyInfo> openKeys = getAllOpenKeys(openKeyTable);
       Map<String, RepeatedOmKeyInfo> deletedKeys = getAllDeletedKeys(deletedTable);
+
       // There should be no key in openKeyTable
       assertEquals(0, openKeys.size());
       // There should be one key in delete table
@@ -1503,6 +1506,8 @@ public class TestHSync {
       // hsync/close second hsync key should success
       outputStream2.hsync();
       outputStream2.close();
+      // wait until double buffer flush
+      cluster.getOzoneManager().awaitDoubleBufferFlush();
 
       Map<String, OmKeyInfo> openKeys = getAllOpenKeys(openKeyTable);
       Map<String, RepeatedOmKeyInfo> deletedKeys = getAllDeletedKeys(deletedTable);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testHSyncKeyOverwriteHSyncKey` and `testHSyncKeyOverwriteNormalKey` are frequently failed under the ratis enabled mode, this pr fixed it by waiting for double buffer cache to flush.

## What is the link to the Apache JIRA
Please check [HDDS-11870](https://issues.apache.org/jira/browse/HDDS-11870) for more details, thanks.

## How was this patch tested?
It can be tested by CI.