### PR TITLE
HDDS-11969. getFilechecksum() API fails if checksum type is NONE.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -481,16 +481,12 @@ public class OzoneClientConfig {
     this.dataStreamBufferFlushSize = dataStreamBufferFlushSize;
   }
 
-  public ChecksumCombineMode getChecksumCombineMode() {
-    try {
-      return ChecksumCombineMode.valueOf(checksumCombineMode);
-    } catch (IllegalArgumentException iae) {
-      LOG.warn("Bad checksum combine mode: {}. Using default {}",
-          checksumCombineMode,
-          ChecksumCombineMode.COMPOSITE_CRC.name());
-      return ChecksumCombineMode.valueOf(
-          ChecksumCombineMode.COMPOSITE_CRC.name());
-    }
+  public String getChecksumCombineMode() {
+    return checksumCombineMode;
+  }
+
+  public void setChecksumCombineMode(String checksumCombineMode) {
+    this.checksumCombineMode = checksumCombineMode;
   }
 
   public void setEcReconstructStripeReadPoolLimit(int poolLimit) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -481,8 +481,14 @@ public class OzoneClientConfig {
     this.dataStreamBufferFlushSize = dataStreamBufferFlushSize;
   }
 
-  public String getChecksumCombineMode() {
-    return checksumCombineMode;
+  public ChecksumCombineMode getChecksumCombineMode() {
+    try {
+      return ChecksumCombineMode.valueOf(checksumCombineMode);
+    } catch (IllegalArgumentException iae) {
+      LOG.warn("Bad checksum combine mode: {}.",
+          checksumCombineMode);
+      return null;
+    }
   }
 
   public void setChecksumCombineMode(String checksumCombineMode) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -1582,8 +1582,8 @@ abstract class AbstractOzoneFileSystemTest {
     Configuration conf = new OzoneConfiguration(cluster.getConf());
     conf.set(FS_DEFAULT_NAME_KEY, rootPath);
     // Set the number of keys to be processed during batch operate.
-    try {
-      OzoneFileSystem o3FS = (OzoneFileSystem) FileSystem.get(conf);
+    try (FileSystem fileSystem = FileSystem.get(conf)) {
+      OzoneFileSystem o3FS = (OzoneFileSystem) fileSystem;
 
       //Let's reset the clock to control the time.
       ((BasicOzoneClientAdapterImpl) (o3FS.getAdapter())).setClock(testClock);
@@ -1617,8 +1617,6 @@ abstract class AbstractOzoneFileSystemTest {
 
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key4"),
           ReplicationType.RATIS);
-    } finally {
-      o3fs.close();
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -2289,8 +2289,9 @@ abstract class AbstractOzoneFileSystemTest {
     OzoneConfiguration conf = cluster.getConf();
     conf.setFromObject(clientConfig);
     conf.setBoolean("fs.o3fs.impl.disable.cache", true);
-    FileSystem fileSystem = FileSystem.get(conf);
-    assertNull(fileSystem.getFileChecksum(file));
+    try (FileSystem fileSystem = FileSystem.get(conf)) {
+      assertNull(fileSystem.getFileChecksum(file));
+    }
   }
 
   private String getCurrentUser() {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -647,12 +647,9 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       throws IOException {
     OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
-    if (null == combineMode) {
-      LOG.error("Unsupported checksum combine mode {}, skipping checksum " +
-              "computation", combineMode);
+    if (combineMode == null) {
       return null;
     }
-
     return OzoneClientUtils.getFileChecksumWithCombineMode(
         volume, bucket, keyName,
         length, combineMode,

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -646,12 +645,9 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public FileChecksum getFileChecksum(String keyName, long length)
       throws IOException {
-    String combineMode = config.getObject(OzoneClientConfig.class)
-        .getChecksumCombineMode();
-    boolean isCombineModeSupported =
-        Arrays.stream(OzoneClientConfig.ChecksumCombineMode.values())
-            .anyMatch(mode -> mode.name().equals(combineMode));
-    if (!isCombineModeSupported) {
+    OzoneClientConfig.ChecksumCombineMode combineMode =
+        config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
+    if (null == combineMode) {
       LOG.error("Unsupported checksum combine mode {}, skipping checksum " +
               "computation", combineMode);
       return null;
@@ -659,9 +655,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
 
     return OzoneClientUtils.getFileChecksumWithCombineMode(
         volume, bucket, keyName,
-        length, OzoneClientConfig.ChecksumCombineMode.valueOf(combineMode),
+        length, combineMode,
         ozoneClient.getObjectStore().getClientProxy());
-
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1297,12 +1296,9 @@ public class BasicRootedOzoneClientAdapterImpl
   @Override
   public FileChecksum getFileChecksum(String keyName, long length)
       throws IOException {
-    String combineMode = config.getObject(OzoneClientConfig.class)
-        .getChecksumCombineMode();
-    boolean isCombineModeSupported =
-        Arrays.stream(OzoneClientConfig.ChecksumCombineMode.values())
-            .anyMatch(mode -> mode.name().equals(combineMode));
-    if (!isCombineModeSupported) {
+    OzoneClientConfig.ChecksumCombineMode combineMode =
+        config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
+    if (null == combineMode) {
       LOG.error("Unsupported checksum combine mode {}, skipping checksum " +
           "computation", combineMode);
       return null;
@@ -1313,7 +1309,7 @@ public class BasicRootedOzoneClientAdapterImpl
     OzoneBucket bucket = getBucket(ofsPath, false);
     return OzoneClientUtils.getFileChecksumWithCombineMode(
         volume, bucket, ofsPath.getKeyName(),
-        length, OzoneClientConfig.ChecksumCombineMode.valueOf(combineMode),
+        length, combineMode,
         ozoneClient.getObjectStore().getClientProxy());
 
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1298,13 +1298,10 @@ public class BasicRootedOzoneClientAdapterImpl
       throws IOException {
     OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
-    if (null == combineMode) {
-      LOG.error("Unsupported checksum combine mode {}, skipping checksum " +
-          "computation", combineMode);
+    if (combineMode == null) {
       return null;
     }
     OFSPath ofsPath = new OFSPath(keyName, config);
-
     OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
     OzoneBucket bucket = getBucket(ofsPath, false);
     return OzoneClientUtils.getFileChecksumWithCombineMode(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Return null when unsupported combine mode is passed and skip checksum compute.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11969

## How was this patch tested?
Unit test
