### PR TITLE
HDDS-12142. Save logs from build and compile checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,13 @@ jobs:
         run: hadoop-ozone/dev-support/checks/build.sh -Pdist -Psrc -Dmaven.javadoc.skip=true ${{ inputs.ratis_args }}
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: Archive build results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ github.job }}
+          path: target/${{ github.job }}
+        continue-on-error: true
       - name: Store binaries for tests
         uses: actions/upload-artifact@v4
         with:
@@ -227,10 +234,17 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Compile Ozone using Java ${{ matrix.java }}
-        run: hadoop-ozone/dev-support/checks/build.sh -Pdist -DskipRecon -Dmaven.javadoc.failOnWarnings=${{ matrix.java != 8 }} -Djavac.version=${{ matrix.java }} ${{ inputs.ratis_args }}
+        run: hadoop-ozone/dev-support/checks/compile.sh -Pdist -DskipRecon -Dmaven.javadoc.failOnWarnings=${{ matrix.java != 8 }} -Djavac.version=${{ matrix.java }} ${{ inputs.ratis_args }}
         env:
           OZONE_WITH_COVERAGE: false
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: Archive build results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ github.job }}-${{ matrix.java }}
+          path: target/${{ github.job }}
+        continue-on-error: true
   basic:
     needs:
       - build-info

--- a/hadoop-ozone/dev-support/checks/_build.sh
+++ b/hadoop-ozone/dev-support/checks/_build.sh
@@ -13,10 +13,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -u -o pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
+: ${CHECK:="build"}
+: ${ERROR_PATTERN:="\[ERROR\]"}
 : ${OZONE_WITH_COVERAGE:="false"}
+
+BASE_DIR="$(pwd -P)"
+REPORT_DIR=${OUTPUT_DIR:-"${BASE_DIR}/target/${CHECK}"}
+REPORT_FILE="$REPORT_DIR/summary.txt"
 
 MAVEN_OPTIONS='-V -B -DskipTests -DskipDocs --no-transfer-progress'
 
@@ -27,5 +36,10 @@ else
 fi
 
 export MAVEN_OPTS="-Xmx4096m ${MAVEN_OPTS:-}"
-mvn ${MAVEN_OPTIONS} clean "$@"
+mvn ${MAVEN_OPTIONS} clean "$@" | tee output.log
 rc=$?
+
+mkdir -p "$REPORT_DIR" # after `mvn clean`
+mv output.log "$REPORT_DIR"/
+
+source "${DIR}/_post_process.sh"

--- a/hadoop-ozone/dev-support/checks/compile.sh
+++ b/hadoop-ozone/dev-support/checks/compile.sh
@@ -18,4 +18,6 @@ set -u -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-source "${DIR}"/_build.sh install "$@"
+CHECK=compile
+
+source "${DIR}"/_build.sh verify "$@"

--- a/hadoop-ozone/dev-support/checks/repro.sh
+++ b/hadoop-ozone/dev-support/checks/repro.sh
@@ -19,19 +19,8 @@
 set -u -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "$DIR/../../.." || exit 1
 
-BASE_DIR="$(pwd -P)"
-REPORT_DIR=${OUTPUT_DIR:-"${BASE_DIR}/target/repro"}
+CHECK=repro
+ERROR_PATTERN='ERROR.*mismatch'
 
-rc=0
-source "${DIR}"/_build.sh verify artifact:compare "$@" | tee output.log
-
-mkdir -p "$REPORT_DIR"
-mv output.log "$REPORT_DIR"/
-
-REPORT_FILE="$REPORT_DIR/summary.txt"
-grep 'ERROR.*mismatch' "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
-
-ERROR_PATTERN="\[ERROR\]"
-source "${DIR}/_post_process.sh"
+source "${DIR}"/_build.sh verify artifact:compare "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logs of most checks are uploaded as artifacts at the end, but logs of `build` and `compile` checks are only visible in GitHub UI.

(Most of this is extracted from #7497.)

https://issues.apache.org/jira/browse/HDDS-12142

## How was this patch tested?

Downloaded artifacts from CI:
https://github.com/adoroszlai/ozone/actions/runs/13051118776

```
$ unzip -t build.zip 
Archive:  build.zip
    testing: failures                 OK
    testing: output.log               OK
No errors detected in compressed data of build.zip.

$ unzip -t compile-11.zip 
Archive:  compile-11.zip
    testing: failures                 OK
    testing: output.log               OK
No errors detected in compressed data of compile-11.zip.
```
