### PR TITLE
HDDS-12212. Fix grammar in decommissioning and observability documentation

### DIFF
--- a/hadoop-hdds/docs/content/feature/Decommission.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.md
@@ -70,7 +70,7 @@ ozone admin datanode recommission [-hV] [-id=<scmServiceId>]
 Ozone Manager (OM) decommissioning is the process in which you gracefully remove one of the OM from the OM HA Ring.
 
 To decommission an OM and remove the node from the OM HA ring, the following steps need to be executed.
-1. Add the _OM NodeId_ of the to be decommissioned OM node to the _ozone.om.decommissioned.nodes.<omServiceId>_ property in _ozone-site.xml_ of all
+1. Add the _OM NodeId_ of the OM Node to be decommissioned to the _ozone.om.decommissioned.nodes.<omServiceId>_ property in _ozone-site.xml_ of all
    other OMs.
 2. Run the following command to decommission an OM node.
 ```shell

--- a/hadoop-hdds/docs/content/feature/Observability.md
+++ b/hadoop-hdds/docs/content/feature/Observability.md
@@ -56,7 +56,7 @@ scrape_configs:
 
 ## Grafana
 
-Once Prometheus is up and running, Grana can be configured to monitor and visualize Ozone metrics.
+Once Prometheus is up and running, Grafana can be configured to monitor and visualize Ozone metrics.
 
 ### Add Prometheus as a data source
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. In the Decommissioning feature in upstream doc for the OM decommissioning one grammatical mistake is there:

"Add **the OM NodeId of the to be decommissioned OM node** to the ozone.om.decommissioned.nodes. property in ozone-site.xml of all other OMs."
Here I corrected to "Add the OM NodeId of the OM Node to be decommissioned to"

2. In the Observability feature in upstream doc for the Grafana , there is a spelling mistake.

"Grana" is corrected to "Grafana"

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12212

## How was this patch tested?

Tested locally through hugo serve
