### PR TITLE
HDDS-12073. Don't show Source Bucket and Volume if null in DU metadata

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duMetadata/duMetadata.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duMetadata/duMetadata.tsx
@@ -137,8 +137,7 @@ const DUMetadata: React.FC<MetadataProps> = ({
      */
     const selectedInfoKeys = [
       'bucketName', 'bucketLayout', 'encInfo', 'fileName', 'keyName',
-      'name', 'owner', 'sourceBucket', 'sourceVolume', 'storageType',
-      'usedNamespace', 'volumeName', 'volume'
+      'name', 'owner', 'storageType', 'usedNamespace', 'volumeName', 'volume'
     ] as const;
     const objectInfo: ObjectInfo = summaryResponse.objectInfo ?? {};
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duMetadata/duMetadata.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duMetadata/duMetadata.tsx
@@ -155,6 +155,22 @@ const DUMetadata: React.FC<MetadataProps> = ({
       }
     });
 
+    // Source Volume and Source Bucket are present for linked buckets and volumes.
+    // If it is not linked it will be null and should not be shown
+    if (objectInfo?.sourceBucket !== undefined && objectInfo?.sourceBucket !== null) {
+      data.push({
+        key: 'Source Bucket',
+        value: objectInfo.sourceBucket
+      });
+    }
+
+    if(objectInfo?.sourceVolume !== undefined && objectInfo?.sourceVolume !== null) {
+      data.push({
+        key: 'Source Volume',
+        value: objectInfo.sourceVolume
+      });
+    }
+
     if (objectInfo?.creationTime !== undefined && objectInfo?.creationTime !== -1) {
       data.push({
         key: 'Creation Time',


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12073. Don't show Source Bucket and Volume if null in DU metadata

Please describe your PR in detail:
* Disk Usage metadata table provides us with two fields Source Bucket and Source Volume which are populated for a linked Bucket and Volume respectively.
* However for a non-linked bucket/volume this field will be null and it shows up as empty fields in the UI. This should not happen and we should not show the fields if it is empty.
* This PR addresses this issue by adding extra checks for null values in this scenario.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12073

## How was this patch tested?
Patch was tested manually.
Created a base volume and bucket as `/src-vol/src-buck`
Created a linked bucket from `src-buck`

Base Bucket metadata
<img width="1497" alt="Screenshot 2025-02-03 at 11 18 04" src="https://github.com/user-attachments/assets/60b188be-7753-4e13-98bd-7bb9c7774a70" />

Linked Bucket metadata
<img width="1499" alt="Screenshot 2025-02-03 at 11 17 49" src="https://github.com/user-attachments/assets/0ac5f8b3-d561-444a-93a6-fdc998bf7c2b" />