### PR TITLE
HDDS-12095. Include AWS request ID in S3G audit logs

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadResponse;
 import org.apache.hadoop.ozone.s3.endpoint.MultipartUploadInitiateResponse;
@@ -98,6 +99,7 @@ public class TestMultipartObjectGet {
     REST.setClient(client);
     REST.setOzoneConfiguration(conf);
     REST.setContext(context);
+    REST.setRequestIdentifier(new RequestIdentifier());
     S3GatewayMetrics.create(conf);
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -80,6 +80,8 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_NUM_LIMIT;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_REGEX_PATTERN;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_VALUE_LENGTH_LIMIT;
 
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
+
 /**
  * Basic helpers for all the REST endpoints.
  */
@@ -91,6 +93,8 @@ public abstract class EndpointBase implements Auditor {
   private OzoneClient client;
   @Inject
   private SignatureInfo signatureInfo;
+  @Inject
+  private RequestIdentifier requestIdentifier;
 
   private S3Auth s3Auth;
   @Context
@@ -443,6 +447,10 @@ public abstract class EndpointBase implements Auditor {
 
   private AuditMessage.Builder auditMessageBaseBuilder(AuditAction op,
       Map<String, String> auditMap) {
+    // Add request IDs to audit parameters
+    auditMap.put("x-amz-request-id", requestIdentifier.getRequestId());
+    auditMap.put("x-amz-id-2", requestIdentifier.getAmzId());
+    
     AuditMessage.Builder builder = new AuditMessage.Builder()
         .forOperation(op)
         .withParams(auditMap);
@@ -486,6 +494,11 @@ public abstract class EndpointBase implements Auditor {
   @VisibleForTesting
   public void setClient(OzoneClient ozoneClient) {
     this.client = ozoneClient;
+  }
+
+  @VisibleForTesting
+  public void setRequestIdentifier(RequestIdentifier requestIdentifier) {
+    this.requestIdentifier = requestIdentifier;
   }
 
   public OzoneClient getClient() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -447,7 +447,6 @@ public abstract class EndpointBase implements Auditor {
 
   private AuditMessage.Builder auditMessageBaseBuilder(AuditAction op,
       Map<String, String> auditMap) {
-    // Add request IDs to audit parameters
     auditMap.put("x-amz-request-id", requestIdentifier.getRequestId());
     auditMap.put("x-amz-id-2", requestIdentifier.getAmzId());
     

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -21,7 +21,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 
 import org.apache.hadoop.ozone.audit.S3GAction;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -78,14 +78,14 @@ public class RootEndpoint extends EndpointBase {
       auditSuccess = false;
       AUDIT.logReadFailure(
           buildAuditMessageForFailure(S3GAction.LIST_S3_BUCKETS,
-              Collections.emptyMap(), ex)
+              getAuditParameters(), ex)
       );
       throw ex;
     } finally {
       if (auditSuccess) {
         AUDIT.logReadSuccess(
             buildAuditMessageForSuccess(S3GAction.LIST_S3_BUCKETS,
-                Collections.emptyMap())
+                getAuditParameters())
         );
       }
     }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayAuditLog.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayAuditLog.java
@@ -118,8 +118,11 @@ public class TestS3GatewayAuditLog {
     parametersMap.put("bucket", "[bucket]");
 
     bucketEndpoint.head(bucketName);
+
     String expected = "INFO  | S3GAudit | ? | user=null | ip=null | " +
-        "op=HEAD_BUCKET {bucket=[bucket]} | ret=SUCCESS";
+        "op=HEAD_BUCKET {bucket=[bucket], x-amz-request-id=" + 
+        requestIdentifier.getRequestId() + ", x-amz-id-2=" + 
+        requestIdentifier.getAmzId() + "} | ret=SUCCESS";
     verifyLog(expected);
   }
 
@@ -128,7 +131,9 @@ public class TestS3GatewayAuditLog {
 
     rootEndpoint.get().getEntity();
     String expected = "INFO  | S3GAudit | ? | user=null | ip=null | " +
-        "op=LIST_S3_BUCKETS {} | ret=SUCCESS";
+        "op=LIST_S3_BUCKETS {x-amz-request-id=" + 
+        requestIdentifier.getRequestId() + ", x-amz-id-2=" + 
+        requestIdentifier.getAmzId() + "} | ret=SUCCESS";
     verifyLog(expected);
   }
 
@@ -147,20 +152,7 @@ public class TestS3GatewayAuditLog {
 
     keyEndpoint.head(bucketName, "key1");
     String expected = "INFO  | S3GAudit | ? | user=null | ip=null | " +
-        "op=HEAD_KEY {bucket=[bucket], path=[key1]} | ret=SUCCESS";
-    verifyLog(expected);
-
-  }
-
-  @Test
-  public void testHeadBucketWithS3RequestIds() throws Exception {
-    parametersMap.put("bucket", "[bucket]");
-    parametersMap.put("x-amz-request-id", requestIdentifier.getRequestId());
-    parametersMap.put("x-amz-id-2", requestIdentifier.getAmzId());
-
-    bucketEndpoint.head(bucketName);
-    String expected = "INFO  | S3GAudit | ? | user=null | ip=null | " +
-        "op=HEAD_BUCKET {bucket=[bucket], x-amz-request-id=" + 
+        "op=HEAD_KEY {bucket=[bucket], path=[key1], x-amz-request-id=" + 
         requestIdentifier.getRequestId() + ", x-amz-id-2=" + 
         requestIdentifier.getAmzId() + "} | ret=SUCCESS";
     verifyLog(expected);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -58,6 +59,7 @@ public class TestAbortMultipartUpload {
     rest.setHeaders(headers);
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
+    rest.setRequestIdentifier(new RequestIdentifier());
 
     Response response = rest.initializeMultipartUpload(bucket, key);
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAcl.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 
@@ -73,6 +74,7 @@ public class TestBucketAcl {
 
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setRequestIdentifier(new RequestIdentifier());
   }
 
   @AfterEach

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.ObjectStoreStub;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -59,6 +60,7 @@ public class TestBucketDelete {
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setRequestIdentifier(new RequestIdentifier());
 
 
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -51,6 +52,7 @@ public class TestBucketHead {
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setRequestIdentifier(new RequestIdentifier());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.commontypes.EncodingTypeObject;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
@@ -54,6 +55,7 @@ public class TestBucketList {
     OzoneClient client = createClientWithKeys("file1", "dir1/file2");
 
     getBucket.setClient(client);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, 100, "",
@@ -78,6 +80,7 @@ public class TestBucketList {
     OzoneClient client = createClientWithKeys("dir1/file2", "dir1/dir2/file2");
 
     getBucket.setClient(client);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, 100,
@@ -101,7 +104,7 @@ public class TestBucketList {
             "dir1bha/file2");
 
     getBucket.setClient(ozoneClient);
-
+    getBucket.setRequestIdentifier(new RequestIdentifier());
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket
             .get("b1", "/", null, null, 100, "dir1/", null,
@@ -138,6 +141,7 @@ public class TestBucketList {
     bucket.createKey("key2", 0).close();
 
     getBucket.setClient(client);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, 100,
             "key", null, null, null, null, null).getEntity();
@@ -160,6 +164,7 @@ public class TestBucketList {
             "dir1bha/file2", "file2");
 
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, 100,
@@ -179,6 +184,7 @@ public class TestBucketList {
             "dir1bha/file2", "file2");
 
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, 100,
@@ -200,7 +206,7 @@ public class TestBucketList {
             "dir1bha/file2", "file2");
 
     getBucket.setClient(ozoneClient);
-
+    getBucket.setRequestIdentifier(new RequestIdentifier());
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, 100, "dir1bh",
             null, "dir1/dir2/file2", null, null, null).getEntity();
@@ -219,7 +225,7 @@ public class TestBucketList {
           "dir1/dir2/file2");
 
     getBucket.setClient(ozoneClient);
-
+    getBucket.setRequestIdentifier(new RequestIdentifier());
     // Should behave the same if delimiter is null
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "", null, null, 100, "dir1/",
@@ -248,7 +254,7 @@ public class TestBucketList {
             "dir1bha/file2", "file2");
 
     getBucket.setClient(ozoneClient);
-
+    getBucket.setRequestIdentifier(new RequestIdentifier());
     int maxKeys = 2;
     // As we have 5 keys, with max keys 2 we should call list 3 times.
 
@@ -299,6 +305,7 @@ public class TestBucketList {
             "test/file8");
 
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     int maxKeys = 2;
 
@@ -342,6 +349,7 @@ public class TestBucketList {
             "dir1bha/file1", "dir0/file1", "dir2/file1");
 
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     int maxKeys = 2;
     // As we have 5 keys, with max keys 2 we should call list 3 times.
@@ -383,6 +391,7 @@ public class TestBucketList {
             "dir1bha/file2", "dir1", "dir2", "dir3");
 
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     OS3Exception e = assertThrows(OS3Exception.class, () -> getBucket.get("b1",
         "/", null, null, 2, "dir", "random", null, null, null, null)
@@ -401,6 +410,7 @@ public class TestBucketList {
             "dir1bha/file1", "dir0/file1", "dir2/file1");
 
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     ListObjectResponse getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", null, null, null, 1000,
@@ -460,6 +470,7 @@ public class TestBucketList {
     OzoneClient ozoneClient =
         createClientWithKeys("data=1970", "data==1970");
     getBucket.setClient(ozoneClient);
+    getBucket.setRequestIdentifier(new RequestIdentifier());
 
     String delimiter = "=";
     String prefix = "data=";
@@ -508,7 +519,7 @@ public class TestBucketList {
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket("b1");
     getBucket.setClient(client);
-
+    getBucket.setRequestIdentifier(new RequestIdentifier());
     OS3Exception e = assertThrows(OS3Exception.class, () -> getBucket.get(
         "b1", null, "unSupportType", null, 1000, null,
         null, null, null, null, null).getEntity());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
@@ -58,6 +59,7 @@ public class TestBucketPut {
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setRequestIdentifier(new RequestIdentifier());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
+
 import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
@@ -99,6 +101,7 @@ public class TestInitiateMultipartUpload {
     rest.setHeaders(headers);
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
+    rest.setRequestIdentifier(new RequestIdentifier());
     return rest;
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -42,6 +42,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest.Part;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -74,6 +76,7 @@ public class TestMultipartUploadComplete {
     REST.setHeaders(HEADERS);
     REST.setClient(CLIENT);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setRequestIdentifier(new RequestIdentifier());
   }
 
   private String initiateMultipartUpload(String key) throws IOException,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest.Part;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
@@ -127,6 +128,7 @@ public class TestMultipartUploadWithCopy {
     REST.setHeaders(headers);
     REST.setClient(CLIENT);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setRequestIdentifier(new RequestIdentifier());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ public class TestObjectDelete {
 
     ObjectEndpoint rest = new ObjectEndpoint();
     rest.setClient(client);
+    rest.setRequestIdentifier(new RequestIdentifier());
     rest.setOzoneConfiguration(new OzoneConfiguration());
 
     //WHEN

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.apache.commons.io.IOUtils;
@@ -92,6 +93,7 @@ public class TestObjectGet {
     rest.setOzoneConfiguration(new OzoneConfiguration());
     headers = mock(HttpHeaders.class);
     rest.setHeaders(headers);
+    rest.setRequestIdentifier(new RequestIdentifier());
 
     ByteArrayInputStream body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     rest.put(BUCKET_NAME, KEY_NAME, CONTENT.length(),

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -66,6 +67,7 @@ public class TestObjectHead {
     // Create HeadBucket and setClient to OzoneClientStub
     keyEndpoint = new ObjectEndpoint();
     keyEndpoint.setClient(clientStub);
+    keyEndpoint.setRequestIdentifier(new RequestIdentifier());
     keyEndpoint.setOzoneConfiguration(new OzoneConfiguration());
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteRequest.DeleteObject;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
@@ -51,6 +52,7 @@ public class TestObjectMultiDelete {
 
     BucketEndpoint rest = new BucketEndpoint();
     rest.setClient(client);
+    rest.setRequestIdentifier(new RequestIdentifier());
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
     mdr.getObjects().add(new DeleteObject("key1"));
@@ -82,6 +84,7 @@ public class TestObjectMultiDelete {
 
     BucketEndpoint rest = new BucketEndpoint();
     rest.setClient(client);
+    rest.setRequestIdentifier(new RequestIdentifier());
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
     mdr.setQuiet(true);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.http.HttpStatus;
@@ -134,6 +135,7 @@ class TestObjectPut {
     objectEndpoint = spy(new ObjectEndpoint());
     objectEndpoint.setClient(clientStub);
     objectEndpoint.setOzoneConfiguration(config);
+    objectEndpoint.setRequestIdentifier(new RequestIdentifier());
 
     headers = mock(HttpHeaders.class);
     objectEndpoint.setHeaders(headers);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingDelete.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,7 @@ public class TestObjectTaggingDelete {
     rest = new ObjectEndpoint();
     rest.setClient(client);
     rest.setOzoneConfiguration(config);
+    rest.setRequestIdentifier(new RequestIdentifier());
     headers = Mockito.mock(HttpHeaders.class);
     rest.setHeaders(headers);
     body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
@@ -137,7 +139,7 @@ public class TestObjectTaggingDelete {
 
     ObjectEndpoint endpoint = new ObjectEndpoint();
     endpoint.setClient(mockClient);
-
+    endpoint.setRequestIdentifier(new RequestIdentifier());
     doThrow(new OMException("DeleteObjectTagging is not currently supported for FSO directory",
         ResultCodes.NOT_SUPPORTED_OPERATION)).when(mockBucket).deleteObjectTagging("dir/");
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingGet.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.endpoint.S3Tagging.Tag;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,7 @@ public class TestObjectTaggingGet {
     rest = new ObjectEndpoint();
     rest.setClient(client);
     rest.setOzoneConfiguration(config);
+    rest.setRequestIdentifier(new RequestIdentifier());
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
     rest.setHeaders(headers);
     ByteArrayInputStream body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingPut.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,7 @@ public class TestObjectTaggingPut {
     objectEndpoint = new ObjectEndpoint();
     objectEndpoint.setClient(clientStub);
     objectEndpoint.setOzoneConfiguration(config);
+    objectEndpoint.setRequestIdentifier(new RequestIdentifier());
 
     HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
@@ -172,6 +174,7 @@ public class TestObjectTaggingPut {
     twoTagsMap.put("tag1", "val1");
     twoTagsMap.put("tag2", "val2");
     endpoint.setClient(mockClient);
+    endpoint.setRequestIdentifier(new RequestIdentifier());
 
     doThrow(new OMException("PutObjectTagging is not currently supported for FSO directory",
         ResultCodes.NOT_SUPPORTED_OPERATION)).when(mockBucket).putObjectTagging("dir/", twoTagsMap);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,7 @@ public class TestPartUpload {
     REST.setHeaders(headers);
     REST.setClient(client);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setRequestIdentifier(new RequestIdentifier());
   }
 
 
@@ -159,6 +161,7 @@ public class TestPartUpload {
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setClient(client);
     objectEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    objectEndpoint.setRequestIdentifier(new RequestIdentifier());
     String keyName = UUID.randomUUID().toString();
 
     String chunkedContent = "0a;chunk-signature=signature\r\n"
@@ -221,6 +224,7 @@ public class TestPartUpload {
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setClient(clientStub);
     objectEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    objectEndpoint.setRequestIdentifier(new RequestIdentifier());
 
     Response response = objectEndpoint.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
         OzoneConsts.KEY);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUploadWithStream.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -66,6 +67,7 @@ public class TestPartUploadWithStream {
 
     REST.setHeaders(headers);
     REST.setClient(client);
+    REST.setRequestIdentifier(new RequestIdentifier());
 
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATASTREAM_ENABLED,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.ErrorInfo;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,6 +74,7 @@ public class TestPermissionCheck {
   private OzoneVolume volume;
   private OMException exception;
   private HttpHeaders headers;
+  private RequestIdentifier requestIdentifier;
 
   @BeforeEach
   public void setup() {
@@ -92,6 +94,7 @@ public class TestPermissionCheck {
     clientProtocol = mock(ClientProtocol.class);
     S3GatewayMetrics.create(conf);
     when(client.getProxy()).thenReturn(clientProtocol);
+    requestIdentifier = new RequestIdentifier();
   }
 
   /**
@@ -102,6 +105,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).getS3Volume();
     RootEndpoint rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(client);
+    rootEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () -> rootEndpoint.get());
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
   }
@@ -114,6 +118,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).getS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         bucketEndpoint.head("bucketName"));
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
@@ -125,6 +130,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).createS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         bucketEndpoint.put("bucketName", null, null, null));
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
@@ -135,7 +141,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).deleteS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
-
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         bucketEndpoint.delete("bucketName"));
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
@@ -146,7 +152,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(bucket).listMultipartUploads(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
-
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         bucketEndpoint.listMultipartUploads("bucketName", "prefix"));
     assertEquals(HTTP_FORBIDDEN, e.getHttpCode());
@@ -160,7 +166,7 @@ public class TestPermissionCheck {
         anyBoolean());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
-
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () -> bucketEndpoint.get(
         "bucketName", null, null, null, 1000,
         null, null, null, null, null, null));
@@ -177,6 +183,7 @@ public class TestPermissionCheck {
 
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     MultiDeleteRequest request = new MultiDeleteRequest();
     List<MultiDeleteRequest.DeleteObject> objectList = new ArrayList<>();
     objectList.add(new MultiDeleteRequest.DeleteObject("deleteKeyName"));
@@ -204,6 +211,7 @@ public class TestPermissionCheck {
         .thenReturn(S3Acl.ACLIdentityType.USER.getHeaderType() + "=root");
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     OS3Exception e = assertThrows(OS3Exception.class, () -> bucketEndpoint.get(
         "bucketName", null, null, null, 1000, null, null, null, null, "acl",
         null), "Expected OS3Exception with FORBIDDEN http code.");
@@ -225,6 +233,7 @@ public class TestPermissionCheck {
         .thenReturn(S3Acl.ACLIdentityType.USER.getHeaderType() + "=root");
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
     try {
       bucketEndpoint.put("bucketName", "acl", headers, null);
     } catch (Exception e) {
@@ -245,6 +254,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setRequestIdentifier(requestIdentifier);
 
     OS3Exception e = assertThrows(OS3Exception.class, () -> objectEndpoint.get(
         "bucketName", "keyPath", 0, null, 1000, "marker", null));
@@ -261,6 +271,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setRequestIdentifier(requestIdentifier);
 
     OS3Exception e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(
         "bucketName", "keyPath", 1024, 0, null, null, null,
@@ -277,6 +288,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setRequestIdentifier(requestIdentifier);
 
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         objectEndpoint.delete("bucketName", "keyPath", null, null));
@@ -291,6 +303,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setRequestIdentifier(requestIdentifier);
 
     OS3Exception e = assertThrows(OS3Exception.class, () ->
         objectEndpoint.initializeMultipartUpload("bucketName", "keyPath"));
@@ -309,7 +322,7 @@ public class TestPermissionCheck {
 
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
     objectEndpoint.setClient(client);
-
+    objectEndpoint.setRequestIdentifier(requestIdentifier);
     String xml =
         "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
             "   <TagSet>" +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -45,6 +46,7 @@ public class TestRootList {
     // Create HeadBucket and setClient to OzoneClientStub
     rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(clientStub);
+    rootEndpoint.setRequestIdentifier(new RequestIdentifier());
 
 
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +80,7 @@ public class TestUploadWithStream {
 
     REST.setHeaders(HEADERS);
     REST.setClient(client);
+    REST.setRequestIdentifier(new RequestIdentifier());
 
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATASTREAM_ENABLED,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.RequestIdentifier;
 import org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint;
 import org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint;
 import org.apache.hadoop.ozone.s3.endpoint.RootEndpoint;
@@ -87,15 +88,20 @@ public class TestS3GatewayMetrics {
     clientStub.getObjectStore().createS3Bucket(bucketName);
     bucket = clientStub.getObjectStore().getS3Bucket(bucketName);
 
+    RequestIdentifier requestIdentifier = new RequestIdentifier();
+
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setRequestIdentifier(requestIdentifier);
 
     rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(clientStub);
+    rootEndpoint.setRequestIdentifier(requestIdentifier);
 
     keyEndpoint = new ObjectEndpoint();
     keyEndpoint.setClient(clientStub);
     keyEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    keyEndpoint.setRequestIdentifier(requestIdentifier);
 
     headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(


### PR DESCRIPTION
### What changes were proposed in this pull request?

We have a RequestIdentifier object that is used to generate the request ID and amz ID to the S3 response.
It will be useful to include this S3G audit so that it's easier to for the administrators to locate problematic request from the audit logs when only request ID is provided.

### What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12095

### How was this patch tested?

unit tests
