### PR TITLE
HDDS-12331. BlockOutputStream.failedServers is not thread-safe

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -228,7 +229,7 @@ public class BlockOutputStream extends OutputStream {
     totalWriteChunkLength = 0;
     totalPutBlockLength = 0;
     writtenDataLength = 0;
-    failedServers = new ArrayList<>(0);
+    failedServers = new CopyOnWriteArrayList<>();
     ioException = new AtomicReference<>(null);
     this.checksum = new Checksum(config.getChecksumType(), config.getBytesPerChecksum(), true);
     this.clientMetrics = clientMetrics;


### PR DESCRIPTION
## What changes were proposed in this pull request?
`BlockOutputStream.failedServers` is not thread-safe, we can replace it with `CopyOnWriteArrayList<>()` to make sure it's thread-safe.

## What is the link to the Apache JIRA
[HDDS-12331](https://issues.apache.org/jira/browse/HDDS-12331)

## How was this patch tested?
It can test by CI.
