### PR TITLE
HDDS-12140. Replace leftover rebot in k8s/examples/test-all.sh

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/test-all.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/test-all.sh
@@ -22,6 +22,8 @@ set -u -o pipefail
 #
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 
+source "${SCRIPT_DIR}/testlib.sh"
+
 ALL_RESULT_DIR="$SCRIPT_DIR/result"
 rm "$ALL_RESULT_DIR"/* || true
 mkdir -p "$ALL_RESULT_DIR"
@@ -51,6 +53,6 @@ for test in $(find "$SCRIPT_DIR" -name test.sh | grep "${OZONE_TEST_SELECTOR:-""
   fi
 done
 
-rebot -N "smoketests" -d "$ALL_RESULT_DIR/" "$ALL_RESULT_DIR/*.xml"
+run_rebot "$ALL_RESULT_DIR" "$ALL_RESULT_DIR" "-N smoketests *.xml"
 
 exit ${RESULT}

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -170,7 +170,7 @@ execute_robot_test() {
 combine_reports() {
   if [[ -d result ]]; then
     rm -f result/output.xml
-    run_rebot result result -o output.xml -N "$(basename "$(pwd)")" result/*.xml
+    run_rebot result result "-o output.xml -N '$(basename $(pwd))' *.xml"
   fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12099 missed one usage of `rebot` which should also be run in Docker.

https://issues.apache.org/jira/browse/HDDS-12140

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12984942205/job/36209435256

Verified contents of artifact:
https://github.com/adoroszlai/ozone/actions/runs/12984942205/artifacts/2489253879