### PR TITLE
HDDS-12192. Fix TestOzoneShellHA and extract set-bucket-encryption test case

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -36,6 +36,7 @@ execute_robot_test scm kinit.robot
 execute_robot_test scm basic
 
 execute_robot_test scm security
+execute_robot_test scm repair/bucket-encryption.robot
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-ofs-bucket ozonefs/ozonefs.robot
 

--- a/hadoop-ozone/dist/src/main/smoketest/repair/bucket-encryption.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/repair/bucket-encryption.robot
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Resource    ../lib/os.robot
+Resource    ../ozone-lib/shell.robot
+
+*** Variables ***
+${ENCRYPTION_KEY}        key1
+
+
+*** Keywords ***
+Verify Bucket Encryption Key
+    [arguments]    ${bucket}    ${expected}
+    ${output} =    Execute    ozone sh bucket info ${bucket}
+    ${actual} =    Execute    echo '${output}' | jq -r '.encryptionKeyName'
+    Should Be Equal     ${expected}    ${actual}
+
+
+*** Test Cases ***
+Set Bucket Encryption Key
+    ${random} =    Generate Random String  10  [NUMBERS]
+    ${bucket} =    Set Variable    /vol${random}/encrypted
+
+    Ozone Shell Batch   volume create /vol${random}
+    ...                 bucket create ${bucket}
+    Verify Bucket Encryption Key    ${bucket}    null
+
+    Execute             ozone sh bucket set-encryption-key -k ${ENCRYPTION_KEY} ${bucket}
+    Verify Bucket Encryption Key    ${bucket}    ${ENCRYPTION_KEY}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHAWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHAWithFSO.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.shell;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 /**
@@ -34,22 +33,15 @@ public class TestOzoneShellHAWithFSO extends TestOzoneShellHA {
    * handler type.
    */
   @BeforeAll
-  public static void init() throws Exception {
+  @Override
+  public void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED);
     conf.setBoolean(OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED, true);
     conf.setBoolean("ozone.client.hbase.enhancements.allowed", true);
     conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
-    startKMS();
+    // startKMS();
     startCluster(conf);
-  }
-
-  /**
-   * shutdown MiniOzoneCluster.
-   */
-  @AfterAll
-  public static void shutdownCluster() {
-    shutdown();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestOzoneShellHA and TestOzoneShellHAWithFSO are not run due `ClassNotFoundException` when starting MiniKMS (HDDS-11879).  KMS is required for only one test case.  This PR disables and re-creates it as Robot test.

Also fix:
- failures introduced while the tests were effectively disabled
- OzoneClient leak in TestOzoneShellHAWithFSO, as it starts two clusters, but stops only one

https://issues.apache.org/jira/browse/HDDS-12192

## How was this patch tested?

```
[INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 78.721 s - in org.apache.hadoop.ozone.shell.TestOzoneShellHAWithFSO
[INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 79.443 s - in org.apache.hadoop.ozone.shell.TestOzoneShellHA
```

https://github.com/adoroszlai/ozone/actions/runs/13123151647/job/36614089604#step:6:3987

```
Set Bucket Encryption Key                                             | PASS |
```

https://github.com/adoroszlai/ozone/actions/runs/13123151647/job/36614275274#step:6:952

CI:
https://github.com/adoroszlai/ozone/actions/runs/13123151647
