### PR TITLE
HDDS-12054. Move ozone debug prefix to ozone debug om prefix

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.debug.PrefixParser;
+import org.apache.hadoop.ozone.debug.om.PrefixParser;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.jupiter.api.AfterAll;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/OMDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/OMDebug.java
@@ -27,7 +27,7 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
     name = "om",
-    description = "Runs OM related subcommands.",
+    description = "Debug commands related to OM.",
     subcommands = {
         PrefixParser.class
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/OMDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/OMDebug.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.om;
+
+import org.apache.hadoop.hdds.cli.DebugSubcommand;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * OM debug related commands.
+ */
+@CommandLine.Command(
+    name = "om",
+    description = "Runs OM related subcommands.",
+    subcommands = {
+        PrefixParser.class
+    }
+)
+@MetaInfServices(DebugSubcommand.class)
+public class OMDebug implements DebugSubcommand {
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/PrefixParser.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import java.nio.file.Path;
-import org.apache.hadoop.hdds.cli.DebugSubcommand;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
@@ -40,10 +39,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/PrefixParser.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug;
+package org.apache.hadoop.ozone.debug.om;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -53,8 +53,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 @CommandLine.Command(
     name = "prefix",
     description = "Parse prefix contents")
-@MetaInfServices(DebugSubcommand.class)
-public class PrefixParser implements Callable<Void>, DebugSubcommand {
+public class PrefixParser implements Callable<Void> {
 
   /**
    * Types to represent the level or path component type.
@@ -69,9 +68,6 @@ public class PrefixParser implements Callable<Void>, DebugSubcommand {
   }
 
   private final int[] parserStats = new int[Types.values().length];
-
-  @Spec
-  private CommandSpec spec;
 
   @CommandLine.Option(names = {"--db"},
       required = true,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/om/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * OM debug related commands.
+ */
+package org.apache.hadoop.ozone.debug.om;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The prefix subcommand only works on OM using the FSO namespace so it should be under the om subcommand.

## What is the link to the Apache JIRA
[HDDS-12054](https://issues.apache.org/jira/browse/HDDS-12054)

## How was this patch tested?
Tested the patch on a docker cluster and through `TestOzoneFileSystemPrefixParser.java`
```
bash-5.1$ ozone debug om
Missing required subcommand
Usage: ozone debug om [COMMAND]
Runs OM related subcommands.
Commands:
  prefix  Parse prefix contents

```

```
bash-5.1$ ozone debug om prefix
Missing required options: '--db=<dbPath>', '--path=<filePath>', '--bucket=<bucket>', '--volume=<volume>'
Usage: ozone debug om prefix --bucket=<bucket> --db=<dbPath> --path=<filePath>
                             --volume=<volume>
Parse prefix contents
      --bucket=<bucket>   bucket name
      --db=<dbPath>       Database File Path
      --path=<filePath>   prefixFile Path
      --volume=<volume>   volume name
```

