### PR TITLE
HDDS-12098. Bump Hugo to 0.141.0

### DIFF
--- a/hadoop-ozone/dev-support/checks/install/hugo.sh
+++ b/hadoop-ozone/dev-support/checks/install/hugo.sh
@@ -17,7 +17,7 @@
 # This script installs Hugo.
 # Requires _install_tool from _lib.sh.  Use `source` for both scripts, because it modifies $PATH.
 
-: ${HUGO_VERSION:=0.83.1}
+: ${HUGO_VERSION:=0.141.0}
 
 _install_hugo() {
   local os=$(uname -s)
@@ -25,15 +25,22 @@ _install_hugo() {
 
   mkdir bin
 
-  case "${os}" in
-    Darwin)
-      os=macOS
+  case "${arch}" in
+    x86_64)
+      arch=amd64
+      ;;
+    aarch64)
+      arch=arm64
       ;;
   esac
 
-  case "${arch}" in
-    x86_64)
-      arch=64bit
+  case "${os}" in
+    Darwin)
+      os=darwin
+      arch=universal
+      ;;
+    Linux)
+      os=linux
       ;;
   esac
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Hugo to latest, 0.141.0.

Tweak artifact `arch` and `os` based on assets found at https://github.com/gohugoio/hugo/releases/tag/v0.141.0

https://issues.apache.org/jira/browse/HDDS-12098

## How was this patch tested?

```
Installed hugo in /home/runner/work/ozone/ozone/.dev-tools/hugo
...
hugo v0.141.0-e7bd51698e5c3778a86003018702b1a7dcb9559a linux/amd64 BuildDate=2025-01-16T13:11:18Z VendorInfo=gohugoio
```

https://github.com/adoroszlai/ozone/actions/runs/12892096067/job/35945572356
