### PR TITLE
HDDS-11125. Sanitize tag variable to prevent log injection

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/HddsConfServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/HddsConfServlet.java
@@ -164,6 +164,7 @@ public class HddsConfServlet extends HttpServlet {
           propMap.put(tag, properties);
         } else {
           if (LOG.isDebugEnabled()) {
+            tag = tag.replaceAll("[\n\r]", "_");
             LOG.debug("Not a valid tag {}", tag);
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `tag` variable can cause log injection because it does not sanitize untrusted data used for logging.
An attacker can forge log content to prevent an organization from being able to trace back malicious activities.

This change prevents it by altering carriage return (CR) and line feed (LF) characters if any.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11125
## How was this patch tested?
N/A
