### PR TITLE
HDDS-12040. "ozone freon cr" does not work

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -240,21 +240,7 @@ public final class ReplicationSupervisor {
       return;
     }
 
-    if (requestCounter.get(task.getMetricName()) == null) {
-      synchronized (this) {
-        if (requestCounter.get(task.getMetricName()) == null) {
-          requestCounter.put(task.getMetricName(), new AtomicLong(0));
-          successCounter.put(task.getMetricName(), new AtomicLong(0));
-          failureCounter.put(task.getMetricName(), new AtomicLong(0));
-          timeoutCounter.put(task.getMetricName(), new AtomicLong(0));
-          skippedCounter.put(task.getMetricName(), new AtomicLong(0));
-          queuedCounter.put(task.getMetricName(), new AtomicLong(0));
-          opsLatencyMs.put(task.getMetricName(), registry.newRate(
-              task.getClass().getSimpleName() + "Ms"));
-          METRICS_MAP.put(task.getMetricName(), task.getMetricDescriptionSegment());
-        }
-      }
-    }
+    initCounters(task);
 
     if (inFlight.add(task)) {
       if (task.getPriority() != ReplicationCommandPriority.LOW) {
@@ -266,6 +252,24 @@ public final class ReplicationSupervisor {
       }
       queuedCounter.get(task.getMetricName()).incrementAndGet();
       executor.execute(new TaskRunner(task));
+    }
+  }
+
+  public void initCounters(AbstractReplicationTask task) {
+    if (requestCounter.get(task.getMetricName()) == null) {
+      synchronized (this) {
+        if (requestCounter.get(task.getMetricName()) == null) {
+          requestCounter.put(task.getMetricName(), new AtomicLong(0));
+          successCounter.put(task.getMetricName(), new AtomicLong(0));
+          failureCounter.put(task.getMetricName(), new AtomicLong(0));
+          timeoutCounter.put(task.getMetricName(), new AtomicLong(0));
+          skippedCounter.put(task.getMetricName(), new AtomicLong(0));
+          queuedCounter.put(task.getMetricName(), new AtomicLong(0));
+          opsLatencyMs.put(task.getMetricName(), registry.newRate(
+                  task.getClass().getSimpleName() + "Ms"));
+          METRICS_MAP.put(task.getMetricName(), task.getMetricDescriptionSegment());
+        }
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -266,7 +266,7 @@ public final class ReplicationSupervisor {
           skippedCounter.put(task.getMetricName(), new AtomicLong(0));
           queuedCounter.put(task.getMetricName(), new AtomicLong(0));
           opsLatencyMs.put(task.getMetricName(), registry.newRate(
-                  task.getClass().getSimpleName() + "Ms"));
+              task.getClass().getSimpleName() + "Ms"));
           METRICS_MAP.put(task.getMetricName(), task.getMetricDescriptionSegment());
         }
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -236,6 +236,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
     timer.time(() -> {
       final ReplicationTask replicationTask =
           replicationTasks.get((int) counter);
+      supervisor.initCounters(replicationTask);
       supervisor.new TaskRunner(replicationTask).run();
       return null;
     });

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerT
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;


### PR DESCRIPTION
## What changes were proposed in this pull request?
"ozone freon cr" command runs into exceptions because `requestCounter` map in `ReplicationSupervisor` class is not initiated during the following reproducing steps. `addTask` method in the class is supposed to initiate it but it is not called, so I extracted that part into a new method called `initCounters` and call this new method before running the task.

How to reproduce the error:
```
// create a key
ozone freon ockg -n 10
// close a container
ozone admin container close 1
// run the command
ozone freon cr -n 1
```

Also this PR handles the followings to make it work:

- ClosedContainerReplicator needs update for [HDDS-10804](https://issues.apache.org/jira/browse/HDDS-10804)
- It needs DB volumes with directories.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12040

## How was this patch tested?
Manually tested