### PR TITLE
HDDS-11946. Require all ozone repair commands to support a --dry-run option

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -346,8 +346,8 @@ public class TestFSORepairTool {
 
   private int execute(boolean dryRun, String... args) {
     List<String> argList = new ArrayList<>(Arrays.asList("om", "fso-tree", "--db", dbPath));
-    if (!dryRun) {
-      argList.add("--repair");
+    if (dryRun) {
+      argList.add("--dry-run");
     }
     argList.addAll(Arrays.asList(args));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -346,8 +346,8 @@ public class TestFSORepairTool {
 
   private int execute(boolean dryRun, String... args) {
     List<String> argList = new ArrayList<>(Arrays.asList("om", "fso-tree", "--db", dbPath));
-    if (dryRun) {
-      argList.add("--dry-run");
+    if (!dryRun) {
+      argList.add("--repair");
     }
     argList.addAll(Arrays.asList(args));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -92,6 +92,7 @@ public class TestOzoneRepairShell {
     String testIndex = "1111";
     int exitCode = withTextFromSystemIn("y")
         .execute(() -> cmd.execute("om", "update-transaction",
+            "--repair",
             "--db", dbPath,
             "--term", testTerm,
             "--index", testIndex));
@@ -108,6 +109,7 @@ public class TestOzoneRepairShell {
 
     withTextFromSystemIn("y")
         .execute(() -> cmd.execute("om", "update-transaction",
+            "--repair",
             "--db", dbPath,
             "--term", originalHighestTermIndex[0],
             "--index", originalHighestTermIndex[1]));
@@ -136,17 +138,18 @@ public class TestOzoneRepairShell {
   public void testQuotaRepair() throws Exception {
     CommandLine cmd = new OzoneRepair().getCmd();
 
-    int exitCode = cmd.execute("om", "quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+    String omAddress = conf.get(OZONE_OM_ADDRESS_KEY);
+    int exitCode = cmd.execute("om", "quota", "status", "--service-host", omAddress);
     assertEquals(0, exitCode, err);
 
     exitCode = withTextFromSystemIn("y")
-        .execute(() -> cmd.execute("om", "quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)));
+        .execute(() -> cmd.execute("om", "quota", "start", "--repair", "--service-host", omAddress));
     assertEquals(0, exitCode, err);
 
     GenericTestUtils.waitFor(() -> {
       out.reset();
       // verify quota trigger is completed having non-zero lastRunFinishedTime
-      cmd.execute("om", "quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
+      cmd.execute("om", "quota", "status", "--service-host", omAddress);
       try {
         return out.get().contains("\"lastRunFinishedTime\":\"\"");
       } catch (Exception ex) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -92,7 +92,6 @@ public class TestOzoneRepairShell {
     String testIndex = "1111";
     int exitCode = withTextFromSystemIn("y")
         .execute(() -> cmd.execute("om", "update-transaction",
-            "--repair",
             "--db", dbPath,
             "--term", testTerm,
             "--index", testIndex));
@@ -109,7 +108,6 @@ public class TestOzoneRepairShell {
 
     withTextFromSystemIn("y")
         .execute(() -> cmd.execute("om", "update-transaction",
-            "--repair",
             "--db", dbPath,
             "--term", originalHighestTermIndex[0],
             "--index", originalHighestTermIndex[1]));
@@ -138,18 +136,17 @@ public class TestOzoneRepairShell {
   public void testQuotaRepair() throws Exception {
     CommandLine cmd = new OzoneRepair().getCmd();
 
-    String omAddress = conf.get(OZONE_OM_ADDRESS_KEY);
-    int exitCode = cmd.execute("om", "quota", "status", "--service-host", omAddress);
+    int exitCode = cmd.execute("om", "quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
     assertEquals(0, exitCode, err);
 
     exitCode = withTextFromSystemIn("y")
-        .execute(() -> cmd.execute("om", "quota", "start", "--repair", "--service-host", omAddress));
+        .execute(() -> cmd.execute("om", "quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)));
     assertEquals(0, exitCode, err);
 
     GenericTestUtils.waitFor(() -> {
       out.reset();
       // verify quota trigger is completed having non-zero lastRunFinishedTime
-      cmd.execute("om", "quota", "status", "--service-host", omAddress);
+      cmd.execute("om", "quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY));
       try {
         return out.get().contains("\"lastRunFinishedTime\":\"\"");
       } catch (Exception ex) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ReadOnlyCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ReadOnlyCommand.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.repair;
+
+/** Marker interface for repair subcommands that do not modify state. */
+public interface ReadOnlyCommand {
+  // marker
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -48,7 +48,9 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
 
   @Override
   public final Void call() throws Exception {
-    confirmUser();
+    if (!dryRun) {
+      confirmUser();
+    }
     execute();
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -37,18 +37,18 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
       description = "Use this flag if you want to bypass the check in false-positive cases.")
   private boolean force;
 
-  @CommandLine.Option(names = {"--dry-run"},
+  @CommandLine.Option(names = {"--repair"},
       defaultValue = "false",
       fallbackValue = "true",
-      description = "Simulate repair, but do not make any changes")
-  private boolean dryRun;
+      description = "Whether to make permanent changes, or only show what would be done (i.e. dry-run mode)")
+  private boolean repair;
 
   /** Hook method for subclasses for performing actual repair task. */
   protected abstract void execute() throws Exception;
 
   @Override
   public final Void call() throws Exception {
-    if (!dryRun) {
+    if (!isDryRun()) {
       confirmUser();
     }
     execute();
@@ -76,7 +76,7 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   }
 
   protected boolean isDryRun() {
-    return dryRun;
+    return !repair;
   }
 
   protected void info(String msg, Object... args) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -37,18 +37,18 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
       description = "Use this flag if you want to bypass the check in false-positive cases.")
   private boolean force;
 
-  @CommandLine.Option(names = {"--repair"},
+  @CommandLine.Option(names = {"--dry-run"},
       defaultValue = "false",
       fallbackValue = "true",
-      description = "Whether to make permanent changes, or only show what would be done (i.e. dry-run mode)")
-  private boolean repair;
+      description = "Simulate repair, but do not make any changes")
+  private boolean dryRun;
 
   /** Hook method for subclasses for performing actual repair task. */
   protected abstract void execute() throws Exception;
 
   @Override
   public final Void call() throws Exception {
-    if (!isDryRun()) {
+    if (!dryRun) {
       confirmUser();
     }
     execute();
@@ -76,7 +76,7 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   }
 
   protected boolean isDryRun() {
-    return !repair;
+    return dryRun;
   }
 
   protected void info(String msg, Object... args) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -26,6 +26,7 @@ import java.util.Scanner;
 import java.util.concurrent.Callable;
 
 /** Parent class for all actionable repair commands. */
+@CommandLine.Command
 public abstract class RepairTool extends AbstractSubcommand implements Callable<Void> {
 
   private static final String WARNING_SYS_USER_MESSAGE =
@@ -35,6 +36,12 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   @CommandLine.Option(names = {"--force"},
       description = "Use this flag if you want to bypass the check in false-positive cases.")
   private boolean force;
+
+  @CommandLine.Option(names = {"--dry-run"},
+      defaultValue = "false",
+      fallbackValue = "true",
+      description = "Simulate repair, but do not make any changes")
+  private boolean dryRun;
 
   /** Hook method for subclasses for performing actual repair task. */
   protected abstract void execute() throws Exception;
@@ -66,6 +73,10 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
     return false;
   }
 
+  protected boolean isDryRun() {
+    return dryRun;
+  }
+
   protected void info(String msg, Object... args) {
     out().println(formatMessage(msg, args));
   }
@@ -87,6 +98,9 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   private String formatMessage(String msg, Object[] args) {
     if (args != null && args.length > 0) {
       msg = String.format(msg, args);
+    }
+    if (isDryRun()) {
+      msg = "[dry run] " + msg;
     }
     return msg;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -85,11 +85,6 @@ public class FSORepairTool extends RepairTool {
       description = "Path to OM RocksDB")
   private String omDBPath;
 
-  @CommandLine.Option(names = {"-r", "--repair"},
-      defaultValue = "false",
-      description = "Run in repair mode to move unreferenced files and directories to deleted tables.")
-  private boolean repair;
-
   @CommandLine.Option(names = {"-v", "--volume"},
       description = "Filter by volume name. Add '/' before the volume name.")
   private String volumeFilter;
@@ -107,7 +102,7 @@ public class FSORepairTool extends RepairTool {
     if (checkIfServiceIsRunning("OM")) {
       return;
     }
-    if (repair) {
+    if (!isDryRun()) {
       info("FSO Repair Tool is running in repair mode");
     } else {
       info("FSO Repair Tool is running in debug mode");
@@ -276,7 +271,7 @@ public class FSORepairTool extends RepairTool {
     private void processBucket(OmVolumeArgs volume, OmBucketInfo bucketInfo) throws IOException {
       info("Processing bucket: " + volume.getVolume() + "/" + bucketInfo.getBucketName());
       if (checkIfSnapshotExistsForBucket(volume.getVolume(), bucketInfo.getBucketName())) {
-        if (!repair) {
+        if (isDryRun()) {
           info(
               "Snapshot detected in bucket '" + volume.getVolume() + "/" + bucketInfo.getBucketName() + "'. ");
         } else {
@@ -362,7 +357,7 @@ public class FSORepairTool extends RepairTool {
               info("Found unreferenced directory: " + dirKey);
               unreferencedStats.addDir();
 
-              if (!repair) {
+              if (isDryRun()) {
                 if (verbose) {
                   info("Marking unreferenced directory " + dirKey + " for deletion.");
                 }
@@ -396,7 +391,7 @@ public class FSORepairTool extends RepairTool {
               info("Found unreferenced file: " + fileKey);
               unreferencedStats.addFile(fileInfo.getDataSize());
 
-              if (!repair) {
+              if (isDryRun()) {
                 if (verbose) {
                   info("Marking unreferenced file " + fileKey + " for deletion." + fileKey);
                 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/TransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/TransactionInfoRepair.java
@@ -89,12 +89,17 @@ public class TransactionInfoRepair extends RepairTool {
       TransactionInfo transactionInfo = TransactionInfo.valueOf(highestTransactionTerm, highestTransactionIndex);
 
       byte[] transactionInfoBytes = TransactionInfo.getCodec().toPersistedFormat(transactionInfo);
-      db.get()
-          .put(transactionInfoCfh, StringCodec.get().toPersistedFormat(TRANSACTION_INFO_KEY), transactionInfoBytes);
+      byte[] key = StringCodec.get().toPersistedFormat(TRANSACTION_INFO_KEY);
 
-      info("The highest transaction info has been updated to: %s",
-          RocksDBUtils.getValue(db, transactionInfoCfh, TRANSACTION_INFO_KEY,
-              TransactionInfo.getCodec()).getTermIndex());
+      info("Updating transaction info to %s", transactionInfo.getTermIndex());
+
+      if (!isDryRun()) {
+        db.get().put(transactionInfoCfh, key, transactionInfoBytes);
+
+        info("The highest transaction info has been updated to: %s",
+            RocksDBUtils.getValue(db, transactionInfoCfh, TRANSACTION_INFO_KEY,
+                TransactionInfo.getCodec()).getTermIndex());
+      }
     } catch (RocksDBException exception) {
       error("Failed to update the RocksDB for the given path: %s", dbPath);
       error(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaStatus.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaStatus.java
@@ -24,6 +24,7 @@ package org.apache.hadoop.ozone.repair.om.quota;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.repair.ReadOnlyCommand;
 import picocli.CommandLine;
 
 /**
@@ -35,7 +36,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
-public class QuotaStatus implements Callable<Void> {
+public class QuotaStatus implements Callable<Void>, ReadOnlyCommand {
 
   @CommandLine.Option(
       names = {"--service-id", "--om-service-id"},
@@ -57,9 +58,9 @@ public class QuotaStatus implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-    OzoneManagerProtocol ozoneManagerClient =
-        parent.createOmClient(omServiceId, omHost, false);
-    System.out.println(ozoneManagerClient.getQuotaRepairStatus());
+    try (OzoneManagerProtocol omClient = parent.createOmClient(omServiceId, omHost, false)) {
+      System.out.println(omClient.getQuotaRepairStatus());
+    }
     return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaTrigger.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/quota/QuotaTrigger.java
@@ -77,8 +77,10 @@ public class QuotaTrigger extends RepairTool {
           bucketList.isEmpty()
               ? "all buckets"
               : ("buckets " + buckets));
-      omClient.startQuotaRepair(bucketList);
-      info(omClient.getQuotaRepairStatus());
+      if (!isDryRun()) {
+        omClient.startQuotaRepair(bucketList);
+        info(omClient.getQuotaRepairStatus());
+      }
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/RecoverSCMCertificate.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/RecoverSCMCertificate.java
@@ -194,29 +194,31 @@ public class RecoverSCMCertificate extends RepairTool {
     CertificateCodec certCodec =
         new CertificateCodec(securityConfig, SCMCertificateClient.COMPONENT_NAME);
 
-    info("Writing certs to path : %s", certCodec.getLocation());
-
     CertPath certPath = addRootCertInPath(scmCertificate, rootCertificate);
     CertPath rootCertPath = getRootCertPath(rootCertificate);
     String encodedCert = CertificateCodec.getPEMEncodedString(certPath);
     String certName = String.format(CERT_FILE_NAME_FORMAT,
         CAType.NONE.getFileNamePrefix() + scmCertificate.getSerialNumber());
-    certCodec.writeCertificate(certName, encodedCert);
+    writeCertificate(certCodec, certName, encodedCert);
 
     String rootCertName = String.format(CERT_FILE_NAME_FORMAT,
         CAType.SUBORDINATE.getFileNamePrefix() + rootCertificate.getSerialNumber());
     String encodedRootCert = CertificateCodec.getPEMEncodedString(rootCertPath);
-    certCodec.writeCertificate(rootCertName, encodedRootCert);
+    writeCertificate(certCodec, rootCertName, encodedRootCert);
 
-    certCodec.writeCertificate(certCodec.getLocation().toAbsolutePath(),
-        securityConfig.getCertificateFileName(), encodedCert);
+    writeCertificate(certCodec, securityConfig.getCertificateFileName(), encodedCert);
 
     if (isRootCA) {
       CertificateCodec rootCertCodec =
           new CertificateCodec(securityConfig, OzoneConsts.SCM_ROOT_CA_COMPONENT_NAME);
-      info("Writing root certs to path : %s", rootCertCodec.getLocation());
-      rootCertCodec.writeCertificate(rootCertCodec.getLocation().toAbsolutePath(),
-          securityConfig.getCertificateFileName(), encodedRootCert);
+      writeCertificate(rootCertCodec, securityConfig.getCertificateFileName(), encodedRootCert);
+    }
+  }
+
+  private void writeCertificate(CertificateCodec codec, String name, String encodedCert) throws IOException {
+    info("Writing cert %s to %s", name, codec.getLocation());
+    if (!isDryRun()) {
+      codec.writeCertificate(name, encodedCert);
     }
   }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -69,10 +69,10 @@ public class TestOzoneRepair {
     System.setProperty("user.name", OLD_USER);
   }
 
-  /** All leaf subcommands should support {@code --dry-run},
+  /** All leaf subcommands should support {@code --repair},
    * except if marked as {@link ReadOnlyCommand}. */
   @Test
-  void subcommandsSupportDryRun() {
+  void subcommandsSupportRepairFlag() {
     assertSubcommandOptionRecursively(new OzoneRepair().getCmd());
   }
 
@@ -85,8 +85,8 @@ public class TestOzoneRepair {
       if (!(userObject instanceof ReadOnlyCommand)) {
         assertThat(spec.optionsMap().keySet())
             .as(() -> "'" + spec.qualifiedName() + "' defined by " + userObject.getClass()
-                + " should support --dry-run or implement " + ReadOnlyCommand.class)
-            .contains("--dry-run");
+                + " should support --repair or implement " + ReadOnlyCommand.class)
+            .contains("--repair");
       }
     } else {
       // parent command
@@ -101,7 +101,7 @@ public class TestOzoneRepair {
     OzoneRepair ozoneRepair = new OzoneRepair();
     System.setIn(new ByteArrayInputStream("N".getBytes(DEFAULT_ENCODING)));
 
-    int res = ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
+    int res = ozoneRepair.execute(new String[]{"om", "fso-tree", "--repair", "--db", "/dev/null"});
     assertThat(res).isNotEqualTo(CommandLine.ExitCode.OK);
     assertThat(err.toString(DEFAULT_ENCODING)).contains("Aborting command.");
     // prompt should contain the current user name as well
@@ -113,7 +113,7 @@ public class TestOzoneRepair {
     OzoneRepair ozoneRepair = new OzoneRepair();
     System.setIn(new ByteArrayInputStream("y".getBytes(DEFAULT_ENCODING)));
 
-    ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
+    ozoneRepair.execute(new String[]{"om", "fso-tree", "--repair", "--db", "/dev/null"});
     assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_USER);
     // prompt should contain the current user name as well
     assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
@@ -126,7 +126,8 @@ public class TestOzoneRepair {
         singletonList("om"),
         asList("om", "fso-tree"),
         asList("om", "fso-tree", "-h"),
-        asList("om", "fso-tree", "--help")
+        asList("om", "fso-tree", "--help"),
+        asList("om", "fso-tree", "--db", "/dev/null") // dry-run
     );
   }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -69,10 +69,10 @@ public class TestOzoneRepair {
     System.setProperty("user.name", OLD_USER);
   }
 
-  /** All leaf subcommands should support {@code --repair},
+  /** All leaf subcommands should support {@code --dry-run},
    * except if marked as {@link ReadOnlyCommand}. */
   @Test
-  void subcommandsSupportRepairFlag() {
+  void subcommandsSupportDryRun() {
     assertSubcommandOptionRecursively(new OzoneRepair().getCmd());
   }
 
@@ -85,8 +85,8 @@ public class TestOzoneRepair {
       if (!(userObject instanceof ReadOnlyCommand)) {
         assertThat(spec.optionsMap().keySet())
             .as(() -> "'" + spec.qualifiedName() + "' defined by " + userObject.getClass()
-                + " should support --repair or implement " + ReadOnlyCommand.class)
-            .contains("--repair");
+                + " should support --dry-run or implement " + ReadOnlyCommand.class)
+            .contains("--dry-run");
       }
     } else {
       // parent command
@@ -101,7 +101,7 @@ public class TestOzoneRepair {
     OzoneRepair ozoneRepair = new OzoneRepair();
     System.setIn(new ByteArrayInputStream("N".getBytes(DEFAULT_ENCODING)));
 
-    int res = ozoneRepair.execute(new String[]{"om", "fso-tree", "--repair", "--db", "/dev/null"});
+    int res = ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
     assertThat(res).isNotEqualTo(CommandLine.ExitCode.OK);
     assertThat(err.toString(DEFAULT_ENCODING)).contains("Aborting command.");
     // prompt should contain the current user name as well
@@ -113,7 +113,7 @@ public class TestOzoneRepair {
     OzoneRepair ozoneRepair = new OzoneRepair();
     System.setIn(new ByteArrayInputStream("y".getBytes(DEFAULT_ENCODING)));
 
-    ozoneRepair.execute(new String[]{"om", "fso-tree", "--repair", "--db", "/dev/null"});
+    ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
     assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_USER);
     // prompt should contain the current user name as well
     assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
@@ -126,8 +126,7 @@ public class TestOzoneRepair {
         singletonList("om"),
         asList("om", "fso-tree"),
         asList("om", "fso-tree", "-h"),
-        asList("om", "fso-tree", "--help"),
-        asList("om", "fso-tree", "--db", "/dev/null") // dry-run
+        asList("om", "fso-tree", "--help")
     );
   }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestTransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestTransactionInfoRepair.java
@@ -131,7 +131,6 @@ public class TestTransactionInfoRepair {
               "om",
               "update-transaction",
               "--db", DB_PATH,
-              "--repair",
               "--term", String.valueOf(TEST_TERM),
               "--index", String.valueOf(TEST_INDEX)
           ));

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestTransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestTransactionInfoRepair.java
@@ -131,6 +131,7 @@ public class TestTransactionInfoRepair {
               "om",
               "update-transaction",
               "--db", DB_PATH,
+              "--repair",
               "--term", String.valueOf(TEST_TERM),
               "--index", String.valueOf(TEST_INDEX)
           ));


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add `--dry-run` option to all `ozone repair` subcommands that modify state.  The new option currently defaults to `false`, so commands _perform repair by default_.  (Otherwise we'd need to use it as `--dry-run=false`.)
2. Implement dry-run mode where needed.

https://issues.apache.org/jira/browse/HDDS-11946

## How was this patch tested?

### Enforce `--dry-run` option

Added unit test to verify that each subcommand under `ozone repair` satisfies one of the following:

- has subcommands
- has `--dry-run` option
- implements `ReadOnlySubcommand` (currently only `QuotaStatus`)

Test failure before implementing `ReadOnlyCommand` in `QuotaStatus`:

```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.261 s <<< FAILURE! - in org.apache.hadoop.ozone.repair.TestOzoneRepair
[ERROR] org.apache.hadoop.ozone.repair.TestOzoneRepair.subcommandsSupportDryRun  Time elapsed: 0.211 s  <<< FAILURE!
java.lang.AssertionError: 
['ozone repair quota status' defined by class org.apache.hadoop.ozone.repair.quota.QuotaStatus should support --dry-run or implement interface org.apache.hadoop.ozone.repair.ReadOnlyCommand] 
Expecting UnmodifiableSet:
  ["--service-id",
    "--om-service-id",
    "--service-host",
    "-h",
    "--help",
    "-V",
    "--version"]
to contain:
  ["--dry-run"]
but could not find the following element(s):
  ["--dry-run"]

	at org.apache.hadoop.ozone.repair.TestOzoneRepair.assertSubcommandOptionRecursively(TestOzoneRepair.java:84)
	at org.apache.hadoop.ozone.repair.TestOzoneRepair.assertSubcommandOptionRecursively(TestOzoneRepair.java:89)
	at org.apache.hadoop.ozone.repair.TestOzoneRepair.assertSubcommandOptionRecursively(TestOzoneRepair.java:89)
	at org.apache.hadoop.ozone.repair.TestOzoneRepair.subcommandsSupportDryRun(TestOzoneRepair.java:71)
```

### Tool operation

Sample output of `ozone repair om fso-tree` from integration tests:

```
[dry run] No running OM service detected. Proceeding with repair.
[dry run] Creating database of reachable directories at hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-430e6515-4d93-4d63-99d9-2d0e1801aa90/ozone-meta/reachable.db
[dry run] Processing volume: /vol2
[dry run] Processing bucket: vol2/bucket1
[dry run] Deleting unreferenced directory /-9223372036854768896/-9223372036854768384/-9223372036854767871/dir2
[dry run] Deleting unreferenced file /-9223372036854768896/-9223372036854768384/-9223372036854767359/file3
[dry run] Deleting unreferenced file /-9223372036854768896/-9223372036854768384/-9223372036854767871/file1
[dry run] Deleting unreferenced file /-9223372036854768896/-9223372036854768384/-9223372036854767871/file2
[dry run] Processing bucket: vol2/bucket2
2025-01-10 16:46:50,087 [main] INFO  rocksdiff.RocksDBCheckpointDiffer (RocksDBCheckpointDiffer.java:close(307)) - Shutting down CompactionDagPruningService.
[dry run] 
Reachable:
	Directories: 4
	Files: 5
	Bytes: 50
Unreachable:
	Directories: 0
	Files: 0
	Bytes: 0
Unreferenced:
	Directories: 1
	Files: 3
	Bytes: 30
```

Manual test of `ozone repair om update-transaction` in compose environment:

```
$ ozone repair om update-transaction --db=/data/metadata/om.db --term 2 --index 3 --dry-run
[dry run] No running OM service detected. Proceeding with repair.
[dry run] The original highest transaction Info was (t:1, i:14)
[dry run] Updating transaction info to (t:2, i:3)

$ ozone repair om update-transaction --db=/data/metadata/om.db --term 2 --index 3 
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: hadoop
No running OM service detected. Proceeding with repair.
The original highest transaction Info was (t:1, i:14)
Updating transaction info to (t:2, i:3)
The highest transaction info has been updated to: (t:2, i:3)

$ ozone repair om update-transaction --db=/data/metadata/om.db --term 2 --index 3 --dry-run
[dry run] No running OM service detected. Proceeding with repair.
[dry run] The original highest transaction Info was (t:2, i:3)
[dry run] Updating transaction info to (t:2, i:3)
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12714010228
