### PR TITLE
HDDS-11992. Replace GenericCli#createOzoneConfiguration calls with getOzoneConf.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.cli;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.function.Supplier;
 
 import com.google.common.base.Strings;
 import org.apache.hadoop.fs.Path;
@@ -27,7 +26,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.ratis.util.MemoizedSupplier;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Model.CommandSpec;
@@ -40,24 +38,24 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
 
   public static final int EXECUTION_ERROR_EXIT_CODE = -1;
 
+  private final OzoneConfiguration config = new OzoneConfiguration();
+  private final CommandLine cmd;
+
+  private UserGroupInformation user;
+
   @Option(names = {"--verbose"},
       description = "More verbose output. Show the stack trace of the errors.")
   private boolean verbose;
 
   @Option(names = {"-D", "--set"})
   public void setConfigurationOverrides(Map<String, String> configOverrides) {
-    configOverrides.forEach(getOzoneConf()::set);
+    configOverrides.forEach(config::set);
   }
 
   @Option(names = {"-conf"})
   public void setConfigurationPath(String configPath) {
-    getOzoneConf().addResource(new Path(configPath));
+    config.addResource(new Path(configPath));
   }
-
-  private final Supplier<OzoneConfiguration> configSupplier =
-      MemoizedSupplier.valueOf(OzoneConfiguration::new);
-  private final CommandLine cmd;
-  private UserGroupInformation user;
 
   public GenericCli() {
     this(CommandLine.defaultFactory());
@@ -112,7 +110,7 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
 
   @Override
   public OzoneConfiguration getOzoneConf() {
-    return configSupplier.get();
+    return config;
   }
 
   public UserGroupInformation getUser() throws IOException {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -169,7 +169,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   @Override
   public Void call() throws Exception {
-    OzoneConfiguration configuration = createOzoneConfiguration();
+    OzoneConfiguration configuration = getOzoneConf();
     if (printBanner) {
       HddsServerUtil.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
           HddsDatanodeService.class, args, LOG, configuration);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -150,7 +150,7 @@ public class StorageContainerManagerStarter extends GenericCli {
    * is set and print the startup banner message.
    */
   private void commonInit() {
-    conf = createOzoneConfiguration();
+    conf = getOzoneConf();
     TracingUtil.initTracing("StorageContainerManager", conf);
 
     String[] originalArgs = getCmd().getParseResult().originalArgs()

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -37,7 +37,7 @@ public class OzoneAdmin extends GenericCli implements ExtensibleParentCommand {
 
   @Override
   public int execute(String[] argv) {
-    TracingUtil.initTracing("shell", createOzoneConfiguration());
+    TracingUtil.initTracing("shell", getOzoneConf());
     String spanName = "ozone admin " + String.join(" ", argv);
     return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));

--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
@@ -54,7 +54,7 @@ public class CsiServer extends GenericCli implements Callable<Void> {
   public Void call() throws Exception {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
             .toArray(new String[0]);
-    OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
+    OzoneConfiguration ozoneConfiguration = getOzoneConf();
     HddsServerUtil.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
             CsiServer.class, originalArgs, LOG, ozoneConfiguration);
     CsiConfig csiConfig = ozoneConfiguration.getObject(CsiConfig.class);

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -46,7 +46,7 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
   @Override
   public Void call() throws Exception {
     InsightPoint insight =
-        getInsight(getInsightCommand().createOzoneConfiguration(), insightName);
+        getInsight(getInsightCommand().getOzoneConf(), insightName);
     System.out.println(
         "Configuration for `" + insightName + "` (" + insight.getDescription()
             + ")");

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
@@ -72,7 +72,7 @@ public class LogSubcommand extends BaseInsightSubCommand
   @Override
   public Void call() {
     OzoneConfiguration conf =
-        getInsightCommand().createOzoneConfiguration();
+        getInsightCommand().getOzoneConf();
     InsightPoint insight =
         getInsight(conf, insightName);
 

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/MetricsSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/MetricsSubCommand.java
@@ -62,7 +62,7 @@ public class MetricsSubCommand extends BaseInsightSubCommand
   @Override
   public Void call() throws Exception {
     OzoneConfiguration conf =
-        getInsightCommand().createOzoneConfiguration();
+        getInsightCommand().getOzoneConf();
     InsightPoint insight =
         getInsight(conf, insightName);
     Set<Component> sources =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
@@ -304,7 +304,7 @@ public final class TestBlockTokensCLI {
    * format.
    */
   private String[] createArgsForCommand(String[] additionalArgs) {
-    OzoneConfiguration defaultConf = ozoneAdmin.createOzoneConfiguration();
+    OzoneConfiguration defaultConf = ozoneAdmin.getOzoneConf();
     Map<String, String> diff = Maps.difference(defaultConf.getOzoneProperties(),
         conf.getOzoneProperties()).entriesOnlyOnRight();
     String[] args = new String[diff.size() + additionalArgs.length];

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -167,7 +167,7 @@ public class OzoneManagerStarter extends GenericCli {
    * is set and print the startup banner message.
    */
   private void commonInit() {
-    conf = createOzoneConfiguration();
+    conf = getOzoneConf();
     TracingUtil.initTracing("OzoneManager", conf);
 
     String[] originalArgs = getCmd().getParseResult().originalArgs()

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -101,7 +101,7 @@ public class ReconServer extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
 
-    configuration = createOzoneConfiguration();
+    configuration = getOzoneConf();
     HddsServerUtil.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
             ReconServer.class, originalArgs, LOG, configuration);
     ConfigurationProvider.setConfiguration(configuration);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -72,7 +72,7 @@ public class Gateway extends GenericCli {
 
   @Override
   public Void call() throws Exception {
-    OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
+    OzoneConfiguration ozoneConfiguration = getOzoneConf();
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     TracingUtil.initTracing("S3gateway", OzoneConfigurationHolder.configuration());
     UserGroupInformation.setConfiguration(OzoneConfigurationHolder.configuration());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -572,7 +572,7 @@ public class BaseFreonGenerator {
   }
 
   public OzoneConfiguration createOzoneConfiguration() {
-    return freonCommand.createOzoneConfiguration();
+    return freonCommand.getOzoneConf();
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DNRPCLoadGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DNRPCLoadGenerator.java
@@ -127,7 +127,7 @@ public class DNRPCLoadGenerator extends BaseFreonGenerator
             "OM echo response payload size should be positive value or zero.");
 
     if (configuration == null) {
-      configuration = freon.createOzoneConfiguration();
+      configuration = freon.getOzoneConf();
     }
     ContainerOperationClient scmClient = new ContainerOperationClient(configuration);
     ContainerInfo containerInfo = scmClient.getContainer(containerID);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulator.java
@@ -422,7 +422,7 @@ public class DatanodeSimulator implements Callable<Void> {
   }
 
   private void init() throws IOException {
-    conf = freonCommand.createOzoneConfiguration();
+    conf = freonCommand.getOzoneConf();
     Collection<InetSocketAddress> addresses = getSCMAddressForDatanodes(conf);
     scmClients = new HashMap<>(addresses.size());
     for (InetSocketAddress address : addresses) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -96,7 +96,7 @@ public class Freon extends GenericCli {
 
   @Override
   public int execute(String[] argv) {
-    conf = createOzoneConfiguration();
+    conf = getOzoneConf();
     HddsServerUtil.initializeMetrics(conf, "ozone-freon");
     TracingUtil.initTracing("freon", conf);
     return super.execute(argv);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HsyncGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HsyncGenerator.java
@@ -100,7 +100,7 @@ public class HsyncGenerator extends BaseFreonGenerator implements Callable<Void>
     init();
 
     if (configuration == null) {
-      configuration = freon.createOzoneConfiguration();
+      configuration = freon.getOzoneConf();
     }
     URI uri = URI.create(rootPath);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -285,7 +285,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
   @Override
   public Void call() throws Exception {
     if (ozoneConfiguration == null) {
-      ozoneConfiguration = freon.createOzoneConfiguration();
+      ozoneConfiguration = freon.getOzoneConf();
     }
     if (!ozoneConfiguration.getBoolean(
         HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
@@ -190,7 +190,7 @@ public final class SCMThroughputBenchmark implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-    conf = freon.createOzoneConfiguration();
+    conf = freon.getOzoneConf();
 
     ThroughputBenchmark benchmark = createBenchmark();
     initCluster(benchmark);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneRatis.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneRatis.java
@@ -39,7 +39,7 @@ public class OzoneRatis extends GenericCli {
 
   @Override
   public int execute(String[] argv) {
-    TracingUtil.initTracing("shell", createOzoneConfiguration());
+    TracingUtil.initTracing("shell", getOzoneConf());
     String spanName = "ozone ratis" + String.join(" ", argv);
     return TracingUtil.executeInNewSpan(spanName, () -> {
       // TODO: When Ozone has RATIS-2155, update this line to use the RatisShell.Builder

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -58,7 +58,7 @@ public class OzoneShell extends Shell {
 
   @Override
   public int execute(String[] argv) {
-    TracingUtil.initTracing("shell", createOzoneConfiguration());
+    TracingUtil.initTracing("shell", getOzoneConf());
     String spanName = "ozone sh " + String.join(" ", argv);
     return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
@@ -36,7 +36,7 @@ public class S3Shell extends Shell {
 
   @Override
   public int execute(String[] argv) {
-    TracingUtil.initTracing("s3shell", createOzoneConfiguration());
+    TracingUtil.initTracing("s3shell", getOzoneConf());
     String spanName = "ozone s3 " + String.join(" ", argv);
     return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
@@ -37,7 +37,7 @@ public class TenantShell extends Shell {
 
   @Override
   public int execute(String[] argv) {
-    TracingUtil.initTracing("tenant-shell", createOzoneConfiguration());
+    TracingUtil.initTracing("tenant-shell", getOzoneConf());
     String spanName = "ozone tenant " + String.join(" ", argv);
     return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace `GenericCli#createOzoneConfiguration` calls with `GenericCli#getOzoneConf`.

`GenericCli#getOzoneConf` is getting called before `picocli` injects the command-line Options `configurationOverrides` and `configurationPath`, so the `OzoneConfigutation` object is created before `picocli` updates these Options.

To update the `OzoneConfigutation` object with `configurationOverrides` and `configurationPath`, this PR changes the `configurationOverrides` and `configurationPath` instance variables to methods.

## What is the link to the Apache JIRA

HDDS-11992

## How was this patch tested?
CI Run: [12523963928](https://github.com/nandakumar131/ozone/actions/runs/12523963928)

