### PR TITLE
HDDS-12202. OpsCreate and OpsAppend metrics not incremented

### DIFF
--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/FSOperations.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/FSOperations.java
@@ -455,6 +455,7 @@ public final class FSOperations {
       OutputStream os = fs.append(path, bufferSize);
       long bytes = copyBytes(is, os);
       HttpFSServerWebApp.get().getMetrics().incrBytesWritten(bytes);
+      HttpFSServerWebApp.get().getMetrics().incrOpsAppend();
       return null;
     }
 
@@ -667,6 +668,7 @@ public final class FSOperations {
           null);
       long bytes = copyBytes(is, os);
       HttpFSServerWebApp.get().getMetrics().incrBytesWritten(bytes);
+      HttpFSServerWebApp.get().getMetrics().incrOpsCreate();
       return null;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

FSCreate and FSAppend only update bytesWritten, but not opsCreate and opsAppend counters.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12202

## How was this patch tested?

CI: https://github.com/peterxcli/ozone/actions/runs/13140722679