### PR TITLE
HDDS-12165. Refactor VolumeInfoMetrics to use getCurrentUsage

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -18,11 +18,18 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
+import org.apache.hadoop.hdds.fs.SpaceUsageSource;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.ozone.OzoneConsts;
 
 
@@ -31,20 +38,37 @@ import org.apache.hadoop.ozone.OzoneConsts;
  */
 @Metrics(about = "Ozone Volume Information Metrics",
     context = OzoneConsts.OZONE)
-public class VolumeInfoMetrics {
+public class VolumeInfoMetrics implements MetricsSource {
 
-  private String metricsSourceName = VolumeInfoMetrics.class.getSimpleName();
+  private static final String SOURCE_BASENAME =
+      VolumeInfoMetrics.class.getSimpleName();
+
+  private static final MetricsInfo CAPACITY =
+      Interns.info("Capacity", "Capacity");
+  private static final MetricsInfo AVAILABLE =
+      Interns.info("Available", "Available Space");
+  private static final MetricsInfo USED =
+      Interns.info("Used", "Used Space");
+  private static final MetricsInfo RESERVED =
+      Interns.info("Reserved", "Reserved Space");
+  private static final MetricsInfo TOTAL_CAPACITY =
+      Interns.info("TotalCapacity", "Total Capacity");
+
+  private final MetricsRegistry registry;
+  private final String metricsSourceName;
   private final HddsVolume volume;
   @Metric("Returns the RocksDB compact times of the Volume")
   private MutableRate dbCompactLatency;
-  private long containers;
 
   /**
    * @param identifier Typically, path to volume root. E.g. /data/hdds
    */
-  public VolumeInfoMetrics(String identifier, HddsVolume ref) {
-    this.metricsSourceName += '-' + identifier;
-    this.volume = ref;
+  public VolumeInfoMetrics(String identifier, HddsVolume volume) {
+    this.volume = volume;
+
+    metricsSourceName = SOURCE_BASENAME + '-' + identifier;
+    registry = new MetricsRegistry(metricsSourceName);
+
     init();
   }
 
@@ -88,63 +112,6 @@ public class VolumeInfoMetrics {
     return volume.getType().name();
   }
 
-  public String getMetricsSourceName() {
-    return metricsSourceName;
-  }
-
-  /**
-   * Test conservative avail space.
-   * |----used----|   (avail)   |++++++++reserved++++++++|
-   * |<------- capacity ------->|
-   * |<------------------- Total capacity -------------->|
-   * A) avail = capacity - used
-   * B) capacity = used + avail
-   * C) Total capacity = used + avail + reserved
-   */
-
-  /**
-   * Return the Storage type for the Volume.
-   */
-  @Metric("Returns the Used space")
-  public long getUsed() {
-    return volume.getVolumeInfo().map(VolumeInfo::getScmUsed)
-            .orElse(0L);
-  }
-
-  /**
-   * Return the Total Available capacity of the Volume.
-   */
-  @Metric("Returns the Available space")
-  public long getAvailable() {
-    return volume.getVolumeInfo().map(VolumeInfo::getAvailable)
-            .orElse(0L);
-  }
-
-  /**
-   * Return the Total Reserved of the Volume.
-   */
-  @Metric("Fetches the Reserved Space")
-  public long getReserved() {
-    return volume.getVolumeInfo().map(VolumeInfo::getReservedInBytes)
-            .orElse(0L);
-  }
-
-  /**
-   * Return the Total capacity of the Volume.
-   */
-  @Metric("Returns the Capacity of the Volume")
-  public long getCapacity() {
-    return getUsed() + getAvailable();
-  }
-
-  /**
-   * Return the Total capacity of the Volume.
-   */
-  @Metric("Returns the Total Capacity of the Volume")
-  public long getTotalCapacity() {
-    return (getUsed() + getAvailable() + getReserved());
-  }
-
   @Metric("Returns the Committed bytes of the Volume")
   public long getCommitted() {
     return volume.getCommittedBytes();
@@ -160,5 +127,21 @@ public class VolumeInfoMetrics {
   @Metric("Returns the Container Count of the Volume")
   public long getContainers() {
     return volume.getContainers();
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder builder = collector.addRecord(metricsSourceName);
+    registry.snapshot(builder, all);
+    volume.getVolumeInfo().ifPresent(volumeInfo -> {
+      SpaceUsageSource usage = volumeInfo.getCurrentUsage();
+      long reserved = volumeInfo.getReservedInBytes();
+      builder
+          .addGauge(CAPACITY, usage.getCapacity())
+          .addGauge(AVAILABLE, usage.getAvailable())
+          .addGauge(USED, usage.getUsedSpace())
+          .addGauge(RESERVED, reserved)
+          .addGauge(TOTAL_CAPACITY, usage.getCapacity() + reserved);
+    });
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.hdds.fs.SpaceUsagePersistence;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 
 import static org.apache.hadoop.hdds.fs.MockSpaceUsagePersistence.inMemory;
@@ -504,13 +506,9 @@ public class TestHddsVolume {
     VolumeInfoMetrics volumeInfoMetrics = volume.getVolumeInfoStats();
 
     try {
-      // In case of failed volume all stats should return 0.
-      assertEquals(0, volumeInfoMetrics.getUsed());
-      assertEquals(0, volumeInfoMetrics.getAvailable());
-      assertEquals(0, volumeInfoMetrics.getCapacity());
-      assertEquals(0, volumeInfoMetrics.getReserved());
-      assertEquals(0, volumeInfoMetrics.getTotalCapacity());
-      assertEquals(0, volumeInfoMetrics.getCommitted());
+      // In case of failed volume, metrics should not throw
+      MetricsCollector collector = new MetricsCollectorImpl();
+      volumeInfoMetrics.getMetrics(collector, true);
     } finally {
       // Shutdown the volume.
       volume.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Refactor `VolumeInfoMetrics` to fetch volume usage with a single call, instead of getting individual values separately.
2. Fix wrong `Capacity` and `TotalCapacity`.  `Used + Available != Capacity`, because `Used` only includes the space used by the HDDS data dir.  `Capacity` is already queried from the filesystem, so we should display that.

https://issues.apache.org/jira/browse/HDDS-12165

## How was this patch tested?

Started `ozone` compose cluster, created keys using Freon.

Checked Datanode web UI, verified that volume info is present.

Before:

![before](https://github.com/user-attachments/assets/80324d9d-2b8f-492d-a31b-017aee44c041)

After:

![after](https://github.com/user-attachments/assets/105ec394-ec46-473d-bb57-b4578694d8ad)

Checked metrics in JMX endpoint, verified that metrics keys are the same as before.  Values are similar, except capacity, which is correct with the patch (`TotalCapacity` matches the value reported by `df` (times 1024, since it reports 1K blocks)).

Before:

```
{
  "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds",
  "modelerType" : "VolumeInfoMetrics-/data/hdds",
  "tag.Context" : "ozone",
  "tag.StorageType" : "DISK",
  "tag.DatanodeUuid" : "9ab8037b-59f4-4f99-b762-8a33649c6f11",
  "tag.StorageDirectory" : "/data/hdds/hdds",
  "tag.VolumeState" : "NORMAL",
  "tag.VolumeType" : "DATA_VOLUME",
  "tag.Hostname" : "0f71994a6169",
  "DbCompactLatencyNumOps" : 0,
  "DbCompactLatencyAvgTime" : 0.0,
  "TotalCapacity" : 49547334340,
  "Capacity" : 49497374720,
  "Available" : 49392513024,
  "Containers" : 1,
  "LayoutVersion" : 1,
  "Used" : 104861696,
  "Committed" : 968884224,
  "Reserved" : 49959620
}
```

After:

```
{
  "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds",
  "modelerType" : "VolumeInfoMetrics-/data/hdds",
  "tag.Context" : "ozone",
  "tag.StorageType" : "DISK",
  "tag.DatanodeUuid" : "1bbe31d4-9dd9-4fcf-93aa-fd4717876414",
  "tag.VolumeState" : "NORMAL",
  "tag.VolumeType" : "DATA_VOLUME",
  "tag.StorageDirectory" : "/data/hdds/hdds",
  "tag.Hostname" : "f1c5efee2f91",
  "DbCompactLatencyNumOps" : 0,
  "DbCompactLatencyAvgTime" : 0.0,
  "Committed" : 968884224,
  "LayoutVersion" : 1,
  "Containers" : 1,
  "Capacity" : 499546271036,
  "Available" : 49390276608,
  "Used" : 104861696,
  "Reserved" : 49959620,
  "TotalCapacity" : 499596230656
}
```
