### PR TITLE
HDDS-12241. Improve error message for FileSystemException

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -16,8 +16,13 @@
  */
 package org.apache.hadoop.hdds.cli;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.NoSuchFileException;
 import java.util.Map;
 
 import com.google.common.base.Strings;
@@ -122,5 +127,21 @@ public abstract class GenericCli implements GenericParentCommand {
 
   protected PrintWriter err() {
     return cmd.getErr();
+  }
+
+  public static String handleFileSystemException(FileSystemException e, File dataFile) {
+    String message = e.getMessage();
+    String errorMessage;
+    if (e instanceof NoSuchFileException) {
+      errorMessage = String.format("Error: File not found: %s", dataFile.getPath());
+    } else if (e instanceof AccessDeniedException) {
+      errorMessage = String.format("Error: Access denied to file: %s", dataFile.getPath());
+    } else if (e instanceof FileAlreadyExistsException) {
+      errorMessage = String.format("Error: File already exists: %s", dataFile.getPath());
+    } else {
+      errorMessage = String.format("Error with file: %s. Details: %s", dataFile.getPath(), message);
+    }
+
+    return errorMessage;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -133,26 +133,23 @@ public abstract class GenericCli implements GenericParentCommand {
     return cmd.getErr();
   }
 
-  private String handleFileSystemException(FileSystemException e) {
-    String errorMessage = e.getClass().getSimpleName() + ": ";
+  private static String handleFileSystemException(FileSystemException e) {
+    String errorMessage = e.getMessage();
 
     // If reason is set, return the exception's message as it is.
-    if (e.getReason() != null) {
-      return errorMessage + e.getMessage();
-    }
-
     // Otherwise, construct a custom message based on the type of exception
-    if (e instanceof NoSuchFileException) {
-      errorMessage += "File not found ";
-    } else if (e instanceof AccessDeniedException) {
-      errorMessage += "Access denied to file ";
-    } else if (e instanceof FileAlreadyExistsException) {
-      errorMessage += "File already exists ";
-    } else {
-      errorMessage += "Error with file ";
+    if (e.getReason() == null) {
+      if (e instanceof NoSuchFileException) {
+        errorMessage = "File not found: " + errorMessage;
+      } else if (e instanceof AccessDeniedException) {
+        errorMessage = "Access denied: " + errorMessage;
+      } else if (e instanceof FileAlreadyExistsException) {
+        errorMessage = "File already exists: " + errorMessage;
+      } else {
+        errorMessage = e.getClass().getSimpleName() + ": " + errorMessage;
+      }
     }
 
-    errorMessage += e.getMessage();
-    return errorMessage;
+    return "Error: " + errorMessage;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.hdds.cli;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.AccessDeniedException;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -93,7 +93,7 @@ public abstract class GenericCli implements GenericParentCommand {
     if (error instanceof FileSystemException) {
       String errorMessage = handleFileSystemException((FileSystemException) error);
       cmd.getErr().println(errorMessage);
-    }else {
+    } else {
       //message could be null in case of NPE. This is unexpected so we can
       //print out the stack trace.
       if (verbose || Strings.isNullOrEmpty(error.getMessage())) {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -25,14 +25,12 @@ import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.StorageUnit;
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.io.IOUtils;
@@ -88,8 +86,6 @@ public class PutKeyHandler extends KeyHandler {
       try (InputStream stream = Files.newInputStream(dataFile.toPath())) {
         String hash = DigestUtils.sha256Hex(stream);
         out().printf("File sha256 checksum : %s%n", hash);
-      } catch (FileSystemException e) {
-        out().println(GenericCli.handleFileSystemException(e, dataFile));
       }
     }
 
@@ -128,8 +124,6 @@ public class PutKeyHandler extends KeyHandler {
     try (InputStream input = Files.newInputStream(dataFile.toPath());
          OutputStream output = createOrReplaceKey(bucket, keyName, dataFile.length(), keyMetadata, replicationConfig)) {
       IOUtils.copyBytes(input, output, chunkSize);
-    } catch (FileSystemException e) {
-      out().println(GenericCli.handleFileSystemException(e, dataFile));
     }
   }
 
@@ -175,8 +169,6 @@ public class PutKeyHandler extends KeyHandler {
         off += writeLen;
         len -= writeLen;
       }
-    } catch (FileSystemException e) {
-      out().println(GenericCli.handleFileSystemException(e, dataFile));
     }
   }
 }

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -88,8 +88,7 @@ public class PutKeyHandler extends KeyHandler {
       try (InputStream stream = Files.newInputStream(dataFile.toPath())) {
         String hash = DigestUtils.sha256Hex(stream);
         out().printf("File sha256 checksum : %s%n", hash);
-      }
-      catch (FileSystemException e) {
+      } catch (FileSystemException e) {
         out().println(GenericCli.handleFileSystemException(e, dataFile));
       }
     }
@@ -129,8 +128,7 @@ public class PutKeyHandler extends KeyHandler {
     try (InputStream input = Files.newInputStream(dataFile.toPath());
          OutputStream output = createOrReplaceKey(bucket, keyName, dataFile.length(), keyMetadata, replicationConfig)) {
       IOUtils.copyBytes(input, output, chunkSize);
-    }
-    catch (FileSystemException e) {
+    } catch (FileSystemException e) {
       out().println(GenericCli.handleFileSystemException(e, dataFile));
     }
   }
@@ -177,8 +175,7 @@ public class PutKeyHandler extends KeyHandler {
         off += writeLen;
         len -= writeLen;
       }
-    }
-    catch (FileSystemException e) {
+    } catch (FileSystemException e) {
       out().println(GenericCli.handleFileSystemException(e, dataFile));
     }
   }

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -187,7 +187,7 @@ Test key handling
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
     ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bb1/key1 sample.txt          255
-                    Should Contain         ${result}       File not found sample.txt
+                    Should Contain         ${result}       File not found: sample.txt
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
                     Should not contain  ${result}       ETag

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -131,8 +131,7 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
-    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt          255
-                    Should Match Regexp                    ${result}       Error: File not found: .*
+
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -131,7 +131,8 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
-
+    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt          255
+                    Should Match Regexp                    ${result}       Error: File not found: .*
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -187,7 +187,7 @@ Test key handling
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
     ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bb1/key1 sample.txt          255
-                    Should Match Regexp    ${result}       Error: File not found: .*
+                    Should Contain         ${result}       File not found sample.txt
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
                     Should not contain  ${result}       ETag

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -131,8 +131,6 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
                     Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
-    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 sample.txt          255
-                    Should Match Regexp                    ${result}       Error: File not found: .*
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}
@@ -188,6 +186,8 @@ Test key handling
                     Should Contain      ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
+    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bb1/key1 sample.txt          255
+                    Should Match Regexp    ${result}       Error: File not found: .*
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
                     Should not contain  ${result}       ETag


### PR DESCRIPTION
## What changes were proposed in this pull request?
The handling of FileSystemException has been improved to provide more detailed and specific error messages. Previously, only file name would be displayed for the exceptions like NoSuchFileException, AccessDeniedException, or FileAlreadyExistsException.
This update ensures that the exception type is checked and accordingly the error message is given.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12241

## How was this patch tested?

below is the workflow link that passes successfully
https://github.com/sreejasahithi/ozone/actions/runs/13289875378
