### PR TITLE
HDDS-12306. OmMetadataManager metrics are always zero

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -340,15 +340,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    */
   public OmMetadataManagerImpl(OzoneConfiguration conf,
       OzoneManager ozoneManager) throws IOException {
-    this(conf, ozoneManager, null);
-  }
-
-  public OmMetadataManagerImpl(OzoneConfiguration conf,
-                               OzoneManager ozoneManager,
-                               OMPerformanceMetrics perfMetrics)
-      throws IOException {
     this.ozoneManager = ozoneManager;
-    this.perfMetrics = perfMetrics;
+    if (this.ozoneManager == null) {
+      this.perfMetrics = null;
+    } else {
+      this.perfMetrics = this.ozoneManager.getPerfMetrics();
+    }
     this.lock = new OzoneManagerLock(conf);
     this.omEpoch = OmUtils.getOMEpoch();
     // For test purpose only

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tenant/TestSetRangerServiceVersionRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tenant/TestSetRangerServiceVersionRequest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -60,8 +61,12 @@ public class TestSetRangerServiceVersionRequest {
     final OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         folder.toAbsolutePath().toString());
+    OmMetadataManagerImpl omMetadataManager = new OmMetadataManagerImpl(conf,
+        ozoneManager);
     when(ozoneManager.getMetadataManager())
-        .thenReturn(new OmMetadataManagerImpl(conf, ozoneManager));
+        .thenReturn(omMetadataManager);
+    OMPerformanceMetrics omPerformanceMetrics = mock(OMPerformanceMetrics.class);
+    when(ozoneManager.getPerfMetrics()).thenReturn(omPerformanceMetrics);
   }
 
   @AfterEach


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12306. OmMetadataManager metrics are always zero

Please describe your PR in detail:
* Pass over the OMPerformanceMetrics object instance from OzoneManager, to be used by OmMetadataManagerImpl.
* Fixed a mock test error due to the change inside the OmMetadataManagerImpl constructor.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12306

## How was this patch tested?

Existing UT. https://github.com/jojochuang/ozone/actions/runs/13267337134
