### PR TITLE
HDDS-8175. getFileChecksum() throws exception in debug mode.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -174,7 +174,7 @@ public abstract class BaseFileChecksumHelper {
    *     debug is enabled, otherwise null.
    */
 
-  protected String populateBlockChecksumBuf(ByteBuffer blockChecksumByteBuffer) throws IOException{
+  protected String populateBlockChecksumBuf(ByteBuffer blockChecksumByteBuffer) throws IOException {
     String blockChecksumForDebug = null;
     switch (getCombineMode()) {
     case MD5MD5CRC:

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -187,7 +187,7 @@ public abstract class BaseFileChecksumHelper {
     case COMPOSITE_CRC:
       byte[] crcBytes = blockChecksumByteBuffer.array();
       if (LOG.isDebugEnabled()) {
-        blockChecksumForDebug = CrcUtil.toSingleCrcString(crcBytes);
+        blockChecksumForDebug = CrcUtil.toMultiCrcString(crcBytes);
       }
       getBlockChecksumBuf().write(crcBytes);
       break;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -156,8 +156,6 @@ public abstract class BaseFileChecksumHelper {
   protected abstract AbstractBlockChecksumComputer getBlockChecksumComputer(List<ContainerProtos.ChunkInfo> chunkInfos,
       long blockLength);
 
-  protected abstract String populateBlockChecksumBuf(ByteBuffer blockChecksumByteBuffer) throws IOException;
-
   protected abstract List<ContainerProtos.ChunkInfo> getChunkInfos(
       OmKeyLocationInfo keyLocationInfo) throws IOException;
 
@@ -166,6 +164,39 @@ public abstract class BaseFileChecksumHelper {
     blockChecksumComputer.compute(getCombineMode());
     return blockChecksumComputer.getOutByteBuffer();
   }
+
+  /**
+   * Parses out the raw blockChecksum bytes from {@code checksumData} byte
+   * buffer according to the blockChecksumType and populates the cumulative
+   * blockChecksumBuf with it.
+   *
+   * @return a debug-string representation of the parsed checksum if
+   *     debug is enabled, otherwise null.
+   */
+
+  protected String populateBlockChecksumBuf(ByteBuffer blockChecksumByteBuffer) throws IOException{
+    String blockChecksumForDebug = null;
+    switch (getCombineMode()) {
+    case MD5MD5CRC:
+      final MD5Hash md5 = new MD5Hash(blockChecksumByteBuffer.array());
+      md5.write(getBlockChecksumBuf());
+      if (LOG.isDebugEnabled()) {
+        blockChecksumForDebug = md5.toString();
+      }
+      break;
+    case COMPOSITE_CRC:
+      byte[] crcBytes = blockChecksumByteBuffer.array();
+      if (LOG.isDebugEnabled()) {
+        blockChecksumForDebug = CrcUtil.toSingleCrcString(crcBytes);
+      }
+      getBlockChecksumBuf().write(crcBytes);
+      break;
+    default:
+      throw new IOException(
+          "Unknown combine mode: " + getCombineMode());
+    }
+    return blockChecksumForDebug;
+  };
 
   /**
    * Compute block checksums block by block and append the raw bytes of the

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -61,33 +61,6 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
   }
 
   @Override
-  protected String populateBlockChecksumBuf(
-      ByteBuffer blockChecksumByteBuffer) throws IOException {
-    String blockChecksumForDebug = null;
-    switch (getCombineMode()) {
-    case MD5MD5CRC:
-      final MD5Hash md5 = new MD5Hash(blockChecksumByteBuffer.array());
-      md5.write(getBlockChecksumBuf());
-      if (LOG.isDebugEnabled()) {
-        blockChecksumForDebug = md5.toString();
-      }
-      break;
-    case COMPOSITE_CRC:
-      byte[] crcBytes = blockChecksumByteBuffer.array();
-      if (LOG.isDebugEnabled()) {
-        blockChecksumForDebug = CrcUtil.toSingleCrcString(crcBytes);
-      }
-      getBlockChecksumBuf().write(crcBytes);
-      break;
-    default:
-      throw new IOException(
-          "Unknown combine mode: " + getCombineMode());
-    }
-
-    return blockChecksumForDebug;
-  }
-
-  @Override
   protected List<ContainerProtos.ChunkInfo> getChunkInfos(OmKeyLocationInfo
                                                               keyLocationInfo) throws IOException {
     // To read an EC block, we create a STANDALONE pipeline that contains the

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
-import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
@@ -37,7 +36,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
-import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
@@ -36,7 +35,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.List;
 
 /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -107,48 +107,4 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
 
     return chunks;
   }
-
-  /**
-   * Parses out the raw blockChecksum bytes from {@code checksumData} byte
-   * buffer according to the blockChecksumType and populates the cumulative
-   * blockChecksumBuf with it.
-   *
-   * @return a debug-string representation of the parsed checksum if
-   *     debug is enabled, otherwise null.
-   */
-  @Override
-  protected String populateBlockChecksumBuf(ByteBuffer checksumData)
-      throws IOException {
-    String blockChecksumForDebug = null;
-    switch (getCombineMode()) {
-    case MD5MD5CRC:
-      //read md5
-      final MD5Hash md5 = new MD5Hash(checksumData.array());
-      md5.write(getBlockChecksumBuf());
-      if (LOG.isDebugEnabled()) {
-        blockChecksumForDebug = md5.toString();
-      }
-      break;
-    case COMPOSITE_CRC:
-      // TODO: abort if chunk checksum type is not CRC32/CRC32C
-      //BlockChecksumType returnedType = PBHelperClient.convert(
-      //    checksumData.getBlockChecksumOptions().getBlockChecksumType());
-      /*if (returnedType != BlockChecksumType.COMPOSITE_CRC) {
-        throw new IOException(String.format(
-            "Unexpected blockChecksumType '%s', expecting COMPOSITE_CRC",
-            returnedType));
-      }*/
-      byte[] crcBytes = checksumData.array();
-      if (LOG.isDebugEnabled()) {
-        blockChecksumForDebug = CrcUtil.toMultiCrcString(crcBytes);
-      }
-      getBlockChecksumBuf().write(crcBytes);
-      break;
-    default:
-      throw new IOException(
-          "Unknown combine mode: " + getCombineMode());
-    }
-
-    return blockChecksumForDebug;
-  }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -140,7 +140,7 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
       }*/
       byte[] crcBytes = checksumData.array();
       if (LOG.isDebugEnabled()) {
-        blockChecksumForDebug = CrcUtil.toSingleCrcString(crcBytes);
+        blockChecksumForDebug = CrcUtil.toMultiCrcString(crcBytes);
       }
       getBlockChecksumBuf().write(crcBytes);
       break;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `blockChecksumForDebug` would throw exception due to some of the checksum data is not a single CRC, it would be better to use `toMultiCrcString()` to avoid exception for debug information.

## What is the link to the Apache JIRA
Please check [HDDS-8175](https://issues.apache.org/jira/browse/HDDS-8175) for more details, thanks.

## How was this patch tested?
- follow the [Command Line Interface](https://ozone.apache.org/docs/edge/interface/cli.html)
- create key `README.md` into  /vol1/bucket1/
```shell
ozone sh key put /vol1/bucket1/README.md README.md
```
- then verify the exception didn't throw in `DEBUG` mode after `checksum` command.
```shell
ozone sh key checksum /vol1/bucket1/README.md
```
The result is belowed, please take a look.
```shell
2025-01-01 12:08:15,364 [main] DEBUG checksum.CrcComposer: crcPolynomial=0x-12477ce0, precomputedMonomialForHint=0x27b1b63d, bytesPerCrcHint=4068, stripeLength=9223372036854775807
2025-01-01 12:08:15,364 [main] DEBUG checksum.CrcComposer: crcPolynomial=0x-12477ce0, precomputedMonomialForHint=0x30362f1a, bytesPerCrcHint=16384, stripeLength=9223372036854775807
2025-01-01 12:08:15,364 [main] DEBUG checksum.ReplicatedBlockChecksumComputer: number of chunks = 1, chunk checksum type is CRC32, composite checksum = [63, -24, -96, 28]
2025-01-01 12:08:15,365 [main] DEBUG checksum.BaseFileChecksumHelper: Got reply from pipeline Pipeline[ Id: 9943f91f-7c16-4820-adbd-1d8903fe9dad, Nodes: 6738a3ee-bf8c-4238-b17a-0c9935d518bb(ozone-datanode-1.ozone_default/172.19.0.6) ReplicaIndex: 0, ReplicationConfig: RATIS/ONE, State:OPEN, leaderId:6738a3ee-bf8c-4238-b17a-0c9935d518bb, CreationTimestamp2025-01-01T12:03:41.688Z[UTC]] for block conID: 1 locID: 115816896921600001 bcsId: 2 replicaIndex: null: blockChecksum=[0x3fe8a01c], blockChecksumType=CRC32
2025-01-01 12:08:15,365 [main] DEBUG checksum.CrcComposer: crcPolynomial=0x-12477ce0, precomputedMonomialForHint=0x27b1b63d, bytesPerCrcHint=4068, stripeLength=9223372036854775807
2025-01-01 12:08:15,365 [main] DEBUG checksum.BaseFileChecksumHelper: Added blockCrc 0x3fe8a01c for block index 0 of size 4068
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "README.md",
  "dataSize" : 4068,
  "algorithm" : "COMPOSITE-CRC32",
  "checksum" : "3FE8A01C"
}
```
