### PR TITLE
HDDS-11952. Enable sortpom in hadoop-ozone.

### DIFF
--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -28,6 +28,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone Client</name>
   <packaging>jar</packaging>
   <properties>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -29,6 +29,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
 
   <properties>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -31,6 +31,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <classpath.skip>false</classpath.skip>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -30,6 +30,7 @@
     <classpath.skip>false</classpath.skip>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
     <spotbugs.skip>true</spotbugs.skip>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -33,6 +33,7 @@
     <docker.ozone-runner.version>20241212-1-jdk21</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20241129-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    <sort.skip>true</sort.skip>
   </properties>
 
   <build>

--- a/hadoop-ozone/fault-injection-test/pom.xml
+++ b/hadoop-ozone/fault-injection-test/pom.xml
@@ -28,6 +28,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone Fault Injection Tests</name>
   <packaging>pom</packaging>
 
+  <properties>
+    <sort.skip>true</sort.skip>
+  </properties>
+
   <modules>
     <module>network-tests</module>
     <module>mini-chaos-tests</module>

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -38,6 +38,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <httpfs.build.timestamp>${maven.build.timestamp}</httpfs.build.timestamp>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -30,6 +30,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <classpath.skip>false</classpath.skip>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -28,6 +28,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone Integration Tests</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <sort.skip>true</sort.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
     <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -28,6 +28,7 @@
   <name>Apache Ozone Storage Interface</name>
   <packaging>jar</packaging>
   <properties>
+    <sort.skip>true</sort.skip>
   </properties>
   <dependencies>
 

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -30,6 +30,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <classpath.skip>false</classpath.skip>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <build>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -27,6 +27,7 @@
   <version>2.0.0-SNAPSHOT</version>
   <properties>
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
+    <sort.skip>true</sort.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
@@ -40,6 +40,7 @@
   </dependencies>
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    <sort.skip>true</sort.skip>
   </properties>
   <build>
     <plugins>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
+    <sort.skip>true</sort.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <build>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -11,7 +11,8 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.ozone</groupId>
@@ -20,123 +21,50 @@
   </parent>
   <artifactId>ozone</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <description>Apache Ozone Project</description>
-  <name>Apache Ozone</name>
   <packaging>pom</packaging>
+  <name>Apache Ozone</name>
+  <description>Apache Ozone Project</description>
+  <modules>
+    <module>client</module>
+    <module>common</module>
+    <module>csi</module>
+    <module>datanode</module>
+    <module>dist</module>
+    <module>fault-injection-test</module>
+    <module>httpfsgateway</module>
+    <module>insight</module>
+    <module>integration-test</module>
+    <module>interface-client</module>
+    <module>interface-storage</module>
+    <module>ozone-manager</module>
+    <module>ozonefs</module>
+    <module>ozonefs-common</module>
+    <module>recon</module>
+    <module>recon-codegen</module>
+    <module>s3-secret-store</module>
+    <module>s3gateway</module>
+    <module>tools</module>
+  </modules>
 
   <properties>
     <docker.image>apache/ozone:${project.version}</docker.image>
-    <sort.skip>true</sort.skip>
   </properties>
-  <modules>
-    <module>interface-client</module>
-    <module>interface-storage</module>
-    <module>common</module>
-    <module>client</module>
-    <module>ozone-manager</module>
-    <module>tools</module>
-    <module>integration-test</module>
-    <module>ozonefs-common</module>
-    <module>ozonefs</module>
-    <module>datanode</module>
-    <module>recon</module>
-    <module>recon-codegen</module>
-    <module>s3gateway</module>
-    <module>dist</module>
-    <module>csi</module>
-    <module>fault-injection-test</module>
-    <module>insight</module>
-    <module>httpfsgateway</module>
-    <module>s3-secret-store</module>
-  </modules>
 
   <dependencyManagement>
-
     <dependencies>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-common</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-common</artifactId>
-        <version>${ozone.version}</version>
-        <type>test-jar</type>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-client</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-interface-client</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-interface-storage</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-manager</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-s3gateway</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-csi</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-datanode</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-tools</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem-shaded</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem-common</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem-hadoop3</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem-hadoop3-client</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem-hadoop2</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
         <artifactId>hdds-annotation-processing</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-client</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-common</artifactId>
         <version>${hdds.version}</version>
       </dependency>
       <dependency>
@@ -146,7 +74,33 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-container-service</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-container-service</artifactId>
+        <version>${hdds.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-docs</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
         <artifactId>hdds-erasurecode</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-hadoop-dependency-client</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-hadoop-dependency-server</artifactId>
         <version>${hdds.version}</version>
       </dependency>
       <dependency>
@@ -171,59 +125,8 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-s3-secret-store</artifactId>
-        <version>${hdds.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-test-utils</artifactId>
-        <version>${hdds.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-hadoop-dependency-client</artifactId>
-        <version>${hdds.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-hadoop-dependency-server</artifactId>
-        <version>${hdds.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>rocksdb-checkpoint-differ</artifactId>
-        <version>${hdds.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-hadoop-dependency-test</artifactId>
-        <version>${hdds.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-common</artifactId>
-        <version>${hdds.version}</version>
-        <type>test-jar</type>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-integration-test</artifactId>
-        <version>${ozone.version}</version>
-        <type>test-jar</type>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-manager</artifactId>
-        <version>${ozone.version}</version>
-        <type>test-jar</type>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-common</artifactId>
-        <version>${hdds.version}</version>
+        <artifactId>hdds-rocks-native</artifactId>
+        <version>${hdds.rocks.native.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
@@ -237,17 +140,131 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-docs</artifactId>
+        <artifactId>hdds-server-scm</artifactId>
+        <version>${hdds.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-tools</artifactId>
         <version>${hdds.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-container-service</artifactId>
+        <artifactId>ozone-client</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-common</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-common</artifactId>
+        <version>${ozone.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-csi</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-datanode</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem-common</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem-hadoop2</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem-hadoop3</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem-hadoop3-client</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem-shaded</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-httpfsgateway</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-insight</artifactId>
         <version>${hdds.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-client</artifactId>
+        <artifactId>ozone-integration-test</artifactId>
+        <version>${ozone.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-interface-client</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-interface-storage</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-manager</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-manager</artifactId>
+        <version>${ozone.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-recon</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-s3-secret-store</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-s3gateway</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-tools</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>rocksdb-checkpoint-differ</artifactId>
         <version>${hdds.version}</version>
       </dependency>
       <dependency>
@@ -259,45 +276,27 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-tools</artifactId>
-        <version>${hdds.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-insight</artifactId>
-        <version>${hdds.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-httpfsgateway</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-recon</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-container-service</artifactId>
+        <artifactId>hdds-common</artifactId>
         <version>${hdds.version}</version>
         <type>test-jar</type>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-server-scm</artifactId>
-        <type>test-jar</type>
+        <artifactId>hdds-hadoop-dependency-test</artifactId>
         <version>${hdds.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>hdds-rocks-native</artifactId>
-        <version>${hdds.rocks.native.version}</version>
+        <artifactId>hdds-test-utils</artifactId>
+        <version>${hdds.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <dependencies>
-  </dependencies>
+
+  <dependencies />
 
   <build>
     <plugins>
@@ -307,6 +306,10 @@
         <executions>
           <execution>
             <id>depcheck</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
             <configuration>
               <rules>
                 <DependencyConvergence>
@@ -314,10 +317,6 @@
                 </DependencyConvergence>
               </rules>
             </configuration>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>
@@ -379,17 +378,17 @@
         </property>
       </activation>
       <modules>
-        <module>ozonefs-shaded</module>
         <module>ozonefs-hadoop2</module>
         <module>ozonefs-hadoop3</module>
         <module>ozonefs-hadoop3-client</module>
+        <module>ozonefs-shaded</module>
       </modules>
     </profile>
     <profile>
       <id>go-offline</id>
       <modules>
-        <module>ozonefs-shaded</module>
         <module>ozonefs-hadoop2</module>
+        <module>ozonefs-shaded</module>
       </modules>
     </profile>
     <profile>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -25,6 +25,7 @@
   <name>Apache Ozone Recon CodeGen</name>
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -26,6 +26,7 @@
   <properties>
     <classpath.skip>false</classpath.skip>
     <pnpm.version>8.15.7</pnpm.version>
+    <sort.skip>true</sort.skip>
   </properties>
   <build>
     <resources>

--- a/hadoop-ozone/s3-secret-store/pom.xml
+++ b/hadoop-ozone/s3-secret-store/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -29,6 +29,7 @@
     <classpath.skip>false</classpath.skip>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -30,6 +30,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <classpath.skip>false</classpath.skip>
+    <sort.skip>true</sort.skip>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enable sortpom in hadoop-ozone.

Sortpom plugin was added as part of #7555.
This PR enables the plugin for hadoop-ozone sub-modules.
Sorting all the sub-modules under hadoop-ozone creates a big change, which will be hard to review. So, breaking this into multiple PRs.
This PR sorts pom of hadoop-ozone.

## What is the link to the Apache JIRA
HDDS-11952

## How was this patch tested?

Manually tested by adding out of order property.

`hadoop-ozone/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ ozone ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/pom.xml
[ERROR] The line 51 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-ozone/pom.xml is not sorted
