### PR TITLE
HDDS-11995. Acceptance Test test-all script fails to delete old result directories.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -22,8 +22,8 @@
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 ALL_RESULT_DIR="$SCRIPT_DIR/result"
 PROJECT_DIR="$SCRIPT_DIR/.."
-mkdir -p "$ALL_RESULT_DIR"
-rm -rf "${ALL_RESULT_DIR:?}"/* || true
+rm -rf "${ALL_RESULT_DIR}"
+mkdir -p "${ALL_RESULT_DIR}"
 
 source "$SCRIPT_DIR"/testlib.sh
 

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -23,7 +23,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 ALL_RESULT_DIR="$SCRIPT_DIR/result"
 PROJECT_DIR="$SCRIPT_DIR/.."
 mkdir -p "$ALL_RESULT_DIR"
-rm "$ALL_RESULT_DIR"/* || true
+rm -rf "${ALL_RESULT_DIR:?}"/* || true
 
 source "$SCRIPT_DIR"/testlib.sh
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Acceptance Test test-all script fails to delete old result directories.

The fix deletes the directories recursively.

## What is the link to the Apache JIRA
HDDS-11995

## How was this patch tested?
Manually tested the fix

Before fix
```
╰─❯ ./test-all.sh
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/compatibility: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozone: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozone-balancer: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozone-csi: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozone-ha: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozone-om-prepare: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozone-topology: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozonescripts: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozonesecure: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozonesecure-ha: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/ozonesecure-mr: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/restart: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/upgrade: is a directory
rm: /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/xcompat: is a directory
Using Docker Compose v2
Executing test compatibility/test.sh
Using Docker Compose v2
```

After fix
```
╰─❯ ./test-all.sh
Using Docker Compose v2
Executing test compatibility/test.sh
Using Docker Compose v2
```
