### PR TITLE
HDDS-12094. Update BasicKeyInfo to include isFile payload

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -228,7 +228,7 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getFactor(),
             basicKeyInfo.getEcReplicationConfig()))
         .setETag(basicKeyInfo.getETag())
-        .setIsFile(!keyName.endsWith("/"))
+        .setIsFile(basicKeyInfo.getIsFile())
         .setOwnerName(basicKeyInfo.getOwnerName());
 
     return builder.build();
@@ -254,7 +254,7 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getFactor(),
             basicKeyInfo.getEcReplicationConfig()))
         .setETag(basicKeyInfo.getETag())
-        .setIsFile(!keyName.endsWith("/"))
+        .setIsFile(basicKeyInfo.getIsFile())
         .setOwnerName(basicKeyInfo.getOwnerName());
 
     return builder.build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -190,6 +190,7 @@ public final class BasicOmKeyInfo {
         .setDataSize(dataSize)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
+        .setIsFile(isFile)
         .setType(replicationConfig.getReplicationType());
     if (ownerName != null) {
       builder.setOwnerName(ownerName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -2844,18 +2844,18 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       throws IOException {
     // Test that directories in multilevel keys are not marked as files
 
-    String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
-    String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);
+    String volumeA = "volume-a-" + RandomStringUtils.randomNumeric(5);
+    String bucketA = "bucket-a-" + RandomStringUtils.randomNumeric(5);
     store.createVolume(volumeA);
     OzoneVolume volA = store.getVolume(volumeA);
     volA.createBucket(bucketA);
     OzoneBucket volAbucketA = volA.getBucket(bucketA);
 
-    String keyBaseC = "key-c/";
+    String keyBaseA = "key-a/";
     for (int i = 0; i < 10; i++) {
       byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
       OzoneOutputStream one = volAbucketA.createKey(
-          keyBaseC + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
           value.length, RATIS, ONE,
           new HashMap<>());
       one.write(value);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -2837,8 +2837,20 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           .startsWith("key-b-" + i + "-"));
     }
     assertFalse(volABucketBIter.hasNext());
+  }
 
+  @Test
+  public void testListKeyDirectoriesAreNotFiles()
+      throws IOException {
     // Test that directories in multilevel keys are not marked as files
+
+    String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
+    String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);
+    store.createVolume(volumeA);
+    OzoneVolume volA = store.getVolume(volumeA);
+    volA.createBucket(bucketA);
+    OzoneBucket volAbucketA = volA.getBucket(bucketA);
+
     String keyBaseC = "key-c/";
     for (int i = 0; i < 10; i++) {
       byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
@@ -2848,24 +2860,6 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           new HashMap<>());
       one.write(value);
       one.close();
-      OzoneOutputStream two = volAbucketB.createKey(
-          keyBaseC + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      two.write(value);
-      two.close();
-      OzoneOutputStream three = volBbucketA.createKey(
-          keyBaseC + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      three.write(value);
-      three.close();
-      OzoneOutputStream four = volBbucketB.createKey(
-          keyBaseC + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      four.write(value);
-      four.close();
     }
 
     Iterator<? extends OzoneKey> volABucketAIter1 = volAbucketA.listKeys(null);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1182,6 +1182,7 @@ message BasicKeyInfo {
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
     optional string eTag = 8;
     optional string ownerName = 9;
+    optional bool isFile = 10;
 }
 
 message DirectoryInfo {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The name of directories and subdirectories do not have a trailing slash.
This results in them being interpreted as files instead of directories.
As a result `isFile()` incorrectly returns `true` even for directories.

This PR :
* adds the `isFile` payload to the `BasicKeyInfo` proto message
* updates the protobuf (de)serialization in `BasicOmKeyInfo` to get/set the `isFile` status
* adds a new integration test

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12094

## How was this patch tested?

Added new integration test in `OzoneRpcClientTests#testListKey`.

CI: https://github.com/ptlrs/ozone/actions/runs/12945031804