### PR TITLE
HDDS-12179. Improve Container Log to also capture the Command fired to Datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -51,7 +51,7 @@ public final class ContainerLogger {
    * @param containerData The container that was created and opened.
    */
   public static void logOpen(ContainerData containerData) {
-    LOG.info(getMessage(containerData,"CommandType=CreateContainer"));
+    LOG.info(getMessage(containerData, "CommandType=CreateContainer"));
   }
 
   /**
@@ -80,7 +80,7 @@ public final class ContainerLogger {
    * @param containerData The container that was closed.
    */
   public static void logClosed(ContainerData containerData) {
-    LOG.info(getMessage(containerData,"CommandType=CloseContainer"));
+    LOG.info(getMessage(containerData, "CommandType=CloseContainer"));
   }
 
   /**
@@ -128,7 +128,7 @@ public final class ContainerLogger {
    * @param containerData The container that was imported to this datanode.
    */
   public static void logImported(ContainerData containerData) {
-    LOG.info(getMessage(containerData,"action=Imported"));
+    LOG.info(getMessage(containerData, "action=Imported"));
   }
 
   /**
@@ -137,7 +137,7 @@ public final class ContainerLogger {
    * @param containerData The container that was exported from this datanode.
    */
   public static void logExported(ContainerData containerData) {
-    LOG.info(getMessage(containerData,"action=Exported"));
+    LOG.info(getMessage(containerData, "action=Exported"));
   }
 
   /**
@@ -146,7 +146,7 @@ public final class ContainerLogger {
    * @param containerData The container that was recovered on this datanode.
    */
   public static void logRecovered(ContainerData containerData) {
-    LOG.info(getMessage(containerData,"action=Recovered"));
+    LOG.info(getMessage(containerData, "action=Recovered"));
   }
 
   private static String getMessage(ContainerData containerData,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -51,7 +51,7 @@ public final class ContainerLogger {
    * @param containerData The container that was created and opened.
    */
   public static void logOpen(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData,"CommandType=CreateContainer"));
   }
 
   /**
@@ -80,7 +80,7 @@ public final class ContainerLogger {
    * @param containerData The container that was closed.
    */
   public static void logClosed(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData,"CommandType=CloseContainer"));
   }
 
   /**
@@ -116,9 +116,9 @@ public final class ContainerLogger {
    */
   public static void logDeleted(ContainerData containerData, boolean force) {
     if (force) {
-      LOG.info(getMessage(containerData, "Container force deleted"));
+      LOG.info(getMessage(containerData, "Container force deleted, CommandType=DeleteContainer"));
     } else {
-      LOG.info(getMessage(containerData, "Empty container deleted"));
+      LOG.info(getMessage(containerData, "Empty container deleted, CommandType=DeleteContainer"));
     }
   }
 
@@ -128,7 +128,7 @@ public final class ContainerLogger {
    * @param containerData The container that was imported to this datanode.
    */
   public static void logImported(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData,"action=Imported"));
   }
 
   /**
@@ -137,7 +137,7 @@ public final class ContainerLogger {
    * @param containerData The container that was exported from this datanode.
    */
   public static void logExported(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData,"action=Exported"));
   }
 
   /**
@@ -146,7 +146,7 @@ public final class ContainerLogger {
    * @param containerData The container that was recovered on this datanode.
    */
   public static void logRecovered(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData,"action=Recovered"));
   }
 
   private static String getMessage(ContainerData containerData,
@@ -159,6 +159,7 @@ public final class ContainerLogger {
         "ID=" + containerData.getContainerID(),
         "Index=" + containerData.getReplicaIndex(),
         "BCSID=" + containerData.getBlockCommitSequenceId(),
-        "State=" + containerData.getState());
+        "State=" + containerData.getState(),
+        "Volume=" + containerData.getVolume());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, container logs capture only the state of the container.
To enhance the debugging process and provide more context, we have added additional details, including volume information and the specific CommandType, to the container logs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12179

## How was this patch tested?
Reviewed the Container logs in docker after making the changes.
below is the workflow link that passes successfully
https://github.com/sreejasahithi/ozone/actions/runs/13278272097
