### PR TITLE
HDDS-12204. Improve failover logging

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -35,8 +35,8 @@ public class ServerNotLeaderException extends IOException {
       Pattern.compile(".*Suggested leader is Server:([^:]*)(:[0-9]+).*",
           Pattern.DOTALL);
 
-  public ServerNotLeaderException(RaftPeerId currentPeerId, String hostname
-      , String roleType) {
+  public ServerNotLeaderException(RaftPeerId currentPeerId, String hostname,
+                                  String roleType) {
     super(roleType + " Server:" + currentPeerId + "(" + hostname + ") is not the leader. Could not " +
         "determine the leader node.");
     this.leader = null;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -30,20 +30,21 @@ import java.util.regex.Pattern;
 public class ServerNotLeaderException extends IOException {
   private final String leader;
   private static final Pattern CURRENT_PEER_ID_PATTERN =
-      Pattern.compile("Server:(.*) is not the leader[.]+.*", Pattern.DOTALL);
+      Pattern.compile(".* Server:(.*?) is not the leader[.]+.*", Pattern.DOTALL);
   private static final Pattern SUGGESTED_LEADER_PATTERN =
       Pattern.compile(".*Suggested leader is Server:([^:]*)(:[0-9]+).*",
           Pattern.DOTALL);
 
-  public ServerNotLeaderException(RaftPeerId currentPeerId, String hostname) {
-    super("Server:" + currentPeerId + "(" + hostname + ") is not the leader. Could not " +
+  public ServerNotLeaderException(RaftPeerId currentPeerId, String hostname
+      , String roleType) {
+    super(roleType + " Server:" + currentPeerId + "(" + hostname + ") is not the leader. Could not " +
         "determine the leader node.");
     this.leader = null;
   }
 
   public ServerNotLeaderException(RaftPeerId currentPeerId,
-      String suggestedLeader, String hostname) {
-    super("Server:" + currentPeerId + "(" + hostname + ") is not the leader. Suggested leader is"
+      String suggestedLeader, String hostname, String roleType) {
+    super(roleType + " Server:" + currentPeerId + "(" + hostname + ") is not the leader. Suggested leader is"
         + " Server:" + suggestedLeader + ".");
     this.leader = suggestedLeader;
   }
@@ -90,7 +91,7 @@ public class ServerNotLeaderException extends IOException {
    */
   public static ServerNotLeaderException convertToNotLeaderException(
       NotLeaderException notLeaderException,
-      RaftPeerId currentPeer, String port, String hostname) {
+      RaftPeerId currentPeer, String port, String hostname, String roleType) {
     String suggestedLeader = notLeaderException.getSuggestedLeader() != null ?
         HddsUtils
             .getHostName(notLeaderException.getSuggestedLeader().getAddress())
@@ -100,9 +101,9 @@ public class ServerNotLeaderException extends IOException {
     if (suggestedLeader != null) {
       String suggestedLeaderHostPort = suggestedLeader + ":" + port;
       serverNotLeaderException =
-          new ServerNotLeaderException(currentPeer, suggestedLeaderHostPort, hostname);
+          new ServerNotLeaderException(currentPeer, suggestedLeaderHostPort, hostname, roleType);
     } else {
-      serverNotLeaderException = new ServerNotLeaderException(currentPeer, hostname);
+      serverNotLeaderException = new ServerNotLeaderException(currentPeer, hostname, roleType);
     }
     return serverNotLeaderException;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -35,15 +35,15 @@ public class ServerNotLeaderException extends IOException {
       Pattern.compile(".*Suggested leader is Server:([^:]*)(:[0-9]+).*",
           Pattern.DOTALL);
 
-  public ServerNotLeaderException(RaftPeerId currentPeerId) {
-    super("Server:" + currentPeerId + " is not the leader. Could not " +
+  public ServerNotLeaderException(RaftPeerId currentPeerId, String hostname) {
+    super("Server:" + currentPeerId + "(" + hostname + ") is not the leader. Could not " +
         "determine the leader node.");
     this.leader = null;
   }
 
   public ServerNotLeaderException(RaftPeerId currentPeerId,
-      String suggestedLeader) {
-    super("Server:" + currentPeerId + " is not the leader. Suggested leader is"
+      String suggestedLeader, String hostname) {
+    super("Server:" + currentPeerId + "(" + hostname + ") is not the leader. Suggested leader is"
         + " Server:" + suggestedLeader + ".");
     this.leader = suggestedLeader;
   }
@@ -90,7 +90,7 @@ public class ServerNotLeaderException extends IOException {
    */
   public static ServerNotLeaderException convertToNotLeaderException(
       NotLeaderException notLeaderException,
-      RaftPeerId currentPeer, String port) {
+      RaftPeerId currentPeer, String port, String hostname) {
     String suggestedLeader = notLeaderException.getSuggestedLeader() != null ?
         HddsUtils
             .getHostName(notLeaderException.getSuggestedLeader().getAddress())
@@ -100,9 +100,9 @@ public class ServerNotLeaderException extends IOException {
     if (suggestedLeader != null) {
       String suggestedLeaderHostPort = suggestedLeader + ":" + port;
       serverNotLeaderException =
-          new ServerNotLeaderException(currentPeer, suggestedLeaderHostPort);
+          new ServerNotLeaderException(currentPeer, suggestedLeaderHostPort, hostname);
     } else {
-      serverNotLeaderException = new ServerNotLeaderException(currentPeer);
+      serverNotLeaderException = new ServerNotLeaderException(currentPeer, hostname);
     }
     return serverNotLeaderException;
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderExceptionMessageParsing.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderExceptionMessageParsing.java
@@ -30,13 +30,13 @@ class TestServerNotLeaderExceptionMessageParsing {
 
     // Test hostname with "."
     final String msg =
-        "SCM Server:cf0bc565-a41b-4784-a24d-3048d5a5b013 (172.16.102.111) is not the leader. "
+        "SCM Server:cf0bc565-a41b-4784-a24d-3048d5a5b013(172.16.102.111) is not the leader. "
             + "Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863";
     ServerNotLeaderException snle = new ServerNotLeaderException(msg);
     assertEquals(snle.getSuggestedLeader(), "scm5-3.scm5.root.hwx" +
         ".site:9863");
 
-    String message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
+    String message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39(172.16.102.111) is not the " +
         "leader.Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
@@ -45,7 +45,7 @@ class TestServerNotLeaderExceptionMessageParsing {
         snle.getSuggestedLeader());
 
     // Test hostname with out "."
-    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39(172.16.102.111) is not the " +
         "leader.Suggested leader is Server:localhost:98634 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
@@ -53,14 +53,14 @@ class TestServerNotLeaderExceptionMessageParsing {
     assertEquals("localhost:98634",
         snle.getSuggestedLeader());
 
-    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39(172.16.102.111) is not the " +
         "leader.Suggested leader is Server::98634 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
     assertNull(snle.getSuggestedLeader());
 
-    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39(172.16.102.111) is not the " +
         "leader.Suggested leader is Server:localhost:98634:8988 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
@@ -68,7 +68,7 @@ class TestServerNotLeaderExceptionMessageParsing {
     assertEquals("localhost:98634",
         snle.getSuggestedLeader());
 
-    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39(172.16.102.111) is not the " +
         "leader.Suggested leader is Server:localhost \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java)";

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderExceptionMessageParsing.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderExceptionMessageParsing.java
@@ -30,13 +30,13 @@ class TestServerNotLeaderExceptionMessageParsing {
 
     // Test hostname with "."
     final String msg =
-        "Server:cf0bc565-a41b-4784-a24d-3048d5a5b013 is not the leader. "
+        "SCM Server:cf0bc565-a41b-4784-a24d-3048d5a5b013 (172.16.102.111) is not the leader. "
             + "Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863";
     ServerNotLeaderException snle = new ServerNotLeaderException(msg);
     assertEquals(snle.getSuggestedLeader(), "scm5-3.scm5.root.hwx" +
         ".site:9863");
 
-    String message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+    String message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
         "leader.Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
@@ -45,7 +45,7 @@ class TestServerNotLeaderExceptionMessageParsing {
         snle.getSuggestedLeader());
 
     // Test hostname with out "."
-    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
         "leader.Suggested leader is Server:localhost:98634 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
@@ -53,14 +53,14 @@ class TestServerNotLeaderExceptionMessageParsing {
     assertEquals("localhost:98634",
         snle.getSuggestedLeader());
 
-    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
         "leader.Suggested leader is Server::98634 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
     assertNull(snle.getSuggestedLeader());
 
-    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
         "leader.Suggested leader is Server:localhost:98634:8988 \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
@@ -68,7 +68,7 @@ class TestServerNotLeaderExceptionMessageParsing {
     assertEquals("localhost:98634",
         snle.getSuggestedLeader());
 
-    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+    message = "SCM Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 (172.16.102.111) is not the " +
         "leader.Suggested leader is Server:localhost \n" +
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java)";

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -236,7 +236,7 @@ public final class RatisUtil {
   }
 
   public static void checkRatisException(IOException e, String port,
-      String scmId, String hostname) throws ServiceException {
+      String scmId, String hostname, String roleType) throws ServiceException {
     if (SCMHAUtils.isNonRetriableException(e)) {
       throw new ServiceException(new NonRetriableException(e));
     } else if (SCMHAUtils.isRetriableWithNoFailoverException(e)) {
@@ -246,7 +246,7 @@ public final class RatisUtil {
           (NotLeaderException) SCMHAUtils.getNotLeaderException(e);
       throw new ServiceException(ServerNotLeaderException
           .convertToNotLeaderException(nle,
-              SCMRatisServerImpl.getSelfPeerId(scmId), port, hostname));
+              SCMRatisServerImpl.getSelfPeerId(scmId), port, hostname, roleType));
     } else if (e instanceof SCMSecurityException) {
       // For NOT_A_PRIMARY_SCM error client needs to retry on next SCM.
       // GetSCMCertificate call can happen on non-leader SCM and only an

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -236,7 +236,7 @@ public final class RatisUtil {
   }
 
   public static void checkRatisException(IOException e, String port,
-      String scmId) throws ServiceException {
+      String scmId, String hostname) throws ServiceException {
     if (SCMHAUtils.isNonRetriableException(e)) {
       throw new ServiceException(new NonRetriableException(e));
     } else if (SCMHAUtils.isRetriableWithNoFailoverException(e)) {
@@ -246,7 +246,7 @@ public final class RatisUtil {
           (NotLeaderException) SCMHAUtils.getNotLeaderException(e);
       throw new ServiceException(ServerNotLeaderException
           .convertToNotLeaderException(nle,
-              SCMRatisServerImpl.getSelfPeerId(scmId), port));
+              SCMRatisServerImpl.getSelfPeerId(scmId), port, hostname));
     } else if (e instanceof SCMSecurityException) {
       // For NOT_A_PRIMARY_SCM error client needs to retry on next SCM.
       // GetSCMCertificate call can happen on non-leader SCM and only an

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -61,7 +61,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
 
   private final SCMSecurityProtocol impl;
   private final StorageContainerManager scm;
-  private final static String roleType = "SCM";
+  private static final String ROLE_TYPE = "SCM";
 
   private OzoneProtocolMessageDispatcher<SCMSecurityRequest,
       SCMSecurityResponse, ProtocolMessageEnum>
@@ -83,7 +83,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), ROLE_TYPE);
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -151,7 +151,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname(), roleType);
+          scm.getScmId(), scm.getHostname(), ROLE_TYPE);
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -82,7 +82,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname());
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -150,7 +150,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname());
+          scm.getScmId(), scm.getHostname(), "SCM");
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -61,6 +61,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
 
   private final SCMSecurityProtocol impl;
   private final StorageContainerManager scm;
+  private final static String roleType = "SCM";
 
   private OzoneProtocolMessageDispatcher<SCMSecurityRequest,
       SCMSecurityResponse, ProtocolMessageEnum>
@@ -82,7 +83,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -150,7 +151,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getScmId(), scm.getHostname(), roleType);
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -82,7 +82,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId());
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname());
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -150,7 +150,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId());
+          scm.getScmId(), scm.getHostname());
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -111,7 +111,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname());
+          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
     }
     return dispatcher.processRequest(
         request,
@@ -173,7 +173,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getBlockProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname());
+          scm.getScmId(), scm.getHostname(), "SCM");
       response.setSuccess(false);
       response.setStatus(exceptionToResponseStatus(e));
       if (e.getMessage() != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -111,7 +111,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getBlockProtocolRpcPort(), scm.getScmId());
+          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname());
     }
     return dispatcher.processRequest(
         request,
@@ -173,7 +173,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getBlockProtocolRpcPort(),
-          scm.getScmId());
+          scm.getScmId(), scm.getHostname());
       response.setSuccess(false);
       response.setStatus(exceptionToResponseStatus(e));
       if (e.getMessage() != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -72,7 +72,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
 
   private final ScmBlockLocationProtocol impl;
   private final StorageContainerManager scm;
-  private final static String roleType = "SCM";
+  private static final String ROLE_TYPE = "SCM";
 
   private static final Logger LOG = LoggerFactory
       .getLogger(ScmBlockLocationProtocolServerSideTranslatorPB.class);
@@ -112,7 +112,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
+          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname(), ROLE_TYPE);
     }
     return dispatcher.processRequest(
         request,
@@ -174,7 +174,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getBlockProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname(), roleType);
+          scm.getScmId(), scm.getHostname(), ROLE_TYPE);
       response.setSuccess(false);
       response.setStatus(exceptionToResponseStatus(e));
       if (e.getMessage() != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -72,6 +72,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
 
   private final ScmBlockLocationProtocol impl;
   private final StorageContainerManager scm;
+  private final static String roleType = "SCM";
 
   private static final Logger LOG = LoggerFactory
       .getLogger(ScmBlockLocationProtocolServerSideTranslatorPB.class);
@@ -111,7 +112,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getBlockProtocolRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
     }
     return dispatcher.processRequest(
         request,
@@ -173,7 +174,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getBlockProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getScmId(), scm.getHostname(), roleType);
       response.setSuccess(false);
       response.setStatus(exceptionToResponseStatus(e));
       if (e.getMessage() != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
@@ -55,7 +55,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
 
   private final SecretKeyProtocolScm impl;
   private final StorageContainerManager scm;
-  private final static String roleType = "SCM";
+  private static final String ROLE_TYPE = "SCM";
 
   private OzoneProtocolMessageDispatcher<SCMSecretKeyRequest,
       SCMSecretKeyResponse, ProtocolMessageEnum> dispatcher;
@@ -76,7 +76,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), ROLE_TYPE);
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -116,7 +116,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname(), roleType);
+          scm.getScmId(), scm.getHostname(), ROLE_TYPE);
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
@@ -75,7 +75,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname());
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -115,7 +115,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname());
+          scm.getScmId(), scm.getHostname(), "SCM");
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
@@ -55,6 +55,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
 
   private final SecretKeyProtocolScm impl;
   private final StorageContainerManager scm;
+  private final static String roleType = "SCM";
 
   private OzoneProtocolMessageDispatcher<SCMSecretKeyRequest,
       SCMSecretKeyResponse, ProtocolMessageEnum> dispatcher;
@@ -75,7 +76,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -115,7 +116,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getScmId(), scm.getHostname(), roleType);
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SecretKeyProtocolServerSideTranslatorPB.java
@@ -75,7 +75,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
     if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getSecurityProtocolRpcPort(), scm.getScmId());
+          scm.getSecurityProtocolRpcPort(), scm.getScmId(), scm.getHostname());
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());
@@ -115,7 +115,7 @@ public class SecretKeyProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil.checkRatisException(e, scm.getSecurityProtocolRpcPort(),
-          scm.getScmId());
+          scm.getScmId(), scm.getHostname());
       scmSecurityResponse.setSuccess(false);
       scmSecurityResponse.setStatus(exceptionToResponseStatus(e));
       // If actual cause is set in SCMSecurityException, set message with

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -179,7 +179,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   private final StorageContainerLocationProtocol impl;
   private final StorageContainerManager scm;
-  private final static String roleType = "SCM";
+  private static final String ROLE_TYPE = "SCM";
 
   private OzoneProtocolMessageDispatcher<ScmContainerLocationRequest,
       ScmContainerLocationResponse, ProtocolMessageEnum>
@@ -212,7 +212,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         && !ADMIN_COMMAND_TYPE.contains(request.getCmdType())) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
+          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), ROLE_TYPE);
     }
     // After the request interceptor (now validator) framework is extended to
     // this server interface, this should be removed and solved via new
@@ -738,7 +738,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil
-          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
+          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), ROLE_TYPE);
       throw new ServiceException(e);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -211,7 +211,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         && !ADMIN_COMMAND_TYPE.contains(request.getCmdType())) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getClientRpcPort(), scm.getScmId());
+          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname());
     }
     // After the request interceptor (now validator) framework is extended to
     // this server interface, this should be removed and solved via new
@@ -737,7 +737,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil
-          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId());
+          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname());
       throw new ServiceException(e);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -211,7 +211,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         && !ADMIN_COMMAND_TYPE.contains(request.getCmdType())) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname());
+          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
     }
     // After the request interceptor (now validator) framework is extended to
     // this server interface, this should be removed and solved via new
@@ -737,7 +737,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil
-          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname());
+          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
       throw new ServiceException(e);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -179,6 +179,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   private final StorageContainerLocationProtocol impl;
   private final StorageContainerManager scm;
+  private final static String roleType = "SCM";
 
   private OzoneProtocolMessageDispatcher<ScmContainerLocationRequest,
       ScmContainerLocationResponse, ProtocolMessageEnum>
@@ -211,7 +212,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         && !ADMIN_COMMAND_TYPE.contains(request.getCmdType())) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
-          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
+          scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
     }
     // After the request interceptor (now validator) framework is extended to
     // this server interface, this should be removed and solved via new
@@ -737,7 +738,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       }
     } catch (IOException e) {
       RatisUtil
-          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), "SCM");
+          .checkRatisException(e, scm.getClientRpcPort(), scm.getScmId(), scm.getHostname(), roleType);
       throw new ServiceException(e);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr enhanced the content of `ServerNotLeaderException` by add `hostname` into the content (in example: 172.16.102.166). Please take a look.
## What is the link to the Apache JIRA
[HDDS-12204](https://issues.apache.org/jira/browse/HDDS-12204)

## How was this patch tested?
Deploy and check the error output.
```shell
2025-02-13 13:30:29,329 [IPC Server listener on 9860] INFO ipc.Server: IPC Server listener on 9860: starting
2025-02-13 13:30:29,338 [main] INFO server.StorageContainerManager: ScmBlockLocationProtocol RPC server is listening at /0.0.0.0:9863
2025-02-13 13:30:29,338 [main] ERROR server.StorageContainerManagerStarter: SCM start failed with exception
org.apache.hadoop.hdds.ratis.ServerNotLeaderException: Server:f9732a56-9253-4537-ad92-51af5875dc2e(172.16.102.166) is not the leader. Could not determine the leader node.

```