### PR TITLE
HDDS-12044. Fix Heatmap calendar closing on skipping years/months

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/heatmap/heatmap.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/heatmap/heatmap.tsx
@@ -17,9 +17,9 @@
  */
 import React, { ChangeEvent, useRef, useState } from 'react';
 import moment, { Moment } from 'moment';
-import { Row, Button, Menu, Input, Dropdown, DatePicker, Form, Result, message, Spin } from 'antd';
+import { Button, Menu, Input, Dropdown, DatePicker, Form, Result, Spin } from 'antd';
 import { MenuProps } from 'antd/es/menu';
-import { DownOutlined, LoadingOutlined, UndoOutlined } from '@ant-design/icons';
+import { DownOutlined } from '@ant-design/icons';
 
 
 import { showDataFetchError } from '@/utils/common';
@@ -30,7 +30,6 @@ import HeatmapPlot from '@/v2/components/plots/heatmapPlot';
 
 import './heatmap.less';
 import { useLocation } from 'react-router-dom';
-import { AxiosResponse } from 'axios';
 
 let minSize = Infinity;
 let maxSize = 0;
@@ -266,13 +265,13 @@ const Heatmap: React.FC<{}> = () => {
         90 Days
       </Menu.Item>
       <Menu.SubMenu title='Custom Select Last 90 Days'>
-        <Menu.Item key='heatmapDatePicker'>
+        <div>
           <DatePicker
             format="YYYY-MM-DD"
             onChange={handleDatePickerChange}
             onClick={(e) => { e.stopPropagation() }}
             disabledDate={isDateDisabled} />
-        </Menu.Item>
+        </div>
       </Menu.SubMenu>
     </Menu>
   );


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12044. Fix Heatmap calendar closing on skipping years/months

*  Currently the DatePicker component is buggy and closes when the parent menu closes.
* As a result of this when we are skipping the years or months in the calendar the menu is out of focused and everything closes.
* This PR wraps the calendar component under a div instead of a menu item to prevent the default behaviour on blur as a workaround.
* It also removes unused imports from the heatmap.tsx file.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12044

## How was this patch tested?
Patch was tested manually.

https://github.com/user-attachments/assets/e90781f6-13e6-4028-abb9-66ad468c7e86
