### PR TITLE
HDDS-11990. Use arity in decommission subcommands

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
@@ -24,9 +24,7 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 /**
  * Decommission one or more datanodes.
@@ -38,12 +36,8 @@ import java.util.Scanner;
     versionProvider = HddsVersionProvider.class)
 public class DecommissionSubCommand extends ScmSubcommand {
 
-  @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
-          "To read from stdin, specify '-' and supply the host names " +
-          "separated by newlines.",
-          arity = "1..*",
-          paramLabel = "<host name>")
-  private List<String> parameters = new ArrayList<>();
+  @CommandLine.Mixin
+  private HostNameParameters hostNameParams;
 
   @CommandLine.Option(names = { "--force" },
       defaultValue = "false",
@@ -52,17 +46,7 @@ public class DecommissionSubCommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    List<String> hosts;
-    // Whether to read from stdin
-    if (parameters.get(0).equals("-")) {
-      hosts = new ArrayList<>();
-      Scanner scanner = new Scanner(System.in, "UTF-8");
-      while (scanner.hasNextLine()) {
-        hosts.add(scanner.nextLine().trim());
-      }
-    } else {
-      hosts = parameters;
-    }
+    List<String> hosts = hostNameParams.getHostNames();
     List<DatanodeAdminError> errors = scmClient.decommissionNodes(hosts, force);
     System.out.println("Started decommissioning datanode(s):\n" +
         String.join("\n", hosts));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
@@ -50,15 +50,18 @@ public class DecommissionSubCommand extends ScmSubcommand {
     List<DatanodeAdminError> errors = scmClient.decommissionNodes(hosts, force);
     System.out.println("Started decommissioning datanode(s):\n" +
         String.join("\n", hosts));
-    if (errors.size() > 0) {
+    showErrors(errors, "Some nodes could not enter the decommission workflow");
+  }
+
+  static void showErrors(List<DatanodeAdminError> errors, String message) throws IOException {
+    if (!errors.isEmpty()) {
       for (DatanodeAdminError error : errors) {
         System.err.println("Error: " + error.getHostname() + ": "
             + error.getError());
       }
       // Throwing the exception will cause a non-zero exit status for the
       // command.
-      throw new IOException(
-          "Some nodes could not enter the decommission workflow");
+      throw new IOException(message);
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
@@ -39,12 +38,10 @@ import java.util.Scanner;
     versionProvider = HddsVersionProvider.class)
 public class DecommissionSubCommand extends ScmSubcommand {
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
   @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
           "To read from stdin, specify '-' and supply the host names " +
           "separated by newlines.",
+          arity = "1..*",
           paramLabel = "<host name>")
   private List<String> parameters = new ArrayList<>();
 
@@ -55,33 +52,29 @@ public class DecommissionSubCommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    if (parameters.size() > 0) {
-      List<String> hosts;
-      // Whether to read from stdin
-      if (parameters.get(0).equals("-")) {
-        hosts = new ArrayList<>();
-        Scanner scanner = new Scanner(System.in, "UTF-8");
-        while (scanner.hasNextLine()) {
-          hosts.add(scanner.nextLine().trim());
-        }
-      } else {
-        hosts = parameters;
-      }
-      List<DatanodeAdminError> errors = scmClient.decommissionNodes(hosts, force);
-      System.out.println("Started decommissioning datanode(s):\n" +
-          String.join("\n", hosts));
-      if (errors.size() > 0) {
-        for (DatanodeAdminError error : errors) {
-          System.err.println("Error: " + error.getHostname() + ": "
-              + error.getError());
-        }
-        // Throwing the exception will cause a non-zero exit status for the
-        // command.
-        throw new IOException(
-            "Some nodes could not enter the decommission workflow");
+    List<String> hosts;
+    // Whether to read from stdin
+    if (parameters.get(0).equals("-")) {
+      hosts = new ArrayList<>();
+      Scanner scanner = new Scanner(System.in, "UTF-8");
+      while (scanner.hasNextLine()) {
+        hosts.add(scanner.nextLine().trim());
       }
     } else {
-      GenericCli.missingSubcommand(spec);
+      hosts = parameters;
+    }
+    List<DatanodeAdminError> errors = scmClient.decommissionNodes(hosts, force);
+    System.out.println("Started decommissioning datanode(s):\n" +
+        String.join("\n", hosts));
+    if (errors.size() > 0) {
+      for (DatanodeAdminError error : errors) {
+        System.err.println("Error: " + error.getHostname() + ": "
+            + error.getError());
+      }
+      // Throwing the exception will cause a non-zero exit status for the
+      // command.
+      throw new IOException(
+          "Some nodes could not enter the decommission workflow");
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/HostNameParameters.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/HostNameParameters.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import picocli.CommandLine;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+/** Parameter for specifying list of hostnames. */
+@CommandLine.Command
+public class HostNameParameters {
+
+  @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
+      "To read from stdin, specify '-' and supply the host names " +
+      "separated by newlines.",
+      arity = "1..*",
+      paramLabel = "<host name>")
+  private List<String> parameters = new ArrayList<>();
+
+  public List<String> getHostNames() {
+    List<String> hosts;
+    // Whether to read from stdin
+    if (parameters.get(0).equals("-")) {
+      hosts = new ArrayList<>();
+      Scanner scanner = new Scanner(System.in, StandardCharsets.UTF_8.name());
+      while (scanner.hasNextLine()) {
+        hosts.add(scanner.nextLine().trim());
+      }
+    } else {
+      hosts = parameters;
+    }
+    return hosts;
+  }
+
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -26,6 +26,8 @@ import picocli.CommandLine.Command;
 import java.io.IOException;
 import java.util.List;
 
+import static org.apache.hadoop.hdds.scm.cli.datanode.DecommissionSubCommand.showErrors;
+
 /**
  * Place one or more datanodes into Maintenance Mode.
  */
@@ -57,15 +59,6 @@ public class MaintenanceSubCommand extends ScmSubcommand {
         scmClient.startMaintenanceNodes(hosts, endInHours, force);
     System.out.println("Entering maintenance mode on datanode(s):\n" +
         String.join("\n", hosts));
-    if (errors.size() > 0) {
-      for (DatanodeAdminError error : errors) {
-        System.err.println("Error: " + error.getHostname() + ": "
-            + error.getError());
-      }
-      // Throwing the exception will cause a non-zero exit status for the
-      // command.
-      throw new IOException(
-          "Some nodes could not start the maintenance workflow");
-    }
+    showErrors(errors, "Some nodes could not start the maintenance workflow");
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -24,9 +24,7 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 /**
  * Place one or more datanodes into Maintenance Mode.
@@ -38,12 +36,8 @@ import java.util.Scanner;
     versionProvider = HddsVersionProvider.class)
 public class MaintenanceSubCommand extends ScmSubcommand {
 
-  @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
-          "To read from stdin, specify '-' and supply the host names " +
-          "separated by newlines.",
-          arity = "1..*",
-          paramLabel = "<host name>")
-  private List<String> parameters = new ArrayList<>();
+  @CommandLine.Mixin
+  private HostNameParameters hostNameParams;
 
   @CommandLine.Option(names = {"--end"},
       description = "Automatically end maintenance after the given hours. " +
@@ -58,17 +52,7 @@ public class MaintenanceSubCommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    List<String> hosts;
-    // Whether to read from stdin
-    if (parameters.get(0).equals("-")) {
-      hosts = new ArrayList<>();
-      Scanner scanner = new Scanner(System.in, "UTF-8");
-      while (scanner.hasNextLine()) {
-        hosts.add(scanner.nextLine().trim());
-      }
-    } else {
-      hosts = parameters;
-    }
+    List<String> hosts = hostNameParams.getHostNames();
     List<DatanodeAdminError> errors =
         scmClient.startMaintenanceNodes(hosts, endInHours, force);
     System.out.println("Entering maintenance mode on datanode(s):\n" +

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
@@ -39,12 +38,10 @@ import java.util.Scanner;
     versionProvider = HddsVersionProvider.class)
 public class MaintenanceSubCommand extends ScmSubcommand {
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
   @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
           "To read from stdin, specify '-' and supply the host names " +
           "separated by newlines.",
+          arity = "1..*",
           paramLabel = "<host name>")
   private List<String> parameters = new ArrayList<>();
 
@@ -61,34 +58,30 @@ public class MaintenanceSubCommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    if (parameters.size() > 0) {
-      List<String> hosts;
-      // Whether to read from stdin
-      if (parameters.get(0).equals("-")) {
-        hosts = new ArrayList<>();
-        Scanner scanner = new Scanner(System.in, "UTF-8");
-        while (scanner.hasNextLine()) {
-          hosts.add(scanner.nextLine().trim());
-        }
-      } else {
-        hosts = parameters;
-      }
-      List<DatanodeAdminError> errors =
-          scmClient.startMaintenanceNodes(hosts, endInHours, force);
-      System.out.println("Entering maintenance mode on datanode(s):\n" +
-          String.join("\n", hosts));
-      if (errors.size() > 0) {
-        for (DatanodeAdminError error : errors) {
-          System.err.println("Error: " + error.getHostname() + ": "
-              + error.getError());
-        }
-        // Throwing the exception will cause a non-zero exit status for the
-        // command.
-        throw new IOException(
-            "Some nodes could not start the maintenance workflow");
+    List<String> hosts;
+    // Whether to read from stdin
+    if (parameters.get(0).equals("-")) {
+      hosts = new ArrayList<>();
+      Scanner scanner = new Scanner(System.in, "UTF-8");
+      while (scanner.hasNextLine()) {
+        hosts.add(scanner.nextLine().trim());
       }
     } else {
-      GenericCli.missingSubcommand(spec);
+      hosts = parameters;
+    }
+    List<DatanodeAdminError> errors =
+        scmClient.startMaintenanceNodes(hosts, endInHours, force);
+    System.out.println("Entering maintenance mode on datanode(s):\n" +
+        String.join("\n", hosts));
+    if (errors.size() > 0) {
+      for (DatanodeAdminError error : errors) {
+        System.err.println("Error: " + error.getHostname() + ": "
+            + error.getError());
+      }
+      // Throwing the exception will cause a non-zero exit status for the
+      // command.
+      throw new IOException(
+          "Some nodes could not start the maintenance workflow");
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
@@ -40,44 +39,38 @@ import java.util.Scanner;
     versionProvider = HddsVersionProvider.class)
 public class RecommissionSubCommand extends ScmSubcommand {
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
   @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
           "To read from stdin, specify '-' and supply the host names " +
           "separated by newlines.",
+          arity = "1..*",
           paramLabel = "<host name>")
   private List<String> parameters = new ArrayList<>();
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    if (parameters.size() > 0) {
-      List<String> hosts;
-      // Whether to read from stdin
-      if (parameters.get(0).equals("-")) {
-        hosts = new ArrayList<>();
-        Scanner scanner = new Scanner(System.in, "UTF-8");
-        while (scanner.hasNextLine()) {
-          hosts.add(scanner.nextLine().trim());
-        }
-      } else {
-        hosts = parameters;
-      }
-      List<DatanodeAdminError> errors = scmClient.recommissionNodes(hosts);
-      System.out.println("Started recommissioning datanode(s):\n" +
-          String.join("\n", hosts));
-      if (errors.size() > 0) {
-        for (DatanodeAdminError error : errors) {
-          System.err.println("Error: " + error.getHostname() + ": "
-              + error.getError());
-        }
-        // Throwing the exception will cause a non-zero exit status for the
-        // command.
-        throw new IOException(
-            "Some nodes could be recommissioned");
+    List<String> hosts;
+    // Whether to read from stdin
+    if (parameters.get(0).equals("-")) {
+      hosts = new ArrayList<>();
+      Scanner scanner = new Scanner(System.in, "UTF-8");
+      while (scanner.hasNextLine()) {
+        hosts.add(scanner.nextLine().trim());
       }
     } else {
-      GenericCli.missingSubcommand(spec);
+      hosts = parameters;
+    }
+    List<DatanodeAdminError> errors = scmClient.recommissionNodes(hosts);
+    System.out.println("Started recommissioning datanode(s):\n" +
+        String.join("\n", hosts));
+    if (errors.size() > 0) {
+      for (DatanodeAdminError error : errors) {
+        System.err.println("Error: " + error.getHostname() + ": "
+            + error.getError());
+      }
+      // Throwing the exception will cause a non-zero exit status for the
+      // command.
+      throw new IOException(
+          "Some nodes could be recommissioned");
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
@@ -24,9 +24,7 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 /**
  * Recommission one or more datanodes.
@@ -39,26 +37,12 @@ import java.util.Scanner;
     versionProvider = HddsVersionProvider.class)
 public class RecommissionSubCommand extends ScmSubcommand {
 
-  @CommandLine.Parameters(description = "One or more host names separated by spaces. " +
-          "To read from stdin, specify '-' and supply the host names " +
-          "separated by newlines.",
-          arity = "1..*",
-          paramLabel = "<host name>")
-  private List<String> parameters = new ArrayList<>();
+  @CommandLine.Mixin
+  private HostNameParameters hostNameParams;
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    List<String> hosts;
-    // Whether to read from stdin
-    if (parameters.get(0).equals("-")) {
-      hosts = new ArrayList<>();
-      Scanner scanner = new Scanner(System.in, "UTF-8");
-      while (scanner.hasNextLine()) {
-        hosts.add(scanner.nextLine().trim());
-      }
-    } else {
-      hosts = parameters;
-    }
+    List<String> hosts = hostNameParams.getHostNames();
     List<DatanodeAdminError> errors = scmClient.recommissionNodes(hosts);
     System.out.println("Started recommissioning datanode(s):\n" +
         String.join("\n", hosts));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
@@ -26,6 +26,8 @@ import picocli.CommandLine.Command;
 import java.io.IOException;
 import java.util.List;
 
+import static org.apache.hadoop.hdds.scm.cli.datanode.DecommissionSubCommand.showErrors;
+
 /**
  * Recommission one or more datanodes.
  * Place decommissioned or maintenance nodes back into service.
@@ -46,15 +48,6 @@ public class RecommissionSubCommand extends ScmSubcommand {
     List<DatanodeAdminError> errors = scmClient.recommissionNodes(hosts);
     System.out.println("Started recommissioning datanode(s):\n" +
         String.join("\n", hosts));
-    if (errors.size() > 0) {
-      for (DatanodeAdminError error : errors) {
-        System.err.println("Error: " + error.getHostname() + ": "
-            + error.getError());
-      }
-      // Throwing the exception will cause a non-zero exit status for the
-      // command.
-      throw new IOException(
-          "Some nodes could be recommissioned");
-    }
+    showErrors(errors, "Some nodes could be recommissioned");
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce code duplication in decommission and maintenance subcommands.

- Specify `arity` to require at least one parameter, instead of checking explicitly.
- Extract duplicated "list of host names" parameter and logic.
- Reuse "show errors" logic.

https://issues.apache.org/jira/browse/HDDS-11990

## How was this patch tested?

Tested in `ozone-topology` env:

```
$ ozone admin datanode maintenance
Missing required parameter: '<host name>'
Usage: ozone admin datanode maintenance [-hV] [--force] [--end=<endInHours>]
                                        [-id=<scmServiceId>] [--scm=<scm>]
                                        <host name>...
Put a datanode into Maintenance Mode
      <host name>...       One or more host names separated by spaces. To read
                             from stdin, specify '-' and supply the host names
                             separated by newlines.
      --end=<endInHours>   Automatically end maintenance after the given hours.
                             By default, maintenance must be ended manually.
      --force              Forcefully try to decommission the datanode(s)
  -h, --help               Show this help message and exit.
      -id, --service-id=<scmServiceId>
                           ServiceId of SCM HA Cluster
      --scm=<scm>          The destination scm (host:port)
  -V, --version            Print version information and exit.


$ ozone admin datanode maintenance - <<EOF
> 18f367dac6f6
> 2f5e52c1f56b
> EOF
Entering maintenance mode on datanode(s):
18f367dac6f6
2f5e52c1f56b


$ ozone admin datanode maintenance asdf
Entering maintenance mode on datanode(s):
asdf
Error: asdf: asdf: Name or service not known
Some nodes could not start the maintenance workflow
```