### PR TITLE
HDDS-12010. Refactor check for running service in ozone repair

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.repair;
 
+import jakarta.annotation.Nullable;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import picocli.CommandLine;
 
@@ -45,33 +46,55 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   /** Hook method for subclasses for performing actual repair task. */
   protected abstract void execute() throws Exception;
 
+  /** Which Ozone component should be verified to be offline. */
+  @Nullable
+  protected Component serviceToBeOffline() {
+    return null;
+  }
+
   @Override
   public final Void call() throws Exception {
     if (!dryRun) {
       confirmUser();
     }
-    execute();
+    if (isServiceStateOK()) {
+      execute();
+    }
     return null;
   }
 
-  protected boolean checkIfServiceIsRunning(String serviceName) {
-    String runningEnvVar = String.format("OZONE_%s_RUNNING", serviceName);
-    String pidEnvVar = String.format("OZONE_%s_PID", serviceName);
-    String isServiceRunning = System.getenv(runningEnvVar);
-    String servicePid = System.getenv(pidEnvVar);
-    if ("true".equals(isServiceRunning)) {
-      if (!force) {
-        error("Error: %s is currently running on this host with PID %s. " +
-            "Stop the service before running the repair tool.", serviceName, servicePid);
-        return true;
-      } else {
-        info("Warning: --force flag used. Proceeding despite %s being detected as running with PID %s.",
-            serviceName, servicePid);
-      }
-    } else {
-      info("No running %s service detected. Proceeding with repair.", serviceName);
+  private boolean isServiceStateOK() {
+    final Component service = serviceToBeOffline();
+
+    if (service == null) {
+      return true; // online tool
     }
+
+    if (!isServiceRunning(service)) {
+      info("No running %s service detected. Proceeding with repair.", service);
+      return true;
+    }
+
+    String servicePid = getServicePid(service);
+
+    if (force) {
+      info("Warning: --force flag used. Proceeding despite %s being detected as running with PID %s.",
+          service, servicePid);
+      return true;
+    }
+
+    error("Error: %s is currently running on this host with PID %s. " +
+        "Stop the service before running the repair tool.", service, servicePid);
+
     return false;
+  }
+
+  private static String getServicePid(Component service) {
+    return System.getenv(String.format("OZONE_%s_PID", service));
+  }
+
+  private static boolean isServiceRunning(Component service) {
+    return "true".equals(System.getenv(String.format("OZONE_%s_RUNNING", service)));
   }
 
   protected boolean isDryRun() {
@@ -116,5 +139,12 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
     return new Scanner(System.in, StandardCharsets.UTF_8.name())
         .nextLine()
         .trim();
+  }
+
+  /** Ozone component for offline tools. */
+  protected enum Component {
+    DATANODE,
+    OM,
+    SCM,
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.repair.om;
 
+import jakarta.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -97,11 +98,14 @@ public class FSORepairTool extends RepairTool {
       description = "Verbose output. Show all intermediate steps.")
   private boolean verbose;
 
+  @Nonnull
+  @Override
+  protected Component serviceToBeOffline() {
+    return Component.OM;
+  }
+
   @Override
   public void execute() throws Exception {
-    if (checkIfServiceIsRunning("OM")) {
-      return;
-    }
     try {
       Impl repairTool = new Impl();
       repairTool.run();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.repair.om;
 
+import jakarta.annotation.Nonnull;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
@@ -76,11 +77,14 @@ public class SnapshotChainRepair extends RepairTool {
       description = "Path previous snapshotId to set for the given snapshot")
   private UUID pathPreviousSnapshotId;
 
+  @Nonnull
+  @Override
+  protected Component serviceToBeOffline() {
+    return Component.OM;
+  }
+
   @Override
   public void execute() throws Exception {
-    if (checkIfServiceIsRunning("OM")) {
-      return;
-    }
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
     List<ColumnFamilyDescriptor> cfDescList = RocksDBUtils.getColumnFamilyDescriptors(dbPath);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/RecoverSCMCertificate.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/scm/cert/RecoverSCMCertificate.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.repair.scm.cert;
 
+import jakarta.annotation.Nonnull;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
@@ -71,11 +72,14 @@ public class RecoverSCMCertificate extends RepairTool {
       description = "SCM DB Path")
   private String dbPath;
 
+  @Nonnull
+  @Override
+  protected Component serviceToBeOffline() {
+    return Component.SCM;
+  }
+
   @Override
   public void execute() throws Exception {
-    if (checkIfServiceIsRunning("SCM")) {
-      return;
-    }
     dbPath = removeTrailingSlashIfNeeded(dbPath);
     String tableName = VALID_SCM_CERTS.getName();
     DBDefinition dbDefinition =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Offline repair tools check if Ozone service, e.g. OM is running.  This PR centralizes the check, so that tools only need to declare which service they apply to.

https://issues.apache.org/jira/browse/HDDS-12010

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/12986816805

@sarvekshayr @Tejaskriya 