### PR TITLE
HDDS-12330. Convert Volume, Bucket and Key count to use comma separated numbers

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/common.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/common.tsx
@@ -67,30 +67,13 @@ export const byteToSize = (bytes: number, decimals: number) => {
 };
 
 /**
- * This method converts a number to the respective closest value in words
- * Ex:
- *    (num: 1234, digits: 1) = 1.2k
- *    (num: 1234, digits: 2) = 1.23k
- * 
- * In case it reaches 1e18 i.e more than 18 digits present, it will give the nearest value
- * Ex (if it was going upto a thousand, i.e K is the largest prefix it can provide)
- *    (num: 12300000, digits: 1) = 12300k
- * 
- * Similarly for something exceeding billions, it will give to the closest billionth value
- * @param num: The number to convert
- * @param digits: The number of digits after decimal 
+ * The function transforms the provided number to a comma separated value
+ * Ex: 1000 will be 1,000
+ * @param num The number to convert
+ * @returns The number separated at every thousandth place by commas
  */
-export function numberToWord(num: number, digits: number) {
-  const matcherTable = [
-    { value: 1, symbol: "" },
-    { value: 1e3, symbol: "K" },
-    { value: 1e6, symbol: "M" },
-    { value: 1e9, symbol: "B" }
-  ]
-
-  const regexp = /\.0+$|(?<=\.[0-9]*[1-9])0+$/;
-  const item = matcherTable.slice().reverse().find(item => num >= item.value);
-  return item ? (num / item.value).toFixed(digits).replace(regexp, "").concat(item.symbol) : "0";
+export function numberWithCommas(num: number) {
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
 export const nullAwareLocaleCompare = (a: string, b: string) => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/common.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/common.tsx
@@ -66,6 +66,33 @@ export const byteToSize = (bytes: number, decimals: number) => {
   return isNaN(i) ? `Not Defined` : `${Number.parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
 };
 
+/**
+ * This method converts a number to the respective closest value in words
+ * Ex:
+ *    (num: 1234, digits: 1) = 1.2k
+ *    (num: 1234, digits: 2) = 1.23k
+ * 
+ * In case it reaches 1e18 i.e more than 18 digits present, it will give the nearest value
+ * Ex (if it was going upto a thousand, i.e K is the largest prefix it can provide)
+ *    (num: 12300000, digits: 1) = 12300k
+ * 
+ * Similarly for something exceeding billions, it will give to the closest billionth value
+ * @param num: The number to convert
+ * @param digits: The number of digits after decimal 
+ */
+export function numberToWord(num: number, digits: number) {
+  const matcherTable = [
+    { value: 1, symbol: "" },
+    { value: 1e3, symbol: "K" },
+    { value: 1e6, symbol: "M" },
+    { value: 1e9, symbol: "B" }
+  ]
+
+  const regexp = /\.0+$|(?<=\.[0-9]*[1-9])0+$/;
+  const item = matcherTable.slice().reverse().find(item => num >= item.value);
+  return item ? (num / item.value).toFixed(digits).replace(regexp, "").concat(item.symbol) : "0";
+}
+
 export const nullAwareLocaleCompare = (a: string, b: string) => {
   if (!a && !b) {
     return 0;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
@@ -30,6 +30,7 @@ import {
   InboxOutlined,
   QuestionCircleOutlined
 } from '@ant-design/icons';
+import { numberToWord } from '@/utils/common';
 
 
 // ------------- Types -------------- //
@@ -138,7 +139,7 @@ const OverviewSimpleCard: React.FC<OverviewCardProps> = ({
           <IconSelector iconType={icon} style={iconStyle} />
         </Col>
         <Col style={dataColStyle}>
-          {data}
+          {numberToWord(data, 1)}
         </Col>
       </Row>
     </Card>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
@@ -30,7 +30,7 @@ import {
   InboxOutlined,
   QuestionCircleOutlined
 } from '@ant-design/icons';
-import { numberToWord, numberWithCommas } from '@/utils/common';
+import { numberWithCommas } from '@/utils/common';
 
 
 // ------------- Types -------------- //

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
@@ -30,7 +30,7 @@ import {
   InboxOutlined,
   QuestionCircleOutlined
 } from '@ant-design/icons';
-import { numberToWord } from '@/utils/common';
+import { numberToWord, numberWithCommas } from '@/utils/common';
 
 
 // ------------- Types -------------- //
@@ -139,7 +139,7 @@ const OverviewSimpleCard: React.FC<OverviewCardProps> = ({
           <IconSelector iconType={icon} style={iconStyle} />
         </Col>
         <Col style={dataColStyle}>
-          {numberToWord(data, 1)}
+          {numberWithCommas(data)}
         </Col>
       </Row>
     </Card>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12330. Convert Volume, Bucket and Key count to the nearest word

Please describe your PR in detail:
Currently in the Recon overview page the metrics for Keys, Buckets and Volumes are given as plain numbers. This causes issues while trying to read the value.
This PR adds commas to the number at every thousandth place making it easier to read in the UI


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12330

## How was this patch tested?
Patch was tested manually.
For the API response:
```
{
    "pipelines": 32,
    "totalDatanodes": 24,
    "healthyDatanodes": 24,
    "storageReport": {
      "capacity": 202114732032,
      "used": 4667099648,
      "remaining": 182447632384,
      "committed": 12000222315
    },
    "containers": 3230,
    "missingContainers": 1002,
    "openContainers": 5,
    "deletedContainers": 4,
    "volumes": 5,
    "buckets": 1569,
    "keys": 253123,
    "keysPendingDeletion": 1000,
    "scmServiceId": "scmservice",
    "omServiceId": "omservice"
  }
  ```
  Overview Page UI:

<img width="1524" alt="Screenshot 2025-02-14 at 21 23 32" src="https://github.com/user-attachments/assets/260122a9-c622-460f-b790-83387308fd61" />
  