### PR TITLE
HDDS-12238. Improve OM DELETE_KEY audit log to include key size

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -231,13 +231,13 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       remoteGroupName, ACCESS, READ);
   private static MessageDigest eTagProvider;
   private static Set<OzoneClient> ozoneClients = new HashSet<>();
-  private static GenericTestUtils.PrintStreamCapturer out;
+  private static GenericTestUtils.PrintStreamCapturer output;
 
   @BeforeAll
   public static void initialize() throws NoSuchAlgorithmException, UnsupportedEncodingException {
     eTagProvider = MessageDigest.getInstance(MD5_HASH);
     AuditLogTestUtils.enableAuditLog();
-    out = GenericTestUtils.captureOut();
+    output = GenericTestUtils.captureOut();
   }
 
   /**
@@ -276,7 +276,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   static void shutdownCluster() {
     org.apache.hadoop.hdds.utils.IOUtils.closeQuietly(ozoneClients);
     ozoneClients.clear();
-    org.apache.hadoop.hdds.utils.IOUtils.closeQuietly(out);
+    org.apache.hadoop.hdds.utils.IOUtils.closeQuietly(output);
 
     if (storageContainerLocationClient != null) {
       storageContainerLocationClient.close();
@@ -1111,7 +1111,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     TestDataUtil.createKey(bucket, keyName3, THREE, RATIS, value);
 
     // delete files and directory
-    out.reset();
+    output.reset();
     bucket.deleteKey(keyName1);
     bucket.deleteKey(keyName2);
     bucket.deleteDirectory(dirName, true);
@@ -1128,7 +1128,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     keysToDelete.add(dirName + "/" + keyName5);
     bucket.deleteKeys(keysToDelete);
 
-    String consoleOutput = out.get();
+    String consoleOutput = output.get();
     assertThat(consoleOutput).contains("op=DELETE_KEY {volume=" + volumeName + ", bucket=" + bucketName +
         ", key=key1, dataSize=" + valueLength + ", replicationConfig=RATIS/THREE");
     assertThat(consoleOutput).contains("op=DELETE_KEY {volume=" + volumeName + ", bucket=" + bucketName +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -60,15 +60,27 @@ public interface RequestAuditor {
    * Build auditMap for KeyArgs.
    * @param keyArgs
    */
-  default Map<String, String> buildKeyArgsAuditMap(KeyArgs keyArgs) {
-
+  default Map<String, String> buildLightKeyArgsAuditMap(KeyArgs keyArgs) {
     if (keyArgs == null) {
       return new HashMap<>(0);
     } else {
-      Map< String, String > auditMap = new LinkedHashMap<>();
+      Map<String, String> auditMap = new LinkedHashMap<>();
       auditMap.put(OzoneConsts.VOLUME, keyArgs.getVolumeName());
       auditMap.put(OzoneConsts.BUCKET, keyArgs.getBucketName());
       auditMap.put(OzoneConsts.KEY, keyArgs.getKeyName());
+      return auditMap;
+    }
+  }
+
+  /**
+   * Build auditMap for KeyArgs.
+   * @param keyArgs
+   */
+  default Map<String, String> buildKeyArgsAuditMap(KeyArgs keyArgs) {
+    if (keyArgs == null) {
+      return new HashMap<>(0);
+    } else {
+      Map< String, String > auditMap = buildLightKeyArgsAuditMap(keyArgs);
       auditMap.put(OzoneConsts.DATA_SIZE,
           String.valueOf(keyArgs.getDataSize()));
       if (keyArgs.hasType()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -113,7 +113,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     DeleteKeyRequest deleteKeyRequest = getOmRequest().getDeleteKeyRequest();
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
-    Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    Map<String, String> auditMap = buildLightKeyArgsAuditMap(keyArgs);
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();
@@ -187,6 +187,10 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
           omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder())
               .build(), omKeyInfo, ozoneManager.isRatisEnabled(),
           omBucketInfo.copyObject(), deletedOpenKeyInfo);
+      if (omKeyInfo.isFile()) {
+        auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(omKeyInfo.getDataSize()));
+        auditMap.put(OzoneConsts.REPLICATION_CONFIG, omKeyInfo.getReplicationConfig().toString());
+      }
 
       result = Result.SUCCESS;
       long endNanosDeleteKeySuccessLatencyNs = Time.monotonicNowNanos();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -77,7 +77,7 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs =
         deleteKeyRequest.getKeyArgs();
-    Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    Map<String, String> auditMap = buildLightKeyArgsAuditMap(keyArgs);
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();
@@ -173,6 +173,11 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
         } else {
           LOG.warn("Potentially inconsistent DB state: open key not found with dbOpenKey '{}'", dbOpenKey);
         }
+      }
+
+      if (keyStatus.isFile()) {
+        auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(omKeyInfo.getDataSize()));
+        auditMap.put(OzoneConsts.REPLICATION_CONFIG, omKeyInfo.getReplicationConfig().toString());
       }
 
       omClientResponse = new OMKeyDeleteResponseWithFSO(omResponse

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -66,8 +66,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.OzoneConsts.BUCKET;
+import static org.apache.hadoop.ozone.OzoneConsts.DATA_SIZE;
 import static org.apache.hadoop.ozone.OzoneConsts.DELETED_HSYNC_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.DELETED_KEYS_LIST;
+import static org.apache.hadoop.ozone.OzoneConsts.KEY;
+import static org.apache.hadoop.ozone.OzoneConsts.REPLICATION_CONFIG;
 import static org.apache.hadoop.ozone.OzoneConsts.UNDELETED_KEYS_LIST;
 import static org.apache.hadoop.ozone.OzoneConsts.VOLUME;
 import static org.apache.hadoop.ozone.audit.OMAction.DELETE_KEYS;
@@ -96,6 +99,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
         deleteKeyRequest.getDeleteKeys();
 
     List<String> deleteKeys = new ArrayList<>(deleteKeyArgs.getKeysList());
+    List<OmKeyInfo> deleteKeysInfo = new ArrayList<>();
 
     Exception exception = null;
     OMClientResponse omClientResponse = null;
@@ -175,6 +179,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
               ozoneManager, omMetadataManager, volumeName, bucketName, keyName);
           addKeyToAppropriateList(omKeyInfoList, omKeyInfo, dirList,
               fileStatus);
+          deleteKeysInfo.add(omKeyInfo);
         } catch (Exception ex) {
           deleteStatus = false;
           LOG.error("Acl check failed for Key: {}", objectKey, ex);
@@ -211,6 +216,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
 
       // reset deleteKeys as request failed.
       deleteKeys = new ArrayList<>();
+      deleteKeysInfo.clear();
       // Add all keys which are failed due to any other exception .
       for (int i = indexFailed; i < length; i++) {
         unDeletedKeys.addKeys(deleteKeyArgs.getKeys(i));
@@ -235,7 +241,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       }
     }
 
-    addDeletedKeys(auditMap, deleteKeys, unDeletedKeys.getKeysList());
+    addDeletedKeys(auditMap, deleteKeysInfo, unDeletedKeys.getKeysList());
 
     markForAudit(auditLogger,
         buildAuditMessage(DELETE_KEYS, auditMap, exception, userInfo));
@@ -346,8 +352,18 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
    * Add key info to audit map for DeleteKeys request.
    */
   protected static void addDeletedKeys(Map<String, String> auditMap,
-      List<String> deletedKeys, List<String> unDeletedKeys) {
-    auditMap.put(DELETED_KEYS_LIST, String.join(",", deletedKeys));
+      List<OmKeyInfo> deletedKeyInfos, List<String> unDeletedKeys) {
+    StringBuffer keys = new StringBuffer();
+    for (int i = 0; i < deletedKeyInfos.size(); i++) {
+      OmKeyInfo key = deletedKeyInfos.get(i);
+      keys.append("{").append(KEY).append("=").append(key.getKeyName()).append(", ");
+      keys.append(DATA_SIZE).append("=").append(key.getDataSize()).append(", ");
+      keys.append(REPLICATION_CONFIG).append("=").append(key.getReplicationConfig()).append("}");
+      if (i < deletedKeyInfos.size() - 1) {
+        keys.append(", ");
+      }
+    }
+    auditMap.put(DELETED_KEYS_LIST, keys.toString());
     auditMap.put(UNDELETED_KEYS_LIST, String.join(",", unDeletedKeys));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -353,7 +353,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
    */
   protected static void addDeletedKeys(Map<String, String> auditMap,
       List<OmKeyInfo> deletedKeyInfos, List<String> unDeletedKeys) {
-    StringBuffer keys = new StringBuffer();
+    StringBuilder keys = new StringBuilder();
     for (int i = 0; i < deletedKeyInfos.size(); i++) {
       OmKeyInfo key = deletedKeyInfos.get(i);
       keys.append("{").append(KEY).append("=").append(key.getKeyName()).append(", ");


### PR DESCRIPTION
## What changes were proposed in this pull request?


Here is one example of current DELETE_KEY audit log. The dataSize is always 0.

2025-01-24 03:13:23,876 | INFO  | OMAudit | user=mi_staging.deploy@CORP.HULU.COM | ip=10.80.141.10 | op=DELETE_KEY {volume=hive, bucket=mi-staging.db, key=nova_upstream_collections_hive_temp_2025_01_24_03_09_24/_temporary/0/_temporary/attempt_20250124030924_0006_m_000147_3170, dataSize=0, replicationType=NONE, replicationFactor=ZERO} | ret=SUCCESS |

This task aims to have the real data size for deleted key, so that it's easy to calculate the total size of deleted keys in a period of time, which is useful when investigating Ozone space reclaimed different than expectation cases.



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12238

## How was this patch tested?

new unit test
