### PR TITLE
HDDS-12175. Audit logs in SCM shouldn't print delete txns

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CloseContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CloseContainerCommand.java
@@ -90,7 +90,11 @@ public class CloseContainerCommand
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(getType())
-        .append(": containerID: ").append(getContainerID())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", containerID: ").append(getContainerID())
         .append(", pipelineID: ").append(getPipelineID())
         .append(", force: ").append(force);
     return sb.toString();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ClosePipelineCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ClosePipelineCommand.java
@@ -70,4 +70,16 @@ public class ClosePipelineCommand
   public PipelineID getPipelineID() {
     return pipelineID;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", pipelineID: ").append(getPipelineID());
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CreatePipelineCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CreatePipelineCommand.java
@@ -155,4 +155,20 @@ public class CreatePipelineCommand
   public ReplicationFactor getFactor() {
     return factor;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", pipelineID: ").append(getPipelineID())
+        .append(", replicationFactor: ").append(factor)
+        .append(", replicationType: ").append(type)
+        .append(", nodelist: ").append(nodelist)
+        .append(", priorityList: ").append(priorityList);
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteBlocksCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteBlocksCommand.java
@@ -79,13 +79,15 @@ public class DeleteBlocksCommand extends
         .append(", deadlineMsSinceEpoch: ").append(getDeadline())
         .append(", deletedBlocksTransaction: [");
     for (DeletedBlocksTransaction txn : blocksTobeDeleted) {
-      sb.append(" txnID:").append(txn.getTxID())
-          .append(",containerID:").append(txn.getContainerID())
-          .append(",deleteBlockCount:").append(txn.getLocalIDCount())
-          .append(",count:").append(txn.getCount())
-          .append(",");
+      sb.append("{ txnID: ").append(txn.getTxID())
+          .append(", containerID: ").append(txn.getContainerID())
+          .append(", deleteBlockCount: ").append(txn.getLocalIDCount())
+          .append(", count: ").append(txn.getCount())
+          .append("}, ");
     }
-    sb.deleteCharAt(sb.length() - 1);
+    if (!blocksTobeDeleted.isEmpty()) {
+      sb.delete(sb.length() - 2, sb.length());
+    }
     sb.append("]");
     return sb.toString();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteBlocksCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteBlocksCommand.java
@@ -68,4 +68,25 @@ public class DeleteBlocksCommand extends
         .setCmdId(getId())
         .addAllDeletedBlocksTransactions(blocksTobeDeleted).build();
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", deletedBlocksTransaction: [");
+    for (DeletedBlocksTransaction txn : blocksTobeDeleted) {
+      sb.append(" txnID:").append(txn.getTxID())
+          .append(",containerID:").append(txn.getContainerID())
+          .append(",deleteBlockCount:").append(txn.getLocalIDCount())
+          .append(",count:").append(txn.getCount())
+          .append(",");
+    }
+    sb.deleteCharAt(sb.length() - 1);
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteContainerCommand.java
@@ -110,7 +110,11 @@ public class DeleteContainerCommand extends
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(getType())
-        .append(": containerID: ").append(getContainerID())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", containerID: ").append(getContainerID())
         .append(", replicaIndex: ").append(getReplicaIndex())
         .append(", force: ").append(force);
     return sb.toString();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/FinalizeNewLayoutVersionCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/FinalizeNewLayoutVersionCommand.java
@@ -77,4 +77,17 @@ public class FinalizeNewLayoutVersionCommand
         finalizeProto.getFinalizeNewLayoutVersion(),
         finalizeProto.getDataNodeLayoutVersion(), finalizeProto.getCmdId());
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", finalizeUpgrade: ").append(finalizeUpgrade)
+        .append(", layoutInfo: ").append(layoutInfo);
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -132,7 +132,11 @@ public class ReconstructECContainersCommand
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(getType())
-        .append(": containerID: ").append(containerID)
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", containerID: ").append(containerID)
         .append(", replicationConfig: ").append(ecReplicationConfig)
         .append(", sources: [").append(getSources().stream()
             .map(a -> a.dnDetails

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/RefreshVolumeUsageCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/RefreshVolumeUsageCommand.java
@@ -54,4 +54,15 @@ public class RefreshVolumeUsageCommand
     Preconditions.checkNotNull(refreshVolumeUsageProto);
     return new RefreshVolumeUsageCommand();
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline());
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -164,7 +164,11 @@ public final class ReplicateContainerCommand
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(getType());
-    sb.append(": containerId=").append(getContainerID());
+    sb.append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline());
+    sb.append(", containerId=").append(getContainerID());
     sb.append(", replicaIndex=").append(getReplicaIndex());
     if (targetDatanode != null) {
       sb.append(", targetNode=").append(targetDatanode);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReregisterCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReregisterCommand.java
@@ -55,4 +55,15 @@ public class ReregisterCommand extends
         .newBuilder()
         .build();
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline());
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SetNodeOperationalStateCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SetNodeOperationalStateCommand.java
@@ -95,9 +95,6 @@ public class SetNodeOperationalStateCommand
         .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
         .append(", term: ").append(getTerm())
         .append(", deadlineMsSinceEpoch: ").append(getDeadline())
-        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
-        .append(", term: ").append(getTerm())
-        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
         .append(", opState: ").append(opState)
         .append(", stateExpiryEpochSeconds: ").append(stateExpiryEpochSeconds);
     return sb.toString();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SetNodeOperationalStateCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SetNodeOperationalStateCommand.java
@@ -86,4 +86,20 @@ public class SetNodeOperationalStateCommand
         cmdProto.getNodeOperationalState(),
         cmdProto.getStateExpiryEpochSeconds());
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": cmdID: ").append(getId())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", encodedToken: \"").append(getEncodedToken()).append("\"")
+        .append(", term: ").append(getTerm())
+        .append(", deadlineMsSinceEpoch: ").append(getDeadline())
+        .append(", opState: ").append(opState)
+        .append(", stateExpiryEpochSeconds: ").append(stateExpiryEpochSeconds);
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -207,9 +207,9 @@ public final class SCMDatanodeHeartbeatDispatcher {
       StringBuilder allCommands = new StringBuilder();
       for (SCMCommand cmd : commands) {
         allCommands.append("cmdID: ").append(cmd.getId());
-        allCommands.append(" encodedToken: " + cmd.getEncodedToken());
-        allCommands.append(" term: " + cmd.getTerm());
-        allCommands.append(" deadlineMsSinceEpoch: " + cmd.getDeadline());
+        allCommands.append(" encodedToken: \"").append(cmd.getEncodedToken()).append("\"");
+        allCommands.append(" term: ").append(cmd.getTerm());
+        allCommands.append(" deadlineMsSinceEpoch: ").append(cmd.getDeadline());
         if (cmd.getType().equals(deleteBlocksCommand)) {
           DeleteBlocksCommand delCmd = (DeleteBlocksCommand) cmd;
           allCommands.append(" deleteBlocksTransactions: {");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -229,7 +229,7 @@ public final class SCMDatanodeHeartbeatDispatcher {
       }
       int len = allCommands.length();
       allCommands.delete(len - 2, len);
-      LOG.info("Heartbeat dispatched: datanode=" + datanodeDetails.getUuid() + ", Commands= [" + allCommands + "]");
+      LOG.debug("Heartbeat dispatched: datanode=" + datanodeDetails.getUuid() + ", Commands= [" + allCommands + "]");
     }
 
     return commands;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.server;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
@@ -42,7 +41,6 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.IEventInfo;
-import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReregisterCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
@@ -55,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.deleteBlocksCommand;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_ACTIONS;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents
@@ -206,29 +203,12 @@ public final class SCMDatanodeHeartbeatDispatcher {
     if (LOG.isDebugEnabled()) {
       StringBuilder allCommands = new StringBuilder();
       for (SCMCommand cmd : commands) {
-        allCommands.append("cmdID: ").append(cmd.getId());
-        allCommands.append(" encodedToken: \"").append(cmd.getEncodedToken()).append("\"");
-        allCommands.append(" term: ").append(cmd.getTerm());
-        allCommands.append(" deadlineMsSinceEpoch: ").append(cmd.getDeadline());
-        if (cmd.getType().equals(deleteBlocksCommand)) {
-          DeleteBlocksCommand delCmd = (DeleteBlocksCommand) cmd;
-          allCommands.append(" deleteBlocksTransactions: {");
-          for (DeletedBlocksTransaction txn : delCmd.blocksTobeDeleted()) {
-            allCommands.append(" txnId:").append(txn.getTxID());
-            allCommands.append(" containerID:").append(txn.getContainerID());
-            allCommands.append(" deleteBlockCount:").append(txn.getLocalIDCount());
-            allCommands.append(" count:").append(txn.getCount());
-            allCommands.append(",");
-          }
-          allCommands.deleteCharAt(allCommands.length() - 1);
-          allCommands.append(" }");
-        } else {
-          allCommands.append(" ").append(cmd.getProto());
-        }
-        allCommands.append(", ");
+        allCommands.append(cmd).append(", ");
       }
       int len = allCommands.length();
-      allCommands.delete(len - 2, len);
+      if (len > 2) {
+        allCommands.delete(len - 2, len);
+      }
       LOG.debug("Heartbeat dispatched: datanode=" + datanodeDetails.getUuid() + ", Commands= [" + allCommands + "]");
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -201,15 +201,7 @@ public final class SCMDatanodeHeartbeatDispatcher {
       }
     }
     if (LOG.isDebugEnabled()) {
-      StringBuilder allCommands = new StringBuilder();
-      for (SCMCommand cmd : commands) {
-        allCommands.append(cmd).append(", ");
-      }
-      int len = allCommands.length();
-      if (len > 2) {
-        allCommands.delete(len - 2, len);
-      }
-      LOG.debug("Heartbeat dispatched: datanode=" + datanodeDetails.getUuid() + ", Commands= [" + allCommands + "]");
+      LOG.debug("Heartbeat dispatched: datanode=" + datanodeDetails.getUuid() + ", Commands= " + commands);
     }
 
     return commands;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -286,8 +286,11 @@ public class SCMDatanodeProtocolServer implements
     for (SCMCommandProto cmd : cmds) {
       if (cmd.getCommandType().equals(deleteBlocksCommand)) {
         auditMap.append("commandType: ").append(cmd.getCommandType());
-        auditMap.append(" deleteTransactionsCount:");
-        auditMap.append(cmd.getDeleteBlocksCommandProto().getDeletedBlocksTransactionsList().size());
+        auditMap.append(" deleteTransactionsCount: ")
+            .append(cmd.getDeleteBlocksCommandProto().getDeletedBlocksTransactionsCount());
+        auditMap.append(" cmdID: ").append(cmd.getDeleteBlocksCommandProto().getCmdId());
+        auditMap.append(" encodedToken: " + cmd.getEncodedToken());
+        auditMap.append(" deadlineMsSinceEpoch: " + cmd.getDeadlineMsSinceEpoch());
       } else {
         auditMap.append(cmd);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -282,16 +282,21 @@ public class SCMDatanodeProtocolServer implements
 
   private String constructCommandAuditMap(List<SCMCommandProto> cmds) {
     StringBuilder auditMap = new StringBuilder();
-    auditMap.append('[');
+    auditMap.append("[");
     for (SCMCommandProto cmd : cmds) {
       if (cmd.getCommandType().equals(deleteBlocksCommand)) {
-        auditMap.append("commandType:" + cmd.getCommandType());
-        auditMap.append(" No. of deleteTransactions:");
+        auditMap.append("commandType: ").append(cmd.getCommandType());
+        auditMap.append(" deleteTransactionsCount:");
         auditMap.append(cmd.getDeleteBlocksCommandProto().getDeletedBlocksTransactionsList().size());
       } else {
         auditMap.append(cmd);
       }
+      auditMap.append(" , ");
     }
+    int len = auditMap.toString().length();
+    auditMap.deleteCharAt(len - 1);
+    auditMap.deleteCharAt(len - 2);
+    auditMap.deleteCharAt(len - 3);
     auditMap.append(']');
     return auditMap.toString();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -294,9 +294,11 @@ public class SCMDatanodeProtocolServer implements
       auditMap.append(" , ");
     }
     int len = auditMap.toString().length();
-    auditMap.deleteCharAt(len - 1);
-    auditMap.deleteCharAt(len - 2);
-    auditMap.deleteCharAt(len - 3);
+    if (len > 3) {
+      auditMap.deleteCharAt(len - 1);
+      auditMap.deleteCharAt(len - 2);
+      auditMap.deleteCharAt(len - 3);
+    }
     auditMap.append(']');
     return auditMap.toString();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -280,6 +280,22 @@ public class SCMDatanodeProtocolServer implements
     return cmd.getProtoBufMessage();
   }
 
+  private String constructCommandAuditMap(List<SCMCommandProto> cmds) {
+    StringBuilder auditMap = new StringBuilder();
+    auditMap.append('[');
+    for (SCMCommandProto cmd : cmds) {
+      if (cmd.getCommandType().equals(deleteBlocksCommand)) {
+        auditMap.append("commandType:" + cmd.getCommandType());
+        auditMap.append(" No. of deleteTransactions:");
+        auditMap.append(cmd.getDeleteBlocksCommandProto().getDeletedBlocksTransactionsList().size());
+      } else {
+        auditMap.append(cmd);
+      }
+    }
+    auditMap.append(']');
+    return auditMap.toString();
+  }
+
   @Override
   public SCMHeartbeatResponseProto sendHeartbeat(
       SCMHeartbeatRequestProto heartbeat) throws IOException, TimeoutException {
@@ -291,7 +307,7 @@ public class SCMDatanodeProtocolServer implements
     boolean auditSuccess = true;
     Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("datanodeUUID", heartbeat.getDatanodeDetails().getUuid());
-    auditMap.put("command", flatten(cmdResponses.toString()));
+    auditMap.put("command", flatten(constructCommandAuditMap(cmdResponses)));
     term.ifPresent(t -> auditMap.put("term", String.valueOf(t)));
     try {
       SCMHeartbeatResponseProto.Builder builder =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -289,8 +289,8 @@ public class SCMDatanodeProtocolServer implements
         auditMap.append(" deleteTransactionsCount: ")
             .append(cmd.getDeleteBlocksCommandProto().getDeletedBlocksTransactionsCount());
         auditMap.append(" cmdID: ").append(cmd.getDeleteBlocksCommandProto().getCmdId());
-        auditMap.append(" encodedToken: " + cmd.getEncodedToken());
-        auditMap.append(" deadlineMsSinceEpoch: " + cmd.getDeadlineMsSinceEpoch());
+        auditMap.append(" encodedToken: \"").append(cmd.getEncodedToken()).append("\"");
+        auditMap.append(" deadlineMsSinceEpoch: ").append(cmd.getDeadlineMsSinceEpoch());
       } else {
         auditMap.append(cmd);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -295,9 +295,9 @@ public class SCMDatanodeProtocolServer implements
     }
     int len = auditMap.length();
     if (len > 2) {
-      auditMap.delete(len - 2, len - 1);
+      auditMap.delete(len - 2, len);
     }
-    auditMap.append(']');
+    auditMap.append("]");
     return auditMap.toString();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -291,13 +291,11 @@ public class SCMDatanodeProtocolServer implements
       } else {
         auditMap.append(cmd);
       }
-      auditMap.append(" , ");
+      auditMap.append(", ");
     }
-    int len = auditMap.toString().length();
-    if (len > 3) {
-      auditMap.deleteCharAt(len - 1);
-      auditMap.deleteCharAt(len - 2);
-      auditMap.deleteCharAt(len - 3);
+    int len = auditMap.length();
+    if (len > 2) {
+      auditMap.delete(len - 2, len - 1);
     }
     auditMap.append(']');
     return auditMap.toString();


### PR DESCRIPTION
## What changes were proposed in this pull request?

As a part of SCM audits for datanode's heartbeats, the command.toString for the commands being sent to the datanodes are logged. For most commands this results in a short string, but for deleteBlocks command, all the delete transactions are also added. This leads to a very verbose audit log. 
SCM should add only the metadata response to the logs appropriately for each of the commands. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12175

## How was this patch tested?

Tested manually.
Before the change:
```
2025-02-05 17:12:56,748 | INFO  | SCMAudit | user=hadoop | ip=172.18.0.10 | op=SEND_HEARTBEAT {datanodeUUID=b8ca7816-1298-4f9b-b962-a8b43351fb30, term=3, command=[commandType: deleteBlocksCommand deleteBlocksCommandProto { deletedBlocksTransactions { txID: 4 containerID: 4 localID: 115816896921600004 localID: 115816896921600005 localID: 115816896921600006 count: 0 } cmdId: 1738775521193 } term: 3 encodedToken: "" deadlineMsSinceEpoch: 0 ]} | ret=SUCCESS |
```
After the change:
```
2025-02-12 07:33:13,336 | INFO  | SCMAudit | user=hadoop | ip=172.18.0.5 | op=SEND_HEARTBEAT {datanodeUUID=6ad9c70a-b177-4e4a-b562-02019e68b957, term=4, command=[commandType: deleteBlocksCommand deleteTransactionsCount: 1 cmdID: 1739345533733 encodedToken: "" deadlineMsSinceEpoch: 0]} | ret=SUCCESS |
```
The debug log added:
```
2025-02-12 07:33:13,335 [IPC Server handler 10 on default port 9861] DEBUG server.SCMDatanodeHeartbeatDispatcher: Heartbeat dispatched: datanode=6ad9c70a-b177-4e4a-b562-02019e68b957, Commands= [deleteBlocksCommand: cmdID: 1739345533733, encodedToken: "", term: 4, deadlineMsSinceEpoch: 0, deletedBlocksTransaction: [ txnID:3,containerID:3,deleteBlockCount:3,count:0]]
```