### PR TITLE
HDDS-12248. Make allowListAllVolumes reconfigurable in OM

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -22,12 +22,15 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -91,6 +94,14 @@ class TestOmReconfiguration extends ReconfigurationTestBase {
         String.valueOf(newValue));
 
     assertEquals(newValue, getCluster().getOzoneManager().getAllowListAllVolumes());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "invalid"})
+  void unsetAllowListAllVolumes(String newValue) throws ReconfigurationException {
+    getSubject().reconfigurePropertyImpl(OZONE_OM_VOLUME_LISTALL_ALLOWED, newValue);
+
+    assertEquals(OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT, getCluster().getOzoneManager().getAllowListAllVolumes());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -27,6 +27,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -43,6 +44,7 @@ class TestOmReconfiguration extends ReconfigurationTestBase {
   void reconfigurableProperties() {
     assertProperties(getSubject(),
         ImmutableSet.of(OZONE_ADMINISTRATORS, OZONE_READONLY_ADMINISTRATORS,
+            OZONE_OM_VOLUME_LISTALL_ALLOWED,
             OZONE_KEY_DELETING_LIMIT_PER_TASK));
   }
 
@@ -79,6 +81,16 @@ class TestOmReconfiguration extends ReconfigurationTestBase {
 
     assertEquals(originLimit + 1, getCluster().getOzoneManager()
         .getKeyManager().getDeletingService().getKeyLimitPerTask());
+  }
+
+  @Test
+  void allowListAllVolumes() throws ReconfigurationException {
+    final boolean newValue = !getCluster().getOzoneManager().getAllowListAllVolumes();
+
+    getSubject().reconfigurePropertyImpl(OZONE_OM_VOLUME_LISTALL_ALLOWED,
+        String.valueOf(newValue));
+
+    assertEquals(newValue, getCluster().getOzoneManager().getAllowListAllVolumes());
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4984,9 +4984,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   private String reconfigureAllowListAllVolumes(String newVal) {
-    getConfiguration().setBoolean(OZONE_OM_VOLUME_LISTALL_ALLOWED, Boolean.parseBoolean(newVal));
+    getConfiguration().set(OZONE_OM_VOLUME_LISTALL_ALLOWED, newVal);
     setAllowListAllVolumesFromConfig();
-    return newVal;
+    return String.valueOf(allowListAllVolumes);
   }
 
   public void validateReplicationConfig(ReplicationConfig replicationConfig)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -527,6 +527,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .register(OZONE_ADMINISTRATORS, this::reconfOzoneAdmins)
             .register(OZONE_READONLY_ADMINISTRATORS,
                 this::reconfOzoneReadOnlyAdmins)
+            .register(OZONE_OM_VOLUME_LISTALL_ALLOWED, this::reconfigureAllowListAllVolumes)
             .register(OZONE_KEY_DELETING_LIMIT_PER_TASK,
                 this::reconfOzoneKeyDeletingLimitPerTask);
 
@@ -759,7 +760,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private void setInstanceVariablesFromConf() {
     this.isAclEnabled = configuration.getBoolean(OZONE_ACL_ENABLED,
         OZONE_ACL_ENABLED_DEFAULT);
-    this.allowListAllVolumes = configuration.getBoolean(
+    setAllowListAllVolumesFromConfig();
+  }
+
+  public void setAllowListAllVolumesFromConfig() {
+    allowListAllVolumes = configuration.getBoolean(
         OZONE_OM_VOLUME_LISTALL_ALLOWED,
         OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT);
   }
@@ -4975,6 +4980,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     getKeyManager().getDeletingService()
         .setKeyLimitPerTask(Integer.parseInt(newVal));
+    return newVal;
+  }
+
+  private String reconfigureAllowListAllVolumes(String newVal) {
+    getConfiguration().setBoolean(OZONE_OM_VOLUME_LISTALL_ALLOWED, Boolean.parseBoolean(newVal));
+    setAllowListAllVolumesFromConfig();
     return newVal;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAuthorizerFactory.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAuthorizerFactory.java
@@ -112,7 +112,7 @@ public final class OzoneAuthorizerFactory {
     authorizer.setPrefixManager(pm);
     authorizer.setAdminCheck(om::isAdmin);
     authorizer.setReadOnlyAdminCheck(om::isReadOnlyAdmin);
-    authorizer.setAllowListAllVolumes(om.getAllowListAllVolumes());
+    authorizer.setAllowListAllVolumes(om::getAllowListAllVolumes);
     return authorizer;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
@@ -54,7 +55,7 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
   private PrefixManager prefixManager;
   private Predicate<UserGroupInformation> adminCheck = NO_ADMIN;
   private Predicate<UserGroupInformation> readOnlyAdminCheck = NO_ADMIN;
-  private boolean allowListAllVolumes;
+  private BooleanSupplier allowListAllVolumes = () -> false;
 
   public OzoneNativeAuthorizer() {
     // required for instantiation in OmMetadataReader#getACLAuthorizerInstance
@@ -222,12 +223,12 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     readOnlyAdminCheck = Objects.requireNonNull(check, "read-only admin check");
   }
 
-  public void setAllowListAllVolumes(boolean allowListAllVolumes) {
-    this.allowListAllVolumes = allowListAllVolumes;
+  public void setAllowListAllVolumes(BooleanSupplier allowListAllVolumes) {
+    this.allowListAllVolumes = Objects.requireNonNull(allowListAllVolumes, "allowListAllVolumes");
   }
 
   public boolean getAllowListAllVolumes() {
-    return allowListAllVolumes;
+    return allowListAllVolumes.getAsBoolean();
   }
 
   private static boolean isOwner(UserGroupInformation ugi, String ownerName) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `allowListAllVolumes` reconfigurable in OM, for testing with both settings without OM restart.

https://issues.apache.org/jira/browse/HDDS-12248

## How was this patch tested?

Added integration test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/13204314582
