### PR TITLE
HDDS-12288. Improve bootstrap logging to indicate progress

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -22,6 +22,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.FileOutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -144,7 +144,7 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
     URL omCheckpointUrl = leader.getOMDBCheckpointEndpointUrl(
         httpPolicy.isHttpEnabled(), true);
     LOG.info("Downloading latest checkpoint from Leader OM {}. Checkpoint: {} " + "URL: {}",
-             leaderNodeID, targetFile.getName() , omCheckpointUrl);
+             leaderNodeID, targetFile.getName(), omCheckpointUrl);
     SecurityUtil.doAsCurrentUser(() -> {
       HttpURLConnection connection = (HttpURLConnection)
           connectionFactory.openConnection(omCheckpointUrl, spnegoEnabled);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -145,7 +145,7 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
     URL omCheckpointUrl = leader.getOMDBCheckpointEndpointUrl(
         httpPolicy.isHttpEnabled(), true);
     LOG.info("Downloading latest checkpoint from Leader OM {}. Checkpoint: {} URL: {}",
-             leaderNodeID, targetFile.getName(), omCheckpointUrl);
+        leaderNodeID, targetFile.getName(), omCheckpointUrl);
     SecurityUtil.doAsCurrentUser(() -> {
       HttpURLConnection connection = (HttpURLConnection)
           connectionFactory.openConnection(omCheckpointUrl, spnegoEnabled);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -187,26 +187,27 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
    */
   public static void downloadFileWithProgress(InputStream inputStream, File targetFile)
           throws IOException {
-    FileOutputStream outputStream = new FileOutputStream(targetFile);
-    byte[] buffer = new byte[8 * 1024];
-    long totalBytesRead = 0;
-    int bytesRead;
-    long lastLoggedTime = System.currentTimeMillis();
+    try (FileOutputStream outputStream = new FileOutputStream(targetFile)) {
+      byte[] buffer = new byte[8 * 1024];
+      long totalBytesRead = 0;
+      int bytesRead;
+      long lastLoggedTime = System.currentTimeMillis();
 
-    while ((bytesRead = inputStream.read(buffer)) != -1) {
-      outputStream.write(buffer, 0, bytesRead);
-      totalBytesRead += bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, bytesRead);
+        totalBytesRead += bytesRead;
 
-      // Log progress every 30 seconds
-      if (System.currentTimeMillis() - lastLoggedTime >= 30000) {
-        LOG.info("Downloading '{}': {} KB downloaded so far...",
-                targetFile.getName(), totalBytesRead / (1024));
-        lastLoggedTime = System.currentTimeMillis();
+        // Log progress every 30 seconds
+        if (System.currentTimeMillis() - lastLoggedTime >= 30000) {
+          LOG.info("Downloading '{}': {} KB downloaded so far...",
+                  targetFile.getName(), totalBytesRead / (1024));
+          lastLoggedTime = System.currentTimeMillis();
+        }
       }
-    }
 
-    LOG.info("Download completed for '{}'. Total size: {} KB",
-            targetFile.getName(), totalBytesRead / (1024));
+      LOG.info("Download completed for '{}'. Total size: {} KB",
+              targetFile.getName(), totalBytesRead / (1024));
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -200,13 +200,13 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
         // Log progress every 30 seconds
         if (System.currentTimeMillis() - lastLoggedTime >= 30000) {
           LOG.info("Downloading '{}': {} KB downloaded so far...",
-                  targetFile.getName(), totalBytesRead / (1024));
+              targetFile.getName(), totalBytesRead / (1024));
           lastLoggedTime = System.currentTimeMillis();
         }
       }
 
       LOG.info("Download completed for '{}'. Total size: {} KB",
-              targetFile.getName(), totalBytesRead / (1024));
+          targetFile.getName(), totalBytesRead / (1024));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -186,7 +186,7 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
    * Writes data from the given InputStream to the target file while logging download progress every 30 seconds.
    */
   public static void downloadFileWithProgress(InputStream inputStream, File targetFile)
-          throws IOException{
+          throws IOException {
     FileOutputStream outputStream = new FileOutputStream(targetFile);
     byte[] buffer = new byte[8 * 1024];
     long totalBytesRead = 0;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.ozone.om.ratis_snapshot;
 
-import java.io.*;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
@@ -142,7 +145,6 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
         httpPolicy.isHttpEnabled(), true);
     LOG.info("Downloading latest checkpoint from Leader OM {}. Checkpoint: {} " + "URL: {}",
              leaderNodeID, targetFile.getName() , omCheckpointUrl);
-
     SecurityUtil.doAsCurrentUser(() -> {
       HttpURLConnection connection = (HttpURLConnection)
           connectionFactory.openConnection(omCheckpointUrl, spnegoEnabled);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -144,7 +144,7 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
     OMNodeDetails leader = peerNodesMap.get(leaderNodeID);
     URL omCheckpointUrl = leader.getOMDBCheckpointEndpointUrl(
         httpPolicy.isHttpEnabled(), true);
-    LOG.info("Downloading latest checkpoint from Leader OM {}. Checkpoint: {} " + "URL: {}",
+    LOG.info("Downloading latest checkpoint from Leader OM {}. Checkpoint: {} URL: {}",
              leaderNodeID, targetFile.getName(), omCheckpointUrl);
     SecurityUtil.doAsCurrentUser(() -> {
       HttpURLConnection connection = (HttpURLConnection)


### PR DESCRIPTION
## What changes were proposed in this pull request?
On Large clusters with 1000s of snapshot, Sometimes bootstrap takes hours together and current log doesn't indicate which snapshot download is under progress. We need to find a way to print progress of bootstrap.
Overall ask in this jira would be to have some logging indicating the progress on bootstrap process.

Fix done :

1.  Included om db checkpoint name that is being downloaded in the logs.
2. Printing progress of the download after an interval of 30s .

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-12288

## How was this patch tested?

Verified via stdout of "**TestOzoneManagerSnapshotProvider**" that the logs were printed while downloading the snapshot. 
Output of test logs:
1. This output shows the log including the om db checkpoint name

`2025-02-13 13:28:45,796 [main] INFO  ratis_snapshot.OmRatisSnapshotProvider (OmRatisSnapshotProvider.java:downloadSnapshot(147)) - Downloading latest checkpoint from Leader OM omNode-1. Checkpoint: om.db-omNode-1-1739433525792.tar URL: http://127.0.0.1:15007/dbCheckpoint?includeSnapshotData=true&flushBeforeCheckpoint=true
`

2. This output shows printing progress of the download after an interval of 30s 

`Downloading 'om.db-omNode-1-1739433817858.tar': 96 KB downloaded so far...`
`Download completed for 'om.db-omNode-1-1739433817858.tar'. Total size: 121 KB`