### PR TITLE
HDDS-12240. [Snapshot] Add a config to generate compaction DAG for RocksDB.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -650,6 +650,13 @@ public final class OzoneConfigKeys {
       "org.apache.hadoop.ozone.om.TrashPolicyOzone";
 
   public static final String
+      OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED =
+      "ozone.om.snapshot.compaction.dag.enabled";
+
+  public static final boolean
+      OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED_DEFAULT =
+      true;
+  public static final String
       OZONE_OM_SNAPSHOT_COMPACTION_DAG_MAX_TIME_ALLOWED =
       "ozone.om.snapshot.compaction.dag.max.time.allowed";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4334,6 +4334,15 @@
   </property>
 
   <property>
+    <name>ozone.om.snapshot.compaction.dag.enabled</name>
+    <value>true</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      If true, compaction DAG will be generated during RocksDB compaction.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.snapshot.compaction.dag.prune.daemon.run.interval</name>
     <value>3600s</value>
     <tag>OZONE, OM</tag>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotDisabled.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotDisabled.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.DBProfile;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Timeout;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FEATURE_NOT_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -57,6 +59,7 @@ public class TestOmSnapshotDisabled {
     conf.setEnum(HDDS_DB_PROFILE, DBProfile.TEST);
     // Disable filesystem snapshot feature for this test
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, false);
+    conf.setBoolean(OzoneConfigKeys.OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED, false);
 
     cluster = MiniOzoneCluster.newHABuilder(conf)
         .setOMServiceId("om-service-test1")
@@ -94,5 +97,6 @@ public class TestOmSnapshotDisabled {
     omException = assertThrows(OMException.class,
         () -> store.deleteSnapshot(volumeName, bucketName, snapshotName));
     assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
+    assertNull(cluster.getOzoneManager().getMetadataManager().getStore().getRocksDBCheckpointDiffer());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -590,7 +590,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     boolean enableCompactionDag =
         configuration.getBoolean(OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED,
             OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED_DEFAULT);
-    return loadDB(configuration, metaDir, OM_DB_NAME, false, java.util.Optional.empty(), maxOpenFiles, enableCompactionDag, true);
+    return loadDB(configuration, metaDir, OM_DB_NAME, false,
+        java.util.Optional.empty(), maxOpenFiles, enableCompactionDag, true);
   }
 
   @SuppressWarnings("checkstyle:parameternumber")

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -101,6 +101,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
@@ -584,7 +587,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir, int maxOpenFiles) throws IOException {
-    return loadDB(configuration, metaDir, OM_DB_NAME, false, java.util.Optional.empty(), maxOpenFiles, true, true);
+    boolean enableCompactionDag =
+        configuration.getBoolean(OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED,
+            OZONE_OM_SNAPSHOT_COMPACTION_DAG_ENABLED_DEFAULT);
+    return loadDB(configuration, metaDir, OM_DB_NAME, false, java.util.Optional.empty(), maxOpenFiles, enableCompactionDag, true);
   }
 
   @SuppressWarnings("checkstyle:parameternumber")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently we do not have a way to switch off the compaction listener and the compaction DAG is generated even if Ozone snapshots are not used in the system. We can add a config to control this.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12240

## How was this patch tested?
added a unit test
