### PR TITLE
HDDS-12220. Limit OM/SCM/Recon RocksDB max user log files total size

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -48,10 +48,10 @@ public class RocksDBConfiguration {
 
   @Config(key = "rocksdb.max.log.file.size",
       type = ConfigType.SIZE,
-      defaultValue = "0MB",
+      defaultValue = "100MB",
       tags = {OM, SCM, DATANODE},
       description = "Maximum size of RocksDB application log file.")
-  private long rocksdbMaxLogFileSize = 0;
+  private long rocksdbMaxLogFileSize = 100;
 
   @Config(key = "rocksdb.keep.log.file.num",
       type = ConfigType.INT,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -51,7 +51,7 @@ public class RocksDBConfiguration {
       defaultValue = "100MB",
       tags = {OM, SCM, DATANODE},
       description = "Maximum size of RocksDB application log file.")
-  private long rocksdbMaxLogFileSize = 100MB;
+  private long rocksdbMaxLogFileSize = 100 * 1024 * 1024;
 
   @Config(key = "rocksdb.keep.log.file.num",
       type = ConfigType.INT,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -51,7 +51,7 @@ public class RocksDBConfiguration {
       defaultValue = "100MB",
       tags = {OM, SCM, DATANODE},
       description = "Maximum size of RocksDB application log file.")
-  private long rocksdbMaxLogFileSize = 100;
+  private long rocksdbMaxLogFileSize = 100MB;
 
   @Config(key = "rocksdb.keep.log.file.num",
       type = ConfigType.INT,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -55,10 +55,10 @@ public class RocksDBConfiguration {
 
   @Config(key = "rocksdb.keep.log.file.num",
       type = ConfigType.INT,
-      defaultValue = "1000",
+      defaultValue = "10",
       tags = {OM, SCM, DATANODE},
       description = "Maximum number of RocksDB application log files.")
-  private int rocksdbKeepLogFileNum = 1000;
+  private int rocksdbKeepLogFileNum = 10;
 
   @Config(key = "rocksdb.writeoption.sync",
       type = ConfigType.BOOLEAN,


### PR DESCRIPTION
## What changes were proposed in this pull request?
It currently appears that the RocksDB LOG.old files can be generated without limit for OM, SCM, and Recon. I have observed these files filling up the disk, bringing down the Recon instance in a cluster.

The DataNode has this property to control them: hdds.datanode.rocksdb.log.max-file-num

Can we add a similar property for the other three? So:

hdds.scm.rocksdb.log.max-file-num

hdds.om.rocksdb.log.max-file-num

hdds.recon.rocksdb.log.max-file-num

One reasonable default value would be 10.

Fix done:
1. Already a support was added for this config so just the default is just changed from 1000 to 10

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12220

## How was this patch tested?

Existing tests.
Below is the workflow link which passed successfully:
https://github.com/Gargi-jais11/ozone/actions/runs/13237283906
