### PR TITLE
HDDS-12130. Improve assertion compatibility with old Hadoop

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java
@@ -394,7 +394,7 @@ public abstract class AbstractContractGetFileStatusTest extends
     Assertions.assertThat(statusList)
             .describedAs(msg)
             .hasSize(1);
-    Assertions.assertThat(statusList.get(0).getPath())
+    Assertions.assertThatObject(statusList.get(0).getPath())
             .describedAs("path returned should match with the input path")
             .isEqualTo(f);
     Assertions.assertThat(statusList.get(0).isFile())
@@ -471,7 +471,7 @@ public abstract class AbstractContractGetFileStatusTest extends
    * @param fileStatus status to validate
    */
   private void assertIsNamedFile(Path f, FileStatus fileStatus) {
-    Assertions.assertThat(fileStatus.getPath())
+    Assertions.assertThatObject(fileStatus.getPath())
         .withFailMessage("Wrong pathname in " + fileStatus)
         .isEqualTo(f);
     Assertions.assertThat(fileStatus.isFile())
@@ -569,15 +569,15 @@ public abstract class AbstractContractGetFileStatusTest extends
 
     MatchesNameFilter file1Filter = new MatchesNameFilter("file-1.txt");
     result = verifyListStatus(1, parent, file1Filter);
-    Assertions.assertThat(result[0].getPath())
+    Assertions.assertThatObject(result[0].getPath())
         .isEqualTo(file1);
 
     verifyListStatus(0, file1, NO_PATHS);
     result = verifyListStatus(1, file1, ALL_PATHS);
-    Assertions.assertThat(result[0].getPath())
+    Assertions.assertThatObject(result[0].getPath())
         .isEqualTo(file1);
     result = verifyListStatus(1, file1, file1Filter);
-    Assertions.assertThat(result[0].getPath())
+    Assertions.assertThatObject(result[0].getPath())
         .isEqualTo(file1);
 
     // empty subdirectory
@@ -608,15 +608,15 @@ public abstract class AbstractContractGetFileStatusTest extends
 
     MatchesNameFilter file1Filter = new MatchesNameFilter("file-1.txt");
     result = verifyListLocatedStatus(xfs, 1, parent, file1Filter);
-    Assertions.assertThat(result.get(0).getPath())
+    Assertions.assertThatObject(result.get(0).getPath())
         .isEqualTo(file1);
 
     verifyListLocatedStatus(xfs, 0, file1, NO_PATHS);
     verifyListLocatedStatus(xfs, 1, file1, ALL_PATHS);
-    Assertions.assertThat(result.get(0).getPath())
+    Assertions.assertThatObject(result.get(0).getPath())
         .isEqualTo(file1);
     verifyListLocatedStatus(xfs, 1, file1, file1Filter);
-    Assertions.assertThat(result.get(0).getPath())
+    Assertions.assertThatObject(result.get(0).getPath())
         .isEqualTo(file1);
     verifyListLocatedStatusNextCalls(xfs, 1, file1, file1Filter);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Assertions.assertThat` is overloaded, returning different assertion object depending on the argument.  Passing an instance of raw `Comparable` results in compile error.  Hadoop's `Path` used to implement raw `Comparable` before it was parameterized in HADOOP-16196.  Thus, compiling Ozone with old Hadoop that does not have HADOOP-16196 fails.

```
[ERROR] hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractGetFileStatusTest.java:[404,13] cannot find symbol
  symbol:   method isEqualTo(org.apache.hadoop.fs.Path)
  location: class java.lang.Object
```

This can be improved by using more specific assertion factory method (e.g. `assertThatObject`).

https://issues.apache.org/jira/browse/HDDS-12130

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12929097463
