### PR TITLE
HDDS-12325. Recon OM DB Incremental update events are not processed correctly.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -454,7 +454,7 @@ public class OzoneManagerServiceProviderImpl
   Long getAndApplyDeltaUpdatesFromOM(
       long fromSequenceNumber, OMDBUpdatesHandler omdbUpdatesHandler)
       throws IOException, RocksDBException {
-    LOG.info("OriginalFromSequenceNumber : {} ", fromSequenceNumber);
+    LOG.debug("OriginalFromSequenceNumber : {} ", fromSequenceNumber);
     ImmutablePair<Boolean, Long> dbUpdatesLatestSeqNumOfOMDB =
         innerGetAndApplyDeltaUpdatesFromOM(fromSequenceNumber, omdbUpdatesHandler);
     if (!dbUpdatesLatestSeqNumOfOMDB.getLeft()) {
@@ -466,7 +466,6 @@ public class OzoneManagerServiceProviderImpl
               fromSequenceNumber);
     }
     omdbUpdatesHandler.setLatestSequenceNumber(getCurrentOMDBSequenceNumber());
-    LOG.info("Delta updates received from OM : {} records", getCurrentOMDBSequenceNumber() - fromSequenceNumber);
     return dbUpdatesLatestSeqNumOfOMDB.getRight();
   }
 
@@ -514,11 +513,10 @@ public class OzoneManagerServiceProviderImpl
     long lag = latestSequenceNumberOfOM == -1 ? 0 :
         latestSequenceNumberOfOM - getCurrentOMDBSequenceNumber();
     metrics.setSequenceNumberLag(lag);
-    LOG.info("Number of updates received from OM : {}, " +
-            "SequenceNumber diff: {}, SequenceNumber Lag from OM {}, " +
-            "isDBUpdateSuccess: {}", numUpdates, getCurrentOMDBSequenceNumber()
-            - fromSequenceNumber, lag,
-        null != dbUpdates && dbUpdates.isDBUpdateSuccess());
+    LOG.info("From Sequence Number:{}, Recon DB Sequence Number: {}, Number of updates received from OM : {}, " +
+            "SequenceNumber diff: {}, SequenceNumber Lag from OM {}, isDBUpdateSuccess: {}",
+        fromSequenceNumber, getCurrentOMDBSequenceNumber(), numUpdates,
+        getCurrentOMDBSequenceNumber() - fromSequenceNumber, lag, null != dbUpdates && dbUpdates.isDBUpdateSuccess());
     return new ImmutablePair<>(null != dbUpdates && dbUpdates.isDBUpdateSuccess(), lag);
   }
 
@@ -540,9 +538,8 @@ public class OzoneManagerServiceProviderImpl
     ReconTaskStatusUpdater reconTaskUpdater;
     if (isSyncDataFromOMRunning.compareAndSet(false, true)) {
       try {
-        LOG.info("Syncing data from Ozone Manager.");
         long currentSequenceNumber = getCurrentOMDBSequenceNumber();
-        LOG.debug("Seq number of Recon's OM DB : {}", currentSequenceNumber);
+        LOG.info("Seq number of Recon's OM DB : {}", currentSequenceNumber);
         boolean fullSnapshot = false;
 
         if (currentSequenceNumber <= 0) {
@@ -551,29 +548,27 @@ public class OzoneManagerServiceProviderImpl
           reconTaskUpdater = taskStatusUpdaterManager.getTaskStatusUpdater(
               OmSnapshotTaskName.OmDeltaRequest.name());
 
-          try (OMDBUpdatesHandler omdbUpdatesHandler =
-              new OMDBUpdatesHandler(omMetadataManager)) {
-            LOG.info("Obtaining delta updates from Ozone Manager");
+          // Get updates from OM and apply to local Recon OM DB and update task status in table
+          reconTaskUpdater.recordRunStart();
+          int loopCount = 0;
+          long fromSequenceNumber = currentSequenceNumber;
+          long diffBetweenOMDbAndReconDBSeqNumber = deltaUpdateLimit + 1;
+          /**
+           * This loop will continue to fetch and apply OM DB updates and with every
+           * OM DB fetch request, it will fetch {@code deltaUpdateLimit} count of DB updates.
+           * It continues to fetch from OM till the lag, between OM DB WAL sequence number
+           * and Recon OM DB snapshot WAL sequence number, is less than this lag threshold value.
+           * In high OM write TPS cluster, this simulates continuous pull from OM without any delay.
+           */
+          while (diffBetweenOMDbAndReconDBSeqNumber > omDBLagThreshold) {
+            try (OMDBUpdatesHandler omdbUpdatesHandler =
+                     new OMDBUpdatesHandler(omMetadataManager)) {
 
-            // If interrupt was previously signalled,
-            // we should check for it before starting delta update sync.
-            if (Thread.currentThread().isInterrupted()) {
-              throw new InterruptedException("Thread interrupted during delta update.");
-            }
-
-            // Get updates from OM and apply to local Recon OM DB and update task status in table
-            reconTaskUpdater.recordRunStart();
-            int loopCount = 0;
-            long fromSequenceNumber = currentSequenceNumber;
-            long diffBetweenOMDbAndReconDBSeqNumber = deltaUpdateLimit + 1;
-            /**
-            * This loop will continue to fetch and apply OM DB updates and with every
-            * OM DB fetch request, it will fetch {@code deltaUpdateLimit} count of DB updates.
-            * It continues to fetch from OM till the lag, between OM DB WAL sequence number
-            * and Recon OM DB snapshot WAL sequence number, is less than this lag threshold value.
-            * In high OM write TPS cluster, this simulates continuous pull from OM without any delay.
-            */
-            while (diffBetweenOMDbAndReconDBSeqNumber > omDBLagThreshold) {
+              // If interrupt was previously signalled,
+              // we should check for it before starting delta update sync.
+              if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread interrupted during delta update.");
+              }
               diffBetweenOMDbAndReconDBSeqNumber =
                   getAndApplyDeltaUpdatesFromOM(currentSequenceNumber, omdbUpdatesHandler);
               reconTaskUpdater.setLastTaskRunStatus(0);
@@ -585,25 +580,30 @@ public class OzoneManagerServiceProviderImpl
               currentSequenceNumber = getCurrentOMDBSequenceNumber();
               LOG.debug("Updated current sequence number: {}", currentSequenceNumber);
               loopCount++;
+            } catch (InterruptedException intEx) {
+              LOG.error("OM DB Delta update sync thread was interrupted and delta sync failed.");
+              // We are updating the table even if it didn't run i.e. got interrupted beforehand
+              // to indicate that a task was supposed to run, but it didn't.
+              reconTaskUpdater.setLastTaskRunStatus(-1);
+              reconTaskUpdater.recordRunCompletion();
+              Thread.currentThread().interrupt();
+              // Since thread is interrupted, we do not fall back to snapshot sync.
+              // Return with sync failed status.
+              return false;
+            } catch (Exception e) {
+              metrics.incrNumDeltaRequestsFailed();
+              reconTaskUpdater.setLastTaskRunStatus(-1);
+              reconTaskUpdater.recordRunCompletion();
+              LOG.warn("Unable to get and apply delta updates from OM: {}, falling back to full snapshot",
+                  e.getMessage());
+              fullSnapshot = true;
             }
-            LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
-                getCurrentOMDBSequenceNumber() - fromSequenceNumber);
-          } catch (InterruptedException intEx) {
-            LOG.error("OM DB Delta update sync thread was interrupted.");
-            // We are updating the table even if it didn't run i.e. got interrupted beforehand
-            // to indicate that a task was supposed to run, but it didn't.
-            reconTaskUpdater.setLastTaskRunStatus(-1);
-            reconTaskUpdater.recordRunCompletion();
-            Thread.currentThread().interrupt();
-            // Since thread is interrupted, we do not fall back to snapshot sync. Return with sync failed status.
-            return false;
-          } catch (Exception e) {
-            metrics.incrNumDeltaRequestsFailed();
-            reconTaskUpdater.setLastTaskRunStatus(-1);
-            reconTaskUpdater.recordRunCompletion();
-            LOG.warn("Unable to get and apply delta updates from OM: {}", e.getMessage());
-            fullSnapshot = true;
+            if (fullSnapshot) {
+              break;
+            }
           }
+          LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
+              getCurrentOMDBSequenceNumber() - fromSequenceNumber);
         }
 
         if (fullSnapshot) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -175,7 +175,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
                     "event is on {} table which is not useful for Recon to " +
                     "capture.", tableName);
           }
-          LOG.warn("Old Value of Key: {} in table: {} should not be null " +
+          LOG.debug("Old Value of Key: {} in table: {} should not be null " +
               "for DELETE event ", keyStr, tableName);
           return;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to fix the processing and consume of OM DB events by Recon when Recon was syncing with OM continuously in while loop.

When Recon sync with OM for incremental DB updates in a while loop continuously, It had a bug where OMDBUpdates handler was not clearing the DB update events consumed already in previous iteration in while loop.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12325

## How was this patch tested?
Patch is tested by running existing Junit and integration tests and running following freon test:

```
ozone sh volume create volume1
ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED volume1/fso-bucket
ozone freon omkg -n=200000 -v=volume1 -b=fso-bucket
```

**After running above freon load, verified the OM DB `fileTable` count :**

`ozone debug ldb --db=/data/metadata/om.db scan --column_family=fileTable —count  --> 200000`
<img width="1041" alt="image" src="https://github.com/user-attachments/assets/ebf13966-bcd4-4086-bca5-8f8dca2206f9" />

**Then Verified the Recon OM DB `fileTable` count :**
`ozone debug ldb --db=/data/metadata/om.db scan --column_family=fileTable —count  --> 200000`
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/6c22941c-8583-4625-83f8-91fd0f6cb165" />

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/8a60b664-b022-46d9-a833-469cdc2677c4" />
