### PR TITLE
HDDS-12373. Use File.getUsableSpace() instead of File.getFreeSpace() to calcuate usedSpace in DedicatedDiskSpaceUsage

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/AbstractSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/AbstractSpaceUsageSource.java
@@ -86,6 +86,7 @@ public abstract class AbstractSpaceUsageSource implements SpaceUsageSource {
 
   @Override
   public long getCapacity() {
-    return file.getTotalSpace();
+    // system reserve: fsFree - fsUsable
+    return file.getTotalSpace() - (file.getFreeSpace() - file.getUsableSpace());
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/AbstractSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/AbstractSpaceUsageSource.java
@@ -86,7 +86,6 @@ public abstract class AbstractSpaceUsageSource implements SpaceUsageSource {
 
   @Override
   public long getCapacity() {
-    // system reserve: fsFree - fsUsable
-    return file.getTotalSpace() - (file.getFreeSpace() - file.getUsableSpace());
+    return file.getTotalSpace();
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/DedicatedDiskSpaceUsage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/DedicatedDiskSpaceUsage.java
@@ -51,7 +51,7 @@ public class DedicatedDiskSpaceUsage extends AbstractSpaceUsageSource {
    * @return used space
    */
   private long calculateUsedSpace() {
-    return getCapacity() - getFile().getFreeSpace();
+    return getCapacity() - getFile().getUsableSpace();
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current logic for "hdds.datanode.dir.du.reserved" is as follows:

```
private long getRemainingReserved(){
 return Math.max(reservedInBytes - getOtherUsed(), 0L); 
} 
```
which means if OtherUsed() is larger than reservedInBytes, then remainingReserved will be count to 0.

When we set a "hdds.datanode.dir.du.reserved" to 100GB, we actually want the disk to spare 100GB in case of "SPACE not enough exceptions".

But normally servers have a system level block reservation, which is 5%. So for a 10T disk, the system level reserved space is about 500GB, when we set the configuration to 100GB, the "remaningReserved" is calculated as 0, so for capacity and availabilty, reservation is not counted.

In current calculation logic ,in order to reserve a 100GB space, we need to set configuration to "600GB" (500 + 100) or "0.06" (0.05 + 0.01 for percent).

This ticket is to change the logic of the reservation calculation to have a more intuitive aspect for the users, thus no need to take care of the Other usages.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12373

## How was this patch tested?

unit test.
