### PR TITLE
HDDS-11953. Improve Recon OM sync process based on continuous pull of OM data.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3371,7 +3371,7 @@
   </property>
   <property>
     <name>recon.om.delta.update.limit</name>
-    <value>1000</value>
+    <value>0</value>
     <tag>OZONE, RECON</tag>
     <description>
       Recon each time get a limited delta updates from OM.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3371,7 +3371,7 @@
   </property>
   <property>
     <name>recon.om.delta.update.limit</name>
-    <value>0</value>
+    <value>50000</value>
     <tag>OZONE, RECON</tag>
     <description>
       Recon each time get a limited delta updates from OM.
@@ -3388,6 +3388,16 @@
       log files and each log batch data may be huge depending on frequent writes and
       updates by ozone client, so to avoid increase in heap memory, this config is used
       as limiting factor of default 1 GB while preparing DB updates object.
+    </description>
+  </property>
+  <property>
+    <name>recon.om.delta.update.lag.threshold</name>
+    <value>0</value>
+    <tag>OZONE, RECON</tag>
+    <description>
+      At every Recon OM sync, recon starts fetching OM DB updates, and it continues to
+      fetch from OM till the lag, between OM DB WAL sequence number and Recon OM DB
+      snapshot WAL sequence number, is less than this lag threshold value.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3358,7 +3358,7 @@
     <value>5s</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
-      Interval in MINUTES by Recon to request OM DB Snapshot.
+      Interval in SECONDS by Recon to request OM DB Snapshot.
     </description>
   </property>
   <property>
@@ -3371,7 +3371,7 @@
   </property>
   <property>
     <name>recon.om.delta.update.limit</name>
-    <value>50000</value>
+    <value>1000</value>
     <tag>OZONE, RECON</tag>
     <description>
       Recon each time get a limited delta updates from OM.
@@ -3388,15 +3388,6 @@
       log files and each log batch data may be huge depending on frequent writes and
       updates by ozone client, so to avoid increase in heap memory, this config is used
       as limiting factor of default 1 GB while preparing DB updates object.
-    </description>
-  </property>
-  <property>
-    <name>recon.om.delta.update.loop.limit</name>
-    <value>50</value>
-    <tag>OZONE, RECON</tag>
-    <description>
-      The sync between Recon and OM consists of several small
-      fetch loops.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -414,7 +414,7 @@ public class RDBStore implements DBStore {
           }
           // If the above condition was not satisfied, then it is OK to reset
           // the flag.
-          checkValidStartingSeqNumber = false;
+//          checkValidStartingSeqNumber = false;
           if (currSequenceNumber <= sequenceNumber) {
             logIterator.get().next();
             continue;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -414,7 +414,7 @@ public class RDBStore implements DBStore {
           }
           // If the above condition was not satisfied, then it is OK to reset
           // the flag.
-//          checkValidStartingSeqNumber = false;
+          checkValidStartingSeqNumber = false;
           if (currSequenceNumber <= sequenceNumber) {
             logIterator.get().next();
             continue;

--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-taskstatus.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-taskstatus.robot
@@ -105,6 +105,8 @@ Validate All Tasks Updated After Sync
 
 Validate Sequence number is updated after sync
     Log To Console          Triggering OM DB sync for updates
+    Log To Console          Wait for few seconds to let previous OM DB Sync thread to finish
+    Sleep  2s               # Waits for 2 seconds
     Sync OM Data
     ${tasks} =              Fetch Task Status
     Should Not Be Empty     ${tasks}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -25,7 +25,6 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SOCKET_TIMEOUT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LOOP_LIMIT;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,7 +107,6 @@ public class TestReconWithOzoneManager {
         TimeUnit.MILLISECONDS
     );
     conf.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 2);
-    conf.setLong(RECON_OM_DELTA_UPDATE_LOOP_LIMIT, 10);
 
     RequestConfig config = RequestConfig.custom()
         .setConnectTimeout(socketTimeout)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -106,7 +106,7 @@ public class TestReconWithOzoneManager {
             OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT),
         TimeUnit.MILLISECONDS
     );
-    conf.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 2);
+    conf.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 10);
 
     RequestConfig config = RequestConfig.custom()
         .setConnectTimeout(socketTimeout)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -98,7 +98,11 @@ public final class  ReconServerConfigKeys {
 
   public static final String RECON_OM_DELTA_UPDATE_LIMIT =
       "recon.om.delta.update.limit";
-  public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT = 0;
+  public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT = 50000;
+
+  public static final String RECON_OM_DELTA_UPDATE_LAG_THRESHOLD =
+      "recon.om.delta.update.lag.threshold";
+  public static final long RECON_OM_DELTA_UPDATE_LAG_THRESHOLD_DEFAULT = 0;
 
   public static final String OZONE_RECON_TASK_THREAD_COUNT_KEY =
       "ozone.recon.task.thread.count";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -99,9 +99,6 @@ public final class  ReconServerConfigKeys {
   public static final String RECON_OM_DELTA_UPDATE_LIMIT =
       "recon.om.delta.update.limit";
   public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT = 50000;
-  public static final String RECON_OM_DELTA_UPDATE_LOOP_LIMIT =
-      "recon.om.delta.update.loop.limit";
-  public static final int RECON_OM_DELTA_UPDATE_LOOP_LIMIT_DEFAULT = 50;
 
   public static final String OZONE_RECON_TASK_THREAD_COUNT_KEY =
       "ozone.recon.task.thread.count";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -98,7 +98,7 @@ public final class  ReconServerConfigKeys {
 
   public static final String RECON_OM_DELTA_UPDATE_LIMIT =
       "recon.om.delta.update.limit";
-  public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT = 50000;
+  public static final long RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT = 0;
 
   public static final String OZONE_RECON_TASK_THREAD_COUNT_KEY =
       "ozone.recon.task.thread.count";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -310,7 +310,7 @@ public class OzoneManagerServiceProviderImpl
       startSyncDataFromOM(0L);
       return true;
     } else {
-      LOG.debug("OM DB sync is already running.");
+      LOG.info("OM DB sync is already running when trying to trigger OM DB sync manually.");
     }
     return false;
   }
@@ -465,6 +465,7 @@ public class OzoneManagerServiceProviderImpl
           "Unable to get delta updates since sequenceNumber - " +
               fromSequenceNumber);
     }
+    omdbUpdatesHandler.setLatestSequenceNumber(getCurrentOMDBSequenceNumber());
     LOG.info("Delta updates received from OM : {} records", getCurrentOMDBSequenceNumber() - fromSequenceNumber);
     return dbUpdatesLatestSeqNumOfOMDB.getRight();
   }
@@ -582,7 +583,7 @@ public class OzoneManagerServiceProviderImpl
               reconTaskController.consumeOMEvents(new OMUpdateEventBatch(
                   omdbUpdatesHandler.getEvents(), omdbUpdatesHandler.getLatestSequenceNumber()), omMetadataManager);
               currentSequenceNumber = getCurrentOMDBSequenceNumber();
-              LOG.error("Updated current sequence number: {}", currentSequenceNumber);
+              LOG.debug("Updated current sequence number: {}", currentSequenceNumber);
               loopCount++;
             }
             LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
@@ -664,7 +665,7 @@ public class OzoneManagerServiceProviderImpl
         isSyncDataFromOMRunning.set(false);
       }
     } else {
-      LOG.info("OM DB sync is already running.");
+      LOG.info("OM DB sync is already running in syncDataFromOM.");
       return false;
     }
     return true;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -103,7 +103,6 @@ import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.LEADER;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sqlite.core.DB;
 
 /**
  * Implementation of the OzoneManager Service provider.

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -417,6 +417,7 @@ public class TestOzoneManagerServiceProviderImpl {
       result.writeBatch().markWalTerminationPoint();
       WriteBatch writeBatch = result.writeBatch();
       dbUpdatesWrapper[index] = new DBUpdates();
+      dbUpdatesWrapper[index].setLatestSequenceNumber(dbUpdatesWrapper.length);
       dbUpdatesWrapper[index].addWriteBatch(writeBatch.data(),
           result.sequenceNumber());
       index++;
@@ -429,7 +430,7 @@ public class TestOzoneManagerServiceProviderImpl {
 
     OzoneConfiguration withLimitConfiguration =
         new OzoneConfiguration(configuration);
-    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 1);
+    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 10);
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(withLimitConfiguration,
             getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),
@@ -443,15 +444,14 @@ public class TestOzoneManagerServiceProviderImpl {
     assertTrue(dbUpdatesWrapper[2].isDBUpdateSuccess());
     assertTrue(dbUpdatesWrapper[3].isDBUpdateSuccess());
 
-    /*OMDBUpdatesHandler updatesHandler =
+    OMDBUpdatesHandler updatesHandler =
         new OMDBUpdatesHandler(omMetadataManager);
     ozoneManagerServiceProvider.getAndApplyDeltaUpdatesFromOM(
-        0L, updatesHandler);*/
+        0L, updatesHandler);
     // ReconOM snapshot DB initialized with Volume and bucket creation events already
     assertEquals(2, ozoneManagerServiceProvider.getCurrentOMDBSequenceNumber());
 
-    ozoneManagerServiceProvider.syncDataFromOM();
-
+    //ozoneManagerServiceProvider.syncDataFromOM();
 
     OzoneManagerSyncMetrics metrics = ozoneManagerServiceProvider.getMetrics();
     assertEquals(1.0,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LAG_THRESHOLD;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT;
 import static org.apache.hadoop.ozone.recon.ReconUtils.createTarFile;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
@@ -363,7 +364,7 @@ public class TestOzoneManagerServiceProviderImpl {
 
     OzoneConfiguration withLimitConfiguration =
         new OzoneConfiguration(configuration);
-    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 0);
+    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 10);
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(configuration,
             getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),
@@ -430,7 +431,8 @@ public class TestOzoneManagerServiceProviderImpl {
 
     OzoneConfiguration withLimitConfiguration =
         new OzoneConfiguration(configuration);
-    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 1);
+    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 3);
+    withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LAG_THRESHOLD, 1);
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(withLimitConfiguration,
             getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to get rid of interval delay configs for Recon OM DB snapshot sync with active OM DB because these configs may not make much sense when OM write TPS is very high in the range of more than 5k.

Currently Recon sync with OM based on following configs:

ozone.recon.om.snapshot.task.interval.delay -> 5s
recon.om.delta.update.limit -> 50000
recon.om.delta.update.loop.limit -> 50
Above are recommended and default configs for high write TPS workload in the range of approx 5k to achieve near real time sync between Recon and OM data. However in future, TPS may achieve higher targets in OM and Recon needs to pull data continuously to keep lag and latency minimum. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11953

## How was this patch tested?
Tested with junit and integration tests of recon OM DB sync.