### PR TITLE
HDDS-12029. Move ozone debug recover to ozone admin om lease recover

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -48,8 +48,6 @@ execute_robot_test scm freon
 execute_robot_test scm cli
 execute_robot_test scm admincli
 
-execute_robot_test scm debug/ozone-debug-lease-recovery.robot
-
 execute_robot_test scm -v USERNAME:httpfs httpfs
 execute_debug_tests
 

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/lease-recovery.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/lease-recovery.robot
@@ -18,7 +18,6 @@ Documentation       Test lease recovery of ozone filesystem
 Library             OperatingSystem
 Resource            ../lib/os.robot
 Resource            ../lib/fs.robot
-Resource            ozone-debug.robot
 Test Timeout        5 minute
 Suite Setup         Create volume bucket and put key
 
@@ -35,8 +34,13 @@ Create volume bucket and put key
     Create File             ${TEMP_DIR}/${TESTFILE}
     Execute                 ozone sh key put /${VOLUME}/${BUCKET}/${TESTFILE} ${TEMP_DIR}/${TESTFILE}
 
+Execute Lease recovery cli
+    [Arguments]             ${KEY_PATH}
+    ${result} =             Execute And Ignore Error      ozone admin om lease recover --path=${KEY_PATH}
+    [Return]                ${result}
+
 *** Test Cases ***
-Test ozone debug recover for o3fs
+Test ozone admin om lease recover for o3fs
     ${o3fs_path} =     Format FS URL         o3fs    ${VOLUME}    ${BUCKET}    ${TESTFILE}
     ${result} =        Execute Lease recovery cli    ${o3fs_path}
                        Should Contain    ${result}   Lease recovery SUCCEEDED
@@ -44,7 +48,7 @@ Test ozone debug recover for o3fs
     ${result} =        Execute Lease recovery cli    ${o3fs_path}
                        Should Contain    ${result}    not found
 
-Test ozone debug recover for ofs
+Test ozone admin om lease recover for ofs
     ${ofs_path} =      Format FS URL         ofs     ${VOLUME}    ${BUCKET}    ${TESTFILE}
     ${result} =        Execute Lease recovery cli    ${ofs_path}
                        Should Contain    ${result}   Lease recovery SUCCEEDED

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -154,4 +154,4 @@ HSync Lease Recover Can Be Used
     Pass Execution If    '${DATA_VERSION}' < '${FSO_VERSION}'      Skipped write test case
     Pass Execution If    '${CLIENT_VERSION}' < '${HSYNC_VERSION}'    Client does not support HSYNC
     Pass Execution If    '${CLUSTER_VERSION}' < '${HSYNC_VERSION}'   Cluster does not support HSYNC
-    Execute    ozone debug recover --path=ofs://om/vol1/fso-bucket-${DATA_VERSION}/dir/subdir/file
+    Execute    ozone admin om lease recover --path=ofs://om/vol1/fso-bucket-${DATA_VERSION}/dir/subdir/file

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -26,11 +26,6 @@ Execute read-replicas CLI tool
     File Should Exist               ${directory}/${TESTFILE}_manifest
     [Return]                        ${directory}
 
-Execute Lease recovery cli
-    [Arguments]                     ${KEY_PATH}
-    ${result} =                     Execute And Ignore Error      ozone debug recover --path=${KEY_PATH}
-    [Return]                        ${result}
-
 Read Replicas Manifest
     ${manifest} =        Get File        ${DIR}/${TESTFILE}_manifest
     ${json} =            Evaluate        json.loads('''${manifest}''')        json

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestLeaseRecoverer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestLeaseRecoverer.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.hadoop.ozone.debug;
+package org.apache.hadoop.ozone;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.LeaseRecoverable;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.ozone.admin.om.lease.LeaseRecoverer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -37,9 +38,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/admin/om/lease/TestLeaseRecoverer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/admin/om/lease/TestLeaseRecoverer.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.hadoop.ozone;
+package org.apache.hadoop.ozone.admin.om.lease;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.LeaseRecoverable;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
-import org.apache.hadoop.ozone.admin.om.lease.LeaseRecoverer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -38,6 +37,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.admin.om.lease.LeaseSubCommand;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
@@ -58,7 +59,8 @@ import java.util.Collection;
         DecommissionOMSubcommand.class,
         UpdateRangerSubcommand.class,
         TransferOmLeaderSubCommand.class,
-        FetchKeySubCommand.class
+        FetchKeySubCommand.class,
+        LeaseSubCommand.class
     })
 @MetaInfServices(AdminSubcommand.class)
 public class OMAdmin implements AdminSubcommand {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/lease/LeaseRecoverer.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/lease/LeaseRecoverer.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug;
+package org.apache.hadoop.ozone.admin.om.lease;
 
 import java.net.URI;
 import java.util.concurrent.Callable;
@@ -24,24 +24,21 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.LeaseRecoverable;
-import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
 /**
- * Tool that recover the lease of a specified file.
+ * CLI to recover the lease of a specified file.
  */
 @CommandLine.Command(
     name = "recover",
-    customSynopsis = "ozone debug recover --path=<path>",
-    description = "recover the lease of a specified file. Make sure to specify "
+    customSynopsis = "ozone admin om lease recover --path=<path>",
+    description = "Recover the lease of a specified file. Make sure to specify "
         + "file system scheme if ofs:// is not the default.")
-@MetaInfServices(DebugSubcommand.class)
-public class LeaseRecoverer implements Callable<Void>, DebugSubcommand {
+public class LeaseRecoverer implements Callable<Void> {
 
   @Spec
   private CommandSpec spec;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/lease/LeaseSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/lease/LeaseSubCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om.lease;
+
+import picocli.CommandLine;
+
+/**
+ * Handler of ozone admin om lease command.
+ */
+@CommandLine.Command(
+    name = "lease",
+    description = "Command for all lease related queries.",
+    subcommands = {
+        LeaseRecoverer.class
+    }
+)
+public class LeaseSubCommand {
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/lease/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/lease/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Lease related OM Admin tools.
+ */
+package org.apache.hadoop.ozone.admin.om.lease;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `ozone debug recover` command that is currently used for lease recovery has a few problems:

- It modifies the cluster, so it should not be under `debug`.
- The name does not specify that it deals with leases.
- It uses a standard API from the `FileSystem` interface unlike other low level tools in this package.

The command is unique because it goes through the `FileSystem` interface but is not exposed through the `fs` command line in Hadoop or Ozone. For these reasons, we propose moving this command to its own Ozone subcommand: `ozone admin om lease recover`. This also allows other lease related subcommands (like querying of existing leases) to be added in the future.

## What is the link to the Apache JIRA
[HDDS-12029](https://issues.apache.org/jira/browse/HDDS-12029)

## How was this patch tested?
Tested the patch on a docker cluster.

```
bash-5.1$ ozone admin om lease
Missing required subcommand
Usage: ozone admin om lease [COMMAND]
Command for all lease related queries.
Commands:
  recover  Recover the lease of a specified file. Make sure to specify file
             system scheme if ofs:// is not the default.
```

```
bash-5.1$ ozone admin om lease recover --path=/vol1/bucket1/key1
Lease recovery SUCCEEDED on /vol1/bucket1/key1
```