### PR TITLE
HDDS-12085. Add manual refresh button for DU page.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duBreadcrumbNav/duBreadcrumbNav.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/duBreadcrumbNav/duBreadcrumbNav.tsx
@@ -164,10 +164,10 @@ const DUBreadcrumbNav: React.FC<File> = ({
   return (
     <div id='breadcrumb-container'>
       <Breadcrumb
-      separator={'/'}
-      className='breadcrumb-nav'>
-      {generateBreadCrumbs()}
-    </Breadcrumb>
+        separator={'/'}
+        className='breadcrumb-nav'>
+          {generateBreadCrumbs()}
+      </Breadcrumb>
     </div>
   )
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/plots/duPieChart.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/plots/duPieChart.tsx
@@ -203,7 +203,7 @@ const DUPieChart: React.FC<PieChartProps> = ({
     <EChart
       loading={loading}
       option={eChartsOptions}
-      style={{ flex: '0 1 90%', height: '50vh' }}
+      style={{ flex: '1 3 80%', height: '50vh' }}
       eventHandler={{name: 'legendselectchanged', handler: handleLegendChange}}/>
   );
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.less
@@ -35,6 +35,7 @@
     margin-bottom: 10px;
     width: 83vw;
     height: 20%;
+    flex: 0.98;
 
     .breadcrumb-nav {
       font-size: 0.9vw;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.tsx
@@ -19,7 +19,7 @@
 import React, { useRef, useState } from 'react';
 import { AxiosError } from 'axios';
 import {
-  Alert, Button
+  Alert, Button, Tooltip
 } from 'antd';
 import {
   InfoCircleFilled, ReloadOutlined,
@@ -122,9 +122,13 @@ const DiskUsage: React.FC<{}> = () => {
               path={duResponse.path}
               subPaths={duResponse.subPaths}
               updateHandler={loadData} />
-            <Button
-              icon={<ReloadOutlined />}
-              onClick={() => loadData(duResponse.path)} />
+            <Tooltip
+              title="Click to reload Disk Usage data">
+              <Button
+                type='primary'
+                icon={<ReloadOutlined />}
+                onClick={() => loadData(duResponse.path)} />
+            </Tooltip>
           </div>
           <div className='du-table-header-section'>
             <SingleSelect

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.tsx
@@ -19,10 +19,10 @@
 import React, { useRef, useState } from 'react';
 import { AxiosError } from 'axios';
 import {
-  Alert
+  Alert, Button
 } from 'antd';
 import {
-  InfoCircleFilled
+  InfoCircleFilled, ReloadOutlined,
 } from '@ant-design/icons';
 import { ValueType } from 'react-select';
 
@@ -113,10 +113,19 @@ const DiskUsage: React.FC<{}> = () => {
           showIcon={true}
           closable={false} />
         <div className='content-div'>
-          <DUBreadcrumbNav
-            path={duResponse.path}
-            subPaths={duResponse.subPaths}
-            updateHandler={loadData} />
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}>
+            <DUBreadcrumbNav
+              path={duResponse.path}
+              subPaths={duResponse.subPaths}
+              updateHandler={loadData} />
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => loadData(duResponse.path)} />
+          </div>
           <div className='du-table-header-section'>
             <SingleSelect
               options={LIMIT_OPTIONS}


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12085. Add manual refresh button for DU page.

Please describe your PR in detail:
* Currently the V2 UI doesn't have a refresh button to reload new data that might get added, the whole page needs to be refreshed.
* This PR introduces the refresh button to load the data which was present in v1 UI.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12085

## How was this patch tested?
Patch was tested manually
<img width="1728" alt="Screenshot 2025-01-29 at 16 26 45" src="https://github.com/user-attachments/assets/1db44ecb-02bd-415b-a470-86566ed6595a" />
<img width="1725" alt="Screenshot 2025-01-29 at 16 16 22" src="https://github.com/user-attachments/assets/962b5591-b423-4e0b-84e7-e6273c8d0630" />
