### PR TITLE
HDDS-11726. Add leader readiness state to OM UI

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -923,7 +923,7 @@ public final class OmUtils {
   }
   
   public static List<List<String>> format(
-          List<ServiceInfo> nodes, int port, String leaderId) {
+          List<ServiceInfo> nodes, int port, String leaderId, String leaderReadiness) {
     List<List<String>> omInfoList = new ArrayList<>();
     // Ensuring OM's are printed in correct order
     List<ServiceInfo> omNodes = nodes.stream()
@@ -940,6 +940,7 @@ public final class OmUtils {
         omInfo.add(info.getOmRoleInfo().getNodeId());
         omInfo.add(String.valueOf(port));
         omInfo.add(role);
+        omInfo.add(leaderReadiness);
         omInfoList.add(omInfo);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3091,7 +3091,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public List<List<String>> getRatisRoles() {
-    String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     int port = omNodeDetails.getRatisPort();
     if (!isRatisEnabled) {
       return getRatisRolesException("Ratis is disabled");
@@ -3099,6 +3098,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (null == omRatisServer) {
       return getRatisRolesException("Server is shutting down");
     }
+    String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
       LOG.error("No leader found");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3091,6 +3091,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public List<List<String>> getRatisRoles() {
+    String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     int port = omNodeDetails.getRatisPort();
     if (!isRatisEnabled) {
       return getRatisRolesException("Ratis is disabled");
@@ -3111,7 +3112,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.error("Failed to getServiceList", e);
       return getRatisRolesException("IO-Exception Occurred, " + e.getMessage());
     }
-    return OmUtils.format(serviceList, port, leaderId.toString());
+    return OmUtils.format(serviceList, port, leaderId.toString(), leaderReadiness);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -55,6 +55,7 @@
             <th>Node ID</th>
             <th>Ratis Port</th>
             <th>Role</th>
+            <th>Leader Readiness</th>
         </tr>
         </thead>
         <tbody ng-repeat="roles in $ctrl.overview.jmx.RatisRoles">
@@ -63,12 +64,14 @@
             <td>{{roles[1]}}</td>
             <td>{{roles[2]}}</td>
             <td>{{roles[3]}}</td>
+            <td>{{roles[4]}}</td>
         </tr>
         <tr ng-if="$ctrl.role.Id != roles[1]">
             <td>{{roles[0]}}</td>
             <td>{{roles[1]}}</td>
             <td>{{roles[2]}}</td>
             <td>{{roles[3]}}</td>
+            <td>{{roles[4]}}</td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the Ozone Manager UI, it would be better to add leader readiness in it to provide more detail information. Please take a look, thanks and happy new year!

## What is the link to the Apache JIRA
[HDDS-11726](https://issues.apache.org/jira/browse/HDDS-11726)

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
Please check the attachment to confirm.
![snapshot](https://github.com/user-attachments/assets/5afcf7da-ea7e-45f1-ac55-501e572011b8)

