### PR TITLE
HDDS-12088. Speed up TestStorageContainerManager

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -375,9 +375,6 @@ public class TestStorageContainerManager {
     // start the new SCM
     try {
       scm.start();
-      // Initially DatanodeStateMachine will be in Running state
-      assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
-          dsm.getContext().getState());
       // DN heartbeats to new SCM, SCM doesn't recognize the node, sends the
       // command to DN to re-register. Wait for SCM to send re-register command
       String expectedLog = String.format(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up `TestStorageContainerManager` by combining test to reduce cluster creation time.

Before:

```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 331.957 s - in org.apache.hadoop.hdds.scm.TestStorageContainerManager
```

After:

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 180.093 s - in org.apache.hadoop.hdds.scm.TestStorageContainerManager
```

https://issues.apache.org/jira/browse/HDDS-12088

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12793512097
