### PR TITLE
HDDS-12075. Update read replica command to handle slash character in key names

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -574,12 +574,13 @@ execute_debug_tests() {
 
   local volume="cli-debug-volume${prefix}"
   local bucket="cli-debug-bucket"
-  local key="testfile"
+  local key="testfileprefix/testfile"
 
   execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-tests.robot
 
   # get block locations for key
   local chunkinfo="${key}-blocks-${prefix}"
+  mkdir -p $(dirname "$chunkinfo")
   docker-compose exec -T ${SCM} bash -c "ozone debug chunkinfo ${volume}/${bucket}/${key}" > "$chunkinfo"
   local host="$(jq -r '.KeyLocations[0][0]["Datanode-HostName"]' ${chunkinfo})"
   local container="${host%%.*}"

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -23,7 +23,8 @@ Test Timeout        5 minute
 ${PREFIX}              ${EMPTY}
 ${VOLUME}              cli-debug-volume${PREFIX}
 ${BUCKET}              cli-debug-bucket
-${TESTFILE}            testfile
+${TESTFILEPREFIX}      testfileprefix/
+${TESTFILE}            ${TESTFILEPREFIX}testfile
 ${CORRUPT_DATANODE}    ozone_datanode_1.ozone_default
 
 *** Test Cases ***
@@ -31,7 +32,7 @@ Test ozone debug read-replicas with corrupt block replica
     ${directory} =                      Execute read-replicas CLI tool
     Set Test Variable    ${DIR}         ${directory}
 
-    ${count_files} =                    Count Files In Directory    ${directory}
+    ${count_files} =                    Count Files In Directory Recursively    ${directory}
     Should Be Equal As Integers         ${count_files}     7
 
     ${json} =                           Read Replicas Manifest

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-dead-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-dead-datanode.robot
@@ -23,14 +23,15 @@ Test Timeout        5 minute
 ${PREFIX}           ${EMPTY}
 ${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
-${TESTFILE}         testfile
+${TESTFILEPREFIX}   testfileprefix/
+${TESTFILE}         ${TESTFILEPREFIX}testfile
 
 *** Test Cases ***
 Test ozone debug read-replicas with one datanode DEAD
     ${directory} =                 Execute read-replicas CLI tool
     Set Test Variable    ${DIR}         ${directory}
 
-    ${count_files} =               Count Files In Directory    ${directory}
+    ${count_files} =               Count Files In Directory Recursively    ${directory}
     Should Be Equal As Integers    ${count_files}     5
 
     ${json} =                      Read Replicas Manifest

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
@@ -23,7 +23,8 @@ Test Timeout        5 minute
 ${PREFIX}           ${EMPTY}
 ${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
-${TESTFILE}         testfile
+${TESTFILEPREFIX}      testfileprefix/
+${TESTFILE}            ${TESTFILEPREFIX}testfile
 ${STALE_DATANODE}   ozone_datanode_1.ozone_default
 
 *** Test Cases ***
@@ -31,7 +32,7 @@ Test ozone debug read-replicas with one datanode STALE
     ${directory} =                 Execute read-replicas CLI tool
     Set Test Variable    ${DIR}         ${directory}
 
-    ${count_files} =               Count Files In Directory    ${directory}
+    ${count_files} =               Count Files In Directory Recursively    ${directory}
     Should Be Equal As Integers    ${count_files}     7
 
     ${json} =                      Read Replicas Manifest

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -26,12 +26,14 @@ ${PREFIX}           ${EMPTY}
 ${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
 ${DEBUGKEY}         debugKey
-${TESTFILE}         testfile
+${TESTFILEPREFIX}   testfileprefix/
+${TESTFILE}         ${TESTFILEPREFIX}testfile
 
 *** Keywords ***
 Write keys
     Execute             ozone sh volume create o3://om/${VOLUME} --space-quota 100TB --namespace-quota 100
     Execute             ozone sh bucket create o3://om/${VOLUME}/${BUCKET} --space-quota 1TB
+    Execute             mkdir -p ${TEMP_DIR}/${TESTFILEPREFIX}
     Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE} bs=100000 count=15
     Execute             ozone sh key put o3://om/${VOLUME}/${BUCKET}/${TESTFILE} ${TEMP_DIR}/${TESTFILE}
 
@@ -40,7 +42,7 @@ Test ozone debug read-replicas
     ${directory} =                      Execute read-replicas CLI tool
     Set Test Variable    ${DIR}         ${directory}
 
-    ${count_files} =                    Count Files In Directory    ${directory}
+    ${count_files} =                    Count Files In Directory Recursively    ${directory}
     Should Be Equal As Integers         ${count_files}     7
 
     ${json} =                           Read Replicas Manifest

--- a/hadoop-ozone/dist/src/main/smoketest/lib/os.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/lib/os.robot
@@ -66,3 +66,8 @@ Get Random Filename
 List All Processes
     ${output} =    Execute    ps aux
     [return]    ${output}
+
+Count Files In Directory Recursively
+    [Arguments]                     ${PATH}
+    ${count_files} =                Execute          find ${PATH} -type f | wc -l
+    [Return]                        ${count_files}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -187,8 +187,9 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
         String fileName = keyName + "_block" + blockIndex + "_" +
             datanode.getHostName();
         Path path = new File(dir, fileName).toPath();
-        if (path.getParent() != null) {
-          Files.createDirectories(path.getParent());
+        Path parentPath = path.getParent();
+        if (parentPath != null) {
+          Files.createDirectories(parentPath);
         }
         System.out.println("Writing block file: " + path.toAbsolutePath());
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -139,7 +139,9 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
       File manifestFile
           = new File(dir, manifestFileName);
       System.out.println("Writing manifest file: " + manifestFile.getAbsolutePath());
-      Files.createDirectories(Paths.get(manifestFile.getParent()));
+      if (manifestFile.getParent() != null) {
+        Files.createDirectories(Paths.get(manifestFile.getParent()));
+      }
       Files.write(manifestFile.toPath(),
           prettyJson.getBytes(StandardCharsets.UTF_8));
     } finally {
@@ -185,7 +187,9 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
         String fileName = keyName + "_block" + blockIndex + "_" +
             datanode.getHostName();
         Path path = new File(dir, fileName).toPath();
-        Files.createDirectories(path.getParent());
+        if (path.getParent() != null) {
+          Files.createDirectories(path.getParent());
+        }
         System.out.println("Writing block file: " + path.toAbsolutePath());
 
         try (InputStream is = replica.getValue()) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -135,9 +136,10 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
       String prettyJson = JsonUtils.toJsonStringWithDefaultPrettyPrinter(result);
 
       String manifestFileName = keyName + "_manifest";
-      System.out.println("Writing manifest file : " + manifestFileName);
       File manifestFile
           = new File(dir, manifestFileName);
+      System.out.println("Writing manifest file: " + manifestFile.getAbsolutePath());
+      Files.createDirectories(Paths.get(manifestFile.getParent()));
       Files.write(manifestFile.toPath(),
           prettyJson.getBytes(StandardCharsets.UTF_8));
     } finally {
@@ -182,8 +184,9 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
 
         String fileName = keyName + "_block" + blockIndex + "_" +
             datanode.getHostName();
-        System.out.println("Writing : " + fileName);
         Path path = new File(dir, fileName).toPath();
+        Files.createDirectories(path.getParent());
+        System.out.println("Writing block file: " + path.toAbsolutePath());
 
         try (InputStream is = replica.getValue()) {
           Files.copy(is, path, StandardCopyOption.REPLACE_EXISTING);
@@ -231,11 +234,11 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
         = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
     String directoryName = volumeName + "_" + bucketName + "_" + keyName +
         "_" + fileSuffix;
-    System.out.println("Creating directory : " + directoryName);
     File dir = new File(outputDir, directoryName);
+    System.out.println("Creating directory: " + dir.getAbsolutePath());
     if (!dir.exists()) {
-      if (dir.mkdir()) {
-        System.out.println("Successfully created!");
+      if (dir.mkdirs()) {
+        System.out.println("Successfully created directory: " + dir.getAbsolutePath());
       } else {
         throw new IOException(String.format(
             "Failed to create directory %s.", dir));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -139,8 +139,9 @@ public class ReadReplicas extends KeyHandler implements DebugSubcommand {
       File manifestFile
           = new File(dir, manifestFileName);
       System.out.println("Writing manifest file: " + manifestFile.getAbsolutePath());
-      if (manifestFile.getParent() != null) {
-        Files.createDirectories(Paths.get(manifestFile.getParent()));
+      Path parentPath = manifestFile.getParentFile() != null ? manifestFile.getParentFile().toPath() : null;
+      if (parentPath != null) {
+        Files.createDirectories(parentPath);
       }
       Files.write(manifestFile.toPath(),
           prettyJson.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Key names may include arbitrary number of `/` characters, such as `/volumename/bucketname/test1/test2`.

The read-replicas command assumes key names will be single level or not include any `/` characters. This results in failures when the command is run on multilevel keys.

This PR:
* Updates the ReadReplicas class to create parent directories of key names
* Update robot tests to handle multilevel key names
* Update robot tests to search in directories recursively as the concerned files may be nested and not at the top level of the directory

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12075

## How was this patch tested?
Tested locally by running the robot tests
CI:
https://github.com/ptlrs/ozone/actions/runs/12763363095