### PR TITLE
HDDS-12001. Create parent class for repair tools

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RecoverSCMCertificate.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RecoverSCMCertificate.java
@@ -38,7 +38,6 @@ import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +51,6 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Arrays;
-import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_SCM_CERTS;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.DefaultCertificateClient.CERT_FILE_NAME_FORMAT;
@@ -68,7 +66,7 @@ import static org.apache.hadoop.ozone.om.helpers.OzoneFSUtils.removeTrailingSlas
     name = "cert-recover",
     description = "Recover Deleted SCM Certificate from RocksDB")
 @MetaInfServices(RepairSubcommand.class)
-public class RecoverSCMCertificate implements Callable<Void>, RepairSubcommand {
+public class RecoverSCMCertificate extends RepairTool implements RepairSubcommand {
 
   @CommandLine.Option(names = {"--db"},
       required = true,
@@ -78,19 +76,8 @@ public class RecoverSCMCertificate implements Callable<Void>, RepairSubcommand {
   @CommandLine.ParentCommand
   private OzoneRepair parent;
 
-  @CommandLine.Spec
-  private CommandLine.Model.CommandSpec spec;
-
-  private PrintWriter err() {
-    return spec.commandLine().getErr();
-  }
-
-  private PrintWriter out() {
-    return spec.commandLine().getOut();
-  }
-
   @Override
-  public Void call() throws Exception {
+  public void execute() throws Exception {
     dbPath = removeTrailingSlashIfNeeded(dbPath);
     String tableName = VALID_SCM_CERTS.getName();
     DBDefinition dbDefinition =
@@ -112,15 +99,15 @@ public class RecoverSCMCertificate implements Callable<Void>, RepairSubcommand {
         SecurityConfig securityConfig = new SecurityConfig(parent.getOzoneConf());
 
         Map<BigInteger, X509Certificate> allCerts = getAllCerts(columnFamilyDefinition, cfHandle, db);
-        out().println("All Certs in DB : " +  allCerts.keySet());
+        info("All Certs in DB : %s", allCerts.keySet());
         String hostName = InetAddress.getLocalHost().getHostName();
-        out().println("Host: " + hostName);
+        info("Host: %s", hostName);
 
         X509Certificate subCertificate = getSubCertificate(allCerts, hostName);
         X509Certificate rootCertificate = getRootCertificate(allCerts);
 
-        out().println("Sub cert serialID for this host: " + subCertificate.getSerialNumber().toString());
-        out().println("Root cert serialID: " + rootCertificate.getSerialNumber().toString());
+        info("Sub cert serialID for this host: %s", subCertificate.getSerialNumber());
+        info("Root cert serialID: %s", rootCertificate.getSerialNumber());
 
         boolean isRootCA = false;
 
@@ -131,9 +118,8 @@ public class RecoverSCMCertificate implements Callable<Void>, RepairSubcommand {
         storeCerts(subCertificate, rootCertificate, isRootCA, securityConfig);
       }
     } catch (RocksDBException | CertificateException exception) {
-      err().print("Failed to recover scm cert");
+      error("Failed to recover scm cert");
     }
-    return null;
   }
 
   private static ColumnFamilyHandle getColumnFamilyHandle(
@@ -210,17 +196,17 @@ public class RecoverSCMCertificate implements Callable<Void>, RepairSubcommand {
     CertificateCodec certCodec =
         new CertificateCodec(securityConfig, SCMCertificateClient.COMPONENT_NAME);
 
-    out().println("Writing certs to path : " + certCodec.getLocation().toString());
+    info("Writing certs to path : %s", certCodec.getLocation());
 
     CertPath certPath = addRootCertInPath(scmCertificate, rootCertificate);
     CertPath rootCertPath = getRootCertPath(rootCertificate);
     String encodedCert = CertificateCodec.getPEMEncodedString(certPath);
     String certName = String.format(CERT_FILE_NAME_FORMAT,
-        CAType.NONE.getFileNamePrefix() + scmCertificate.getSerialNumber().toString());
+        CAType.NONE.getFileNamePrefix() + scmCertificate.getSerialNumber());
     certCodec.writeCertificate(certName, encodedCert);
 
     String rootCertName = String.format(CERT_FILE_NAME_FORMAT,
-        CAType.SUBORDINATE.getFileNamePrefix() + rootCertificate.getSerialNumber().toString());
+        CAType.SUBORDINATE.getFileNamePrefix() + rootCertificate.getSerialNumber());
     String encodedRootCert = CertificateCodec.getPEMEncodedString(rootCertPath);
     certCodec.writeCertificate(rootCertName, encodedRootCert);
 
@@ -230,7 +216,7 @@ public class RecoverSCMCertificate implements Callable<Void>, RepairSubcommand {
     if (isRootCA) {
       CertificateCodec rootCertCodec =
           new CertificateCodec(securityConfig, OzoneConsts.SCM_ROOT_CA_COMPONENT_NAME);
-      out().println("Writing root certs to path : " + rootCertCodec.getLocation().toString());
+      info("Writing root certs to path : %s", rootCertCodec.getLocation());
       rootCertCodec.writeCertificate(rootCertCodec.getLocation().toAbsolutePath(),
           securityConfig.getCertificateFileName(), encodedRootCert);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.repair;
+
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
+
+import java.io.PrintWriter;
+import java.util.concurrent.Callable;
+
+/** Parent class for all actionable repair commands. */
+public abstract class RepairTool extends AbstractSubcommand implements Callable<Void> {
+
+  /** Hook method for subclasses for performing actual repair task. */
+  protected abstract void execute() throws Exception;
+
+  @Override
+  public final Void call() throws Exception {
+    execute();
+    return null;
+  }
+
+  protected void info(String msg, Object... args) {
+    out().println(formatMessage(msg, args));
+  }
+
+  protected void error(String msg, Object... args) {
+    err().println(formatMessage(msg, args));
+  }
+
+  private PrintWriter out() {
+    return spec().commandLine()
+        .getOut();
+  }
+
+  private PrintWriter err() {
+    return spec().commandLine()
+        .getErr();
+  }
+
+  private String formatMessage(String msg, Object[] args) {
+    if (args != null && args.length > 0) {
+      msg = String.format(msg, args);
+    }
+    return msg;
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/TransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/TransactionInfoRepair.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.debug.RocksDBUtils;
+import org.apache.hadoop.ozone.repair.RepairTool;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
@@ -35,7 +36,6 @@ import picocli.CommandLine;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TRANSACTION_INFO_TABLE;
@@ -49,10 +49,7 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TRANSACTION_INFO_
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
-public class TransactionInfoRepair implements Callable<Void>  {
-
-  @CommandLine.Spec
-  private static CommandLine.Model.CommandSpec spec;
+public class TransactionInfoRepair extends RepairTool {
 
   @CommandLine.ParentCommand
   private RDBRepair parent;
@@ -67,20 +64,8 @@ public class TransactionInfoRepair implements Callable<Void>  {
       description = "Highest index of transactionInfoTable. The input should be non-zero long integer.")
   private long highestTransactionIndex;
 
-
-  protected void setHighestTransactionTerm(
-      long highestTransactionTerm) {
-    this.highestTransactionTerm = highestTransactionTerm;
-  }
-
-  protected void setHighestTransactionIndex(
-      long highestTransactionIndex) {
-    this.highestTransactionIndex = highestTransactionIndex;
-  }
-
-
   @Override
-  public Void call() throws Exception {
+  public void execute() throws Exception {
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
     String dbPath = getParent().getDbPath();
     List<ColumnFamilyDescriptor> cfDescList = RocksDBUtils.getColumnFamilyDescriptors(
@@ -95,7 +80,7 @@ public class TransactionInfoRepair implements Callable<Void>  {
       TransactionInfo originalTransactionInfo =
           RocksDBUtils.getValue(db, transactionInfoCfh, TRANSACTION_INFO_KEY, TransactionInfo.getCodec());
 
-      System.out.println("The original highest transaction Info was " + originalTransactionInfo.getTermIndex());
+      info("The original highest transaction Info was %s", originalTransactionInfo.getTermIndex());
 
       TransactionInfo transactionInfo = TransactionInfo.valueOf(highestTransactionTerm, highestTransactionIndex);
 
@@ -103,19 +88,17 @@ public class TransactionInfoRepair implements Callable<Void>  {
       db.get()
           .put(transactionInfoCfh, StringCodec.get().toPersistedFormat(TRANSACTION_INFO_KEY), transactionInfoBytes);
 
-      System.out.println("The highest transaction info has been updated to: " +
+      info("The highest transaction info has been updated to: %s",
           RocksDBUtils.getValue(db, transactionInfoCfh, TRANSACTION_INFO_KEY,
               TransactionInfo.getCodec()).getTermIndex());
     } catch (RocksDBException exception) {
-      System.err.println("Failed to update the RocksDB for the given path: " + dbPath);
-      System.err.println(
+      error("Failed to update the RocksDB for the given path: %s", dbPath);
+      error(
           "Make sure that Ozone entity (OM) is not running for the give database path and current host.");
       throw new IOException("Failed to update RocksDB.", exception);
     } finally {
       IOUtils.closeQuietly(cfHandleList);
     }
-
-    return null;
   }
 
   protected RDBRepair getParent() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairCLI.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairCLI.java
@@ -18,9 +18,8 @@
 
 package org.apache.hadoop.ozone.repair.om;
 
+import org.apache.hadoop.ozone.repair.RepairTool;
 import picocli.CommandLine;
-
-import java.util.concurrent.Callable;
 
 /**
  * Parser for scm.db file.
@@ -30,7 +29,7 @@ import java.util.concurrent.Callable;
     description = "Identify and repair a disconnected FSO tree by marking unreferenced entries for deletion. " +
         "OM should be stopped while this tool is run."
 )
-public class FSORepairCLI implements Callable<Void> {
+public class FSORepairCLI extends RepairTool {
 
   @CommandLine.Option(names = {"--db"},
       required = true,
@@ -55,11 +54,11 @@ public class FSORepairCLI implements Callable<Void> {
   private boolean verbose;
 
   @Override
-  public Void call() throws Exception {
+  public void execute() throws Exception {
     if (repair) {
-      System.out.println("FSO Repair Tool is running in repair mode");
+      info("FSO Repair Tool is running in repair mode");
     } else {
-      System.out.println("FSO Repair Tool is running in debug mode");
+      info("FSO Repair Tool is running in debug mode");
     }
     try {
       FSORepairTool
@@ -70,9 +69,7 @@ public class FSORepairCLI implements Callable<Void> {
     }
 
     if (verbose) {
-      System.out.println("FSO repair finished.");
+      info("FSO repair finished.");
     }
-
-    return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
@@ -24,10 +24,10 @@ package org.apache.hadoop.ozone.repair.quota;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.repair.RepairTool;
 import picocli.CommandLine;
 
 /**
@@ -39,9 +39,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
-public class QuotaTrigger implements Callable<Void>  {
-  @CommandLine.Spec
-  private static CommandLine.Model.CommandSpec spec;
+public class QuotaTrigger extends RepairTool {
 
   @CommandLine.ParentCommand
   private QuotaRepair parent;
@@ -68,20 +66,19 @@ public class QuotaTrigger implements Callable<Void>  {
   private String buckets;
 
   @Override
-  public Void call() throws Exception {
+  public void execute() throws Exception {
     List<String> bucketList = Collections.emptyList();
     if (StringUtils.isNotEmpty(buckets)) {
       bucketList = Arrays.asList(buckets.split(","));
     }
-    
-    OzoneManagerProtocol ozoneManagerClient =
-        parent.createOmClient(omServiceId, omHost, false);
-    try {
-      ozoneManagerClient.startQuotaRepair(bucketList);
-      System.out.println(ozoneManagerClient.getQuotaRepairStatus());
-    } catch (Exception ex) {
-      System.out.println(ex.getMessage());
+
+    try (OzoneManagerProtocol omClient = parent.createOmClient(omServiceId, omHost, false)) {
+      info("Triggering quota repair for %s",
+          bucketList.isEmpty()
+              ? "all buckets"
+              : ("buckets " + buckets));
+      omClient.startQuotaRepair(bucketList);
+      info(omClient.getQuotaRepairStatus());
     }
-    return null;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce parent class for repair tools where common logic can be added later:
- Move up `out()` and `err()` from `RecoverSCMCertificate`
- Add methods to show informational and error messages

Additional minor cleanup:
- Ensure OM client is closed in `QuotaTrigger`
- Remove unused methods from `TransactionInfoRepair`

https://issues.apache.org/jira/browse/HDDS-12001

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12583280950
