### PR TITLE
HDDS-12309. Intermittent failure in TestCloseContainerCommandHandler.testThreadPoolPoolSize

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -44,7 +44,6 @@ import static java.util.Collections.singletonMap;
 import static org.apache.hadoop.ozone.OzoneConsts.GB;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -296,24 +295,6 @@ public class TestCloseContainerCommandHandler {
   @Test
   public void testThreadPoolPoolSize() {
     assertEquals(1, subject.getThreadPoolMaxPoolSize());
-    assertEquals(0, subject.getThreadPoolActivePoolSize());
-
-    CloseContainerCommandHandler closeContainerCommandHandler =
-        new CloseContainerCommandHandler(10, 10, "");
-    closeContainerCommandHandler.handle(new CloseContainerCommand(
-        CONTAINER_ID + 1, PipelineID.randomId()),
-        ozoneContainer, context, null);
-    closeContainerCommandHandler.handle(new CloseContainerCommand(
-        CONTAINER_ID + 2, PipelineID.randomId()),
-        ozoneContainer, context, null);
-    closeContainerCommandHandler.handle(new CloseContainerCommand(
-        CONTAINER_ID + 3, PipelineID.randomId()),
-        ozoneContainer, context, null);
-    closeContainerCommandHandler.handle(new CloseContainerCommand(
-        CONTAINER_ID + 4, PipelineID.randomId()),
-        ozoneContainer, context, null);
-    assertEquals(10, closeContainerCommandHandler.getThreadPoolMaxPoolSize());
-    assertTrue(closeContainerCommandHandler.getThreadPoolActivePoolSize() > 0);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent test failure:

```
AssertionFailedError: expected: <true> but was: <false>
  ...
  at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
  at org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestCloseContainerCommandHandler.testThreadPoolPoolSize(TestCloseContainerCommandHandler.java:316)
```

This started happening with Ubuntu 24.04 runner ([example](https://github.com/apache/ozone/actions/runs/13259625320/job/37013543693?pr=7852#step:6:1621)).

Fixed by removing the part of the test related to `activePoolSize`.

- commands may be already handled by the time when the assertion is reached
- return value from `ThreadPoolExecutor#getActiveCount()` is approximate, anyway
- the value is only used for metrics

https://issues.apache.org/jira/browse/HDDS-12309

## How was this patch tested?

10x10 run:
https://github.com/adoroszlai/ozone/actions/runs/13262417511

CI:
https://github.com/adoroszlai/ozone/actions/runs/13260576575
