### PR TITLE
HDDS-12034. Enable sortpom in hadoop-hdds-interface server, admin & client

### DIFF
--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -12,10 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.ozone</groupId>
@@ -24,15 +21,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hdds-interface-admin</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <description>Apache Ozone Distributed Data Store Admin interface
-  </description>
-  <name>Apache Ozone HDDS Admin Interface</name>
   <packaging>jar</packaging>
+  <name>Apache Ozone HDDS Admin Interface</name>
+  <description>Apache Ozone Distributed Data Store Admin interface</description>
 
   <properties>
-    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
-    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
-    <sort.skip>true</sort.skip>
+    <!-- no testable code in this module -->
+    <maven.test.skip>true</maven.test.skip>
+    <!-- only generated code in this module -->
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <dependencies>
@@ -72,9 +69,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>test-compile</goal>
             </goals>
             <configuration>
-              <protocArtifact>
-                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
-              </protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <outputDirectory>target/generated-sources/java</outputDirectory>
               <clearOutputDirectory>false</clearOutputDirectory>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -12,10 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.ozone</groupId>
@@ -24,21 +21,25 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hdds-interface-client</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <description>Apache Ozone Distributed Data Store Client interface
-  </description>
-  <name>Apache Ozone HDDS Client Interface</name>
   <packaging>jar</packaging>
+  <name>Apache Ozone HDDS Client Interface</name>
+  <description>Apache Ozone Distributed Data Store Client interface</description>
 
   <properties>
-    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
-    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
-    <sort.skip>true</sort.skip>
+    <!-- no testable code in this module -->
+    <maven.test.skip>true</maven.test.skip>
+    <!-- only generated code in this module -->
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
@@ -48,10 +49,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-thirdparty-misc</artifactId>
       <version>${ratis.thirdparty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -82,9 +79,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>test-compile-custom</goal>
             </goals>
             <configuration>
-              <protocArtifact>
-                com.google.protobuf:protoc:${grpc.protobuf-compile.version}:exe:${os.detected.classifier}
-              </protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${grpc.protobuf-compile.version}:exe:${os.detected.classifier}</protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <includes>
                 <include>DatanodeClientProtocol.proto</include>
@@ -93,9 +88,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <outputDirectory>target/generated-sources/java</outputDirectory>
               <clearOutputDirectory>false</clearOutputDirectory>
               <pluginId>grpc-java</pluginId>
-              <pluginArtifact>
-                io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}
-              </pluginArtifact>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
             </configuration>
           </execution>
           <execution>
@@ -105,9 +98,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>test-compile</goal>
             </goals>
             <configuration>
-              <protocArtifact>
-                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
-              </protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <includes>
                 <include>hdds.proto</include>
@@ -124,9 +115,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>test-compile</goal>
             </goals>
             <configuration>
-              <protocArtifact>
-                com.google.protobuf:protoc:${proto3.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
-              </protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${proto3.hadooprpc.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <includes>
                 <include>hdds.proto</include>
@@ -143,38 +132,21 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <replace token="com.google.protobuf"
-                         value="org.apache.ratis.thirdparty.com.google.protobuf"
-                         dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto">
-                </replace>
-                <replace token="io.grpc"
-                         value="org.apache.ratis.thirdparty.io.grpc"
-                         dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto">
-                </replace>
-                <replace token="com.google.common"
-                         value="org.apache.ratis.thirdparty.com.google.common"
-                         dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto">
-                </replace>
-                <replace token="org.apache.hadoop.hdds.protocol.proto"
-                         value="org.apache.hadoop.hdds.protocol.proto3"
-                         dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto">
-                </replace>
-                <replace token="com.google.protobuf"
-                         value="org.apache.hadoop.thirdparty.protobuf"
-                         dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto">
-                </replace>
-                <move file="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto"
-                      tofile="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto3"/>
-                <move file="target/generated-sources/java/proto3"
-                      tofile="target/generated-sources/java"/>
-              </target>
-            </configuration>
             <goals>
               <goal>run</goal>
             </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <target>
+                <replace dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto" token="com.google.protobuf" value="org.apache.ratis.thirdparty.com.google.protobuf" />
+                <replace dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto" token="io.grpc" value="org.apache.ratis.thirdparty.io.grpc" />
+                <replace dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto" token="com.google.common" value="org.apache.ratis.thirdparty.com.google.common" />
+                <replace dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto" token="org.apache.hadoop.hdds.protocol.proto" value="org.apache.hadoop.hdds.protocol.proto3" />
+                <replace dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto" token="com.google.protobuf" value="org.apache.hadoop.thirdparty.protobuf" />
+                <move file="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto" tofile="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto3" />
+                <move file="target/generated-sources/java/proto3" tofile="target/generated-sources/java" />
+              </target>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -12,10 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.ozone</groupId>
@@ -24,22 +21,18 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hdds-interface-server</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <description>Apache Ozone Distributed Data Store Server interface
-  </description>
-  <name>Apache Ozone HDDS Server Interface</name>
   <packaging>jar</packaging>
+  <name>Apache Ozone HDDS Server Interface</name>
+  <description>Apache Ozone Distributed Data Store Server interface</description>
 
   <properties>
-    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
-    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
-    <sort.skip>true</sort.skip>
+    <!-- no testable code in this module -->
+    <maven.test.skip>true</maven.test.skip>
+    <!-- only generated code in this module -->
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.ratis</groupId>
-      <artifactId>ratis-thirdparty-misc</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
@@ -49,6 +42,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-thirdparty-misc</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -79,9 +76,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>test-compile-custom</goal>
             </goals>
             <configuration>
-              <protocArtifact>
-                com.google.protobuf:protoc:${grpc.protobuf-compile.version}:exe:${os.detected.classifier}
-              </protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${grpc.protobuf-compile.version}:exe:${os.detected.classifier}</protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <includes>
                 <include>InterSCMProtocol.proto</include>
@@ -90,9 +85,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <outputDirectory>target/generated-sources/java</outputDirectory>
               <clearOutputDirectory>false</clearOutputDirectory>
               <pluginId>grpc-java</pluginId>
-              <pluginArtifact>
-                io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}
-              </pluginArtifact>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
             </configuration>
           </execution>
           <execution>
@@ -102,9 +95,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>test-compile</goal>
             </goals>
             <configuration>
-              <protocArtifact>
-                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
-              </protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <excludes>
                 <exclude>InterSCMProtocol.proto</exclude>
@@ -121,26 +112,17 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <replace token="com.google.protobuf"
-                         value="org.apache.ratis.thirdparty.com.google.protobuf"
-                         dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
-                </replace>
-                <replace token="io.grpc"
-                         value="org.apache.ratis.thirdparty.io.grpc"
-                         dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
-                </replace>
-                <replace token="com.google.common"
-                         value="org.apache.ratis.thirdparty.com.google.common"
-                         dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
-                </replace>
-              </target>
-            </configuration>
             <goals>
               <goal>run</goal>
             </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <target>
+                <replace dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto" token="com.google.protobuf" value="org.apache.ratis.thirdparty.com.google.protobuf" />
+                <replace dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto" token="io.grpc" value="org.apache.ratis.thirdparty.io.grpc" />
+                <replace dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto" token="com.google.common" value="org.apache.ratis.thirdparty.com.google.common" />
+              </target>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enable sortpom in hadoop-hdds-interface server, admin & client

Sortpom plugin was added as part of https://github.com/apache/ozone/pull/7555.
This PR enables the plugin for hadoop-hdds sub-modules. (part 5)
Sorting all the sub-modules under hadoop-hdds creates a big change, which will be hard to review. So, breaking this into multiple PRs.
This PR sorts pom of the following sub-modules.

- interface-server
- interface-admin
- interface-client

## What is the link to the Apache JIRA
HDDS-12034

## How was this patch tested?

Manually tested by adding out of order property.

`hadoop-hdds/interface-server/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-interface-server ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/interface-server/pom.xml
[ERROR] The line 31 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/interface-server/pom.xml is not sorted
```

`hadoop-hdds/interface-admin/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-interface-admin ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/interface-admin/pom.xml
[ERROR] The line 31 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/interface-admin/pom.xml is not sorted
```

`hadoop-hdds/interface-client/pom.xml`
```
[INFO] --- sortpom:3.0.1:verify (default) @ hdds-interface-client ---
[INFO] Verifying file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/interface-client/pom.xml
[ERROR] The line 31 is not considered sorted, should be '    <property.one>one</property.one>'
[ERROR] The file /Users/nvadivelu/Codebase/Github/ozone/hadoop-hdds/interface-client/pom.xml is not sorted
```
