### PR TITLE
HDDS-12337. Speed up list tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -63,12 +63,14 @@ public abstract class TestListKeys implements NonHATests.TestCase {
   private OzoneBucket legacyOzoneBucket;
   private OzoneBucket obsOzoneBucket;
   private OzoneClient client;
-
+  private boolean originalFileSystemPathEnabled;
   private long originalMaxListSize;
 
   @BeforeAll
   void init() throws Exception {
     OmConfig omConfig = cluster().getOzoneManager().getConfig();
+    originalFileSystemPathEnabled = omConfig.isFileSystemPathEnabled();
+    omConfig.setFileSystemPathEnabled(true);
     originalMaxListSize = omConfig.getMaxListSize();
     omConfig.setMaxListSize(2);
 
@@ -93,7 +95,9 @@ public abstract class TestListKeys implements NonHATests.TestCase {
   @AfterAll
   void cleanup() {
     IOUtils.closeQuietly(client);
-    cluster().getOzoneManager().getConfig().setMaxListSize(originalMaxListSize);
+    OmConfig omConfig = cluster().getOzoneManager().getConfig();
+    omConfig.setFileSystemPathEnabled(originalFileSystemPathEnabled);
+    omConfig.setMaxListSize(originalMaxListSize);
   }
 
   private void initFSNameSpace() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -21,22 +21,23 @@ import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -53,38 +54,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Test covers listKeys(keyPrefix, startKey) combinations
  * in a FSO bucket layout type.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(1200)
-public class TestListKeysWithFSO {
+public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster = null;
-  private static OzoneConfiguration conf;
+  private OzoneBucket legacyOzoneBucket;
+  private OzoneBucket fsoOzoneBucket;
+  private OzoneBucket legacyOzoneBucket2;
+  private OzoneBucket fsoOzoneBucket2;
+  private OzoneBucket emptyLegacyOzoneBucket;
+  private OzoneBucket emptyFsoOzoneBucket;
+  private OzoneClient client;
+  private long originalMaxListSize;
 
-  private static OzoneBucket legacyOzoneBucket;
-  private static OzoneBucket fsoOzoneBucket;
-  private static OzoneBucket legacyOzoneBucket2;
-  private static OzoneBucket fsoOzoneBucket2;
-  private static OzoneBucket emptyLegacyOzoneBucket;
-  private static OzoneBucket emptyFsoOzoneBucket;
-  private static OzoneClient client;
-
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   *
-   * @throws IOException
-   */
   @BeforeAll
-  public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
-        true);
+  void init() throws Exception {
+    OmConfig omConfig = cluster().getOzoneManager().getConfig();
+    originalMaxListSize = omConfig.getMaxListSize();
+    omConfig.setMaxListSize(2);
+
+    OzoneConfiguration conf = new OzoneConfiguration(cluster().getConf());
     // Set the number of keys to be processed during batch operate.
     conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 3);
     conf.setInt(OZONE_CLIENT_LIST_CACHE_SIZE, 3);
-    conf.setInt(OmConfig.Keys.SERVER_LIST_MAX_SIZE, 2);
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
+
+    client = OzoneClientFactory.getRpcClient(conf);
 
     // create a volume and a LEGACY bucket
     legacyOzoneBucket = TestDataUtil
@@ -128,14 +122,12 @@ public class TestListKeysWithFSO {
   }
 
   @AfterAll
-  public static void teardownClass() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+    cluster().getOzoneManager().getConfig().setMaxListSize(originalMaxListSize);
   }
 
-  private static void initFSNameSpace() throws Exception {
+  private void initFSNameSpace() throws Exception {
     /*
     Keys Namespace:
 
@@ -615,7 +607,7 @@ public class TestListKeysWithFSO {
         fsoBucket.listKeys(keyPrefix, startKey, shallow);
     ReplicationConfig expectedReplication =
         Optional.ofNullable(fsoBucket.getReplicationConfig())
-            .orElse(cluster.getOzoneManager().getDefaultReplicationConfig());
+            .orElse(cluster().getOzoneManager().getDefaultReplicationConfig());
 
     List <String> keyLists = new ArrayList<>();
     while (ozoneKeyIterator.hasNext()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -65,11 +65,14 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
   private OzoneBucket emptyLegacyOzoneBucket;
   private OzoneBucket emptyFsoOzoneBucket;
   private OzoneClient client;
+  private boolean originalFileSystemPathEnabled;
   private long originalMaxListSize;
 
   @BeforeAll
   void init() throws Exception {
     OmConfig omConfig = cluster().getOzoneManager().getConfig();
+    originalFileSystemPathEnabled = omConfig.isFileSystemPathEnabled();
+    omConfig.setFileSystemPathEnabled(true);
     originalMaxListSize = omConfig.getMaxListSize();
     omConfig.setMaxListSize(2);
 
@@ -124,7 +127,9 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
   @AfterAll
   void cleanup() {
     IOUtils.closeQuietly(client);
-    cluster().getOzoneManager().getConfig().setMaxListSize(originalMaxListSize);
+    OmConfig omConfig = cluster().getOzoneManager().getConfig();
+    omConfig.setFileSystemPathEnabled(originalFileSystemPathEnabled);
+    omConfig.setMaxListSize(originalMaxListSize);
   }
 
   private void initFSNameSpace() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -147,22 +147,6 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ListStatus extends org.apache.hadoop.ozone.om.TestListStatus {
-    @Override
-    public MiniOzoneCluster cluster() {
-      return getCluster();
-    }
-  }
-
-  @Nested
-  class ObjectStore extends org.apache.hadoop.ozone.om.TestObjectStore {
-    @Override
-    public MiniOzoneCluster cluster() {
-      return getCluster();
-    }
-  }
-
-  @Nested
   class BucketLayoutWithOlderClient extends org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient {
     @Override
     public MiniOzoneCluster cluster() {
@@ -180,6 +164,22 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class ListKeysWithFSO extends org.apache.hadoop.ozone.om.TestListKeysWithFSO {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ListStatus extends org.apache.hadoop.ozone.om.TestListStatus {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ObjectStore extends org.apache.hadoop.ozone.om.TestObjectStore {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -163,6 +163,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
+  class ListKeys extends org.apache.hadoop.ozone.om.TestListKeys {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class ListKeysWithFSO extends org.apache.hadoop.ozone.om.TestListKeysWithFSO {
     @Override
     public MiniOzoneCluster cluster() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -163,6 +163,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
+  class ListKeysWithFSO extends org.apache.hadoop.ozone.om.TestListKeysWithFSO {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class ObjectStoreWithFSO extends org.apache.hadoop.ozone.om.TestObjectStoreWithFSO {
     @Override
     public MiniOzoneCluster cluster() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -147,6 +147,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
+  class ListStatus extends org.apache.hadoop.ozone.om.TestListStatus {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
   class ObjectStore extends org.apache.hadoop.ozone.om.TestObjectStore {
     @Override
     public MiniOzoneCluster cluster() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up `TestList*` by running with shared cluster.

https://issues.apache.org/jira/browse/HDDS-12337

## How was this patch tested?

Before:

```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.151 s - in org.apache.hadoop.ozone.om.TestListStatus
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.264 s - in org.apache.hadoop.ozone.om.TestListKeysWithFSO
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 39.002 s - in org.apache.hadoop.ozone.om.TestListKeys
```

After:

```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.182 s - in org.apache.ozone.test.NonHATests$ListStatus
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.101 s - in org.apache.ozone.test.NonHATests$ListKeysWithFSO
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.933 s - in org.apache.ozone.test.NonHATests$ListKeys
```

https://github.com/adoroszlai/ozone/actions/runs/13352674274