### PR TITLE
HDDS-12082. CI checks fail with Maven 3.9.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   # Minimum required Java version for running Ozone is defined in pom.xml (javac.version).
   TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
-  MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml --show-version
+  MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   HADOOP_IMAGE: ghcr.io/apache/hadoop
   OZONE_IMAGE: ghcr.io/apache/ozone

--- a/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
@@ -98,7 +98,7 @@ EOF
   # - ITestS3AContractDistCp: HDDS-10616
   # - ITestS3AContractMkdirWithCreatePerf: HDDS-11662
   # - ITestS3AContractRename: HDDS-10665
-  mvn ${MAVEN_ARGS:-} --fail-never \
+  mvn ${MAVEN_ARGS:-} --fail-never --show-version \
     -Dtest='ITestS3AContract*, ITestS3ACommitterMRJob, !ITestS3AContractBulkDelete, !ITestS3AContractCreate#testOverwrite*EmptyDirectory[*], !ITestS3AContractDistCp, !ITestS3AContractMkdirWithCreatePerf, !ITestS3AContractRename' \
     clean test
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`acceptance` and some other checks fail intermittently (when run with Maven 3.9.9, [example](https://github.com/apache/ozone/actions/runs/12770988974/job/35597951560#step:6:5238)) due to:

- Maven 3.9.x automatically picks up options from `MAVEN_ARGS` variable.
- With `--show-version`, version is shown in the output, even with `--quiet`.
- Property queries from POM (e.g. `ozone.version`) rely on only the value being output.
- GitHub started gradual roll-out of runners with Maven 3.9.9.

This fix removes `--show-version` from global `MAVEN_ARGS` to avoid unwanted content in output of property queries.

https://issues.apache.org/jira/browse/HDDS-12082

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12772268115
