### PR TITLE
HDDS-12093. Exclude generated code when verifying import restrictions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1456,6 +1456,10 @@
                       <!-- Allow RocksDB constants and static methods to be used. -->
                       <allowedImport>org.rocksdb.RocksDB.*</allowedImport>
                     </allowedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                     <exclusions>
                       <exclusion>org.apache.hadoop.hdds.utils.db.managed.*</exclusion>
                       <exclusion>org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer</exclusion>
@@ -1480,6 +1484,10 @@
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.**</bannedImport>
                       <bannedImport>org.apache.hadoop.util.Preconditions</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
@@ -1487,6 +1495,10 @@
                     <bannedImports>
                       <bannedImport>org.junit.jupiter.api.Disabled</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
@@ -1498,6 +1510,10 @@
                       <bannedImport>org.apache.hadoop.classification.InterfaceAudience</bannedImport>
                       <bannedImport>org.apache.hadoop.classification.InterfaceStability</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                     <exclusions>
                       <exclusion>org.apache.hadoop.fs.contract.*</exclusion>
                       <exclusion>org.apache.hadoop.tools.contract.*</exclusion>
@@ -1510,6 +1526,10 @@
                       <bannedImport>org.apache.hadoop.hdfs.MiniDFSCluster</bannedImport>
                       <bannedImport>org.apache.hadoop.hdfs.DFSConfigKeys</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
@@ -1522,6 +1542,10 @@
                       <allowedImport>org.junit.jupiter.**</allowedImport>
                       <allowedImport>org.junit.platform.**</allowedImport>
                     </allowedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
@@ -1534,6 +1558,10 @@
                       <bannedImport>org.jetbrains.annotations.NotNull</bannedImport>
                       <bannedImport>org.jetbrains.annotations.Nullable</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
@@ -1541,6 +1569,10 @@
                     <bannedImports>
                       <bannedImport>org.apache.commons.lang.**</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                 </rules>
               </configuration>
@@ -1562,6 +1594,10 @@
                       <bannedImport>org.apache.hadoop.hdds.scm.metadata.Replicate</bannedImport>
                       <bannedImport>org.kohsuke.MetaInfServices</bannedImport>
                     </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
                   </restrictImports>
                 </rules>
               </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stop spending time analyzing generated code when validating import restrictions.  Saves around 6 seconds, which is not much for a normal build, but about 10% for local build when skipping tests.

https://issues.apache.org/jira/browse/HDDS-12093

## How was this patch tested?

```bash
mvn -DskipShade -DskipTests -Dskip.installnodenpm -Dskip.npx
```

Before:

```
[INFO] Apache Ozone HDDS Client Interface ................. SUCCESS [  5.458 s]
[INFO] Apache Ozone HDDS Admin Interface .................. SUCCESS [  1.606 s]
[INFO] Apache Ozone HDDS Server Interface ................. SUCCESS [  2.077 s]
[INFO] Apache Ozone Client Interface ...................... SUCCESS [ 11.998 s]
[INFO] Apache Ozone Storage Interface ..................... SUCCESS [  0.367 s]
```

After:

```
[INFO] Apache Ozone HDDS Client Interface ................. SUCCESS [  3.858 s]
[INFO] Apache Ozone HDDS Admin Interface .................. SUCCESS [  1.109 s]
[INFO] Apache Ozone HDDS Server Interface ................. SUCCESS [  1.481 s]
[INFO] Apache Ozone Client Interface ...................... SUCCESS [  7.201 s]
[INFO] Apache Ozone Storage Interface ..................... SUCCESS [  0.421 s]
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12805099339
