### PR TITLE
HDDS-12064. Optimize bootstrap logic to reduce loop while checking file links

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -203,6 +203,10 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     Map<String, Map<Path, Path>> paths = new HashMap<>();
     Path metaDirPath = getMetaDirPath(checkpointLocation);
     for (String s : toExcludeList) {
+      Path fileName = Paths.get(s).getFileName();
+      if (fileName == null) {
+        continue;
+      }
       Path destPath = Paths.get(metaDirPath.toString(), s);
       if (destPath.toString().startsWith(
           sstBackupDir.getOriginalDir().toString())) {
@@ -212,12 +216,12 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             sstBackupDir.getOriginalDir().toString().length() + 1;
         Path srcPath = Paths.get(sstBackupDir.getTmpDir().toString(),
             truncateFileName(truncateLength, destPath));
-        paths.computeIfAbsent(srcPath.getFileName().toString(), (k) -> new HashMap<>()).put(srcPath, destPath);
+        paths.computeIfAbsent(fileName.toString(), (k) -> new HashMap<>()).put(srcPath, destPath);
       } else if (!s.startsWith(OM_SNAPSHOT_DIR)) {
         Path fixedPath = Paths.get(checkpointLocation.toString(), s);
-        paths.computeIfAbsent(fixedPath.getFileName().toString(), (k) -> new HashMap<>()).put(fixedPath, fixedPath);
+        paths.computeIfAbsent(fileName.toString(), (k) -> new HashMap<>()).put(fixedPath, fixedPath);
       } else {
-        paths.computeIfAbsent(destPath.getFileName().toString(), (k) -> new HashMap<>()).put(destPath, destPath);
+        paths.computeIfAbsent(fileName.toString(), (k) -> new HashMap<>()).put(destPath, destPath);
       }
     }
     return paths;
@@ -460,8 +464,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     if (destDir != null) {
       destFile = Paths.get(destDir.toString(), fileName);
     }
-    if (sstFilesToExclude.getOrDefault(file.getFileName().getFileName().toString(), Collections.emptyMap())
-        .containsKey(file)) {
+    if (sstFilesToExclude.getOrDefault(fileNamePath.toString(), Collections.emptyMap()).containsKey(file)) {
       excluded.add(destFile.toString());
     } else {
       if (fileName.endsWith(ROCKSDB_SST_SUFFIX)) {
@@ -476,13 +479,13 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             hardLinkFiles.put(destFile, linkPath);
           } else {
             // Add to tarball.
-            copyFiles.computeIfAbsent(file.getFileName().toString(), (k) -> new HashMap<>()).put(file, destFile);
+            copyFiles.computeIfAbsent(fileNamePath.toString(), (k) -> new HashMap<>()).put(file, destFile);
             fileSize = Files.size(file);
           }
         }
       } else {
         // Not sst file.
-        copyFiles.computeIfAbsent(file.getFileName().toString(), (k) -> new HashMap<>()).put(file, destFile);
+        copyFiles.computeIfAbsent(fileNamePath.toString(), (k) -> new HashMap<>()).put(file, destFile);
       }
     }
     return fileSize;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -209,7 +209,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         continue;
       }
       Path destPath = Paths.get(metaDirPath.toString(), s);
-      paths.computeIfAbsent(fileName.toString(), (k) -> new HashMap<>());
+      Map<Path, Path> fileMap = paths.computeIfAbsent(fileName.toString(), (k) -> new HashMap<>());
       if (destPath.toString().startsWith(
           sstBackupDir.getOriginalDir().toString())) {
         // The source of the sstBackupDir is a temporary directory and needs
@@ -218,12 +218,12 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             sstBackupDir.getOriginalDir().toString().length() + 1;
         Path srcPath = Paths.get(sstBackupDir.getTmpDir().toString(),
             truncateFileName(truncateLength, destPath));
-        paths.get(fileName.toString()).put(srcPath, destPath);
+        fileMap.put(srcPath, destPath);
       } else if (!s.startsWith(OM_SNAPSHOT_DIR)) {
         Path fixedPath = Paths.get(checkpointLocation.toString(), s);
-        paths.get(fileName.toString()).put(fixedPath, fixedPath);
+        fileMap.put(fixedPath, fixedPath);
       } else {
-        paths.get(fileName.toString()).put(destPath, destPath);
+        fileMap.put(destPath, destPath);
       }
     }
     return paths;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -51,6 +51,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -149,7 +150,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     // the same.  For synchronization purposes, some files are copied
     // to a temp directory on the leader.  In those cases the source
     // and dest won't be the same.
-    Map<Path, Path> copyFiles = new HashMap<>();
+    Map<String, Map<Path, Path>> copyFiles = new HashMap<>();
 
     // Map of link to path.
     Map<Path, Path> hardLinkFiles = new HashMap<>();
@@ -168,13 +169,14 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
           differ.getCompactionLogDir());
 
       // Files to be excluded from tarball
-      Map<Path, Path> sstFilesToExclude = normalizeExcludeList(toExcludeList,
+      Map<String, Map<Path, Path>> sstFilesToExclude = normalizeExcludeList(toExcludeList,
           checkpoint.getCheckpointLocation(), sstBackupDir);
       boolean completed = getFilesForArchive(checkpoint, copyFiles,
           hardLinkFiles, sstFilesToExclude, includeSnapshotData(request),
           excludedList, sstBackupDir, compactionLogDir);
-      writeFilesToArchive(copyFiles, hardLinkFiles, archiveOutputStream,
-          completed, checkpoint.getCheckpointLocation());
+      writeFilesToArchive(copyFiles.values().stream().flatMap(map -> map.entrySet().stream())
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+          hardLinkFiles, archiveOutputStream, completed, checkpoint.getCheckpointLocation());
     } catch (Exception e) {
       LOG.error("got exception writing to archive " + e);
       throw e;
@@ -194,11 +196,11 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
    *         include sst files.)
    */
   @VisibleForTesting
-  public static Map<Path, Path> normalizeExcludeList(
+  public static Map<String, Map<Path, Path>> normalizeExcludeList(
       List<String> toExcludeList,
       Path checkpointLocation,
       DirectoryData sstBackupDir) {
-    Map<Path, Path> paths = new HashMap<>();
+    Map<String, Map<Path, Path>> paths = new HashMap<>();
     Path metaDirPath = getMetaDirPath(checkpointLocation);
     for (String s : toExcludeList) {
       Path destPath = Paths.get(metaDirPath.toString(), s);
@@ -210,12 +212,12 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             sstBackupDir.getOriginalDir().toString().length() + 1;
         Path srcPath = Paths.get(sstBackupDir.getTmpDir().toString(),
             truncateFileName(truncateLength, destPath));
-        paths.put(srcPath, destPath);
+        paths.computeIfAbsent(srcPath.getFileName().toString(), (k) -> new HashMap<>()).put(srcPath, destPath);
       } else if (!s.startsWith(OM_SNAPSHOT_DIR)) {
         Path fixedPath = Paths.get(checkpointLocation.toString(), s);
-        paths.put(fixedPath, fixedPath);
+        paths.computeIfAbsent(fixedPath.getFileName().toString(), (k) -> new HashMap<>()).put(fixedPath, fixedPath);
       } else {
-        paths.put(destPath, destPath);
+        paths.computeIfAbsent(destPath.getFileName().toString(), (k) -> new HashMap<>()).put(destPath, destPath);
       }
     }
     return paths;
@@ -266,9 +268,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   private boolean getFilesForArchive(DBCheckpoint checkpoint,
-                                  Map<Path, Path> copyFiles,
+                                  Map<String, Map<Path, Path>> copyFiles,
                                   Map<Path, Path> hardLinkFiles,
-                                  Map<Path, Path> sstFilesToExclude,
+                                  Map<String, Map<Path, Path>> sstFilesToExclude,
                                   boolean includeSnapshotData,
                                   List<String> excluded,
                                   DirectoryData sstBackupDir,
@@ -360,9 +362,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
-  private boolean processDir(Path dir, Map<Path, Path> copyFiles,
+  private boolean processDir(Path dir, Map<String, Map<Path, Path>> copyFiles,
                           Map<Path, Path> hardLinkFiles,
-                          Map<Path, Path> sstFilesToExclude,
+                          Map<String, Map<Path, Path>> sstFilesToExclude,
                           Set<Path> snapshotPaths,
                           List<String> excluded,
                           AtomicLong copySize,
@@ -437,9 +439,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
    * @param excluded The list of db files that actually were excluded.
    */
   @VisibleForTesting
-  public static long processFile(Path file, Map<Path, Path> copyFiles,
+  public static long processFile(Path file, Map<String, Map<Path, Path>> copyFiles,
                                  Map<Path, Path> hardLinkFiles,
-                                 Map<Path, Path> sstFilesToExclude,
+                                 Map<String, Map<Path, Path>> sstFilesToExclude,
                                  List<String> excluded,
                                  Path destDir)
       throws IOException {
@@ -458,7 +460,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     if (destDir != null) {
       destFile = Paths.get(destDir.toString(), fileName);
     }
-    if (sstFilesToExclude.containsKey(file)) {
+    if (sstFilesToExclude.getOrDefault(file.getFileName().getFileName().toString(), Collections.emptyMap())
+        .containsKey(file)) {
       excluded.add(destFile.toString());
     } else {
       if (fileName.endsWith(ROCKSDB_SST_SUFFIX)) {
@@ -473,13 +476,13 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             hardLinkFiles.put(destFile, linkPath);
           } else {
             // Add to tarball.
-            copyFiles.put(file, destFile);
+            copyFiles.computeIfAbsent(file.getFileName().toString(), (k) -> new HashMap<>()).put(file, destFile);
             fileSize = Files.size(file);
           }
         }
       } else {
         // Not sst file.
-        copyFiles.put(file, destFile);
+        copyFiles.computeIfAbsent(file.getFileName().toString(), (k) -> new HashMap<>()).put(file, destFile);
       }
     }
     return fileSize;
@@ -494,7 +497,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
    * @param  file - File to be linked.
    * @return dest path of file to be linked to.
    */
-  private static Path findLinkPath(Map<Path, Path> files, Path file)
+  private static Path findLinkPath(Map<String, Map<Path, Path>> files, Path file)
       throws IOException {
     // findbugs nonsense
     Path fileNamePath = file.getFileName();
@@ -503,7 +506,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     }
     String fileName = fileNamePath.toString();
 
-    for (Map.Entry<Path, Path> entry: files.entrySet()) {
+    for (Map.Entry<Path, Path> entry : files.getOrDefault(fileName, Collections.emptyMap()).entrySet()) {
       Path srcPath = entry.getKey();
       Path destPath = entry.getValue();
       if (!srcPath.toString().endsWith(fileName)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -73,6 +73,7 @@ import static org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils.truncateFileNa
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -397,11 +398,15 @@ class TestOmSnapshotManager {
     assertTrue(new File(testDir, "snap2").mkdirs());
     Path copyFile = Paths.get(testDir.toString(),
         "snap1/copyfile.sst");
+    Path copyFileName = copyFile.getFileName();
+    assertNotNull(copyFileName);
     Files.write(copyFile,
         "dummyData".getBytes(StandardCharsets.UTF_8));
     long expectedFileSize = Files.size(copyFile);
     Path excludeFile = Paths.get(testDir.toString(),
         "snap1/excludeFile.sst");
+    Path excludeFileName = excludeFile.getFileName();
+    assertNotNull(excludeFileName);
     Files.write(excludeFile,
         "dummyData".getBytes(StandardCharsets.UTF_8));
     Path linkToExcludedFile = Paths.get(testDir.toString(),
@@ -420,10 +425,11 @@ class TestOmSnapshotManager {
         "dummyData".getBytes(StandardCharsets.UTF_8));
 
     Map<String, Map<Path, Path>> toExcludeFiles = new HashMap<>();
-    toExcludeFiles.computeIfAbsent(excludeFile.getFileName().toString(), (k) -> new HashMap<>()).put(excludeFile,
+    toExcludeFiles.computeIfAbsent(excludeFileName.toString(), (k) -> new HashMap<>()).put(excludeFile,
         excludeFile);
     Map<String, Map<Path, Path>> copyFiles = new HashMap<>();
-    copyFiles.computeIfAbsent(copyFile.getFileName().toString(), (k) -> new HashMap<>()).put(copyFile, copyFile);
+    copyFiles.computeIfAbsent(copyFileName.toString(), (k) -> new HashMap<>()).put(copyFile,
+        copyFile);
     List<String> excluded = new ArrayList<>();
     Map<Path, Path> hardLinkFiles = new HashMap<>();
     long fileSize;
@@ -466,7 +472,7 @@ class TestOmSnapshotManager {
     assertEquals(copyFiles.get(addToCopiedFiles.getFileName().toString()).get(addToCopiedFiles), addToCopiedFiles);
     assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
-    copyFiles.computeIfAbsent(copyFile.getFileName().toString(), (k) -> new HashMap<>()).put(copyFile, copyFile);
+    copyFiles.computeIfAbsent(copyFileName.toString(), (k) -> new HashMap<>()).put(copyFile, copyFile);
 
     // Confirm the addNonSstToCopiedFiles gets added to list of copied files
     fileSize = processFile(addNonSstToCopiedFiles, copyFiles, hardLinkFiles,
@@ -494,6 +500,8 @@ class TestOmSnapshotManager {
     // Create test files.
     Path copyFile = Paths.get(testDir.toString(),
         "snap1/copyfile.sst");
+    Path copyFileName = copyFile.getFileName();
+    assertNotNull(copyFileName);
     Path destCopyFile = Paths.get(destDir.toString(),
         "snap1/copyfile.sst");
     Files.write(copyFile,
@@ -507,6 +515,8 @@ class TestOmSnapshotManager {
     long expectedFileSize = Files.size(copyFile);
     Path excludeFile = Paths.get(testDir.toString(),
         "snap1/excludeFile.sst");
+    Path excludeFileName = excludeFile.getFileName();
+    assertNotNull(excludeFileName);
     Path destExcludeFile = Paths.get(destDir.toString(),
         "snap1/excludeFile.sst");
     Files.write(excludeFile,
@@ -542,9 +552,9 @@ class TestOmSnapshotManager {
 
     // Create test data structures.
     Map<String, Map<Path, Path>> toExcludeFiles = new HashMap<>();
-    toExcludeFiles.put(excludeFile.getFileName().toString(), ImmutableMap.of(excludeFile, destExcludeFile));
+    toExcludeFiles.put(excludeFileName.toString(), ImmutableMap.of(excludeFile, destExcludeFile));
     Map<String, Map<Path, Path>> copyFiles = new HashMap<>();
-    copyFiles.computeIfAbsent(copyFile.getFileName().toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
+    copyFiles.computeIfAbsent(copyFileName.toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
     List<String> excluded = new ArrayList<>();
     Map<Path, Path> hardLinkFiles = new HashMap<>();
     long fileSize;
@@ -581,7 +591,7 @@ class TestOmSnapshotManager {
         destSameNameAsExcludeFile);
     assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
-    copyFiles.computeIfAbsent(copyFile.getFileName().toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
+    copyFiles.computeIfAbsent(copyFileName.toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
 
 
     // Confirm the file with same name as copy file gets copied.
@@ -594,7 +604,7 @@ class TestOmSnapshotManager {
         destSameNameAsCopyFile);
     assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
-    copyFiles.computeIfAbsent(copyFile.getFileName().toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
+    copyFiles.computeIfAbsent(copyFileName.toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
 
 
     // Confirm the linkToCopiedFile gets added as a link.
@@ -617,7 +627,7 @@ class TestOmSnapshotManager {
         destAddToCopiedFiles);
     assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
-    copyFiles.computeIfAbsent(copyFile.getFileName().toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
+    copyFiles.computeIfAbsent(copyFileName.toString(), (k) -> new HashMap<>()).put(copyFile, destCopyFile);
 
     // Confirm the addNonSstToCopiedFiles gets added to list of copied files
     fileSize = processFile(addNonSstToCopiedFiles, copyFiles, hardLinkFiles,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently while checking file links, the exclude sst file list & files already present in the current tarball is checked in the entries by sequentially iterating through the entries, for each and every file in the om data directory (snapshot directory, active om.db, compaction backup sst file). Now if the exclude list or files present in the tarball is really long order of 1000s and the total number of sst files are in the order of millions, the bootstrap is going to read timeout and might take hours. We need to optimize and not perform this unnecessary iteration to avoid this n^2 operation and do it in O

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12064

## How was this patch tested?
Existing unit tests modification
