### PR TITLE
HDDS-12081. TestKeyInputStream repeats tests with default container layout

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerLayoutTestInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerLayoutTestInfo.java
@@ -122,7 +122,7 @@ public enum ContainerLayoutTestInfo {
   }
 
   /**
-   * Composite annotation for tests parameterized with {@link  ContainerLayoutTestInfo}.
+   * Composite annotation for tests parameterized with {@link ContainerLayoutVersion}.
    */
   @Target(ElementType.METHOD)
   @Retention(RetentionPolicy.RUNTIME)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -22,12 +22,13 @@ import java.nio.ByteBuffer;
 
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.om.TestBucket;
+import org.junit.jupiter.api.TestInstance;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Tests {@link ChunkInputStream}.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TestChunkInputStream extends TestInputStreamBase {
 
   /**
@@ -44,16 +46,14 @@ class TestChunkInputStream extends TestInputStreamBase {
    */
   @ContainerLayoutTestInfo.ContainerTest
   void testAll(ContainerLayoutVersion layout) throws Exception {
-    try (MiniOzoneCluster cluster = newCluster(layout)) {
-      cluster.waitForClusterToBeReady();
+    try (OzoneClient client = getCluster().newClient()) {
+      updateConfig(getCluster(), layout);
 
-      try (OzoneClient client = cluster.newClient()) {
-        TestBucket bucket = TestBucket.newBuilder(client).build();
+      TestBucket bucket = TestBucket.newBuilder(client).build();
 
-        testChunkReadBuffers(bucket);
-        testBufferRelease(bucket);
-        testCloseReleasesBuffers(bucket);
-      }
+      testChunkReadBuffers(bucket);
+      testBufferRelease(bucket);
+      testCloseReleasesBuffers(bucket);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -47,7 +47,7 @@ class TestChunkInputStream extends TestInputStreamBase {
   @ContainerLayoutTestInfo.ContainerTest
   void testAll(ContainerLayoutVersion layout) throws Exception {
     try (OzoneClient client = getCluster().newClient()) {
-      updateConfig(getCluster(), layout);
+      updateConfig(layout);
 
       TestBucket bucket = TestBucket.newBuilder(client).build();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -25,15 +25,23 @@ import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.ClientConfigForTesting;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_LAYOUT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
-// TODO remove this class, set config as default in integration tests
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class TestInputStreamBase {
 
   static final int CHUNK_SIZE = 1024 * 1024;          // 1MB
@@ -42,8 +50,7 @@ abstract class TestInputStreamBase {
   static final int BLOCK_SIZE = 2 * MAX_FLUSH_SIZE;   // 8MB
   static final int BYTES_PER_CHECKSUM = 256 * 1024;   // 256KB
 
-  protected static MiniOzoneCluster newCluster(
-      ContainerLayoutVersion containerLayout) throws Exception {
+  protected static MiniOzoneCluster newCluster() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
 
     OzoneClientConfig config = conf.getObject(OzoneClientConfig.class);
@@ -57,8 +64,6 @@ abstract class TestInputStreamBase {
     conf.setQuietMode(false);
     conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 64,
         StorageUnit.MB);
-    conf.set(ScmConfigKeys.OZONE_SCM_CONTAINER_LAYOUT_KEY,
-        containerLayout.toString());
 
     ReplicationManagerConfiguration repConf =
         conf.getObject(ReplicationManagerConfiguration.class);
@@ -81,4 +86,38 @@ abstract class TestInputStreamBase {
     return UUID.randomUUID().toString();
   }
 
+  protected static void updateConfig(MiniOzoneCluster cluster, ContainerLayoutVersion layout) {
+    cluster.getHddsDatanodes().forEach(dn -> dn.getConf().setEnum(OZONE_SCM_CONTAINER_LAYOUT_KEY, layout));
+  }
+
+  private MiniOzoneCluster cluster;
+
+  protected MiniOzoneCluster getCluster() {
+    return cluster;
+  }
+
+  @BeforeAll
+  void setup() throws Exception {
+    cluster = newCluster();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @AfterAll
+  void cleanup() {
+    IOUtils.closeQuietly(cluster);
+  }
+
+  @AfterEach
+  void closeContainers() {
+    StorageContainerManager scm = cluster.getStorageContainerManager();
+    scm.getContainerManager().getContainers().forEach(container -> {
+      if (container.isOpen()) {
+        try {
+          TestHelper.waitForContainerClose(getCluster(), container.getContainerID());
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    });
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
@@ -86,8 +85,9 @@ abstract class TestInputStreamBase {
     return UUID.randomUUID().toString();
   }
 
-  protected static void updateConfig(MiniOzoneCluster cluster, ContainerLayoutVersion layout) {
+  protected void updateConfig(ContainerLayoutVersion layout) {
     cluster.getHddsDatanodes().forEach(dn -> dn.getConf().setEnum(OZONE_SCM_CONTAINER_LAYOUT_KEY, layout));
+    closeContainers();
   }
 
   private MiniOzoneCluster cluster;
@@ -107,8 +107,7 @@ abstract class TestInputStreamBase {
     IOUtils.closeQuietly(cluster);
   }
 
-  @AfterEach
-  void closeContainers() {
+  private void closeContainers() {
     StorageContainerManager scm = cluster.getStorageContainerManager();
     scm.getContainerManager().getContainers().forEach(container -> {
       if (container.isOpen()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
@@ -46,15 +45,16 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.container.TestHelper.countReplicas;
-import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_BLOCK;
-import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_CHUNK;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -63,6 +63,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * Tests {@link KeyInputStream}.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class TestKeyInputStream extends TestInputStreamBase {
 
   /**
@@ -123,20 +125,18 @@ class TestKeyInputStream extends TestInputStreamBase {
    */
   @ContainerLayoutTestInfo.ContainerTest
   void testNonReplicationReads(ContainerLayoutVersion layout) throws Exception {
-    try (MiniOzoneCluster cluster = newCluster(layout)) {
-      cluster.waitForClusterToBeReady();
+    try (OzoneClient client = getCluster().newClient()) {
+      updateConfig(getCluster(), layout);
 
-      try (OzoneClient client = cluster.newClient()) {
-        TestBucket bucket = TestBucket.newBuilder(client).build();
+      TestBucket bucket = TestBucket.newBuilder(client).build();
 
-        testInputStreams(bucket);
-        testSeekRandomly(bucket);
-        testSeek(bucket);
-        testReadChunkWithByteArray(bucket);
-        testReadChunkWithByteBuffer(bucket);
-        testSkip(bucket);
-        testECSeek(bucket);
-      }
+      testInputStreams(bucket);
+      testSeekRandomly(bucket);
+      testSeek(bucket);
+      testReadChunkWithByteArray(bucket);
+      testReadChunkWithByteBuffer(bucket);
+      testSkip(bucket);
+      testECSeek(bucket);
     }
   }
 
@@ -379,32 +379,18 @@ class TestKeyInputStream extends TestInputStreamBase {
     }
   }
 
-  private static List<Arguments> readAfterReplicationArgs() {
-    return Arrays.asList(
-        Arguments.arguments(FILE_PER_BLOCK, false),
-        Arguments.arguments(FILE_PER_BLOCK, true),
-        Arguments.arguments(FILE_PER_CHUNK, false),
-        Arguments.arguments(FILE_PER_CHUNK, true)
-    );
-  }
-
   @ParameterizedTest
-  @MethodSource("readAfterReplicationArgs")
-  void readAfterReplication(ContainerLayoutVersion layout,
-      boolean doUnbuffer) throws Exception {
-    try (MiniOzoneCluster cluster = newCluster(layout)) {
-      cluster.waitForClusterToBeReady();
+  @ValueSource(booleans = {false, true})
+  @Order(Integer.MAX_VALUE) // shuts down datanodes
+  void readAfterReplication(boolean doUnbuffer) throws Exception {
+    try (OzoneClient client = getCluster().newClient()) {
+      TestBucket bucket = TestBucket.newBuilder(client).build();
 
-      try (OzoneClient client = cluster.newClient()) {
-        TestBucket bucket = TestBucket.newBuilder(client).build();
-
-        testReadAfterReplication(cluster, bucket, doUnbuffer);
-      }
+      testReadAfterReplication(bucket, doUnbuffer);
     }
   }
 
-  private void testReadAfterReplication(MiniOzoneCluster cluster,
-      TestBucket bucket, boolean doUnbuffer) throws Exception {
+  private void testReadAfterReplication(TestBucket bucket, boolean doUnbuffer) throws Exception {
     int dataLength = 2 * CHUNK_SIZE;
     String keyName = getNewKeyName();
     byte[] data = bucket.writeRandomBytes(keyName, dataLength);
@@ -415,7 +401,7 @@ class TestKeyInputStream extends TestInputStreamBase {
         .setKeyName(keyName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .build();
-    OmKeyInfo keyInfo = cluster.getOzoneManager()
+    OmKeyInfo keyInfo = getCluster().getOzoneManager()
         .getKeyInfo(keyArgs, false)
         .getKeyInfo();
 
@@ -425,23 +411,11 @@ class TestKeyInputStream extends TestInputStreamBase {
     assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo loc = locationInfoList.get(0);
     long containerID = loc.getContainerID();
-    assertEquals(3, countReplicas(containerID, cluster));
+    assertEquals(3, countReplicas(containerID, getCluster()));
 
-    TestHelper.waitForContainerClose(cluster, containerID);
+    TestHelper.waitForContainerClose(getCluster(), containerID);
 
     List<DatanodeDetails> pipelineNodes = loc.getPipeline().getNodes();
-
-    // read chunk data
-    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
-      int b = keyInputStream.read();
-      assertNotEquals(-1, b);
-      if (doUnbuffer) {
-        keyInputStream.unbuffer();
-      }
-      cluster.shutdownHddsDatanode(pipelineNodes.get(0));
-      // check that we can still read it
-      assertReadFully(data, keyInputStream, dataLength - 1, 1);
-    }
 
     // read chunk data with ByteBuffer
     try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
@@ -450,7 +424,7 @@ class TestKeyInputStream extends TestInputStreamBase {
       if (doUnbuffer) {
         keyInputStream.unbuffer();
       }
-      cluster.shutdownHddsDatanode(pipelineNodes.get(0));
+      getCluster().shutdownHddsDatanode(pipelineNodes.get(0));
       // check that we can still read it
       assertReadFullyUsingByteBuffer(data, keyInputStream, dataLength - 1, 1);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -126,7 +126,7 @@ class TestKeyInputStream extends TestInputStreamBase {
   @ContainerLayoutTestInfo.ContainerTest
   void testNonReplicationReads(ContainerLayoutVersion layout) throws Exception {
     try (OzoneClient client = getCluster().newClient()) {
-      updateConfig(getCluster(), layout);
+      updateConfig(layout);
 
       TestBucket bucket = TestBucket.newBuilder(client).build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem:
`TestChunkInputStream` and `TestKeyInputStream` repeat tests with default container layout, instead of testing with both `FILE_PER_BLOCK` and `FILE_PER_CHUNK`.

Causes:
- The tests set wrong string representation of the configured container layout (since HDDS-4552).  Test cluster always falls back to the default layout, `FILE_PER_BLOCK`.
- `KeyValueHandler` does not allow creating containers with `FILE_PER_CHUNK` layout, even if configured correctly (since HDDS-11753).

Fix:
- Change the tests to start the cluster only once, with the default layout.
- Set the layout in datanode configs right before creating data.
- Close existing containers afterwards, to ensure each test writes data to new container, created with the layout being tested.

https://issues.apache.org/jira/browse/HDDS-12081

## How was this patch tested?

Added temporary log in `KeyValueHandler.handleCreateContainer` to show the layout being used.

https://github.com/apache/ozone/blob/0723902ac927d19faeab735c0d1fcd8339fb58b6/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java#L395-L399

CI:
https://github.com/adoroszlai/ozone/actions/runs/12783565176
