### PR TITLE
HDDS-12218. Add more to integration test with shared cluster

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMMXBean.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm;
 
+import org.apache.ozone.test.NonHATests;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -27,22 +28,18 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Iterator;
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
@@ -56,33 +53,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  *
  * This class is to test JMX management interface for scm information.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestSCMMXBean {
+public abstract class TestSCMMXBean implements NonHATests.TestCase {
 
   public static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
-  private static int numOfDatanodes = 3;
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static StorageContainerManager scm;
-  private static MBeanServer mbs;
+  private StorageContainerManager scm;
+  private MBeanServer mbs;
 
   @BeforeAll
-  public static void init() throws IOException, TimeoutException,
-      InterruptedException {
-    conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(numOfDatanodes)
-        .build();
-    cluster.waitForClusterToBeReady();
-    scm = cluster.getStorageContainerManager();
+  void init() {
+    scm = cluster().getStorageContainerManager();
     mbs = ManagementFactory.getPlatformMBeanServer();
-  }
-
-  @AfterAll
-  public static void shutdown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test
@@ -119,8 +101,8 @@ public class TestSCMMXBean {
             + "component=ServerRuntime");
     TabularData data = (TabularData) mbs.getAttribute(
         bean, "ContainerStateCount");
-    Map<String, Integer> containerStateCount = scm.getContainerStateCount();
-    verifyEquals(data, containerStateCount);
+    final Map<String, Integer> originalContainerStateCount = scm.getContainerStateCount();
+    verifyEquals(data, originalContainerStateCount);
 
     // Do some changes like allocate containers and change the container states
     ContainerManager scmContainerManager = scm.getContainerManager();
@@ -154,23 +136,16 @@ public class TestSCMMXBean {
 
     }
 
+    final String closing = HddsProtos.LifeCycleState.CLOSING.name();
+    final String closed = HddsProtos.LifeCycleState.CLOSED.name();
+    final Map<String, Integer> containerStateCount = scm.getContainerStateCount();
+    assertThat(containerStateCount.get(closing))
+        .isGreaterThanOrEqualTo(originalContainerStateCount.getOrDefault(closing, 0) + 5);
+    assertThat(containerStateCount.get(closed))
+        .isGreaterThanOrEqualTo(originalContainerStateCount.getOrDefault(closed, 0) + 5);
     data = (TabularData) mbs.getAttribute(
         bean, "ContainerStateCount");
-    containerStateCount = scm.getContainerStateCount();
-
-    containerStateCount.forEach((k, v) -> {
-      if (k.equals(HddsProtos.LifeCycleState.CLOSING.toString())) {
-        assertEquals(5, (int)v);
-      } else if (k.equals(HddsProtos.LifeCycleState.CLOSED.toString())) {
-        assertEquals(5, (int)v);
-      } else  {
-        // Remaining all container state count should be zero.
-        assertEquals(0, (int)v);
-      }
-    });
-
     verifyEquals(data, containerStateCount);
-
   }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDiscardPreallocatedBlocks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDiscardPreallocatedBlocks.java
@@ -17,126 +17,85 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ReplicationType;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
-import org.apache.hadoop.hdds.scm.OzoneClientConfig;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.BlockOutputStreamEntry;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
-import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.container.TestHelper.createKey;
+import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 /**
- * Tests Close Container Exception handling by Ozone Client.
+ * Tests that unused block pre-allocated for write is discarded when container is closed.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestDiscardPreallocatedBlocks {
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf = new OzoneConfiguration();
-  private static OzoneClient client;
-  private static ObjectStore objectStore;
-  private static int chunkSize;
-  private static int blockSize;
-  private static String volumeName;
-  private static String bucketName;
-  private static String keyString;
-
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   *
-   * @throws IOException
-   */
+public abstract class TestDiscardPreallocatedBlocks implements NonHATests.TestCase {
+  private MiniOzoneCluster cluster;
+  private OzoneClient client;
+  private ObjectStore objectStore;
+  private int blockSize;
+  private String volumeName;
+  private String bucketName;
+  private String keyString;
 
   @BeforeAll
-  public static void init() throws Exception {
-    chunkSize = (int) OzoneConsts.MB;
-    blockSize = 4 * chunkSize;
+  void init() throws Exception {
+    blockSize = (int) cluster().getConf().getStorageSize(OZONE_SCM_BLOCK_SIZE,
+        OZONE_SCM_BLOCK_SIZE_DEFAULT, StorageUnit.BYTES);
 
-    OzoneClientConfig config = conf.getObject(OzoneClientConfig.class);
-    config.setChecksumType(ChecksumType.NONE);
-    conf.setFromObject(config);
-
-    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
-    conf.setQuietMode(false);
-    conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 4,
-        StorageUnit.MB);
-    conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 1);
-    conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
-    cluster.waitForClusterToBeReady();
-    //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getRpcClient(conf);
+    cluster = cluster();
+    client = cluster.newClient();
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
-    volumeName = "closecontainerexceptionhandlingtest";
-    bucketName = volumeName;
+    volumeName = UUID.randomUUID().toString();
+    bucketName = "bucket";
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
 
-  private String getKeyName() {
-    return UUID.randomUUID().toString();
-  }
-
-  /**
-   * Shutdown MiniDFSCluster.
-   */
-
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test
   public void testDiscardPreallocatedBlocks() throws Exception {
-    String keyName = getKeyName();
+    String keyName = "key";
     OzoneOutputStream key =
-        createKey(keyName, ReplicationType.RATIS, 2 * blockSize);
+        createKey(keyName, ReplicationType.RATIS, 2L * blockSize, objectStore, volumeName, bucketName);
     KeyOutputStream keyOutputStream =
         assertInstanceOf(KeyOutputStream.class, key.getOutputStream());
     // With the initial size provided, it should have pre allocated 2 blocks
     assertEquals(2, keyOutputStream.getStreamEntries().size());
-    long containerID1 = keyOutputStream.getStreamEntries().get(0)
-        .getBlockID().getContainerID();
-    long containerID2 = keyOutputStream.getStreamEntries().get(1)
-        .getBlockID().getContainerID();
-    assertEquals(containerID1, containerID2);
     String dataString =
         ContainerTestHelper.getFixedLengthString(keyString, (1 * blockSize));
     byte[] data = dataString.getBytes(UTF_8);
@@ -154,7 +113,7 @@ public class TestDiscardPreallocatedBlocks {
             .getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
     assertEquals(3, datanodes.size());
-    waitForContainerClose(key);
+    waitForContainerClose(key, cluster);
     dataString =
         ContainerTestHelper.getFixedLengthString(keyString, (1 * blockSize));
     data = dataString.getBytes(UTF_8);
@@ -169,19 +128,6 @@ public class TestDiscardPreallocatedBlocks {
     assertNotEquals(locationStreamInfos.get(1).getBlockID(),
         keyOutputStream.getLocationInfoList().get(1).getBlockID());
     key.close();
-
-  }
-
-  private OzoneOutputStream createKey(String keyName, ReplicationType type,
-                                      long size) throws Exception {
-    return TestHelper
-        .createKey(keyName, type, size, objectStore, volumeName, bucketName);
-  }
-
-  private void waitForContainerClose(OzoneOutputStream outputStream)
-      throws Exception {
-    TestHelper
-        .waitForContainerClose(outputStream, cluster);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -20,19 +20,19 @@ import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.TestDataUtil;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
-import java.io.IOException;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,42 +41,36 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * Tests to verify bucket ops with older version client.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(1200)
-public class TestBucketLayoutWithOlderClient {
+public abstract class TestBucketLayoutWithOlderClient implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster = null;
-  private static OzoneConfiguration conf;
-  private static OzoneClient client;
+  private MiniOzoneCluster cluster;
+  private OzoneClient client;
 
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   *
-   * @throws IOException
-   */
   @BeforeAll
-  public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
-        BucketLayout.OBJECT_STORE.name());
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
+  void init() throws Exception {
+    cluster = cluster();
     client = cluster.newClient();
   }
 
   @Test
   public void testCreateBucketWithOlderClient() throws Exception {
     // create a volume and a bucket without bucket layout argument
+    BucketLayout defaultLayout = cluster().getConf().getEnum(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client, null);
     String volumeName = bucket.getVolumeName();
     // OM defaulted bucket layout
-    assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
+    assertEquals(defaultLayout, bucket.getBucketLayout());
 
     // Sets bucket layout explicitly.
     OzoneBucket fsobucket = TestDataUtil
         .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);
     assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         fsobucket.getBucketLayout());
+    OzoneBucket obsBucket = TestDataUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
+    assertEquals(BucketLayout.OBJECT_STORE, obsBucket.getBucketLayout());
 
     // Create bucket request by an older client.
     // Here sets ClientVersion.DEFAULT_VERSION
@@ -113,14 +107,8 @@ public class TestBucketLayoutWithOlderClient {
     assertEquals(BucketLayout.LEGACY, bucketInfo.getBucketLayout());
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
@@ -20,6 +20,7 @@ package org.apache.ozone.test;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.junit.jupiter.api.AfterAll;
@@ -27,9 +28,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LEASE_SOFT_LIMIT;
 
 /**
  * Base class for Ozone integration tests.  Manages lifecycle of {@link MiniOzoneCluster}.
@@ -59,9 +62,14 @@ public abstract class ClusterForTests<C extends MiniOzoneCluster> {
     raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(10));
     conf.setFromObject(raftClientConfig);
 
+    OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
+    clientConfig.setStreamBufferFlushDelay(false);
+    conf.setFromObject(clientConfig);
+
     conf.setBoolean(OZONE_HBASE_ENHANCEMENTS_ALLOWED, true);
     conf.setBoolean("ozone.client.hbase.enhancements.allowed", true);
     conf.setBoolean(OZONE_FS_HSYNC_ENABLED, true);
+    conf.setTimeDuration(OZONE_OM_LEASE_SOFT_LIMIT, 0, TimeUnit.SECONDS);
 
     return conf;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/HATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/HATests.java
@@ -57,6 +57,14 @@ public abstract class HATests extends ClusterForTests<MiniOzoneHAClusterImpl> {
   }
 
   @Nested
+  class ScmApplyTransactionFailure extends org.apache.hadoop.hdds.scm.container.TestScmApplyTransactionFailure {
+    @Override
+    public MiniOzoneHAClusterImpl cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class GetClusterTreeInformation extends org.apache.hadoop.ozone.TestGetClusterTreeInformation {
     @Override
     public MiniOzoneHAClusterImpl cluster() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -75,7 +75,23 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
+  class SCMMXBean extends org.apache.hadoop.hdds.scm.TestSCMMXBean {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class SCMNodeManagerMXBean extends org.apache.hadoop.hdds.scm.TestSCMNodeManagerMXBean {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class Node2PipelineMap extends org.apache.hadoop.hdds.scm.pipeline.TestNode2PipelineMap {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -91,7 +107,23 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
+  class SCMPipelineMetrics extends org.apache.hadoop.hdds.scm.pipeline.TestSCMPipelineMetrics {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class CpuMetrics extends org.apache.hadoop.ozone.TestCpuMetrics {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class DiscardPreallocatedBlocks extends org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -107,7 +139,23 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
+  class LeaseRecoverer extends org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class ObjectStore extends org.apache.hadoop.ozone.om.TestObjectStore {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class BucketLayoutWithOlderClient extends org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Run few more integration tests with shared cluster to save time.

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s - in org.apache.ozone.test.HATests$ScmApplyTransactionFailure
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.075 s - in org.apache.ozone.test.NonHATests$BucketLayoutWithOlderClient
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.932 s - in org.apache.ozone.test.NonHATests$DiscardPreallocatedBlocks
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.271 s - in org.apache.ozone.test.NonHATests$LeaseRecoverer
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s - in org.apache.ozone.test.NonHATests$Node2PipelineMap
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s - in org.apache.ozone.test.NonHATests$SCMMXBean
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.282 s - in org.apache.ozone.test.NonHATests$SCMPipelineMetrics
```

https://issues.apache.org/jira/browse/HDDS-12218

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/13170949852/job/36761414304#step:6:4321
