### PR TITLE
HDDS-11998. XceiverClientMetrics#decrPendingContainerOpsMetrics should be called in BlockDataStreamOutput

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -253,7 +253,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     }
     while (len > 0) {
       allocateNewBufferIfNeeded();
-      int writeLen = Math.min(len, currentBuffer.length());
+      int writeLen = Math.min(len, currentBuffer.remaining());
       final StreamBuffer buf = new StreamBuffer(b, off, writeLen);
       currentBuffer.put(buf);
       writeChunkIfNeeded();
@@ -265,7 +265,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
   }
 
   private void writeChunkIfNeeded() throws IOException {
-    if (currentBuffer.length() == 0) {
+    if (currentBuffer.remaining() == 0) {
       writeChunk(currentBuffer);
       currentBuffer = null;
     }
@@ -672,6 +672,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
             out.writeAsync(buf, StandardWriteOption.SYNC) :
             out.writeAsync(buf))
             .whenCompleteAsync((r, e) -> {
+              metrics.decrPendingContainerOpsMetrics(ContainerProtos.Type.WriteChunk);
               if (e != null || !r.isSuccess()) {
                 if (e == null) {
                   e = new IOException("result is not success");

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBuffer.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBuffer.java
@@ -39,8 +39,8 @@ public class StreamBuffer {
     return buffer.duplicate();
   }
 
-  public int length() {
-    return buffer.limit() - buffer.position();
+  public int remaining() {
+    return buffer.remaining();
   }
 
   public int position() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unlike in Write Pipeline V1 writeChunk, XceiverClientMetrics#decrPendingContainerOpsMetrics is not called in the BlockDataStreamOutput#writeChunkToContainer which causes the pending ops to always increase.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11998

## How was this patch tested?

Update `TestBlockDataStreamOutput` to check for `WriteChunk` `pendingContainerOpsMetrics`. Also slightly improve the tests.
