### PR TITLE
HDDS-12042. Fix capacity count for cluster capacity card.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -154,7 +154,12 @@ class OverviewCard extends React.Component<IOverviewCardProps> {
         <div className='ant-card-percentage'>
           {meta}
           <div className='storage-bar'>
-            <StorageBar total={storageReport.capacity} used={storageReport.used} remaining={storageReport.remaining} showMeta={false} />
+            <StorageBar
+              total={storageReport.capacity}
+              used={storageReport.used}
+              remaining={storageReport.remaining}
+              committed={storageReport.committed}
+              showMeta={false} />
           </div>
         </div>
       );

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewStorageCard.tsx
@@ -44,7 +44,7 @@ function getUsagePercentages(
     ozoneUsedPercentage: Math.floor(used / capacity * 100),
     nonOzoneUsedPercentage: Math.floor((capacity - remaining - used) / capacity * 100),
     committedPercentage: Math.floor(committed / capacity * 100),
-    usagePercentage: Math.floor((capacity - remaining) / capacity * 100)
+    usagePercentage: Math.round((capacity - remaining) / capacity * 100)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12042. Fix capacity count for cluster capacity card.

Please describe your PR in detail:
* In the new vs old UI we have a discrepancy in the details of the cluster capacity card.
* Mismatch between the Capacity report percentage:
    * In the new UI we are calculating the percentage for the Overview page storage guage chart by choosing the floor value.
    * In the old UI this is done as the rounded value.
    * We are changing the new UI to use the rounded value instead of floor.

* Mismatch between the Pre-allocated size:
    * In the new UI we are making use of the committed field from the storage report response.
    * In the old UI we are not passing this value to StorageBar component, hence it is picking default value of 0.
    * We should change the old UI to make use of the committed size.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12042

## How was this patch tested?
Patch was tested manually
<img width="869" alt="Screenshot 2025-01-08 at 20 02 21" src="https://github.com/user-attachments/assets/f9bb0c48-4fcb-42d4-aeb6-1baa8caac125" />
<img width="376" alt="Screenshot 2025-01-08 at 20 02 41" src="https://github.com/user-attachments/assets/309ef534-2d3a-42cf-a7ec-06e53bd9fded" />
