### PR TITLE
HDDS-12291. XceiverClientRatis allows adding ratis data stream configuration

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -367,7 +367,7 @@ public final class RatisHelper {
         getDatanodeRatisPrefixProps(ozoneConf);
     ratisClientConf.forEach((key, val) -> {
       if (isClientConfig(key) || isGrpcClientConfig(key)
-              || isNettyStreamConfig(key)) {
+              || isNettyStreamConfig(key) || isDataStreamConfig(key)) {
         raftProperties.set(key, val);
       }
     });
@@ -375,6 +375,10 @@ public final class RatisHelper {
 
   private static boolean isClientConfig(String key) {
     return key.startsWith(RaftClientConfigKeys.PREFIX);
+  }
+
+  private static boolean isDataStreamConfig(String key) {
+    return key.startsWith(RaftConfigKeys.DataStream.PREFIX);
   }
 
   private static boolean isGrpcClientConfig(String key) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
- XceiverClientRatis allows adding ratis data stream configuration.
- According to the discussion at https://github.com/apache/ozone/pull/7645, we can skip `sendForward` by adding `hdds.ratis.raft.datastream.skip.send-forward=true` on the client side, thus avoiding an invalid ratis transaction (current streaming write will generate an invalid streamInit transaction)
https://github.com/apache/ozone/blob/ab29a55eaea71db9f2912d2fc69c2865cad34af8/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java#L206-L226

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12291

## How was this patch tested?
Existing Tests
