### PR TITLE
HDDS-12387. Cleanup TestContainerOperations

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.utils.IOUtils;


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Use `storageClient` in place of `storageContainerLocationClient` and remove `storageContainerLocationClient` altogether in the test.
- The [comment](https://github.com/apache/ozone/blob/c0da9afea477bea4101fb2f3849d09b9b8591fb1/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java#L230) // All nodes should be returned as they are all in service seems incorrect, one of the node is in DECOMMISSIONING state. The code is correct in asserting numOfdatanodes - 1, just the comment is misleading.
- Use `cluster().getHddsDatanodes().size()` instead of [hardcoded value](https://github.com/apache/ozone/blob/c0da9afea477bea4101fb2f3849d09b9b8591fb1/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java#L266).

## What is the link to the Apache JIRA
[HDDS-12387](https://issues.apache.org/jira/browse/HDDS-12387)

## How was this patch tested?
It can test by CI.