### PR TITLE
HDDS-12003. Reduce code duplication related to tracing init

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.ozone.admin;
 
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.ExtensibleParentCommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 
+import org.apache.hadoop.ozone.shell.Shell;
 import picocli.CommandLine;
 
 /**
@@ -33,7 +33,7 @@ import picocli.CommandLine;
     description = "Developer tools for Ozone Admin operations",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
-public class OzoneAdmin extends GenericCli implements ExtensibleParentCommand {
+public class OzoneAdmin extends Shell implements ExtensibleParentCommand {
 
   public static void main(String[] argv) {
     new OzoneAdmin().run(argv);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
@@ -20,9 +20,8 @@ package org.apache.hadoop.ozone.admin;
 import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.ExtensibleParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
-
 import org.apache.hadoop.ozone.shell.Shell;
+
 import picocli.CommandLine;
 
 /**
@@ -37,14 +36,6 @@ public class OzoneAdmin extends Shell implements ExtensibleParentCommand {
 
   public static void main(String[] argv) {
     new OzoneAdmin().run(argv);
-  }
-
-  @Override
-  public int execute(String[] argv) {
-    TracingUtil.initTracing("shell", getOzoneConf());
-    String spanName = "ozone admin " + String.join(" ", argv);
-    return TracingUtil.executeInNewSpan(spanName,
-        () -> super.execute(argv));
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -20,9 +20,8 @@ package org.apache.hadoop.ozone.debug;
 
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.cli.ExtensibleParentCommand;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-
+import org.apache.hadoop.ozone.shell.Shell;
 import picocli.CommandLine;
 
 /**
@@ -32,7 +31,7 @@ import picocli.CommandLine;
         description = "Developer tools for Ozone Debug operations",
         versionProvider = HddsVersionProvider.class,
         mixinStandardHelpOptions = true)
-public class OzoneDebug extends GenericCli implements ExtensibleParentCommand {
+public class OzoneDebug extends Shell implements ExtensibleParentCommand {
 
   public static void main(String[] argv) {
     new OzoneDebug().run(argv);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.shell.bucket.BucketCommands;
 import org.apache.hadoop.ozone.shell.keys.KeyCommands;
 import org.apache.hadoop.ozone.shell.prefix.PrefixCommands;
@@ -47,21 +46,7 @@ import picocli.CommandLine.Command;
     mixinStandardHelpOptions = true)
 public class OzoneShell extends Shell {
 
-  /**
-   * Main for the ozShell Command handling.
-   *
-   * @param argv - System Args Strings[]
-   */
   public static void main(String[] argv) throws Exception {
     new OzoneShell().run(argv);
   }
-
-  @Override
-  public int execute(String[] argv) {
-    TracingUtil.initTracing("shell", getOzoneConf());
-    String spanName = "ozone sh " + String.join(" ", argv);
-    return TracingUtil.executeInNewSpan(spanName,
-        () -> super.execute(argv));
-  }
-
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -19,7 +19,9 @@
 package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+
 import picocli.CommandLine;
 import picocli.shell.jline3.PicocliCommands.PicocliCommandsFactory;
 
@@ -85,7 +87,9 @@ public abstract class Shell extends GenericCli {
       spec.name(""); // use short name (e.g. "token get" instead of "ozone sh token get")
       new REPL(this, getCmd(), (PicocliCommandsFactory) getCmd().getFactory());
     } else {
-      super.run(argv);
+      TracingUtil.initTracing("shell", getOzoneConf());
+      String spanName = spec.name() + " " + String.join(" ", argv);
+      TracingUtil.executeInNewSpan(spanName, () -> super.run(argv));
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.shell.s3;
 
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.shell.Shell;
 
 import picocli.CommandLine.Command;
@@ -34,19 +33,6 @@ import picocli.CommandLine.Command;
     })
 public class S3Shell extends Shell {
 
-  @Override
-  public int execute(String[] argv) {
-    TracingUtil.initTracing("s3shell", getOzoneConf());
-    String spanName = "ozone s3 " + String.join(" ", argv);
-    return TracingUtil.executeInNewSpan(spanName,
-        () -> super.execute(argv));
-  }
-
-  /**
-   * Main for the S3Shell Command handling.
-   *
-   * @param argv - System Args Strings[]
-   */
   public static void main(String[] argv) {
     new S3Shell().run(argv);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.shell.Shell;
+
 import picocli.CommandLine.Command;
 
 /**
@@ -35,19 +35,6 @@ import picocli.CommandLine.Command;
     })
 public class TenantShell extends Shell {
 
-  @Override
-  public int execute(String[] argv) {
-    TracingUtil.initTracing("tenant-shell", getOzoneConf());
-    String spanName = "ozone tenant " + String.join(" ", argv);
-    return TracingUtil.executeInNewSpan(spanName,
-        () -> super.execute(argv));
-  }
-
-  /**
-   * Main for the TenantShell Command handling.
-   *
-   * @param argv - System Args Strings[]
-   */
   public static void main(String[] argv) {
     new TenantShell().run(argv);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Subclasses of `Shell` override `execute()` to initialize tracing.  The goal of this task is to reduce this code duplication.

https://issues.apache.org/jira/browse/HDDS-12003

## How was this patch tested?

Started cluster in `ozone` compose environment with tracing enabled:


```
cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/ozone
export COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
OZONE_DATANODES=3 ./run.sh -d
```

Ran some commands in `ozone` compose environment with tracing enabled:

```
docker compose exec om bash
ozone freon ockg -n1 -t1 -p warmup
ozone sh key put /vol1/bucket1/passwd /etc/passwd
ozone admin container list
ozone s3 getsecret
```

Verified in Jaeger that traces got created:

![tracing](https://github.com/user-attachments/assets/d37aa10b-1379-4437-8609-a718e9ec7637)

CI:
https://github.com/adoroszlai/ozone/actions/runs/12649976634