### PR TITLE
HDDS-12011. Show PID of running service

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -257,8 +257,10 @@ function check_running_ozone_services
   for service in "${services[@]}"; do
     for pid_file in ${OZONE_PID_DIR}/ozone-*-${service}.pid; do
       if [[ -f "${pid_file}" ]]; then
-        if kill -0 "$(cat "${pid_file}")" 2>/dev/null; then
+        pid=$(cat "${pid_file}")
+        if kill -0 "${pid}" 2>/dev/null; then
           export "OZONE_${service^^}_RUNNING=true"
+          export "OZONE_${service^^}_PID=${pid}"
         fi
       fi
     done

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -40,15 +40,18 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   }
 
   protected boolean checkIfServiceIsRunning(String serviceName) {
-    String envVariable = String.format("OZONE_%s_RUNNING", serviceName);
-    String runningServices = System.getenv(envVariable);
-    if ("true".equals(runningServices)) {
+    String runningEnvVar = String.format("OZONE_%s_RUNNING", serviceName);
+    String pidEnvVar = String.format("OZONE_%s_PID", serviceName);
+    String isServiceRunning = System.getenv(runningEnvVar);
+    String servicePid = System.getenv(pidEnvVar);
+    if ("true".equals(isServiceRunning)) {
       if (!force) {
-        error("Error: %s is currently running on this host. " +
-              "Stop the service before running the repair tool.", serviceName);
+        error("Error: %s is currently running on this host with PID %s. " +
+            "Stop the service before running the repair tool.", serviceName, servicePid);
         return true;
       } else {
-        info("Warning: --force flag used. Proceeding despite %s being detected as running.", serviceName);
+        info("Warning: --force flag used. Proceeding despite %s being detected as running with PID %s.",
+            serviceName, servicePid);
       }
     } else {
       info("No running %s service detected. Proceeding with repair.", serviceName);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The check added in [HDDS-11727](https://issues.apache.org/jira/browse/HDDS-11727) only shows if the service is running. Show the PID of the process found to be running as well.

## What is the link to the Apache JIRA
[HDDS-12011](https://issues.apache.org/jira/browse/HDDS-12011)

## How was this patch tested?
Tested the patch on a docker cluster.
```
bash-5.1$ ozone repair om fso-tree --db /data/metadata/om.db
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Error: OM is currently running on this host with PID 7. Stop the service before running the repair tool.
```

```
bash-5.1$ ozone repair om fso-tree --db /data/metadata/om.db --force
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Warning: --force flag used. Proceeding despite OM being detected as running with PID 7.
FSO Repair Tool is running in debug mode
```