### PR TITLE
HDDS-11880. Intermediate subcommands do not need to implement Callable

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerCommands.java
@@ -18,14 +18,9 @@
 package org.apache.hadoop.hdds.scm.cli;
 
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
-
-import java.util.concurrent.Callable;
 
 /**
  * Subcommand to group container balancer related operations.
@@ -90,14 +85,6 @@ import java.util.concurrent.Callable;
         ContainerBalancerStatusSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class ContainerBalancerCommands implements Callable<Void>, AdminSubcommand {
+public class ContainerBalancerCommands implements AdminSubcommand {
 
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ReplicationManagerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ReplicationManagerCommands.java
@@ -17,16 +17,11 @@
  */
 package org.apache.hadoop.hdds.scm.cli;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Subcommand to group replication manager related operations.
@@ -42,14 +37,6 @@ import picocli.CommandLine.Spec;
         ReplicationManagerStatusSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class ReplicationManagerCommands implements Callable<Void>, AdminSubcommand {
+public class ReplicationManagerCommands implements AdminSubcommand {
 
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCommands.java
@@ -17,16 +17,11 @@
  */
 package org.apache.hadoop.hdds.scm.cli;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Subcommand to group safe mode related operations.
@@ -42,14 +37,6 @@ import picocli.CommandLine.Spec;
         SafeModeWaitSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class SafeModeCommands implements Callable<Void>, AdminSubcommand {
+public class SafeModeCommands implements AdminSubcommand {
 
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CertCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CertCommands.java
@@ -17,16 +17,11 @@
  */
 package org.apache.hadoop.hdds.scm.cli.cert;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Sub command for certificate related operations.
@@ -43,14 +38,5 @@ import picocli.CommandLine.Spec;
     })
 
 @MetaInfServices(AdminSubcommand.class)
-public class CertCommands implements Callable<Void>, AdminSubcommand {
-
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
+public class CertCommands implements AdminSubcommand {
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerCommands.java
@@ -17,16 +17,11 @@
  */
 package org.apache.hadoop.hdds.scm.cli.container;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Subcommand to group container related operations.
@@ -45,14 +40,6 @@ import picocli.CommandLine.Spec;
         UpgradeSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class ContainerCommands implements Callable<Void>, AdminSubcommand {
+public class ContainerCommands implements AdminSubcommand {
 
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DatanodeCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DatanodeCommands.java
@@ -18,14 +18,9 @@
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
-
-import java.util.concurrent.Callable;
 
 /**
  * Subcommand for datanode related operations.
@@ -44,14 +39,6 @@ import java.util.concurrent.Callable;
         UsageInfoSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class DatanodeCommands implements Callable<Void>, AdminSubcommand {
+public class DatanodeCommands implements AdminSubcommand {
 
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/StatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/StatusSubCommand.java
@@ -17,11 +17,8 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
  * limitations under the License.
  */
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import java.util.concurrent.Callable;
 
 /**
  * View status of one or more datanodes.
@@ -35,14 +32,6 @@ import java.util.concurrent.Callable;
         DecommissionStatusSubCommand.class
     })
 
-public class StatusSubCommand implements Callable<Void> {
+public class StatusSubCommand {
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/PipelineCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/PipelineCommands.java
@@ -17,16 +17,11 @@
  */
 package org.apache.hadoop.hdds.scm.cli.pipeline;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Subcommand to group pipeline related operations.
@@ -44,14 +39,6 @@ import picocli.CommandLine.Spec;
         ClosePipelineSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class PipelineCommands implements Callable<Void>, AdminSubcommand {
+public class PipelineCommands implements AdminSubcommand {
 
-  @Spec
-  private CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
@@ -105,7 +105,7 @@ Close container
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin container
-                        Should contain   ${output}   Incomplete command
+                        Should contain   ${output}   Missing required subcommand
                         Should contain   ${output}   list
                         Should contain   ${output}   info
                         Should contain   ${output}   create

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -90,7 +90,7 @@ Get usage info with invalid address
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin datanode
-                        Should contain   ${output}   Incomplete command
+                        Should contain   ${output}   Missing required subcommand
                         Should contain   ${output}   list
 
 #List datanodes on unknown host

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
@@ -60,7 +60,7 @@ Close pipeline
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin pipeline
-                        Should contain   ${output}   Incomplete command
+                        Should contain   ${output}   Missing required subcommand
                         Should contain   ${output}   close
                         Should contain   ${output}   create
                         Should contain   ${output}   deactivate

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/replicationmanager.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/replicationmanager.robot
@@ -46,7 +46,7 @@ Start replicationmanager
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin replicationmanager
-                        Should contain   ${output}   Incomplete command
+                        Should contain   ${output}   Missing required subcommand
                         Should contain   ${output}   start
                         Should contain   ${output}   stop
                         Should contain   ${output}   status

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/safemode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/safemode.robot
@@ -37,7 +37,7 @@ Wait for safemode exit
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin safemode
-                        Should contain   ${output}   Incomplete command
+                        Should contain   ${output}   Missing required subcommand
                         Should contain   ${output}   status
                         Should contain   ${output}   exit
                         Should contain   ${output}   wait

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureCommands.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.admin.reconfig;
 
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -27,12 +26,9 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 /**
  * Subcommand to group reconfigure OM related operations.
@@ -48,13 +44,10 @@ import java.util.concurrent.Callable;
         ReconfigurePropertiesSubcommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
-public class ReconfigureCommands implements Callable<Void>, AdminSubcommand {
+public class ReconfigureCommands implements AdminSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
-
-  @Spec
-  private CommandSpec spec;
 
   @CommandLine.Option(names = {"--service"},
       description = "service: OM, SCM, DATANODE.",
@@ -71,12 +64,6 @@ public class ReconfigureCommands implements Callable<Void>, AdminSubcommand {
           "to all available DataNodes in the IN_SERVICE operational state.",
       required = false)
   private boolean batchReconfigDatanodes;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 
   public String getAddress() {
     return address;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/DeletedBlocksTxnCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/DeletedBlocksTxnCommands.java
@@ -17,11 +17,8 @@
  */
 package org.apache.hadoop.ozone.admin.scm;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 /**
  * Subcommand to group container related operations.
@@ -35,15 +32,7 @@ import java.util.concurrent.Callable;
         GetFailedDeletedBlocksTxnSubcommand.class,
         ResetDeletedBlockRetryCountSubcommand.class,
     })
-public class DeletedBlocksTxnCommands implements Callable<Void> {
+public class DeletedBlocksTxnCommands {
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerCommands.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.debug.container;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -48,9 +47,7 @@ import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +60,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 
 /**
@@ -82,7 +78,7 @@ import java.util.stream.Stream;
         InspectSubcommand.class
     })
 @MetaInfServices(DebugSubcommand.class)
-public class ContainerCommands implements Callable<Void>, DebugSubcommand {
+public class ContainerCommands implements DebugSubcommand {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerCommands.class);
@@ -90,18 +86,9 @@ public class ContainerCommands implements Callable<Void>, DebugSubcommand {
   @ParentCommand
   private OzoneDebug parent;
 
-  @Spec
-  private CommandSpec spec;
-
   private MutableVolumeSet volumeSet;
 
   private ContainerController controller;
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 
   OzoneConfiguration getOzoneConf() {
     return parent.getOzoneConf();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/RDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/RDBParser.java
@@ -18,15 +18,10 @@
 
 package org.apache.hadoop.ozone.debug.ldb;
 
-import java.util.concurrent.Callable;
-
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 /**
  * Tool that parses rocksdb file.
@@ -41,10 +36,7 @@ import picocli.CommandLine.Spec;
         },
         description = "Parse rocksdb file content")
 @MetaInfServices(DebugSubcommand.class)
-public class RDBParser implements Callable<Void>, DebugSubcommand {
-
-  @Spec
-  private CommandSpec spec;
+public class RDBParser implements DebugSubcommand {
 
   @CommandLine.Option(names = {"--db"},
       required = true,
@@ -57,11 +49,5 @@ public class RDBParser implements Callable<Void>, DebugSubcommand {
 
   public void setDbPath(String dbPath) {
     this.dbPath = dbPath;
-  }
-
-  @Override
-  public Void call() throws Exception {
-    GenericCli.missingSubcommand(spec);
-    return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/RDBRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/RDBRepair.java
@@ -18,12 +18,9 @@
 
 package org.apache.hadoop.ozone.repair.ldb;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.RepairSubcommand;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 /**
  * Ozone Repair CLI for RocksDB.
@@ -35,10 +32,7 @@ import java.util.concurrent.Callable;
     },
     description = "Operational tool to repair RocksDB table.")
 @MetaInfServices(RepairSubcommand.class)
-public class RDBRepair implements Callable<Void>, RepairSubcommand {
-
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
+public class RDBRepair implements RepairSubcommand {
 
   @CommandLine.Option(names = {"--db"},
       required = true,
@@ -47,11 +41,5 @@ public class RDBRepair implements Callable<Void>, RepairSubcommand {
 
   public String getDbPath() {
     return dbPath;
-  }
-
-  @Override
-  public Void call() {
-    GenericCli.missingSubcommand(spec);
-    return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/OMRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/OMRepair.java
@@ -18,12 +18,9 @@
 
 package org.apache.hadoop.ozone.repair.om;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.RepairSubcommand;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 /**
  * Ozone Repair CLI for OM.
@@ -34,14 +31,6 @@ import java.util.concurrent.Callable;
     },
     description = "Operational tool to repair OM.")
 @MetaInfServices(RepairSubcommand.class)
-public class OMRepair implements Callable<Void>, RepairSubcommand {
+public class OMRepair implements RepairSubcommand {
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
-  @Override
-  public Void call() {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaRepair.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.ozone.repair.quota;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.concurrent.Callable;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.RepairSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
@@ -51,19 +49,10 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
     },
     description = "Operational tool to repair quota in OM DB.")
 @MetaInfServices(RepairSubcommand.class)
-public class QuotaRepair implements Callable<Void>, RepairSubcommand {
-
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
+public class QuotaRepair implements RepairSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneRepair parent;
-
-  @Override
-  public Void call() {
-    GenericCli.missingSubcommand(spec);
-    return null;
-  }
 
   public OzoneManagerProtocolClientSideTranslatorPB createOmClient(
       String omServiceID,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
@@ -18,14 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.bucket;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Subcommands for the bucket related operations.
@@ -50,14 +45,5 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class BucketCommands implements Callable<Void> {
-
-  @ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("bucket"));
-  }
+public class BucketCommands {
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
@@ -18,14 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.keys;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Subcommand to group key related operations.
@@ -50,14 +45,6 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class KeyCommands implements Callable<Void> {
+public class KeyCommands {
 
-  @ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("key"));
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixCommands.java
@@ -18,14 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.prefix;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Subcommands for the prefix related operations.
@@ -40,14 +35,6 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class PrefixCommands implements Callable<Void> {
+public class PrefixCommands {
 
-  @ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("prefix"));
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
@@ -18,14 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.snapshot;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Subcommands for the snapshot related operations.
@@ -43,14 +38,6 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class SnapshotCommands implements Callable<Void> {
+public class SnapshotCommands {
 
-  @ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("snapshot"));
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantUserCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantUserCommands.java
@@ -18,11 +18,7 @@
 package org.apache.hadoop.ozone.shell.tenant;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 /**
  * Subcommand to group tenant user related operations.
@@ -41,14 +37,6 @@ import java.util.concurrent.Callable;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class TenantUserCommands implements Callable<Void> {
+public class TenantUserCommands {
 
-  @CommandLine.ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("user"));
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenCommands.java
@@ -18,14 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.token;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Sub-command to group token related operations.
@@ -40,14 +35,6 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class TokenCommands implements Callable<Void> {
+public class TokenCommands {
 
-  @ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("token"));
-  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
@@ -18,14 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.volume;
 
-import java.util.concurrent.Callable;
-
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 /**
  * Subcommand to group volume related operations.
@@ -48,14 +43,6 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class VolumeCommands implements Callable<Void> {
+public class VolumeCommands {
 
-  @ParentCommand
-  private Shell shell;
-
-  @Override
-  public Void call() throws Exception {
-    throw new MissingSubcommandException(
-        this.shell.getCmd().getSubcommands().get("volume"));
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Intermediate subcommands (ones that only group other subcommands) do not need to implement `Callable`.  Currently they show "missing subcommand" error as action.  The same can be achieved by using picocli built-in behavior.

https://issues.apache.org/jira/browse/HDDS-11880

## How was this patch tested?

Ran some of these without subcommands:

```
$ ozone admin cert
Missing required subcommand
Usage: ozone admin cert [-hV] [COMMAND]
Certificate related operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  info   Show detailed information for a specific certificate
  list   List certificates
  clean  Clean expired certificates from the SCM metadata.


$ ozone admin container
Missing required subcommand
Usage: ozone admin container [-hV] [COMMAND]
Container specific operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  list     List containers
  info     Show information about a specific container
  create   Create container
  close    close container
  report   Display the container summary report
  upgrade  Offline upgrade all schema V2 containers to schema V3 for this
             datanode.


$ ozone admin replicationmanager
Missing required subcommand
Usage: ozone admin replicationmanager [-hV] [COMMAND]
ReplicationManager specific operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  start   Start ReplicationManager
  stop    Stop ReplicationManager
  status  Check if ReplicationManager is running or not


$ ozone debug container
Missing required subcommand
Usage: ozone debug container [-hV] [COMMAND]
Container replica specific operations to be executed on datanodes only
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  list     Show container info of all container replicas on datanode
  info     Show container info of a container replica on datanode
  export   Export one container to a tarball
  inspect  Check the metadata of all container replicas on this datanode.


$ ozone sh bucket
Missing required subcommand
Usage: ozone sh bucket [-hV] [COMMAND]
Bucket specific operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  info                    returns information about a bucket
  list, ls                lists the buckets in a volume.
  create                  creates a bucket in a given volume
  setquota                Set quota of the buckets. At least one of the quota
                            set flag is mandatory.
  link                    creates a symlink to another bucket
  delete                  deletes a bucket
  addacl                  Add one or more new ACLs.
  removeacl               Remove one or more existing ACLs.
  getacl                  List all ACLs.
  setacl                  Set one or more ACLs, replacing the existing ones.
  clrquota                clear quota of the bucket. At least one of the quota
                            clear flag is mandatory.
  set-replication-config  Set replication config on bucket
  update                  Updates the parameters of the bucket


$ ozone sh user
Missing required subcommand
Usage: ozone sh user [-hV] [COMMAND]
Tenant user management
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  info                       Get tenant related information of a user
  assign                     Assign user accessId to tenant
  revoke                     Revoke user accessId to tenant
  assign-admin, assignadmin  Assign admin role to accessIds in a tenant
  revoke-admin, revokeadmin  Revoke admin role from accessIds in a tenant
  list, ls                   List users in a tenant
  get-secret, getsecret      Get secret given tenant user accessId. This
                               differs from `ozone s3 getsecret` that this
                               would not generate secret when the given access
                               ID doesn't exist.
  set-secret, setsecret      Set secret for a tenant user accessId.
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12502398129