### PR TITLE
HDDS-10607. Remove unused ozone.block.deleting.container.limit.per.interval config property

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -333,8 +333,6 @@ public final class OzoneConfigKeys {
   public static final int OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT
       = 1000;
 
-
-
   public static final String HDDS_CONTAINER_RATIS_ENABLED_KEY
       = ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
   public static final boolean HDDS_CONTAINER_RATIS_ENABLED_DEFAULT

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -333,10 +333,7 @@ public final class OzoneConfigKeys {
   public static final int OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT
       = 1000;
 
-  public static final String OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL
-      = "ozone.block.deleting.container.limit.per.interval";
-  public static final int
-      OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL_DEFAULT = 10;
+
 
   public static final String HDDS_CONTAINER_RATIS_ENABLED_KEY
       = ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -427,17 +427,6 @@
     </description>
   </property>
   <property>
-    <name>ozone.block.deleting.container.limit.per.interval</name>
-    <value>10</value>
-    <tag>OZONE, PERFORMANCE, SCM</tag>
-    <description>A maximum number of containers to be scanned by block deleting
-      service per
-      time interval. The block deleting service spawns a thread to handle block
-      deletions in a container. This property is used to throttle the number of
-      threads spawned for block deletions.
-    </description>
-  </property>
-  <property>
     <name>ozone.block.deleting.limit.per.task</name>
     <value>1000</value>
     <tag>OZONE, PERFORMANCE, SCM</tag>

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -95,7 +95,6 @@ import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V1;
@@ -770,7 +769,6 @@ public class TestBlockDeletingService {
     setLayoutAndSchemaForTest(versionInfo);
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 500,
         TimeUnit.MILLISECONDS);
-    conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 10);
 
     ContainerSet containerSet = new ContainerSet(1000);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -66,7 +66,7 @@ import java.util.HashSet;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -555,7 +555,6 @@ public class TestSchemaOneBackwardsCompatibility {
 
   private void runBlockDeletingService(KeyValueHandler keyValueHandler)
       throws Exception {
-    conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 2);
 
     OzoneContainer container = makeMockOzoneContainer(keyValueHandler);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -66,7 +66,6 @@ import java.util.HashSet;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
@@ -68,7 +68,6 @@ import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.BLOCK_COUNT;
 import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_BYTES_USED;
 import static org.apache.hadoop.ozone.OzoneConsts.PENDING_DELETE_BLOCK_COUNT;
@@ -224,7 +223,6 @@ public class TestSchemaTwoBackwardsCompatibility {
   @Test
   public void testDeleteViaTransation() throws IOException, TimeoutException,
       InterruptedException {
-    conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER,
         BLOCKS_PER_CONTAINER);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The ozone.block.deleting.container.limit.per.interval property, along with the test cases referring to this property, were removed as it is not used anymore by the block deletion logic.

The modifications done are as follows:
1. The ozone.block.deleting.container.limit.per.interval property has been removed from the ozone-default.xml file.
2. References to this property have been removed from the following files:
      -       TestBlockDeletingService.java
      -       TestSchemaOneBackwardCompatibility.java
      -       TestSchemaTwoBackwardCompatibility.java
      -       OzoneConfigKeys.java


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10607

## How was this patch tested?
The patch was tested by the following tests:
Integration (client)
Integration (container)
Integration (filesystem)
Integration (flaky)
Integration (hdds)
Integration (om)
Integration (ozone)
Integration (recon)
Integration (shell)
Integration (snapshot)

acceptance (EC)
acceptance (HA-secure)
acceptance (HA-unsecure)
acceptance (MR)
acceptance (balancer)
acceptance (cert-roration)
acceptance (compat-new)
acceptance (compat-old)
acceptance (leadership)
acceptance (misc)
acceptance (s3a)
acceptance (secure)
acceptance (unsecure)
acceptance (upgrade)

The link to the workflow is as follows:
https://github.com/sreejasahithi/ozone/actions/runs/13156101983
