### PR TITLE
HDDS-12329. Specify S3 error for Quota Exceeded

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -60,6 +60,7 @@ import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.services.s3.transfer.model.UploadResult;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -812,6 +813,28 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
     assertEquals(ErrorType.Client, ase.getErrorType());
     assertEquals(404, ase.getStatusCode());
     assertEquals("NoSuchUpload", ase.getErrorCode());
+  }
+
+  @Test
+  public void testQuotaExceeded() throws IOException {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+
+    s3Client.createBucket(bucketName);
+
+    cluster.newClient().getObjectStore()
+        .getVolume("s3v")
+        .getBucket(bucketName)
+        .setQuota(OzoneQuota.parseQuota("1", "10"));
+
+    // Upload some objects to the bucket
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.putObject(bucketName, "key",
+            RandomStringUtils.randomAlphanumeric(1024)));
+
+    assertEquals(ErrorType.Client, ase.getErrorType());
+    assertEquals(403, ase.getStatusCode());
+    assertEquals("QuotaExceeded", ase.getErrorCode());
   }
 
   private boolean isBucketEmpty(Bucket bucket) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -829,7 +829,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
 
     // Upload some objects to the bucket
     AmazonServiceException ase = assertThrows(AmazonServiceException.class,
-        () -> s3Client.putObject(bucketName, "key",
+        () -> s3Client.putObject(bucketName, keyName,
             RandomStringUtils.randomAlphanumeric(1024)));
 
     assertEquals(ErrorType.Client, ase.getErrorType());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -366,6 +366,8 @@ public class ObjectEndpoint extends EndpointBase {
         throw os3Exception;
       } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
+      } else if (ex.getResult() == ResultCodes.QUOTA_EXCEEDED) {
+        throw newError(S3ErrorTable.QUOTA_EXCEEDED, keyPath, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.FILE_ALREADY_EXISTS) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -149,6 +149,12 @@ public final class S3ErrorTable {
       "MalformedXML", "The XML you provided was not well-formed or did not " +
       "validate against our published schema", HTTP_BAD_REQUEST);
 
+  public static final OS3Exception QUOTA_EXCEEDED = new OS3Exception(
+      "QuotaExceeded", "The quota has been exceeded. " +
+      "Please review your disk space or namespace usage and adjust accordingly.",
+      HTTP_FORBIDDEN
+  );
+
   public static OS3Exception newError(OS3Exception e, String resource) {
     return newError(e, resource, null);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This ticket is to explicitly return the error of QUOTA_EXCEEDED instead of an internal error.

For internal error, clients will retry to send the same request, for 4xx errors clients will fail directly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12329

## How was this patch tested?

manual test
