### PR TITLE
HDDS-12041. Add ozone repair scm cert command and its subcommand

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/SCMRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/SCMRepair.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.repair.scm;
+
+import org.apache.hadoop.hdds.cli.RepairSubcommand;
+import org.apache.hadoop.ozone.repair.scm.cert.CertRepair;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * Ozone Repair CLI for SCM.
+ */
+@CommandLine.Command(name = "scm",
+    description = "Operational tool to repair SCM.",
+    subcommands = {
+        CertRepair.class,
+    }
+)
+@MetaInfServices(RepairSubcommand.class)
+public class SCMRepair implements RepairSubcommand {
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/CertRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/CertRepair.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.repair.scm.cert;
+
+import picocli.CommandLine;
+
+/**
+ * A dedicated subcommand for all certificate related repairs on SCM.
+ */
+
+@CommandLine.Command(name = "cert",
+    description = "Subcommand for all certificate related repairs on SCM",
+    subcommands = {
+        RecoverSCMCertificate.class
+    }
+)
+public class CertRepair {
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * SCM Cert Repair tools.
+ */
+package org.apache.hadoop.ozone.repair.scm.cert;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * SCM related repair tools.
+ */
+package org.apache.hadoop.ozone.repair.scm;


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ozone repair scm` -  These commands make repairs to an individual SCM instance.
- `ozone repair scm cert`
A dedicated subcommand for all certificate related repairs on SCM we may need now or in the future.
- `ozone repair scm cert recover`
The new location of `ozone repair cert-recover`

## What is the link to the Apache JIRA
[HDDS-12041](https://issues.apache.org/jira/browse/HDDS-12041)

## How was this patch tested?
Tested the patch on a docker cluster.
```
bash-5.1$ ozone repair scm
...
Usage: ozone repair scm [COMMAND]
Operational tool to repair SCM.
Commands:
  cert  Subcommand for all certificate related repairs on SCM
```

```
bash-5.1$ ozone repair scm cert recover
...
Missing required option: '--db=<dbPath>'
Usage: ozone repair scm cert recover [-hV] [--force] --db=<dbPath>
Recover Deleted SCM Certificate from RocksDB
      --db=<dbPath>   SCM DB Path
      --force         Use this flag if you want to bypass the check in
                        false-positive cases.
  -h, --help          Show this help message and exit.
  -V, --version       Print version information and exit.
```

```
bash-5.1$ ozone repair scm cert recover --db /data/metadata/scm.db
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Error: SCM is currently running on this host. Stop the service before running the repair tool.
```

```
bash-5.1$ ozone repair scm cert recover --db /data/metadata/scm.db --force
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
Warning: --force flag used. Proceeding despite SCM being detected as running.
All Certs in DB : []
Host: 6f869b54ec3e
Sub CA Cert not found in the DB for this host, Certs in the DB : []
```