### PR TITLE
HDDS-12304. Bump GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -58,7 +58,7 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 jobs:
   ratis:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     outputs:
       ratis-version: ${{ steps.versions.outputs.ratis }}
@@ -102,7 +102,7 @@ jobs:
             ~/.m2/repository/org/apache/ratis
           retention-days: 1
   ratis-thirdparty:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - ratis
     timeout-minutes: 30
@@ -123,7 +123,7 @@ jobs:
           echo "netty=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.netty.version)" >> $GITHUB_OUTPUT
           echo "protobuf=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.protobuf.version)" >> $GITHUB_OUTPUT
   debug:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - ratis
       - ratis-thirdparty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,11 +527,11 @@ jobs:
           mkdir -p hadoop-ozone/dist/target
           tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
           rm ozone*.tar.gz
-      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
+      - name: Setup java 11
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ env.TEST_JAVA_VERSION }}
+          java-version: 11 # Hadoop may not work with newer Java
       - name: Execute tests
         run: |
           ./hadoop-ozone/dev-support/checks/acceptance.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ env:
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}
 jobs:
   build-info:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
@@ -108,7 +108,7 @@ jobs:
   build:
     needs:
       - build-info
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     if: needs.build-info.outputs.needs-build == 'true'
     steps:
@@ -192,7 +192,7 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
           - java: 8
             os: macos-13
       fail-fast: false
@@ -247,7 +247,7 @@ jobs:
   basic:
     needs:
       - build-info
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: needs.build-info.outputs.needs-basic-check == 'true'
     strategy:
@@ -306,7 +306,7 @@ jobs:
     needs:
       - build-info
       - basic
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-native-check == 'true'
     steps:
@@ -353,7 +353,7 @@ jobs:
     needs:
       - build-info
       - build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Checkout project
@@ -392,7 +392,7 @@ jobs:
     needs:
       - build-info
       - build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Checkout project
@@ -440,7 +440,7 @@ jobs:
       - basic
       - dependency
       - license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout project
@@ -497,7 +497,7 @@ jobs:
       - basic
       - dependency
       - license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-compose-tests == 'true'
     strategy:
@@ -550,7 +550,7 @@ jobs:
       - basic
       - dependency
       - license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     if: needs.build-info.outputs.needs-kubernetes-tests == 'true'
     steps:
@@ -592,7 +592,7 @@ jobs:
     needs:
       - build-info
       - basic
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-integration-tests == 'true'
     strategy:
@@ -645,7 +645,7 @@ jobs:
           path: target/integration
         continue-on-error: true
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name == 'push'
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,11 @@ jobs:
           mkdir -p hadoop-ozone/dist/target
           tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
           rm ozone*.tar.gz
+      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.TEST_JAVA_VERSION }}
       - name: Execute tests
         run: |
           ./hadoop-ozone/dev-support/checks/acceptance.sh

--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   close-pending:
     name: close-pending
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   process-comment:
     name: check-comment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -59,7 +59,7 @@ env:
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations) || '' }}
 jobs:
   prepare-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{steps.generate.outputs.matrix}}
     steps:
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare-job
       - ratis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout project
@@ -139,7 +139,7 @@ jobs:
       - ratis
       - build
     name: Run-Split
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         split: ${{fromJson(needs.prepare-job.outputs.matrix)}}  # Define  splits
@@ -216,7 +216,7 @@ jobs:
   count-failures:
     if: ${{ failure() }}
     needs: run-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download build results
         uses: actions/download-artifact@v4

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   title:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -51,7 +51,7 @@ env:
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}[{1}]-{2}', inputs.test-suite || inputs.test-filter, inputs.ref, inputs.splits) || '' }}
 jobs:
   prepare-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{steps.generate.outputs.matrix}}
     steps:
@@ -76,7 +76,7 @@ jobs:
   build:
     needs:
       - prepare-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout project
@@ -124,7 +124,7 @@ jobs:
       - prepare-job
       - build
     name: Run-Split
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         split: ${{ fromJson(needs.prepare-job.outputs.matrix) }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ubuntu 20.04 is being deprecated: https://github.com/actions/runner-images/issues/11101

Upgrade to 24.04.

Setup Java 11 for acceptance check.  (Java 11 was the default version for 20.04, while 24.04 comes with Java 17 by default.)  This only affects the GitHub runner, where Hadoop S3A contract tests are run.  We still use Java 21 for running Ozone in `ozone-runner` Docker image.

https://issues.apache.org/jira/browse/HDDS-12304

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13258221266