### PR TITLE
HDDS-12084. Persist currently selected UI type after refresh

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
@@ -48,7 +48,8 @@ class App extends React.Component<Record<string, object>, IAppState> {
     super(props);
     this.state = {
       collapsed: false,
-      enableOldUI: false
+      // Set the state from data persisted in current session storage, else default to new UI
+      enableOldUI: JSON.parse(sessionStorage.getItem('enableOldUI') ?? 'false')
     };
   }
 
@@ -78,9 +79,15 @@ class App extends React.Component<Record<string, object>, IAppState> {
                   <AntDSwitch
                     unCheckedChildren={<div style={{ paddingRight: '2px' }}>Old UI</div>}
                     checkedChildren={<div style={{ paddingLeft: '2px' }}>New UI</div>}
+                    checked={this.state.enableOldUI}
                     onChange={(checked: boolean) => {
                       this.setState({
                         enableOldUI: checked
+                      }, () => {
+                        // This is to persist the state of the UI between refreshes.
+                        // While using session storage to store state is an anti-pattern, provided the size of the data stored in this case
+                        // and the plan to deprecate UI v1 (old UI) in the future - this is the simplest approach/fix for persisting state.
+                        sessionStorage.setItem('enableOldUI', JSON.stringify(checked));
                       });
                     }} />
                 </span>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12084. Persist currently selected UI type after refresh

Please describe your PR in detail:
* Currently the state of the UI that is selected i.e old or new is lost if we refresh the page.
* This PR uses the session storage to store the selection state and persist it across refresh.
* Session storage will persist the state for existing session (i.e when page is visited) and clear when page is closed ensuring we do keep the data even after we close the page.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12084

## How was this patch tested?
Patch was tested manually.

https://github.com/user-attachments/assets/0159e1ca-ebd6-403e-b9f7-034336a2f022
