### PR TITLE
HDDS-12199. Update in explanation in Merge Container RocksDB in DN Documentation

### DIFF
--- a/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.md
+++ b/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.md
@@ -27,7 +27,8 @@ In Ozone, user data are separated into blocks and stored in HDDS Containers. Con
 
 Earlier, there was one RocksDB for each Container on datanode. With user data continously growing, there will be hundreds of thousands of RocksDB instances on one datanode. It's a big challenge to manage this amount of RocksDB instances in one JVM. 
 
-Unlike the previous approach, this "Merge Container RocksDB in DN" feature will use only one RocksDB for each data volume, holding all metadata of Containers in this RocksDB. 
+Unlike the previous approach, this "Merge Container RocksDB in DN" feature will use only one RocksDB for each data volume 
+(here, data volume means the disc volume and not the ozone metadata volume) holding all metadata of Containers in this RocksDB. 
   
 ## Configuration
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

In the Merge Container RocksDB in DN Documentation in The third paragraph "Unlike the previous approach, this “Merge Container RocksDB in DN” feature will use only one RocksDB for each data volume, holding all metadata of Containers in this RocksDB.",the statement "It use only one RocksDB for each data volume ", the **data volume** mentioned over there is not clear and can be confused with the **ozone volume**. 

In this PR a small update has been done to explain the readers what the data volume it is refering to over here.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12199

## How was this patch tested?

Tested locally through **hugo serve**
