### PR TITLE
HDDS-11989. Enable SCM Ratis in tests related to DeletedBlockLog

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -990,6 +990,7 @@ public class TestStorageContainerManager {
       DeletedBlockLog delLog,
       Map<Long, List<Long>> containerBlocksMap)
       throws IOException, TimeoutException {
+    delLog.addTransactions(containerBlocksMap);
     if (SCMHAUtils.isSCMHAEnabled(scm.getConfiguration())) {
       scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -345,10 +345,8 @@ public class TestStorageContainerManager {
       // eventually these TX will success.
       GenericTestUtils.waitFor(() -> {
         try {
-          if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
-            cluster.getStorageContainerManager().getScmHAManager()
-                .asSCMHADBTransactionBuffer().flush();
-          }
+          cluster.getStorageContainerManager().getScmHAManager()
+              .asSCMHADBTransactionBuffer().flush();
           return delLog.getFailedTransactions(-1, 0).size() == 0;
         } catch (IOException e) {
           return false;
@@ -991,9 +989,7 @@ public class TestStorageContainerManager {
       Map<Long, List<Long>> containerBlocksMap)
       throws IOException, TimeoutException {
     delLog.addTransactions(containerBlocksMap);
-    if (SCMHAUtils.isSCMHAEnabled(scm.getConfiguration())) {
-      scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
-    }
+    scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
   }
 
   private static class CloseContainerCommandMatcher

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -323,17 +323,7 @@ public class TestStorageContainerManager {
       // after sometime, all the TX should be proceed and by then
       // the number of containerBlocks of all known containers will be
       // empty again.
-      GenericTestUtils.waitFor(() -> {
-        try {
-          if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
-            cluster.getStorageContainerManager().getScmHAManager()
-                .asSCMHADBTransactionBuffer().flush();
-          }
-          return delLog.getNumOfValidTransactions() == 0;
-        } catch (IOException e) {
-          return false;
-        }
-      }, 1000, 22000);
+      OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
       assertTrue(verifyBlocksWithTxnTable(cluster, conf, containerBlocks));
       // Continue the work, add some TXs that with known container names,
       // but unknown block IDs.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.RatisUtil;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -173,10 +173,9 @@ public final class OzoneTestUtils {
         if (scm.getScmBlockManager().getDeletedBlockLog().getNumOfValidTransactions() > 0) {
           return true;
         }
-        return false;
       } catch (IOException e) {
-        throw new RuntimeException(e);
       }
+      return false;
     }, 100, 3000);
   }
 
@@ -193,6 +192,6 @@ public final class OzoneTestUtils {
       } catch (IOException e) {
       }
       return false;
-    }, 100, 30000);
+    }, 1000, 60000);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -161,4 +161,38 @@ public final class OzoneTestUtils {
             container.getState() == HddsProtos.LifeCycleState.CLOSED,
         200, 30000);
   }
+
+  /**
+   * Flush deleted block log & wait till something was flushed.
+   */
+  public static void waitForDeletedBlockLog(StorageContainerManager scm)
+      throws InterruptedException, TimeoutException {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
+        if (scm.getScmBlockManager().getDeletedBlockLog().getNumOfValidTransactions() > 0) {
+          return true;
+        }
+        return false;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 100, 3000);
+  }
+
+  /**
+   * Wait till all blocks are removed.
+   */
+  public static void waitBlockDeleted(StorageContainerManager scm)
+      throws InterruptedException, TimeoutException {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        if (scm.getScmBlockManager().getDeletedBlockLog().getNumOfValidTransactions() == 0) {
+          return true;
+        }
+      } catch (IOException e) {
+      }
+      return false;
+    }, 100, 30000);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -165,7 +165,7 @@ public final class OzoneTestUtils {
   /**
    * Flush deleted block log & wait till something was flushed.
    */
-  public static void waitForDeletedBlockLog(StorageContainerManager scm)
+  public static void flushAndWaitForDeletedBlockLog(StorageContainerManager scm)
       throws InterruptedException, TimeoutException {
     GenericTestUtils.waitFor(() -> {
       try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithInAdequateDN.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithInAdequateDN.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -39,7 +38,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -78,7 +76,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithInAdequateDN.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithInAdequateDN.java
@@ -285,7 +285,7 @@ public class TestDeleteWithInAdequateDN {
     //cluster.getOzoneManager().deleteKey(keyArgs);
     client.getObjectStore().getVolume(volumeName).getBucket(bucketName).
         deleteKey("ratis");
-    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.flushAndWaitForDeletedBlockLog(cluster.getStorageContainerManager());
     // make sure the chunk was never deleted on the leader even though
     // deleteBlock handler is invoked
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -393,7 +393,7 @@ public class TestBlockDeletion {
       return scm.getContainerManager().getContainers().stream()
           .allMatch(c -> c.getUsedBytes() == 0 &&
               c.getNumberOfKeys() == 0);
-      }, 500, 20000);
+    }, 500, 20000);
     Thread.sleep(5000);
     // Verify that pending block delete num are as expected with resent cmds
     cluster.getHddsDatanodes().forEach(dn -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -827,18 +827,7 @@ public class TestBlockDeletion {
     }
 
     // Wait for block delete command sent from OM
-    GenericTestUtils.waitFor(() -> {
-      try {
-        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
-        if (scm.getScmBlockManager().getDeletedBlockLog()
-            .getNumOfValidTransactions() > 0) {
-          return true;
-        }
-      } catch (IOException e) {
-      }
-      return false;
-    }, 100, 5000);
-
+    OzoneTestUtils.flushAndWaitForDeletedBlockLog(scm);
     long start = System.currentTimeMillis();
     // Wait for all blocks been deleted.
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -385,15 +385,15 @@ public class TestBlockDeletion {
     writeClient.deleteKey(keyArgs);
     // Wait for blocks to be deleted and container reports to be processed
     GenericTestUtils.waitFor(() -> {
-          try {
-            scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-          return scm.getContainerManager().getContainers().stream()
-              .allMatch(c -> c.getUsedBytes() == 0 &&
-                  c.getNumberOfKeys() == 0);
-        }, 500, 20000);
+      try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return scm.getContainerManager().getContainers().stream()
+          .allMatch(c -> c.getUsedBytes() == 0 &&
+              c.getNumberOfKeys() == 0);
+      }, 500, 20000);
     Thread.sleep(5000);
     // Verify that pending block delete num are as expected with resent cmds
     cluster.getHddsDatanodes().forEach(dn -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hdds.scm.block.SCMBlockDeletingService;
 import org.apache.hadoop.hdds.scm.block.ScmBlockDeletingServiceMetrics;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
 import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
@@ -96,6 +95,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_I
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
@@ -135,6 +135,7 @@ public class TestBlockDeletion {
     GenericTestUtils.setLogLevel(LegacyReplicationManager.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(ReplicationManager.LOG, Level.DEBUG);
 
+    conf.setBoolean(OZONE_SCM_HA_ENABLE_KEY, true);
     conf.set("ozone.replication.allowed-configs",
         "^(RATIS/THREE)|(EC/2-1-256k)$");
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100,
@@ -241,6 +242,7 @@ public class TestBlockDeletion {
     // verify key blocks were created in DN.
     GenericTestUtils.waitFor(() -> {
       try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
         verifyBlocksCreated(omKeyLocationInfoGroupList);
         return true;
       } catch (Throwable t) {
@@ -285,6 +287,7 @@ public class TestBlockDeletion {
     // The blocks should be deleted in the DN.
     GenericTestUtils.waitFor(() -> {
       try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
         verifyBlocksDeleted(omKeyLocationInfoGroupList);
         return true;
       } catch (Throwable t) {
@@ -301,6 +304,7 @@ public class TestBlockDeletion {
     // Verify transactions committed
     GenericTestUtils.waitFor(() -> {
       try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
         verifyTransactionsCommitted();
         return true;
       } catch (Throwable t) {
@@ -380,10 +384,16 @@ public class TestBlockDeletion {
 
     writeClient.deleteKey(keyArgs);
     // Wait for blocks to be deleted and container reports to be processed
-    GenericTestUtils.waitFor(() ->
-            scm.getContainerManager().getContainers().stream()
-                .allMatch(c -> c.getUsedBytes() == 0 &&
-                    c.getNumberOfKeys() == 0), 500, 20000);
+    GenericTestUtils.waitFor(() -> {
+          try {
+            scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+          return scm.getContainerManager().getContainers().stream()
+              .allMatch(c -> c.getUsedBytes() == 0 &&
+                  c.getNumberOfKeys() == 0);
+        }, 500, 20000);
     Thread.sleep(5000);
     // Verify that pending block delete num are as expected with resent cmds
     cluster.getHddsDatanodes().forEach(dn -> {
@@ -428,6 +438,7 @@ public class TestBlockDeletion {
           assertEquals(HddsProtos.LifeCycleState.DELETED,
               container.getState());
           try {
+            scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
             assertEquals(HddsProtos.LifeCycleState.DELETED,
                 scm.getScmMetadataStore().getContainerTable()
                     .get(container.containerID()).getState());
@@ -519,14 +530,14 @@ public class TestBlockDeletion {
 
     GenericTestUtils.waitFor(() -> {
       try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
         return scm.getContainerManager().getContainerReplicas(
             containerId).stream().
             allMatch(replica -> replica.isEmpty());
-      } catch (ContainerNotFoundException e) {
+      } catch (IOException e) {
         throw new RuntimeException(e);
       }
-    },
-        100, 10 * 1000);
+    }, 100, 10 * 1000);
 
     // Container state should be empty now as key got deleted
     assertTrue(getContainerFromDN(
@@ -549,6 +560,7 @@ public class TestBlockDeletion {
           assertEquals(HddsProtos.LifeCycleState.DELETED,
               container.getState());
           try {
+            scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
             assertEquals(HddsProtos.LifeCycleState.DELETED,
                 scm.getScmMetadataStore().getContainerTable()
                     .get(container.containerID()).getState());
@@ -563,7 +575,6 @@ public class TestBlockDeletion {
       }
       return true;
     }, 500, 30000);
-    LOG.info(metrics.toString());
   }
 
   /**
@@ -649,14 +660,14 @@ public class TestBlockDeletion {
     // Ensure isEmpty are true for all replica after delete key
     GenericTestUtils.waitFor(() -> {
       try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
         return scm.getContainerManager().getContainerReplicas(
             containerId).stream()
             .allMatch(replica -> replica.isEmpty());
-      } catch (ContainerNotFoundException e) {
+      } catch (IOException e) {
         throw new RuntimeException(e);
       }
-    },
-        500, 5 * 2000);
+    }, 500, 5 * 2000);
 
     // Update container replica by making invalid keyCount in one replica
     ContainerReplica replicaOne = ContainerReplica.newBuilder()
@@ -686,6 +697,7 @@ public class TestBlockDeletion {
           assertEquals(HddsProtos.LifeCycleState.DELETED,
               container.getState());
           try {
+            scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
             assertEquals(HddsProtos.LifeCycleState.DELETED,
                 scm.getScmMetadataStore().getContainerTable()
                     .get(container.containerID()).getState());
@@ -817,6 +829,7 @@ public class TestBlockDeletion {
     // Wait for block delete command sent from OM
     GenericTestUtils.waitFor(() -> {
       try {
+        scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
         if (scm.getScmBlockManager().getDeletedBlockLog()
             .getNumOfValidTransactions() > 0) {
           return true;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -198,7 +198,7 @@ public class TestDeleteContainerHandler {
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
         .getBucket(bucketName).deleteKey(keyName);
-    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.flushAndWaitForDeletedBlockLog(cluster.getStorageContainerManager());
     OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
@@ -317,7 +317,7 @@ public class TestDeleteContainerHandler {
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
         .getBucket(bucketName).deleteKey(keyName);
-    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.flushAndWaitForDeletedBlockLog(cluster.getStorageContainerManager());
     OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
@@ -658,7 +658,7 @@ public class TestDeleteContainerHandler {
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
         .getBucket(bucketName).deleteKey(keyName);
-    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.flushAndWaitForDeletedBlockLog(cluster.getStorageContainerManager());
     OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
 
     // Ensure isEmpty flag is true when key is deleted

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -69,7 +68,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -68,6 +69,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +77,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -97,6 +100,7 @@ public class TestDeleteContainerHandler {
   @BeforeAll
   public static void setup() throws Exception {
     conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_SCM_HA_ENABLE_KEY, true);
     conf.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
     conf.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
         0, StorageUnit.MB);
@@ -196,6 +200,8 @@ public class TestDeleteContainerHandler {
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
         .getBucket(bucketName).deleteKey(keyName);
+    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
     GenericTestUtils.waitFor(() -> getContainerfromDN(
@@ -313,6 +319,8 @@ public class TestDeleteContainerHandler {
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
         .getBucket(bucketName).deleteKey(keyName);
+    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
     GenericTestUtils.waitFor(() -> getContainerfromDN(
@@ -652,6 +660,8 @@ public class TestDeleteContainerHandler {
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
         .getBucket(bucketName).deleteKey(keyName);
+    OzoneTestUtils.waitForDeletedBlockLog(cluster.getStorageContainerManager());
+    OzoneTestUtils.waitBlockDeleted(cluster.getStorageContainerManager());
 
     // Ensure isEmpty flag is true when key is deleted
     GenericTestUtils.waitFor(() -> getContainerfromDN(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tests related to DeletedBlockLog needs to be tweaked to work with SCM Ratis enabled:

```
Error:  Tests run: 4, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 225.079 s <<< FAILURE! - in org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestBlockDeletion
20468Error:  org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestBlockDeletion.testBlockDeleteCommandParallelProcess  Time elapsed: 45.39 s  <<< ERROR!

Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 65.86 s <<< FAILURE! - in org.apache.hadoop.ozone.client.rpc.TestDeleteWithInAdequateDN
2897Error:  org.apache.hadoop.ozone.client.rpc.TestDeleteWithInAdequateDN.testDeleteKeyWithInAdequateDN  Time elapsed: 27.673 s  <<< FAILURE!
2898org.opentest4j.AssertionFailedError: Expected org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:73)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3128)
	at org.apache.hadoop.ozone.client.rpc.TestDeleteWithInAdequateDN.testDeleteKeyWithInAdequateDN(TestDeleteWithInAdequateDN.java:314)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

Error:  Tests run: 6, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 108.02 s <<< FAILURE! - in org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestDeleteContainerHandler
3162Error:  org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestDeleteContainerHandler.testDeleteContainerRequestHandlerOnClosedContainer  Time elapsed: 16.098 s  <<< ERROR!
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11989

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/12570960386