### PR TITLE
HDDS-10760. SCMExceptions resulting from admin CLI commands are treated as retriable.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
@@ -32,6 +32,14 @@ public class BadDataLocationException extends IOException {
   private final List<DatanodeDetails> failedLocations = new ArrayList<>();
   private int failedLocationIndex;
 
+  /**
+   * Required for Unwrapping {@code RemoteException}. Used by
+   * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}
+   */
+  public BadDataLocationException(String message) {
+    super(message);
+  }
+
   public BadDataLocationException(DatanodeDetails dn) {
     super();
     failedLocations.add(dn);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerException.java
@@ -26,6 +26,16 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 public class ContainerException extends SCMException {
 
   /**
+   * Constructs an {@code SCMException} with {@code null}
+   * as its result code. <p>
+   * Required for Unwrapping {@code RemoteException}. Used by
+   * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}
+   */
+  public ContainerException(String message) {
+    super(message);
+  }
+
+  /**
    * Constructs an {@code ContainerException} with {@code null}
    * as its error detail message.
    * @param resultCode ResultCode for the exception

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerException.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 public class ContainerException extends SCMException {
 
   /**
-   * Constructs an {@code SCMException} with {@code null}
+   * Constructs a {@code ContainerException} with {@code null}
    * as its result code. <p>
    * Required for Unwrapping {@code RemoteException}. Used by
    * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/exceptions/SCMException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/exceptions/SCMException.java
@@ -27,6 +27,17 @@ public class SCMException extends IOException {
 
   /**
    * Constructs an {@code IOException} with {@code null}
+   * as its result code. <p>
+   * Required for Unwrapping {@code RemoteException}. Used by
+   * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}
+   */
+  public SCMException(String message) {
+    super(message);
+    this.result = null;
+  }
+
+  /**
+   * Constructs an {@code IOException} with {@code null}
    * as its error detail message.
    */
   public SCMException(ResultCodes result) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/exceptions/SCMException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/exceptions/SCMException.java
@@ -26,7 +26,7 @@ public class SCMException extends IOException {
   private final ResultCodes result;
 
   /**
-   * Constructs an {@code IOException} with {@code null}
+   * Constructs an {@code SCMException} with {@code null}
    * as its result code. <p>
    * Required for Unwrapping {@code RemoteException}. Used by
    * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/NonRetriableException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/NonRetriableException.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 public class NonRetriableException extends IOException {
 
   /**
-   * Constructs an {@code IOException} with the given detailed message. <p>
+   * Constructs a {@code NonRetriableException} with the given detailed message. <p>
    * Required for Unwrapping {@code RemoteException}. Used by
    * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/NonRetriableException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/NonRetriableException.java
@@ -24,6 +24,15 @@ import java.io.IOException;
  */
 public class NonRetriableException extends IOException {
 
+  /**
+   * Constructs an {@code IOException} with the given detailed message. <p>
+   * Required for Unwrapping {@code RemoteException}. Used by
+   * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}
+   */
+  public NonRetriableException(String message) {
+    super(message);
+  }
+
   public NonRetriableException(IOException exception) {
     super(exception);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/InsufficientDatanodesException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/InsufficientDatanodesException.java
@@ -28,6 +28,16 @@ public final class InsufficientDatanodesException extends IOException {
   private final int required;
   private final int available;
 
+  /**
+   * Required for Unwrapping {@code RemoteException}. Used by
+   * {@link org.apache.hadoop.ipc.RemoteException#unwrapRemoteException()}
+   */
+  public InsufficientDatanodesException(String message) {
+    super(message);
+    this.required = 0;
+    this.available = 0;
+  }
+
   public InsufficientDatanodesException(int required, int available,
       String message) {
     super(message);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This error occurs because the `SCMException` is thrown as a `RemoteException` to the Client (`StorageContainerLocationProtocolClientSideTranslatorPB`) from the server side (`StorageContainerLocationProtocolServerSideTranslatorPB`). We unwrap the exception using `RemoteException#unwrapRemoteException()`. This function expects a constructor with a `String.class` parameter, which is not present in `SCMException` and a few other Exception classes. This results in unwrap failure, and the commands are retried until the client exhausts the retry policy.

Currently, `SCMHAUtils#checkNonRetriableException()` is used to fail non-retriable commands. It fails to unwrap exceptions, resulting in incorrect retry logic. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10760

## How was this patch tested?

Manual testing with docker.
