### PR TITLE
HDDS-12124. Disable resource filtering for VI swap files

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -509,10 +509,6 @@
                   <filtering>true</filtering>
                 </resource>
               </resources>
-              <nonFilteredFileExtensions>
-                <nonFilteredFileExtension>woff</nonFilteredFileExtension>
-                <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
-              </nonFilteredFileExtensions>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1370,6 +1370,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>
+          <configuration>
+            <nonFilteredFileExtensions>
+              <nonFilteredFileExtension>swp</nonFilteredFileExtension>
+              <nonFilteredFileExtension>woff</nonFilteredFileExtension>
+              <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
+            </nonFilteredFileExtensions>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Build fails when files from `hadoop-ozone/dist/src/main/compose` (or similar directories) are open in VI due to the binary swap files it creates:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.3.0:copy-resources (copy-compose-files) on project ozone-dist: filtering hadoop-ozone/dist/src/main/compose/restart/.docker-compose.yaml.swp to hadoop-ozone/dist/target/compose/restart/.docker-compose.yaml.swp failed with MalformedInputException: Input length = 1 -> [Help 1]
```

This patch disables resource filtering for `.swp` files.  It also moves definition of non-filtered extensions to the root POM, so that it applies to all submodules, without having to duplicate.

https://issues.apache.org/jira/browse/HDDS-12124

## How was this patch tested?

```
gvim hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml 
mvn -DskipTests -DskipShade clean package
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12904340058
