### PR TITLE
HDDS-11883. SCM HA: Move proxy object creation code to SCMRatisServer.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.block;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,11 +27,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
+import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
@@ -303,18 +301,11 @@ public class DeletedBlockLogStateManagerImpl
       Preconditions.checkNotNull(conf);
       Preconditions.checkNotNull(table);
 
-      final DeletedBlockLogStateManager impl =
-          new DeletedBlockLogStateManagerImpl(conf, table, containerManager,
-              transactionBuffer);
+      final DeletedBlockLogStateManager impl = new DeletedBlockLogStateManagerImpl(
+          conf, table, containerManager, transactionBuffer);
 
-      final SCMHAInvocationHandler invocationHandler =
-          new SCMHAInvocationHandler(SCMRatisProtocol.RequestType.BLOCK,
-              impl, scmRatisServer);
-
-      return (DeletedBlockLogStateManager) Proxy.newProxyInstance(
-          SCMHAInvocationHandler.class.getClassLoader(),
-          new Class<?>[]{DeletedBlockLogStateManager.class},
-          invocationHandler);
+      return scmRatisServer.getProxyHandler(RequestType.BLOCK,
+          DeletedBlockLogStateManager.class, impl);
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -35,7 +35,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_LOCK_
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Striped;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -58,7 +57,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingO
 import org.apache.hadoop.hdds.scm.container.states.ContainerState;
 import org.apache.hadoop.hdds.scm.container.states.ContainerStateMap;
 import org.apache.hadoop.hdds.scm.ha.ExecutionUtil;
-import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -609,13 +607,8 @@ public final class ContainerStateManagerImpl
           conf, pipelineMgr, table, transactionBuffer,
           containerReplicaPendingOps);
 
-      final SCMHAInvocationHandler invocationHandler =
-          new SCMHAInvocationHandler(RequestType.CONTAINER, csm,
-              scmRatisServer);
-
-      return (ContainerStateManager) Proxy.newProxyInstance(
-          SCMHAInvocationHandler.class.getClassLoader(),
-          new Class<?>[]{ContainerStateManager.class}, invocationHandler);
+      return scmRatisServer.getProxyHandler(RequestType.CONTAINER,
+          ContainerStateManager.class, csm);
     }
 
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -291,5 +291,11 @@ public final class SCMHAManagerStub implements SCMHAManager {
     public RaftPeerId getLeaderId() {
       return leaderId;
     }
+
+    @Override
+    public <T> T getProxyHandler(RequestType type, Class<T> intf, T supplier) {
+      return supplier;
+    }
+
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
@@ -70,4 +70,5 @@ public interface SCMRatisServer {
 
   RaftPeerId getLeaderId();
 
+  <T> T getProxyHandler(RequestType type, Class<T> intf, T supplier);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -429,4 +430,14 @@ public class SCMRatisServerImpl implements SCMRatisServer {
           division.getRaftConf().getPeer(RaftPeerId.valueOf(leaderId));
     }
   }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T getProxyHandler(final RequestType type, final Class<T> intf, final T obj) {
+    final SCMHAInvocationHandler invocationHandler =
+        new SCMHAInvocationHandler(type, obj, this);
+    return (T) Proxy.newProxyInstance(getClass().getClassLoader(),
+        new Class<?>[] {intf}, invocationHandler);
+  }
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SEQUENCE_ID_BAT
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
 import java.time.LocalDate;
@@ -330,13 +329,7 @@ public class SequenceIdGenerator {
 
         final StateManager impl = new StateManagerImpl(table, buffer);
 
-        final SCMHAInvocationHandler invocationHandler
-            = new SCMHAInvocationHandler(SEQUENCE_ID, impl, ratisServer);
-
-        return (StateManager) Proxy.newProxyInstance(
-            SCMHAInvocationHandler.class.getClassLoader(),
-            new Class<?>[]{StateManager.class},
-            invocationHandler);
+        return ratisServer.getProxyHandler(SEQUENCE_ID, StateManager.class, impl);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManagerImpl.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.ha;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -135,13 +134,8 @@ public final class StatefulServiceStateManagerImpl
           new StatefulServiceStateManagerImpl(statefulServiceConfig,
               transactionBuffer);
 
-      final SCMHAInvocationHandler invocationHandler =
-          new SCMHAInvocationHandler(RequestType.STATEFUL_SERVICE_CONFIG,
-              stateManager, scmRatisServer);
-
-      return (StatefulServiceStateManager) Proxy.newProxyInstance(
-          SCMHAInvocationHandler.class.getClassLoader(),
-          new Class<?>[]{StatefulServiceStateManager.class}, invocationHandler);
+      return scmRatisServer.getProxyHandler(RequestType.STATEFUL_SERVICE_CONFIG,
+          StatefulServiceStateManager.class, stateManager);
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.List;
 import java.util.NavigableSet;
@@ -28,9 +27,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
+import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -380,13 +378,8 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
           new PipelineStateManagerImpl(
               pipelineStore, nodeManager, transactionBuffer);
 
-      final SCMHAInvocationHandler invocationHandler =
-          new SCMHAInvocationHandler(SCMRatisProtocol.RequestType.PIPELINE,
-              pipelineStateManager, scmRatisServer);
-
-      return (PipelineStateManager) Proxy.newProxyInstance(
-          SCMHAInvocationHandler.class.getClassLoader(),
-          new Class<?>[]{PipelineStateManager.class}, invocationHandler);
+      return scmRatisServer.getProxyHandler(RequestType.PIPELINE,
+          PipelineStateManager.class, pipelineStateManager);
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationHandlerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationHandlerImpl.java
@@ -23,14 +23,12 @@ import static org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.SecurityConfig;
@@ -230,13 +228,8 @@ public class RootCARotationHandlerImpl implements RootCARotationHandler {
       final RootCARotationHandler impl =
           new RootCARotationHandlerImpl(scm, rootCARotationManager);
 
-      final SCMHAInvocationHandler invocationHandler
-          = new SCMHAInvocationHandler(CERT_ROTATE, impl, ratisServer);
-
-      return (RootCARotationHandler) Proxy.newProxyInstance(
-          SCMHAInvocationHandler.class.getClassLoader(),
-          new Class<?>[]{RootCARotationHandler.class},
-          invocationHandler);
+      return ratisServer.getProxyHandler(CERT_ROTATE,
+          RootCARotationHandler.class, impl);
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -118,6 +118,12 @@ public class TestReplicationAnnotation {
       public RaftPeerId getLeaderId() {
         return RaftPeerId.valueOf(UUID.randomUUID().toString());
       }
+
+      @Override
+      public <T> T getProxyHandler(RequestType type, Class<T> intf, T supplier) {
+        return supplier;
+      }
+
     };
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCM HA: Move proxy object creation code to SCMRatisServer.

Currently each handler has some code duplication where it creates the proxy object, this logic can be moved to RatisServer and the code can be simplified.

## What is the link to the Apache JIRA
HDDS-11883

## How was this patch tested?
CI Run: https://github.com/nandakumar131/ozone/actions/runs/13376223779