### PR TITLE
HDDS-12022. Enable SCM Ratis in TestStorageContainerManager

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -368,6 +368,7 @@ public class TestStorageContainerManager {
   @Test
   public void testOldDNRegistersToReInitialisedSCM() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1000, TimeUnit.MILLISECONDS);
     conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL, 3000, TimeUnit.MILLISECONDS);
 
@@ -379,10 +380,13 @@ public class TestStorageContainerManager {
       cluster.waitForClusterToBeReady();
       HddsDatanodeService datanode = cluster.getHddsDatanodes().get(0);
       StorageContainerManager scm = cluster.getStorageContainerManager();
+      File dbDir = scm.getScmMetadataStore().getStore().getDbLocation();
       scm.stop();
 
       // re-initialise SCM with new clusterID
 
+      GenericTestUtils.deleteDirectory(new File(SCMHAUtils.getRatisStorageDir(conf)));
+      GenericTestUtils.deleteDirectory(dbDir);
       GenericTestUtils.deleteDirectory(
           new File(scm.getScmStorageConfig().getStorageDir()));
       String newClusterId = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -427,7 +427,7 @@ public class TestStorageContainerManager {
           datanode.getDatanodeDetails());
       GenericTestUtils.waitFor(
           () -> scmDnHBDispatcherLog.getOutput().contains(expectedLog), 100,
-          5000);
+          30000);
       ExitUtil.disableSystemExit();
       // As part of processing response for re-register, DN EndpointStateMachine
       // goes to GET-VERSION state which checks if there is already existing


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestStorageContainerManager needs to be tweaked to work with SCM Ratis enabled:

```
Error:  Tests run: 13, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 281.285 s <<< FAILURE! - in org.apache.hadoop.hdds.scm.TestStorageContainerManager
18332Error:  org.apache.hadoop.hdds.scm.TestStorageContainerManager.testOldDNRegistersToReInitialisedSCM  Time elapsed: 35.243 s  <<< ERROR! 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12022

## How was this patch tested?

CI: https://github.com/chungen0126/ozone/actions/runs/12643884999