### PR TITLE
HDDS-12099. Generate kubernetes Robot report in container

### DIFF
--- a/hadoop-ozone/dev-support/checks/kubernetes.sh
+++ b/hadoop-ozone/dev-support/checks/kubernetes.sh
@@ -24,28 +24,6 @@ export KUBECONFIG
 source "${DIR}/_lib.sh"
 source "${DIR}/install/flekszible.sh"
 
-# TODO these functions will be removed in HDDS-12099
-install_virtualenv() {
-  _install_tool virtualenv
-}
-
-_install_virtualenv() {
-  sudo pip3 install virtualenv
-}
-
-install_robot() {
-  _install_tool robot venv/bin
-}
-
-_install_robot() {
-  virtualenv venv
-  source venv/bin/activate
-  pip install robotframework
-}
-
-install_virtualenv
-install_robot
-
 if [[ "$(uname -s)" = "Darwin" ]]; then
   echo "Skip installing k3s, not supported on Mac.  Make sure a working Kubernetes cluster is available." >&2
 else

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -124,7 +124,7 @@ run cp -r "${ROOT}/dev-support/byteman" "share/ozone/"
 #Copy docker compose files
 #compose files are preprocessed: properties (eg. project.version) are replaced first by maven.
 run cp -p -R "${ROOT}/hadoop-ozone/dist/target/compose" .
-run cp -p -r "${ROOT}/hadoop-ozone/dist/src/main/smoketest" .
+run cp -p -r "${ROOT}/hadoop-ozone/dist/target/smoketest" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/k8s" kubernetes
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/Dockerfile" .
 

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -124,7 +124,7 @@ run cp -r "${ROOT}/dev-support/byteman" "share/ozone/"
 #Copy docker compose files
 #compose files are preprocessed: properties (eg. project.version) are replaced first by maven.
 run cp -p -R "${ROOT}/hadoop-ozone/dist/target/compose" .
-run cp -p -r "${ROOT}/hadoop-ozone/dist/target/smoketest" .
+run cp -p -r "${ROOT}/hadoop-ozone/dist/target/main/smoketest" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/k8s" kubernetes
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/Dockerfile" .
 

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -124,7 +124,7 @@ run cp -r "${ROOT}/dev-support/byteman" "share/ozone/"
 #Copy docker compose files
 #compose files are preprocessed: properties (eg. project.version) are replaced first by maven.
 run cp -p -R "${ROOT}/hadoop-ozone/dist/target/compose" .
-run cp -p -r "${ROOT}/hadoop-ozone/dist/target/main/smoketest" .
+run cp -p -r "${ROOT}/hadoop-ozone/dist/target/smoketest" .
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/k8s" kubernetes
 run cp -p -r "${ROOT}/hadoop-ozone/dist/target/Dockerfile" .
 

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -166,22 +166,6 @@
             </configuration>
           </execution>
           <execution>
-            <id>copy-smoketest-files</id>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <phase>compile</phase>
-            <configuration>
-              <outputDirectory>${basedir}/target/smoketest</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/smoketest</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
             <id>copy-and-filter-dockerfile</id>
             <goals>
               <goal>copy-resources</goal>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -166,6 +166,22 @@
             </configuration>
           </execution>
           <execution>
+            <id>copy-smoketest-files</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <outputDirectory>${basedir}/target/smoketest</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/smoketest</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
             <id>copy-and-filter-dockerfile</id>
             <goals>
               <goal>copy-resources</goal>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -197,6 +197,22 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-smoketest-files</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <outputDirectory>${basedir}/target/smoketest</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/smoketest</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <!-- there is no problem to have multiple versions of the jar files from

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -530,18 +530,6 @@ prepare_for_binary_image() {
 ## @description Define variables required for using `ozone-runner` docker image
 ##   (no binaries included)
 ## @param `ozone-runner` image version (optional)
-get_runner_image_spec() {
-  local default_version=${docker.ozone-runner.version} # set at build-time from Maven property
-  local runner_version=${OZONE_RUNNER_VERSION:-${default_version}} # may be specified by user running the test
-  local runner_image=${OZONE_RUNNER_IMAGE:-apache/ozone-runner} # may be specified by user running the test
-  local v=${1:-${runner_version}} # prefer explicit argument
-
-  echo "${runner_image}:${v}"
-}
-
-## @description Define variables required for using `ozone-runner` docker image
-##   (no binaries included)
-## @param `ozone-runner` image version (optional)
 prepare_for_runner_image() {
   export OZONE_DIR=/opt/hadoop
   export OZONE_TEST_IMAGE="$(get_runner_image_spec "$@")"

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -18,7 +18,6 @@ set -e -o pipefail
 
 _testlib_this="${BASH_SOURCE[0]}"
 _testlib_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 COMPOSE_ENV_NAME=$(basename "$COMPOSE_DIR")
 RESULT_DIR=${RESULT_DIR:-"$COMPOSE_DIR/result"}
 RESULT_DIR_INSIDE="/tmp/smoketest/$(basename "$COMPOSE_ENV_NAME")/result"
@@ -29,6 +28,7 @@ if [[ -n "${OM_SERVICE_ID}" ]] && [[ "${OM_SERVICE_ID}" != "om" ]]; then
 fi
 
 source ${_testlib_dir}/compose_v2_compatibility.sh
+source "${_testlib_dir}/../smoketest/testlib.sh"
 
 : ${OZONE_COMPOSE_RUNNING:=false}
 : ${SCM:=scm}
@@ -408,27 +408,6 @@ cleanup_docker_images() {
   if [[ "${KEEP_IMAGE:-true}" == false ]]; then
     docker image rm "$@"
   fi
-}
-
-## @description  Run Robot Framework report generator (rebot) in ozone-runner container.
-## @param input directory where source Robot XML files are
-## @param output directory where report should be placed
-## @param rebot options and arguments
-run_rebot() {
-  local input_dir="$(realpath "$1")"
-  local output_dir="$(realpath "$2")"
-
-  shift 2
-
-  local tempdir="$(mktemp -d "${output_dir}"/rebot-XXXXXX)"
-  #Should be writeable from the docker containers where user is different.
-  chmod a+wx "${tempdir}"
-  if docker run --rm -v "${input_dir}":/rebot-input -v "${tempdir}":/rebot-output -w /rebot-input \
-      $(get_runner_image_spec) \
-      bash -c "rebot --nostatusrc -d /rebot-output $@"; then
-    mv -v "${tempdir}"/* "${output_dir}"/
-  fi
-  rmdir "${tempdir}"
 }
 
 ## @description  Generate robot framework reports based on the saved results.

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -17,6 +17,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPT_DIR}/../../smoketest/testlib.sh"
+source "${SCRIPT_DIR}/../../compose/testlib.sh"
 
 retry() {
    local -i n=0

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -17,7 +17,6 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPT_DIR}/../../smoketest/testlib.sh"
-source "${SCRIPT_DIR}/../../compose/testlib.sh"
 
 retry() {
    local -i n=0

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/../../smoketest/testlib.sh"
+
 retry() {
    local -i n=0
    local -i attempts=${RETRY_ATTEMPTS:-100}
@@ -167,7 +170,7 @@ execute_robot_test() {
 combine_reports() {
   if [[ -d result ]]; then
     rm -f result/output.xml
-    rebot -d result --nostatusrc -o output.xml -N $(basename "$(pwd)") result/*.xml
+    run_rebot "result" "result" -o output.xml -N "$(basename "$(pwd)")" result/*.xml
   fi
 }
 

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -171,7 +171,7 @@ execute_robot_test() {
 combine_reports() {
   if [[ -d result ]]; then
     rm -f result/output.xml
-    run_rebot "result" "result" -o output.xml -N "$(basename "$(pwd)")" result/*.xml
+    run_rebot result result -o output.xml -N "$(basename "$(pwd)")" result/*.xml
   fi
 }
 

--- a/hadoop-ozone/dist/src/main/smoketest/.env
+++ b/hadoop-ozone/dist/src/main/smoketest/.env
@@ -15,4 +15,3 @@
 # limitations under the License.
 
 HADOOP_VERSION=${hadoop.version}
-OZONE_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/smoketest/.env
+++ b/hadoop-ozone/dist/src/main/smoketest/.env
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 HADOOP_VERSION=${hadoop.version}
+OZONE_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/smoketest/testlib.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/testlib.sh
@@ -20,6 +20,9 @@
 ## @param output directory where report should be placed
 ## @param rebot options and arguments
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/../compose/testlib.sh"
+
 run_rebot() {
   local input_dir="$(realpath "$1")"
   local output_dir="$(realpath "$2")"

--- a/hadoop-ozone/dist/src/main/smoketest/testlib.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/testlib.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## @description  Run Robot Framework report generator (rebot) in ozone-runner container.
+## @param input directory where source Robot XML files are
+## @param output directory where report should be placed
+## @param rebot options and arguments
+
+run_rebot() {
+  local input_dir="$(realpath "$1")"
+  local output_dir="$(realpath "$2")"
+
+  shift 2
+
+  local tempdir="$(mktemp -d "${output_dir}"/rebot-XXXXXX)"
+  #Should be writeable from the docker containers where user is different.
+  chmod a+wx "${tempdir}"
+  if docker run --rm -v "${input_dir}":/rebot-input -v "${tempdir}":/rebot-output -w /rebot-input \
+      $(get_runner_image_spec) \
+      bash -c "rebot --nostatusrc -d /rebot-output $@"; then
+    mv -v "${tempdir}"/* "${output_dir}"/
+  fi
+  rmdir "${tempdir}"
+}

--- a/hadoop-ozone/dist/src/main/smoketest/testlib.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/testlib.sh
@@ -20,9 +20,6 @@
 ## @param output directory where report should be placed
 ## @param rebot options and arguments
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "${SCRIPT_DIR}/../compose/testlib.sh"
-
 run_rebot() {
   local input_dir="$(realpath "$1")"
   local output_dir="$(realpath "$2")"
@@ -38,4 +35,16 @@ run_rebot() {
     mv -v "${tempdir}"/* "${output_dir}"/
   fi
   rmdir "${tempdir}"
+}
+
+## @description Define variables required for using `ozone-runner` docker image
+##   (no binaries included)
+## @param `ozone-runner` image version (optional)
+get_runner_image_spec() {
+  local default_version=${docker.ozone-runner.version} # set at build-time from Maven property
+  local runner_version=${OZONE_RUNNER_VERSION:-${default_version}} # may be specified by user running the test
+  local runner_image=${OZONE_RUNNER_IMAGE:-apache/ozone-runner} # may be specified by user running the test
+  local v=${1:-${runner_version}} # prefer explicit argument
+
+  echo "${runner_image}:${v}"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1375,6 +1375,7 @@
               <nonFilteredFileExtension>swp</nonFilteredFileExtension>
               <nonFilteredFileExtension>woff</nonFilteredFileExtension>
               <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
+              <nonFilteredFileExtension>robot</nonFilteredFileExtension>
             </nonFilteredFileExtensions>
           </configuration>
         </plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Similar to [HDDS-11105](https://issues.apache.org/jira/browse/HDDS-11105), generate report for Robot tests by running rebot in ozone-runner container. This reduces the number of dependencies that have to be installed locally for running tests in Kubernetes environment. Please take a look, thanks!


## What is the link to the Apache JIRA
[HDDS-12099](https://issues.apache.org/jira/browse/HDDS-12099)

## How was this patch tested?
It can be tested by CI (downloading artifacts)
https://github.com/chiacyu/ozone/actions/runs/12976631919