### PR TITLE
HDDS-12249. Share cluster in reconfiguration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/ReconfigurationTestBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/ReconfigurationTestBase.java
@@ -18,11 +18,10 @@
 
 package org.apache.hadoop.ozone.reconfig;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.jupiter.api.AfterAll;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
@@ -40,30 +39,19 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-abstract class ReconfigurationTestBase {
+abstract class ReconfigurationTestBase implements NonHATests.TestCase {
 
-  private MiniOzoneCluster cluster;
   private String currentUser;
 
   @BeforeAll
   void setup() throws Exception {
-    cluster = MiniOzoneCluster.newBuilder(new OzoneConfiguration())
-        .build();
-    cluster.waitForClusterToBeReady();
     currentUser = UserGroupInformation.getCurrentUser().getShortUserName();
-  }
-
-  @AfterAll
-  void shutdown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   abstract ReconfigurationHandler getSubject();
 
   MiniOzoneCluster getCluster() {
-    return cluster;
+    return cluster();
   }
 
   String getCurrentUser() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/ReconfigurationTestBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/ReconfigurationTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.reconfig;
 
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,10 +48,6 @@ abstract class ReconfigurationTestBase implements NonHATests.TestCase {
   }
 
   abstract ReconfigurationHandler getSubject();
-
-  MiniOzoneCluster getCluster() {
-    return cluster();
-  }
 
   String getCurrentUser() {
     return currentUser;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests for Datanode reconfiguration.
  */
-class TestDatanodeReconfiguration extends ReconfigurationTestBase {
+public abstract class TestDatanodeReconfiguration extends ReconfigurationTestBase {
   @Override
   ReconfigurationHandler getSubject() {
     return getFirstDatanode().getReconfigurationHandler();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
@@ -108,7 +108,7 @@ public abstract class TestDatanodeReconfiguration extends ReconfigurationTestBas
   }
 
   private HddsDatanodeService getFirstDatanode() {
-    return getCluster().getHddsDatanodes().get(0);
+    return cluster().getHddsDatanodes().get(0);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -40,7 +40,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
 
   @Override
   ReconfigurationHandler getSubject() {
-    return getCluster().getOzoneManager().getReconfigurationHandler();
+    return cluster().getOzoneManager().getReconfigurationHandler();
   }
 
   @Test
@@ -59,7 +59,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
 
     assertEquals(
         ImmutableSet.of(newValue, getCurrentUser()),
-        getCluster().getOzoneManager().getOmAdminUsernames());
+        cluster().getOzoneManager().getOmAdminUsernames());
   }
 
   @Test
@@ -71,29 +71,29 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
 
     assertEquals(
         ImmutableSet.of(newValue),
-        getCluster().getOzoneManager().getOmReadOnlyAdminUsernames());
+        cluster().getOzoneManager().getOmReadOnlyAdminUsernames());
   }
 
   @Test
   public void keyDeletingLimitPerTask() throws ReconfigurationException {
-    int originLimit = getCluster().getOzoneManager()
+    int originLimit = cluster().getOzoneManager()
         .getKeyManager().getDeletingService().getKeyLimitPerTask();
 
     getSubject().reconfigurePropertyImpl(OZONE_KEY_DELETING_LIMIT_PER_TASK,
         String.valueOf(originLimit + 1));
 
-    assertEquals(originLimit + 1, getCluster().getOzoneManager()
+    assertEquals(originLimit + 1, cluster().getOzoneManager()
         .getKeyManager().getDeletingService().getKeyLimitPerTask());
   }
 
   @Test
   void allowListAllVolumes() throws ReconfigurationException {
-    final boolean newValue = !getCluster().getOzoneManager().getAllowListAllVolumes();
+    final boolean newValue = !cluster().getOzoneManager().getAllowListAllVolumes();
 
     getSubject().reconfigurePropertyImpl(OZONE_OM_VOLUME_LISTALL_ALLOWED,
         String.valueOf(newValue));
 
-    assertEquals(newValue, getCluster().getOzoneManager().getAllowListAllVolumes());
+    assertEquals(newValue, cluster().getOzoneManager().getAllowListAllVolumes());
   }
 
   @ParameterizedTest
@@ -101,7 +101,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
   void unsetAllowListAllVolumes(String newValue) throws ReconfigurationException {
     getSubject().reconfigurePropertyImpl(OZONE_OM_VOLUME_LISTALL_ALLOWED, newValue);
 
-    assertEquals(OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT, getCluster().getOzoneManager().getAllowListAllVolumes());
+    assertEquals(OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT, cluster().getOzoneManager().getAllowListAllVolumes());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests for OM reconfiguration.
  */
-class TestOmReconfiguration extends ReconfigurationTestBase {
+public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
 
   @Override
   ReconfigurationHandler getSubject() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests for SCM reconfiguration.
  */
-class TestScmReconfiguration extends ReconfigurationTestBase {
+public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
 
   @Override
   ReconfigurationHandler getSubject() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
@@ -42,7 +42,7 @@ public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
 
   @Override
   ReconfigurationHandler getSubject() {
-    return getCluster().getStorageContainerManager()
+    return cluster().getStorageContainerManager()
         .getReconfigurationHandler();
   }
 
@@ -69,7 +69,7 @@ public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
 
     assertEquals(
         ImmutableSet.of(newValue, getCurrentUser()),
-        getCluster().getStorageContainerManager().getScmAdminUsernames());
+        cluster().getStorageContainerManager().getScmAdminUsernames());
   }
 
   @Test
@@ -81,7 +81,7 @@ public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
 
     assertEquals(
         ImmutableSet.of(newValue),
-        getCluster().getStorageContainerManager()
+        cluster().getStorageContainerManager()
             .getScmReadOnlyAdminUsernames());
   }
 
@@ -97,14 +97,14 @@ public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
   }
 
   private ReplicationManagerConfiguration replicationManagerConfig() {
-    return getCluster().getStorageContainerManager().getReplicationManager()
+    return cluster().getStorageContainerManager().getReplicationManager()
         .getConfig();
   }
 
   @Test
   void blockDeletionPerInterval() throws ReconfigurationException {
     SCMBlockDeletingService blockDeletingService =
-        getCluster().getStorageContainerManager().getScmBlockManager()
+        cluster().getStorageContainerManager().getScmBlockManager()
         .getSCMBlockDeletingService();
     int blockDeleteTXNum = blockDeletingService.getBlockDeleteTXNum();
     int newValue = blockDeleteTXNum + 1;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -186,4 +186,28 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
     }
   }
 
+  @Nested
+  class DatanodeReconfiguration extends org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class OmReconfiguration extends org.apache.hadoop.ozone.reconfig.TestOmReconfiguration {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ScmReconfiguration extends org.apache.hadoop.ozone.reconfig.TestScmReconfiguration {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Run the following tests on the same cluster as some other integration tests:
- `TestDatanodeReconfiguration`
- `TestOmReconfiguration`
- `TestScmReconfiguration`

to reduce test runtime.

https://issues.apache.org/jira/browse/HDDS-12249

## How was this patch tested?

Before:

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36 s - in org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.293 s - in org.apache.hadoop.ozone.reconfig.TestOmReconfiguration
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.048 s - in org.apache.hadoop.ozone.reconfig.TestScmReconfiguration
```

After:

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s - in org.apache.ozone.test.NonHATests$ScmReconfiguration
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s - in org.apache.ozone.test.NonHATests$OmReconfiguration
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.apache.ozone.test.NonHATests$DatanodeReconfiguration
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/13246893553
