### PR TITLE
HDDS-12119. Move find-missing-padding command under ozone debug replicas

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/FindMissingPadding.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/FindMissingPadding.java
@@ -71,8 +71,8 @@ import static java.util.Comparator.comparing;
 /**
  * Find EC keys affected by missing padding blocks (HDDS-10681).
  */
-@CommandLine.Command(name = "find-missing-padding",
-    aliases = { "fmp" },
+@CommandLine.Command(name = "padding",
+    aliases = { "fmp", "find-missing-padding" },
     description = "List all keys with any missing padding, optionally limited to a volume/bucket/key URI.")
 @MetaInfServices(DebugSubcommand.class)
 public class FindMissingPadding extends Handler implements DebugSubcommand {
@@ -80,7 +80,7 @@ public class FindMissingPadding extends Handler implements DebugSubcommand {
   @CommandLine.Mixin
   private ScmOption scmOption;
 
-  @CommandLine.Parameters(arity = "0..1",
+  @CommandLine.Parameters(arity = "1",
       description = Shell.OZONE_URI_DESCRIPTION)
   private String uri;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR:
* renames `find-missing-padding` command to `padding` command
* makes the URI a required parameter to make it consistent with the other `replicas verify` commands
* PR https://github.com/apache/ozone/pull/7748 moves it under `ozone debug replicas verify` command

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12119

## How was this patch tested?
Manual tested in docker compose environment
CI: https://github.com/ptlrs/ozone/actions/runs/12954408156