### PR TITLE
HDDS-12135. Set RM default deadline to 12 minutes and the datanode offset to 6 minutes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1096,13 +1096,13 @@ public class ReplicationManager implements SCMService {
      */
     @Config(key = "event.timeout",
         type = ConfigType.TIME,
-        defaultValue = "10m",
+        defaultValue = "12m",
         reconfigurable = true,
         tags = {SCM, OZONE},
         description = "Timeout for the container replication/deletion commands "
             + "sent to datanodes. After this timeout the command will be "
             + "retried.")
-    private long eventTimeout = Duration.ofMinutes(10).toMillis();
+    private long eventTimeout = Duration.ofMinutes(12).toMillis();
     public void setInterval(Duration interval) {
       this.interval = interval;
     }
@@ -1118,7 +1118,7 @@ public class ReplicationManager implements SCMService {
      */
     @Config(key = "event.timeout.datanode.offset",
         type = ConfigType.TIME,
-        defaultValue = "30s",
+        defaultValue = "6m",
         reconfigurable = true,
         tags = {SCM, OZONE},
         description = "The amount of time to subtract from "
@@ -1126,7 +1126,7 @@ public class ReplicationManager implements SCMService {
             + "datanodes which is less than the SCM timeout. This ensures "
             + "the datanodes will not process a command after SCM believes it "
             + "should have expired.")
-    private long datanodeTimeoutOffset = Duration.ofSeconds(30).toMillis();
+    private long datanodeTimeoutOffset = Duration.ofMinutes(6).toMillis();
     public long getDatanodeTimeoutOffset() {
       return datanodeTimeoutOffset;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We recently found that delete commands can run for a long time once picked off the queue, and the default of a 10 minute deadline on SCM and 30 seconds less deadline on the datanodes can result in currently running commands being seen as expired in SCM.

This PR is to make the defaults less aggressive - giving a SCM / RM timeout of 12 minutes and a datanode timeout of 6 minutes. That way, there is longer for commands to be processed before RM will resend them.

With the throttling that RM employs, there should not be a large number of commands on the queue anyway, as the goal of RM is to schedule only the number of commands which can be processed in a heartbeat or two.

Other related Jiras to this one are: [HDDS-12127](https://issues.apache.org/jira/browse/HDDS-12127), [HDDS-12115](https://issues.apache.org/jira/browse/HDDS-12115), [HDDS-12114](https://issues.apache.org/jira/browse/HDDS-12114)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12135

## How was this patch tested?

Simple config change. No new tests added or modified.
