### PR TITLE
HDDS-11987. Remove duplicate Quota In Bytes field from DU metadata

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duMetadata/duMetadata.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duMetadata/duMetadata.tsx
@@ -179,11 +179,6 @@ const DUMetadata: React.FC<MetadataProps> = ({
       values.push(moment(objectInfo.modificationTime).format('ll LTS'));
     }
 
-    if (objectInfo?.quotaInBytes !== undefined && objectInfo?.quotaInBytes !== -1) {
-      keys.push('Quota In Bytes');
-      values.push(byteToSize(objectInfo.quotaInBytes, 3));
-    }
-
     if (objectInfo?.quotaInNamespace !== undefined && objectInfo?.quotaInNamespace !== -1) {
       keys.push('Quota In Namespace');
       values.push(byteToSize(objectInfo.quotaInNamespace, 3));


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11987. Remove duplicate Quota In Bytes field from DU metadata

Please describe your PR in detail:
Currently the `/summary` endpoint provides a **Quota in Bytes** field which is the same as `/quota` endpoint **Quota Allowed** field.
We should use the /quota endpoint field only and remove the duplicate information we get from Quota in Bytes.

From the backend `quotaInBytes` is being set as a part of ObjectDBInfo class where is it set by the corresponding builder for bucket, volume. Refactoring this might cause breaking change, so we only remove the duplicate field from the UI as a part of this PR

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11987

## How was this patch tested?
Patch was tested manually
<img width="497" alt="Screenshot 2025-01-06 at 16 49 05" src="https://github.com/user-attachments/assets/9a33a42f-0062-4813-b540-59223906daea" />
<img width="487" alt="Screenshot 2025-01-06 at 16 49 20" src="https://github.com/user-attachments/assets/c8ebaa98-6517-4029-b4ba-ad7973f0dd78" />