### PR TITLE
HDDS-12311. flaky-test-check split exit code is always 1

### DIFF
--- a/hadoop-ozone/dev-support/checks/_post_process.sh
+++ b/hadoop-ozone/dev-support/checks/_post_process.sh
@@ -43,7 +43,7 @@ if [[ ! -s "${REPORT_DIR}/failures" ]]; then
 fi
 
 # exit with failure if report is not empty
-if [[ -s "${REPORT_FILE}" ]]; then
+if [[ -s "${REPORT_FILE}" ]] && [[ ${ITERATIONS:-1} -eq 1 ]]; then
   rc=1
 fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`flaky-test-check` splits always return `completed with exit code 1`, even if there are no failed tests.

https://github.com/adoroszlai/ozone/actions/runs/13262417511

https://issues.apache.org/jira/browse/HDDS-12311

## How was this patch tested?

No `completed with exit code 1` in run where all passed:
https://github.com/adoroszlai/ozone/actions/runs/13271627157

Failed runs reported correctly for flaky test:
https://github.com/adoroszlai/ozone/actions/runs/13271802577

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/13271514006