### PR TITLE
HDDS-11837. Support executing multiple commands in Ozone CLI

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -31,23 +31,20 @@ Create volumes
     ${random} =         Generate Random String  5  [NUMBERS]
     Set Suite Variable  ${source}  ${random}-source
     Set Suite Variable  ${target}  ${random}-target
-    Execute             ozone sh volume create ${source}
-    Execute             ozone sh volume create ${target}
+    Ozone Shell Batch   volume create ${source}
+    ...                 volume create ${target}
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'    Setup ACL tests
 
 Setup ACL tests
-    Execute             ozone sh bucket create ${source}/readable-bucket
-    Execute             ozone sh key put ${source}/readable-bucket/key-in-readable-bucket /etc/passwd
-    Execute             ozone sh bucket create ${source}/unreadable-bucket
-
-    Execute             ozone sh bucket link ${source}/unreadable-bucket ${target}/link-to-unreadable-bucket
-    Execute             ozone sh volume addacl --acl user:testuser2:r[DEFAULT] ${target}
-
-    Execute             ozone sh bucket link ${source}/readable-bucket ${target}/readable-link
-    Execute             ozone sh bucket link ${source}/readable-bucket ${target}/readable-link2
-
-    Execute             ozone sh volume addacl --acl user:testuser2:rl ${source}
-    Execute             ozone sh bucket addacl --acl user:testuser2:rl ${source}/readable-bucket
+    Ozone Shell Batch   bucket create ${source}/readable-bucket
+    ...                 key put ${source}/readable-bucket/key-in-readable-bucket /etc/passwd
+    ...                 bucket create ${source}/unreadable-bucket
+    ...                 bucket link ${source}/unreadable-bucket ${target}/link-to-unreadable-bucket
+    ...                 volume addacl --acl user:testuser2:r[DEFAULT] ${target}
+    ...                 bucket link ${source}/readable-bucket ${target}/readable-link
+    ...                 bucket link ${source}/readable-bucket ${target}/readable-link2
+    ...                 volume addacl --acl user:testuser2:rl ${source}
+    ...                 bucket addacl --acl user:testuser2:rl ${source}/readable-bucket
 
 Verify Bucket ACL
     [arguments]         ${source_option}   ${object}    ${type}   ${name}    ${acls}
@@ -81,25 +78,25 @@ ACL verified on source and target bucket
 
 Create link loop
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
-                        Execute                     ozone sh bucket link ${target}/loop1 ${target}/loop2
-                        Execute                     ozone sh bucket link ${target}/loop2 ${target}/loop3
-                        Execute                     ozone sh bucket link ${target}/loop3 ${target}/loop1
+                        Ozone Shell Batch   bucket link ${target}/loop1 ${target}/loop2
+                        ...                 bucket link ${target}/loop2 ${target}/loop3
+                        ...                 bucket link ${target}/loop3 ${target}/loop1
 
 Delete link loop
-                        Execute                     ozone sh bucket delete ${target}/loop1
-                        Execute                     ozone sh bucket delete ${target}/loop2
-                        Execute                     ozone sh bucket delete ${target}/loop3
+                        Ozone Shell Batch   bucket delete ${target}/loop1
+                        ...                 bucket delete ${target}/loop2
+                        ...                 bucket delete ${target}/loop3
 
 *** Test Cases ***
 Link to non-existent bucket
-                        Execute                     ozone sh bucket link ${source}/no-such-bucket ${target}/dangling-link
-    ${result} =         Execute And Ignore Error    ozone sh key list ${target}/dangling-link
+    ${result} =         Ozone Shell Batch           bucket link ${source}/no-such-bucket ${target}/dangling-link
+                        ...                         key list ${target}/dangling-link
                         Should Contain              ${result}         BUCKET_NOT_FOUND
 
 Key create passthrough
-                        Execute                     ozone sh bucket link ${source}/bucket1 ${target}/link1
-                        Execute                     ozone sh bucket create ${source}/bucket1
-                        Execute                     ozone sh key put ${target}/link1/key1 /etc/passwd
+                        Ozone Shell Batch           bucket link ${source}/bucket1 ${target}/link1
+                        ...                         bucket create ${source}/bucket1
+                        ...                         key put ${target}/link1/key1 /etc/passwd
                         Key Should Match Local File     ${target}/link1/key1    /etc/passwd
 
 Key read passthrough
@@ -211,8 +208,8 @@ Loop in link chain is detected
     [teardown]          Delete link loop
 
 Multiple links to same bucket are allowed
-    Execute                         ozone sh bucket link ${source}/bucket1 ${target}/link3
-    Execute                         ozone sh key put ${target}/link3/key3 /etc/group
+    Ozone Shell Batch               bucket link ${source}/bucket1 ${target}/link3
+    ...                             key put ${target}/link3/key3 /etc/group
     Key Should Match Local File     ${target}/link1/key3    /etc/group
 
 Source bucket not affected by deleting link

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -89,8 +89,8 @@ Delete link loop
 
 *** Test Cases ***
 Link to non-existent bucket
-    ${result} =         Ozone Shell Batch           bucket link ${source}/no-such-bucket ${target}/dangling-link
-                        ...                         key list ${target}/dangling-link
+                        Execute                     ozone sh bucket link ${source}/no-such-bucket ${target}/dangling-link
+    ${result} =         Execute And Ignore Error    ozone sh key list ${target}/dangling-link
                         Should Contain              ${result}         BUCKET_NOT_FOUND
 
 Key create passthrough

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -17,6 +17,7 @@
 Documentation       Test ozone shell CLI usage
 Library             OperatingSystem
 Resource            ../commonlib.robot
+Resource            ../ozone-lib/shell.robot
 
 *** Variables ***
 ${prefix}    generated
@@ -168,24 +169,20 @@ Test Bucket Acls
 
 Test key handling
     [arguments]     ${protocol}         ${server}       ${volume}
-                    Execute             ozone sh key put ${protocol}${server}/${volume}/bb1/key1 /opt/hadoop/NOTICE.txt
-                    Execute             rm -f /tmp/NOTICE.txt.1
-                    Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
+                    Execute             rm -f /tmp/NOTICE.txt.1 /tmp/key1_RATIS /tmp/key1-copy
+                    Ozone Shell Batch   key put ${protocol}${server}/${volume}/bb1/key1 /opt/hadoop/NOTICE.txt
+                    ...                 key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
+                    ...                 key put -t RATIS ${protocol}${server}/${volume}/bb1/key1_RATIS /opt/hadoop/NOTICE.txt
+                    ...                 key get ${protocol}${server}/${volume}/bb1/key1_RATIS /tmp/key1_RATIS
+                    ...                 key cp ${protocol}${server}/${volume}/bb1 key1 key1-copy
+                    ...                 key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/NOTICE.txt.1
-
-                    Execute             ozone sh key put -t RATIS ${protocol}${server}/${volume}/bb1/key1_RATIS /opt/hadoop/NOTICE.txt
-                    Execute             rm -f /tmp/key1_RATIS
-                    Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1_RATIS /tmp/key1_RATIS
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1_RATIS
+
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1_RATIS | jq -r '. | select(.name=="key1_RATIS")'
                     Should contain      ${result}       RATIS
-                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1_RATIS
 
-                    Execute             ozone sh key cp ${protocol}${server}/${volume}/bb1 key1 key1-copy
-                    Execute             rm -f /tmp/key1-copy
-                    Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1-copy
-                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1-copy
 
     ${result} =     Execute And Ignore Error    ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Contain      ${result}       NOTICE.txt.1 exists
@@ -199,7 +196,9 @@ Test key handling
                     Execute             ozone sh key rename ${protocol}${server}/${volume}/bb1 key1 key2
     ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '.[] | select(.name=="key2") | .name'
                     Should Be Equal     ${result}       key2
-                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key2
+                    Ozone Shell Batch   key delete ${protocol}${server}/${volume}/bb1/key2
+                    ...                 key delete ${protocol}${server}/${volume}/bb1/key1_RATIS
+                    ...                 key delete ${protocol}${server}/${volume}/bb1/key1-copy
 
 Test key Acls
     [arguments]     ${protocol}         ${server}       ${volume}
@@ -274,18 +273,18 @@ Test native authorizer
 
 Test Delete key with Trash
     [arguments]    ${protocol}         ${server}       ${volume}
-                   Execute               ozone sh volume create ${protocol}${server}/${volume}
-                   Execute               ozone sh bucket create ${protocol}${server}/${volume}/bfso --layout FILE_SYSTEM_OPTIMIZED
-                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key3 /opt/hadoop/NOTICE.txt
-                   Execute               ozone sh key delete ${protocol}${server}/${volume}/bfso/key3
+                   Ozone Shell Batch     volume create ${protocol}${server}/${volume}
+                   ...                   bucket create ${protocol}${server}/${volume}/bfso --layout FILE_SYSTEM_OPTIMIZED
+                   ...                   key put -t RATIS ${protocol}${server}/${volume}/bfso/key3 /opt/hadoop/NOTICE.txt
+                   ...                   key delete ${protocol}${server}/${volume}/bfso/key3
     ${fsokey} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso
     ${result} =    Execute               echo '${fsokey}' | jq -r '.[] | select(.name | startswith(".Trash")) | .name'
                    Should Contain Any    ${result}    .Trash/hadoop    .Trash/testuser    .Trash/root
                    Should contain        ${result}    key3
     ${result} =    Execute               echo '${fsokey}' | jq -r '.[] | select(.name | startswith(".Trash") | not) | .name'
                    Should Not contain    ${result}    key3
-                   Execute               ozone sh bucket create ${protocol}${server}/${volume}/obsbkt --layout OBJECT_STORE
-                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/obsbkt/key2 /opt/hadoop/NOTICE.txt
-                   Execute               ozone sh key delete ${protocol}${server}/${volume}/obsbkt/key2
+                   Ozone Shell Batch     bucket create ${protocol}${server}/${volume}/obsbkt --layout OBJECT_STORE
+                   ...                   key put -t RATIS ${protocol}${server}/${volume}/obsbkt/key2 /opt/hadoop/NOTICE.txt
+                   ...                   key delete ${protocol}${server}/${volume}/obsbkt/key2
     ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/obsbkt
                    Should not contain    ${result}    key2

--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
@@ -19,6 +19,11 @@ Library     String
 
 
 *** Keywords ***
+Ozone Shell Batch
+    [arguments]    @{commands}
+    ${cmd} =    Catenate    SEPARATOR=' --execute '    @{commands}
+    Run Keyword And Return    Execute and checkrc    ozone sh --execute '${cmd}'    0
+
 Bucket Exists
     [arguments]    ${bucket}
     ${rc}    ${output} =      Run And Return Rc And Output             timeout 15 ozone sh bucket info ${bucket}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/REPL.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/REPL.java
@@ -66,7 +66,7 @@ class REPL {
           .variable(LineReader.LIST_MAX, 50)
           .build();
 
-      if (terminal.getType() != Terminal.TYPE_DUMB && terminal.getType() != Terminal.TYPE_DUMB_COLOR) {
+      if (!Terminal.TYPE_DUMB.equals(terminal.getType()) && !Terminal.TYPE_DUMB_COLOR.equals(terminal.getType())) {
         TailTipWidgets widgets = new TailTipWidgets(reader, registry::commandDescription, 5, TipType.COMPLETER);
         widgets.enable();
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support batch mode in Ozone CLI subcommands which already have `--interactive` mode enabled, by adding repeatable `--execute <cmd>` option.

This allows running multiple commands with the same invocation, like:

```
ozone sh \
  --execute 'volume create /vol1' \
  --execute 'bucket create /vol1/bucket1'
```

Update Robot tests to utilize batch mode in few test cases.

(Initially I wanted to use input redirection.  It is still supported, but Robot tests are not great with here-docs.)

Also fix a warning from `TailTipWidgets` when running without TTY.

https://issues.apache.org/jira/browse/HDDS-11837

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12871125080
