### PR TITLE
HDDS-12162. Log available space of HddsVolume and DbVolume upon Datanode startup

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/SpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/SpaceUsageSource.java
@@ -82,5 +82,10 @@ public interface SpaceUsageSource {
     public SpaceUsageSource snapshot() {
       return this; // immutable
     }
+
+    @Override
+    public String toString() {
+      return "capacity=" + capacity + ", used=" + used + ", available=" + available;
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
@@ -57,9 +57,9 @@ public class DbVolume extends StorageVolume {
 
     this.hddsDbStorePathMap = new HashMap<>();
     if (!b.getFailedVolume() && getVolumeInfo().isPresent()) {
-      LOG.info("Creating DbVolume: {} of storage type : {} capacity : {}",
+      LOG.info("Creating DbVolume: {} of storage type: {}, {}",
               getStorageDir(), b.getStorageType(),
-              getVolumeInfo().get().getCapacity());
+              getCurrentUsage());
 
       initialize();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -131,11 +131,10 @@ public class HddsVolume extends StorageVolume {
       this.volumeInfoMetrics =
           new VolumeInfoMetrics(b.getVolumeRootStr(), this);
 
-      LOG.info("Creating HddsVolume: {} of storage type: {}, capacity: {}, available: {}",
+      LOG.info("Creating HddsVolume: {} of storage type: {}, {}",
           getStorageDir(),
           b.getStorageType(),
-          getVolumeInfo().get().getCapacity(),
-          getVolumeInfo().get().getAvailable());
+          getCurrentUsage());
 
       initialize();
     } else {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -131,9 +131,11 @@ public class HddsVolume extends StorageVolume {
       this.volumeInfoMetrics =
           new VolumeInfoMetrics(b.getVolumeRootStr(), this);
 
-      LOG.info("Creating HddsVolume: {} of storage type : {} capacity : {}",
-          getStorageDir(), b.getStorageType(),
-              getVolumeInfo().get().getCapacity());
+      LOG.info("Creating HddsVolume: {} of storage type: {}, capacity: {}, available: {}",
+          getStorageDir(),
+          b.getStorageType(),
+          getVolumeInfo().get().getCapacity(),
+          getVolumeInfo().get().getAvailable());
 
       initialize();
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This aims to provide slightly more info to identify issues like completely full volumes.

Related: [HDDS-12151](https://issues.apache.org/jira/browse/HDDS-12151) and [HDDS-12150](https://issues.apache.org/jira/browse/HDDS-12150).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12162

## How was this patch tested?

- Verified in the test output that available (and used) space is now printed. e.g.:

- `TestHddsVolume#testOverUsedReservedSpace`:
```
2025-01-29 15:35:02,159 [main] INFO  volume.HddsVolume (HddsVolume.java:<init>(134)) - Creating HddsVolume: /var/folders/ns/ls79bcr17wg7r__2j8lqkz6m0000gn/T/junit-8615142427860431562/hdds of storage type: null, capacity=400, used=0, available=300
```

- `TestHddsVolume#testOverUsedHddsSpace`:
```
2025-01-29 15:35:02,388 [main] INFO  volume.HddsVolume (HddsVolume.java:<init>(134)) - Creating HddsVolume: /var/folders/ns/ls79bcr17wg7r__2j8lqkz6m0000gn/T/junit-3498499940805584038/hdds of storage type: null, capacity=400, used=450, available=0
```