### PR TITLE
HDDS-11997. Duplicate snapshot purge request causes NPE

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -227,7 +227,9 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
 
     if (snapshotInfo == null) {
       snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(snapshotTableKey);
-      updatedSnapshotInfos.put(snapshotTableKey, snapshotInfo);
+      if (snapshotInfo != null) {
+        updatedSnapshotInfos.put(snapshotTableKey, snapshotInfo);
+      }
     }
     return snapshotInfo;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.ozone.om.response.snapshot;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -137,5 +138,10 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
             snapshotInfo.getBucketName(), snapshotInfo.getName());
       }
     }
+  }
+
+  @VisibleForTesting
+  public Map<String, SnapshotInfo> getUpdatedSnapInfos() {
+    return updatedSnapInfos;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Duplicate snapshot purge request causes NPE.
The fix would be add a check if the snapshotInfo is not null before adding to updatedSnapshotInfos map. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11997

## How was this patch tested?
Added a unit test for duplicate snapshot purge request which repros the issue