### PR TITLE
HDDS-12328. Set the log for starting LeakDetector to DEBUG level.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/LeakDetector.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/LeakDetector.java
@@ -71,7 +71,7 @@ public class LeakDetector {
     Thread t = new Thread(this::run);
     t.setName(LeakDetector.class.getSimpleName() + "-" + name);
     t.setDaemon(true);
-    LOG.info("Starting leak detector thread {}.", name);
+    LOG.debug("Starting leak detector thread {}.", name);
     t.start();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Whenever the Ozone client starts, it always logs 'Starting leak detector thread...'. I think this message should be at the DEBUG level.

```
$ hadoop fs -ls /
2025-02-14 04:50:58,937 INFO utils.LeakDetector: Starting leak detector thread OzoneClientObject0.
Found 1 items
drwxrwxrwx   - ozone ozone          0 2025-02-14 04:15 /tmp
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12328

## How was this patch tested?
I have tested this fix in my local cluster and confirmed that the log is suppressed.