### PR TITLE
HDDS-12203. Initialize block length before skip

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/MultipartInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/MultipartInputStream.java
@@ -220,6 +220,11 @@ public class MultipartInputStream extends ExtendedInputStream {
 
   @Override
   public synchronized long skip(long n) throws IOException {
+    checkOpen();
+    if (!initialized) {
+      initialize();
+    }
+
     if (n <= 0) {
       return 0;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`HDDS-12203. Initialize block length before skip`

Please describe your PR in detail:
* skip() in MultipartInputStream doesn't call initialize(), which means `length` isn't valid before use.
* Similar issue as https://issues.apache.org/jira/browse/HDDS-11220


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12203

## How was this patch tested?
Integration Tests