### PR TITLE
HDDS-12227. Avoid Clutter in Recon Logs by Reducing Log Level of ContainerSizeCountTask.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -106,7 +106,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
             durationMilliseconds);
       }
     } catch (Throwable t) {
-      LOG.error("Exception in Container Size Distribution task Thread.", t);
+      LOG.debug("Exception in Container Size Distribution task Thread.", t);
       if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, ContainerSizeCountTask logs an error when processing containers with negative sizes. However, these containers are already ignored from the count, meaning they do not cause any functional issues. The repeated logging of such messages results in excessive noise, making it difficult to diagnose real issues in Recon.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12227?filter=-1

## How was this patch tested?
