### PR TITLE
HDDS-12089. Move execute_debug_tests out of testlib.sh

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/replicas-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/replicas-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+prefix=${RANDOM}
+
+volume="cli-debug-volume${prefix}"
+bucket="cli-debug-bucket"
+key="testfile"
+
+execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-tests.robot
+
+# get block locations for key
+chunkinfo="${key}-blocks-${prefix}"
+docker-compose exec -T ${SCM} bash -c "ozone debug replicas chunk-info ${volume}/${bucket}/${key}" > "$chunkinfo"
+host="$(jq -r '.KeyLocations[0][0]["Datanode-HostName"]' ${chunkinfo})"
+container="${host%%.*}"
+
+# corrupt the first block of key on one of the datanodes
+datafile="$(jq -r '.KeyLocations[0][0].Locations.files[0]' ${chunkinfo})"
+docker exec "${container}" sed -i -e '1s/^/a/' "${datafile}"
+
+execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v "CORRUPT_DATANODE:${host}" debug/ozone-debug-corrupt-block.robot
+
+docker stop "${container}"
+
+wait_for_datanode "${container}" STALE 60
+execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v "STALE_DATANODE:${host}" debug/ozone-debug-stale-datanode.robot
+
+wait_for_datanode "${container}" DEAD 60
+execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-dead-datanode.robot
+
+docker start "${container}"
+
+wait_for_datanode "${container}" HEALTHY 60

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -49,7 +49,7 @@ execute_robot_test scm cli
 execute_robot_test scm admincli
 
 execute_robot_test scm -v USERNAME:httpfs httpfs
-execute_debug_tests
+source "$COMPOSE_DIR/../common/replicas-test.sh"
 
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-o3fs-bucket ozonefs/ozonefs.robot
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance test for `ozone debug read-replicas` is defined in `testlib.sh` to allow running in different compose environments.  Since it's not a generic funtion for all acceptance tests, this PR moves it out to a test script in `common`, which can also be reused.

https://issues.apache.org/jira/browse/HDDS-12089

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12937429292
