### PR TITLE
HDDS-12186. Avoid array allocation for table iterator.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -337,12 +337,8 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
 
     VALUE getValue() throws IOException;
 
-    default byte[] getRawKey() throws IOException {
-      return null;
-    }
-
-    default byte[] getRawValue() throws IOException {
-      return null;
+    default int getReadableBytes()  throws IOException {
+      return -1;
     }
   }
 
@@ -383,7 +379,7 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
     };
   }
 
-  static <K, V> KeyValue<K, V> newKeyValue(K key, V value, byte[] rawKey, byte[] rawValue) {
+  static <K, V> KeyValue<K, V> newKeyValue(K key, V value, int readableBytes) {
     return new KeyValue<K, V>() {
       @Override
       public K getKey() {
@@ -396,13 +392,8 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
       }
 
       @Override
-      public byte[] getRawKey() throws IOException {
-        return rawKey;
-      }
-
-      @Override
-      public byte[] getRawValue() throws IOException {
-        return rawValue;
+      public int getReadableBytes() throws IOException {
+        return readableBytes;
       }
 
       @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -605,11 +605,9 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       @Override
       KeyValue<KEY, VALUE> convert(KeyValue<CodecBuffer, CodecBuffer> raw)
           throws IOException {
-        CodecBuffer keyCodecBuffer = raw.getKey();
-        final KEY key = keyCodec.fromCodecBuffer(keyCodecBuffer);
-        CodecBuffer valueCodecBuffer = raw.getValue();
-        final VALUE value = valueCodec.fromCodecBuffer(valueCodecBuffer);
-        return Table.newKeyValue(key, value, keyCodecBuffer.getArray(), valueCodecBuffer.getArray());
+        final KEY key = keyCodec.fromCodecBuffer(raw.getKey());
+        final VALUE value = valueCodec.fromCodecBuffer(raw.getValue());
+        return Table.newKeyValue(key, value, raw.getReadableBytes());
       }
     };
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2102,7 +2102,7 @@ public class KeyManagerImpl implements KeyManager {
     while (iterator.hasNext() && remainingBufLimit > 0) {
       Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
-      long objectSerializedSize = entry.getRawValue().length;
+      long objectSerializedSize = entry.getReadableBytes();
       if (!OMFileRequest.isImmediateChild(dirInfo.getParentObjectID(),
           parentInfo.getObjectID())) {
         processedSubDirs = true;
@@ -2149,7 +2149,7 @@ public class KeyManagerImpl implements KeyManager {
       while (iterator.hasNext() && remainingBufLimit > 0) {
         Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
         OmKeyInfo fileInfo = entry.getValue();
-        long objectSerializedSize = entry.getRawValue().length;
+        long objectSerializedSize = entry.getReadableBytes();
         if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
             parentInfo.getObjectID())) {
           processedSubFiles = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changes in [HDDS-11508](https://issues.apache.org/jira/browse/HDDS-11508) [cause](https://github.com/apache/ozone/pull/7365#pullrequestreview-2589186593) byte[] allocation on iteration. The array is used only for getting its size. Using codecBuffer.getReadableBytes() instead.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12186

## How was this patch tested?
Existing unit tests
