### PR TITLE
HDDS-12217. Remove reference to FileUtil in hdds-common

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.common;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_INIT_DEFAULT_LAYOUT_VERSION_DEFAULT;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.util.Time;
@@ -235,7 +234,7 @@ public abstract class Storage {
         LOG.warn("{} is not a directory", rootPath);
         return StorageState.NON_EXISTENT;
       }
-      if (!FileUtil.canWrite(root)) {
+      if (!root.canWrite()) {
         LOG.warn("Cannot access storage directory {}", rootPath);
         return StorageState.NON_EXISTENT;
       }

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -86,10 +86,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hadoop `FileUtil` requires `commons-compress` at runtime.  Remove a reference to it from `hdds-common` to reduce client's dependencies.

https://issues.apache.org/jira/browse/HDDS-12217

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13165660996