### PR TITLE
HDDS-12049. Rename OM ID and OM Service ID to Ozone Service ID.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -103,7 +103,7 @@ class OverviewCardWrapper extends React.Component<IOverviewCardWrapperProps> {
         active: '3'
       }
     }
-    else if (title === 'OM Service') {
+    else if (title === 'Ozone Service ID') {
       return {
         active: '4'
       }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.tsx
@@ -530,7 +530,7 @@ const Overview: React.FC<{}> = () => {
           </Col>
         </Row>
         <span style={{ paddingLeft: '8px' }}>
-          <span style={{ color: '#6E6E6E' }}>OM ID:&nbsp;</span>
+          <span style={{ color: '#6E6E6E' }}>Ozone Service ID:&nbsp;</span>
           {omServiceId}
         </span>
         <span style={{ marginLeft: '12px', marginRight: '12px' }}> | </span>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -438,7 +438,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
           }
           {omServiceId &&
             <Col xs={24} sm={18} md={12} lg={12} xl={6}>
-              <OverviewCard title="OM Service" loading={loading} data={omServiceId} icon='file-text' linkToUrl='/Om' />
+              <OverviewCard title="Ozone Service ID" loading={loading} data={omServiceId} icon='file-text' linkToUrl='/Om' />
             </Col>
           }
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12049. Rename OM ID and OM Service ID to Ozone Service ID.

Please describe your PR in detail:
* Currently in Recon UI we show the Service ID as OM ID and OM Service.
* Both of the above is misleading - OM ID and Ozone Service ID are different and so we should show it properly i.e Ozone Service ID
* This PR addresses this issue.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12049

## How was this patch tested?
Patch was tested manually
Old UI:
<img width="761" alt="Screenshot 2025-01-10 at 18 30 46" src="https://github.com/user-attachments/assets/5b96746b-2af1-4bc6-8a24-f4e3018e3cf4" />

New UI:
<img width="358" alt="Screenshot 2025-01-10 at 17 48 20" src="https://github.com/user-attachments/assets/aa9d456d-3165-4f99-9ea5-eeea28eecdae" />
