### PR TITLE
HDDS-12036. Add storage indicators when reaching capacity

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
@@ -18,12 +18,13 @@
 
 import React, { HTMLAttributes, useMemo } from 'react';
 import filesize from 'filesize';
-import { Card, Row, Col, Table, Tag } from 'antd';
+import { Card, Row, Col, Table, Tag, Alert } from 'antd';
 
 import EChart from '@/v2/components/eChart/eChart';
 import OverviewCardWrapper from '@/v2/components/overviewCard/overviewCardWrapper';
 
 import { StorageReport } from '@/v2/types/overview.types';
+import { WarningFilled } from '@ant-design/icons';
 
 // ------------- Types -------------- //
 type OverviewStorageCardProps = {
@@ -175,7 +176,16 @@ const OverviewStorageCard: React.FC<OverviewStorageCardProps> = ({
       title='Cluster Capacity'
       headStyle={cardHeadStyle}
       bodyStyle={cardBodyStyle}
-      style={cardStyle}>
+      style={cardStyle}
+      actions={(
+        usagePercentage > 80
+        ? [
+          <div style={{
+            color: '#f5222d'
+          }}> <WarningFilled /> Storage almost full. Free up some space. </div>
+        ]
+        : []
+      )}>
       <Row justify='space-between'>
         <Col
           className='echart-col'

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
@@ -18,7 +18,7 @@
 
 import React, { HTMLAttributes, useMemo } from 'react';
 import filesize from 'filesize';
-import { Card, Row, Col, Table, Tag, Alert } from 'antd';
+import { Card, Row, Col, Table, Tag } from 'antd';
 
 import EChart from '@/v2/components/eChart/eChart';
 import OverviewCardWrapper from '@/v2/components/overviewCard/overviewCardWrapper';

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
@@ -24,7 +24,6 @@ import EChart from '@/v2/components/eChart/eChart';
 import OverviewCardWrapper from '@/v2/components/overviewCard/overviewCardWrapper';
 
 import { StorageReport } from '@/v2/types/overview.types';
-import { WarningFilled } from '@ant-design/icons';
 
 // ------------- Types -------------- //
 type OverviewStorageCardProps = {
@@ -55,6 +54,10 @@ const cardBodyStyle: React.CSSProperties = { padding: '16px' };
 const cardStyle: React.CSSProperties = {
   boxSizing: 'border-box',
   height: '100%'
+}
+const cardErrorStyle: React.CSSProperties = {
+  borderColor: '#FF4D4E',
+  borderWidth: '1.4px'
 }
 const eChartStyle: React.CSSProperties = {
   width: '280px',
@@ -176,16 +179,7 @@ const OverviewStorageCard: React.FC<OverviewStorageCardProps> = ({
       title='Cluster Capacity'
       headStyle={cardHeadStyle}
       bodyStyle={cardBodyStyle}
-      style={cardStyle}
-      actions={(
-        usagePercentage > 80
-        ? [
-          <div style={{
-            color: '#f5222d'
-          }}> <WarningFilled /> Storage almost full. Free up some space. </div>
-        ]
-        : []
-      )}>
+      style={(usagePercentage > 79) ? {...cardStyle, ...cardErrorStyle} : cardStyle} >
       <Row justify='space-between'>
         <Col
           className='echart-col'

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.less
@@ -16,12 +16,6 @@
 * limitations under the License.
 */
 
-@progress-gray: #d0d0d0;
-@progress-light-blue: rgb(230, 235, 248);
-@progress-blue: #1890ff;
-@progress-green: #52c41a;
-@progress-red: #FFA39E;
-
 .storage-cell-container-v2 {
   .capacity-bar-v2 {
     font-size: 1em;
@@ -33,20 +27,4 @@
       color: #F5222D;
     }
   }
-}
-
-.ozone-used-bg-v2 {
-  color: @progress-green !important;
-}
-
-.non-ozone-used-bg-v2 {
-  color: @progress-blue !important;
-}
-
-.remaining-bg-v2 {
-  color: @progress-light-blue !important;
-}
-
-.committed-bg-v2 {
-  color: @progress-red !important;
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.less
@@ -26,6 +26,13 @@
   .capacity-bar-v2 {
     font-size: 1em;
   }
+  
+  .capacity-bar-v2-error {
+    font-size: 1em;
+    .ant-progress-text {
+      color: #F5222D;
+    }
+  }
 }
 
 .ozone-used-bg-v2 {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.tsx
@@ -19,10 +19,8 @@
 import React from 'react';
 import { Progress } from 'antd';
 import filesize from 'filesize';
-import Icon from '@ant-design/icons';
 import Tooltip from 'antd/lib/tooltip';
 
-import { FilledIcon } from '@/utils/themeIcons';
 import { getCapacityPercent } from '@/utils/common';
 import type { StorageReport } from '@/v2/types/overview.types';
 
@@ -52,27 +50,30 @@ const StorageBar: React.FC<StorageReportProps> = ({
   const totalUsed = capacity - remaining;
   const tooltip = (
     <>
-      <div>
-        <Icon component={FilledIcon} className='ozone-used-bg-v2' />
-        Ozone Used ({size(used)})
-      </div>
-      <div>
-        <Icon component={FilledIcon} className='non-ozone-used-bg-v2' />
-        Non Ozone Used ({size(nonOzoneUsed)})
-      </div>
-      <div>
-        <Icon component={FilledIcon} className='remaining-bg-v2' />
-        Remaining ({size(remaining)})
-      </div>
-      <div>
-        <Icon component={FilledIcon} className='committed-bg-v2' />
-        Container Pre-allocated ({size(committed)})
-      </div>
+      <table cellPadding={5}>
+        <tbody>
+          <tr>
+            <td>Ozone Used</td>
+            <td><strong>{size(used)}</strong></td>
+          </tr>
+          <tr>
+            <td>Non Ozone Used</td>
+            <td><strong>{size(nonOzoneUsed)}</strong></td>
+          </tr>
+          <tr>
+            <td>Remaining</td>
+            <td><strong>{size(remaining)}</strong></td>
+          </tr>
+          <tr>
+            <td>Container Pre-allocated</td>
+            <td><strong>{size(committed)}</strong></td>
+          </tr>
+        </tbody>
+      </table>
     </>
   );
 
   const percentage = getCapacityPercent(totalUsed, capacity)
-  const progressClassname = (percentage > 80) ? 'capacity-bar-v2-error' : 'capacity-bar-v2';
 
   return (
       <Tooltip
@@ -87,8 +88,8 @@ const StorageBar: React.FC<StorageReportProps> = ({
         <Progress
           strokeLinecap='round'
           percent={percentage}
-          success={{ percent: getCapacityPercent(used, capacity) }}
-          className={progressClassname} strokeWidth={strokeWidth} />
+          strokeColor={(percentage > 80) ? '#FF4D4E' : '#52C41A'}
+          className={(percentage > 80) ? 'capacity-bar-v2-error' : 'capacity-bar-v2'} strokeWidth={strokeWidth} />
       </Tooltip>
   );
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/storageBar/storageBar.tsx
@@ -71,6 +71,9 @@ const StorageBar: React.FC<StorageReportProps> = ({
     </>
   );
 
+  const percentage = getCapacityPercent(totalUsed, capacity)
+  const progressClassname = (percentage > 80) ? 'capacity-bar-v2-error' : 'capacity-bar-v2';
+
   return (
       <Tooltip
         title={tooltip}
@@ -83,9 +86,9 @@ const StorageBar: React.FC<StorageReportProps> = ({
         }
         <Progress
           strokeLinecap='round'
-          percent={getCapacityPercent(totalUsed, capacity)}
+          percent={percentage}
           success={{ percent: getCapacityPercent(used, capacity) }}
-          className='capacity-bar-v2' strokeWidth={strokeWidth} />
+          className={progressClassname} strokeWidth={strokeWidth} />
       </Tooltip>
   );
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12036. Add storage indicators when reaching capacity

Please describe your PR in detail:
* Currently in Recon we do not have any quick indication for whether the storage is reaching it's capacity or not. This followed by the fact that Ozone storage is indicated by green colour is misleading.
* As a part of this we make two main changes:
    * On the Overview page we are adding a red border
    * In the tables, the "storage bar" progress-bar and percentage text will turn red when storage is almost full.
    * The limit for the indication is set to above 80% i.e. when the storage is above 80% full, the above indicators will be shown.
* We also remove the older separation of colors for the progress-bar for different category of capacity usage and instead formatting the tooltip to clearly show the data

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12036

## How was this patch tested?
Patch was tested manually
<img width="1523" alt="Screenshot 2025-01-08 at 17 30 57" src="https://github.com/user-attachments/assets/f4a8fe47-2af6-4576-bfda-7535c91db1cc" />
<img width="1519" alt="Screenshot 2025-01-08 at 17 30 41" src="https://github.com/user-attachments/assets/e5fceb1a-8246-497e-a87a-3ae870e6e050" />
