### PR TITLE
HDDS-12186. (addendum) Avoid array allocation for table iterator

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -605,9 +605,10 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       @Override
       KeyValue<KEY, VALUE> convert(KeyValue<CodecBuffer, CodecBuffer> raw)
           throws IOException {
+        final int rawSize = raw.getValue().readableBytes();
         final KEY key = keyCodec.fromCodecBuffer(raw.getKey());
         final VALUE value = valueCodec.fromCodecBuffer(raw.getValue());
-        return Table.newKeyValue(key, value, raw.getRawSize());
+        return Table.newKeyValue(key, value, rawSize);
       }
     };
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -600,8 +600,11 @@ public class TestRDBTableStore {
     try (Table.KeyValueIterator<String, String> i = table.iterator(prefix)) {
       int keyCount = 0;
       for (; i.hasNext(); keyCount++) {
+        Table.KeyValue<String, String> entry = i.next();
         assertEquals(prefix,
-            i.next().getKey().substring(0, PREFIX_LENGTH));
+            entry.getKey().substring(0, PREFIX_LENGTH));
+        assertEquals(entry.getValue().getBytes(StandardCharsets.UTF_8).length,
+            entry.getRawSize());
       }
       assertEquals(expectedCount, keyCount);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addendum for #7797.  Get raw size from value, not iterator, which always returns 0.

https://issues.apache.org/jira/browse/HDDS-12186

## How was this patch tested?

N/A