### PR TITLE
HDDS-12002. Move up out() and err() to AbstractSubcommand

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ratis.util.MemoizedSupplier;
 import picocli.CommandLine;
 
+import java.io.PrintWriter;
 import java.util.function.Supplier;
 
 /** Base functionality for all Ozone subcommands. */
@@ -77,4 +78,8 @@ public abstract class AbstractSubcommand {
       return conf;
     }
   }
+
+  protected PrintWriter out() { return spec().commandLine().getOut(); }
+
+  protected PrintWriter err() { return spec().commandLine().getErr(); }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AbstractSubcommand.java
@@ -79,7 +79,11 @@ public abstract class AbstractSubcommand {
     }
   }
 
-  protected PrintWriter out() { return spec().commandLine().getOut(); }
+  protected PrintWriter out() {
+    return spec().commandLine().getOut();
+  }
 
-  protected PrintWriter err() { return spec().commandLine().getErr(); }
+  protected PrintWriter err() {
+    return spec().commandLine().getErr();
+  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/UpgradeSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/UpgradeSubcommand.java
@@ -41,7 +41,6 @@ import picocli.CommandLine.Command;
 
 import java.io.File;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/UpgradeSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/UpgradeSubcommand.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.cli.container;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -56,13 +57,10 @@ import java.util.concurrent.Callable;
         "for this datanode.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-public class UpgradeSubcommand implements Callable<Void> {
+public class UpgradeSubcommand extends AbstractSubcommand implements Callable<Void> {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(UpgradeSubcommand.class);
-
-  @CommandLine.Spec
-  private static CommandLine.Model.CommandSpec spec;
 
   @CommandLine.Option(names = {"--volume"},
       required = false,
@@ -193,13 +191,5 @@ public class UpgradeSubcommand implements Callable<Void> {
       ozoneConfiguration = new OzoneConfiguration();
     }
     return ozoneConfiguration;
-  }
-
-  private static PrintWriter err() {
-    return spec.commandLine().getErr();
-  }
-
-  private static PrintWriter out() {
-    return spec.commandLine().getOut();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -102,8 +102,8 @@ public class TestOzoneTenantShell {
   private static OzoneShell ozoneSh = null;
   private static TenantShell tenantShell = null;
 
-  private static final StringWriter out = new StringWriter();
-  private static final StringWriter err = new StringWriter();
+  private static final StringWriter OUT = new StringWriter();
+  private static final StringWriter ERR = new StringWriter();
 
   private static String omServiceId;
   private static int numOfOMs;
@@ -171,10 +171,10 @@ public class TestOzoneTenantShell {
 
   @BeforeEach
   public void setup() throws UnsupportedEncodingException {
-    tenantShell.getCmd().setOut(new PrintWriter(out));
-    tenantShell.getCmd().setErr(new PrintWriter(err));
-    ozoneSh.getCmd().setOut(new PrintWriter(out));
-    ozoneSh.getCmd().setErr(new PrintWriter(err));
+    tenantShell.getCmd().setOut(new PrintWriter(OUT));
+    tenantShell.getCmd().setErr(new PrintWriter(ERR));
+    ozoneSh.getCmd().setOut(new PrintWriter(OUT));
+    ozoneSh.getCmd().setErr(new PrintWriter(ERR));
     // Suppress OMNotLeaderException in the log
     GenericTestUtils.setLogLevel(RetryInvocationHandler.LOG, Level.WARN);
     // Enable debug logging for interested classes
@@ -189,8 +189,8 @@ public class TestOzoneTenantShell {
   @AfterEach
   public void reset() {
     // reset stream after each unit test
-    out.getBuffer().setLength(0);
-    err.getBuffer().setLength(0);
+    OUT.getBuffer().setLength(0);
+    ERR.getBuffer().setLength(0);
   }
 
   /**
@@ -201,7 +201,7 @@ public class TestOzoneTenantShell {
     CommandLine cmd = shell.getCmd();
     CommandLine.IExecutionExceptionHandler exceptionHandler =
         (ex, commandLine, parseResult) -> {
-          new PrintWriter(err).println(ex.getMessage());
+          new PrintWriter(ERR).println(ex.getMessage());
           return commandLine.getCommandSpec().exitCodeOnExecutionException();
         };
 
@@ -336,8 +336,8 @@ public class TestOzoneTenantShell {
 
   private void deleteVolume(String volumeName) throws IOException {
     int exitC = execute(ozoneSh, new String[] {"volume", "delete", volumeName});
-    checkOutput(out, "Volume " + volumeName + " is deleted\n", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "Volume " + volumeName + " is deleted\n", true);
+    checkOutput(ERR, "", true);
     // Exit code should be 0
     assertEquals(0, exitC);
   }
@@ -349,48 +349,48 @@ public class TestOzoneTenantShell {
     final String userName = "alice";
 
     executeHA(tenantShell, new String[] {"create", tenantName});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Loop assign-revoke 4 times
     for (int i = 0; i < 4; i++) {
       executeHA(tenantShell, new String[] {
           "user", "assign", userName, "--tenant=" + tenantName});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID=", false);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID=", false);
+      checkOutput(ERR, "", true);
 
       executeHA(tenantShell, new String[] {"--verbose", "user", "assign-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName,
           "--delegated=true"});
-      checkOutput(out, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
+      checkOutput(OUT, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
           + "  \"tenantId\" : \"devaa\",\n" + "  \"isAdmin\" : true,\n"
           + "  \"isDelegatedAdmin\" : true\n" + "}\n", true, true);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
 
       // Clean up
       executeHA(tenantShell, new String[] {"--verbose", "user", "revoke-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName});
-      checkOutput(out, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
+      checkOutput(OUT, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
           + "  \"tenantId\" : \"devaa\",\n" + "  \"isAdmin\" : false,\n"
           + "  \"isDelegatedAdmin\" : false\n" + "}\n", true, true);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
 
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$" + userName});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
     }
 
     // Clean up
     executeHA(tenantShell, new String[] {"delete", tenantName});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant '" + tenantName + "'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant '" + tenantName + "'.\n", false);
     deleteVolume(tenantName);
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
   }
 
   /**
@@ -405,19 +405,19 @@ public class TestOzoneTenantShell {
     assertEquals(0, lines.size());
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Create tenants
     // Equivalent to `ozone tenant create finance`
     executeHA(tenantShell, new String[] {"create", "finance"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    String test = out.toString();
-    checkOutput(out, "finance\n", true);
-    checkOutput(err, "", true);
+    String test = OUT.toString();
+    checkOutput(OUT, "finance\n", true);
+    checkOutput(ERR, "", true);
 
     lines = FileUtils.readLines(AUDIT_LOG_FILE, (String)null);
     assertThat(lines.size()).isGreaterThan(0);
@@ -429,93 +429,93 @@ public class TestOzoneTenantShell {
 
     // Creating the tenant with the same name again should fail
     executeHA(tenantShell, new String[] {"create", "finance"});
-    checkOutput(out, "", true);
-    checkOutput(err, "Tenant 'finance' already exists\n", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Tenant 'finance' already exists\n", true);
 
     executeHA(tenantShell, new String[] {"create", "research"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"create", "dev"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"ls"});
-    checkOutput(out, "dev\nfinance\nresearch\n", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "dev\nfinance\nresearch\n", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"list", "--json"});
     // Not checking the full output here
-    checkOutput(out, "\"tenantId\" : \"dev\",", false);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "\"tenantId\" : \"dev\",", false);
+    checkOutput(ERR, "", true);
 
     // Attempt user getsecret before assignment, should fail
     executeHA(tenantShell, new String[] {
         "user", "getsecret", "finance$bob"});
-    checkOutput(out, "", false);
-    checkOutput(err, "accessId 'finance$bob' doesn't exist\n",
+    checkOutput(OUT, "", false);
+    checkOutput(ERR, "accessId 'finance$bob' doesn't exist\n",
         true);
 
     // Assign user accessId
     // Equivalent to `ozone tenant user assign bob --tenant=finance`
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "assign", "bob", "--tenant=finance"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='finance$bob'\n"
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='finance$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "Assigned 'bob' to 'finance' with accessId"
+    checkOutput(ERR, "Assigned 'bob' to 'finance' with accessId"
         + " 'finance$bob'.\n", true);
 
     // Try user getsecret again after assignment, should succeed
     executeHA(tenantShell, new String[] {
         "user", "getsecret", "finance$bob"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='finance$bob'\n",
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='finance$bob'\n",
         false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "assign", "bob", "--tenant=research"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='research$bob'\n"
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='research$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "Assigned 'bob' to 'research' with accessId"
+    checkOutput(ERR, "Assigned 'bob' to 'research' with accessId"
         + " 'research$bob'.\n", true);
 
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=dev"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='dev$bob'\n"
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='dev$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // accessId length exceeding limit, should fail
     executeHA(tenantShell, new String[] {
         "user", "assign", StringUtils.repeat('a', 100), "--tenant=dev"});
-    checkOutput(out, "", true);
-    checkOutput(err, "accessId length (104) exceeds the maximum length "
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "accessId length (104) exceeds the maximum length "
         + "allowed (100)\n", true);
 
     // Get user info
     // Equivalent to `ozone tenant user info bob`
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(out, "User 'bob' is assigned to:\n"
+    checkOutput(OUT, "User 'bob' is assigned to:\n"
         + "- Tenant 'research' with accessId 'research$bob'\n"
         + "- Tenant 'finance' with accessId 'finance$bob'\n"
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Assign admin
     executeHA(tenantShell, new String[] {
         "user", "assign-admin", "dev$bob", "--tenant=dev", "--delegated"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(out, "Tenant 'dev' delegated admin with accessId", false);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "Tenant 'dev' delegated admin with accessId", false);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "--json", "bob"});
-    checkOutput(out,
+    checkOutput(OUT,
         "{\n" +
             "  \"user\" : \"bob\",\n" +
             "  \"tenants\" : [ {\n" +
@@ -536,97 +536,97 @@ public class TestOzoneTenantShell {
             "  } ]\n" +
             "}\n",
         true, true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Revoke admin
     executeHA(tenantShell, new String[] {
         "user", "revoke-admin", "dev$bob", "--tenant=dev"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(out, "User 'bob' is assigned to:\n"
+    checkOutput(OUT, "User 'bob' is assigned to:\n"
         + "- Tenant 'research' with accessId 'research$bob'\n"
         + "- Tenant 'finance' with accessId 'finance$bob'\n"
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Revoke user accessId
     executeHA(tenantShell, new String[] {
         "user", "revoke", "research$bob"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(out, "User 'bob' is assigned to:\n"
+    checkOutput(OUT, "User 'bob' is assigned to:\n"
         + "- Tenant 'finance' with accessId 'finance$bob'\n"
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Assign user again
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=research"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='research$bob'\n"
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='research$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Attempt to assign the user to the tenant again
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=research",
         "--accessId=research$bob"});
-    checkOutput(out, "", false);
-    checkOutput(err, "accessId 'research$bob' already exists!\n", true);
+    checkOutput(OUT, "", false);
+    checkOutput(ERR, "accessId 'research$bob' already exists!\n", true);
 
     // Attempt to assign the user to the tenant with a custom accessId
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=research",
         "--accessId=research$bob42"});
-    checkOutput(out, "", false);
+    checkOutput(OUT, "", false);
     // HDDS-6366: Disallow specifying custom accessId.
-    checkOutput(err, "Invalid accessId 'research$bob42'. "
+    checkOutput(ERR, "Invalid accessId 'research$bob42'. "
         + "Specifying a custom access ID disallowed. "
         + "Expected accessId to be assigned is 'research$bob'\n", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "dev\nfinance\nresearch\n", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "dev\nfinance\nresearch\n", true);
+    checkOutput(ERR, "", true);
 
     // Clean up
     executeHA(tenantShell, new String[] {
         "user", "revoke", "research$bob"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"delete", "research"});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant 'research'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant 'research'.\n", false);
     deleteVolume("research");
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", "finance$bob"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "dev\nfinance\n", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "dev\nfinance\n", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"delete", "finance"});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant 'finance'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant 'finance'.\n", false);
     deleteVolume("finance");
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "dev\n", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "dev\n", true);
+    checkOutput(ERR, "", true);
 
     // Attempt to delete tenant with accessIds still assigned to it, should fail
     int exitCode = executeHA(tenantShell, new String[] {"delete", "dev"});
     assertNotEquals(0, exitCode, "Tenant delete should fail!");
-    checkOutput(out, "", true);
-    checkOutput(err, "Tenant 'dev' is not empty. All accessIds associated "
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Tenant 'dev' is not empty. All accessIds associated "
         + "to this tenant must be revoked before the tenant can be deleted. "
         + "See `ozone tenant user revoke`\n", true);
 
@@ -643,64 +643,64 @@ public class TestOzoneTenantShell {
     // Delete dev volume should fail because the volume reference count > 0L
     exitCode = execute(ozoneSh, new String[] {"volume", "delete", "dev"});
     assertNotEquals(0, exitCode, "Volume delete should fail!");
-    checkOutput(out, "", true);
-    checkOutput(err, "Volume reference count is not zero (1). "
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Volume reference count is not zero (1). "
         + "Ozone features are enabled on this volume. "
         + "Try `ozone tenant delete <tenantId>` first.\n", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "dev\n", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "dev\n", true);
+    checkOutput(ERR, "", true);
 
     // Revoke accessId first
     executeHA(tenantShell, new String[] {
         "user", "revoke", "dev$bob"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Then delete tenant, should succeed
     executeHA(tenantShell, new String[] {"--verbose", "delete", "dev"});
-    checkOutput(out, "{\n" + "  \"tenantId\" : \"dev\",\n"
+    checkOutput(OUT, "{\n" + "  \"tenantId\" : \"dev\",\n"
             + "  \"volumeName\" : \"dev\",\n" + "  \"volumeRefCount\" : 0\n" + "}\n",
         true, true);
-    checkOutput(err, "Deleted tenant 'dev'.\n", false);
+    checkOutput(ERR, "Deleted tenant 'dev'.\n", false);
     deleteVolume("dev");
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
   }
 
   @Test
   public void testListTenantUsers() throws IOException {
     executeHA(tenantShell, new String[] {"--verbose", "create", "tenant1"});
-    checkOutput(out, "{\n" +
+    checkOutput(OUT, "{\n" +
         "  \"tenantId\" : \"tenant1\"\n" + "}\n", true, true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "assign", "alice", "--tenant=tenant1"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='tenant1$alice'\n"
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='tenant1$alice'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "Assigned 'alice' to 'tenant1'" +
+    checkOutput(ERR, "Assigned 'alice' to 'tenant1'" +
         " with accessId 'tenant1$alice'.\n", true);
 
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=tenant1"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='tenant1$bob'\n"
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='tenant1$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1"});
-    checkOutput(out, "- User 'bob' with accessId 'tenant1$bob'\n" +
+    checkOutput(OUT, "- User 'bob' with accessId 'tenant1$bob'\n" +
         "- User 'alice' with accessId 'tenant1$alice'\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--json"});
-    checkOutput(out,
+    checkOutput(OUT,
         "[ {\n" +
             "  \"user\" : \"bob\",\n" +
             "  \"accessId\" : \"tenant1$bob\"\n" +
@@ -708,48 +708,48 @@ public class TestOzoneTenantShell {
             "  \"user\" : \"alice\",\n" +
             "  \"accessId\" : \"tenant1$alice\"\n" +
             "} ]\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--prefix=b"});
-    checkOutput(out, "- User 'bob' with accessId " +
+    checkOutput(OUT, "- User 'bob' with accessId " +
         "'tenant1$bob'\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--prefix=b", "--json"});
-    checkOutput(out, "[ {\n" +
+    checkOutput(OUT, "[ {\n" +
         "  \"user\" : \"bob\",\n" +
         "  \"accessId\" : \"tenant1$bob\"\n" +
         "} ]\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     int exitCode = executeHA(tenantShell, new String[] {
         "user", "list", "unknown"});
     assertNotEquals(0, exitCode, "Expected non-zero exit code");
-    checkOutput(out, "", true);
-    checkOutput(err, "Tenant 'unknown' doesn't exist.\n", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Tenant 'unknown' doesn't exist.\n", true);
 
     // Clean up
     executeHA(tenantShell, new String[] {
         "user", "revoke", "tenant1$alice"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "revoke", "tenant1$bob"});
-    checkOutput(out, "", true);
-    checkOutput(err, "Revoked accessId", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Revoked accessId", false);
 
     executeHA(tenantShell, new String[] {"delete", "tenant1"});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant 'tenant1'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant 'tenant1'.\n", false);
     deleteVolume("tenant1");
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
   }
 
   @Test
@@ -759,44 +759,44 @@ public class TestOzoneTenantShell {
 
     // Create test tenant
     executeHA(tenantShell, new String[] {"create", tenantName});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Set secret for non-existent accessId. Expect failure
     executeHA(tenantShell, new String[] {
         "user", "set-secret", tenantName + "$alice", "--secret=somesecret0"});
-    checkOutput(out, "", true);
-    checkOutput(err, "accessId '" + tenantName + "$alice' not found.\n", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "accessId '" + tenantName + "$alice' not found.\n", true);
 
     // Assign a user to the tenant so that we have an accessId entry
     executeHA(tenantShell, new String[] {
         "user", "assign", "alice", "--tenant=" + tenantName});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Set secret as OM admin should succeed
     executeHA(tenantShell, new String[] {
         "user", "setsecret", tenantName + "$alice",
         "--secret=somesecret1"});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='somesecret1'\n", true);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Set empty secret key should fail
     int exitCode = executeHA(tenantShell, new String[] {
         "user", "setsecret", tenantName + "$alice",
         "--secret=short"});
     assertNotEquals(0, exitCode, "Expected non-zero exit code");
-    checkOutput(out, "", true);
-    checkOutput(err, "Secret key length should be at least 8 characters\n",
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Secret key length should be at least 8 characters\n",
         true);
 
     // Get secret should still give the previous secret key
     executeHA(tenantShell, new String[] {
         "user", "getsecret", tenantName + "$alice"});
-    checkOutput(out, "somesecret1", false);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "somesecret1", false);
+    checkOutput(ERR, "", true);
 
     // Set secret as alice should succeed
     final UserGroupInformation ugiAlice = UserGroupInformation
@@ -806,18 +806,18 @@ public class TestOzoneTenantShell {
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
       return null;
     });
 
     // Set secret as bob should fail
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=" + tenantName});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     final UserGroupInformation ugiBob = UserGroupInformation
         .createUserForTesting("bob",  new String[] {"usergroup"});
@@ -827,8 +827,8 @@ public class TestOzoneTenantShell {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
       assertNotEquals(0, exitC, "Should return non-zero exit code!");
-      checkOutput(out, "", true);
-      checkOutput(err, "Requested accessId 'tenant-test-set-secret$alice'"
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "Requested accessId 'tenant-test-set-secret$alice'"
           + " doesn't belong to current user 'bob', nor does current user"
           + " have Ozone or tenant administrator privilege\n", true);
       return null;
@@ -839,45 +839,45 @@ public class TestOzoneTenantShell {
     executeHA(tenantShell, new String[] {"user", "assign-admin",
         tenantName + "$" + ugiBob.getShortUserName(),
         "--tenant=" + tenantName, "--delegated=false"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Set secret should succeed now
     ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
       return null;
     });
 
     // Clean up
     executeHA(tenantShell, new String[] {"user", "revoke-admin",
         tenantName + "$" + ugiBob.getShortUserName()});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$bob"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$alice"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"delete", tenantName});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant '" + tenantName + "'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant '" + tenantName + "'.\n", false);
     deleteVolume(tenantName);
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
   }
 
   @Test
@@ -895,35 +895,35 @@ public class TestOzoneTenantShell {
 
     // Create test tenant
     executeHA(tenantShell, new String[] {"create", tenantName});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Assign alice and bob as tenant users
     executeHA(tenantShell, new String[] {
         "user", "assign", "alice", "--tenant=" + tenantName});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=" + tenantName});
-    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
+    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(err, "", true);
+    checkOutput(ERR, "", true);
 
     // Make alice a delegated tenant admin
     executeHA(tenantShell, new String[] {"user", "assign-admin",
         tenantName + "$" + ugiAlice.getShortUserName(),
         "--tenant=" + tenantName, "--delegated=true"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Make bob a non-delegated tenant admin
     executeHA(tenantShell, new String[] {"user", "assign-admin",
         tenantName + "$" + ugiBob.getShortUserName(),
         "--tenant=" + tenantName, "--delegated=false"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Start test matrix
 
@@ -935,49 +935,49 @@ public class TestOzoneTenantShell {
       // Assign carol as a new tenant user
       executeHA(tenantShell, new String[] {
           "user", "assign", "carol", "--tenant=" + tenantName});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
           + "export AWS_SECRET_ACCESS_KEY='", false);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
 
       // Set secret should work
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
 
       // Make carol a tenant delegated tenant admin
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=true"});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
 
       // Revoke carol's tenant admin privilege
       executeHA(tenantShell, new String[] {"user", "revoke-admin",
           tenantName + "$carol"});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
 
       // Make carol a tenant non-delegated tenant admin
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=false"});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
 
       // Revoke carol's tenant admin privilege
       executeHA(tenantShell, new String[] {"user", "revoke-admin",
           tenantName + "$carol"});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
 
       // Revoke carol's accessId from this tenant
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$carol"});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
       return null;
     });
 
@@ -991,73 +991,73 @@ public class TestOzoneTenantShell {
       // Assign carol as a new tenant user
       executeHA(tenantShell, new String[] {
           "user", "assign", "carol", "--tenant=" + tenantName});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
           + "export AWS_SECRET_ACCESS_KEY='", false);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
 
       // Set secret should work, even for a non-delegated admin
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(err, "", true);
+      checkOutput(ERR, "", true);
 
       // Attempt to make carol a tenant delegated tenant admin, should fail
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=true"});
-      checkOutput(out, "", true);
-      checkOutput(err, "User 'bob' is neither an Ozone admin "
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "User 'bob' is neither an Ozone admin "
           + "nor a delegated admin of tenant", false);
 
       // Attempt to make carol a tenant non-delegated tenant admin, should fail
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=false"});
-      checkOutput(out, "", true);
-      checkOutput(err, "User 'bob' is neither an Ozone admin "
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "User 'bob' is neither an Ozone admin "
           + "nor a delegated admin of tenant", false);
 
       // Attempt to revoke tenant admin, should fail at the permission check
       executeHA(tenantShell, new String[] {"user", "revoke-admin",
           tenantName + "$carol"});
-      checkOutput(out, "", true);
-      checkOutput(err, "User 'bob' is neither an Ozone admin "
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "User 'bob' is neither an Ozone admin "
           + "nor a delegated admin of tenant", false);
 
       // Revoke carol's accessId from this tenant
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$carol"});
-      checkOutput(out, "", true);
-      checkOutput(err, "", true);
+      checkOutput(OUT, "", true);
+      checkOutput(ERR, "", true);
       return null;
     });
 
     // Clean up
     executeHA(tenantShell, new String[] {"user", "revoke-admin",
         tenantName + "$" + ugiAlice.getShortUserName()});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$" + ugiAlice.getShortUserName()});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"user", "revoke-admin",
         tenantName + "$" + ugiBob.getShortUserName()});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$" + ugiBob.getShortUserName()});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"delete", tenantName});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant '" + tenantName + "'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant '" + tenantName + "'.\n", false);
     deleteVolume(tenantName);
   }
 
@@ -1067,29 +1067,29 @@ public class TestOzoneTenantShell {
     int exitC = execute(ozoneSh, new String[] {"volume", "create", testVolume});
     // Volume create should succeed
     assertEquals(0, exitC);
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Try to create tenant on the same volume, should fail by default
     executeHA(tenantShell, new String[] {"create", testVolume});
-    checkOutput(out, "", true);
-    checkOutput(err, "Volume already exists\n", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Volume already exists\n", true);
 
     // Try to create tenant on the same volume with --force, should work
     executeHA(tenantShell, new String[] {"create", testVolume, "--force"});
-    checkOutput(out, "", true);
-    checkOutput(err, "", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "", true);
 
     // Try to create the same tenant one more time, should fail even
     // with --force because the tenant already exists.
     executeHA(tenantShell, new String[] {"create", testVolume, "--force"});
-    checkOutput(out, "", true);
-    checkOutput(err, "Tenant '" + testVolume + "' already exists\n", true);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Tenant '" + testVolume + "' already exists\n", true);
 
     // Clean up
     executeHA(tenantShell, new String[] {"delete", testVolume});
-    checkOutput(out, "", true);
-    checkOutput(err, "Deleted tenant '" + testVolume + "'.\n", false);
+    checkOutput(OUT, "", true);
+    checkOutput(ERR, "Deleted tenant '" + testVolume + "'.\n", false);
     deleteVolume(testVolume);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -415,7 +415,6 @@ public class TestOzoneTenantShell {
     checkOutput(ERR, "", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    String test = OUT.toString();
     checkOutput(OUT, "finance\n", true);
     checkOutput(ERR, "", true);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -102,8 +102,8 @@ public class TestOzoneTenantShell {
   private static OzoneShell ozoneSh = null;
   private static TenantShell tenantShell = null;
 
-  private static final StringWriter OUT = new StringWriter();
-  private static final StringWriter ERR = new StringWriter();
+  private final StringWriter out = new StringWriter();
+  private final StringWriter err = new StringWriter();
 
   private static String omServiceId;
   private static int numOfOMs;
@@ -171,10 +171,10 @@ public class TestOzoneTenantShell {
 
   @BeforeEach
   public void setup() throws UnsupportedEncodingException {
-    tenantShell.getCmd().setOut(new PrintWriter(OUT));
-    tenantShell.getCmd().setErr(new PrintWriter(ERR));
-    ozoneSh.getCmd().setOut(new PrintWriter(OUT));
-    ozoneSh.getCmd().setErr(new PrintWriter(ERR));
+    tenantShell.getCmd().setOut(new PrintWriter(out));
+    tenantShell.getCmd().setErr(new PrintWriter(err));
+    ozoneSh.getCmd().setOut(new PrintWriter(out));
+    ozoneSh.getCmd().setErr(new PrintWriter(err));
     // Suppress OMNotLeaderException in the log
     GenericTestUtils.setLogLevel(RetryInvocationHandler.LOG, Level.WARN);
     // Enable debug logging for interested classes
@@ -186,13 +186,6 @@ public class TestOzoneTenantShell {
     GenericTestUtils.setLogLevel(OMRangerBGSyncService.LOG, Level.DEBUG);
   }
 
-  @AfterEach
-  public void reset() {
-    // reset stream after each unit test
-    OUT.getBuffer().setLength(0);
-    ERR.getBuffer().setLength(0);
-  }
-
   /**
    * Returns exit code.
    */
@@ -201,9 +194,7 @@ public class TestOzoneTenantShell {
     CommandLine cmd = shell.getCmd();
     CommandLine.IExecutionExceptionHandler exceptionHandler =
         (ex, commandLine, parseResult) -> {
-          try (PrintWriter writer = new PrintWriter(ERR)) {
-            writer.println(ex.getMessage());
-          }
+          commandLine.getErr().println(ex.getMessage());
           return commandLine.getCommandSpec().exitCodeOnExecutionException();
         };
 
@@ -338,8 +329,8 @@ public class TestOzoneTenantShell {
 
   private void deleteVolume(String volumeName) throws IOException {
     int exitC = execute(ozoneSh, new String[] {"volume", "delete", volumeName});
-    checkOutput(OUT, "Volume " + volumeName + " is deleted\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "Volume " + volumeName + " is deleted\n", true);
+    checkOutput(err, "", true);
     // Exit code should be 0
     assertEquals(0, exitC);
   }
@@ -351,48 +342,48 @@ public class TestOzoneTenantShell {
     final String userName = "alice";
 
     executeHA(tenantShell, new String[] {"create", tenantName});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Loop assign-revoke 4 times
     for (int i = 0; i < 4; i++) {
       executeHA(tenantShell, new String[] {
           "user", "assign", userName, "--tenant=" + tenantName});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID=", false);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "export AWS_ACCESS_KEY_ID=", false);
+      checkOutput(err, "", true);
 
       executeHA(tenantShell, new String[] {"--verbose", "user", "assign-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName,
           "--delegated=true"});
-      checkOutput(OUT, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
+      checkOutput(out, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
           + "  \"tenantId\" : \"devaa\",\n" + "  \"isAdmin\" : true,\n"
           + "  \"isDelegatedAdmin\" : true\n" + "}\n", true, true);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
 
       // Clean up
       executeHA(tenantShell, new String[] {"--verbose", "user", "revoke-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName});
-      checkOutput(OUT, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
+      checkOutput(out, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
           + "  \"tenantId\" : \"devaa\",\n" + "  \"isAdmin\" : false,\n"
           + "  \"isDelegatedAdmin\" : false\n" + "}\n", true, true);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
 
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$" + userName});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
     }
 
     // Clean up
     executeHA(tenantShell, new String[] {"delete", tenantName});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant '" + tenantName + "'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant '" + tenantName + "'.\n", false);
     deleteVolume(tenantName);
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
   }
 
   /**
@@ -407,18 +398,18 @@ public class TestOzoneTenantShell {
     assertEquals(0, lines.size());
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Create tenants
     // Equivalent to `ozone tenant create finance`
     executeHA(tenantShell, new String[] {"create", "finance"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "finance\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "finance\n", true);
+    checkOutput(err, "", true);
 
     lines = FileUtils.readLines(AUDIT_LOG_FILE, (String)null);
     assertThat(lines.size()).isGreaterThan(0);
@@ -430,93 +421,93 @@ public class TestOzoneTenantShell {
 
     // Creating the tenant with the same name again should fail
     executeHA(tenantShell, new String[] {"create", "finance"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Tenant 'finance' already exists\n", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "Tenant 'finance' already exists\n", true);
 
     executeHA(tenantShell, new String[] {"create", "research"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"create", "dev"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"ls"});
-    checkOutput(OUT, "dev\nfinance\nresearch\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "dev\nfinance\nresearch\n", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"list", "--json"});
     // Not checking the full output here
-    checkOutput(OUT, "\"tenantId\" : \"dev\",", false);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "\"tenantId\" : \"dev\",", false);
+    checkOutput(err, "", true);
 
     // Attempt user getsecret before assignment, should fail
     executeHA(tenantShell, new String[] {
         "user", "getsecret", "finance$bob"});
-    checkOutput(OUT, "", false);
-    checkOutput(ERR, "accessId 'finance$bob' doesn't exist\n",
+    checkOutput(out, "", false);
+    checkOutput(err, "accessId 'finance$bob' doesn't exist\n",
         true);
 
     // Assign user accessId
     // Equivalent to `ozone tenant user assign bob --tenant=finance`
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "assign", "bob", "--tenant=finance"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='finance$bob'\n"
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='finance$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "Assigned 'bob' to 'finance' with accessId"
+    checkOutput(err, "Assigned 'bob' to 'finance' with accessId"
         + " 'finance$bob'.\n", true);
 
     // Try user getsecret again after assignment, should succeed
     executeHA(tenantShell, new String[] {
         "user", "getsecret", "finance$bob"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='finance$bob'\n",
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='finance$bob'\n",
         false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "assign", "bob", "--tenant=research"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='research$bob'\n"
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='research$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "Assigned 'bob' to 'research' with accessId"
+    checkOutput(err, "Assigned 'bob' to 'research' with accessId"
         + " 'research$bob'.\n", true);
 
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=dev"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='dev$bob'\n"
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='dev$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // accessId length exceeding limit, should fail
     executeHA(tenantShell, new String[] {
         "user", "assign", StringUtils.repeat('a', 100), "--tenant=dev"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "accessId length (104) exceeds the maximum length "
+    checkOutput(out, "", true);
+    checkOutput(err, "accessId length (104) exceeds the maximum length "
         + "allowed (100)\n", true);
 
     // Get user info
     // Equivalent to `ozone tenant user info bob`
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(OUT, "User 'bob' is assigned to:\n"
+    checkOutput(out, "User 'bob' is assigned to:\n"
         + "- Tenant 'research' with accessId 'research$bob'\n"
         + "- Tenant 'finance' with accessId 'finance$bob'\n"
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Assign admin
     executeHA(tenantShell, new String[] {
         "user", "assign-admin", "dev$bob", "--tenant=dev", "--delegated"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(OUT, "Tenant 'dev' delegated admin with accessId", false);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "Tenant 'dev' delegated admin with accessId", false);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "--json", "bob"});
-    checkOutput(OUT,
+    checkOutput(out,
         "{\n" +
             "  \"user\" : \"bob\",\n" +
             "  \"tenants\" : [ {\n" +
@@ -537,97 +528,97 @@ public class TestOzoneTenantShell {
             "  } ]\n" +
             "}\n",
         true, true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Revoke admin
     executeHA(tenantShell, new String[] {
         "user", "revoke-admin", "dev$bob", "--tenant=dev"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(OUT, "User 'bob' is assigned to:\n"
+    checkOutput(out, "User 'bob' is assigned to:\n"
         + "- Tenant 'research' with accessId 'research$bob'\n"
         + "- Tenant 'finance' with accessId 'finance$bob'\n"
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Revoke user accessId
     executeHA(tenantShell, new String[] {
         "user", "revoke", "research$bob"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "info", "bob"});
-    checkOutput(OUT, "User 'bob' is assigned to:\n"
+    checkOutput(out, "User 'bob' is assigned to:\n"
         + "- Tenant 'finance' with accessId 'finance$bob'\n"
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Assign user again
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=research"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='research$bob'\n"
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='research$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Attempt to assign the user to the tenant again
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=research",
         "--accessId=research$bob"});
-    checkOutput(OUT, "", false);
-    checkOutput(ERR, "accessId 'research$bob' already exists!\n", true);
+    checkOutput(out, "", false);
+    checkOutput(err, "accessId 'research$bob' already exists!\n", true);
 
     // Attempt to assign the user to the tenant with a custom accessId
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=research",
         "--accessId=research$bob42"});
-    checkOutput(OUT, "", false);
+    checkOutput(out, "", false);
     // HDDS-6366: Disallow specifying custom accessId.
-    checkOutput(ERR, "Invalid accessId 'research$bob42'. "
+    checkOutput(err, "Invalid accessId 'research$bob42'. "
         + "Specifying a custom access ID disallowed. "
         + "Expected accessId to be assigned is 'research$bob'\n", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "dev\nfinance\nresearch\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "dev\nfinance\nresearch\n", true);
+    checkOutput(err, "", true);
 
     // Clean up
     executeHA(tenantShell, new String[] {
         "user", "revoke", "research$bob"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"delete", "research"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant 'research'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant 'research'.\n", false);
     deleteVolume("research");
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", "finance$bob"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "dev\nfinance\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "dev\nfinance\n", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"delete", "finance"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant 'finance'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant 'finance'.\n", false);
     deleteVolume("finance");
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "dev\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "dev\n", true);
+    checkOutput(err, "", true);
 
     // Attempt to delete tenant with accessIds still assigned to it, should fail
     int exitCode = executeHA(tenantShell, new String[] {"delete", "dev"});
     assertNotEquals(0, exitCode, "Tenant delete should fail!");
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Tenant 'dev' is not empty. All accessIds associated "
+    checkOutput(out, "", true);
+    checkOutput(err, "Tenant 'dev' is not empty. All accessIds associated "
         + "to this tenant must be revoked before the tenant can be deleted. "
         + "See `ozone tenant user revoke`\n", true);
 
@@ -644,64 +635,64 @@ public class TestOzoneTenantShell {
     // Delete dev volume should fail because the volume reference count > 0L
     exitCode = execute(ozoneSh, new String[] {"volume", "delete", "dev"});
     assertNotEquals(0, exitCode, "Volume delete should fail!");
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Volume reference count is not zero (1). "
+    checkOutput(out, "", true);
+    checkOutput(err, "Volume reference count is not zero (1). "
         + "Ozone features are enabled on this volume. "
         + "Try `ozone tenant delete <tenantId>` first.\n", true);
 
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "dev\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "dev\n", true);
+    checkOutput(err, "", true);
 
     // Revoke accessId first
     executeHA(tenantShell, new String[] {
         "user", "revoke", "dev$bob"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Then delete tenant, should succeed
     executeHA(tenantShell, new String[] {"--verbose", "delete", "dev"});
-    checkOutput(OUT, "{\n" + "  \"tenantId\" : \"dev\",\n"
+    checkOutput(out, "{\n" + "  \"tenantId\" : \"dev\",\n"
             + "  \"volumeName\" : \"dev\",\n" + "  \"volumeRefCount\" : 0\n" + "}\n",
         true, true);
-    checkOutput(ERR, "Deleted tenant 'dev'.\n", false);
+    checkOutput(err, "Deleted tenant 'dev'.\n", false);
     deleteVolume("dev");
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
   }
 
   @Test
   public void testListTenantUsers() throws IOException {
     executeHA(tenantShell, new String[] {"--verbose", "create", "tenant1"});
-    checkOutput(OUT, "{\n" +
+    checkOutput(out, "{\n" +
         "  \"tenantId\" : \"tenant1\"\n" + "}\n", true, true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "assign", "alice", "--tenant=tenant1"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='tenant1$alice'\n"
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='tenant1$alice'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "Assigned 'alice' to 'tenant1'" +
+    checkOutput(err, "Assigned 'alice' to 'tenant1'" +
         " with accessId 'tenant1$alice'.\n", true);
 
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=tenant1"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='tenant1$bob'\n"
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='tenant1$bob'\n"
         + "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1"});
-    checkOutput(OUT, "- User 'bob' with accessId 'tenant1$bob'\n" +
+    checkOutput(out, "- User 'bob' with accessId 'tenant1$bob'\n" +
         "- User 'alice' with accessId 'tenant1$alice'\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--json"});
-    checkOutput(OUT,
+    checkOutput(out,
         "[ {\n" +
             "  \"user\" : \"bob\",\n" +
             "  \"accessId\" : \"tenant1$bob\"\n" +
@@ -709,48 +700,48 @@ public class TestOzoneTenantShell {
             "  \"user\" : \"alice\",\n" +
             "  \"accessId\" : \"tenant1$alice\"\n" +
             "} ]\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--prefix=b"});
-    checkOutput(OUT, "- User 'bob' with accessId " +
+    checkOutput(out, "- User 'bob' with accessId " +
         "'tenant1$bob'\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--prefix=b", "--json"});
-    checkOutput(OUT, "[ {\n" +
+    checkOutput(out, "[ {\n" +
         "  \"user\" : \"bob\",\n" +
         "  \"accessId\" : \"tenant1$bob\"\n" +
         "} ]\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     int exitCode = executeHA(tenantShell, new String[] {
         "user", "list", "unknown"});
     assertNotEquals(0, exitCode, "Expected non-zero exit code");
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Tenant 'unknown' doesn't exist.\n", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "Tenant 'unknown' doesn't exist.\n", true);
 
     // Clean up
     executeHA(tenantShell, new String[] {
         "user", "revoke", "tenant1$alice"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "--verbose", "user", "revoke", "tenant1$bob"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Revoked accessId", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Revoked accessId", false);
 
     executeHA(tenantShell, new String[] {"delete", "tenant1"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant 'tenant1'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant 'tenant1'.\n", false);
     deleteVolume("tenant1");
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
   }
 
   @Test
@@ -760,44 +751,44 @@ public class TestOzoneTenantShell {
 
     // Create test tenant
     executeHA(tenantShell, new String[] {"create", tenantName});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Set secret for non-existent accessId. Expect failure
     executeHA(tenantShell, new String[] {
         "user", "set-secret", tenantName + "$alice", "--secret=somesecret0"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "accessId '" + tenantName + "$alice' not found.\n", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "accessId '" + tenantName + "$alice' not found.\n", true);
 
     // Assign a user to the tenant so that we have an accessId entry
     executeHA(tenantShell, new String[] {
         "user", "assign", "alice", "--tenant=" + tenantName});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Set secret as OM admin should succeed
     executeHA(tenantShell, new String[] {
         "user", "setsecret", tenantName + "$alice",
         "--secret=somesecret1"});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='somesecret1'\n", true);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Set empty secret key should fail
     int exitCode = executeHA(tenantShell, new String[] {
         "user", "setsecret", tenantName + "$alice",
         "--secret=short"});
     assertNotEquals(0, exitCode, "Expected non-zero exit code");
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Secret key length should be at least 8 characters\n",
+    checkOutput(out, "", true);
+    checkOutput(err, "Secret key length should be at least 8 characters\n",
         true);
 
     // Get secret should still give the previous secret key
     executeHA(tenantShell, new String[] {
         "user", "getsecret", tenantName + "$alice"});
-    checkOutput(OUT, "somesecret1", false);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "somesecret1", false);
+    checkOutput(err, "", true);
 
     // Set secret as alice should succeed
     final UserGroupInformation ugiAlice = UserGroupInformation
@@ -807,18 +798,18 @@ public class TestOzoneTenantShell {
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
       return null;
     });
 
     // Set secret as bob should fail
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=" + tenantName});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     final UserGroupInformation ugiBob = UserGroupInformation
         .createUserForTesting("bob",  new String[] {"usergroup"});
@@ -828,8 +819,8 @@ public class TestOzoneTenantShell {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
       assertNotEquals(0, exitC, "Should return non-zero exit code!");
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "Requested accessId 'tenant-test-set-secret$alice'"
+      checkOutput(out, "", true);
+      checkOutput(err, "Requested accessId 'tenant-test-set-secret$alice'"
           + " doesn't belong to current user 'bob', nor does current user"
           + " have Ozone or tenant administrator privilege\n", true);
       return null;
@@ -840,45 +831,45 @@ public class TestOzoneTenantShell {
     executeHA(tenantShell, new String[] {"user", "assign-admin",
         tenantName + "$" + ugiBob.getShortUserName(),
         "--tenant=" + tenantName, "--delegated=false"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Set secret should succeed now
     ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
       return null;
     });
 
     // Clean up
     executeHA(tenantShell, new String[] {"user", "revoke-admin",
         tenantName + "$" + ugiBob.getShortUserName()});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$bob"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$alice"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"delete", tenantName});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant '" + tenantName + "'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant '" + tenantName + "'.\n", false);
     deleteVolume(tenantName);
 
     // Sanity check: tenant list should be empty
     executeHA(tenantShell, new String[] {"list"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
   }
 
   @Test
@@ -896,35 +887,35 @@ public class TestOzoneTenantShell {
 
     // Create test tenant
     executeHA(tenantShell, new String[] {"create", tenantName});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Assign alice and bob as tenant users
     executeHA(tenantShell, new String[] {
         "user", "assign", "alice", "--tenant=" + tenantName});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "assign", "bob", "--tenant=" + tenantName});
-    checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
         "export AWS_SECRET_ACCESS_KEY='", false);
-    checkOutput(ERR, "", true);
+    checkOutput(err, "", true);
 
     // Make alice a delegated tenant admin
     executeHA(tenantShell, new String[] {"user", "assign-admin",
         tenantName + "$" + ugiAlice.getShortUserName(),
         "--tenant=" + tenantName, "--delegated=true"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Make bob a non-delegated tenant admin
     executeHA(tenantShell, new String[] {"user", "assign-admin",
         tenantName + "$" + ugiBob.getShortUserName(),
         "--tenant=" + tenantName, "--delegated=false"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Start test matrix
 
@@ -936,49 +927,49 @@ public class TestOzoneTenantShell {
       // Assign carol as a new tenant user
       executeHA(tenantShell, new String[] {
           "user", "assign", "carol", "--tenant=" + tenantName});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
           + "export AWS_SECRET_ACCESS_KEY='", false);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
 
       // Set secret should work
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
 
       // Make carol a tenant delegated tenant admin
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=true"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
 
       // Revoke carol's tenant admin privilege
       executeHA(tenantShell, new String[] {"user", "revoke-admin",
           tenantName + "$carol"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
 
       // Make carol a tenant non-delegated tenant admin
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=false"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
 
       // Revoke carol's tenant admin privilege
       executeHA(tenantShell, new String[] {"user", "revoke-admin",
           tenantName + "$carol"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
 
       // Revoke carol's accessId from this tenant
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$carol"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
       return null;
     });
 
@@ -992,73 +983,73 @@ public class TestOzoneTenantShell {
       // Assign carol as a new tenant user
       executeHA(tenantShell, new String[] {
           "user", "assign", "carol", "--tenant=" + tenantName});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$carol'\n"
           + "export AWS_SECRET_ACCESS_KEY='", false);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
 
       // Set secret should work, even for a non-delegated admin
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2"});
-      checkOutput(OUT, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
-      checkOutput(ERR, "", true);
+      checkOutput(err, "", true);
 
       // Attempt to make carol a tenant delegated tenant admin, should fail
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=true"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "User 'bob' is neither an Ozone admin "
+      checkOutput(out, "", true);
+      checkOutput(err, "User 'bob' is neither an Ozone admin "
           + "nor a delegated admin of tenant", false);
 
       // Attempt to make carol a tenant non-delegated tenant admin, should fail
       executeHA(tenantShell, new String[] {"user", "assign-admin",
           tenantName + "$carol",
           "--tenant=" + tenantName, "--delegated=false"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "User 'bob' is neither an Ozone admin "
+      checkOutput(out, "", true);
+      checkOutput(err, "User 'bob' is neither an Ozone admin "
           + "nor a delegated admin of tenant", false);
 
       // Attempt to revoke tenant admin, should fail at the permission check
       executeHA(tenantShell, new String[] {"user", "revoke-admin",
           tenantName + "$carol"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "User 'bob' is neither an Ozone admin "
+      checkOutput(out, "", true);
+      checkOutput(err, "User 'bob' is neither an Ozone admin "
           + "nor a delegated admin of tenant", false);
 
       // Revoke carol's accessId from this tenant
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$carol"});
-      checkOutput(OUT, "", true);
-      checkOutput(ERR, "", true);
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
       return null;
     });
 
     // Clean up
     executeHA(tenantShell, new String[] {"user", "revoke-admin",
         tenantName + "$" + ugiAlice.getShortUserName()});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$" + ugiAlice.getShortUserName()});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"user", "revoke-admin",
         tenantName + "$" + ugiBob.getShortUserName()});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$" + ugiBob.getShortUserName()});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"delete", tenantName});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant '" + tenantName + "'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant '" + tenantName + "'.\n", false);
     deleteVolume(tenantName);
   }
 
@@ -1068,29 +1059,29 @@ public class TestOzoneTenantShell {
     int exitC = execute(ozoneSh, new String[] {"volume", "create", testVolume});
     // Volume create should succeed
     assertEquals(0, exitC);
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Try to create tenant on the same volume, should fail by default
     executeHA(tenantShell, new String[] {"create", testVolume});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Volume already exists\n", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "Volume already exists\n", true);
 
     // Try to create tenant on the same volume with --force, should work
     executeHA(tenantShell, new String[] {"create", testVolume, "--force"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
 
     // Try to create the same tenant one more time, should fail even
     // with --force because the tenant already exists.
     executeHA(tenantShell, new String[] {"create", testVolume, "--force"});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Tenant '" + testVolume + "' already exists\n", true);
+    checkOutput(out, "", true);
+    checkOutput(err, "Tenant '" + testVolume + "' already exists\n", true);
 
     // Clean up
     executeHA(tenantShell, new String[] {"delete", testVolume});
-    checkOutput(OUT, "", true);
-    checkOutput(ERR, "Deleted tenant '" + testVolume + "'.\n", false);
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant '" + testVolume + "'.\n", false);
     deleteVolume(testVolume);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import picocli.CommandLine;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.security.PrivilegedExceptionAction;
@@ -102,10 +102,8 @@ public class TestOzoneTenantShell {
   private static OzoneShell ozoneSh = null;
   private static TenantShell tenantShell = null;
 
-  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
-  private static final PrintStream OLD_OUT = System.out;
-  private static final PrintStream OLD_ERR = System.err;
+  private static final StringWriter out = new StringWriter();
+  private static final StringWriter err = new StringWriter();
 
   private static String omServiceId;
   private static int numOfOMs;
@@ -173,9 +171,10 @@ public class TestOzoneTenantShell {
 
   @BeforeEach
   public void setup() throws UnsupportedEncodingException {
-    System.setOut(new PrintStream(out, false, UTF_8.name()));
-    System.setErr(new PrintStream(err, false, UTF_8.name()));
-
+    tenantShell.getCmd().setOut(new PrintWriter(out));
+    tenantShell.getCmd().setErr(new PrintWriter(err));
+    ozoneSh.getCmd().setOut(new PrintWriter(out));
+    ozoneSh.getCmd().setErr(new PrintWriter(err));
     // Suppress OMNotLeaderException in the log
     GenericTestUtils.setLogLevel(RetryInvocationHandler.LOG, Level.WARN);
     // Enable debug logging for interested classes
@@ -190,12 +189,8 @@ public class TestOzoneTenantShell {
   @AfterEach
   public void reset() {
     // reset stream after each unit test
-    out.reset();
-    err.reset();
-
-    // restore system streams
-    System.setOut(OLD_OUT);
-    System.setErr(OLD_ERR);
+    out.getBuffer().setLength(0);
+    err.getBuffer().setLength(0);
   }
 
   /**
@@ -204,10 +199,9 @@ public class TestOzoneTenantShell {
   private int execute(GenericCli shell, String[] args) {
     LOG.info("Executing shell command with args {}", Arrays.asList(args));
     CommandLine cmd = shell.getCmd();
-
     CommandLine.IExecutionExceptionHandler exceptionHandler =
         (ex, commandLine, parseResult) -> {
-          new PrintStream(err, true, DEFAULT_ENCODING).println(ex.getMessage());
+          new PrintWriter(err).println(ex.getMessage());
           return commandLine.getCommandSpec().exitCodeOnExecutionException();
         };
 
@@ -310,25 +304,25 @@ public class TestOzoneTenantShell {
   /**
    * Helper function that checks command output AND clears it.
    */
-  private void checkOutput(ByteArrayOutputStream stream, String stringToMatch,
+  private void checkOutput(StringWriter writer, String stringToMatch,
                            boolean exactMatch) throws IOException {
-    stream.flush();
-    final String str = stream.toString(DEFAULT_ENCODING);
+    writer.flush();
+    final String str = writer.toString();
     checkOutput(str, stringToMatch, exactMatch);
-    stream.reset();
+    writer.getBuffer().setLength(0);
   }
 
-  private void checkOutput(ByteArrayOutputStream stream, String stringToMatch,
+  private void checkOutput(StringWriter writer, String stringToMatch,
       boolean exactMatch, boolean expectValidJSON) throws IOException {
-    stream.flush();
-    final String str = stream.toString(DEFAULT_ENCODING);
+    writer.flush();
+    final String str = writer.toString();
     if (expectValidJSON) {
       // Verify if the String can be parsed as a valid JSON
       final ObjectMapper objectMapper = new ObjectMapper();
       objectMapper.readTree(str);
     }
     checkOutput(str, stringToMatch, exactMatch);
-    stream.reset();
+    writer.getBuffer().setLength(0);
   }
 
   private void checkOutput(String str, String stringToMatch,
@@ -421,6 +415,7 @@ public class TestOzoneTenantShell {
     checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {"list"});
+    String test = out.toString();
     checkOutput(out, "finance\n", true);
     checkOutput(err, "", true);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -201,7 +201,9 @@ public class TestOzoneTenantShell {
     CommandLine cmd = shell.getCmd();
     CommandLine.IExecutionExceptionHandler exceptionHandler =
         (ex, commandLine, parseResult) -> {
-          new PrintWriter(ERR).println(ex.getMessage());
+          try (PrintWriter writer = new PrintWriter(ERR)) {
+            writer.println(ex.getMessage());
+          }
           return commandLine.getCommandSpec().exitCodeOnExecutionException();
         };
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
@@ -83,7 +83,7 @@ public class ValueSchema extends AbstractSubcommand implements Callable<Void> {
 
     String dbPath = parent.getDbPath();
     Map<String, Object> fields = new HashMap<>();
-    success = getValueFields(dbPath, fields, depth, tableName, dnDBSchemaVersion);
+    success = getValueFields(dbPath, fields);
 
     out().println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(fields));
 
@@ -96,25 +96,24 @@ public class ValueSchema extends AbstractSubcommand implements Callable<Void> {
     return null;
   }
 
-  public boolean getValueFields(String dbPath, Map<String, Object> valueSchema, int d, String table,
-                                       String dndbschemaversion) {
+  public boolean getValueFields(String dbPath, Map<String, Object> valueSchema) {
 
     dbPath = removeTrailingSlashIfNeeded(dbPath);
-    DBDefinitionFactory.setDnDBSchemaVersion(dndbschemaversion);
+    DBDefinitionFactory.setDnDBSchemaVersion(dnDBSchemaVersion);
     DBDefinition dbDefinition = DBDefinitionFactory.getDefinition(Paths.get(dbPath), new OzoneConfiguration());
     if (dbDefinition == null) {
       err().println("Error: Incorrect DB Path");
       return false;
     }
     final DBColumnFamilyDefinition<?, ?> columnFamilyDefinition =
-        dbDefinition.getColumnFamily(table);
+        dbDefinition.getColumnFamily(tableName);
     if (columnFamilyDefinition == null) {
-      err().print("Error: Table with name '" + table + "' not found");
+      err().print("Error: Table with name '" + tableName + "' not found");
       return false;
     }
 
     Class<?> c = columnFamilyDefinition.getValueType();
-    valueSchema.put(c.getSimpleName(), getFieldsStructure(c, d));
+    valueSchema.put(c.getSimpleName(), getFieldsStructure(c, depth));
 
     return true;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.debug.ldb;
 
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
@@ -51,15 +52,12 @@ import java.util.stream.Collectors;
     name = "value-schema",
     description = "Schema of value in metadataTable"
 )
-public class ValueSchema implements Callable<Void> {
+public class ValueSchema extends AbstractSubcommand implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private RDBParser parent;
 
   public static final Logger LOG = LoggerFactory.getLogger(ValueSchema.class);
-
-  @CommandLine.Spec
-  private static CommandLine.Model.CommandSpec spec;
 
   @CommandLine.Option(names = {"--column_family", "--column-family", "--cf"},
       required = true,
@@ -99,7 +97,7 @@ public class ValueSchema implements Callable<Void> {
     return null;
   }
 
-  public static boolean getValueFields(String dbPath, Map<String, Object> valueSchema, int d, String table,
+  public boolean getValueFields(String dbPath, Map<String, Object> valueSchema, int d, String table,
                                        String dnDBSchemaVersion) {
 
     dbPath = removeTrailingSlashIfNeeded(dbPath);
@@ -160,14 +158,6 @@ public class ValueSchema implements Callable<Void> {
         .collect(Collectors.toList());
     result.addAll(filteredFields);
     return result;
-  }
-
-  private static PrintWriter err() {
-    return spec.commandLine().getErr();
-  }
-
-  private static PrintWriter out() {
-    return spec.commandLine().getOut();
   }
 
   private static String removeTrailingSlashIfNeeded(String dbPath) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
@@ -97,10 +97,10 @@ public class ValueSchema extends AbstractSubcommand implements Callable<Void> {
   }
 
   public boolean getValueFields(String dbPath, Map<String, Object> valueSchema, int d, String table,
-                                       String dnDBSchemaVersion) {
+                                       String dndbschemaversion) {
 
     dbPath = removeTrailingSlashIfNeeded(dbPath);
-    DBDefinitionFactory.setDnDBSchemaVersion(dnDBSchemaVersion);
+    DBDefinitionFactory.setDnDBSchemaVersion(dndbschemaversion);
     DBDefinition dbDefinition = DBDefinitionFactory.getDefinition(Paths.get(dbPath), new OzoneConfiguration());
     if (dbDefinition == null) {
       err().println("Error: Incorrect DB Path");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.repair;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import picocli.CommandLine;
 
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.concurrent.Callable;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -74,16 +74,6 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
     err().println(formatMessage(msg, args));
   }
 
-  private PrintWriter out() {
-    return spec().commandLine()
-        .getOut();
-  }
-
-  private PrintWriter err() {
-    return spec().commandLine()
-        .getErr();
-  }
-
   private String formatMessage(String msg, Object[] args) {
     if (args != null && args.length > 0) {
       msg = String.format(msg, args);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.shell;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.Iterator;
 import java.util.concurrent.Callable;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -97,7 +97,7 @@ public abstract class Handler extends AbstractSubcommand implements Callable<Voi
   }
 
   protected void printObjectAsJson(Object o) throws IOException {
-    out().println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(o));
+    System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(o));
   }
 
   /**
@@ -121,14 +121,6 @@ public abstract class Handler extends AbstractSubcommand implements Callable<Voi
 
   protected OzoneConfiguration getConf() {
     return conf;
-  }
-
-  protected PrintStream out() {
-    return System.out;
-  }
-
-  protected PrintStream err() {
-    return System.err;
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.shell;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.shell;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
@@ -452,7 +453,7 @@ public class OzoneAddress {
     return null;
   }
 
-  public void print(PrintStream out) {
+  public void print(PrintWriter out) {
     if (!volumeName.isEmpty()) {
       out.printf("Volume Name : %s%n", volumeName);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
@@ -25,6 +25,7 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.List;
 
 /**
@@ -52,7 +53,7 @@ public class AclOption implements CommandLine.ITypeConverter<OzoneAcl> {
     return ImmutableList.copyOf(values);
   }
 
-  public void addTo(OzoneObj obj, ObjectStore objectStore, PrintStream out)
+  public void addTo(OzoneObj obj, ObjectStore objectStore, PrintWriter out)
       throws IOException {
     for (OzoneAcl acl : getAclList()) {
       boolean result = objectStore.addAcl(obj, acl);
@@ -65,7 +66,7 @@ public class AclOption implements CommandLine.ITypeConverter<OzoneAcl> {
     }
   }
 
-  public void removeFrom(OzoneObj obj, ObjectStore objectStore, PrintStream out)
+  public void removeFrom(OzoneObj obj, ObjectStore objectStore, PrintWriter out)
       throws IOException {
     for (OzoneAcl acl : getAclList()) {
       boolean result = objectStore.removeAcl(obj, acl);
@@ -78,7 +79,7 @@ public class AclOption implements CommandLine.ITypeConverter<OzoneAcl> {
     }
   }
 
-  public void setOn(OzoneObj obj, ObjectStore objectStore, PrintStream out)
+  public void setOn(OzoneObj obj, ObjectStore objectStore, PrintWriter out)
       throws IOException {
     objectStore.setAcl(obj, getAclList());
     out.println("ACLs set successfully.");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.List;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 
 import static org.apache.hadoop.hdds.server.JsonUtils.toJsonStringWithDefaultPrettyPrinter;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -36,6 +36,7 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 
 import static org.apache.hadoop.hdds.server.JsonUtils.toJsonStringWithDefaultPrettyPrinter;
 
@@ -117,19 +118,19 @@ public class SnapshotDiffHandler extends Handler {
                                String bucketName) throws IOException {
     SnapshotDiffResponse diffResponse = store.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
         token, pageSize, forceFullDiff, diffDisableNativeLibs);
-    try (PrintStream stream = out()) {
+    try (PrintWriter writer = out()) {
       if (json) {
-        stream.println(toJsonStringWithDefaultPrettyPrinter(getJsonObject(diffResponse)));
+        writer.println(toJsonStringWithDefaultPrettyPrinter(getJsonObject(diffResponse)));
       } else {
-        stream.println(diffResponse);
+        writer.println(diffResponse);
       }
     }
   }
 
   private void cancelSnapshotDiff(ObjectStore store, String volumeName,
                                   String bucketName) throws IOException {
-    try (PrintStream stream = out()) {
-      stream.println(store.cancelSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot));
+    try (PrintWriter writer = out()) {
+      writer.println(store.cancelSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot));
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`out()` and `err()` methods are defined in few different subcommands, it would be better to move it up to `AbstractSubcommand` to reduce code duplication. Please take a look, thanks.

## What is the link to the Apache JIRA
[HDDS-12002](https://issues.apache.org/jira/browse/HDDS-12002)

## How was this patch tested?
It can test by integration tests.