### PR TITLE
HDDS-12163. Reduce number of individual getCapacity/getAvailable/getUsedSpace calls

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -622,12 +622,11 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         .orElse(Boolean.FALSE);
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
-      SpaceUsageSource precomputedVolumeSpace =
-          volume.getCurrentUsage();
-      long volumeCapacity = precomputedVolumeSpace.getCapacity();
+      SpaceUsageSource usage = volume.getCurrentUsage();
+      long volumeCapacity = usage.getCapacity();
       long volumeFreeSpaceToSpare =
           freeSpaceCalculator.get(volumeCapacity);
-      long volumeFree = precomputedVolumeSpace.getAvailable();
+      long volumeFree = usage.getAvailable();
       long volumeCommitted = volume.getCommittedBytes();
       long volumeAvailable = volumeFree - volumeCommitted;
       return (volumeAvailable <= volumeFreeSpaceToSpare);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.container.common.volume;
 
+import org.apache.hadoop.hdds.fs.SpaceUsageSource;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -38,8 +40,9 @@ public class AvailableSpaceFilter implements Predicate<HddsVolume> {
 
   @Override
   public boolean test(HddsVolume vol) {
-    long volumeCapacity = vol.getCapacity();
-    long free = vol.getAvailable();
+    SpaceUsageSource usage = vol.getCurrentUsage();
+    long volumeCapacity = usage.getCapacity();
+    long free = usage.getAvailable();
     long committed = vol.getCommittedBytes();
     long available = free - committed;
     long volumeFreeSpaceToSpare =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -91,9 +91,9 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
       HddsVolume firstVolume = volumesWithEnoughSpace.get(firstIndex);
       HddsVolume secondVolume = volumesWithEnoughSpace.get(secondIndex);
 
-      long firstAvailable = firstVolume.getAvailable()
+      long firstAvailable = firstVolume.getCurrentUsage().getAvailable()
           - firstVolume.getCommittedBytes();
-      long secondAvailable = secondVolume.getAvailable()
+      long secondAvailable = secondVolume.getCurrentUsage().getAvailable()
           - secondVolume.getCommittedBytes();
       return firstAvailable < secondAvailable ? secondVolume : firstVolume;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
@@ -479,9 +480,10 @@ public class MutableVolumeSet implements VolumeSet {
         if (volumeInfo.isPresent()) {
           try {
             rootDir = volumeInfo.get().getRootDir();
-            scmUsed = volumeInfo.get().getScmUsed();
-            remaining = volumeInfo.get().getAvailable();
-            capacity = volumeInfo.get().getCapacity();
+            SpaceUsageSource usage = volumeInfo.get().getCurrentUsage();
+            scmUsed = usage.getUsedSpace();
+            remaining = usage.getAvailable();
+            capacity = usage.getCapacity();
             committed = (volume instanceof HddsVolume) ?
                 ((HddsVolume) volume).getCommittedBytes() : 0;
             failed = false;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -447,23 +447,9 @@ public abstract class StorageVolume
     return volumeInfo.map(VolumeInfo::getRootDir).orElse(null);
   }
 
-  public long getCapacity() {
-    return volumeInfo.map(VolumeInfo::getCapacity).orElse(0L);
-  }
-
-  public long getAvailable() {
-    return volumeInfo.map(VolumeInfo::getAvailable).orElse(0L);
-
-  }
-
   public SpaceUsageSource getCurrentUsage() {
     return volumeInfo.map(VolumeInfo::getCurrentUsage)
         .orElse(SpaceUsageSource.UNKNOWN);
-  }
-
-  public long getUsedSpace() {
-    return volumeInfo.map(VolumeInfo::getScmUsed).orElse(0L);
-
   }
 
   public File getStorageDir() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -152,24 +152,6 @@ public final class VolumeInfo {
     usage = new VolumeUsage(checkParams, b.conf);
   }
 
-  public long getCapacity() {
-    return usage.getCapacity();
-  }
-
-  /**
-   * <pre>
-   * {@code
-   * Calculate available space use method A.
-   * |----used----|   (avail)   |++++++++reserved++++++++|
-   * |<-     capacity         ->|
-   * A) avail = capacity - used
-   * }
-   * </pre>
-   */
-  public long getAvailable() {
-    return usage.getAvailable();
-  }
-
   public SpaceUsageSource getCurrentUsage() {
     return usage.getCurrentUsage();
   }
@@ -184,10 +166,6 @@ public final class VolumeInfo {
 
   public void refreshNow() {
     usage.refreshNow();
-  }
-
-  public long getScmUsed() {
-    return usage.getUsedSpace();
   }
 
   void shutdownUsageThread() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -65,18 +65,6 @@ public class VolumeUsage {
     return source.snapshot();
   }
 
-  public long getCapacity() {
-    return getCurrentUsage().getCapacity();
-  }
-
-  public long getAvailable() {
-    return getCurrentUsage().getAvailable();
-  }
-
-  public long getUsedSpace() {
-    return getCurrentUsage().getUsedSpace();
-  }
-
   /**
    * <pre>
    * {@code

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -114,15 +114,13 @@ public class VolumeUsage {
    * so there could be that DU value > totalUsed when there are deletes.
    * @return other used space
    */
-  private static long getOtherUsed(SpaceUsageSource precomputedVolumeSpace) {
-    long totalUsed = precomputedVolumeSpace.getCapacity() -
-        precomputedVolumeSpace.getAvailable();
-    return Math.max(totalUsed - precomputedVolumeSpace.getUsedSpace(), 0L);
+  private static long getOtherUsed(SpaceUsageSource usage) {
+    long totalUsed = usage.getCapacity() - usage.getAvailable();
+    return Math.max(totalUsed - usage.getUsedSpace(), 0L);
   }
 
-  private long getRemainingReserved(
-      SpaceUsageSource precomputedVolumeSpace) {
-    return Math.max(reservedInBytes - getOtherUsed(precomputedVolumeSpace), 0L);
+  private long getRemainingReserved(SpaceUsageSource usage) {
+    return Math.max(reservedInBytes - getOtherUsed(usage), 0L);
   }
 
   public synchronized void start() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -104,9 +104,9 @@ public class TestCapacityVolumeChoosingPolicy {
     HddsVolume hddsVolume2 = volumes.get(1);
     HddsVolume hddsVolume3 = volumes.get(2);
 
-    assertEquals(100L, hddsVolume1.getAvailable());
-    assertEquals(200L, hddsVolume2.getAvailable());
-    assertEquals(300L, hddsVolume3.getAvailable());
+    assertEquals(100L, hddsVolume1.getCurrentUsage().getAvailable());
+    assertEquals(200L, hddsVolume2.getCurrentUsage().getAvailable());
+    assertEquals(300L, hddsVolume3.getCurrentUsage().getAvailable());
 
     Map<HddsVolume, Integer> chooseCount = new HashMap<>();
     chooseCount.put(hddsVolume1, 0);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -248,7 +248,7 @@ public class TestHddsVolume {
     HddsVolume volume = volumeBuilder.build();
 
     assertEquals(initialUsedSpace, savedUsedSpace.get());
-    assertEquals(expectedUsedSpace, volume.getUsedSpace());
+    assertEquals(expectedUsedSpace, volume.getCurrentUsage().getUsedSpace());
 
     // Shutdown the volume.
     volume.shutdown();
@@ -264,10 +264,12 @@ public class TestHddsVolume {
     StorageSize size = StorageSize.parse(RESERVED_SPACE);
     long reservedSpaceInBytes = (long) size.getUnit().toBytes(size.getValue());
 
+    SpaceUsageSource reportedUsage = volume.getCurrentUsage();
+
     assertEquals(spaceUsage.getCapacity(),
-        volume.getCapacity() + reservedSpaceInBytes);
+        reportedUsage.getCapacity() + reservedSpaceInBytes);
     assertEquals(spaceUsage.getAvailable(),
-        volume.getAvailable() + reservedSpaceInBytes);
+        reportedUsage.getAvailable() + reservedSpaceInBytes);
   }
 
   /**
@@ -300,8 +302,9 @@ public class TestHddsVolume {
 
     HddsVolume volume = volumeBuilder.build();
 
-    assertEquals(400, volume.getCapacity());
-    assertEquals(100, volume.getAvailable());
+    SpaceUsageSource usage = volume.getCurrentUsage();
+    assertEquals(400, usage.getCapacity());
+    assertEquals(100, usage.getAvailable());
 
     // Shutdown the volume.
     volume.shutdown();
@@ -327,8 +330,9 @@ public class TestHddsVolume {
 
     HddsVolume volume = volumeBuilder.build();
 
-    assertEquals(400, volume.getCapacity());
-    assertEquals(190, volume.getAvailable());
+    SpaceUsageSource usage = volume.getCurrentUsage();
+    assertEquals(400, usage.getCapacity());
+    assertEquals(190, usage.getAvailable());
 
     // Shutdown the volume.
     volume.shutdown();
@@ -353,8 +357,9 @@ public class TestHddsVolume {
 
     HddsVolume volume = volumeBuilder.build();
 
-    assertEquals(400, volume.getCapacity());
-    assertEquals(300, volume.getAvailable());
+    SpaceUsageSource usage = volume.getCurrentUsage();
+    assertEquals(400, usage.getCapacity());
+    assertEquals(300, usage.getAvailable());
 
     // Shutdown the volume.
     volume.shutdown();
@@ -379,8 +384,9 @@ public class TestHddsVolume {
 
     HddsVolume volume = volumeBuilder.build();
 
-    assertEquals(400, volume.getCapacity());
-    assertEquals(0, volume.getAvailable());
+    SpaceUsageSource usage = volume.getCurrentUsage();
+    assertEquals(400, usage.getCapacity());
+    assertEquals(0, usage.getAvailable());
 
     // Shutdown the volume.
     volume.shutdown();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
@@ -70,7 +70,7 @@ public class TestReservedVolumeSpace {
 
     // Gets the total capacity reported by Ozone, which may be limited to less than the volume's real capacity by the
     // DU reserved configurations.
-    long volumeCapacity = hddsVolume.getCapacity();
+    long volumeCapacity = hddsVolume.getCurrentUsage().getCapacity();
     VolumeUsage usage = hddsVolume.getVolumeInfo().get().getUsageForTesting();
 
     // Gets the actual total capacity without accounting for DU reserved space configurations.
@@ -94,7 +94,7 @@ public class TestReservedVolumeSpace {
     float percentage = conf.getFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT,
         HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT);
 
-    long volumeCapacity = hddsVolume.getCapacity();
+    long volumeCapacity = hddsVolume.getCurrentUsage().getCapacity();
     VolumeUsage usage = hddsVolume.getVolumeInfo().get().getUsageForTesting();
 
     //Gets the actual total capacity

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -93,8 +93,8 @@ public class TestRoundRobinVolumeChoosingPolicy {
     HddsVolume hddsVolume1 = volumes.get(0);
     HddsVolume hddsVolume2 = volumes.get(1);
 
-    assertEquals(100L, hddsVolume1.getAvailable());
-    assertEquals(200L, hddsVolume2.getAvailable());
+    assertEquals(100L, hddsVolume1.getCurrentUsage().getAvailable());
+    assertEquals(200L, hddsVolume2.getCurrentUsage().getAvailable());
 
     // Test two rounds of round-robin choosing
     assertEquals(hddsVolume1, policy.chooseVolume(volumes, 0));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -220,7 +220,7 @@ public class TestVolumeSet {
     for (StorageVolume volume : volumesList) {
       assertNotNull(volume.getVolumeInfo().get()
               .getUsageForTesting());
-      volume.getAvailable();
+      volume.getCurrentUsage();
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -234,7 +234,7 @@ public class TestOzoneContainer {
       volume.format(clusterId);
 
       // eat up all available space except size of 1 container
-      volume.incCommittedBytes(volume.getAvailable() - containerSize);
+      volume.incCommittedBytes(volume.getCurrentUsage().getAvailable() - containerSize);
       // eat up 10 bytes more, now available space is less than 1 container
       volume.incCommittedBytes(10);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce the number of separate `getAvailable`, `getCapacity()`, `getScmUsed()` calls.  Instead, use `getCurrentUsage()` to fetch all 3 values together.  Goals:
- reduce number of lock acquisitions when reaching `CachingSpaceUsageSource` and provide consistent view of the 3 values
- reduce duplication, e.g. `volumeInfo.map(VolumeInfo::get...).orElse(...)`
- reduce the interface exposed by various volume-related classes

https://issues.apache.org/jira/browse/HDDS-12163

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13086838004
