### PR TITLE
HDDS-12115. RM selects replicas to delete non-deterministically if nodes are overloaded

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AbstractOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AbstractOverReplicationHandler.java
@@ -48,11 +48,10 @@ public abstract class AbstractOverReplicationHandler
    * @param replica the replica to be removed
    */
   public boolean isPlacementStatusActuallyEqualAfterRemove(
+      ContainerPlacementStatus currentCPS,
       final Set<ContainerReplica> replicas,
       final ContainerReplica replica,
       final int replicationFactor) {
-    ContainerPlacementStatus currentCPS =
-        getPlacementStatus(replicas, replicationFactor);
     replicas.remove(replica);
     ContainerPlacementStatus newCPS =
         getPlacementStatus(replicas, replicationFactor);
@@ -78,7 +77,7 @@ public abstract class AbstractOverReplicationHandler
    * @param replicationFactor Expected Replication Factor of the containe
    * @return ContainerPlacementStatus indicating if the policy is met or not
    */
-  private ContainerPlacementStatus getPlacementStatus(
+  protected ContainerPlacementStatus getPlacementStatus(
       Set<ContainerReplica> replicas, int replicationFactor) {
     List<DatanodeDetails> replicaDns = replicas.stream()
         .map(ContainerReplica::getDatanodeDetails)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When RM selects nodes to delete replicas from, it sorts the replicas by datanode UUID and then iterates the list. If a node is overloaded when it is selected for delete, then rather than holding that delete for later, it skips it and tries the next replica in the list. This can result in non-deterministic delete selection, which we want to avoid.

This PR changes that, so that the original replica is no longer skipped, but will be tried again on the next iteration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12115

## How was this patch tested?

A couple of new mis-replication tests added and a test which started failing after the change was modified to reflect the new intended behavior.