### PR TITLE
HDDS-11867. Remove code paths for non-Ratis SCM.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEFAULT_SERVICE
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_RATIS_SNAPSHOT_DIR;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -83,24 +82,12 @@ public final class SCMHAUtils {
     // not used
   }
 
-  // This will be removed in follow-up Jira. Ref. HDDS-11754
-  private static boolean isRatisEnabled = true;
-  public static boolean isSCMHAEnabled(ConfigurationSource conf) {
-    return isRatisEnabled;
-  }
-
-  public static void setRatisEnabled(boolean value) {
-    isRatisEnabled = value;
-  }
-
   public static String getPrimordialSCM(ConfigurationSource conf) {
     return conf.get(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY);
   }
 
   public static boolean isPrimordialSCM(ConfigurationSource conf,
       String selfNodeId, String hostName) {
-    // This should only be called if SCM HA is enabled.
-    Preconditions.checkArgument(isSCMHAEnabled(conf));
     String primordialNode = getPrimordialSCM(conf);
     return primordialNode != null && (primordialNode
         .equals(selfNodeId) || primordialNode.equals(hostName));

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
@@ -221,10 +221,6 @@ public final class StorageVolumeUtil {
     } else if (rootFiles.length == 1) {
       // The one file is the version file.
       // DN started for first time or this is a newly added volume.
-      // Either the SCM ID or cluster ID will be used in naming the
-      // volume's working directory, depending on the datanode's layout version.
-      workingDirName = VersionedDatanodeFeatures.ScmHA
-          .chooseContainerPathID(conf, scmId, clusterId);
       try {
         volume.createWorkingDir(workingDirName, dbVolumeSet);
       } catch (IOException e) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.container.upgrade;
 import java.io.File;
 import java.io.IOException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -107,20 +106,6 @@ public final class VersionedDatanodeFeatures {
               " has more than one directory before SCM HA finalization.");
         }
         return subdirs[0].getName();
-      }
-    }
-
-    /**
-     * Choose whether to use SCM ID or cluster ID based on SCM HA
-     * finalization status and SCM HA configuration.
-     */
-    public static String chooseContainerPathID(ConfigurationSource conf,
-        String scmID, String clusterID) {
-      boolean scmHAEnabled = SCMHAUtils.isSCMHAEnabled(conf);
-      if (isFinalized(HDDSLayoutFeature.SCM_HA) || scmHAEnabled) {
-        return clusterID;
-      } else {
-        return scmID;
       }
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.ScmInfo;
@@ -422,26 +421,13 @@ public final class HAUtils {
     Collection<String> scmNodes = SCMHAUtils.getSCMNodeIds(conf);
     SCMSecurityProtocolClientSideTranslatorPB scmSecurityProtocolClient =
         HddsServerUtil.getScmSecurityClient(conf);
-    if (!SCMHAUtils.isSCMHAEnabled(conf)) {
-      List<String> caCertPemList = new ArrayList<>();
-      SCMGetCertResponseProto scmGetCertResponseProto =
-          scmSecurityProtocolClient.getCACert();
-      if (scmGetCertResponseProto.hasX509Certificate()) {
-        caCertPemList.add(scmGetCertResponseProto.getX509Certificate());
-      }
-      if (scmGetCertResponseProto.hasX509RootCACertificate()) {
-        caCertPemList.add(scmGetCertResponseProto.getX509RootCACertificate());
-      }
-      return OzoneSecurityUtil.convertToX509(caCertPemList);
+    int expectedCount = scmNodes.size() + 1;
+    if (scmNodes.size() > 1) {
+      return OzoneSecurityUtil.convertToX509(getCAListWithRetry(() -> waitForCACerts(
+          scmSecurityProtocolClient::listCACertificate,
+          expectedCount), waitDuration));
     } else {
-      int expectedCount = scmNodes.size() + 1;
-      if (scmNodes.size() > 1) {
-        return OzoneSecurityUtil.convertToX509(getCAListWithRetry(() -> waitForCACerts(
-            scmSecurityProtocolClient::listCACertificate,
-            expectedCount), waitDuration));
-      } else {
-        return OzoneSecurityUtil.convertToX509(scmSecurityProtocolClient.listCACertificate());
-      }
+      return OzoneSecurityUtil.convertToX509(scmSecurityProtocolClient.listCACertificate());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -64,10 +63,8 @@ public class DeletedBlockLogStateManagerImpl
     this.deletedTable = deletedTable;
     this.containerManager = containerManager;
     this.transactionBuffer = txBuffer;
-    final boolean isRatisEnabled = SCMHAUtils.isSCMHAEnabled(conf);
-    this.deletingTxIDs = isRatisEnabled ? ConcurrentHashMap.newKeySet() : null;
-    this.skippingRetryTxIDs =
-        isRatisEnabled ? ConcurrentHashMap.newKeySet() : null;
+    this.deletingTxIDs = ConcurrentHashMap.newKeySet();
+    this.skippingRetryTxIDs = ConcurrentHashMap.newKeySet();
   }
 
   public TableIterator<Long, TypedTable.KeyValue<Long,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
-import org.apache.hadoop.hdds.scm.metadata.SCMDBTransactionBufferImpl;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.security.SecretKeyManagerService;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -68,7 +67,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
   private final ConfigurationSource conf;
   private final OzoneConfiguration ozoneConf;
   private final SecurityConfig securityConfig;
-  private final DBTransactionBuffer transactionBuffer;
+  private final SCMHADBTransactionBufferImpl transactionBuffer;
   private final SCMSnapshotProvider scmSnapshotProvider;
   private final StorageContainerManager scm;
   private ExitManager exitManager;
@@ -88,18 +87,10 @@ public class SCMHAManagerImpl implements SCMHAManager {
     this.securityConfig = securityConfig;
     this.scm = scm;
     this.exitManager = new ExitManager();
-    if (SCMHAUtils.isSCMHAEnabled(conf)) {
-      this.transactionBuffer = new SCMHADBTransactionBufferImpl(scm);
-      this.ratisServer = new SCMRatisServerImpl(conf, scm,
-          (SCMHADBTransactionBuffer) transactionBuffer);
-      this.scmSnapshotProvider = newScmSnapshotProvider(scm);
-      grpcServer = new InterSCMGrpcProtocolService(conf, scm);
-    } else {
-      this.transactionBuffer = new SCMDBTransactionBufferImpl();
-      this.scmSnapshotProvider = null;
-      this.grpcServer = null;
-      this.ratisServer = null;
-    }
+    this.transactionBuffer = new SCMHADBTransactionBufferImpl(scm);
+    this.ratisServer = new SCMRatisServerImpl(conf, scm, transactionBuffer);
+    this.scmSnapshotProvider = newScmSnapshotProvider(scm);
+    this.grpcServer = new InterSCMGrpcProtocolService(conf, scm);
 
   }
 
@@ -152,7 +143,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
         TimeUnit.MILLISECONDS);
     SCMHATransactionBufferMonitorTask monitorTask
         = new SCMHATransactionBufferMonitorTask(
-        (SCMHADBTransactionBuffer) transactionBuffer, ratisServer, interval);
+        transactionBuffer, ratisServer, interval);
     trxBufferMonitorService =
         new BackgroundSCMService.Builder().setClock(scm.getSystemClock())
             .setScmContext(scm.getScmContext())
@@ -180,9 +171,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
 
   @Override
   public SCMHADBTransactionBuffer asSCMHADBTransactionBuffer() {
-    Preconditions
-        .checkArgument(transactionBuffer instanceof SCMHADBTransactionBuffer);
-    return (SCMHADBTransactionBuffer)transactionBuffer;
+    return transactionBuffer;
 
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.hdds.scm.ScmUtils;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
 import org.slf4j.Logger;
@@ -145,23 +144,6 @@ public class SCMHANodeDetails {
     return new SCMHANodeDetails(scmNodeDetails, Collections.emptyList());
   }
 
-  /** Validates SCM HA Config.
-   For Non Initialized SCM the value is true.
-   For Previously Initialized SCM the values are taken from the version file
-   <br>
-   Ratis SCM -> Non Ratis SCM is not supported.
-   This value is validated with the config provided.
-  **/
-  private static void validateSCMHAConfig(SCMStorageConfig scmStorageConfig,
-                                          OzoneConfiguration conf) {
-    Storage.StorageState state = scmStorageConfig.getState();
-    boolean scmHAEnableDefault = state == Storage.StorageState.INITIALIZED
-        ? scmStorageConfig.isSCMHAEnabled()
-        : SCMHAUtils.isSCMHAEnabled(conf);
-    // If we have an initialized cluster, use the value from VERSION file.
-    SCMHAUtils.setRatisEnabled(scmHAEnableDefault);
-  }
-
   public static SCMHANodeDetails loadSCMHAConfig(OzoneConfiguration conf,
                                                  SCMStorageConfig storageConfig)
       throws IOException {
@@ -177,7 +159,6 @@ public class SCMHANodeDetails {
         ScmConfigKeys.OZONE_SCM_DEFAULT_SERVICE_ID);
 
     LOG.info("ServiceID for StorageContainerManager is {}", localScmServiceId);
-    validateSCMHAConfig(storageConfig, conf);
     if (localScmServiceId == null) {
       // There is no internal scm service id is being set, fall back to ozone
       // .scm.service.ids.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -86,7 +86,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.DeletedBlocksTransact
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
@@ -847,10 +846,6 @@ public class SCMClientProtocolServer implements
   public void transferLeadership(String newLeaderId)
       throws IOException {
     getScm().checkAdminAccess(getRemoteUser(), false);
-    if (!SCMHAUtils.isSCMHAEnabled(getScm().getConfiguration())) {
-      throw new SCMException("SCM HA not enabled.", ResultCodes.INTERNAL_ERROR);
-    }
-
     checkIfCertSignRequestAllowed(scm.getRootCARotationManager(),
         false, config, "transferLeadership");
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -362,15 +362,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     initMetrics();
     initPerfMetrics();
 
-    boolean ratisEnabled = SCMHAUtils.isSCMHAEnabled(conf);
     if (scmStorageConfig.getState() != StorageState.INITIALIZED) {
       String errMsg = "Please make sure you have run 'ozone scm --init' " +
           "command to generate all the required metadata to " +
-          scmStorageConfig.getStorageDir();
-      if (ratisEnabled && !scmStorageConfig.isSCMHAEnabled()) {
-        errMsg += " or make sure you have run 'ozone scm --bootstrap' cmd to "
-            + "add the SCM to existing SCM HA group";
-      }
+          scmStorageConfig.getStorageDir() +
+          " or make sure you have run 'ozone scm --bootstrap' cmd to " +
+          "add the SCM to existing SCM HA group";
       LOG.error(errMsg + ".");
       throw new SCMException("SCM not initialized due to storage config " +
           "failure.", ResultCodes.SCM_NOT_INITIALIZED);
@@ -387,7 +384,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     threadNamePrefix = getScmNodeDetails().threadNamePrefix();
     primaryScmNodeId = scmStorageConfig.getPrimaryScmNodeId();
 
-    jvmPauseMonitor = !ratisEnabled ? newJvmPauseMonitor(getScmId()) : null;
+    jvmPauseMonitor = newJvmPauseMonitor(getScmId());
 
     /*
      * Important : This initialization sequence is assumed by some of our tests.
@@ -417,9 +414,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (isSecretKeyEnable(securityConfig)) {
       secretKeyManagerService = new SecretKeyManagerService(scmContext, conf,
               scmHAManager.getRatisServer());
-      if (!ratisEnabled) {
-        secretKeyManagerService.getSecretKeyManager().checkAndInitialize();
-      }
       serviceManager.register(secretKeyManagerService);
     } else {
       secretKeyManagerService = null;
@@ -706,13 +700,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (configurator.getScmContext() != null) {
       scmContext = configurator.getScmContext();
     } else {
-      // When term equals SCMContext.INVALID_TERM, the isLeader() check
-      // and getTermOfLeader() will always pass.
-      long term = SCMHAUtils.isSCMHAEnabled(conf) ? 0 : SCMContext.INVALID_TERM;
       // non-leader of term 0, in safe mode, preCheck not completed.
       scmContext = new SCMContext.Builder()
           .setLeader(false)
-          .setTerm(term)
+          .setTerm(0)
           .setIsInSafeMode(true)
           .setIsPreCheckComplete(false)
           .setSCM(this)
@@ -1137,10 +1128,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    */
   public static boolean scmBootstrap(OzoneConfiguration conf)
       throws AuthenticationException, IOException {
-    if (!SCMHAUtils.isSCMHAEnabled(conf)) {
-      LOG.error("Bootstrap is not supported without SCM HA.");
-      return false;
-    }
     String primordialSCM = SCMHAUtils.getPrimordialSCM(conf);
     SCMStorageConfig scmStorageConfig = new SCMStorageConfig(conf);
     SCMHANodeDetails scmhaNodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf,
@@ -1148,11 +1135,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     String selfNodeId = scmhaNodeDetails.getLocalNodeDetails().getNodeId();
     final String selfHostName =
         scmhaNodeDetails.getLocalNodeDetails().getHostName();
-    if (primordialSCM != null && SCMHAUtils.isSCMHAEnabled(conf)
-        && SCMHAUtils.isPrimordialSCM(conf, selfNodeId, selfHostName)) {
-      LOG.info(
-          "SCM bootstrap command can only be executed in non-Primordial SCM "
-              + "{}, self id {} " + "Ignoring it.", primordialSCM, selfNodeId);
+    if (primordialSCM != null && SCMHAUtils.isPrimordialSCM(conf, selfNodeId, selfHostName)) {
+      LOG.info("SCM bootstrap command can only be executed in non-Primordial SCM "
+          + "{}, self id {} " + "Ignoring it.", primordialSCM, selfNodeId);
       return true;
     }
 
@@ -1316,7 +1301,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
          * to the bootstrapping SCMs later.
          */
         try {
-          SCMHAUtils.setRatisEnabled(true);
           StorageContainerManager scm = createSCM(conf);
           scm.start();
           scm.getScmHAManager().getRatisServer().triggerSnapshot();
@@ -1572,8 +1556,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     setStartTime();
 
-    RaftPeerId leaderId = SCMHAUtils.isSCMHAEnabled(configuration)
-        ? getScmHAManager().getRatisServer().getLeaderId() : null;
+    RaftPeerId leaderId = getScmHAManager().getRatisServer().getLeaderId();
     scmHAMetricsUpdate(Objects.toString(leaderId, null));
 
     if (scmCertificateClient != null) {
@@ -1920,15 +1903,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    * @return - if the current scm is the leader and is ready.
    */
   public boolean checkLeader() {
-    // For NON-HA setup, the node will always be the leader
-    if (!SCMHAUtils.isSCMHAEnabled(configuration)) {
-      return true;
-    } else {
-      // FOR HA setup, the node has to be the leader and ready to serve
-      // requests.
-      return getScmHAManager().getRatisServer().getDivision().getInfo()
+    // The node has to be the leader and ready to serve requests.
+    return getScmHAManager().getRatisServer().getDivision().getInfo()
           .isLeaderReady();
-    }
   }
 
   private void checkAdminAccess(String op) throws IOException {
@@ -2171,23 +2148,19 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    */
   @Override
   public String getPrimordialNode() {
-    if (SCMHAUtils.isSCMHAEnabled(configuration)) {
-      String primordialNode = SCMHAUtils.getPrimordialSCM(configuration);
-      // primordialNode can be nodeId too . If it is then return hostname.
-      if (SCMHAUtils.getSCMNodeIds(configuration).contains(primordialNode)) {
-        List<SCMNodeDetails> localAndPeerNodes =
-            new ArrayList<>(scmHANodeDetails.getPeerNodeDetails());
-        localAndPeerNodes.add(getSCMHANodeDetails().getLocalNodeDetails());
-        for (SCMNodeDetails nodes : localAndPeerNodes) {
-          if (nodes.getNodeId().equals(primordialNode)) {
-            return nodes.getHostName();
-          }
+    String primordialNode = SCMHAUtils.getPrimordialSCM(configuration);
+    // primordialNode can be nodeId too . If it is then return hostname.
+    if (SCMHAUtils.getSCMNodeIds(configuration).contains(primordialNode)) {
+      List<SCMNodeDetails> localAndPeerNodes =
+          new ArrayList<>(scmHANodeDetails.getPeerNodeDetails());
+      localAndPeerNodes.add(getSCMHANodeDetails().getLocalNodeDetails());
+      for (SCMNodeDetails nodes : localAndPeerNodes) {
+        if (nodes.getNodeId().equals(primordialNode)) {
+          return nodes.getHostName();
         }
-
       }
-      return primordialNode;
     }
-    return null;
+    return primordialNode;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.server;
 
 import static org.apache.hadoop.hdds.HddsUtils.preserveThreadName;
-import static org.apache.hadoop.hdds.ratis.RatisHelper.newJvmPauseMonitor;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_EXEC_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_QUEUE_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmUtils.checkIfCertSignRequestAllowed;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -198,7 +198,6 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.util.ExitUtils;
-import org.apache.ratis.util.JvmPauseMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -284,7 +283,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private RootCARotationManager rootCARotationManager;
   private ContainerTokenSecretManager containerTokenMgr;
 
-  private final JvmPauseMonitor jvmPauseMonitor;
   private final OzoneConfiguration configuration;
   private SCMContainerMetrics scmContainerMetrics;
   private SCMContainerPlacementMetrics placementMetrics;
@@ -383,8 +381,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     threadNamePrefix = getScmNodeDetails().threadNamePrefix();
     primaryScmNodeId = scmStorageConfig.getPrimaryScmNodeId();
-
-    jvmPauseMonitor = newJvmPauseMonitor(getScmId());
 
     /*
      * Important : This initialization sequence is assumed by some of our tests.
@@ -1542,10 +1538,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmBlockManager.start();
     leaseManager.start();
 
-    if (jvmPauseMonitor != null) {
-      jvmPauseMonitor.start();
-    }
-
     try {
       httpServer = new StorageContainerManagerHttpServer(configuration, this);
       httpServer.start();
@@ -1697,10 +1689,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       eventQueue.close();
     } catch (Exception ex) {
       LOG.error("SCM Event Queue stop failed", ex);
-    }
-
-    if (jvmPauseMonitor != null) {
-      jvmPauseMonitor.stop();
     }
 
     try {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -613,7 +612,7 @@ public final class HddsTestUtils {
       String scmId = UUID.randomUUID().toString();
       scmStore.setClusterId(clusterId);
       scmStore.setScmId(scmId);
-      scmStore.setSCMHAFlag(SCMHAUtils.isSCMHAEnabled(conf));
+      scmStore.setSCMHAFlag(true);
       // writes the version file properties
       scmStore.initialize();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMConfiguration.java
@@ -37,12 +37,10 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVIC
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -59,8 +57,6 @@ import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test for SCM HA-related configuration.
@@ -292,21 +288,4 @@ class TestSCMConfiguration {
 
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testDefaultConfigWithInitializedSCM(boolean isRatisEnabled)
-      throws IOException {
-    // The default config for RatisEnabled is true.
-    assertTrue(SCMHAUtils.isSCMHAEnabled(conf));
-
-    // If the cluster is already initalized, use the value from StorageConfig.
-    SCMStorageConfig scmStorageConfig = mock(SCMStorageConfig.class);
-    when(scmStorageConfig.getState())
-        .thenReturn(Storage.StorageState.INITIALIZED);
-    when(scmStorageConfig.isSCMHAEnabled()).thenReturn(isRatisEnabled);
-    SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
-
-    assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
-        scmStorageConfig.isSCMHAEnabled());
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -302,10 +302,8 @@ public class TestStorageContainerManager {
     // eventually these TX will success.
     GenericTestUtils.waitFor(() -> {
       try {
-        if (SCMHAUtils.isSCMHAEnabled(cluster.getConf())) {
-          cluster.getStorageContainerManager().getScmHAManager()
-              .asSCMHADBTransactionBuffer().flush();
-        }
+        cluster.getStorageContainerManager().getScmHAManager()
+            .asSCMHADBTransactionBuffer().flush();
         return delLog.getFailedTransactions(-1, 0).size() == 0;
       } catch (IOException e) {
         return false;
@@ -888,9 +886,7 @@ public class TestStorageContainerManager {
       Map<Long, List<Long>> containerBlocksMap)
       throws IOException, TimeoutException {
     delLog.addTransactions(containerBlocksMap);
-    if (SCMHAUtils.isSCMHAEnabled(scm.getConfiguration())) {
-      scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
-    }
+    scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
   }
 
   public List<Long> getAllBlocks(MiniOzoneCluster cluster, Set<Long> containerIDs) throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHA.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.ha.SCMHAMetrics;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -133,9 +132,7 @@ public class TestStorageContainerManagerHA {
         count++;
         leaderScm = scm;
       }
-      if (SCMHAUtils.isSCMHAEnabled(conf)) {
-        assertNotNull(scm.getScmHAManager().getRatisServer().getLeaderId());
-      }
+      assertNotNull(scm.getScmHAManager().getRatisServer().getLeaderId());
       assertEquals(peerSize, numOfSCMs);
     }
     assertEquals(1, count);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.client.ScmTopologyClient;
 import org.apache.hadoop.hdds.scm.ha.HASecurityUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMHANodeDetails;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
@@ -458,11 +457,9 @@ final class TestSecureOzoneCluster {
     scmStore.setPrimaryScmNodeId(scmId);
     // writes the version file properties
     scmStore.initialize();
-    if (SCMHAUtils.isSCMHAEnabled(conf)) {
-      SCMRatisServerImpl.initialize(clusterId, scmId,
-          SCMHANodeDetails.loadSCMHAConfig(conf, scmStore)
-                  .getLocalNodeDetails(), conf);
-    }
+    SCMRatisServerImpl.initialize(clusterId, scmId,
+        SCMHANodeDetails.loadSCMHAConfig(conf, scmStore)
+                .getLocalNodeDetails(), conf);
 
     /*
      * As all these processes run inside the same JVM, there are issues around


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove code paths for non-Ratis SCM.

After #7711, Ratis is always enable in SCM. Non-Ratis code is not used anymore, the non-Ratis code path can be removed from SCM.

## What is the link to the Apache JIRA
HDDS-11867

## How was this patch tested?
CI Run: https://github.com/nandakumar131/ozone/actions/runs/13371649727