### PR TITLE
HDDS-12043. Mark fixed column with disabled checkbox

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/select/multiSelect.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/select/multiSelect.tsx
@@ -28,6 +28,7 @@ import {
 } from 'react-select';
 
 import { selectStyles } from "@/v2/constants/select.constants";
+import { optionCSS } from "react-select/src/components/Option";
 
 
 // ------------- Types -------------- //
@@ -61,7 +62,8 @@ const Option: React.FC<OptionProps<Option, true>> = (props) => {
             marginRight: '8px',
             accentColor: '#1AA57A'
           }}
-          onChange={() => null} />
+          onChange={() => null}
+          disabled={props.isDisabled} />
         <label>{props.label}</label>
       </components.Option>
     </div>
@@ -114,14 +116,13 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
       isSearchable={false}
       controlShouldRenderValue={false}
       classNamePrefix='multi-select'
-      options={options}
+      options={options.map((opt) => ({...opt, isDisabled: (opt.value === fixedColumn)}))}
       components={{
         ValueContainer,
         Option
       }}
       placeholder={placeholder}
       value={selected}
-      isOptionDisabled={(option) => option.value === fixedColumn}
       isDisabled={isDisabled}
       onChange={(selected: ValueType<Option, true>) => {
         if (selected?.length === options.length) return onChange!(options);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/select/multiSelect.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/select/multiSelect.tsx
@@ -28,7 +28,6 @@ import {
 } from 'react-select';
 
 import { selectStyles } from "@/v2/constants/select.constants";
-import { optionCSS } from "react-select/src/components/Option";
 
 
 // ------------- Types -------------- //

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
@@ -273,7 +273,7 @@ const Datanodes: React.FC<{}> = () => {
               onChange={(value) => {
                 setSearchTerm('');
                 setSearchColumn(value as 'hostname' | 'uuid' | 'version' | 'revision')
-              }}/>
+              }} />
           </div>
           <DatanodesTable
             loading={loading}
@@ -283,28 +283,28 @@ const Datanodes: React.FC<{}> = () => {
             searchColumn={searchColumn}
             searchTerm={debouncedSearch}
             handleSelectionChange={handleSelectionChange}
-            decommissionUuids={decommissionUuids}/>
+            decommissionUuids={decommissionUuids} />
         </div>
       </div>
       <Modal
-          title=''
-          centered={true}
-          visible={modalOpen}
-          onOk={handleModalOk}
-          onCancel={handleModalCancel}
-          closable={false}
-          width={400} >
-            <div style={{
-              margin: '0px 0px 5px 0px',
-              fontSize: '16px',
-              fontWeight: 'bold'
-            }}
+        title=''
+        centered={true}
+        visible={modalOpen}
+        onOk={handleModalOk}
+        onCancel={handleModalCancel}
+        closable={false}
+        width={400} >
+        <div style={{
+          margin: '0px 0px 5px 0px',
+          fontSize: '16px',
+          fontWeight: 'bold'
+        }}
           data-testid='dn-remove-modal'>
-              <WarningFilled className='icon-warning' style={{paddingRight: '8px'}}/>
-              Stop Tracking Datanode
-            </div>
-            Are you sure, you want recon to stop tracking the selected <strong>{selectedRows.length}</strong> datanode(s)?
-        </Modal>
+          <WarningFilled className='icon-warning' style={{ paddingRight: '8px' }} />
+          Stop Tracking Datanode
+        </div>
+        Are you sure, you want recon to stop tracking the selected <strong>{selectedRows.length}</strong> datanode(s)?
+      </Modal>
     </>
   );
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
@@ -273,7 +273,7 @@ const Datanodes: React.FC<{}> = () => {
               onChange={(value) => {
                 setSearchTerm('');
                 setSearchColumn(value as 'hostname' | 'uuid' | 'version' | 'revision')
-              }} />
+              }}/>
           </div>
           <DatanodesTable
             loading={loading}
@@ -283,7 +283,7 @@ const Datanodes: React.FC<{}> = () => {
             searchColumn={searchColumn}
             searchTerm={debouncedSearch}
             handleSelectionChange={handleSelectionChange}
-            decommissionUuids={decommissionUuids} />
+            decommissionUuids={decommissionUuids}/>
         </div>
       </div>
       <Modal
@@ -294,17 +294,17 @@ const Datanodes: React.FC<{}> = () => {
           onCancel={handleModalCancel}
           closable={false}
           width={400} >
-        <div style={{
-          margin: '0px 0px 5px 0px',
-          fontSize: '16px',
-          fontWeight: 'bold'
-        }}
+            <div style={{
+              margin: '0px 0px 5px 0px',
+              fontSize: '16px',
+              fontWeight: 'bold'
+            }}
           data-testid='dn-remove-modal'>
-            <WarningFilled className='icon-warning' style={{paddingRight: '8px'}}/>
-            Stop Tracking Datanode
+              <WarningFilled className='icon-warning' style={{paddingRight: '8px'}}/>
+              Stop Tracking Datanode
             </div>
             Are you sure, you want recon to stop tracking the selected <strong>{selectedRows.length}</strong> datanode(s)?
-      </Modal>
+        </Modal>
     </>
   );
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
@@ -287,23 +287,23 @@ const Datanodes: React.FC<{}> = () => {
         </div>
       </div>
       <Modal
-        title=''
-        centered={true}
-        visible={modalOpen}
-        onOk={handleModalOk}
-        onCancel={handleModalCancel}
-        closable={false}
-        width={400} >
+          title=''
+          centered={true}
+          visible={modalOpen}
+          onOk={handleModalOk}
+          onCancel={handleModalCancel}
+          closable={false}
+          width={400} >
         <div style={{
           margin: '0px 0px 5px 0px',
           fontSize: '16px',
           fontWeight: 'bold'
         }}
           data-testid='dn-remove-modal'>
-          <WarningFilled className='icon-warning' style={{ paddingRight: '8px' }} />
-          Stop Tracking Datanode
-        </div>
-        Are you sure, you want recon to stop tracking the selected <strong>{selectedRows.length}</strong> datanode(s)?
+            <WarningFilled className='icon-warning' style={{paddingRight: '8px'}}/>
+            Stop Tracking Datanode
+            </div>
+            Are you sure, you want recon to stop tracking the selected <strong>{selectedRows.length}</strong> datanode(s)?
       </Modal>
     </>
   );


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12043. Mark fixed column with disabled checkbox.

Please describe your PR in detail:
* In MultiSelect component, we pass a `fixedColumn` prop which decides the menu option which should not be selectable. This is useful to make table have at-least one column fixed even if other columns are deselected.
* But in the current implementation this disabled option is rendered with an active checkbox causing the confusion that the option is selectable.
* This PR modifies the option passed to have isDisabled explicitly set for fixedColumn and use that as the options to the menu.
* This will render the fixedColumn with a grey disabled checkbox, which provides proper feedback to the user that the column is not selected/fixed.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12043


## How was this patch tested?
Patch was tested manually
Before the changes:
<img width="275" alt="Screenshot 2025-01-08 at 20 54 20" src="https://github.com/user-attachments/assets/eb941f21-d1cb-493a-8b0e-dcdf262ab560" />

After the changes:
<img width="215" alt="Screenshot 2025-01-08 at 20 54 56" src="https://github.com/user-attachments/assets/5b99a16a-f87c-490f-9784-2fb49ab7185c" />

Same has been tested out for the Pipelines page, Volumes page and Containers page i.e wherever fixedColumn is being passed to MultiSelect