### PR TITLE
HDDS-12230. Fix bug in ozone sh key put for file not found error

### DIFF
--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -82,8 +82,7 @@ public class PutKeyHandler extends KeyHandler {
 
     File dataFile = new File(fileName);
     if (!dataFile.exists()) {
-      out().printf("Error: File not found: %s%n", fileName);
-      return;
+      throw new IOException("Error: File not found: "+ fileName);
     }
 
     if (isVerbose()) {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -82,7 +82,7 @@ public class PutKeyHandler extends KeyHandler {
 
     File dataFile = new File(fileName);
     if (!dataFile.exists()) {
-      throw new IOException("Error: File not found: "+ fileName);
+      throw new IOException("Error: File not found: " + fileName);
     }
 
     if (isVerbose()) {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -82,7 +82,7 @@ public class PutKeyHandler extends KeyHandler {
 
     File dataFile = new File(fileName);
     if (!dataFile.exists()) {
-      out().printf("Error: File not found: %s%n",fileName);
+      out().printf("Error: File not found: %s%n", fileName);
       return;
     }
 

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -81,6 +81,10 @@ public class PutKeyHandler extends KeyHandler {
     String keyName = address.getKeyName();
 
     File dataFile = new File(fileName);
+    if (!dataFile.exists()) {
+      out().printf("Error: File not found: %s%n",fileName);
+      return;
+    }
 
     if (isVerbose()) {
       try (InputStream stream = Files.newInputStream(dataFile.toPath())) {

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -92,7 +92,7 @@ Test ozone shell
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
 
 Test ozone shell errors
-    [arguments]     ${protocol}         ${server}       ${volume}       ${bucket}       ${key}       ${file}
+    [arguments]     ${protocol}         ${server}       ${volume}
     ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --space-quota 1.5GB      255
                     Should contain      ${result}       1.5GB is invalid
     ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --namespace-quota 1.5      255
@@ -131,8 +131,8 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
-    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/${bucket}/${key} ${file}         255
-                    Should contain      ${result}       "Error: File not found: ${file}"
+    ${result} =     Execute and Ignore Error    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt
+                    Should contain      ${result}       Error: File not found: .*
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -132,7 +132,7 @@ Test ozone shell errors
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
     ${result} =     Execute and Ignore Error    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt
-    Should Match Regexp                         ${result}       Error: File not found: .*
+    Should Match                                ${result}       Error: File not found: .*
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -92,7 +92,7 @@ Test ozone shell
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
 
 Test ozone shell errors
-    [arguments]     ${protocol}         ${server}       ${volume}
+    [arguments]     ${protocol}         ${server}       ${volume}       ${bucket}       ${key}       ${file}
     ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --space-quota 1.5GB      255
                     Should contain      ${result}       1.5GB is invalid
     ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --namespace-quota 1.5      255
@@ -131,8 +131,8 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
-
-
+    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/${bucket}/${key} ${file}         255
+                    Should contain      ${result}       "Error: File not found: ${file}"
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -131,8 +131,8 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
-    ${result} =     Execute and Ignore Error    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt
-    Should Match                                ${result}       Error: File not found: .*
+    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt          255
+                    Should Match Regexp                    ${result}       Error: File not found: .*
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -132,7 +132,7 @@ Test ozone shell errors
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
     ${result} =     Execute and Ignore Error    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt
-                    Should contain      ${result}       Error: File not found: .*
+    Should Match Regexp                         ${result}       Error: File not found: .*
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The ozone sh key put command was updated to handle cases where the specified file does not exist. Previously, the command failed silently without providing proper feedback. A check was added in PutKeyHandler.java to verify if the file exists, and an appropriate error message is now displayed when the file does not exist. Additionally, a test was added to the ozone-shell-lib.robot under "Test ozone shell errors" to ensure the error handling works correctly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12230

## How was this patch tested?
This patch was tested locally on docker.
Bellow is the workflow link which passed successfully.
https://github.com/sreejasahithi/ozone/actions/runs/13184833819


Before:
<img width="921" alt="Before" src="https://github.com/user-attachments/assets/f58bfe3c-4ef9-415b-af0d-06669fe93aa1" />

After:
<img width="885" alt="After" src="https://github.com/user-attachments/assets/0ab9738d-26b9-4a7d-bf68-ccb54f84192c" />


