### PR TITLE
HDDS-12357. Add indicators to Overview page data for OmInsightTask

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1869,44 +1869,67 @@
   },
   "taskStatus": [
     {
+      "taskName": "OmSnapshotRequest",
+      "lastUpdatedTimestamp": 1739440826117,
+      "lastUpdatedSeqNumber": 2,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
+    },
+    {
+      "taskName": "OmTableInsightTask",
+      "lastUpdatedTimestamp": 1739440826210,
+      "lastUpdatedSeqNumber": 2,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
+    },
+    {
+      "taskName": "NSSummaryTask",
+      "lastUpdatedTimestamp": 1739440826215,
+      "lastUpdatedSeqNumber": 2,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
+    },
+    {
       "taskName": "ContainerKeyMapperTask",
-      "lastUpdatedTimestamp": 0,
-      "lastUpdatedSeqNumber": 0
+      "lastUpdatedTimestamp": 1739440826220,
+      "lastUpdatedSeqNumber": 2,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
     },
     {
       "taskName": "FileSizeCountTask",
-      "lastUpdatedTimestamp": 0,
-      "lastUpdatedSeqNumber": 0
-    },
-    {
-      "taskName": "TableCountTask",
-      "lastUpdatedTimestamp": 0,
-      "lastUpdatedSeqNumber": 0
-    },
-    {
-      "taskName": "NSSummaryTaskWithFSO",
-      "lastUpdatedTimestamp": 0,
-      "lastUpdatedSeqNumber": 0
+      "lastUpdatedTimestamp": 1739440826231,
+      "lastUpdatedSeqNumber": 2,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
     },
     {
       "taskName": "OmDeltaRequest",
-      "lastUpdatedTimestamp": 1663421088035,
-      "lastUpdatedSeqNumber": 0
-    },
-    {
-      "taskName": "OmSnapshotRequest",
-      "lastUpdatedTimestamp": 1663421088035,
-      "lastUpdatedSeqNumber": 0
-    },
-    {
-      "taskName": "ContainerHealthTask",
-      "lastUpdatedTimestamp": 0,
-      "lastUpdatedSeqNumber": 0
+      "lastUpdatedTimestamp": 1739472227610,
+      "lastUpdatedSeqNumber": 2,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
     },
     {
       "taskName": "PipelineSyncTask",
-      "lastUpdatedTimestamp": 1663421094507,
-      "lastUpdatedSeqNumber": 0
+      "lastUpdatedTimestamp": 1739472179607,
+      "lastUpdatedSeqNumber": 0,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
+    },
+    {
+      "taskName": "ContainerHealthTask",
+      "lastUpdatedTimestamp": 1739472179055,
+      "lastUpdatedSeqNumber": 0,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 0
+    },
+    {
+      "taskName": "ContainerSizeCountTask",
+      "lastUpdatedTimestamp": 1739472242852,
+      "lastUpdatedSeqNumber": 0,
+      "lastTaskRunStatus": 0,
+      "isCurrentTaskRunning": 1
     }
   ],
   "unhealthyContainers": {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSimpleCard.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { Card, Col, Row } from 'antd';
 import { Link } from 'react-router-dom';
 import {
@@ -44,6 +44,7 @@ type OverviewCardProps = {
   hoverable?: boolean;
   loading?: boolean;
   linkToUrl?: string;
+  taskIcon?: ReactElement;
 }
 
 // ------------- Styles -------------- //
@@ -108,27 +109,33 @@ const OverviewSimpleCard: React.FC<OverviewCardProps> = ({
   title = '',
   hoverable = false,
   loading = false,
-  linkToUrl = ''
+  linkToUrl = undefined,
+  taskIcon = undefined
 }) => {
 
-  const titleElement = (linkToUrl)
-    ? (
-      <div className='card-title-div'>
+  const titleElement = (
+    <div className='card-title-div'>
+      <span>
+        {taskIcon}
         {title}
+      </span>
+      {
+        linkToUrl &&
         <Link
           to={linkToUrl}
           style={titleLinkStyle}>
           View More
         </Link>
-      </div>)
-    : title
+      }
+    </div>
+  );
 
   return (
     <Card
       size='small'
       loading={loading}
       hoverable={hoverable}
-      title={(linkToUrl) ? titleElement : title}
+      title={titleElement}
       headStyle={cardHeadStyle}
       bodyStyle={cardBodyStyle}
       data-testid={`overview-${title}`}>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSummaryCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/overviewCard/overviewSummaryCard.tsx
@@ -40,6 +40,7 @@ type OverviewTableCardProps = {
   linkToUrl?: string;
   showHeader?: boolean;
   state?: Record<string, any>;
+  taskIcon?: React.ReactElement;
 }
 
 // ------------- Styles -------------- //
@@ -63,14 +64,20 @@ const OverviewSummaryCard: React.FC<OverviewTableCardProps> = ({
   loading = false,
   columns = [],
   tableData = [],
-  linkToUrl = '',
+  linkToUrl = undefined,
   showHeader = false,
-  state
+  state,
+  taskIcon = undefined
 }) => {
-  const titleElement = (linkToUrl)
-    ? (
-      <div className='card-title-div'>
+
+  const titleElement = (
+    <div className='card-title-div'>
+      <span>
+        {taskIcon}
         {title}
+      </span>
+      {
+        linkToUrl &&
         <Link
           to={{
             pathname: linkToUrl,
@@ -79,8 +86,8 @@ const OverviewSummaryCard: React.FC<OverviewTableCardProps> = ({
           style={{
             fontWeight: 400
           }}>View Insights</Link>
-      </div>)
-    : title
+      }
+    </div>)
 
   return (
     <Card
@@ -107,7 +114,7 @@ const OverviewSummaryCard: React.FC<OverviewTableCardProps> = ({
         columns={columns}
         onRow={(record: TableData) => ({
           'data-testid': `overview-${title}-${record.name}`
-        } as HTMLAttributes<HTMLElement>)}/>
+        } as HTMLAttributes<HTMLElement>)} />
     </Card>
   )
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/components/OmDataCardGroup.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/components/OmDataCardGroup.tsx
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import OverviewSimpleCard from "@/v2/components/overviewCard/overviewSimpleCard";
+import { getTaskIndicatorIcon } from "@/v2/pages/overview/overview.utils";
+import { Col } from "antd";
+import React, { JSXElementConstructor, ReactElement } from "react";
+
+// ------------- Types -------------- //
+type OmData = {
+  volumes: number | ReactElement<any, string | JSXElementConstructor<any>>;
+  buckets: number | ReactElement<any, string | JSXElementConstructor<any>>;
+  keys: number | ReactElement<any, string | JSXElementConstructor<any>>;
+};
+
+type OverviewOMCardProps = {
+  data: OmData;
+  taskRunning: boolean;
+  taskStatus: boolean;
+  loading?: boolean;
+};
+
+
+const OverviewOMCardGroup: React.FC<OverviewOMCardProps> = ({
+  loading = true,
+  data,
+  taskRunning,
+  taskStatus
+}) => {
+  const taskIcon: ReactElement = getTaskIndicatorIcon(taskRunning, taskStatus);
+  return (
+    <>
+      <Col flex="1 0 20%">
+        <OverviewSimpleCard
+          title='Volumes'
+          icon='inbox'
+          loading={loading}
+          data={data.volumes}
+          linkToUrl='/Volumes'
+          taskIcon={taskIcon} />
+      </Col>
+      <Col flex="1 0 20%">
+        <OverviewSimpleCard
+          title='Buckets'
+          icon='folder-open'
+          loading={loading}
+          data={data.buckets}
+          linkToUrl='/Buckets'
+          taskIcon={taskIcon} />
+      </Col>
+      <Col flex="1 0 20%">
+        <OverviewSimpleCard
+          title='Keys'
+          icon='file-text'
+          loading={loading}
+          data={data.keys}
+          taskIcon={taskIcon} />
+      </Col>
+    </>
+  )
+}
+
+export default OverviewOMCardGroup;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/components/SummaryCardGroup.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/components/SummaryCardGroup.tsx
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import OverviewSummaryCard from "@/v2/components/overviewCard/overviewSummaryCard";
+import { getTaskIndicatorIcon } from "@/v2/pages/overview/overview.utils";
+import { Col } from "antd";
+import filesize from "filesize";
+import React from "react";
+
+type OverviewSummaryCardGroupProps = {
+  loading?: boolean;
+  openSummarytotalRepSize: number;
+  openSummarytotalUnrepSize: number;
+  openSummarytotalOpenKeys: number;
+  deletePendingSummarytotalRepSize: number;
+  deletePendingSummarytotalUnrepSize: number;
+  deletePendingSummarytotalDeletedKeys: number;
+  taskRunning: boolean;
+  taskStatus: boolean;
+}
+
+const size = filesize.partial({ round: 1 });
+
+const getSummaryTableValue = (
+  value: number | string | undefined,
+  colType: 'value' | undefined = undefined
+): string => {
+  if (!value) return 'N/A';
+  if (colType === 'value') return String(value as string)
+  return size(value as number)
+}
+
+const OverviewSummaryCardGroup: React.FC<OverviewSummaryCardGroupProps> = ({
+  loading = true,
+  openSummarytotalRepSize,
+  openSummarytotalUnrepSize,
+  openSummarytotalOpenKeys,
+  deletePendingSummarytotalRepSize,
+  deletePendingSummarytotalUnrepSize,
+  deletePendingSummarytotalDeletedKeys,
+  taskRunning,
+  taskStatus
+}) => {
+
+  const taskIcon: React.ReactElement = getTaskIndicatorIcon(taskRunning, taskStatus);
+  return (
+    <>
+      <Col xs={24} sm={24} md={24} lg={12} xl={12}>
+        <OverviewSummaryCard
+          title='Open Keys Summary'
+          loading={loading}
+          columns={[
+            {
+              title: 'Name',
+              dataIndex: 'name',
+              key: 'name'
+            },
+            {
+              title: 'Size',
+              dataIndex: 'value',
+              key: 'size',
+              align: 'right'
+            }
+          ]}
+          tableData={[
+            {
+              key: 'total-replicated-data',
+              name: 'Total Replicated Data',
+              value: getSummaryTableValue(openSummarytotalRepSize)
+            },
+            {
+              key: 'total-unreplicated-data',
+              name: 'Total Unreplicated Data',
+              value: getSummaryTableValue(openSummarytotalUnrepSize)
+            },
+            {
+              key: 'open-keys',
+              name: 'Open Keys',
+              value: getSummaryTableValue(
+                openSummarytotalOpenKeys,
+                'value'
+              )
+            }
+          ]}
+          linkToUrl='/Om'
+          state={{ activeTab: '2' }}
+          taskIcon={taskIcon} />
+      </Col>
+      <Col xs={24} sm={24} md={24} lg={12} xl={12}>
+        <OverviewSummaryCard
+          title='Delete Pending Keys Summary'
+          loading={loading}
+          columns={[
+            {
+              title: 'Name',
+              dataIndex: 'name',
+              key: 'name'
+            },
+            {
+              title: 'Size',
+              dataIndex: 'value',
+              key: 'size',
+              align: 'right'
+            }
+          ]}
+          tableData={[
+            {
+              key: 'total-replicated-data',
+              name: 'Total Replicated Data',
+              value: getSummaryTableValue(deletePendingSummarytotalRepSize)
+            },
+            {
+              key: 'total-unreplicated-data',
+              name: 'Total Unreplicated Data',
+              value: getSummaryTableValue(deletePendingSummarytotalUnrepSize)
+            },
+            {
+              key: 'delete-pending-keys',
+              name: 'Delete Pending Keys',
+              value: getSummaryTableValue(
+                deletePendingSummarytotalDeletedKeys,
+                'value'
+              )
+            }
+          ]}
+          linkToUrl='/Om'
+          state={{ activeTab: '3' }}
+          taskIcon={taskIcon} />
+      </Col>
+    </>
+  )
+}
+
+export default OverviewSummaryCardGroup;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.tsx
@@ -27,6 +27,7 @@ import OverviewSummaryCard from '@/v2/components/overviewCard/overviewSummaryCar
 import OverviewStorageCard from '@/v2/components/overviewCard/overviewStorageCard';
 import OverviewSimpleCard from '@/v2/components/overviewCard/overviewSimpleCard';
 import OverviewOMCardGroup from '@/v2/pages/overview/components/OmDataCardGroup';
+import OverviewSummaryCardGroup from '@/v2/pages/overview/components/SummaryCardGroup';
 
 import { AutoReloadHelper } from '@/utils/autoReloadHelper';
 import { checkResponseError, showDataFetchError } from '@/utils/common';
@@ -36,7 +37,6 @@ import { getHealthIcon } from '@/v2/pages/overview/overview.utils';
 import { ClusterStateResponse, OverviewState, StorageReport } from '@/v2/types/overview.types';
 
 import './overview.less';
-import OverviewSummaryCardGroup from '@/v2/pages/overview/components/SummaryCardGroup';
 
 const Overview: React.FC<{}> = () => {
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.utils.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.utils.tsx
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { ReactElement } from 'react';
+import { Tooltip } from "antd";
+import {
+  CheckCircleFilled,
+  CloseCircleFilled,
+  ExclamationCircleFilled,
+  WarningFilled
+} from "@ant-design/icons";
+
+export const getHealthIcon = (value: string): React.ReactElement => {
+  const values = value.split('/');
+  if (values.length == 2 && values[0] < values[1]) {
+    return (
+      <>
+        <div className='icon-warning' style={{
+          fontSize: '20px',
+          alignItems: 'center'
+        }}>
+          <WarningFilled style={{
+            marginRight: '5px'
+          }} />
+          Unhealthy
+        </div>
+      </>
+    )
+  }
+  return (
+    <div className='icon-success' style={{
+      fontSize: '20px',
+      alignItems: 'center'
+    }}>
+      <CheckCircleFilled style={{
+        marginRight: '5px'
+      }} />
+      Healthy
+    </div>
+  )
+}
+
+export function getTaskIndicatorIcon(taskRunning: boolean, taskStatus: boolean): ReactElement {
+  if (taskRunning) {
+    return (
+      <Tooltip title="OmTableInsight task is still running, values might be outdated">
+        <ExclamationCircleFilled
+          style={{
+            color: '#FBC02D',
+            fontSize: '12px',
+            paddingRight: '10px'
+          }} />
+      </Tooltip>
+    );
+  }
+  if (taskStatus) {
+    return (
+      <Tooltip title="OmTableInsight task completed">
+        <CheckCircleFilled
+          style={{
+            color: '#00C853',
+            fontSize: '12px',
+            paddingRight: '10px'
+          }} />
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip title="OmTableInisght task failed, value is inaccurate">
+      <CloseCircleFilled style={{ color: '#F44336', fontSize: '12px', paddingRight: '10px' }} />
+    </Tooltip>
+  );
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/overview.types.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/overview.types.ts
@@ -33,6 +33,11 @@ export type ClusterStateResponse = {
   omServiceId: string;
 }
 
+type Task = {
+  taskRunning: boolean;
+  taskStatus: boolean;
+}
+
 export type OverviewState = {
   loading: boolean;
   datanodes: string;
@@ -56,6 +61,7 @@ export type OverviewState = {
   deletePendingSummarytotalDeletedKeys: number;
   scmServiceId: string;
   omServiceId: string;
+  omTask: Task;
 }
 
 export type StorageReport = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12357. Add indicators to Overview page data for OmInsightTask

Please describe your PR in detail:
- After HDDS-11680 / #7517 we added extra fields to the task status API response.
- Various cards on the Overview page like Volumes, Keys, Buckets etc. are dependent on the `OmTableInsight` task.
- As a part of this PR we are taking the extra metrics provided for the task via `/task/status` API endpoint and adding indicators to the Overview page data based on this task status.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12357

## How was this patch tested?
Patch was tested manually.
<img width="1727" alt="Screenshot 2025-02-17 at 22 59 33" src="https://github.com/user-attachments/assets/72b37ad8-43a7-4351-9718-bdbc98b340df" />
<img width="1725" alt="Screenshot 2025-02-17 at 23 01 18" src="https://github.com/user-attachments/assets/3728ac0d-1bdc-430b-abcb-6947a7083816" />
<img width="1726" alt="Screenshot 2025-02-17 at 23 00 09" src="https://github.com/user-attachments/assets/9ce4ef6c-8646-4c01-a86f-767c447de3cd" />
