### PR TITLE
HDDS-12234. Improve error log No leader found when jmx endpoint is accessed

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -357,6 +357,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       AuditLoggerType.OMSYSTEMLOGGER);
 
   private static final String OM_DAEMON = "om";
+  private static final String NO_LEADER_ERROR_MESSAGE =
+          "There is no leader among the Ozone Manager servers. If this message " +
+                  "persists, the service may be down. Possible cause: only one OM is up, or " +
+                  "other OMs are unable to respond to Ratis leader vote messages";
+
 
   // This is set for read requests when OMRequest has S3Authentication set,
   // and it is reset when read request is processed.
@@ -3056,12 +3061,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
-      LOG.error("There is no leader among the Ozone Manager servers. If this message persists, the service may " +
-              "be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis " +
-              "leader vote messages.");
-      return getRatisRolesException("There is no leader among the Ozone Manager servers. If this message " +
-              "persists, the service may be down. Possible cause: only one OM is up, or " +
-              "other OMs are unable to respond to Ratis leader vote messages");
+      LOG.error(NO_LEADER_ERROR_MESSAGE);
+      return getRatisRolesException(NO_LEADER_ERROR_MESSAGE);
     }
 
     final List<ServiceInfo> serviceList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3056,8 +3056,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
-      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
-      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
+      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. "+
+              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
+      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. "+
+              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
     }
 
     final List<ServiceInfo> serviceList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3056,12 +3056,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
-      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. " +
-              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote " +
-              "messages");
-      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. " +
-              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote " +
-              "messages");
+      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may " +
+              "be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis " +
+              "leader vote messages.");
+      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message " +
+              "persists, the service may be down. Possible cause: only one OM is up, or " +
+              "other OMs are unable to respond to Ratis leader vote messages");
     }
 
     final List<ServiceInfo> serviceList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3056,8 +3056,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
-      LOG.error("No leader found");
-      return getRatisRolesException("No leader found");
+      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
+      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
     }
 
     final List<ServiceInfo> serviceList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3057,9 +3057,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
       LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. " +
-              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
+              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote " +
+              "messages");
       return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. " +
-              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
+              "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote " +
+              "messages");
     }
 
     final List<ServiceInfo> serviceList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3056,9 +3056,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
-      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. "+
+      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. " +
               "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
-      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. "+
+      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message persists, the service may be down. " +
               "Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages");
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3056,10 +3056,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     String leaderReadiness = omRatisServer.checkLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
-      LOG.error("There are no leader among the Ozone Manager servers. If this message persists, the service may " +
+      LOG.error("There is no leader among the Ozone Manager servers. If this message persists, the service may " +
               "be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis " +
               "leader vote messages.");
-      return getRatisRolesException("There are no leader among the Ozone Manager servers. If this message " +
+      return getRatisRolesException("There is no leader among the Ozone Manager servers. If this message " +
               "persists, the service may be down. Possible cause: only one OM is up, or " +
               "other OMs are unable to respond to Ratis leader vote messages");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The message "no leader found" appears when the jmx endpoint is accessed  when no OM leaders are present, but this message does not help in troubleshooting the problem , so to improve the error log the message is changed to "There is no leader among the Ozone Manager servers. If this message persists, the service may be down. Possible cause: only one OM is up, or other OMs are unable to respond to Ratis leader vote messages".

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12234

## How was this patch tested?
This patch was tested using jmx endpoint for OM
Below is the workflow link which passes successfully.
https://github.com/sreejasahithi/ozone/actions/runs/13236312553