### PR TITLE
HDDS-12086. Allow --db option at leaf subcommand in debug tools

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -293,8 +293,8 @@ public class TestLDBCli {
     // Prepare scan args
     List<String> completeScanArgs = new ArrayList<>();
     completeScanArgs.addAll(Arrays.asList(
-        "--db", dbStore.getDbLocation().getAbsolutePath(),
         "scan",
+        "--db", dbStore.getDbLocation().getAbsolutePath(),
         "--column-family", tableName));
     completeScanArgs.addAll(scanArgs);
 
@@ -353,9 +353,9 @@ public class TestLDBCli {
     // Prepare scan args
     int maxRecordsPerFile = 2;
     List<String> completeScanArgs1 = new ArrayList<>(Arrays.asList(
-        "--db", dbStore.getDbLocation().getAbsolutePath(),
         "scan",
         "--column-family", KEY_TABLE, "--out", scanDir1 + File.separator + "keytable",
+        "--db", dbStore.getDbLocation().getAbsolutePath(),
         "--max-records-per-file", String.valueOf(maxRecordsPerFile)));
     File tmpDir1 = new File(scanDir1);
     tmpDir1.deleteOnExit();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/RDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/RDBParser.java
@@ -40,6 +40,7 @@ public class RDBParser implements DebugSubcommand {
 
   @CommandLine.Option(names = {"--db"},
       required = true,
+      scope = CommandLine.ScopeType.INHERIT,
       description = "Database File Path")
   private String dbPath;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
ozone debug ldb --db <db> <subcommand> [other options]
```

Currently `--db` is accepted only directly after `ldb`, before any subcommand name or options.  The goal of this PR is to improve usability by allowing `--db` after subcommand or even after other options.

https://issues.apache.org/jira/browse/HDDS-12086

## How was this patch tested?

Updated integration test to cover three different positions of the option.

CI:
https://github.com/adoroszlai/ozone/actions/runs/12807326607
