### PR TITLE
HDDS-11836. Interactive mode for ozone admin/debug

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.ozone.admin;
 
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.ExtensibleParentCommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 
+import org.apache.hadoop.ozone.shell.Shell;
 import picocli.CommandLine;
 
 /**
@@ -33,7 +33,7 @@ import picocli.CommandLine;
     description = "Developer tools for Ozone Admin operations",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
-public class OzoneAdmin extends GenericCli implements ExtensibleParentCommand {
+public class OzoneAdmin extends Shell implements ExtensibleParentCommand {
 
   public static void main(String[] argv) {
     new OzoneAdmin().run(argv);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -20,9 +20,8 @@ package org.apache.hadoop.ozone.debug;
 
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.cli.ExtensibleParentCommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-
+import org.apache.hadoop.ozone.shell.Shell;
 import picocli.CommandLine;
 
 /**
@@ -32,7 +31,7 @@ import picocli.CommandLine;
         description = "Developer tools for Ozone Debug operations",
         versionProvider = HddsVersionProvider.class,
         mixinStandardHelpOptions = true)
-public class OzoneDebug extends GenericCli implements ExtensibleParentCommand {
+public class OzoneDebug extends Shell implements ExtensibleParentCommand {
 
   public static void main(String[] argv) {
     new OzoneDebug().run(argv);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable interactive mode for `ozone admin` and `ozone debug`.

https://issues.apache.org/jira/browse/HDDS-11836

## How was this patch tested?

```
$ ozone admin --interactive
ozone admin> help
 -  ozone admin registry
Summary: cert               Certificate related operations
         container         Container specific operations
         containerbalancer ContainerBalancer specific operations
         datanode          Datanode specific operations
         namespace         Namespace Summary specific admin operations
         om                Ozone Manager specific admin operations
         pipeline          Pipeline specific operations
         printTopology     Print a tree of the network topology as reported by SCM
         reconfig          Dynamically reconfigure server without restarting it
         replicationmanager ReplicationManager specific operations
         safemode          Safe mode specific operations
         scm               Ozone Storage Container Manager specific admin operations
ozone admin> exit

$ ozone debug --interactive
ozone debug> help
 -  ozone debug registry
Summary: chunkinfo            returns chunk location information about an existing key
         container           Container replica specific operations to be executed on datanodes only
         find-missing-padding List all keys with any missing padding, optionally limited to a
         fmp                 List all keys with any missing padding, optionally limited to a
         ldb                 Parse rocksdb file content
         pld                 Create an image of the current compaction log DAG in OM.
         prefix              Parse prefix contents
         print-log-dag       Create an image of the current compaction log DAG in OM.
         ratislogparser      Shell of printing Ratis Log in understandable text
         read-replicas       Reads every replica for all the blocks associated with a given key.
         recover             recover the lease of a specified file. Make sure to specify file system scheme
         version             Show internal version of Ozone components, as defined in the artifacts where
ozone debug> exit
```
