### PR TITLE
HDDS-12038. Bump maven-remote-resources-plugin to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
-    <maven-remote-resources-plugin.version>1.7.0</maven-remote-resources-plugin.version>
+    <maven-remote-resources-plugin.version>3.3.0</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-site-plugin.version>3.21.0</maven-site-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `maven-remote-resources-plugin` to 3.3.0.  Fixes intermittent problem with build reproducibility (MRRESOURCES-150).

https://issues.apache.org/jira/browse/HDDS-12038

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12658002446