### PR TITLE
HDDS-12376. Remove scmRatisEnabled from ScmInfo.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmInfo.java
@@ -29,7 +29,6 @@ public final class ScmInfo {
   private final String clusterId;
   private final String scmId;
   private final List<String> peerRoles;
-  private final boolean scmRatisEnabled;
 
   /**
    * Builder for ScmInfo.
@@ -38,7 +37,6 @@ public final class ScmInfo {
     private String clusterId;
     private String scmId;
     private final List<String> peerRoles;
-    private boolean scmRatisEnabled;
 
     public Builder() {
       peerRoles = new ArrayList<>();
@@ -66,36 +64,23 @@ public final class ScmInfo {
 
     /**
      * Set peer address in Scm HA.
-     * @param roles ratis peer address in the format of [ip|hostname]:port
+     * @param roles peer address in the format of [ip|hostname]:port
      * @return  Builder for scmInfo
      */
-    public Builder setRatisPeerRoles(List<String> roles) {
+    public Builder setPeerRoles(List<String> roles) {
       peerRoles.addAll(roles);
       return this;
     }
 
-    /**
-     * Set whether SCM enables Ratis.
-     *
-     * @param ratisEnabled If it is true, it means that the Ratis mode is turned on.
-     * If it is false, it means that the Ratis mode is not turned on.
-     * @return Builder for scmInfo
-     */
-    public Builder setScmRatisEnabled(boolean ratisEnabled) {
-      scmRatisEnabled = ratisEnabled;
-      return this;
-    }
-
     public ScmInfo build() {
-      return new ScmInfo(clusterId, scmId, peerRoles, scmRatisEnabled);
+      return new ScmInfo(clusterId, scmId, peerRoles);
     }
   }
 
-  private ScmInfo(String clusterId, String scmId, List<String> peerRoles, boolean ratisEnabled) {
+  private ScmInfo(String clusterId, String scmId, List<String> peerRoles) {
     this.clusterId = clusterId;
     this.scmId = scmId;
     this.peerRoles = Collections.unmodifiableList(peerRoles);
-    this.scmRatisEnabled = ratisEnabled;
   }
 
   /**
@@ -115,14 +100,11 @@ public final class ScmInfo {
   }
 
   /**
-   * Gets the list of peer roles (currently address) in Scm HA.
+   * Gets the list of peer roles (currently address) in SCM.
    * @return List of peer address
    */
-  public List<String> getRatisPeerRoles() {
+  public List<String> getPeerRoles() {
     return peerRoles;
   }
 
-  public boolean getScmRatisEnabled() {
-    return scmRatisEnabled;
-  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -389,18 +389,9 @@ public interface ScmClient extends Closeable {
   ContainerBalancerStatusInfoResponseProto getContainerBalancerStatusInfo() throws IOException;
 
   /**
-   * returns the list of ratis peer roles. Currently only include peer address.
+   * returns the list of SCM peer roles. Currently only include peer address.
    */
-  List<String> getScmRatisRoles() throws IOException;
-
-  /**
-   * Get the current SCM mode.
-   *
-   * @return `true` indicates that it is in RATIS mode,
-   * while `false` indicates that it is in STANDALONE mode.
-   * @throws IOException  an I/O exception of some sort has occurred.
-   */
-  boolean isScmRatisEnable() throws IOException;
+  List<String> getScmRoles() throws IOException;
 
   /**
    * Force generates new secret keys (rotate).

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -771,24 +771,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
     ScmInfo.Builder builder = new ScmInfo.Builder()
         .setClusterId(resp.getClusterId())
         .setScmId(resp.getScmId())
-        .setRatisPeerRoles(resp.getPeerRolesList());
-
-    // By default, we assume that SCM Ratis is not enabled.
-
-    // If the response contains the `ScmRatisEnabled` field,
-    // we will set it directly; otherwise,
-    // we will determine if Ratis is enabled based on
-    // whether the `peerRolesList` contains the keywords 'leader' or 'follower'.
-    if (resp.hasScmRatisEnabled()) {
-      builder.setScmRatisEnabled(resp.getScmRatisEnabled());
-    } else {
-      List<String> peerRolesList = resp.getPeerRolesList();
-      if (!peerRolesList.isEmpty()) {
-        boolean containsScmRoles = peerRolesList.stream().map(String::toLowerCase)
-            .anyMatch(scmRatisRolesToCheck::contains);
-        builder.setScmRatisEnabled(containsScmRoles);
-      }
-    }
+        .setPeerRoles(resp.getPeerRolesList());
     return builder.build();
   }
 

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -269,7 +269,6 @@ message GetScmInfoResponseProto {
     required string clusterId = 1;
     required string scmId = 2;
     repeated string peerRoles = 3;
-    optional bool scmRatisEnabled = 4;
 }
 
 message AddScmRequestProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -1000,8 +1000,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     return HddsProtos.GetScmInfoResponseProto.newBuilder()
         .setClusterId(scmInfo.getClusterId())
         .setScmId(scmInfo.getScmId())
-        .addAllPeerRoles(scmInfo.getRatisPeerRoles())
-        .setScmRatisEnabled(scmInfo.getScmRatisEnabled())
+        .addAllPeerRoles(scmInfo.getPeerRoles())
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -812,20 +811,8 @@ public class SCMClientProtocolServer implements
       ScmInfo.Builder builder =
           new ScmInfo.Builder()
               .setClusterId(scm.getScmStorageConfig().getClusterID())
-              .setScmId(scm.getScmStorageConfig().getScmId());
-      if (scm.getScmHAManager().getRatisServer() != null) {
-        builder.setRatisPeerRoles(
-            scm.getScmHAManager().getRatisServer().getRatisRoles());
-        builder.setScmRatisEnabled(true);
-      } else {
-        // In case, there is no ratis, there is no ratis role.
-        // This will just print the hostname with ratis port as the default
-        // behaviour.
-        String address = scm.getSCMHANodeDetails().getLocalNodeDetails()
-            .getRatisHostPortStr();
-        builder.setRatisPeerRoles(Arrays.asList(address));
-        builder.setScmRatisEnabled(false);
-      }
+              .setScmId(scm.getScmStorageConfig().getScmId())
+              .setPeerRoles(scm.getScmHAManager().getRatisServer().getRatisRoles());
       return builder.build();
     } catch (Exception ex) {
       auditSuccess = false;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -531,13 +531,8 @@ public class ContainerOperationClient implements ScmClient {
   }
 
   @Override
-  public List<String> getScmRatisRoles() throws IOException {
-    return storageContainerLocationClient.getScmInfo().getRatisPeerRoles();
-  }
-
-  @Override
-  public boolean isScmRatisEnable() throws IOException {
-    return storageContainerLocationClient.getScmInfo().getScmRatisEnabled();
+  public List<String> getScmRoles() throws IOException {
+    return storageContainerLocationClient.getScmInfo().getPeerRoles();
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -29,7 +29,6 @@ import static org.apache.hadoop.security.UserGroupInformation.getCurrentUser;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -60,7 +59,6 @@ import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageConfig;
 import org.apache.hadoop.ozone.recon.security.ReconCertificateClient;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
-import org.apache.hadoop.security.SecurityUtil;
 import org.apache.ratis.proto.RaftProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,39 +181,30 @@ public class StorageContainerServiceProviderImpl
         ".tar");
     try {
       try {
-        List<String> ratisRoles = scmClient.getScmInfo().getRatisPeerRoles();
+        List<String> ratisRoles = scmClient.getScmInfo().getPeerRoles();
         for (String ratisRole : ratisRoles) {
           String[] role = ratisRole.split(":");
-          // This explicit role length check is to support older versions where we cannot change the default value
-          // without breaking backward compatibility during upgrade, because if Ratis is not enabled then the roles
-          // command output is generated outside of Ratis. It will not have the Ratis terminologies.
-          if (role.length > 2) {
-            if (role[2].equals(RaftProtos.RaftPeerRole.LEADER.toString())) {
-              String hostAddress = role[4].trim();
-              int grpcPort = configuration.getInt(
-                  ScmConfigKeys.OZONE_SCM_GRPC_PORT_KEY,
-                  ScmConfigKeys.OZONE_SCM_GRPC_PORT_DEFAULT);
+          if (role[2].equals(RaftProtos.RaftPeerRole.LEADER.toString())) {
+            String hostAddress = role[4].trim();
+            int grpcPort = configuration.getInt(
+                ScmConfigKeys.OZONE_SCM_GRPC_PORT_KEY,
+                ScmConfigKeys.OZONE_SCM_GRPC_PORT_DEFAULT);
 
-              SecurityConfig secConf = new SecurityConfig(configuration);
-              SCMSecurityProtocolClientSideTranslatorPB scmSecurityClient =
-                  getScmSecurityClientWithMaxRetry(
-                      configuration, getCurrentUser());
-              try (ReconCertificateClient certClient =
-                       new ReconCertificateClient(
-                           secConf, scmSecurityClient, reconStorage, null, null);
-                   SCMSnapshotDownloader downloadClient = new InterSCMGrpcClient(
-                       hostAddress, grpcPort, configuration, certClient)) {
-                downloadClient.download(targetFile.toPath()).get();
-              } catch (ExecutionException | InterruptedException e) {
-                LOG.error("Rocks DB checkpoint downloading failed: {}", e);
-                throw new IOException(e);
-              }
-              LOG.info("Downloaded SCM Snapshot from Leader SCM");
-              break;
+            SecurityConfig secConf = new SecurityConfig(configuration);
+            SCMSecurityProtocolClientSideTranslatorPB scmSecurityClient =
+                getScmSecurityClientWithMaxRetry(
+                    configuration, getCurrentUser());
+            try (ReconCertificateClient certClient =
+                     new ReconCertificateClient(
+                         secConf, scmSecurityClient, reconStorage, null, null);
+                 SCMSnapshotDownloader downloadClient = new InterSCMGrpcClient(
+                     hostAddress, grpcPort, configuration, certClient)) {
+              downloadClient.download(targetFile.toPath()).get();
+            } catch (ExecutionException | InterruptedException e) {
+              LOG.error("Rocks DB checkpoint downloading failed: {}", e);
+              throw new IOException(e);
             }
-          } else {
-            fetchSCMDBSnapshotUsingHttpClient(targetFile);
-            LOG.info("Downloaded SCM Snapshot from SCM");
+            LOG.info("Downloaded SCM Snapshot from Leader SCM");
             break;
           }
         }
@@ -230,17 +219,6 @@ public class StorageContainerServiceProviderImpl
       LOG.error("Unable to obtain SCM DB Snapshot: {} ", e);
     }
     return null;
-  }
-
-  private void fetchSCMDBSnapshotUsingHttpClient(File targetFile) throws IOException {
-    SecurityUtil.doAsLoginUser(() -> {
-      try (InputStream inputStream = reconUtils.makeHttpCall(
-          connectionFactory, getScmDBSnapshotUrl(),
-          isOmSpnegoEnabled()).getInputStream()) {
-        FileUtils.copyInputStreamToFile(inputStream, targetFile);
-      }
-      return null;
-    });
   }
 
   @NotNull

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -58,30 +58,21 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
 
   private static final String SCM_ROLES_TITLE = "Storage Container Manager Roles";
 
-  private static final List<String> RATIS_SCM_ROLES_HEADER = Arrays.asList(
+  private static final List<String> SCM_ROLES_HEADER = Arrays.asList(
       "Host Name", "Ratis Port", "Role",  "Node ID", "Host Address");
-
-  private static final List<String> STANDALONE_SCM_ROLES_HEADER = Arrays.asList("Host Name", "Port");
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    List<String> ratisRoles = scmClient.getScmRatisRoles();
-    boolean isRatisEnabled = scmClient.isScmRatisEnable();
+    List<String> peerRoles = scmClient.getScmRoles();
     if (json) {
-      Map<String, Map<String, String>> scmRoles = parseScmRoles(ratisRoles);
+      Map<String, Map<String, String>> scmRoles = parseScmRoles(peerRoles);
       System.out.print(
           JsonUtils.toJsonStringWithDefaultPrettyPrinter(scmRoles));
     } else if (table) {
       FormattingCLIUtils formattingCLIUtils = new FormattingCLIUtils(SCM_ROLES_TITLE);
+      formattingCLIUtils.addHeaders(SCM_ROLES_HEADER);
 
-      // Determine which header to use based on whether Ratis is enabled or not.
-      if (isRatisEnabled) {
-        formattingCLIUtils.addHeaders(RATIS_SCM_ROLES_HEADER);
-      } else {
-        formattingCLIUtils.addHeaders(STANDALONE_SCM_ROLES_HEADER);
-      }
-
-      for (String role : ratisRoles) {
+      for (String role : peerRoles) {
         String[] roleItems = role.split(":");
         if (roleItems.length < 2) {
           err.println("Invalid response received for ScmRatisRoles.");
@@ -90,16 +81,16 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
       }
       System.out.println(formattingCLIUtils.render());
     } else {
-      for (String role: ratisRoles) {
+      for (String role: peerRoles) {
         System.out.println(role);
       }
     }
   }
 
   private Map<String, Map<String, String>> parseScmRoles(
-      List<String> ratisRoles) {
+      List<String> peerRoles) {
     Map<String, Map<String, String>> allRoles = new HashMap<>();
-    for (String role : ratisRoles) {
+    for (String role : peerRoles) {
       Map<String, String> roleDetails = new HashMap<>();
       String[] roles = role.split(":");
       if (roles.length < 2) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/scm/TestGetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/scm/TestGetScmRatisRolesSubcommand.java
@@ -47,8 +47,7 @@ public class TestGetScmRatisRolesSubcommand {
     result.add("bigdata-ozone-online32:9894:LEADER:e428ca07-b2a3-4756-bf9b-a4abb033c7d1:100.3.192.89");
     result.add("bigdata-ozone-online30:9894:FOLLOWER:41f90734-b3ee-4284-ad96-40a286654952:100.3.196.51");
 
-    when(client.getScmRatisRoles()).thenAnswer(invocation -> result);
-    when(client.isScmRatisEnable()).thenAnswer(invocation -> true);
+    when(client.getScmRoles()).thenAnswer(invocation -> result);
 
     try (GenericTestUtils.SystemOutCapturer capture =
         new GenericTestUtils.SystemOutCapturer()) {
@@ -62,24 +61,4 @@ public class TestGetScmRatisRolesSubcommand {
     }
   }
 
-  @Test
-  public void testGetScmStandAloneRoles() throws Exception {
-
-    GetScmRatisRolesSubcommand cmd = new GetScmRatisRolesSubcommand();
-    ScmClient client = mock(ScmClient.class);
-    CommandLine c = new CommandLine(cmd);
-    c.parseArgs("--table");
-
-    List<String> result = new ArrayList<>();
-    result.add("bigdata-ozone-online31:9894");
-
-    when(client.getScmRatisRoles()).thenAnswer(invocation -> result);
-    when(client.isScmRatisEnable()).thenAnswer(invocation -> false);
-
-    try (GenericTestUtils.SystemOutCapturer capture =
-        new GenericTestUtils.SystemOutCapturer()) {
-      cmd.execute(client);
-      assertThat(capture.getOutput()).contains("| bigdata-ozone-online31 | 9894 |");
-    }
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove `scmRatisEnabled` from `ScmInfo`.

Since Ratis is always enabled in SCM, there is no need for `scmRatisEnabled` in `ScmInfo`.


## What is the link to the Apache JIRA
HDDS-12376

## How was this patch tested?
CI Run: https://github.com/nandakumar131/ozone/actions/runs/13410928769
