### PR TITLE
HDDS-12055. Move ozone debug container to ozone debug datanode container

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/dn-one-rocksdb.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/dn-one-rocksdb.robot
@@ -25,5 +25,5 @@ Test Timeout        5 minutes
 Create a container and check container schema version
     ${output} =         Execute          ozone admin container create
                         Should not contain  ${output}       Failed
-    ${output} =         Execute          ozone debug container list
+    ${output} =         Execute          ozone debug datanode container list
                         Should contain  ${output}    \"schemaVersion\" : \"3\"

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/DatanodeDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/DatanodeDebug.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.datanode;
+
+import org.apache.hadoop.hdds.cli.DebugSubcommand;
+import org.apache.hadoop.ozone.debug.datanode.container.ContainerCommands;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * Datanode debug related commands.
+ */
+@CommandLine.Command(
+    name = "datanode",
+    description = "Debug commands related to Datanode.",
+    subcommands = {
+        ContainerCommands.class
+    }
+)
+@MetaInfServices(DebugSubcommand.class)
+public class DatanodeDebug implements DebugSubcommand {
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/ContainerCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/ContainerCommands.java
@@ -16,11 +16,11 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.container;
+package org.apache.hadoop.ozone.debug.datanode.container;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -42,12 +42,9 @@ import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerReader;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
-import org.apache.hadoop.ozone.debug.OzoneDebug;
-import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,25 +74,17 @@ import java.util.stream.Stream;
         ExportSubcommand.class,
         InspectSubcommand.class
     })
-@MetaInfServices(DebugSubcommand.class)
-public class ContainerCommands implements DebugSubcommand {
+public class ContainerCommands extends AbstractSubcommand {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerCommands.class);
-
-  @ParentCommand
-  private OzoneDebug parent;
 
   private MutableVolumeSet volumeSet;
 
   private ContainerController controller;
 
-  OzoneConfiguration getOzoneConf() {
-    return parent.getOzoneConf();
-  }
-
   public void loadContainersFromVolumes() throws IOException {
-    OzoneConfiguration conf = parent.getOzoneConf();
+    OzoneConfiguration conf = getOzoneConf();
 
     ContainerSet containerSet = new ContainerSet(null, 1000, true);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/ExportSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/ExportSubcommand.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.container;
+package org.apache.hadoop.ozone.debug.datanode.container;
 
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
@@ -35,7 +35,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 
 /**
- * Handles {@code ozone debug container export} command.
+ * Handles {@code ozone debug datanode container export} command.
  */
 @Command(
     name = "export",

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/InfoSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/InfoSubcommand.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.container;
+package org.apache.hadoop.ozone.debug.datanode.container;
 
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import picocli.CommandLine;
@@ -24,24 +24,30 @@ import picocli.CommandLine.Command;
 
 import java.util.concurrent.Callable;
 
-import static org.apache.hadoop.ozone.debug.container.ContainerCommands.outputContainer;
+import static org.apache.hadoop.ozone.debug.datanode.container.ContainerCommands.outputContainer;
 
 /**
- * Handles {@code ozone debug container list} command.
+ * Handles {@code ozone debug datanode container info} command.
  */
 @Command(
-    name = "list",
-    description = "Show container info of all container replicas on datanode")
-public class ListSubcommand implements Callable<Void> {
+    name = "info",
+    description = "Show container info of a container replica on datanode")
+public class InfoSubcommand implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private ContainerCommands parent;
+
+  @CommandLine.Option(names = {"--container"},
+      required = true,
+      description = "Container Id")
+  private long containerId;
 
   @Override
   public Void call() throws Exception {
     parent.loadContainersFromVolumes();
 
-    for (Container<?> container : parent.getController().getContainers()) {
+    Container container = parent.getController().getContainer(containerId);
+    if (container != null) {
       outputContainer(container.getContainerData());
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/InspectSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/InspectSubcommand.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.container;
+package org.apache.hadoop.ozone.debug.datanode.container;
 
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 
 /**
- * {@code ozone debug container inspect},
+ * {@code ozone debug datanode container inspect},
  * a command to run {@link KeyValueContainerMetadataInspector}.
  */
 @Command(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/ListSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/ListSubcommand.java
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.container;
+package org.apache.hadoop.ozone.debug.datanode.container;
 
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import picocli.CommandLine;
@@ -24,30 +24,24 @@ import picocli.CommandLine.Command;
 
 import java.util.concurrent.Callable;
 
-import static org.apache.hadoop.ozone.debug.container.ContainerCommands.outputContainer;
+import static org.apache.hadoop.ozone.debug.datanode.container.ContainerCommands.outputContainer;
 
 /**
- * Handles {@code ozone debug container info} command.
+ * Handles {@code ozone debug datanode container list} command.
  */
 @Command(
-    name = "info",
-    description = "Show container info of a container replica on datanode")
-public class InfoSubcommand implements Callable<Void> {
+    name = "list",
+    description = "Show container info of all container replicas on datanode")
+public class ListSubcommand implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private ContainerCommands parent;
-
-  @CommandLine.Option(names = {"--container"},
-      required = true,
-      description = "Container Id")
-  private long containerId;
 
   @Override
   public Void call() throws Exception {
     parent.loadContainersFromVolumes();
 
-    Container container = parent.getController().getContainer(containerId);
-    if (container != null) {
+    for (Container<?> container : parent.getController().getContainers()) {
       outputContainer(container.getContainerData());
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/container/package-info.java
@@ -19,4 +19,4 @@
 /**
  * Contains all of the datanode container replica related commands.
  */
-package org.apache.hadoop.ozone.debug.container;
+package org.apache.hadoop.ozone.debug.datanode.container;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/datanode/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Datanode debug related commands.
+ */
+package org.apache.hadoop.ozone.debug.datanode;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `container` subcommand and all commands under it run locally on a datanode, so they should be moved under the `datanode` subcommand.

## What is the link to the Apache JIRA
[HDDS-12055](https://issues.apache.org/jira/browse/HDDS-12055)

## How was this patch tested?
Tested the patch on a docker cluster.

```
bash-5.1$ ozone debug datanode 
Missing required subcommand
Usage: ozone debug datanode [COMMAND]
Runs datanode related subcommands.
Commands:
  container  Container replica specific operations to be executed on datanodes
               only
```

```
bash-5.1$ ozone debug datanode container
Missing required subcommand
Usage: ozone debug datanode container [-hV] [COMMAND]
Container replica specific operations to be executed on datanodes only
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  list     Show container info of all container replicas on datanode
  info     Show container info of a container replica on datanode
  export   Export one container to a tarball
  inspect  Check the metadata of all container replicas on this datanode.
```