### PR TITLE
HDDS-12232. Move container from QUASI_CLOSED to CLOSED only when SCM sees all 3 origin node replicas

### DIFF
--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -1,0 +1,62 @@
+[
+  { "description": "Quasi-closed replicas with one open", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 12, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"},
+      { "state": "OPEN",         "index": 0,   "datanode": "d3", "sequenceId": 12, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
+    "checkCommands": [
+      { "type": "closeContainerCommand", "datanode": "d3" }
+    ],
+    "commands": []
+  },
+  { "description": "Quasi-closed with 2 replicas", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 12, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
+    "checkCommands": [],
+    "commands": [
+      { "type": "replicateContainerCommand" }
+    ]
+  },
+  { "description": "Quasi-closed with 3 replicas 2 origins", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 12, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 12, "isEmpty": false, "origin": "o2"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
+    "checkCommands": [],
+    "commands": []
+  },
+  { "description": "Quasi-closed with 3 replicas 3 origins", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 12, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 12, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 0 },
+    "checkCommands": [
+      { "type": "closeContainerCommand", "datanode": "d1" },
+      { "type": "closeContainerCommand", "datanode": "d2" },
+      { "type": "closeContainerCommand", "datanode": "d3" }
+    ],
+    "commands": []
+  },
+  { "description": "Quasi-closed with 3 replicas 3 origins different BCSID", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 12, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 11, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 0 },
+    "checkCommands": [
+      { "type": "closeContainerCommand", "datanode": "d1" },
+      { "type": "closeContainerCommand", "datanode": "d2" }
+    ],
+    "commands": []
+  }
+]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to unexpected behavior in Ratis on partial write failure, we have found scenarios where the lead replica is lost / offline and it had the higher BCSID. Then the follower replicas went to quasi_closed and as RM saw two copies with unique origins, is closed the container, hiding the fact that some transaction may be missing.

This PR changes the Quasi Closed handler so it requires 3 replicas from unique origins before it will allow a container to transition from QC -> CLOSED.

Note that this means if a container has lost the lead replica permanently, the container will never reach the CLOSED state - it will stay stuck in QUASI_CLOSED(_STUCK) for ever. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12232

## How was this patch tested?

Existing tests modified. New unit tests added and some new test scenarios added.