### PR TITLE
HDDS-12039. Enhancements to ozone repair om commands

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -128,14 +128,14 @@ public class TestOzoneRepairShell {
   public void testQuotaRepair() throws Exception {
     CommandLine cmd = new OzoneRepair().getCmd();
 
-    int exitCode = cmd.execute("quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+    int exitCode = cmd.execute("om", "quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
     assertEquals(0, exitCode, err);
-    exitCode = cmd.execute("quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+    exitCode = cmd.execute("om", "quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
     assertEquals(0, exitCode, err);
     GenericTestUtils.waitFor(() -> {
       out.reset();
       // verify quota trigger is completed having non-zero lastRunFinishedTime
-      cmd.execute("quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+      cmd.execute("om", "quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
       try {
         return out.get().contains("\"lastRunFinishedTime\":\"\"");
       } catch (Exception ex) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/OMRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/OMRepair.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.repair.om;
 
 import org.apache.hadoop.hdds.cli.RepairSubcommand;
+import org.apache.hadoop.ozone.repair.om.quota.QuotaRepair;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 
@@ -29,7 +30,8 @@ import picocli.CommandLine;
     subcommands = {
         FSORepairTool.class,
         SnapshotRepair.class,
-        TransactionInfoRepair.class
+        TransactionInfoRepair.class,
+        QuotaRepair.class
     },
     description = "Operational tool to repair OM.")
 @MetaInfServices(RepairSubcommand.class)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
@@ -83,6 +83,9 @@ public class SnapshotChainRepair extends RepairTool {
 
   @Override
   public void execute() throws Exception {
+    if (checkIfServiceIsRunning("OM")) {
+      return;
+    }
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
     List<ColumnFamilyDescriptor> cfDescList = RocksDBUtils.getColumnFamilyDescriptors(dbPath);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/TransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/TransactionInfoRepair.java
@@ -68,6 +68,9 @@ public class TransactionInfoRepair extends RepairTool {
 
   @Override
   public void execute() throws Exception {
+    if (checkIfServiceIsRunning("OM")) {
+      return;
+    }
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
     List<ColumnFamilyDescriptor> cfDescList = RocksDBUtils.getColumnFamilyDescriptors(
         dbPath);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaRepair.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.repair.om.quota;
 
 import java.io.IOException;
 import java.util.Collection;
+
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -45,14 +47,14 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
         QuotaTrigger.class,
     },
     description = "Operational tool to repair quota in OM DB.")
-public class QuotaRepair {
+public class QuotaRepair extends AbstractSubcommand {
 
   public OzoneManagerProtocolClientSideTranslatorPB createOmClient(
       String omServiceID,
       String omHost,
       boolean forceHA
   ) throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    OzoneConfiguration conf = getOzoneConf();
     if (omHost != null && !omHost.isEmpty()) {
       omServiceID = null;
       conf.set(OZONE_OM_ADDRESS_KEY, omHost);
@@ -86,7 +88,7 @@ public class QuotaRepair {
   }
 
   private Collection<String> getConfiguredServiceIds() {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    OzoneConfiguration conf = getOzoneConf();
     Collection<String> omServiceIds =
         conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
     return omServiceIds;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaRepair.java
@@ -16,11 +16,10 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.repair.quota;
+package org.apache.hadoop.ozone.repair.om.quota;
 
 import java.io.IOException;
 import java.util.Collection;
-import org.apache.hadoop.hdds.cli.RepairSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -30,10 +29,8 @@ import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
-import org.apache.hadoop.ozone.repair.OzoneRepair;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.protocol.ClientId;
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
@@ -48,18 +45,14 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
         QuotaTrigger.class,
     },
     description = "Operational tool to repair quota in OM DB.")
-@MetaInfServices(RepairSubcommand.class)
-public class QuotaRepair implements RepairSubcommand {
-
-  @CommandLine.ParentCommand
-  private OzoneRepair parent;
+public class QuotaRepair {
 
   public OzoneManagerProtocolClientSideTranslatorPB createOmClient(
       String omServiceID,
       String omHost,
       boolean forceHA
   ) throws Exception {
-    OzoneConfiguration conf = parent.getOzoneConf();
+    OzoneConfiguration conf = new OzoneConfiguration();
     if (omHost != null && !omHost.isEmpty()) {
       omServiceID = null;
       conf.set(OZONE_OM_ADDRESS_KEY, omHost);
@@ -93,7 +86,7 @@ public class QuotaRepair implements RepairSubcommand {
   }
 
   private Collection<String> getConfiguredServiceIds() {
-    OzoneConfiguration conf = parent.getOzoneConf();
+    OzoneConfiguration conf = new OzoneConfiguration();
     Collection<String> omServiceIds =
         conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
     return omServiceIds;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaStatus.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaStatus.java
@@ -21,9 +21,9 @@
  */
 package org.apache.hadoop.ozone.repair.om.quota;
 
+import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.repair.RepairTool;
 import picocli.CommandLine;
 
 /**
@@ -35,9 +35,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
-public class QuotaStatus extends RepairTool {
-  @CommandLine.Spec
-  private static CommandLine.Model.CommandSpec spec;
+public class QuotaStatus implements Callable<Void> {
 
   @CommandLine.Option(
       names = {"--service-id", "--om-service-id"},
@@ -58,9 +56,10 @@ public class QuotaStatus extends RepairTool {
   private QuotaRepair parent;
 
   @Override
-  public void execute() throws Exception {
-    try (OzoneManagerProtocol ozoneManagerClient = parent.createOmClient(omServiceId, omHost, false)) {
-      info(ozoneManagerClient.getQuotaRepairStatus());
-    }
+  public Void call() throws Exception {
+    OzoneManagerProtocol ozoneManagerClient =
+        parent.createOmClient(omServiceId, omHost, false);
+    System.out.println(ozoneManagerClient.getQuotaRepairStatus());
+    return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaStatus.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaStatus.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license
  * agreements. See the NOTICE file distributed with this work for additional
@@ -19,30 +19,25 @@
  * permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.ozone.repair.quota;
+package org.apache.hadoop.ozone.repair.om.quota;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.repair.RepairTool;
 import picocli.CommandLine;
 
 /**
- * Tool to trigger quota repair.
+ * Tool to get status of last triggered quota repair.
  */
 @CommandLine.Command(
-    name = "start",
-    description = "CLI to trigger quota repair.",
+    name = "status",
+    description = "CLI to get the status of last trigger quota repair if available.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
-public class QuotaTrigger extends RepairTool {
-
-  @CommandLine.ParentCommand
-  private QuotaRepair parent;
+public class QuotaStatus extends RepairTool {
+  @CommandLine.Spec
+  private static CommandLine.Model.CommandSpec spec;
 
   @CommandLine.Option(
       names = {"--service-id", "--om-service-id"},
@@ -59,26 +54,13 @@ public class QuotaTrigger extends RepairTool {
   )
   private String omHost;
 
-  @CommandLine.Option(names = {"--buckets"},
-      required = false,
-      description = "start quota repair for specific buckets. Input will be list of uri separated by comma as" +
-          " /<volume>/<bucket>[,...]")
-  private String buckets;
+  @CommandLine.ParentCommand
+  private QuotaRepair parent;
 
   @Override
   public void execute() throws Exception {
-    List<String> bucketList = Collections.emptyList();
-    if (StringUtils.isNotEmpty(buckets)) {
-      bucketList = Arrays.asList(buckets.split(","));
-    }
-
-    try (OzoneManagerProtocol omClient = parent.createOmClient(omServiceId, omHost, false)) {
-      info("Triggering quota repair for %s",
-          bucketList.isEmpty()
-              ? "all buckets"
-              : ("buckets " + buckets));
-      omClient.startQuotaRepair(bucketList);
-      info(omClient.getQuotaRepairStatus());
+    try (OzoneManagerProtocol ozoneManagerClient = parent.createOmClient(omServiceId, omHost, false)) {
+      info(ozoneManagerClient.getQuotaRepairStatus());
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/package-info.java
@@ -17,6 +17,6 @@
  */
 
 /**
- * Ozone Quota Repair tools.
+ * Ozone OM Quota Repair tools.
  */
-package org.apache.hadoop.ozone.repair.quota;
+package org.apache.hadoop.ozone.repair.om.quota;


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ozone repair om`
    These commands make repairs to an individual OM instance.
- `ozone repair om quota`
        The new location of `ozone repair quota` which is an online command (requires running OM).
- Add [HDDS-11727](https://issues.apache.org/jira/browse/HDDS-11727) check to see if OM is running in`ozone repair om snapshot chain` and `ozone repair om update-transaction`.

## What is the link to the Apache JIRA
[HDDS-12039](https://issues.apache.org/jira/browse/HDDS-12039)

## How was this patch tested?
Tested the patch on a docker cluster.

```
bash-5.1$ ozone repair om
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Missing required subcommand
Usage: ozone repair om [COMMAND]
Operational tool to repair OM.
Commands:
  fso-tree            Identify and repair a disconnected FSO tree by marking
                        unreferenced entries for deletion. OM should be stopped
                        while this tool is run.
  snapshot            Subcommand for all snapshot related repairs.
  update-transaction  CLI to update the highest index in transactionInfoTable.
                        Currently it is only supported for OM.
  quota               Operational tool to repair quota in OM DB.

```

```
bash-5.1$ ozone repair om quota
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Missing required subcommand
Usage: ozone repair om quota [COMMAND]
Operational tool to repair quota in OM DB.
Commands:
  status  CLI to get the status of last trigger quota repair if available.
  start   CLI to trigger quota repair.
```

```
bash-5.1$ ozone repair om update-transaction --db /data/metadata/om.db --term 2 --index 2
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Error: OM is currently running on this host with PID 7. Stop the service before running the repair tool.
```

