### PR TITLE
HDDS-12110. Optimize memory overhead for OM background tasks.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.OzoneManagerServiceProvider;
 import org.apache.hadoop.ozone.recon.tasks.OMDBUpdatesHandler;
 import org.apache.hadoop.ozone.recon.tasks.OMUpdateEventBatch;
+import org.apache.hadoop.ozone.recon.tasks.ReconOmTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdater;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdaterManager;
@@ -267,6 +268,10 @@ public class OzoneManagerServiceProviderImpl
             ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
             OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT),
         TimeUnit.MILLISECONDS);
+    // Initialize recon om tasks for any first time initialization of resources.
+    reconTaskController.getRegisteredTasks()
+        .values()
+        .forEach(ReconOmTask::init);
     startSyncDataFromOM(initialDelay);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/DeletedKeysInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/DeletedKeysInsightHandler.java
@@ -49,19 +49,15 @@ public class DeletedKeysInsightHandler implements OmTableHandler {
                              HashMap<String, Long> unReplicatedSizeMap,
                              HashMap<String, Long> replicatedSizeMap) {
 
-    String countKey = getTableCountKeyFromTable(tableName);
-    String unReplicatedSizeKey = getUnReplicatedSizeKeyFromTable(tableName);
-    String replicatedSizeKey = getReplicatedSizeKeyFromTable(tableName);
-
     if (event.getValue() != null) {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           (RepeatedOmKeyInfo) event.getValue();
-      objectCountMap.computeIfPresent(countKey,
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
           (k, count) -> count + repeatedOmKeyInfo.getOmKeyInfoList().size());
       Pair<Long, Long> result = repeatedOmKeyInfo.getTotalSize();
-      unReplicatedSizeMap.computeIfPresent(unReplicatedSizeKey,
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size + result.getLeft());
-      replicatedSizeMap.computeIfPresent(replicatedSizeKey,
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size + result.getRight());
     } else {
       LOG.warn("Put event does not have the Key Info for {}.",
@@ -81,19 +77,15 @@ public class DeletedKeysInsightHandler implements OmTableHandler {
                                 HashMap<String, Long> unReplicatedSizeMap,
                                 HashMap<String, Long> replicatedSizeMap) {
 
-    String countKey = getTableCountKeyFromTable(tableName);
-    String unReplicatedSizeKey = getUnReplicatedSizeKeyFromTable(tableName);
-    String replicatedSizeKey = getReplicatedSizeKeyFromTable(tableName);
-
     if (event.getValue() != null) {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           (RepeatedOmKeyInfo) event.getValue();
-      objectCountMap.computeIfPresent(countKey, (k, count) ->
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName), (k, count) ->
           count > 0 ? count - repeatedOmKeyInfo.getOmKeyInfoList().size() : 0L);
       Pair<Long, Long> result = repeatedOmKeyInfo.getTotalSize();
-      unReplicatedSizeMap.computeIfPresent(unReplicatedSizeKey,
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size > result.getLeft() ? size - result.getLeft() : 0L);
-      replicatedSizeMap.computeIfPresent(replicatedSizeKey,
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size > result.getRight() ? size - result.getRight() :
               0L);
     } else {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/DeletedKeysInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/DeletedKeysInsightHandler.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Manages records in the Deleted Table, updating counts and sizes of
@@ -45,9 +45,9 @@ public class DeletedKeysInsightHandler implements OmTableHandler {
   @Override
   public void handlePutEvent(OMDBUpdateEvent<String, Object> event,
                              String tableName,
-                             HashMap<String, Long> objectCountMap,
-                             HashMap<String, Long> unReplicatedSizeMap,
-                             HashMap<String, Long> replicatedSizeMap) {
+                             Map<String, Long> objectCountMap,
+                             Map<String, Long> unReplicatedSizeMap,
+                             Map<String, Long> replicatedSizeMap) {
 
     if (event.getValue() != null) {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
@@ -73,9 +73,9 @@ public class DeletedKeysInsightHandler implements OmTableHandler {
   @Override
   public void handleDeleteEvent(OMDBUpdateEvent<String, Object> event,
                                 String tableName,
-                                HashMap<String, Long> objectCountMap,
-                                HashMap<String, Long> unReplicatedSizeMap,
-                                HashMap<String, Long> replicatedSizeMap) {
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
 
     if (event.getValue() != null) {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
@@ -101,9 +101,9 @@ public class DeletedKeysInsightHandler implements OmTableHandler {
   @Override
   public void handleUpdateEvent(OMDBUpdateEvent<String, Object> event,
                                 String tableName,
-                                HashMap<String, Long> objectCountMap,
-                                HashMap<String, Long> unReplicatedSizeMap,
-                                HashMap<String, Long> replicatedSizeMap) {
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
     // The size of deleted keys cannot change hence no-op.
     return;
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -100,13 +100,10 @@ public class NSSummaryTaskDbEventHandler {
       // as this is a new ID
       nsSummary = new NSSummary();
     }
-    int numOfFile = nsSummary.getNumOfFiles();
-    long sizeOfFile = nsSummary.getSizeOfFiles();
     int[] fileBucket = nsSummary.getFileSizeBucket();
-    nsSummary.setNumOfFiles(numOfFile + 1);
-    long dataSize = keyInfo.getDataSize();
-    nsSummary.setSizeOfFiles(sizeOfFile + dataSize);
-    int binIndex = ReconUtils.getFileSizeBinIndex(dataSize);
+    nsSummary.setNumOfFiles(nsSummary.getNumOfFiles() + 1);
+    nsSummary.setSizeOfFiles(nsSummary.getSizeOfFiles() + keyInfo.getDataSize());
+    int binIndex = ReconUtils.getFileSizeBinIndex(keyInfo.getDataSize());
 
     ++fileBucket[binIndex];
     nsSummary.setFileSizeBucket(fileBucket);
@@ -168,18 +165,15 @@ public class NSSummaryTaskDbEventHandler {
       LOG.error("The namespace table is not correctly populated.");
       return;
     }
-    int numOfFile = nsSummary.getNumOfFiles();
-    long sizeOfFile = nsSummary.getSizeOfFiles();
     int[] fileBucket = nsSummary.getFileSizeBucket();
 
-    long dataSize = keyInfo.getDataSize();
-    int binIndex = ReconUtils.getFileSizeBinIndex(dataSize);
+    int binIndex = ReconUtils.getFileSizeBinIndex(keyInfo.getDataSize());
 
     // decrement count, data size, and bucket count
     // even if there's no direct key, we still keep the entry because
     // we still need children dir IDs info
-    nsSummary.setNumOfFiles(numOfFile - 1);
-    nsSummary.setSizeOfFiles(sizeOfFile - dataSize);
+    nsSummary.setNumOfFiles(nsSummary.getNumOfFiles() - 1);
+    nsSummary.setSizeOfFiles(nsSummary.getSizeOfFiles() - keyInfo.getDataSize());
     --fileBucket[binIndex];
     nsSummary.setFileSizeBucket(fileBucket);
     nsSummaryMap.put(parentObjectId, nsSummary);
@@ -189,7 +183,6 @@ public class NSSummaryTaskDbEventHandler {
                                       Map<Long, NSSummary> nsSummaryMap)
       throws IOException {
     long parentObjectId = directoryInfo.getParentObjectID();
-    long objectId = directoryInfo.getObjectID();
     // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {
@@ -203,7 +196,7 @@ public class NSSummaryTaskDbEventHandler {
       return;
     }
 
-    nsSummary.removeChildDir(objectId);
+    nsSummary.removeChildDir(directoryInfo.getObjectID());
     nsSummaryMap.put(parentObjectId, nsSummary);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableHandler.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Interface for handling PUT, DELETE and UPDATE events for size-related
@@ -43,9 +43,9 @@ public interface OmTableHandler {
    */
   void handlePutEvent(OMDBUpdateEvent<String, Object> event,
                       String tableName,
-                      HashMap<String, Long> objectCountMap,
-                      HashMap<String, Long> unReplicatedSizeMap,
-                      HashMap<String, Long> replicatedSizeMap);
+                      Map<String, Long> objectCountMap,
+                      Map<String, Long> unReplicatedSizeMap,
+                      Map<String, Long> replicatedSizeMap);
 
 
   /**
@@ -60,9 +60,9 @@ public interface OmTableHandler {
    */
   void handleDeleteEvent(OMDBUpdateEvent<String, Object> event,
                          String tableName,
-                         HashMap<String, Long> objectCountMap,
-                         HashMap<String, Long> unReplicatedSizeMap,
-                         HashMap<String, Long> replicatedSizeMap);
+                         Map<String, Long> objectCountMap,
+                         Map<String, Long> unReplicatedSizeMap,
+                         Map<String, Long> replicatedSizeMap);
 
 
   /**
@@ -77,9 +77,9 @@ public interface OmTableHandler {
    */
   void handleUpdateEvent(OMDBUpdateEvent<String, Object> event,
                          String tableName,
-                         HashMap<String, Long> objectCountMap,
-                         HashMap<String, Long> unReplicatedSizeMap,
-                         HashMap<String, Long> replicatedSizeMap);
+                         Map<String, Long> objectCountMap,
+                         Map<String, Long> unReplicatedSizeMap,
+                         Map<String, Long> replicatedSizeMap);
 
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -112,6 +112,7 @@ public class OmTableInsightTask implements ReconOmTask {
    */
   @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
+    init();
     for (String tableName : tables) {
       Table table = omMetadataManager.getTable(tableName);
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -64,12 +64,10 @@ public class OmTableInsightTask implements ReconOmTask {
   private ReconOMMetadataManager reconOMMetadataManager;
   private Map<String, OmTableHandler> tableHandlers;
   private Collection<String> tables;
-  private HashMap<String, Long> objectCountMap;
-  private HashMap<String, Long> unReplicatedSizeMap;
-  private HashMap<String, Long> replicatedSizeMap;
+  private Map<String, Long> objectCountMap;
+  private Map<String, Long> unReplicatedSizeMap;
+  private Map<String, Long> replicatedSizeMap;
 
-  private List<GlobalStats> insertGlobalStats;
-  private List<GlobalStats> updateGlobalStats;
 
   @Inject
   public OmTableInsightTask(GlobalStatsDao globalStatsDao,
@@ -84,9 +82,6 @@ public class OmTableInsightTask implements ReconOmTask {
     tableHandlers.put(OPEN_KEY_TABLE, new OpenKeysInsightHandler());
     tableHandlers.put(OPEN_FILE_TABLE, new OpenKeysInsightHandler());
     tableHandlers.put(DELETED_TABLE, new DeletedKeysInsightHandler());
-
-    insertGlobalStats = new ArrayList<>();
-    updateGlobalStats = new ArrayList<>();
   }
 
   /**
@@ -270,6 +265,9 @@ public class OmTableInsightTask implements ReconOmTask {
    * @param dataMap Map containing the updated count and size information.
    */
   private void writeDataToDB(Map<String, Long> dataMap) {
+    List<GlobalStats> insertGlobalStats = new ArrayList<>();
+    List<GlobalStats> updateGlobalStats = new ArrayList<>();
+
     for (Entry<String, Long> entry : dataMap.entrySet()) {
       Timestamp now =
           using(sqlConfiguration).fetchValue(select(currentTimestamp()));
@@ -287,9 +285,6 @@ public class OmTableInsightTask implements ReconOmTask {
 
     globalStatsDao.insert(insertGlobalStats);
     globalStatsDao.update(updateGlobalStats);
-
-    insertGlobalStats.clear();
-    updateGlobalStats.clear();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -296,7 +296,7 @@ public class OmTableInsightTask implements ReconOmTask {
    *
    * @return The count map containing the counts for each table.
    */
-  private HashMap<String, Long> initializeCountMap() {
+  public HashMap<String, Long> initializeCountMap() {
     HashMap<String, Long> objCountMap = new HashMap<>(tables.size());
     for (String tableName : tables) {
       String key = getTableCountKeyFromTable(tableName);
@@ -311,7 +311,7 @@ public class OmTableInsightTask implements ReconOmTask {
    *
    * @return The size map containing the size counts for each table.
    */
-  private HashMap<String, Long> initializeSizeMap(boolean replicated) {
+  public HashMap<String, Long> initializeSizeMap(boolean replicated) {
     String tableName;
     OmTableHandler tableHandler;
     HashMap<String, Long> sizeCountMap = new HashMap<>();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -85,6 +85,20 @@ public class OmTableInsightTask implements ReconOmTask {
   }
 
   /**
+   * Initialize the OM table insight task with first time initialization of resources.
+   */
+  @Override
+  public void init() {
+    ReconOmTask.super.init();
+    tables = getTaskTables();
+
+    // Initialize maps to store count and size information
+    objectCountMap = initializeCountMap();
+    unReplicatedSizeMap = initializeSizeMap(false);
+    replicatedSizeMap = initializeSizeMap(true);
+  }
+
+  /**
    * Iterates the rows of each table in the OM snapshot DB and calculates the
    * counts and sizes for table data.
    *
@@ -98,13 +112,6 @@ public class OmTableInsightTask implements ReconOmTask {
    */
   @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
-    tables = getTaskTables();
-
-    // Initialize maps to store count and size information
-    objectCountMap = initializeCountMap();
-    unReplicatedSizeMap = initializeSizeMap(false);
-    replicatedSizeMap = initializeSizeMap(true);
-
     for (String tableName : tables) {
       Table table = omMetadataManager.getTable(tableName);
 
@@ -176,18 +183,15 @@ public class OmTableInsightTask implements ReconOmTask {
       try {
         switch (omdbUpdateEvent.getAction()) {
         case PUT:
-          handlePutEvent(omdbUpdateEvent, tableName
-          );
+          handlePutEvent(omdbUpdateEvent, tableName);
           break;
 
         case DELETE:
-          handleDeleteEvent(omdbUpdateEvent, tableName
-          );
+          handleDeleteEvent(omdbUpdateEvent, tableName);
           break;
 
         case UPDATE:
-          handleUpdateEvent(omdbUpdateEvent, tableName
-          );
+          handleUpdateEvent(omdbUpdateEvent, tableName);
           break;
 
         default:

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -351,6 +352,25 @@ public class OmTableInsightTask implements ReconOmTask {
     return (record == null) ? 0L : record.getValue();
   }
 
+  @VisibleForTesting
+  public void setTables(Collection<String> tables) {
+    this.tables = tables;
+  }
+
+  @VisibleForTesting
+  public void setObjectCountMap(HashMap<String, Long> objectCountMap) {
+    this.objectCountMap = objectCountMap;
+  }
+
+  @VisibleForTesting
+  public void setUnReplicatedSizeMap(HashMap<String, Long> unReplicatedSizeMap) {
+    this.unReplicatedSizeMap = unReplicatedSizeMap;
+  }
+
+  @VisibleForTesting
+  public void setReplicatedSizeMap(HashMap<String, Long> replicatedSizeMap) {
+    this.replicatedSizeMap = replicatedSizeMap;
+  }
 }
 
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OpenKeysInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OpenKeysInsightHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Manages records in the OpenKey Table, updating counts and sizes of
@@ -44,9 +44,9 @@ public class OpenKeysInsightHandler implements OmTableHandler {
   @Override
   public void handlePutEvent(OMDBUpdateEvent<String, Object> event,
                              String tableName,
-                             HashMap<String, Long> objectCountMap,
-                             HashMap<String, Long> unReplicatedSizeMap,
-                             HashMap<String, Long> replicatedSizeMap) {
+                             Map<String, Long> objectCountMap,
+                             Map<String, Long> unReplicatedSizeMap,
+                             Map<String, Long> replicatedSizeMap) {
 
     if (event.getValue() != null) {
       OmKeyInfo omKeyInfo = (OmKeyInfo) event.getValue();
@@ -68,9 +68,9 @@ public class OpenKeysInsightHandler implements OmTableHandler {
   @Override
   public void handleDeleteEvent(OMDBUpdateEvent<String, Object> event,
                                 String tableName,
-                                HashMap<String, Long> objectCountMap,
-                                HashMap<String, Long> unReplicatedSizeMap,
-                                HashMap<String, Long> replicatedSizeMap) {
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
 
     if (event.getValue() != null) {
       OmKeyInfo omKeyInfo = (OmKeyInfo) event.getValue();
@@ -95,9 +95,9 @@ public class OpenKeysInsightHandler implements OmTableHandler {
   @Override
   public void handleUpdateEvent(OMDBUpdateEvent<String, Object> event,
                                 String tableName,
-                                HashMap<String, Long> objectCountMap,
-                                HashMap<String, Long> unReplicatedSizeMap,
-                                HashMap<String, Long> replicatedSizeMap) {
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
 
     if (event.getValue() != null) {
       if (event.getOldValue() == null) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OpenKeysInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OpenKeysInsightHandler.java
@@ -48,16 +48,12 @@ public class OpenKeysInsightHandler implements OmTableHandler {
                              HashMap<String, Long> unReplicatedSizeMap,
                              HashMap<String, Long> replicatedSizeMap) {
 
-    String countKey = getTableCountKeyFromTable(tableName);
-    String unReplicatedSizeKey = getUnReplicatedSizeKeyFromTable(tableName);
-    String replicatedSizeKey = getReplicatedSizeKeyFromTable(tableName);
-
     if (event.getValue() != null) {
       OmKeyInfo omKeyInfo = (OmKeyInfo) event.getValue();
-      objectCountMap.computeIfPresent(countKey, (k, count) -> count + 1L);
-      unReplicatedSizeMap.computeIfPresent(unReplicatedSizeKey,
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName), (k, count) -> count + 1L);
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size + omKeyInfo.getDataSize());
-      replicatedSizeMap.computeIfPresent(replicatedSizeKey,
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size + omKeyInfo.getReplicatedSize());
     } else {
       LOG.warn("Put event does not have the Key Info for {}.",
@@ -76,18 +72,14 @@ public class OpenKeysInsightHandler implements OmTableHandler {
                                 HashMap<String, Long> unReplicatedSizeMap,
                                 HashMap<String, Long> replicatedSizeMap) {
 
-    String countKey = getTableCountKeyFromTable(tableName);
-    String unReplicatedSizeKey = getUnReplicatedSizeKeyFromTable(tableName);
-    String replicatedSizeKey = getReplicatedSizeKeyFromTable(tableName);
-
     if (event.getValue() != null) {
       OmKeyInfo omKeyInfo = (OmKeyInfo) event.getValue();
-      objectCountMap.computeIfPresent(countKey,
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
           (k, count) -> count > 0 ? count - 1L : 0L);
-      unReplicatedSizeMap.computeIfPresent(unReplicatedSizeKey,
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size > omKeyInfo.getDataSize() ?
               size - omKeyInfo.getDataSize() : 0L);
-      replicatedSizeMap.computeIfPresent(replicatedSizeKey,
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size > omKeyInfo.getReplicatedSize() ?
               size - omKeyInfo.getReplicatedSize() : 0L);
     } else {
@@ -113,17 +105,15 @@ public class OpenKeysInsightHandler implements OmTableHandler {
             event.getKey());
         return;
       }
-      String unReplicatedSizeKey = getUnReplicatedSizeKeyFromTable(tableName);
-      String replicatedSizeKey = getReplicatedSizeKeyFromTable(tableName);
 
       // In Update event the count for the open table will not change. So we
       // don't need to update the count.
       OmKeyInfo oldKeyInfo = (OmKeyInfo) event.getOldValue();
       OmKeyInfo newKeyInfo = (OmKeyInfo) event.getValue();
-      unReplicatedSizeMap.computeIfPresent(unReplicatedSizeKey,
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size - oldKeyInfo.getDataSize() +
               newKeyInfo.getDataSize());
-      replicatedSizeMap.computeIfPresent(replicatedSizeKey,
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
           (k, size) -> size - oldKeyInfo.getReplicatedSize() +
               newKeyInfo.getReplicatedSize());
     } else {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconOmTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconOmTask.java
@@ -33,6 +33,11 @@ public interface ReconOmTask {
   String getTaskName();
 
   /**
+   * Initialize the recon om task with first time initialization of resources.
+   */
+  default void init() { }
+
+  /**
    * Process a set of OM events on tables that the task is listening on.
    * @param events Set of events to be processed by the task.
    * @return Pair of task name -&gt; task success.

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -786,7 +786,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
           (ClusterStateResponse) response1.getEntity();
       return (clusterStateResponse1.getContainers() == 1);
     });
-
+    omTableInsightTask.init();
     // check volume, bucket and key count after running table count task
     Pair<String, Boolean> result =
         omTableInsightTask.reprocess(reconOMMetadataManager);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
@@ -44,8 +44,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -127,6 +130,9 @@ public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
   @Mock
   private Table<Long, NSSummary> nsSummaryTable;
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOmTableInsightTask.class);
+
   public TestOmTableInsightTask() {
     super();
   }
@@ -154,6 +160,27 @@ public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
         reconNamespaceSummaryManager, reconOMMetadataManager,
         ozoneConfiguration);
     dslContext = getDslContext();
+
+    try {
+      Field tableField = OmTableInsightTask.class.getDeclaredField("tables");
+      tableField.setAccessible(true);
+      tableField.set(omTableInsightTask, omTableInsightTask.getTaskTables());
+
+      Field objectCountMapField = OmTableInsightTask.class.getDeclaredField("objectCountMap");
+      objectCountMapField.setAccessible(true);
+      objectCountMapField.set(omTableInsightTask, omTableInsightTask.initializeCountMap());
+
+      Field unReplicatedSizeMapField = OmTableInsightTask.class.getDeclaredField("unReplicatedSizeMap");
+      unReplicatedSizeMapField.setAccessible(true);
+      unReplicatedSizeMapField.set(omTableInsightTask, omTableInsightTask.initializeSizeMap(false));
+
+      Field replicatedSizeMapField = OmTableInsightTask.class.getDeclaredField("replicatedSizeMap");
+      replicatedSizeMapField.setAccessible(true);
+      replicatedSizeMapField.set(omTableInsightTask, omTableInsightTask.initializeSizeMap(true));
+
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      LOG.error("Failed to initialize OmTableInsightTask", e);
+    }
   }
 
   @BeforeEach

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
@@ -48,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -161,26 +160,10 @@ public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
         ozoneConfiguration);
     dslContext = getDslContext();
 
-    try {
-      Field tableField = OmTableInsightTask.class.getDeclaredField("tables");
-      tableField.setAccessible(true);
-      tableField.set(omTableInsightTask, omTableInsightTask.getTaskTables());
-
-      Field objectCountMapField = OmTableInsightTask.class.getDeclaredField("objectCountMap");
-      objectCountMapField.setAccessible(true);
-      objectCountMapField.set(omTableInsightTask, omTableInsightTask.initializeCountMap());
-
-      Field unReplicatedSizeMapField = OmTableInsightTask.class.getDeclaredField("unReplicatedSizeMap");
-      unReplicatedSizeMapField.setAccessible(true);
-      unReplicatedSizeMapField.set(omTableInsightTask, omTableInsightTask.initializeSizeMap(false));
-
-      Field replicatedSizeMapField = OmTableInsightTask.class.getDeclaredField("replicatedSizeMap");
-      replicatedSizeMapField.setAccessible(true);
-      replicatedSizeMapField.set(omTableInsightTask, omTableInsightTask.initializeSizeMap(true));
-
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      LOG.error("Failed to initialize OmTableInsightTask", e);
-    }
+    omTableInsightTask.setTables(omTableInsightTask.getTaskTables());
+    omTableInsightTask.setObjectCountMap(omTableInsightTask.initializeCountMap());
+    omTableInsightTask.setUnReplicatedSizeMap(omTableInsightTask.initializeSizeMap(false));
+    omTableInsightTask.setReplicatedSizeMap(omTableInsightTask.initializeSizeMap(true));
   }
 
   @BeforeEach


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to reduce creation of too many local hashmap and other objects on repeated processing of OM events during delta sync of Recon with OM.

Some OM background tasks need code optimisations where the process method is creating static maps and other objects again and again with every run which are not needed, so that memory and GC overhead can be reduced.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12110

## How was this patch tested?
Patch is tested using existing junit tests.
