### PR TITLE
HDDS-11887. Ozone Recon - Identify container replicas difference based on content checksums

### DIFF
--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -424,6 +424,7 @@ message ContainerReplicaHistoryProto {
     required int64 lastSeenTime = 3;
     required int64 bcsId = 4;
     optional string state = 5;
+    optional int64 dataChecksum = 6;
 }
 
 message SCMContainerReplicaProto {

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -53,7 +53,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     MIS_REPLICATED,
     ALL_REPLICAS_BAD,
     NEGATIVE_SIZE, // Added new state to track containers with negative sizes
-    CHECKSUM_ERROR
+    REPLICA_MISMATCH
   }
 
   private static final String CONTAINER_ID = "container_id";

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -52,7 +52,8 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     OVER_REPLICATED,
     MIS_REPLICATED,
     ALL_REPLICAS_BAD,
-    NEGATIVE_SIZE // Added new state to track containers with negative sizes
+    NEGATIVE_SIZE, // Added new state to track containers with negative sizes
+    DATA_CHECKSUM_MISMATCH
   }
 
   private static final String CONTAINER_ID = "container_id";

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -53,7 +53,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     MIS_REPLICATED,
     ALL_REPLICAS_BAD,
     NEGATIVE_SIZE, // Added new state to track containers with negative sizes
-    DATA_CHECKSUM_MISMATCH
+    CHECKSUM_MISMATCH
   }
 
   private static final String CONTAINER_ID = "container_id";

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -53,7 +53,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     MIS_REPLICATED,
     ALL_REPLICAS_BAD,
     NEGATIVE_SIZE, // Added new state to track containers with negative sizes
-    CHECKSUM_MISMATCH
+    CHECKSUM_ERROR
   }
 
   private static final String CONTAINER_ID = "container_id";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -51,10 +51,10 @@ public class UnhealthyContainersResponse {
   private long misReplicatedCount = 0;
 
   /**
-   * Total count of data checksum mismatched containers.
+   * Total count of containers that have replicas with mismatched data checksums.
    */
-  @JsonProperty("dataChecksumMismatchCount")
-  private long dataChecksumMismatchCount = 0;
+  @JsonProperty("replicaMismatchCount")
+  private long replicaMismatchCount = 0;
 
   /**
    * A collection of unhealthy containers.
@@ -85,7 +85,7 @@ public class UnhealthyContainersResponse {
       this.misReplicatedCount = count;
     } else if (state.equals(
         UnHealthyContainerStates.REPLICA_MISMATCH.toString())) {
-      this.dataChecksumMismatchCount = count;
+      this.replicaMismatchCount = count;
     }
   }
 
@@ -105,8 +105,8 @@ public class UnhealthyContainersResponse {
     return misReplicatedCount;
   }
 
-  public long getDataChecksumMismatchCount() {
-    return dataChecksumMismatchCount;
+  public long getReplicaMismatchCount() {
+    return replicaMismatchCount;
   }
 
   public Collection<UnhealthyContainerMetadata> getContainers() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -83,7 +83,7 @@ public class UnhealthyContainersResponse {
     } else if (state.equals(
         UnHealthyContainerStates.MIS_REPLICATED.toString())) {
       this.misReplicatedCount = count;
-    } else if(state.equals(
+    } else if (state.equals(
         UnHealthyContainerStates.CHECKSUM_ERROR.toString())) {
       this.dataChecksumMismatchCount = count;
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -84,7 +84,7 @@ public class UnhealthyContainersResponse {
         UnHealthyContainerStates.MIS_REPLICATED.toString())) {
       this.misReplicatedCount = count;
     } else if(state.equals(
-        UnHealthyContainerStates.CHECKSUM_MISMATCH.toString())) {
+        UnHealthyContainerStates.CHECKSUM_ERROR.toString())) {
       this.dataChecksumMismatchCount = count;
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -84,7 +84,7 @@ public class UnhealthyContainersResponse {
         UnHealthyContainerStates.MIS_REPLICATED.toString())) {
       this.misReplicatedCount = count;
     } else if (state.equals(
-        UnHealthyContainerStates.CHECKSUM_ERROR.toString())) {
+        UnHealthyContainerStates.REPLICA_MISMATCH.toString())) {
       this.dataChecksumMismatchCount = count;
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -51,6 +51,12 @@ public class UnhealthyContainersResponse {
   private long misReplicatedCount = 0;
 
   /**
+   * Total count of data checksum mismatched containers.
+   */
+  @JsonProperty("dataChecksumMismatchCount")
+  private long dataChecksumMismatchCount = 0;
+
+  /**
    * A collection of unhealthy containers.
    */
   @JsonProperty("containers")
@@ -77,6 +83,9 @@ public class UnhealthyContainersResponse {
     } else if (state.equals(
         UnHealthyContainerStates.MIS_REPLICATED.toString())) {
       this.misReplicatedCount = count;
+    } else if(state.equals(
+        UnHealthyContainerStates.CHECKSUM_MISMATCH.toString())) {
+      this.dataChecksumMismatchCount = count;
     }
   }
 
@@ -94,6 +103,10 @@ public class UnhealthyContainersResponse {
 
   public long getMisReplicatedCount() {
     return misReplicatedCount;
+  }
+
+  public long getDataChecksumMismatchCount() {
+    return dataChecksumMismatchCount;
   }
 
   public Collection<UnhealthyContainerMetadata> getContainers() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
@@ -47,6 +47,7 @@ public class ContainerHealthStatus {
 
   private final ContainerInfo container;
   private final int replicaDelta;
+  private final Set<ContainerReplica> replicas;
   private final Set<ContainerReplica> healthyReplicas;
   private final Set<ContainerReplica> healthyAvailReplicas;
   private final ContainerPlacementStatus placementStatus;
@@ -64,6 +65,7 @@ public class ContainerHealthStatus {
     this.reconContainerMetadataManager = reconContainerMetadataManager;
     this.container = container;
     int repFactor = container.getReplicationConfig().getRequiredNodes();
+    this.replicas = replicas;
     this.healthyReplicas = replicas
         .stream()
         .filter(r -> !r.getState()
@@ -158,6 +160,13 @@ public class ContainerHealthStatus {
 
   public boolean isEmpty() {
     return numKeys == 0;
+  }
+
+  public boolean isDataChecksumMismatched() {
+    return replicas.stream()
+            .map(ContainerReplica::getDataChecksum)
+            .distinct()
+            .count() != 1;
   }
 
   private ContainerPlacementStatus getPlacementStatus(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
@@ -191,19 +191,19 @@ public class ContainerHealthStatus {
   }
 
   private ContainerReplicaCount getContainerReplicaCountInstance(
-      OzoneConfiguration conf, Set<ContainerReplica> replicas) {
+      OzoneConfiguration conf, Set<ContainerReplica> containerReplicas) {
     ReplicationManager.ReplicationManagerConfiguration rmConf = conf.getObject(
         ReplicationManager.ReplicationManagerConfiguration.class);
     boolean isEC = container.getReplicationConfig()
                        .getReplicationType() == HddsProtos.ReplicationType.EC;
     return isEC ?
                new ECContainerReplicaCount(container,
-                   replicas, new ArrayList<>(),
+                   containerReplicas, new ArrayList<>(),
                    rmConf.getMaintenanceRemainingRedundancy()) :
                // This class ignores unhealthy replicas,
                // therefore set 'considerUnhealthy' to false.
                new RatisContainerReplicaCount(container,
-                   replicas, new ArrayList<>(),
+                   containerReplicas, new ArrayList<>(),
                    rmConf.getMaintenanceReplicaMinimum(), false);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
@@ -163,7 +163,7 @@ public class ContainerHealthStatus {
   }
 
   public boolean isDataChecksumMismatched() {
-    return replicas.stream()
+    return !replicas.isEmpty() && replicas.stream()
             .map(ContainerReplica::getDataChecksum)
             .distinct()
             .count() != 1;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -117,7 +117,7 @@ public class ContainerHealthTask extends ReconScmTask {
         Thread.sleep(interval);
       }
     } catch (Throwable t) {
-      LOG.error("Exception in Missing Container task Thread.", t);
+      LOG.error("Exception in Container Health task thread.", t);
       if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
@@ -234,6 +234,8 @@ public class ContainerHealthTask extends ReconScmTask {
         UnHealthyContainerStates.MIS_REPLICATED, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
+    unhealthyContainerStateStatsMap.put(
+            UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH, new HashMap<>());
   }
 
   private ContainerHealthStatus setCurrentContainer(long recordId)
@@ -352,7 +354,7 @@ public class ContainerHealthTask extends ReconScmTask {
           containerReplicas, placementPolicy,
           reconContainerMetadataManager, conf);
 
-      if (h.isHealthilyReplicated() || h.isDeleted()) {
+      if ((h.isHealthilyReplicated() && !h.isDataChecksumMismatched()) || h.isDeleted()) {
         return;
       }
       // For containers deleted in SCM, we sync the container state here.
@@ -486,7 +488,7 @@ public class ContainerHealthTask extends ReconScmTask {
      */
     public static boolean retainOrUpdateRecord(
         ContainerHealthStatus container, UnhealthyContainersRecord rec) {
-      boolean returnValue = false;
+      boolean returnValue;
       switch (UnHealthyContainerStates.valueOf(rec.getContainerState())) {
       case MISSING:
         returnValue = container.isMissing() && !container.isEmpty();
@@ -499,6 +501,9 @@ public class ContainerHealthTask extends ReconScmTask {
         break;
       case OVER_REPLICATED:
         returnValue = keepOverReplicatedRecord(container, rec);
+        break;
+      case DATA_CHECKSUM_MISMATCH:
+        returnValue = keepDataChecksumMismatchedRecord(container, rec);
         break;
       default:
         returnValue = false;
@@ -528,7 +533,7 @@ public class ContainerHealthTask extends ReconScmTask {
         Map<UnHealthyContainerStates, Map<String, Long>>
             unhealthyContainerStateStatsMap) {
       List<UnhealthyContainers> records = new ArrayList<>();
-      if (container.isHealthilyReplicated() || container.isDeleted()) {
+      if ((container.isHealthilyReplicated() && !container.isDataChecksumMismatched() ) || container.isDeleted()) {
         return records;
       }
 
@@ -593,6 +598,17 @@ public class ContainerHealthTask extends ReconScmTask {
             unhealthyContainerStateStatsMap);
       }
 
+      if (container.isDataChecksumMismatched()
+              && !recordForStateExists.contains(
+              UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH.toString())) {
+        records.add(recordForState(
+                container, UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH, time));
+        populateContainerStats(container,
+                UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH,
+                unhealthyContainerStateStatsMap);
+      }
+
+
       return records;
     }
 
@@ -645,6 +661,17 @@ public class ContainerHealthTask extends ReconScmTask {
         updateActualReplicaCount(rec, container.actualPlacementCount());
         updateReplicaDelta(rec, container.misReplicatedDelta());
         updateReason(rec, container.misReplicatedReason());
+        return true;
+      }
+      return false;
+    }
+
+    private static boolean keepDataChecksumMismatchedRecord(
+            ContainerHealthStatus container, UnhealthyContainersRecord rec) {
+      if (container.isDataChecksumMismatched()) {
+        updateExpectedReplicaCount(rec, container.expectedPlacementCount());
+        updateActualReplicaCount(rec, container.actualPlacementCount());
+        updateReplicaDelta(rec, container.replicaDelta());
         return true;
       }
       return false;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -235,7 +235,7 @@ public class ContainerHealthTask extends ReconScmTask {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-            UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH, new HashMap<>());
+            UnHealthyContainerStates.CHECKSUM_MISMATCH, new HashMap<>());
   }
 
   private ContainerHealthStatus setCurrentContainer(long recordId)
@@ -502,7 +502,7 @@ public class ContainerHealthTask extends ReconScmTask {
       case OVER_REPLICATED:
         returnValue = keepOverReplicatedRecord(container, rec);
         break;
-      case DATA_CHECKSUM_MISMATCH:
+      case CHECKSUM_MISMATCH:
         returnValue = keepDataChecksumMismatchedRecord(container, rec);
         break;
       default:
@@ -533,7 +533,7 @@ public class ContainerHealthTask extends ReconScmTask {
         Map<UnHealthyContainerStates, Map<String, Long>>
             unhealthyContainerStateStatsMap) {
       List<UnhealthyContainers> records = new ArrayList<>();
-      if ((container.isHealthilyReplicated() && !container.isDataChecksumMismatched() ) || container.isDeleted()) {
+      if ((container.isHealthilyReplicated() && !container.isDataChecksumMismatched()) || container.isDeleted()) {
         return records;
       }
 
@@ -600,11 +600,11 @@ public class ContainerHealthTask extends ReconScmTask {
 
       if (container.isDataChecksumMismatched()
               && !recordForStateExists.contains(
-              UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH.toString())) {
+              UnHealthyContainerStates.CHECKSUM_MISMATCH.toString())) {
         records.add(recordForState(
-                container, UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH, time));
+                container, UnHealthyContainerStates.CHECKSUM_MISMATCH, time));
         populateContainerStats(container,
-                UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH,
+                UnHealthyContainerStates.CHECKSUM_MISMATCH,
                 unhealthyContainerStateStatsMap);
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -503,7 +503,7 @@ public class ContainerHealthTask extends ReconScmTask {
         returnValue = keepOverReplicatedRecord(container, rec);
         break;
       case REPLICA_MISMATCH:
-        returnValue = keepDataChecksumMismatchedRecord(container, rec);
+        returnValue = keepReplicaMismatchRecord(container, rec);
         break;
       default:
         returnValue = false;
@@ -665,7 +665,7 @@ public class ContainerHealthTask extends ReconScmTask {
       return false;
     }
 
-    private static boolean keepDataChecksumMismatchedRecord(
+    private static boolean keepReplicaMismatchRecord(
             ContainerHealthStatus container, UnhealthyContainersRecord rec) {
       if (container.isDataChecksumMismatched()) {
         updateExpectedReplicaCount(rec, container.expectedPlacementCount());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -235,7 +235,7 @@ public class ContainerHealthTask extends ReconScmTask {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-            UnHealthyContainerStates.CHECKSUM_MISMATCH, new HashMap<>());
+            UnHealthyContainerStates.CHECKSUM_ERROR, new HashMap<>());
   }
 
   private ContainerHealthStatus setCurrentContainer(long recordId)
@@ -502,7 +502,7 @@ public class ContainerHealthTask extends ReconScmTask {
       case OVER_REPLICATED:
         returnValue = keepOverReplicatedRecord(container, rec);
         break;
-      case CHECKSUM_MISMATCH:
+      case CHECKSUM_ERROR:
         returnValue = keepDataChecksumMismatchedRecord(container, rec);
         break;
       default:
@@ -600,11 +600,11 @@ public class ContainerHealthTask extends ReconScmTask {
 
       if (container.isDataChecksumMismatched()
               && !recordForStateExists.contains(
-              UnHealthyContainerStates.CHECKSUM_MISMATCH.toString())) {
+              UnHealthyContainerStates.CHECKSUM_ERROR.toString())) {
         records.add(recordForState(
-                container, UnHealthyContainerStates.CHECKSUM_MISMATCH, time));
+                container, UnHealthyContainerStates.CHECKSUM_ERROR, time));
         populateContainerStats(container,
-                UnHealthyContainerStates.CHECKSUM_MISMATCH,
+                UnHealthyContainerStates.CHECKSUM_ERROR,
                 unhealthyContainerStateStatsMap);
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -608,7 +608,6 @@ public class ContainerHealthTask extends ReconScmTask {
                 unhealthyContainerStateStatsMap);
       }
 
-
       return records;
     }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -235,7 +235,7 @@ public class ContainerHealthTask extends ReconScmTask {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-            UnHealthyContainerStates.CHECKSUM_ERROR, new HashMap<>());
+            UnHealthyContainerStates.REPLICA_MISMATCH, new HashMap<>());
   }
 
   private ContainerHealthStatus setCurrentContainer(long recordId)
@@ -502,7 +502,7 @@ public class ContainerHealthTask extends ReconScmTask {
       case OVER_REPLICATED:
         returnValue = keepOverReplicatedRecord(container, rec);
         break;
-      case CHECKSUM_ERROR:
+      case REPLICA_MISMATCH:
         returnValue = keepDataChecksumMismatchedRecord(container, rec);
         break;
       default:
@@ -600,11 +600,11 @@ public class ContainerHealthTask extends ReconScmTask {
 
       if (container.isDataChecksumMismatched()
               && !recordForStateExists.contains(
-              UnHealthyContainerStates.CHECKSUM_ERROR.toString())) {
+              UnHealthyContainerStates.REPLICA_MISMATCH.toString())) {
         records.add(recordForState(
-                container, UnHealthyContainerStates.CHECKSUM_ERROR, time));
+                container, UnHealthyContainerStates.REPLICA_MISMATCH, time));
         populateContainerStats(container,
-                UnHealthyContainerStates.CHECKSUM_ERROR,
+                UnHealthyContainerStates.REPLICA_MISMATCH,
                 unhealthyContainerStateStatsMap);
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHistory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHistory.java
@@ -34,6 +34,7 @@ public class ContainerHistory implements Serializable {
   private String state;
   private long dataChecksum;
 
+  @SuppressWarnings("parameternumber")
   public ContainerHistory(long containerId, String datanodeUuid,
                           String datanodeHost, long firstSeenTime,
                           long lastSeenTime, long lastBcsId, String state, long dataChecksum) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHistory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHistory.java
@@ -32,10 +32,11 @@ public class ContainerHistory implements Serializable {
   private long lastSeenTime;
   private long lastBcsId;
   private String state;
+  private long dataChecksum;
 
   public ContainerHistory(long containerId, String datanodeUuid,
                           String datanodeHost, long firstSeenTime,
-                          long lastSeenTime, long lastBcsId, String state) {
+                          long lastSeenTime, long lastBcsId, String state, long dataChecksum) {
     this.containerId = containerId;
     this.datanodeUuid = datanodeUuid;
     this.datanodeHost = datanodeHost;
@@ -43,6 +44,7 @@ public class ContainerHistory implements Serializable {
     this.lastSeenTime = lastSeenTime;
     this.lastBcsId = lastBcsId;
     this.state = state;
+    this.dataChecksum = dataChecksum;
   }
 
   // Default constructor, used by jackson lib for object deserialization.
@@ -99,5 +101,13 @@ public class ContainerHistory implements Serializable {
 
   public void setState(String state) {
     this.state = state;
+  }
+
+  public long getDataChecksum() {
+    return dataChecksum;
+  }
+
+  public void setDataChecksum(long dataChecksum) {
+    this.dataChecksum = dataChecksum;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistory.java
@@ -41,14 +41,16 @@ public class ContainerReplicaHistory {
 
   private long bcsId;
   private String state;
+  private long dataChecksum;
 
   public ContainerReplicaHistory(UUID id, Long firstSeenTime,
-      Long lastSeenTime, long bcsId, String state) {
+      Long lastSeenTime, long bcsId, String state, long dataChecksum) {
     this.uuid = id;
     this.firstSeenTime = firstSeenTime;
     this.lastSeenTime = lastSeenTime;
     this.bcsId = bcsId;
     this.state = state;
+    this.dataChecksum = dataChecksum;
   }
 
   public long getBcsId() {
@@ -83,16 +85,24 @@ public class ContainerReplicaHistory {
     this.state = state;
   }
 
+  public long getDataChecksum() {
+    return dataChecksum;
+  }
+
+  public void setDataChecksum(long dataChecksum) {
+    this.dataChecksum = dataChecksum;
+  }
+
   public static ContainerReplicaHistory fromProto(
       ContainerReplicaHistoryProto proto) {
     return new ContainerReplicaHistory(UUID.fromString(proto.getUuid()),
         proto.getFirstSeenTime(), proto.getLastSeenTime(), proto.getBcsId(),
-        proto.getState());
+        proto.getState(), proto.getDataChecksum());
   }
 
   public ContainerReplicaHistoryProto toProto() {
     return ContainerReplicaHistoryProto.newBuilder().setUuid(uuid.toString())
         .setFirstSeenTime(firstSeenTime).setLastSeenTime(lastSeenTime)
-        .setBcsId(bcsId).setState(state).build();
+        .setBcsId(bcsId).setState(state).setDataChecksum(dataChecksum).build();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -280,6 +280,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
     boolean flushToDB = false;
     long bcsId = replica.getSequenceId() != null ? replica.getSequenceId() : -1;
     String state = replica.getState().toString();
+    long dataChecksum = replica.getDataChecksum();
 
     // If replica doesn't exist in in-memory map, add to DB and add to map
     if (replicaLastSeenMap == null) {
@@ -287,7 +288,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
       replicaHistoryMap.putIfAbsent(id,
           new ConcurrentHashMap<UUID, ContainerReplicaHistory>() {{
             put(uuid, new ContainerReplicaHistory(uuid, currTime, currTime,
-                bcsId, state));
+                bcsId, state, dataChecksum));
           }});
       flushToDB = true;
     } else {
@@ -297,7 +298,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
         // New Datanode
         replicaLastSeenMap.put(uuid,
             new ContainerReplicaHistory(uuid, currTime, currTime, bcsId,
-                state));
+                state, dataChecksum));
         flushToDB = true;
       } else {
         // if the object exists, only update the last seen time & bcsId fields
@@ -308,7 +309,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
     }
 
     if (flushToDB) {
-      upsertContainerHistory(id, uuid, currTime, bcsId, state);
+      upsertContainerHistory(id, uuid, currTime, bcsId, state, dataChecksum);
     }
   }
 
@@ -325,6 +326,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
     final DatanodeDetails dnInfo = replica.getDatanodeDetails();
     final UUID uuid = dnInfo.getUuid();
     String state = replica.getState().toString();
+    long dataChecksum = replica.getDataChecksum();
 
     final Map<UUID, ContainerReplicaHistory> replicaLastSeenMap =
         replicaHistoryMap.get(id);
@@ -333,7 +335,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
       if (ts != null) {
         // Flush to DB, then remove from in-memory map
         upsertContainerHistory(id, uuid, ts.getLastSeenTime(), ts.getBcsId(),
-            state);
+            state, dataChecksum);
         replicaLastSeenMap.remove(uuid);
       }
     }
@@ -392,9 +394,10 @@ public class ReconContainerManager extends ContainerManagerImpl {
       final long lastSeenTime = entry.getValue().getLastSeenTime();
       long bcsId = entry.getValue().getBcsId();
       String state = entry.getValue().getState();
+      long dataChecksum = entry.getValue().getDataChecksum();
 
       resList.add(new ContainerHistory(containerID, uuid.toString(), hostname,
-          firstSeenTime, lastSeenTime, bcsId, state));
+          firstSeenTime, lastSeenTime, bcsId, state, dataChecksum));
     }
     return resList;
   }
@@ -429,7 +432,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
   }
 
   public void upsertContainerHistory(long containerID, UUID uuid, long time,
-                                     long bcsId, String state) {
+                                     long bcsId, String state, long dataChecksum) {
     Map<UUID, ContainerReplicaHistory> tsMap;
     try {
       tsMap = cdbServiceProvider.getContainerReplicaHistory(containerID);
@@ -437,11 +440,12 @@ public class ReconContainerManager extends ContainerManagerImpl {
       if (ts == null) {
         // New entry
         tsMap.put(uuid, new ContainerReplicaHistory(uuid, time, time, bcsId,
-            state));
+            state, dataChecksum));
       } else {
         // Entry exists, update last seen time and put it back to DB.
         ts.setLastSeenTime(time);
         ts.setState(state);
+        ts.setDataChecksum(dataChecksum);
       }
       cdbServiceProvider.storeContainerReplicaHistory(containerID, tsMap);
     } catch (IOException e) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
@@ -33,7 +33,8 @@ import java.util.Set;
 public enum ReconLayoutFeature {
   // Represents the starting point for Recon's layout versioning system.
   INITIAL_VERSION(0, "Recon Layout Versioning Introduction"),
-  TASK_STATUS_STATISTICS(1, "Recon Task Status Statistics Tracking Introduced");
+  TASK_STATUS_STATISTICS(1, "Recon Task Status Statistics Tracking Introduced"),
+  UNHEALTHY_CONTAINER_DATA_CHECKSUM(2, "Adding data checksum mismatched state to the unhealthy container table");
 
   private final int version;
   private final String description;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
@@ -34,7 +34,7 @@ public enum ReconLayoutFeature {
   // Represents the starting point for Recon's layout versioning system.
   INITIAL_VERSION(0, "Recon Layout Versioning Introduction"),
   TASK_STATUS_STATISTICS(1, "Recon Task Status Statistics Tracking Introduced"),
-  UNHEALTHY_CONTAINER_DATA_CHECKSUM(2, "Adding data checksum mismatched state to the unhealthy container table");
+  UNHEALTHY_CONTAINER_REPLICA_MISMATCH(2, "Adding replica mismatch state to the unhealthy container table");
 
   private final int version;
   private final String description;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UnhealthyContainerDataChecksumAction.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UnhealthyContainerDataChecksumAction.java
@@ -1,0 +1,83 @@
+package org.apache.hadoop.ozone.recon.upgrade;
+
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
+import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+import static org.apache.hadoop.ozone.recon.upgrade.ReconLayoutFeature.UNHEALTHY_CONTAINER_DATA_CHECKSUM;
+import static org.apache.hadoop.ozone.recon.upgrade.ReconUpgradeAction.UpgradeActionType.FINALIZE;
+import static org.hadoop.ozone.recon.codegen.SqlDbUtils.TABLE_EXISTS_CHECK;
+import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+
+/**
+ * Upgrade action for handling the addition of a new unhealthy container state in Recon, which will
+ */
+@UpgradeActionRecon(feature = UNHEALTHY_CONTAINER_DATA_CHECKSUM, type = FINALIZE)
+public class UnhealthyContainerDataChecksumAction implements ReconUpgradeAction {
+    private static final Logger LOG = LoggerFactory.getLogger(InitialConstraintUpgradeAction.class);
+    private DataSource dataSource;
+    private DSLContext dslContext;
+
+    @Override
+    public void execute(ReconStorageContainerManagerFacade scmFacade) throws Exception {
+        this.dataSource = scmFacade.getDataSource();
+        try (Connection conn = dataSource.getConnection()) {
+            if (!TABLE_EXISTS_CHECK.test(conn, UNHEALTHY_CONTAINERS_TABLE_NAME)) {
+                return;
+            }
+            dslContext = DSL.using(conn);
+            // Drop the existing constraint
+            dropConstraint();
+            // Add the updated constraint with all enum states
+            addUpdatedConstraint();
+        } catch (SQLException e) {
+            throw new SQLException("Failed to execute UnhealthyContainerDataChecksumAction", e);
+        }
+    }
+
+    /**
+     * Drops the existing constraint from the UNHEALTHY_CONTAINERS table.
+     */
+    private void dropConstraint() {
+        String constraintName = UNHEALTHY_CONTAINERS_TABLE_NAME + "ck1";
+        dslContext.alterTable(UNHEALTHY_CONTAINERS_TABLE_NAME)
+                .dropConstraint(constraintName)
+                .execute();
+        LOG.debug("Dropped the existing constraint: {}", constraintName);
+    }
+
+    /**
+     * Adds the updated constraint directly within this class.
+     */
+    private void addUpdatedConstraint() {
+        String[] enumStates = Arrays
+                .stream(ContainerSchemaDefinition.UnHealthyContainerStates.values())
+                .map(Enum::name)
+                .toArray(String[]::new);
+
+        dslContext.alterTable(ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME)
+                .add(DSL.constraint(ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME + "ck1")
+                        .check(field(name("container_state"))
+                                .in(enumStates)))
+                .execute();
+
+        LOG.info("Added the updated constraint to the UNHEALTHY_CONTAINERS table for enum state values: {}",
+                Arrays.toString(enumStates));
+    }
+
+    @Override
+    public UpgradeActionType getType() {
+        return FINALIZE;
+    }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UnhealthyContainerReplicaMismatchAction.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UnhealthyContainerReplicaMismatchAction.java
@@ -30,7 +30,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 
-import static org.apache.hadoop.ozone.recon.upgrade.ReconLayoutFeature.UNHEALTHY_CONTAINER_DATA_CHECKSUM;
+import static org.apache.hadoop.ozone.recon.upgrade.ReconLayoutFeature.UNHEALTHY_CONTAINER_REPLICA_MISMATCH;
 import static org.apache.hadoop.ozone.recon.upgrade.ReconUpgradeAction.UpgradeActionType.FINALIZE;
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.TABLE_EXISTS_CHECK;
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME;
@@ -41,8 +41,8 @@ import static org.jooq.impl.DSL.name;
  * Upgrade action for handling the addition of a new unhealthy container state in Recon, which will be for containers,
  * that have replicas with different data checksums.
  */
-@UpgradeActionRecon(feature = UNHEALTHY_CONTAINER_DATA_CHECKSUM, type = FINALIZE)
-public class UnhealthyContainerDataChecksumAction implements ReconUpgradeAction {
+@UpgradeActionRecon(feature = UNHEALTHY_CONTAINER_REPLICA_MISMATCH, type = FINALIZE)
+public class UnhealthyContainerReplicaMismatchAction implements ReconUpgradeAction {
   private static final Logger LOG = LoggerFactory.getLogger(InitialConstraintUpgradeAction.class);
   private DataSource dataSource;
   private DSLContext dslContext;
@@ -60,7 +60,7 @@ public class UnhealthyContainerDataChecksumAction implements ReconUpgradeAction 
       // Add the updated constraint with all enum states
       addUpdatedConstraint();
     } catch (SQLException e) {
-      throw new SQLException("Failed to execute UnhealthyContainerDataChecksumAction", e);
+      throw new SQLException("Failed to execute UnhealthyContainerReplicaMismatchAction", e);
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -813,7 +813,7 @@ public class TestContainerEndpoint {
 
     assertEquals(Collections.EMPTY_LIST, responseObject.getContainers());
 
-    putContainerInfos(14);
+    putContainerInfos(15);
     uuid1 = newDatanode("host1", "127.0.0.1");
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
@@ -1122,8 +1122,8 @@ public class TestContainerEndpoint {
     }
     for (int i = 0; i < dataChecksum; i++) {
       createUnhealthyRecord(++cid,
-              UnHealthyContainerStates.REPLICA_MISMATCH.toString(),
-              3, 3, 0, null, true);
+          UnHealthyContainerStates.REPLICA_MISMATCH.toString(),
+          3, 3, 0, null, true);
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1122,7 +1122,7 @@ public class TestContainerEndpoint {
     }
     for (int i = 0; i < dataChecksum; i++) {
       createUnhealthyRecord(++cid,
-              UnHealthyContainerStates.CHECKSUM_MISMATCH.toString(),
+              UnHealthyContainerStates.CHECKSUM_ERROR.toString(),
               3, 3, 0, null, true);
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -733,7 +733,7 @@ public class TestContainerEndpoint {
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
-    createUnhealthyRecords(5, 0, 0, 0);
+    createUnhealthyRecords(5, 0, 0, 0, 0);
 
     Response responseWithLimit = containerEndpoint.getMissingContainers(3);
     MissingContainersResponse responseWithLimitObject
@@ -818,7 +818,7 @@ public class TestContainerEndpoint {
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
-    createUnhealthyRecords(5, 4, 3, 2);
+    createUnhealthyRecords(5, 4, 3, 2, 1);
 
     response = containerEndpoint.getUnhealthyContainers(1000, 1);
 
@@ -827,6 +827,7 @@ public class TestContainerEndpoint {
     assertEquals(4, responseObject.getOverReplicatedCount());
     assertEquals(3, responseObject.getUnderReplicatedCount());
     assertEquals(2, responseObject.getMisReplicatedCount());
+    assertEquals(1, responseObject.getDataChecksumMismatchCount());
 
     Collection<UnhealthyContainerMetadata> records
         = responseObject.getContainers();
@@ -927,7 +928,7 @@ public class TestContainerEndpoint {
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
-    createUnhealthyRecords(5, 4, 3, 2);
+    createUnhealthyRecords(5, 4, 3, 2, 1);
     createEmptyMissingUnhealthyRecords(2); // For EMPTY_MISSING state
     createNegativeSizeUnhealthyRecords(2); // For NEGATIVE_SIZE state
 
@@ -941,6 +942,7 @@ public class TestContainerEndpoint {
     assertEquals(4, responseObject.getOverReplicatedCount());
     assertEquals(3, responseObject.getUnderReplicatedCount());
     assertEquals(2, responseObject.getMisReplicatedCount());
+    assertEquals(1, responseObject.getDataChecksumMismatchCount());
 
     Collection<UnhealthyContainerMetadata> records = responseObject.getContainers();
     assertTrue(records.stream()
@@ -1097,7 +1099,7 @@ public class TestContainerEndpoint {
 
 
   private void createUnhealthyRecords(int missing, int overRep, int underRep,
-                                      int misRep, int dataCheksum) {
+                                      int misRep, int dataChecksum) {
     int cid = 0;
     for (int i = 0; i < missing; i++) {
       createUnhealthyRecord(++cid, UnHealthyContainerStates.MISSING.toString(),
@@ -1118,9 +1120,9 @@ public class TestContainerEndpoint {
           UnHealthyContainerStates.MIS_REPLICATED.toString(),
           2, 1, 1, "some reason", false);
     }
-    for (int i = 0; i < dataCheksum; i++) {
+    for (int i = 0; i < dataChecksum; i++) {
       createUnhealthyRecord(++cid,
-              UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH.toString(),
+              UnHealthyContainerStates.CHECKSUM_MISMATCH.toString(),
               3, 3, 0, null, true);
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1122,7 +1122,7 @@ public class TestContainerEndpoint {
     }
     for (int i = 0; i < dataChecksum; i++) {
       createUnhealthyRecord(++cid,
-              UnHealthyContainerStates.CHECKSUM_ERROR.toString(),
+              UnHealthyContainerStates.REPLICA_MISMATCH.toString(),
               3, 3, 0, null, true);
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
@@ -177,7 +177,7 @@ public class TestContainerHealthStatus {
 
   @Test
   public void testSameDataChecksumContainer() {
-    Set<ContainerReplica> replicas = generateSameDataChecksumReplicas(container,
+    Set<ContainerReplica> replicas = generateReplicas(container,
             ContainerReplicaProto.State.CLOSED,
             ContainerReplicaProto.State.CLOSED,
             ContainerReplicaProto.State.CLOSED);
@@ -194,7 +194,7 @@ public class TestContainerHealthStatus {
 
   @Test
   public void testDataChecksumMismatchContainer() {
-    Set<ContainerReplica> replicas = generateDataChecksumMismatchedReplicas(container,
+    Set<ContainerReplica> replicas = generateMismatchedReplicas(container,
             ContainerReplicaProto.State.CLOSED,
             ContainerReplicaProto.State.CLOSED,
             ContainerReplicaProto.State.CLOSED);
@@ -416,38 +416,25 @@ public class TestContainerHealthStatus {
       replicas.add(new ContainerReplica.ContainerReplicaBuilder()
           .setContainerID(cont.containerID())
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+          .setDataChecksum(1234L)
           .setContainerState(s)
           .build());
     }
     return replicas;
   }
 
-  private Set<ContainerReplica> generateDataChecksumMismatchedReplicas(ContainerInfo cont,
-                                                                       ContainerReplicaProto.State...states) {
+  private Set<ContainerReplica> generateMismatchedReplicas(ContainerInfo cont,
+                                                           ContainerReplicaProto.State...states) {
     Set<ContainerReplica> replicas = new HashSet<>();
-    long dataChecksum = 10L;
+    long checksum = 1234L;
     for (ContainerReplicaProto.State s : states) {
       replicas.add(new ContainerReplica.ContainerReplicaBuilder()
-              .setContainerID(cont.containerID())
-              .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
-              .setContainerState(s)
-              .setDataChecksum(dataChecksum)
-              .build());
-      dataChecksum++;
-    }
-    return replicas;
-  }
-
-  private Set<ContainerReplica> generateSameDataChecksumReplicas(ContainerInfo cont,
-                                                                 ContainerReplicaProto.State...states) {
-    Set<ContainerReplica> replicas = new HashSet<>();
-    for (ContainerReplicaProto.State s : states) {
-      replicas.add(new ContainerReplica.ContainerReplicaBuilder()
-              .setContainerID(cont.containerID())
-              .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
-              .setContainerState(s)
-              .setDataChecksum(10L)
-              .build());
+          .setContainerID(cont.containerID())
+          .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+          .setContainerState(s)
+          .setDataChecksum(checksum)
+          .build());
+      checksum++;
     }
     return replicas;
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
@@ -175,6 +175,40 @@ public class TestContainerHealthStatus {
     assertEquals(0, status.misReplicatedDelta());
   }
 
+  @Test
+  public void testSameDataChecksumContainer() {
+    Set<ContainerReplica> replicas = generateSameDataChecksumReplicas(container,
+            ContainerReplicaProto.State.CLOSED,
+            ContainerReplicaProto.State.CLOSED,
+            ContainerReplicaProto.State.CLOSED);
+    ContainerHealthStatus status =
+            new ContainerHealthStatus(container, replicas, placementPolicy,
+                    reconContainerMetadataManager, CONF);
+    assertTrue(status.isHealthilyReplicated());
+    assertFalse(status.isMissing());
+    assertFalse(status.isUnderReplicated());
+    assertFalse(status.isOverReplicated());
+    assertFalse(status.isMisReplicated());
+    assertFalse(status.isDataChecksumMismatched());
+  }
+
+  @Test
+  public void testDataChecksumMismatchContainer() {
+    Set<ContainerReplica> replicas = generateDataChecksumMismatchedReplicas(container,
+            ContainerReplicaProto.State.CLOSED,
+            ContainerReplicaProto.State.CLOSED,
+            ContainerReplicaProto.State.CLOSED);
+    ContainerHealthStatus status =
+            new ContainerHealthStatus(container, replicas, placementPolicy,
+                    reconContainerMetadataManager, CONF);
+    assertTrue(status.isHealthilyReplicated());
+    assertFalse(status.isMissing());
+    assertFalse(status.isUnderReplicated());
+    assertFalse(status.isOverReplicated());
+    assertFalse(status.isMisReplicated());
+    assertTrue(status.isDataChecksumMismatched());
+  }
+
   /**
    * Starting with a ContainerHealthStatus of 1 over-replicated container
    * replica and then updating a datanode to one of the out-of-service states.
@@ -384,6 +418,36 @@ public class TestContainerHealthStatus {
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
           .setContainerState(s)
           .build());
+    }
+    return replicas;
+  }
+
+  private Set<ContainerReplica> generateDataChecksumMismatchedReplicas(ContainerInfo cont,
+                                                                       ContainerReplicaProto.State...states) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    long dataChecksum = 10L;
+    for (ContainerReplicaProto.State s : states) {
+      replicas.add(new ContainerReplica.ContainerReplicaBuilder()
+              .setContainerID(cont.containerID())
+              .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+              .setContainerState(s)
+              .setDataChecksum(dataChecksum)
+              .build());
+      dataChecksum++;
+    }
+    return replicas;
+  }
+
+  private Set<ContainerReplica> generateSameDataChecksumReplicas(ContainerInfo cont,
+                                                                 ContainerReplicaProto.State...states) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (ContainerReplicaProto.State s : states) {
+      replicas.add(new ContainerReplica.ContainerReplicaBuilder()
+              .setContainerID(cont.containerID())
+              .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+              .setContainerState(s)
+              .setDataChecksum(10L)
+              .build());
     }
     return replicas;
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -372,7 +372,7 @@ public class TestContainerHealthTaskRecordGenerator {
                     unhealthyContainerStateStatsMap);
     assertEquals(1, records.size());
     assertEquals(1, unhealthyContainerStateStatsMap.get(
-                    UnHealthyContainerStates.CHECKSUM_MISMATCH)
+                    UnHealthyContainerStates.CHECKSUM_ERROR)
             .getOrDefault(CONTAINER_COUNT, 0L));
 
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -388,7 +388,7 @@ public class TestContainerHealthTaskRecordGenerator {
                     unhealthyContainerStateStatsMap);
     assertEquals(0, records.size());
     assertEquals(0, unhealthyContainerStateStatsMap.get(
-                    UnHealthyContainerStates.CHECKSUM_MISMATCH)
+                    UnHealthyContainerStates.CHECKSUM_ERROR)
             .getOrDefault(CONTAINER_COUNT, 0L));
 
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -695,7 +695,7 @@ public class TestContainerHealthTaskRecordGenerator {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-        UnHealthyContainerStates.CHECKSUM_MISMATCH, new HashMap<>());
+        UnHealthyContainerStates.CHECKSUM_ERROR, new HashMap<>());
   }
 
   private void logUnhealthyContainerStats(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -372,7 +372,7 @@ public class TestContainerHealthTaskRecordGenerator {
                     unhealthyContainerStateStatsMap);
     assertEquals(1, records.size());
     assertEquals(1, unhealthyContainerStateStatsMap.get(
-                    UnHealthyContainerStates.CHECKSUM_ERROR)
+                    UnHealthyContainerStates.REPLICA_MISMATCH)
             .getOrDefault(CONTAINER_COUNT, 0L));
 
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -388,7 +388,7 @@ public class TestContainerHealthTaskRecordGenerator {
                     unhealthyContainerStateStatsMap);
     assertEquals(0, records.size());
     assertEquals(0, unhealthyContainerStateStatsMap.get(
-                    UnHealthyContainerStates.CHECKSUM_ERROR)
+                    UnHealthyContainerStates.REPLICA_MISMATCH)
             .getOrDefault(CONTAINER_COUNT, 0L));
 
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -695,7 +695,7 @@ public class TestContainerHealthTaskRecordGenerator {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-        UnHealthyContainerStates.CHECKSUM_ERROR, new HashMap<>());
+        UnHealthyContainerStates.REPLICA_MISMATCH, new HashMap<>());
   }
 
   private void logUnhealthyContainerStats(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -372,7 +372,7 @@ public class TestContainerHealthTaskRecordGenerator {
                     unhealthyContainerStateStatsMap);
     assertEquals(1, records.size());
     assertEquals(1, unhealthyContainerStateStatsMap.get(
-                    UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH)
+                    UnHealthyContainerStates.CHECKSUM_MISMATCH)
             .getOrDefault(CONTAINER_COUNT, 0L));
 
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -388,7 +388,7 @@ public class TestContainerHealthTaskRecordGenerator {
                     unhealthyContainerStateStatsMap);
     assertEquals(0, records.size());
     assertEquals(0, unhealthyContainerStateStatsMap.get(
-                    UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH)
+                    UnHealthyContainerStates.CHECKSUM_MISMATCH)
             .getOrDefault(CONTAINER_COUNT, 0L));
 
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -695,7 +695,7 @@ public class TestContainerHealthTaskRecordGenerator {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-        UnHealthyContainerStates.DATA_CHECKSUM_MISMATCH, new HashMap<>());
+        UnHealthyContainerStates.CHECKSUM_MISMATCH, new HashMap<>());
   }
 
   private void logUnhealthyContainerStats(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -362,8 +362,8 @@ public class TestContainerHealthTaskRecordGenerator {
     logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
     initializeUnhealthyContainerStateStatsMap(unhealthyContainerStateStatsMap);
 
-    // Data checksum mismatch
-    replicas = generateDataChecksumMismatchedReplicas(container, CLOSED, CLOSED, CLOSED);
+    // Replica mismatch
+    replicas = generateMismatchedReplicas(container, CLOSED, CLOSED, CLOSED);
     status =
             new ContainerHealthStatus(container, replicas, placementPolicy,
                     reconContainerMetadataManager, CONF);
@@ -379,7 +379,7 @@ public class TestContainerHealthTaskRecordGenerator {
     initializeUnhealthyContainerStateStatsMap(unhealthyContainerStateStatsMap);
 
     // Same data checksum replicas
-    replicas = generateSameDataChecksumReplicas(container, CLOSED, CLOSED, CLOSED);
+    replicas = generateReplicas(container, CLOSED, CLOSED, CLOSED);
     status =
             new ContainerHealthStatus(container, replicas, placementPolicy,
                     reconContainerMetadataManager, CONF);
@@ -644,37 +644,24 @@ public class TestContainerHealthTaskRecordGenerator {
           .setContainerID(cont.containerID())
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
           .setContainerState(s)
+          .setDataChecksum(1234L)
           .build());
     }
     return replicas;
   }
 
-  private Set<ContainerReplica> generateDataChecksumMismatchedReplicas(ContainerInfo cont,
-                                                                       ContainerReplicaProto.State...states) {
+  private Set<ContainerReplica> generateMismatchedReplicas(ContainerInfo cont,
+                                                 ContainerReplicaProto.State...states) {
     Set<ContainerReplica> replicas = new HashSet<>();
-    long dataChecksum = 10L;
+    long checksum = 1234L;
     for (ContainerReplicaProto.State s : states) {
       replicas.add(new ContainerReplica.ContainerReplicaBuilder()
-              .setContainerID(cont.containerID())
-              .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
-              .setContainerState(s)
-              .setDataChecksum(dataChecksum)
-              .build());
-      dataChecksum++;
-    }
-    return replicas;
-  }
-
-  private Set<ContainerReplica> generateSameDataChecksumReplicas(ContainerInfo cont,
-                                                                       ContainerReplicaProto.State...states) {
-    Set<ContainerReplica> replicas = new HashSet<>();
-    for (ContainerReplicaProto.State s : states) {
-      replicas.add(new ContainerReplica.ContainerReplicaBuilder()
-              .setContainerID(cont.containerID())
-              .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
-              .setContainerState(s)
-              .setDataChecksum(10L)
-              .build());
+          .setContainerID(cont.containerID())
+          .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+          .setContainerState(s)
+          .setDataChecksum(checksum)
+          .build());
+      checksum++;
     }
     return replicas;
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -211,7 +211,7 @@ public class TestReconContainerManager
         .setUuid(uuid1).setHostName("host1").setIpAddress("127.0.0.1").build();
     ContainerReplica containerReplica1 = ContainerReplica.newBuilder()
         .setContainerID(containerID1).setContainerState(State.OPEN)
-        .setDatanodeDetails(datanodeDetails1).setSequenceId(1001L).build();
+        .setDatanodeDetails(datanodeDetails1).setSequenceId(1001L).setDataChecksum(1234L).build();
 
     final ReconContainerManager containerManager = getContainerManager();
     final Map<Long, Map<UUID, ContainerReplicaHistory>> repHistMap =
@@ -239,6 +239,7 @@ public class TestReconContainerManager
     assertEquals(repHist1.getLastSeenTime(), repHist1.getFirstSeenTime());
     assertEquals(containerReplica1.getSequenceId().longValue(),
         repHist1.getBcsId());
+    assertEquals(containerReplica1.getDataChecksum(), repHist1.getDataChecksum());
 
     // Let's update the entry again
     containerReplica1 = ContainerReplica.newBuilder()
@@ -257,7 +258,7 @@ public class TestReconContainerManager
         .setUuid(uuid2).setHostName("host2").setIpAddress("127.0.0.2").build();
     final ContainerReplica containerReplica2 = ContainerReplica.newBuilder()
         .setContainerID(containerID1).setContainerState(State.OPEN)
-        .setDatanodeDetails(datanodeDetails2).setSequenceId(1051L).build();
+        .setDatanodeDetails(datanodeDetails2).setSequenceId(1051L).setDataChecksum(1234L).build();
 
     // Add replica to DN02
     containerManager.updateContainerReplica(containerID1, containerReplica2);
@@ -271,6 +272,7 @@ public class TestReconContainerManager
     // Because this is a new entry, first seen time equals last seen time
     assertEquals(repHist2.getLastSeenTime(), repHist2.getFirstSeenTime());
     assertEquals(1051L, repHist2.getBcsId());
+    assertEquals(containerReplica2.getDataChecksum(), repHist2.getDataChecksum());
 
     // Remove replica from DN01
     containerManager.removeContainerReplica(containerID1, containerReplica1);


### PR DESCRIPTION
## What changes were proposed in this pull request?
#6506 introduced a new container replica field, `dataChecksum`, which will tell us a specific container replica's checksum. In this patch I'm adding the functionality in Recon to behave based on this value.

Recon already processes the container reports from the datanodes and based on these the `ContainerHealthTask` does certain things. It'll scan through the containers and mark containers unhealthy if needed (e.g. missing, under replicated, etc.). I'm introducing a new unhealthy container state in Recon, called `REPLICA_MISMATCH`. A container will be marked `REPLICA_MISMATCH` by Recon if at least one of their replicas data checksum is different from the others. 

To be able to tell which replica has which data checksum value, I added the `dataChecksum` field to ContainerReplicaHistoryProto as an optional field (just like in #4443 the `state` field). In the ContainerEndpoint when we are requesting the /unhealthy containers, we will be able to get the information for each replica ([here](https://github.com/apache/ozone/blob/189a9fe42013e82f93becaede627e509322c38f6/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java#L428)). 

This patch only does the backend changes, in the Recon UI we'll add the new table in [HDDS-12395](https://issues.apache.org/jira/browse/HDDS-12395).

As I'm adding a new unhealthy container state in Recon, it'll introduce a new state in that column in the DB (where Recon maintains the unhealthy containers). With the help of the Recon Schema Versioning I added a new upgrade action, `UnhealthyContainerReplicaMismatchAction`, to handle this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11887

## How was this patch tested?

Updated and added new unit tests: https://github.com/dombizita/ozone/actions/runs/13454086954
