### PR TITLE
HDDS-11857. Freon log flooded by HSync message

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -46,7 +46,7 @@ public class ChecksumCache {
   private static final int BLOCK_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MB
 
   public ChecksumCache(int bytesPerChecksum) {
-    LOG.info("Initializing ChecksumCache with bytesPerChecksum = {}", bytesPerChecksum);
+    LOG.debug("Initializing ChecksumCache with bytesPerChecksum = {}", bytesPerChecksum);
     this.prevChunkLength = 0;
     this.bytesPerChecksum = bytesPerChecksum;
     // Set initialCapacity to avoid costly resizes

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -318,7 +318,7 @@ public final class OzoneFSUtils {
       return confHsyncEnabled;
     } else {
       if (confHsyncEnabled) {
-        LOG.warn("Ignoring {} = {} because HBase enhancements are disallowed. To enable it, set {} = true as well.",
+        LOG.debug("Ignoring {} = {} because HBase enhancements are disallowed. To enable it, set {} = true as well.",
             OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true,
             confKey);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Freon log seems to be flooded by `HSync` message, this information might be helpful for debug, it would be better to keep it in degbug mode. Please take a look, thanks!

## What is the link to the Apache JIRA
[HDDS-11857](https://issues.apache.org/jira/browse/HDDS-11857)

## How was this patch tested?
run the provided command in the docker services can see the msg doesn't show under normal mode.
```c
$ sudo docker compose exec -T scm ozone freon ockg -n10 -t1 2>&1 | grep -o -e 'Ignoring ozone.fs.hsync.enabled' -e 'Initializing ChecksumCache' | sort | uniq -c
7 Initializing ChecksumCache
```
