### PR TITLE
HDDS-12180. Store snapshot in CachingSpaceUsageSource

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -161,6 +161,7 @@ class TestCachingSpaceUsageSource {
     assertEquals(0, subject.getUsedSpace());
     // available and used change by same amount (in opposite directions)
     assertEquals(original.getAvailable() + original.getUsedSpace(), subject.getAvailable());
+    assertSnapshotIsUpToDate(subject);
   }
 
   @Test
@@ -179,6 +180,14 @@ class TestCachingSpaceUsageSource {
     assertEquals(0, subject.getAvailable());
     // available and used change by same amount (in opposite directions)
     assertEquals(original.getUsedSpace() + original.getAvailable(), subject.getUsedSpace());
+    assertSnapshotIsUpToDate(subject);
+  }
+
+  private static void assertSnapshotIsUpToDate(SpaceUsageSource subject) {
+    SpaceUsageSource snapshot = subject.snapshot();
+    assertEquals(subject.getCapacity(), snapshot.getCapacity());
+    assertEquals(subject.getAvailable(), snapshot.getAvailable());
+    assertEquals(subject.getUsedSpace(), snapshot.getUsedSpace());
   }
 
   private static long missingInitialValue() {
@@ -238,6 +247,7 @@ class TestCachingSpaceUsageSource {
 
     assertEquals(source.getCapacity(), subject.getCapacity());
     assertEquals(source.getAvailable(), subject.getAvailable());
+    assertSnapshotIsUpToDate(subject);
   }
 
   private static void assertSubjectWasRefreshed(SpaceUsageSource source,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CachingSpaceUsageSource` may benefit from storing `SpaceUsageSource#snapshot` until individual values change, to reduce object creation.

https://issues.apache.org/jira/browse/HDDS-12180

## How was this patch tested?

Updated unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/13108086955