### PR TITLE
HDDS-12056. Move ozone debug chunkinfo to ozone debug replicas chunk-info

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -580,7 +580,7 @@ execute_debug_tests() {
 
   # get block locations for key
   local chunkinfo="${key}-blocks-${prefix}"
-  docker-compose exec -T ${SCM} bash -c "ozone debug chunkinfo ${volume}/${bucket}/${key}" > "$chunkinfo"
+  docker-compose exec -T ${SCM} bash -c "ozone debug replicas chunk-info ${volume}/${bucket}/${key}" > "$chunkinfo"
   local host="$(jq -r '.KeyLocations[0][0]["Datanode-HostName"]' ${chunkinfo})"
   local container="${host%%.*}"
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -206,7 +206,7 @@ public class TestOzoneDebugShell {
         Path.SEPARATOR + volumeName + Path.SEPARATOR + bucketName;
     String[] args = new String[] {
         getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY),
-        "chunkinfo", bucketPath + Path.SEPARATOR + keyName };
+        "replicas", "chunk-info", bucketPath + Path.SEPARATOR + keyName };
 
     int exitCode = ozoneDebugShell.execute(args);
     return exitCode;
@@ -218,7 +218,7 @@ public class TestOzoneDebugShell {
         Path.SEPARATOR + volumeName + Path.SEPARATOR + bucketName;
     String[] args = new String[] {
         getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY),
-        "chunkinfo", bucketPath + Path.SEPARATOR + keyName };
+        "replicas", "chunk-info", bucketPath + Path.SEPARATOR + keyName };
     int exitCode = 1;
     try (GenericTestUtils.SystemOutCapturer capture = new GenericTestUtils
         .SystemOutCapturer()) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasDebug.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.replicas;
+
+import org.apache.hadoop.hdds.cli.DebugSubcommand;
+import org.apache.hadoop.ozone.debug.replicas.chunk.ChunkKeyHandler;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * Replicas debug related commands.
+ */
+@CommandLine.Command(
+    name = "replicas",
+    description = "Debug commands for replica-related issues, retrieving replica information from the OM and " +
+            "performing checks over the network against a running cluster.",
+    subcommands = {
+        ChunkKeyHandler.class
+    }
+)
+@MetaInfServices(DebugSubcommand.class)
+public class ReplicasDebug implements DebugSubcommand {
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkDataNodeDetails.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkDataNodeDetails.java
@@ -16,39 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.chunk;
-
+package org.apache.hadoop.ozone.debug.replicas.chunk;
 /**
- * Class that gives chunkDetails.
+ * Class that gives datanode details on which the chunk is present.
  */
-public class ChunkDetails {
-  private String chunkName;
-  private long chunkOffset;
+public class ChunkDataNodeDetails {
+  private String ipAddress;
+  private String hostName;
 
-  public String getChunkName() {
-    return chunkName;
-  }
-
-  public void setChunkName(String chunkName) {
-    this.chunkName = chunkName;
+  public ChunkDataNodeDetails(String ipAddress, String hostName) {
+    this.ipAddress = ipAddress;
+    this.hostName = hostName;
   }
 
   @Override
     public String toString() {
     return "{"
-            + "chunkName='"
-            + chunkName
+            + "ipAddress='"
+            + ipAddress
             + '\''
-            + ", chunkOffset="
-            + chunkOffset
+            + ", hostName='"
+            + hostName
+            + '\''
             + '}';
-  }
-
-  public long getChunkOffset() {
-    return chunkOffset;
-  }
-
-  public void setChunkOffset(long chunkOffset) {
-    this.chunkOffset = chunkOffset;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkDetails.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkDetails.java
@@ -16,28 +16,39 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.chunk;
-/**
- * Class that gives datanode details on which the chunk is present.
- */
-public class ChunkDataNodeDetails {
-  private String ipAddress;
-  private String hostName;
+package org.apache.hadoop.ozone.debug.replicas.chunk;
 
-  public ChunkDataNodeDetails(String ipAddress, String hostName) {
-    this.ipAddress = ipAddress;
-    this.hostName = hostName;
+/**
+ * Class that gives chunkDetails.
+ */
+public class ChunkDetails {
+  private String chunkName;
+  private long chunkOffset;
+
+  public String getChunkName() {
+    return chunkName;
+  }
+
+  public void setChunkName(String chunkName) {
+    this.chunkName = chunkName;
   }
 
   @Override
     public String toString() {
     return "{"
-            + "ipAddress='"
-            + ipAddress
+            + "chunkName='"
+            + chunkName
             + '\''
-            + ", hostName='"
-            + hostName
-            + '\''
+            + ", chunkOffset="
+            + chunkOffset
             + '}';
+  }
+
+  public long getChunkOffset() {
+    return chunkOffset;
+  }
+
+  public void setChunkOffset(long chunkOffset) {
+    this.chunkOffset = chunkOffset;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.chunk;
+package org.apache.hadoop.ozone.debug.replicas.chunk;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +27,6 @@ import java.util.HashSet;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -42,15 +41,12 @@ import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
-import org.apache.hadoop.ozone.debug.OzoneDebug;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.keys.KeyHandler;
-import org.kohsuke.MetaInfServices;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
@@ -58,15 +54,9 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 /**
  * Class that gives chunk location given a specific key.
  */
-@Command(name = "chunkinfo",
-        description = "returns chunk location"
-                + " information about an existing key")
-@MetaInfServices(DebugSubcommand.class)
-public class ChunkKeyHandler extends KeyHandler implements
-    DebugSubcommand {
-
-  @CommandLine.ParentCommand
-  private OzoneDebug parent;
+@Command(name = "chunk-info",
+        description = "Returns chunk location information about an existing key")
+public class ChunkKeyHandler extends KeyHandler {
 
   private String getChunkLocationPath(String containerLocation) {
     return containerLocation + File.separator + OzoneConsts.STORAGE_DIR_CHUNKS;
@@ -75,7 +65,7 @@ public class ChunkKeyHandler extends KeyHandler implements
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
           throws IOException {
-    try (ContainerOperationClient containerOperationClient = new ContainerOperationClient(parent.getOzoneConf());
+    try (ContainerOperationClient containerOperationClient = new ContainerOperationClient(getOzoneConf());
         XceiverClientManager xceiverClientManager = containerOperationClient.getXceiverClientManager()) {
       OzoneManagerProtocol ozoneManagerClient = client.getObjectStore().getClientProxy().getOzoneManagerClient();
       address.ensureKeyAddress();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkType.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkType.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.hadoop.ozone.debug.chunk;
+package org.apache.hadoop.ozone.debug.replicas.chunk;
 
 /**
  * The type of chunks of an Erasure Coded key.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ContainerChunkInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ContainerChunkInfo.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.debug.chunk;
+package org.apache.hadoop.ozone.debug.replicas.chunk;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/package-info.java
@@ -17,6 +17,6 @@
  */
 
 /**
- * Command to debug chunk information.
+ * Command to debug replicas chunk information.
  */
-package org.apache.hadoop.ozone.debug.chunk;
+package org.apache.hadoop.ozone.debug.replicas.chunk;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Replicas debug related commands.
+ */
+package org.apache.hadoop.ozone.debug.replicas;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `ozone debug replicas` subcommand is being added to handle commands for online debugging of data replicas. The existing `chunkinfo` command should be moved here.

## What is the link to the Apache JIRA
[HDDS-12056](https://issues.apache.org/jira/browse/HDDS-12056)

## How was this patch tested?
Tested the patch on a docker cluster.

```
bash-5.1$ ozone debug replicas
Missing required subcommand
Usage: ozone debug replicas [COMMAND]
Debug commands for replica-related issues, retrieving replica information from
the OM and performing checks over the network against a running cluster.
Commands:
  chunk-info  Returns chunk location information about an existing key
```

```
bash-5.1$ ozone debug replicas chunk-info /vol1/bucket1/key1
{
  "KeyLocations" : [ [ {
    "Locations" : {
      "files" : [ "/data/hdds/hdds/CID-7aa01916-51f0-4222-b8fc-7e9150f4fa94/current/containerDir0/1/chunks/115816896921600001.block" ],
      "pipelineID" : "17e23702-5766-4166-a80e-40d3a821a156"
    },
    "Datanode-HostName" : "ozone-datanode-1.ozone_default",
    "Datanode-IP" : "172.21.0.3",
    "Container-ID" : 1,
    "Block-ID" : 115816896921600001
  } ] ]
}
```