### PR TITLE
HDDS-12183. Reuse cluster across safe test classes

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/TestOzoneContractFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/TestOzoneContractFSO.java
@@ -30,8 +30,8 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMI
 class TestOzoneContractFSO extends AbstractOzoneContractTest {
 
   @Override
-  OzoneConfiguration createOzoneConfig() {
-    OzoneConfiguration conf = createBaseConfiguration();
+  protected OzoneConfiguration createOzoneConfig() {
+    OzoneConfiguration conf = super.createOzoneConfig();
     conf.set(OZONE_DEFAULT_BUCKET_LAYOUT, FILE_SYSTEM_OPTIMIZED.name());
     return conf;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/TestOzoneContractLegacy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/TestOzoneContractLegacy.java
@@ -30,8 +30,8 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.LEGACY;
 class TestOzoneContractLegacy extends AbstractOzoneContractTest {
 
   @Override
-  OzoneConfiguration createOzoneConfig() {
-    OzoneConfiguration conf = createBaseConfiguration();
+  protected OzoneConfiguration createOzoneConfig() {
+    OzoneConfiguration conf = super.createOzoneConfig();
     conf.set(OZONE_DEFAULT_BUCKET_LAYOUT, LEGACY.name());
     return conf;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestAllocateContainer.java
@@ -21,43 +21,37 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 /**
  * Test allocate container calls.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestAllocateContainer {
+public abstract class TestAllocateContainer implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static StorageContainerLocationProtocolClientSideTranslatorPB
+  private OzoneConfiguration conf;
+  private StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static XceiverClientManager xceiverClientManager;
 
   @BeforeAll
-  public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
-    cluster.waitForClusterToBeReady();
+  void init() throws Exception {
+    conf = cluster().getConf();
     storageContainerLocationClient =
-        cluster.getStorageContainerLocationClient();
-    xceiverClientManager = new XceiverClientManager(conf);
+        cluster().getStorageContainerLocationClient();
   }
 
   @AfterAll
-  public static void shutdown() throws InterruptedException {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+  void cleanup() {
     IOUtils.cleanupWithLogger(null, storageContainerLocationClient);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerReportWithKeys.java
@@ -21,32 +21,27 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.container.common.impl.ContainerData;
-import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,40 +50,23 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * This class tests container report with DN container state info.
  */
-@Timeout(value = 300, unit = TimeUnit.SECONDS)
-public class TestContainerReportWithKeys {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(300)
+public abstract class TestContainerReportWithKeys implements NonHATests.TestCase {
   private static final Logger LOG = LoggerFactory.getLogger(
       TestContainerReportWithKeys.class);
-  private static MiniOzoneCluster cluster = null;
-  private static OzoneClient client;
-  private static OzoneConfiguration conf;
-  private static StorageContainerManager scm;
+  private OzoneClient client;
+  private StorageContainerManager scm;
 
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   *
-   * @throws IOException
-   */
   @BeforeAll
-  public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
-    client = OzoneClientFactory.getRpcClient(conf);
-    scm = cluster.getStorageContainerManager();
+  void init() throws Exception {
+    client = cluster().newClient();
+    scm = cluster().getStorageContainerManager();
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test
@@ -121,7 +99,7 @@ public class TestContainerReportWithKeys {
 
 
     OmKeyLocationInfo keyInfo =
-        cluster.getOzoneManager().lookupKey(keyArgs).getKeyLocationVersions()
+        cluster().getOzoneManager().lookupKey(keyArgs).getKeyLocationVersions()
             .get(0).getBlocksLatestVersionOnly().get(0);
 
 
@@ -137,13 +115,4 @@ public class TestContainerReportWithKeys {
         cinfo.getNumberOfKeys(), cinfo.getUsedBytes());
   }
 
-
-  private static ContainerData getContainerData(long containerID) {
-    ContainerData containerData;
-    ContainerSet containerManager = cluster.getHddsDatanodes().get(0)
-        .getDatanodeStateMachine().getContainer().getContainerSet();
-    containerData =
-        containerManager.getContainer(containerID).getContainerData();
-    return containerData;
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -26,18 +26,18 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
-import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementCapacity;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,34 +53,26 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Test Container calls.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestGetCommittedBlockLengthAndPutKey {
+public abstract class TestGetCommittedBlockLengthAndPutKey implements NonHATests.TestCase {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestGetCommittedBlockLengthAndPutKey.class);
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration ozoneConfig;
-  private static StorageContainerLocationProtocolClientSideTranslatorPB
+  private OzoneConfiguration ozoneConfig;
+  private StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static XceiverClientManager xceiverClientManager;
+  private XceiverClientManager xceiverClientManager;
 
   @BeforeAll
-  public static void init() throws Exception {
-    ozoneConfig = new OzoneConfiguration();
-    ozoneConfig.setClass(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
-        SCMContainerPlacementCapacity.class, PlacementPolicy.class);
-    cluster =
-        MiniOzoneCluster.newBuilder(ozoneConfig).setNumDatanodes(3).build();
-    cluster.waitForClusterToBeReady();
+  void init() throws Exception {
+    ozoneConfig = cluster().getConf();
     storageContainerLocationClient =
-        cluster.getStorageContainerLocationClient();
+        cluster().getStorageContainerLocationClient();
     xceiverClientManager = new XceiverClientManager(ozoneConfig);
   }
 
   @AfterAll
-  public static void shutdown() throws InterruptedException {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+  void cleanup() {
     IOUtils.cleanupWithLogger(null, storageContainerLocationClient);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMNodeManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMNodeManagerMXBean.java
@@ -18,28 +18,24 @@
 
 package org.apache.hadoop.hdds.scm;
 
+import org.apache.ozone.test.NonHATests;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -48,34 +44,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * Class which tests the SCMNodeManagerInfo Bean.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestSCMNodeManagerMXBean {
+public abstract class TestSCMNodeManagerMXBean implements NonHATests.TestCase {
 
   public static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
-  private static int numOfDatanodes = 3;
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static StorageContainerManager scm;
-  private static MBeanServer mbs;
+  private StorageContainerManager scm;
+  private MBeanServer mbs;
 
   @BeforeAll
-  public static void init() throws IOException, TimeoutException,
-      InterruptedException {
-    conf = new OzoneConfiguration();
-    conf.set(OZONE_SCM_STALENODE_INTERVAL, "60000ms");
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(numOfDatanodes)
-        .build();
-    cluster.waitForClusterToBeReady();
-    scm = cluster.getStorageContainerManager();
+  void init() {
+    scm = cluster().getStorageContainerManager();
     mbs = ManagementFactory.getPlatformMBeanServer();
-  }
-
-  @AfterAll
-  public static void cleanup() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -18,10 +18,8 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.AfterEach;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -30,36 +28,26 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
 
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager via MXBean.
  */
 @Timeout(3000)
-public class TestPipelineManagerMXBean {
+public abstract class TestPipelineManagerMXBean implements NonHATests.TestCase {
 
-  private MiniOzoneCluster cluster;
   private MBeanServer mbs;
 
   @BeforeEach
-  public void init()
-      throws IOException, TimeoutException, InterruptedException {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
+  void init() {
     mbs = ManagementFactory.getPlatformMBeanServer();
   }
 
   /**
    * Verifies SCMPipelineManagerInfo metrics.
-   *
-   * @throws Exception
    */
   @Test
   public void testPipelineInfo() throws Exception {
@@ -68,7 +56,7 @@ public class TestPipelineManagerMXBean {
 
     GenericTestUtils.waitFor(() -> {
       try {
-        Map<String, Integer> pipelineStateCount = cluster
+        Map<String, Integer> pipelineStateCount = cluster()
             .getStorageContainerManager().getPipelineManager().getPipelineInfo();
         final TabularData data = (TabularData) mbs.getAttribute(
             bean, "PipelineInfo");
@@ -94,10 +82,5 @@ public class TestPipelineManagerMXBean {
       }
     }
     return null;
-  }
-
-  @AfterEach
-  public void teardown() {
-    cluster.shutdown();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestCpuMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestCpuMetrics.java
@@ -22,13 +22,11 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KE
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.concurrent.TimeoutException;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.hadoop.hdds.HddsUtils;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,25 +35,15 @@ import org.junit.jupiter.api.Test;
  *  <p>jvm_metrics_cpu_system_load</p>
  *  <p>jvm_metrics_cpu_jvm_load</p>
  */
-public class TestCpuMetrics {
+public abstract class TestCpuMetrics implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster;
   private final OkHttpClient httpClient = new OkHttpClient();
-
-  @BeforeAll
-  public static void setup() throws InterruptedException, TimeoutException,
-      IOException {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(1).build();
-    cluster.waitForClusterToBeReady();
-  }
 
   @Test
   public void testCpuMetrics() throws IOException {
     // given
     String scmHttpServerUrl = "http://localhost:" +
-        HddsUtils.getPortNumberFromConfigKeys(cluster.getConf(),
+        HddsUtils.getPortNumberFromConfigKeys(cluster().getConf(),
                 OZONE_SCM_HTTP_ADDRESS_KEY).getAsInt();
     Request prometheusMetricsRequest = new Request.Builder()
         .url(scmHttpServerUrl + "/prom")

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetClusterTreeInformation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetClusterTreeInformation.java
@@ -20,9 +20,10 @@ package org.apache.hadoop.ozone;
 import org.apache.hadoop.hdds.scm.net.InnerNode;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.proxy.SCMBlockLocationFailoverProxyProvider;
+import org.apache.ozone.test.HATests;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -31,7 +32,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import java.io.IOException;
-import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,34 +41,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * This class is to test the serialization/deserialization of cluster tree
  * information from SCM.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestGetClusterTreeInformation {
+public abstract class TestGetClusterTreeInformation implements HATests.TestCase {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(TestGetClusterTreeInformation.class);
-  private static int numOfDatanodes = 3;
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static StorageContainerManager scm;
+  private OzoneConfiguration conf;
+  private StorageContainerManager scm;
 
   @BeforeAll
-  public static void init() throws IOException, TimeoutException,
-      InterruptedException {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newHABuilder(conf)
-        .setNumOfOzoneManagers(3)
-        .setNumOfStorageContainerManagers(3)
-        .setNumDatanodes(numOfDatanodes)
-        .build();
-    cluster.waitForClusterToBeReady();
-    scm = cluster.getStorageContainerManager();
-  }
-
-  @AfterAll
-  public static void shutdown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+  void init() {
+    conf = cluster().getConf();
+    scm = cluster().getStorageContainerManager();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestDatanodeQueueMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestDatanodeQueueMetrics.java
@@ -17,19 +17,12 @@
 
 package org.apache.hadoop.ozone.container.metrics;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeQueueMetrics;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 import static org.apache.commons.text.WordUtils.capitalize;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeQueueMetrics.COMMAND_DISPATCHER_QUEUE_PREFIX;
@@ -41,44 +34,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test for queue metrics of datanodes.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestDatanodeQueueMetrics {
-
-  private MiniOzoneHAClusterImpl cluster = null;
-  private OzoneConfiguration conf;
-  private String omServiceId;
-  private static int numOfOMs = 3;
-  private String scmServiceId;
-  private static int numOfSCMs = 3;
-
-  private static final Logger LOG = LoggerFactory
-      .getLogger(TestDatanodeQueueMetrics.class);
-
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   *
-   * @throws IOException
-   */
-  @BeforeEach
-  public void init() throws Exception {
-    conf = new OzoneConfiguration();
-    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL, "10s");
-    omServiceId = "om-service-test1";
-    scmServiceId = "scm-service-test1";
-    MiniOzoneHAClusterImpl.Builder builder = MiniOzoneCluster.newHABuilder(conf);
-    builder.setOMServiceId(omServiceId)
-        .setSCMServiceId(scmServiceId)
-        .setNumOfStorageContainerManagers(numOfSCMs)
-        .setNumOfOzoneManagers(numOfOMs)
-        .setNumDatanodes(1);
-    cluster = builder.build();
-    cluster.waitForClusterToBeReady();
-  }
-  /**
-    * Set a timeout for each test.
-    */
+public abstract class TestDatanodeQueueMetrics implements NonHATests.TestCase {
 
   @Test
   public void testQueueMetrics() {
@@ -89,7 +47,6 @@ public class TestDatanodeQueueMetrics {
       assertThat(getGauge(COMMAND_DISPATCHER_QUEUE_PREFIX + typeSize))
           .isGreaterThanOrEqualTo(0);
     }
-
   }
 
   private long getGauge(String metricName) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDNRPCLoadGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDNRPCLoadGenerator.java
@@ -18,27 +18,24 @@
 
 package org.apache.hadoop.ozone.freon;
 
-import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientCreator;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
-import org.junit.jupiter.api.AfterAll;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import picocli.CommandLine;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -49,32 +46,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests Freon, with MiniOzoneCluster and validate data.
  */
-public class TestDNRPCLoadGenerator {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TestDNRPCLoadGenerator implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster = null;
-  private static ContainerWithPipeline container;
+  private ContainerWithPipeline container;
 
-  private static void startCluster(OzoneConfiguration conf) throws Exception {
-    DatanodeRatisServerConfig ratisServerConfig =
-        conf.getObject(DatanodeRatisServerConfig.class);
-    ratisServerConfig.setRequestTimeOut(Duration.ofSeconds(3));
-    ratisServerConfig.setWatchTimeOut(Duration.ofSeconds(10));
-    conf.setFromObject(ratisServerConfig);
-
-    RatisClientConfig.RaftConfig raftClientConfig =
-        conf.getObject(RatisClientConfig.RaftConfig.class);
-    raftClientConfig.setRpcRequestTimeout(Duration.ofSeconds(3));
-    raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(10));
-    conf.setFromObject(raftClientConfig);
-
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(5).build();
-    cluster.waitForClusterToBeReady();
-    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
-        180000);
-
+  @BeforeAll
+  void init() throws Exception {
+    OzoneConfiguration conf = cluster().getConf();
     StorageContainerLocationProtocolClientSideTranslatorPB
-        storageContainerLocationClient = cluster
+        storageContainerLocationClient = cluster()
         .getStorageContainerLocationClient();
     container =
         storageContainerLocationClient.allocateContainer(
@@ -85,23 +66,6 @@ public class TestDNRPCLoadGenerator {
       ContainerProtocolCalls.createContainer(client,
           container.getContainerInfo().getContainerID(), null);
     }
-  }
-
-  static void shutdownCluster() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-  }
-
-  @BeforeAll
-  public static void init() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    startCluster(conf);
-  }
-
-  @AfterAll
-  public static void shutdown() {
-    shutdownCluster();
   }
 
   private static Stream<Arguments> provideParameters() {
@@ -117,7 +81,7 @@ public class TestDNRPCLoadGenerator {
   @MethodSource("provideParameters")
   public void test(boolean readOnly, boolean ratis) {
     DNRPCLoadGenerator randomKeyGenerator =
-        new DNRPCLoadGenerator(cluster.getConf());
+        new DNRPCLoadGenerator(cluster().getConf());
     CommandLine cmd = new CommandLine(randomKeyGenerator);
     List<String> cmdArgs = new ArrayList<>(Arrays.asList(
         "--container-id", Long.toString(container.getContainerInfo().getContainerID()),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
@@ -18,7 +18,6 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -26,9 +25,11 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
@@ -40,35 +41,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests to verify Object store without prefix enabled.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(1200)
-public class TestObjectStore {
-  private static MiniOzoneCluster cluster = null;
-  private static OzoneConfiguration conf;
-  private static OzoneClient client;
+public abstract class TestObjectStore implements NonHATests.TestCase {
+  private OzoneConfiguration conf;
+  private OzoneClient client;
 
-  /**
-   * Create a MiniOzoneCluster for testing.
-   * <p>
-   *
-   * @throws IOException
-   */
   @BeforeAll
-  public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
+  void init() throws Exception {
+    conf = cluster().getConf();
+    client = cluster().newClient();
   }
 
-  /**
-   * Shutdown MiniOzoneCluster.
-   */
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -16,15 +16,12 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -40,50 +37,35 @@ import org.apache.commons.lang3.RandomStringUtils;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests the versioning of blocks from OM side.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestOmBlockVersioning {
+public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster = null;
-  private static OzoneClient client;
-  private static OzoneConfiguration conf;
-  private static OzoneManager ozoneManager;
-  private static OzoneManagerProtocol writeClient;
+  private OzoneClient client;
+  private OzoneManager ozoneManager;
+  private OzoneManagerProtocol writeClient;
 
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   *
-   * @throws IOException
-   */
   @BeforeAll
-  public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
-    ozoneManager = cluster.getOzoneManager();
+  void init() throws Exception {
+    client = cluster().newClient();
+    ozoneManager = cluster().getOzoneManager();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestInterface.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestInterface.java
@@ -38,9 +38,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterAll;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,24 +52,17 @@ import static org.apache.hadoop.ozone.OmUtils.getOmAddressForClients;
 /**
  * This class is to test the REST interface exposed by OzoneManager.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestOzoneManagerRestInterface {
+public abstract class TestOzoneManagerRestInterface implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
+  private MiniOzoneCluster cluster;
+  private OzoneConfiguration conf;
 
   @BeforeAll
-  public static void setUp() throws Exception {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
-  }
-
-  @AfterAll
-  public static void tearDown() throws Exception {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+  void setup() {
+    conf = cluster().getConf();
+    cluster = cluster();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestScmAdminHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestScmAdminHA.java
@@ -19,47 +19,26 @@ package org.apache.hadoop.ozone.shell;
 
 import java.net.InetSocketAddress;
 
-import org.apache.hadoop.ozone.admin.OzoneAdmin;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.jupiter.api.AfterAll;
+import org.apache.hadoop.ozone.admin.OzoneAdmin;
+import org.apache.ozone.test.HATests;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 /**
  * This class tests ozone admin scm commands.
  */
-public class TestScmAdminHA {
-  private static OzoneAdmin ozoneAdmin;
-  private static OzoneConfiguration conf;
-  private static String omServiceId;
-  private static int numOfOMs;
-  private static MiniOzoneCluster cluster;
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TestScmAdminHA implements HATests.TestCase {
+
+  private OzoneAdmin ozoneAdmin;
+  private MiniOzoneCluster cluster;
 
   @BeforeAll
-  public static void init() throws Exception {
+  void init() {
     ozoneAdmin = new OzoneAdmin();
-    conf = new OzoneConfiguration();
-
-    // Init HA cluster
-    omServiceId = "om-service-test1";
-    numOfOMs = 3;
-    cluster = MiniOzoneCluster.newHABuilder(conf)
-        .setOMServiceId(omServiceId)
-        .setNumOfOzoneManagers(numOfOMs)
-        .build();
-    conf.setQuietMode(false);
-    // enable ratis for Scm.
-    conf.setBoolean(ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY, true);
-    cluster.waitForClusterToBeReady();
-  }
-
-  @AfterAll
-  public static void shutdown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+    cluster = cluster();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED;
+
+/**
+ * Base class for Ozone integration tests.  Manages lifecycle of {@link MiniOzoneCluster}.
+ * <p/>
+ * Subclasses can tweak configuration by overriding {@link #createOzoneConfig()}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class ClusterForTests<C extends MiniOzoneCluster> {
+
+  private C cluster;
+
+  /**
+   * Creates the base configuration for tests.  This can be tweaked
+   * in subclasses by overriding {@link #createOzoneConfig()}.
+   */
+  protected static OzoneConfiguration createBaseConfiguration() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    DatanodeRatisServerConfig ratisServerConfig =
+        conf.getObject(DatanodeRatisServerConfig.class);
+    ratisServerConfig.setRequestTimeOut(Duration.ofSeconds(3));
+    ratisServerConfig.setWatchTimeOut(Duration.ofSeconds(10));
+    conf.setFromObject(ratisServerConfig);
+
+    RatisClientConfig.RaftConfig raftClientConfig =
+        conf.getObject(RatisClientConfig.RaftConfig.class);
+    raftClientConfig.setRpcRequestTimeout(Duration.ofSeconds(3));
+    raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(10));
+    conf.setFromObject(raftClientConfig);
+
+    conf.setBoolean(OZONE_HBASE_ENHANCEMENTS_ALLOWED, true);
+    conf.setBoolean("ozone.client.hbase.enhancements.allowed", true);
+    conf.setBoolean(OZONE_FS_HSYNC_ENABLED, true);
+
+    return conf;
+  }
+
+  /**
+   * Hook method that allows tweaking the configuration.
+   */
+  OzoneConfiguration createOzoneConfig() {
+    return createBaseConfiguration();
+  }
+
+  /**
+   * Hook method to create cluster with different parameters.
+   */
+  abstract C createCluster() throws Exception;
+
+  C getCluster() {
+    return cluster;
+  }
+
+  @BeforeAll
+  void startCluster() throws Exception {
+    cluster = createCluster();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @AfterAll
+  void shutdownCluster() {
+    IOUtils.closeQuietly(cluster);
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
@@ -69,16 +69,16 @@ public abstract class ClusterForTests<C extends MiniOzoneCluster> {
   /**
    * Hook method that allows tweaking the configuration.
    */
-  OzoneConfiguration createOzoneConfig() {
+  protected OzoneConfiguration createOzoneConfig() {
     return createBaseConfiguration();
   }
 
   /**
    * Hook method to create cluster with different parameters.
    */
-  abstract C createCluster() throws Exception;
+  protected abstract C createCluster() throws Exception;
 
-  C getCluster() {
+  protected C getCluster() {
     return cluster;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/HATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/HATests.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.UUID;
+
+/**
+ * Group tests to be run with a single HA cluster.
+ * <p/>
+ * Specific tests are implemented in separate classes, and they are subclasses
+ * here as {@link Nested} inner classes.  This allows running all tests in the
+ * same cluster.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class HATests extends ClusterForTests<MiniOzoneHAClusterImpl> {
+
+  /** Hook method for subclasses. */
+  MiniOzoneHAClusterImpl.Builder startBuilding() {
+    return MiniOzoneCluster.newHABuilder(createOzoneConfig())
+        .setOMServiceId("om-" + UUID.randomUUID())
+        .setNumOfOzoneManagers(3)
+        .setSCMServiceId("scm-" + UUID.randomUUID())
+        .setNumOfStorageContainerManagers(3);
+  }
+
+  /** Test cases which need HA cluster should implement this. */
+  public interface TestCase {
+    MiniOzoneHAClusterImpl cluster();
+  }
+
+  @Nested
+  class OzoneFsHAURLs extends org.apache.hadoop.fs.ozone.TestOzoneFsHAURLs {
+    @Override
+    public MiniOzoneHAClusterImpl cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class GetClusterTreeInformation extends org.apache.hadoop.ozone.TestGetClusterTreeInformation {
+    @Override
+    public MiniOzoneHAClusterImpl cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class DatanodeQueueMetrics extends org.apache.hadoop.ozone.container.metrics.TestDatanodeQueueMetrics {
+    @Override
+    public MiniOzoneHAClusterImpl cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ScmAdminHA extends org.apache.hadoop.ozone.shell.TestScmAdminHA {
+    @Override
+    public MiniOzoneHAClusterImpl cluster() {
+      return getCluster();
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/HATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/HATests.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 public abstract class HATests extends ClusterForTests<MiniOzoneHAClusterImpl> {
 
   /** Hook method for subclasses. */
-  MiniOzoneHAClusterImpl.Builder startBuilding() {
+  MiniOzoneHAClusterImpl.Builder newClusterBuilder() {
     return MiniOzoneCluster.newHABuilder(createOzoneConfig())
         .setOMServiceId("om-" + UUID.randomUUID())
         .setNumOfOzoneManagers(3)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Group tests to be run with a single non-HA cluster.
+ * <p/>
+ * Specific tests are implemented in separate classes, and they are subclasses
+ * here as {@link Nested} inner classes.  This allows running all tests in the
+ * same cluster.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
+
+  /** Hook method for subclasses. */
+  MiniOzoneCluster.Builder startBuilding() {
+    return MiniOzoneCluster.newBuilder(createOzoneConfig())
+        .setNumDatanodes(5);
+  }
+
+  /** Test cases for non-HA cluster should implement this. */
+  public interface TestCase {
+    MiniOzoneCluster cluster();
+  }
+
+  @Nested
+  class AllocateContainer extends org.apache.hadoop.hdds.scm.TestAllocateContainer {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ContainerReportWithKeys extends org.apache.hadoop.hdds.scm.TestContainerReportWithKeys {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ContainerSmallFile extends org.apache.hadoop.hdds.scm.TestContainerSmallFile {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class GetCommittedBlockLengthAndPutKey extends org.apache.hadoop.hdds.scm.TestGetCommittedBlockLengthAndPutKey {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class SCMNodeManagerMXBean extends org.apache.hadoop.hdds.scm.TestSCMNodeManagerMXBean {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class PipelineManagerMXBean extends org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class CpuMetrics extends org.apache.hadoop.ozone.TestCpuMetrics {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class DNRPCLoadGenerator extends org.apache.hadoop.ozone.freon.TestDNRPCLoadGenerator {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ObjectStore extends org.apache.hadoop.ozone.om.TestObjectStore {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ObjectStoreWithFSO extends org.apache.hadoop.ozone.om.TestObjectStoreWithFSO {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class OmBlockVersioning extends org.apache.hadoop.ozone.om.TestOmBlockVersioning {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class OzoneManagerRestInterface extends org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.TestInstance;
 public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   /** Hook method for subclasses. */
-  MiniOzoneCluster.Builder startBuilding() {
+  MiniOzoneCluster.Builder newClusterBuilder() {
     return MiniOzoneCluster.newBuilder(createOzoneConfig())
         .setNumDatanodes(5);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationHA.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 /** Test Ozone with HA cluster. */
 public class TestOzoneIntegrationHA extends HATests {
   @Override
-  MiniOzoneHAClusterImpl createCluster() throws Exception {
-    return startBuilding()
+  protected MiniOzoneHAClusterImpl createCluster() throws Exception {
+    return newClusterBuilder()
         .build();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationHA.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+
+/** Test Ozone with HA cluster. */
+public class TestOzoneIntegrationHA extends HATests {
+  @Override
+  MiniOzoneHAClusterImpl createCluster() throws Exception {
+    return startBuilding()
+        .build();
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationNonHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationNonHA.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.TestInstance;
 /** Test Ozone with non-HA cluster. */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestOzoneIntegrationNonHA extends NonHATests {
-  MiniOzoneCluster createCluster() throws Exception {
-    return startBuilding()
+  protected MiniOzoneCluster createCluster() throws Exception {
+    return newClusterBuilder()
         .build();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationNonHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/TestOzoneIntegrationNonHA.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.junit.jupiter.api.TestInstance;
+
+/** Test Ozone with non-HA cluster. */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestOzoneIntegrationNonHA extends NonHATests {
+  MiniOzoneCluster createCluster() throws Exception {
+    return startBuilding()
+        .build();
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/package-info.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains test cluster definitions.
+ */
+package org.apache.ozone.test;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cluster startup/shutdown is the most time-consuming part of the test for several classes (30+ seconds for each of the following test classes).

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.108 s - in org.apache.hadoop.fs.ozone.TestOzoneFsHAURLs
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.312 s - in org.apache.hadoop.hdds.scm.TestAllocateContainer
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.292 s - in org.apache.hadoop.hdds.scm.TestContainerReportWithKeys
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.5 s - in org.apache.hadoop.hdds.scm.TestContainerSmallFile
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.365 s - in org.apache.hadoop.hdds.scm.TestGetCommittedBlockLengthAndPutKey
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.138 s - in org.apache.hadoop.hdds.scm.TestSCMNodeManagerMXBean
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.297 s - in org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.23 s - in org.apache.hadoop.ozone.TestCpuMetrics
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.475 s - in org.apache.hadoop.ozone.TestGetClusterTreeInformation
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.577 s - in org.apache.hadoop.ozone.container.metrics.TestDatanodeQueueMetrics
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 42.81 s - in org.apache.hadoop.ozone.freon.TestDNRPCLoadGenerator
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.423 s - in org.apache.hadoop.ozone.om.TestObjectStore
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 39.007 s - in org.apache.hadoop.ozone.om.TestObjectStoreWithFSO
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.304 s - in org.apache.hadoop.ozone.om.TestOmBlockVersioning
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.132 s - in org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.587 s - in org.apache.hadoop.ozone.shell.TestScmAdminHA
```

Safe integration tests (ones which do not stop / restart components) can be run on the same `MiniOzoneCluster` to save time.

This PR creates two such test groups, one for HA and another for non-HA.  Test implementations are kept in existing separate classes, but they no longer manage the lifecycle of the cluster.

Further tests can be updated in follow-up, but wanted to keep the change relatively small here.

https://issues.apache.org/jira/browse/HDDS-12183

## How was this patch tested?

Total time for these grouped tests is less than 2 minutes:

```
2025-02-02T19:34:25.6207523Z [INFO] Running org.apache.ozone.test.TestOzoneIntegrationHA
2025-02-02T19:35:08.0532396Z [INFO] Running org.apache.ozone.test.HATests$ScmAdminHA
2025-02-02T19:35:08.3292991Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.264 s - in org.apache.ozone.test.HATests$ScmAdminHA
2025-02-02T19:35:08.3294514Z [INFO] Running org.apache.ozone.test.HATests$DatanodeQueueMetrics
2025-02-02T19:35:09.7697990Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.429 s - in org.apache.ozone.test.HATests$DatanodeQueueMetrics
2025-02-02T19:35:09.7788304Z [INFO] Running org.apache.ozone.test.HATests$GetClusterTreeInformation
2025-02-02T19:35:11.8574699Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.061 s - in org.apache.ozone.test.HATests$GetClusterTreeInformation
2025-02-02T19:35:11.8650174Z [INFO] Running org.apache.ozone.test.HATests$OzoneFsHAURLs
2025-02-02T19:35:13.6359721Z [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.757 s - in org.apache.ozone.test.HATests$OzoneFsHAURLs
2025-02-02T19:35:22.9608544Z [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 57.336 s - in org.apache.ozone.test.TestOzoneIntegrationHA
2025-02-02T19:35:24.3609647Z [INFO] Running org.apache.ozone.test.TestOzoneIntegrationNonHA
2025-02-02T19:35:56.2101096Z [INFO] Running org.apache.ozone.test.NonHATests$OzoneManagerRestInterface
2025-02-02T19:35:56.4804421Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.265 s - in org.apache.ozone.test.NonHATests$OzoneManagerRestInterface
2025-02-02T19:35:56.4808719Z [INFO] Running org.apache.ozone.test.NonHATests$OmBlockVersioning
2025-02-02T19:35:57.7629080Z [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.276 s - in org.apache.ozone.test.NonHATests$OmBlockVersioning
2025-02-02T19:35:57.7656265Z [INFO] Running org.apache.ozone.test.NonHATests$ObjectStoreWithFSO
2025-02-02T19:35:59.6805203Z [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.912 s - in org.apache.ozone.test.NonHATests$ObjectStoreWithFSO
2025-02-02T19:35:59.6824980Z [INFO] Running org.apache.ozone.test.NonHATests$ObjectStore
2025-02-02T19:35:59.7759688Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.087 s - in org.apache.ozone.test.NonHATests$ObjectStore
2025-02-02T19:35:59.7780535Z [INFO] Running org.apache.ozone.test.NonHATests$DNRPCLoadGenerator
2025-02-02T19:36:04.4931112Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.715 s - in org.apache.ozone.test.NonHATests$DNRPCLoadGenerator
2025-02-02T19:36:04.4932291Z [INFO] Running org.apache.ozone.test.NonHATests$CpuMetrics
2025-02-02T19:36:05.0518019Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.553 s - in org.apache.ozone.test.NonHATests$CpuMetrics
2025-02-02T19:36:05.0524175Z [INFO] Running org.apache.ozone.test.NonHATests$PipelineManagerMXBean
2025-02-02T19:36:05.0637681Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.apache.ozone.test.NonHATests$PipelineManagerMXBean
2025-02-02T19:36:05.0643743Z [INFO] Running org.apache.ozone.test.NonHATests$SCMNodeManagerMXBean
2025-02-02T19:36:05.0823699Z [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.apache.ozone.test.NonHATests$SCMNodeManagerMXBean
2025-02-02T19:36:05.0830009Z [INFO] Running org.apache.ozone.test.NonHATests$GetCommittedBlockLengthAndPutKey
2025-02-02T19:36:05.2385383Z [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.143 s - in org.apache.ozone.test.NonHATests$GetCommittedBlockLengthAndPutKey
2025-02-02T19:36:05.2386091Z [INFO] Running org.apache.ozone.test.NonHATests$ContainerSmallFile
2025-02-02T19:36:05.3736364Z [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.135 s - in org.apache.ozone.test.NonHATests$ContainerSmallFile
2025-02-02T19:36:05.3742900Z [INFO] Running org.apache.ozone.test.NonHATests$ContainerReportWithKeys
2025-02-02T19:36:05.4369321Z [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s - in org.apache.ozone.test.NonHATests$ContainerReportWithKeys
2025-02-02T19:36:05.4370413Z [INFO] Running org.apache.ozone.test.NonHATests$AllocateContainer
2025-02-02T19:36:05.4556415Z [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in org.apache.ozone.test.NonHATests$AllocateContainer
2025-02-02T19:36:12.5130242Z [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 48.148 s - in org.apache.ozone.test.TestOzoneIntegrationNonHA
```

https://github.com/adoroszlai/ozone/actions/runs/13101544695