### PR TITLE
HDDS-12312. NodeManager log aggregation to Ozone FileSystem fails.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneFsServerDefaults.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneFsServerDefaults.java
@@ -37,7 +37,7 @@ public class OzoneFsServerDefaults extends FsServerDefaults {
   }
 
   public OzoneFsServerDefaults(String keyProviderUri) {
-    super(0L, 512, 0, (short)0, 0, false, 0L, null, keyProviderUri);
+    super(0L, 16 * 1024, 0, (short)0, 0, false, 0L, null, keyProviderUri);
   }
 
   public FsServerDefaultsProto getProtobuf() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneFsServerDefaults.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneFsServerDefaults.java
@@ -37,7 +37,7 @@ public class OzoneFsServerDefaults extends FsServerDefaults {
   }
 
   public OzoneFsServerDefaults(String keyProviderUri) {
-    super(0L, 0, 0, (short)0, 0, false, 0L, null, keyProviderUri);
+    super(0L, 512, 0, (short)0, 0, false, 0L, null, keyProviderUri);
   }
 
   public FsServerDefaultsProto getProtobuf() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running a YARN job on the Ozone FileSystem, a NullPointerException occurs, causing NodeManagers to fail during log aggregation.

Upon investigation, an ArithmeticException is thrown in AbstractFileSystem#create, caused by a 0 % 0 calculation:

```java
    FsServerDefaults ssDef = getServerDefaults(f);
    if (ssDef.getBlockSize() % ssDef.getBytesPerChecksum() != 0) {
```

Since HDDS-11227, FsServerDefaults has been extended by OzoneFsServerDefaults. However, most fields (including bytesPerChecksum) are initialized to zero, which triggers the 0 % 0 error:

```java
public OzoneFsServerDefaults(String keyProviderUri) {
  super(0L, 0, 0, (short)0, 0, false, 0L, null, keyProviderUri);
}
```

In Hadoop’s `FileSystem`, the default `bytesPerChecksum` is 512. Changing `OzoneFsServerDefaults` so that `bytesPerChecksum` is not zero solves the problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12312

## How was this patch tested?

I have tested this fix in my cluster, and it prevents the `ArithmeticException` so that log aggregation works correctly.