### PR TITLE
HDDS-12195. Implement skip() in OzoneFSInputStream

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -105,6 +105,11 @@ public class OzoneFSInputStream extends FSInputStream
   }
 
   @Override
+  public long skip(long n) throws IOException {
+    return inputStream.skip(n);
+  }
+
+  @Override
   public boolean seekToNewSource(long targetPos) throws IOException {
     return false;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`HDDS-12195. Implement skip() in OzoneFSInputStream`

Please describe your PR in detail:
* The skip() method is not implemented in `OzoneFSInputStream`. As a result, it defaults to `java.io.InputStream#skip`, which uses `read()` and slows down performance.
* Implement skip() in OzoneFSInputStream to delegate skip() to `inputStream`


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12195

## How was this patch tested?
Integration Tests