### PR TITLE
HDDS-12228. Fix Duplicate Key Violation Condition in FileSizeCountTask.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -95,7 +95,7 @@ public class FileSizeCountTask implements ReconOmTask {
     if (!statusFSO && !statusOBS) {
       return new ImmutablePair<>(getTaskName(), false);
     }
-    writeCountsToDB(true, fileSizeCountMap);
+    writeCountsToDB(fileSizeCountMap);
     LOG.debug("Completed a 'reprocess' run of FileSizeCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
@@ -112,7 +112,7 @@ public class FileSizeCountTask implements ReconOmTask {
         handlePutKeyEvent(kv.getValue(), fileSizeCountMap);
         //  The time complexity of .size() method is constant time, O(1)
         if (fileSizeCountMap.size() >= 100000) {
-          writeCountsToDB(true, fileSizeCountMap);
+          writeCountsToDB(fileSizeCountMap);
           fileSizeCountMap.clear();
         }
       }
@@ -198,7 +198,7 @@ public class FileSizeCountTask implements ReconOmTask {
             value.getClass().getName(), updatedKey);
       }
     }
-    writeCountsToDB(false, fileSizeCountMap);
+    writeCountsToDB(fileSizeCountMap);
     LOG.debug("{} successfully processed in {} milliseconds",
         getTaskName(), (System.currentTimeMillis() - startTime));
     return new ImmutablePair<>(getTaskName(), true);
@@ -209,10 +209,11 @@ public class FileSizeCountTask implements ReconOmTask {
    * using the dao.
    *
    */
-  private void writeCountsToDB(boolean isDbTruncated,
-                               Map<FileSizeCountKey, Long> fileSizeCountMap) {
+  private void writeCountsToDB(Map<FileSizeCountKey, Long> fileSizeCountMap) {
+
     List<FileCountBySize> insertToDb = new ArrayList<>();
     List<FileCountBySize> updateInDb = new ArrayList<>();
+    boolean isDbTruncated = isFileCountBySizeTableEmpty(); // Check if table is empty
 
     fileSizeCountMap.keySet().forEach((FileSizeCountKey key) -> {
       FileCountBySize newRecord = new FileCountBySize();
@@ -293,6 +294,15 @@ public class FileSizeCountTask implements ReconOmTask {
           fileSizeCountMap.get(countKey) - 1L : -1L;
       fileSizeCountMap.put(countKey, count);
     }
+  }
+
+  /**
+   * Checks if the FILE_COUNT_BY_SIZE table is empty.
+   *
+   * @return true if the table is empty, false otherwise.
+   */
+  private boolean isFileCountBySizeTableEmpty() {
+    return dslContext.fetchCount(FILE_COUNT_BY_SIZE) == 0;
   }
 
   private static class FileSizeCountKey {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the `FileSizeCountTask` class, the update logic in `writeCountsToDB()` is never reached because `isDbTruncated` is always passed as true. This means that records are always inserted without checking for existing records, leading to SQL exceptions due to duplicate primary key constraints.

Example of SQL Exception:
```
2025-02-06 12:57:03 Caused by: org.jooq.exception.DataAccessException: SQL [insert into "FILE_COUNT_BY_SIZE" ("volume", "bucket", "file_size", "count") values (cast(? as varchar(32672)), cast(? as varchar(32672)), cast(? as bigint), cast(? as bigint))]; The statement was aborted because it would have caused a duplicate key value in a unique or primary key constraint or unique index identified by 'pk_volume_bucket_file_size' defined on 'FILE_COUNT_BY_SIZE'.
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12228

## How was this patch tested?

Existing UT ran successfully also tested out manually with duplicate sized keys.

<img width="504" alt="image" src="https://github.com/user-attachments/assets/6f29392d-bbaa-44e8-8ba3-0fc38ce45488" />
