### PR TITLE
HDDS-12372. Enable disabled tests which is unhealthy before RATIS-1481

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -294,12 +294,9 @@ public class TestOMRatisSnapshots {
     // Read & Write after snapshot installed.
     List<String> newKeys = writeKeys(1);
     readKeys(newKeys);
-    // TODO: Enable this part after RATIS-1481 used
-    /*
-    Assert.assertNotNull(followerOMMetaMngr.getKeyTable(
+    assertNotNull(followerOMMetaMngr.getKeyTable(
         TEST_BUCKET_LAYOUT).get(followerOMMetaMngr.getOzoneKey(
         volumeName, bucketName, newKeys.get(0))));
-     */
 
     checkSnapshot(leaderOM, followerOM, snapshotName, keys, snapshotInfo);
     int sstFileCount = 0;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -151,7 +151,6 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
    * @throws Exception
    */
   @Test
-  @Unhealthy("RATIS-1481") // until upgrade to Ratis 2.3.0
   public void testPrepareDownedOM() throws Exception {
     // Index of the OM that will be shut down during this test.
     final int shutdownOMIndex = 2;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Prepare
 import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ozone.test.tag.Slow;
-import org.apache.ozone.test.tag.Unhealthy;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/RATIS-1481 is merged in ratis 2.3.0

And current ozone ratis version is 3.1.2, so we can removed those tests marked as disable or unhealthy with by ratis < 2.3.0

- https://github.com/apache/ozone/blob/b84554a1bf05c2d7617814c68f84761d0279dada/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java#L297-L302
- https://github.com/apache/ozone/blob/b84554a1bf05c2d7617814c68f84761d0279dada/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java#L154

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12372

## How was this patch tested?

enable disabled tests and existing tests.

```shell
for i in {1..10}; do
    echo "Run #$i"
    mvn test -pl hadoop-ozone/integration-test '-Dtest=TestOMRatisSnapshots#testInstallSnapshot' > run_$i.log 2>&1

for i in {1..10}; do
    echo "Run #$i"
    mvn test -pl hadoop-ozone/integration-test '-Dtest=TestOzoneManagerPrepare#testPrepareDownedOM' > prepare_run_$i.log 2>&1
```

CI:
https://github.com/peterxcli/ozone/actions/runs/13407309208
