### PR TITLE
HDDS-12045. S3 secret admin test fails with HAProxy

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/s3-haproxy.cfg
+++ b/hadoop-ozone/dist/src/main/compose/common/s3-haproxy.cfg
@@ -36,3 +36,13 @@ backend servers
     server server1 s3g1:9878 maxconn 32
     server server2 s3g2:9878 maxconn 32
     server server3 s3g3:9878 maxconn 32
+
+frontend webadmin
+    bind *:19878
+    default_backend webadmin-servers
+
+backend webadmin-servers
+    balance roundrobin
+    server server1 s3g1:19878 maxconn 32
+    server server2 s3g2:19878 maxconn 32
+    server server3 s3g3:19878 maxconn 32


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-7307 and HDDS-7990 together cause [test failure](https://github.com/apache/ozone/actions/runs/12673824178/job/35321881300#step:7:14):

```
S3 Gateway Generate Secret                                            | FAIL |
7 != 0
...
```

The problem is that HA Proxy is not configured for the web admin port.

https://issues.apache.org/jira/browse/HDDS-12045

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/ozonesecure
$ ./test-haproxy-s3g.sh
...
s3-encrypted :: S3 Secret Generate test                                       
==============================================================================
S3 Gateway Generate Secret                                            | PASS |
------------------------------------------------------------------------------
S3 Gateway Secret Already Exists                                      | PASS |
------------------------------------------------------------------------------
S3 Gateway Generate Secret By Username                                | PASS |
------------------------------------------------------------------------------
S3 Gateway Generate Secret By Username For Other User                 | PASS |
------------------------------------------------------------------------------
S3 Gateway Reject Secret Generation By Non-admin User                 | PASS |
------------------------------------------------------------------------------
s3-encrypted :: S3 Secret Generate test                               | PASS |
5 tests, 5 passed, 0 failed
==============================================================================
...
==============================================================================
s3-encrypted :: S3 Secret Revoke test                                         
==============================================================================
S3 Gateway Revoke Secret                                              | PASS |
------------------------------------------------------------------------------
S3 Gateway Revoke Secret By Username                                  | PASS |
------------------------------------------------------------------------------
S3 Gateway Revoke Secret By Username For Other User                   | PASS |
------------------------------------------------------------------------------
S3 Gateway Reject Secret Revoke By Non-admin User                     | PASS |
------------------------------------------------------------------------------
s3-encrypted :: S3 Secret Revoke test                                 | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
...
==============================================================================
s3-encrypted :: S3 gateway web ui test                                        
==============================================================================
Check web UI                                                          | PASS |
------------------------------------------------------------------------------
s3-encrypted :: S3 gateway web ui test                                | PASS |
1 test, 1 passed, 0 failed
==============================================================================
...
==============================================================================
Web :: Smoke test for spnego with docker-compose environments.                
==============================================================================
Verify SPNEGO URLs without auth                                       | PASS |
------------------------------------------------------------------------------
Verify SPNEGO URLs with auth                                          | PASS |
------------------------------------------------------------------------------
Web :: Smoke test for spnego with docker-compose environments.        | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
```

https://github.com/adoroszlai/ozone/actions/runs/12675689361/job/35327953173#step:6:563
