### PR TITLE
HDDS-11714. resetDeletedBlockRetryCount with --all may fail and can cause long db lock in large cluster

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -57,14 +57,11 @@ public interface DeletedBlockLog extends Closeable {
    * considered to be failed if it has been sent more than MAX_RETRY limit
    * and its count is reset to -1.
    *
-   * @param batchSize Number of failed transactions to be processed in a batch.
+   * @param count Number of failed transactions to be returned.
    * @param startTxId The least transaction id to start with.
    * @return a list of failed deleted block transactions.
    * @throws IOException
    */
-  List<DeletedBlocksTransaction> getFailedTransactionsBatch(int batchSize,
-      long startTxId) throws IOException;
-
   List<DeletedBlocksTransaction> getFailedTransactions(int count,
       long startTxId) throws IOException;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -65,6 +65,9 @@ public interface DeletedBlockLog extends Closeable {
   List<DeletedBlocksTransaction> getFailedTransactionsBatch(int batchSize,
       long startTxId) throws IOException;
 
+  List<DeletedBlocksTransaction> getFailedTransactions(int count,
+      long startTxId) throws IOException;
+
   /**
    * Increments count for given list of transactions by 1.
    * The log maintains a valid range of counts for each transaction

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -53,16 +53,16 @@ public interface DeletedBlockLog extends Closeable {
       throws IOException;
 
   /**
-   * Return the failed transactions in the log. A transaction is
+   * Return the failed transactions in batches in the log. A transaction is
    * considered to be failed if it has been sent more than MAX_RETRY limit
    * and its count is reset to -1.
    *
-   * @param count Maximum num of returned transactions, if &lt; 0. return all.
+   * @param batchSize Number of failed transactions to be processed in a batch.
    * @param startTxId The least transaction id to start with.
    * @return a list of failed deleted block transactions.
    * @throws IOException
    */
-  List<DeletedBlocksTransaction> getFailedTransactions(int count,
+  List<DeletedBlocksTransaction> getFailedTransactionsBatch(int batchSize,
       long startTxId) throws IOException;
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionInfo;
 import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos.ReconfigureProtocolService;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
@@ -904,18 +905,24 @@ public class SCMClientProtocolServer implements
     auditMap.put("count", String.valueOf(count));
     auditMap.put("startTxId", String.valueOf(startTxId));
     try {
-      result = scm.getScmBlockManager().getDeletedBlockLog()
-          .getFailedTransactions(count, startTxId).stream()
+      List<StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>
+          failedTxns;
+      List<StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>
+          allFailedTxns = new ArrayList<>();
+      do {
+        failedTxns = scm.getScmBlockManager().getDeletedBlockLog()
+            .getFailedTransactionsBatch(100, startTxId);
+        allFailedTxns.addAll(failedTxns);
+      } while (!failedTxns.isEmpty());
+      result = allFailedTxns.stream()
           .map(DeletedBlocksTransactionInfoWrapper::fromTxn)
           .collect(Collectors.toList());
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
           SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap));
       return result;
     } catch (IOException ex) {
-      AUDIT.logReadFailure(
-          buildAuditMessageForFailure(
-              SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap, ex)
-      );
+      AUDIT.logReadFailure(buildAuditMessageForFailure(
+          SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap, ex));
       throw ex;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionInfo;
 import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos.ReconfigureProtocolService;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
@@ -904,18 +905,19 @@ public class SCMClientProtocolServer implements
     auditMap.put("count", String.valueOf(count));
     auditMap.put("startTxId", String.valueOf(startTxId));
     try {
-      result = scm.getScmBlockManager().getDeletedBlockLog()
-          .getFailedTransactions(count, startTxId).stream()
-          .map(DeletedBlocksTransactionInfoWrapper::fromTxn)
-          .collect(Collectors.toList());
+      int transactionCount = (count == -1) ? Integer.MAX_VALUE : count;
+      List<StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>
+          failedTXs = scm.getScmBlockManager().getDeletedBlockLog()
+          .getFailedTransactions(transactionCount, startTxId);
+      result =
+          failedTXs.stream().map(DeletedBlocksTransactionInfoWrapper::fromTxn)
+              .collect(Collectors.toList());
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
           SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap));
       return result;
     } catch (IOException ex) {
-      AUDIT.logReadFailure(
-          buildAuditMessageForFailure(
-              SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap, ex)
-      );
+      AUDIT.logReadFailure(buildAuditMessageForFailure(
+          SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap, ex));
       throw ex;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -912,8 +912,10 @@ public class SCMClientProtocolServer implements
           SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap));
       return result;
     } catch (IOException ex) {
-      AUDIT.logReadFailure(buildAuditMessageForFailure(
-          SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap, ex));
+      AUDIT.logReadFailure(
+          buildAuditMessageForFailure(
+              SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap, ex)
+      );
       throw ex;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionInfo;
 import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos.ReconfigureProtocolService;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
@@ -905,13 +904,10 @@ public class SCMClientProtocolServer implements
     auditMap.put("count", String.valueOf(count));
     auditMap.put("startTxId", String.valueOf(startTxId));
     try {
-      int transactionCount = (count == -1) ? Integer.MAX_VALUE : count;
-      List<StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>
-          failedTXs = scm.getScmBlockManager().getDeletedBlockLog()
-          .getFailedTransactions(transactionCount, startTxId);
-      result =
-          failedTXs.stream().map(DeletedBlocksTransactionInfoWrapper::fromTxn)
-              .collect(Collectors.toList());
+      result = scm.getScmBlockManager().getDeletedBlockLog()
+          .getFailedTransactions(count, startTxId).stream()
+          .map(DeletedBlocksTransactionInfoWrapper::fromTxn)
+          .collect(Collectors.toList());
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
           SCMAction.GET_FAILED_DELETED_BLOCKS_TRANSACTION, auditMap));
       return result;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -298,20 +298,20 @@ public class TestStorageContainerManager {
     // Verify a few TX gets created in the TX log.
     assertThat(delLog.getNumOfValidTransactions()).isGreaterThan(0);
 
-    // These blocks cannot be found in the container, skip deleting them
-    // eventually these TX will success.
-    GenericTestUtils.waitFor(() -> {
-      try {
-        if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
-          cluster.getStorageContainerManager().getScmHAManager()
-              .asSCMHADBTransactionBuffer().flush();
+      // These blocks cannot be found in the container, skip deleting them
+      // eventually these TX will success.
+      GenericTestUtils.waitFor(() -> {
+        try {
+          if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
+            cluster.getStorageContainerManager().getScmHAManager()
+                .asSCMHADBTransactionBuffer().flush();
+          }
+          return delLog.getFailedTransactions(Integer.MAX_VALUE, 0).size() == 0;
+        } catch (IOException e) {
+          return false;
         }
-        return delLog.getFailedTransactions(-1, 0).size() == 0;
-      } catch (IOException e) {
-        return false;
-      }
-    }, 1000, 20000);
-  }
+      }, 1000, 20000);
+    }
 
   private static void configureBlockDeletion(OzoneConfiguration conf) {
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -300,18 +300,18 @@ public class TestStorageContainerManager {
 
       // These blocks cannot be found in the container, skip deleting them
       // eventually these TX will success.
-      GenericTestUtils.waitFor(() -> {
-        try {
-          if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
-            cluster.getStorageContainerManager().getScmHAManager()
-                .asSCMHADBTransactionBuffer().flush();
-          }
-          return delLog.getFailedTransactions(Integer.MAX_VALUE, 0).size() == 0;
-        } catch (IOException e) {
-          return false;
+    GenericTestUtils.waitFor(() -> {
+      try {
+        if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
+          cluster.getStorageContainerManager().getScmHAManager()
+              .asSCMHADBTransactionBuffer().flush();
         }
-      }, 1000, 20000);
-    }
+        return delLog.getFailedTransactions(-1, 0).size() == 0;
+      } catch (IOException e) {
+        return false;
+      }
+    }, 1000, 20000);
+  }
 
   private static void configureBlockDeletion(OzoneConfiguration conf) {
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -297,6 +297,7 @@ public class TestStorageContainerManager {
 
     // Verify a few TX gets created in the TX log.
     assertThat(delLog.getNumOfValidTransactions()).isGreaterThan(0);
+    
     // These blocks cannot be found in the container, skip deleting them
     // eventually these TX will success.
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -297,9 +297,8 @@ public class TestStorageContainerManager {
 
     // Verify a few TX gets created in the TX log.
     assertThat(delLog.getNumOfValidTransactions()).isGreaterThan(0);
-
-      // These blocks cannot be found in the container, skip deleting them
-      // eventually these TX will success.
+    // These blocks cannot be found in the container, skip deleting them
+    // eventually these TX will success.
     GenericTestUtils.waitFor(() -> {
       try {
         if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case of resetDeletedBlockRetryCount with --all option, scm takes [lock](https://github.com/apache/ozone/blob/12419fae1f0418793d952227364b04f1d2c3583b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java#L126) and tries to get all the transaction with max retry and then updates DB with 0 count. In some large scale env this count can be huge which can lead to multiple problem.

i) Lock can lead to block all other normal operation.

ii) Since message is passed through ratis, which will fail because of size.

Instead of doing like above we should do this operation in batches to avoid long lock and ratis message size failure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11714

## How was this patch tested?

Tested Manually.
