### PR TITLE
HDDS-10764. Tarball creation failing on leader OM node.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -637,8 +637,10 @@ public final class HddsServerUtil {
     archiveOutputStream.putArchiveEntry(archiveEntry);
     try (FileInputStream fis = new FileInputStream(file)) {
       IOUtils.copy(fis, archiveOutputStream);
+      archiveOutputStream.flush();
+    } finally {
+      archiveOutputStream.closeArchiveEntry();
     }
-    archiveOutputStream.closeArchiveEntry();
   }
 
   // Mark tarball completed.


### PR DESCRIPTION
## What changes were proposed in this pull request?
For the performance fix due to which tarball creation takes time, HDDS-12064 should help.  This PR just makes sure to 
1. closeArchiveEntry in case of Exception to avoid  `Suppressed: java.io.IOException: This archive contains unclosed entries.` when the operation fails midway due to client timeout etc
2. flush after adding each entry so it's visible to the client quicker

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10764

## How was this patch tested?
The issue is not easily reproducible, this is just a code refactor.