### PR TITLE
HDDS-12023. Enable SCM Ratis in TestContainerCommandsEC

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECContainerOperationClient;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionMetrics;
@@ -170,6 +171,7 @@ public class TestContainerCommandsEC {
   @BeforeAll
   public static void init() throws Exception {
     config = new OzoneConfiguration();
+    config.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     config.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
     config.setTimeDuration(ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     config.setBoolean(OzoneConfigKeys.OZONE_ACL_ENABLED, true);
@@ -320,8 +322,10 @@ public class TestContainerCommandsEC {
                 .setTxID(1L)
                 .setCount(10)
                 .build()));
-    dn2Service.getDatanodeStateMachine().getContext()
-        .addCommand(deleteBlocksCommand);
+    StateContext context = dn2Service.getDatanodeStateMachine().getContext();
+    deleteBlocksCommand.setTerm(context.getTermOfLeaderSCM().isPresent() ?
+            context.getTermOfLeaderSCM().getAsLong() : 0);
+    context.addCommand(deleteBlocksCommand);
 
     try (XceiverClientGrpc client = new XceiverClientGrpc(
         createSingleNodePipeline(orphanPipeline, dn2, 1), cluster.getConf())) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestContainerCommandsEC needs to be tweaked to work with SCM Ratis enabled:
```
Error:  Tests run: 54, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 128.527 s <<< FAILURE! - in org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC
3244Error:  org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testOrphanBlock  Time elapsed: 34.199 s  <<< ERROR!
 ```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12023

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/12621698130
