### PR TITLE
HDDS-12335. Fix ozone admin namespace summary to give complete output

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -84,10 +84,12 @@ public class SummarySubCommand implements Callable<Void> {
       printKVSeparator();
       System.out.println(summaryResponse.get("type"));
 
-      int numVol = summaryResponse.path("numVolume").asInt(-1);
-      int numBucket = summaryResponse.path("numBucket").asInt(-1);
-      int numDir = summaryResponse.path("numDir").asInt(-1);
-      int numKey = summaryResponse.path("numKey").asInt(-1);
+      JsonNode countStatsNode = summaryResponse.path("countStats");
+
+      int numVol = countStatsNode.path("numVolume").asInt(-1);
+      int numBucket = countStatsNode.path("numBucket").asInt(-1);
+      int numDir = countStatsNode.path("numDir").asInt(-1);
+      int numKey = countStatsNode.path("numKey").asInt(-1);
 
       if (numVol != -1) {
         printWithUnderline("Volumes", false);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone Recon - admin namespace summary CLI command is not giving complete output:
`ozone admin namespace summary /volume1/obs-bucket`

output:
```
`Connecting to Recon: http://recon:9888/api/v1/namespace/summary?path=/volume1/obs-bucket ...`
 `[Warning] Namespace CLI is not designed for OBS bucket layout.`
 `Bucket being accessed must be of type FILE_SYSTEM_OPTIMIZED bucket layout or 
   LEGACY bucket layout with 'ozone.om.enable.filesystem.paths' set to true.`
  `Entity Type : "BUCKET"`
```
  
  The above output is incomplete it should also print information like
1. "numVolume"
2. "numBucket"
3. "numDir"
4. "numKey"
which is present in the **SummarySubCommand class** which the current code is not reading correct from correct json node.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12335

## How was this patch tested?

Ran the CLI command locally on docker cluster and tested the patch:

1.)
`bash-5.1$ ozone admin namespace summary /vol2/buck1`

`Connecting to Recon: http://recon:9888/api/v1/namespace/summary?path=/vol2/buck1 ...`
`Entity Type : "BUCKET"`
`Directories : 3`
`Keys : 4`

2.)
`bash-5.1$ ozone admin namespace summary /`

`Connecting to Recon: http://recon:9888/api/v1/namespace/summary?path=/ ...`
`Entity Type : "ROOT"`
`Volumes : 4`
`Buckets : 3`
`Directories : 7`
`Keys : 9`
