### PR TITLE
HDDS-12339. Add CI check for PMD

### DIFF
--- a/.github/ci.md
+++ b/.github/ci.md
@@ -44,6 +44,7 @@ Runs a subset of the following subjobs depending on what was selected by build-i
 - checkstyle: [Runs](../hadoop-ozone/dev-support/checks/checkstyle.sh) 'mvn checkstyle' plugin to confirm Java source abides by Ozone coding conventions
 - docs: [Builds](../hadoop-ozone/dev-support/checks/docs.sh) website with [Hugo](https://gohugo.io/)
 - findbugs: [Runs](../hadoop-ozone/dev-support/checks/findbugs.sh) spotbugs static analysis on bytecode
+- pmd: [Runs](../hadoop-ozone/dev-support/checks/pmd.sh) PMD static analysis on project's source code
 - rat (release audit tool): [Confirms](../hadoop-ozone/dev-support/checks/rat.sh) source files include licenses
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,7 @@ The [`hadoop-ozone/dev-support/checks` directory](https://github.com/apache/ozon
     * `docs.sh`: sanity checks for [Ozone documentation](https://github.com/apache/ozone/tree/master/hadoop-hdds/docs)
     * `dependency.sh`: compares list of jars in build output with known list
     * `checkstyle.sh`: Checkstyle
+    * `pmd.sh`: PMD
  3. moderate (around 10 minutes)
     * `findbugs.sh`: SpotBugs
     * `kubernetes.sh`: very limited set of tests run in Kubernetes environment

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -102,7 +102,7 @@ load bats-assert/load.bash
 @test "integration and unit: java change" {
   run dev-support/ci/selective_ci_checks.sh 9aebf6e25
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
@@ -135,7 +135,7 @@ load bats-assert/load.bash
 @test "unit only" {
   run dev-support/ci/selective_ci_checks.sh 1dd1d0ba3
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
@@ -146,7 +146,7 @@ load bats-assert/load.bash
 @test "unit helper" {
   run dev-support/ci/selective_ci_checks.sh 88383d1d5
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
@@ -157,7 +157,7 @@ load bats-assert/load.bash
 @test "integration only" {
   run dev-support/ci/selective_ci_checks.sh 61396ba9f
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
@@ -168,7 +168,7 @@ load bats-assert/load.bash
 @test "native only" {
   run dev-support/ci/selective_ci_checks.sh 5b1319a8c2
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","native"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd","native"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
@@ -179,7 +179,7 @@ load bats-assert/load.bash
 @test "native test in other module" {
   run dev-support/ci/selective_ci_checks.sh 822c0dee1a
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","native"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd","native"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
@@ -212,7 +212,7 @@ load bats-assert/load.bash
 @test "main/java change" {
   run dev-support/ci/selective_ci_checks.sh 86a771dfe
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -223,7 +223,7 @@ load bats-assert/load.bash
 @test "..../java change" {
   run dev-support/ci/selective_ci_checks.sh 01c616536
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -234,7 +234,7 @@ load bats-assert/load.bash
 @test "java and compose change" {
   run dev-support/ci/selective_ci_checks.sh d0f0f806e
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","native"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd","native"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -245,7 +245,7 @@ load bats-assert/load.bash
 @test "java and docs change" {
   run dev-support/ci/selective_ci_checks.sh 2c0adac26
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","docs","findbugs"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","docs","findbugs","pmd"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -256,7 +256,7 @@ load bats-assert/load.bash
 @test "pom change" {
   run dev-support/ci/selective_ci_checks.sh 9129424a9
 
-  assert_output -p 'basic-checks=["rat","checkstyle","findbugs","native"]'
+  assert_output -p 'basic-checks=["rat","checkstyle","findbugs","pmd","native"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -267,7 +267,7 @@ load bats-assert/load.bash
 @test "CI lib change" {
   run dev-support/ci/selective_ci_checks.sh ceb79acaa
 
-  assert_output -p 'basic-checks=["author","bats","checkstyle","docs","findbugs","native","rat"]'
+  assert_output -p 'basic-checks=["author","bats","checkstyle","docs","findbugs","native","pmd","rat"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -278,7 +278,7 @@ load bats-assert/load.bash
 @test "CI workflow change" {
   run dev-support/ci/selective_ci_checks.sh 90a8d7c01
 
-  assert_output -p 'basic-checks=["author","bats","checkstyle","docs","findbugs","native","rat"]'
+  assert_output -p 'basic-checks=["author","bats","checkstyle","docs","findbugs","native","pmd","rat"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
@@ -301,7 +301,7 @@ load bats-assert/load.bash
 @test "CI workflow change (ci.yaml)" {
   run dev-support/ci/selective_ci_checks.sh 90fd5f2adc
 
-  assert_output -p 'basic-checks=["author","bats","checkstyle","docs","findbugs","native","rat"]'
+  assert_output -p 'basic-checks=["author","bats","checkstyle","docs","findbugs","native","pmd","rat"]'
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -424,6 +424,7 @@ function check_needs_pmd() {
         "^hadoop-ozone/dev-support/checks/pmd.sh"
         "pom.xml"
         "src/..../java"
+        "pmd-ruleset.xml"
     )
     local ignore_array=(
         "^hadoop-ozone/dist"

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -418,6 +418,25 @@ function check_needs_findbugs() {
     start_end::group_end
 }
 
+function check_needs_pmd() {
+    start_end::group_start "Check if pmd is needed"
+    local pattern_array=(
+        "^hadoop-ozone/dev-support/checks/pmd.sh"
+        "pom.xml"
+        "src/..../java"
+    )
+    local ignore_array=(
+        "^hadoop-ozone/dist"
+    )
+    filter_changed_files
+
+    if [[ ${match_count} != "0" ]]; then
+        add_basic_check pmd
+    fi
+
+    start_end::group_end
+}
+
 function check_needs_native() {
     start_end::group_start "Check if native is needed"
     local pattern_array=(
@@ -584,6 +603,7 @@ check_needs_bats
 check_needs_checkstyle
 check_needs_docs
 check_needs_findbugs
+check_needs_pmd
 check_needs_native
 calculate_test_types_to_run
 set_outputs

--- a/dev-support/pmd/pmd-ruleset.xml
+++ b/dev-support/pmd/pmd-ruleset.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<ruleset name="Default Maven PMD Plugin Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        PMD Ruleset for Apache Ozone
+    </description>
+
+    <exclude-pattern>.*/generated-sources/.*</exclude-pattern>
+</ruleset>

--- a/hadoop-ozone/dev-support/checks/pmd.sh
+++ b/hadoop-ozone/dev-support/checks/pmd.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#checks:basic
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR/../../.." || exit 1
+
+REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/pmd"}
+mkdir -p "$REPORT_DIR"
+
+REPORT_FILE="$REPORT_DIR/summary.txt"
+
+MAVEN_OPTIONS='-B -fae --no-transfer-progress'
+
+declare -i rc
+
+mvn "$MAVEN_OPTIONS" test-compile pmd:check -Dpmd.failOnViolation=false -Dpmd.printFailingErrors "$@" > "${REPORT_DIR}/pmd-output.log"
+
+rc=$?
+
+cat "${REPORT_DIR}/pmd-output.log"
+
+find "." -name pmd-output.log -print0 \
+  | xargs -0 sed -n -e '/^\[WARNING\] PMD Failure/p' \
+  | tee "$REPORT_FILE"
+
+## generate counter
+grep -c ':' "$REPORT_FILE" > "$REPORT_DIR/failures"
+
+ERROR_PATTERN="\[WARNING\] PMD Failure"
+source "${DIR}/_post_process.sh"

--- a/hadoop-ozone/dev-support/checks/pmd.sh
+++ b/hadoop-ozone/dev-support/checks/pmd.sh
@@ -28,7 +28,8 @@ MAVEN_OPTIONS='-B -fae --no-transfer-progress'
 
 declare -i rc
 
-mvn "$MAVEN_OPTIONS" test-compile pmd:check -Dpmd.failOnViolation=false -Dpmd.printFailingErrors "$@" > "${REPORT_DIR}/pmd-output.log"
+#shellcheck disable=SC2086
+mvn $MAVEN_OPTIONS test-compile pmd:check -Dpmd.failOnViolation=false -Dpmd.printFailingErrors "$@" > "${REPORT_DIR}/pmd-output.log"
 
 rc=$?
 

--- a/hadoop-ozone/dev-support/checks/pmd.sh
+++ b/hadoop-ozone/dev-support/checks/pmd.sh
@@ -26,8 +26,6 @@ mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-declare -i rc
-
 MAVEN_OPTIONS='-B -fae --no-transfer-progress -Dpmd.failOnViolation=false -Dpmd.printFailingErrors -DskipRecon'
 
 declare -i rc

--- a/hadoop-ozone/httpfsgateway/src/site/site.xml
+++ b/hadoop-ozone/httpfsgateway/src/site/site.xml
@@ -17,7 +17,7 @@
     <skin>
       <groupId>org.apache.maven.skins</groupId>
       <artifactId>maven-stylus-skin</artifactId>
-      <version>${maven-stylus-skin.version}</version>
+      <version>1.5</version>
     </skin>
 
     <body>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
     <ozone.version>2.0.0-SNAPSHOT</ozone.version>
     <picocli.version>4.7.5</picocli.version>
     <plexus-archiver.version>4.2.2</plexus-archiver.version>
+    <pmd.version>3.26.0</pmd.version>
     <!-- Enable Reproducible Builds mode -->
     <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
     <!-- platform encoding override -->
@@ -1753,6 +1754,17 @@
           <groupId>org.cyclonedx</groupId>
           <artifactId>cyclonedx-maven-plugin</artifactId>
           <version>${cyclonedx.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>${pmd.version}</version>
+          <configuration>
+            <rulesets>
+              <ruleset>dev-support/pmd/pmd-ruleset.xml</ruleset>
+            </rulesets>
+            <printFailingErrors>true</printFailingErrors>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

PMD checks enabled as one of the step of Basic verification pipeline.
Rationale behind this that PMD is the powerful widely adopted static analysis tool which can help us drastically improve code quality for the project.

Example of potential output can be found here: https://github.com/ivanzlenko/ozone/actions/runs/13354816303/job/37296119138

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12339

## How was this patch tested?

Run verification pipeline with and without enabled PMD rules. 
