### PR TITLE
HDDS-12131. Overwrite an empty file with multipart-upload throws NPE

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -60,6 +60,12 @@ Test Multipart Upload With Adjusted Length
     Perform Multipart Upload    ${BUCKET}    multipart/adjusted_length_${PREFIX}    /tmp/part1    /tmp/part2
     Verify Multipart Upload     ${BUCKET}    multipart/adjusted_length_${PREFIX}    /tmp/part1    /tmp/part2
 
+Overwrite Empty File
+    Execute                     touch ${TEMP_DIR}/empty
+    Execute AWSS3Cli            cp ${TEMP_DIR}/empty s3://${BUCKET}/empty_file_${PREFIX}
+    Perform Multipart Upload    ${BUCKET}    empty_file_${PREFIX}    /tmp/part1    /tmp/part2
+    Verify Multipart Upload     ${BUCKET}    empty_file_${PREFIX}    /tmp/part1    /tmp/part2
+
 Test Multipart Upload
     ${result} =         Execute AWSS3APICli     create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/multipartKey
     ${uploadID} =       Execute and checkrc     echo '${result}' | jq -r '.UploadId'    0

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
@@ -130,6 +131,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     return omKeyInfo;
   }
 
+  @Nullable
   protected OmBucketInfo getOmBucketInfo() {
     return omBucketInfo;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -102,11 +102,14 @@ public class S3MultipartUploadCompleteResponseWithFSO
       }
 
       // namespace quota changes for parent directory
-      String bucketKey = omMetadataManager.getBucketKey(
-          getOmBucketInfo().getVolumeName(),
-          getOmBucketInfo().getBucketName());
-      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
-          bucketKey, getOmBucketInfo());
+      OmBucketInfo omBucketInfo = getOmBucketInfo();
+      if (omBucketInfo != null) {
+        String bucketKey = omMetadataManager.getBucketKey(
+                omBucketInfo.getVolumeName(),
+                omBucketInfo.getBucketName());
+        omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+                bucketKey, omBucketInfo);
+      }
 
       if (OMFileRequest.getOmKeyInfoFromFileTable(true,
           omMetadataManager, getMultiPartKey(), getOmKeyInfo().getKeyName())


### PR DESCRIPTION
## What changes were proposed in this pull request?
S3MultipartUploadCompleteRequestWithFSO seems to throw NPE when an empty file is being overwritten by non-zero file because omBucketInfo allows null value (null value is passed when non-update needed). This patch fix this by checking omBucketInfo before use.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12131

## How was this patch tested?
I've added annotation for `@Nullable`.
Local compilation are passed and it'll be checked by CI. Let me know if more tests are suggested.