### PR TITLE
HDDS-12006. Enable sortpom in hdds-container-service, hdds-crypto-api, hdds-crypto-default, hdds-docs

### DIFF
--- a/hadoop-hdds/annotations/pom.xml
+++ b/hadoop-hdds/annotations/pom.xml
@@ -28,8 +28,8 @@
     annotations at compile time.</description>
 
   <properties>
-    <maven.test.skip>true</maven.test.skip>
     <!-- no tests in this module so far -->
+    <maven.test.skip>true</maven.test.skip>
   </properties>
 
   <build>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -12,10 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.ozone</groupId>
@@ -24,13 +21,109 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hdds-container-service</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <description>Apache Ozone Distributed Data Store Container Service</description>
-  <name>Apache Ozone HDDS Container Service</name>
   <packaging>jar</packaging>
-  <properties>
-    <sort.skip>true</sort.skip>
-  </properties>
+  <name>Apache Ozone HDDS Container Service</name>
+  <description>Apache Ozone Distributed Data Store Container Service</description>
   <dependencies>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-client</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-common</artifactId>
@@ -51,111 +144,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-managed-rocksdb</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.github.luben</groupId>
-      <artifactId>zstd-jni</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-server-framework</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-docs</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.ratis</groupId>
-      <artifactId>ratis-server</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>info.picocli</groupId>
-      <artifactId>picocli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-buffer</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ratis</groupId>
@@ -177,6 +168,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-proto</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-server-api</artifactId>
@@ -184,6 +180,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-thirdparty-misc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
 
     <dependency>
@@ -196,20 +196,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
     </dependency>
+
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-docs</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
@@ -261,7 +255,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>ban-annotations</id> <!-- override default restriction from root POM -->
+            <id>ban-annotations</id>
+            <!-- override default restriction from root POM -->
             <configuration>
               <rules>
                 <restrictImports>
@@ -283,17 +278,16 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <executions>
           <execution>
             <id>copy-common-html</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>unpack</goal>
             </goals>
+            <phase>prepare-package</phase>
             <configuration>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.ozone</groupId>
                   <artifactId>hdds-server-framework</artifactId>
-                  <outputDirectory>${project.build.outputDirectory}
-                  </outputDirectory>
+                  <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                   <includes>webapps/static/**/*.*</includes>
                 </artifactItem>
                 <artifactItem>

--- a/hadoop-hdds/crypto-api/pom.xml
+++ b/hadoop-hdds/crypto-api/pom.xml
@@ -12,27 +12,25 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>hdds-crypto-api</artifactId>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.ozone</groupId>
+    <artifactId>hdds</artifactId>
     <version>2.0.0-SNAPSHOT</version>
-    <description>Apache Ozone Distributed Data Store cryptographic functions</description>
-    <name>Apache Ozone HDDS Crypto</name>
+  </parent>
 
-    <properties>
-        <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
-        <sort.skip>true</sort.skip>
-    </properties>
+  <artifactId>hdds-crypto-api</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <name>Apache Ozone HDDS Crypto</name>
+  <description>Apache Ozone Distributed Data Store cryptographic functions</description>
 
-    <dependencies>
+  <properties>
+    <!-- no tests in this module so far -->
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
 
-    </dependencies>
+  <dependencies>
+
+  </dependencies>
 </project>

--- a/hadoop-hdds/crypto-default/pom.xml
+++ b/hadoop-hdds/crypto-default/pom.xml
@@ -12,27 +12,25 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>hdds-crypto-default</artifactId>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.ozone</groupId>
+    <artifactId>hdds</artifactId>
     <version>2.0.0-SNAPSHOT</version>
-    <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
-    <name>Apache Ozone HDDS Crypto - Default</name>
+  </parent>
 
-    <properties>
-        <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
-        <sort.skip>true</sort.skip>
-    </properties>
+  <artifactId>hdds-crypto-default</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <name>Apache Ozone HDDS Crypto - Default</name>
+  <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
 
-    <dependencies>
+  <properties>
+    <!-- no tests in this module so far -->
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
 
-    </dependencies>
+  <dependencies>
+
+  </dependencies>
 </project>

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -12,10 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.ozone</groupId>
@@ -24,14 +21,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hdds-docs</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <description>Apache Ozone/HDDS Documentation</description>
-  <name>Apache Ozone/HDDS Documentation</name>
   <packaging>jar</packaging>
+  <name>Apache Ozone/HDDS Documentation</name>
+  <description>Apache Ozone/HDDS Documentation</description>
 
   <properties>
-    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+    <!-- no testable code in this module -->
+    <maven.test.skip>true</maven.test.skip>
     <skipDocs>false</skipDocs>
-    <sort.skip>true</sort.skip>
   </properties>
 
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enable sortpom in hadoop-hdds sub-modules : annotations, client, common & config.

Sortpom plugin was added as part of #7555.
This PR enables the plugin for hadoop-hdds sub-modules. (part 2)
Sorting all the sub-modules under hadoop-hdds creates a big change, which will be hard to review. So, breaking this into multiple PRs.
This PR sorts pom of the following sub-modules.

- annotations
- client
- common
- config

## What is the link to the Apache JIRA
HDDS-12006

## How was this patch tested?


Manually tested by adding out of order property.

`hadoop-hdds/container-service/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-container-service ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/container-service/pom.xml
[ERROR] The line 29 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/container-service/pom.xml is not sorted
```
 
`hadoop-hdds/crypto-api/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-crypto-api ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/crypto-api/pom.xml
[ERROR] The line 31 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/crypto-api/pom.xml is not sorted
```
 
`hadoop-hdds/crypto-default/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-crypto-default ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/crypto-default/pom.xml
[ERROR] The line 31 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/crypto-default/pom.xml is not sorted
```
 
`hadoop-hdds/docs/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-docs ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/docs/pom.xml
[ERROR] The line 31 is not considered sorted, should be '    <peoperty.one>one</peoperty.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/docs/pom.xml is not sorted
```
 
