### PR TITLE
HDDS-12152. Stop testing with Hadoop 3.1.2

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -25,9 +25,8 @@ export COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml}":../common/${extra_com
 : ${HADOOP_TEST_IMAGES:=""}
 
 if [[ -z "${HADOOP_TEST_IMAGES}" ]]; then
-  # hadoop2 and flokkr images are only available from Docker Hub
+  # hadoop2 image is only available from Docker Hub
   HADOOP_TEST_IMAGES="${HADOOP_TEST_IMAGES} apache/hadoop:${hadoop2.version}"
-  HADOOP_TEST_IMAGES="${HADOOP_TEST_IMAGES} flokkr/hadoop:3.1.2"
   HADOOP_TEST_IMAGES="${HADOOP_TEST_IMAGES} ${HADOOP_IMAGE}:${hadoop.version}"
 fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove Hadoop 3.1.2 from acceptance test matrix.  Only test with 2.10.2 and 3.4.1.

https://issues.apache.org/jira/browse/HDDS-12152

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13025669367/job/36334632022