### PR TITLE
HDDS-12397. Persist putBlock for closed container.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1103,9 +1103,9 @@ public class KeyValueHandler extends Handler {
    * @param kvContainer           - Container for which block data need to be persisted.
    * @param blockData             - Block Data to be persisted (BlockData should have the chunks).
    * @param blockCommitSequenceId - Block Commit Sequence ID for the block.
-   * @param overwriteBscId        - To overwrite bcsId in the block data. In case of chunk failure during
-   *                              reconciliation, we do not want to overwrite the bcsId as this block is
-   *                              incomplete in its current state.
+   * @param overwriteBscId        - To overwrite bcsId in the block data and container. In case of chunk failure
+   *                              during reconciliation, we do not want to overwrite the bcsId as this block/container
+   *                              is incomplete in its current state.
    */
   public void putBlockForClosedContainer(KeyValueContainer kvContainer, BlockData blockData,
                                          long blockCommitSequenceId, boolean overwriteBscId)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1099,7 +1099,12 @@ public class KeyValueHandler extends Handler {
 
   /**
    * Handle Put Block operation for closed container. Calls BlockManager to process the request.
-   *
+   * This is primarily used by container reconciliation process to persist the block data for closed container.
+   * @param kvContainer - Container for which block data need to be persisted.
+   * @param blockData - Block Data to be persisted (BlockData should have the chunks).
+   * @param blockCommitSequenceId - Block Commit Sequence ID for the block.
+   * @param overwriteBscId - To overwrite bcsId in the block data. In case of chunk failure during reconciliation,
+   *                      we do not want to overwrite the bcsId as this block is incomplete in its current state.
    */
   public void putBlockForClosedContainer(KeyValueContainer kvContainer, BlockData blockData,
                                          long blockCommitSequenceId, boolean overwriteBscId)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1100,11 +1100,12 @@ public class KeyValueHandler extends Handler {
   /**
    * Handle Put Block operation for closed container. Calls BlockManager to process the request.
    * This is primarily used by container reconciliation process to persist the block data for closed container.
-   * @param kvContainer - Container for which block data need to be persisted.
-   * @param blockData - Block Data to be persisted (BlockData should have the chunks).
+   * @param kvContainer           - Container for which block data need to be persisted.
+   * @param blockData             - Block Data to be persisted (BlockData should have the chunks).
    * @param blockCommitSequenceId - Block Commit Sequence ID for the block.
-   * @param overwriteBscId - To overwrite bcsId in the block data. In case of chunk failure during reconciliation,
-   *                      we do not want to overwrite the bcsId as this block is incomplete in its current state.
+   * @param overwriteBscId        - To overwrite bcsId in the block data. In case of chunk failure during
+   *                              reconciliation, we do not want to overwrite the bcsId as this block is
+   *                              incomplete in its current state.
    */
   public void putBlockForClosedContainer(KeyValueContainer kvContainer, BlockData blockData,
                                          long blockCommitSequenceId, boolean overwriteBscId)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1101,9 +1101,9 @@ public class KeyValueHandler extends Handler {
    * Handle Put Block operation for closed container. Calls BlockManager to process the request.
    *
    */
-  public void putBlockForClosedContainer(List<ContainerProtos.ChunkInfo> chunkInfos, KeyValueContainer kvContainer,
-                                          BlockData blockData, long blockCommitSequenceId)
-      throws IOException {
+  public void putBlockForClosedContainer(KeyValueContainer kvContainer, BlockData blockData,
+                                         long blockCommitSequenceId, boolean overwriteBscId)
+          throws IOException {
     Preconditions.checkNotNull(kvContainer);
     Preconditions.checkNotNull(blockData);
     long startTime = Time.monotonicNowNanos();
@@ -1112,11 +1112,12 @@ public class KeyValueHandler extends Handler {
       throw new IOException("Container #" + kvContainer.getContainerData().getContainerID() +
           " is not in closed state, Container state is " + kvContainer.getContainerState());
     }
-    blockData.setChunks(chunkInfos);
     // To be set from the Replica's BCSId
-    blockData.setBlockCommitSequenceId(blockCommitSequenceId);
+    if (overwriteBscId) {
+      blockData.setBlockCommitSequenceId(blockCommitSequenceId);
+    }
 
-    blockManager.putBlock(kvContainer, blockData, false);
+    blockManager.putBlockForClosedContainer(kvContainer, blockData, overwriteBscId);
     ContainerProtos.BlockData blockDataProto = blockData.getProtoBufMessage();
     final long numBytes = blockDataProto.getSerializedSize();
     // Increment write stats for PutBlock after write.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -126,7 +126,7 @@ public class BlockManagerImpl implements BlockManager {
       // update the blockData as well as BlockCommitSequenceId here
       try (BatchOperation batch = db.getStore().getBatchHandler()
           .initBatchOperation()) {
-        // If block exists in cache, blockCount should not be incremented.
+        // If block already exists in the DB, blockCount should not be incremented.
         if (db.getStore().getBlockDataTable().get(containerData.getBlockKey(localID)) == null) {
           // Block does not exist in DB => blockCount needs to be
           // incremented when the block is added into DB.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -144,7 +144,6 @@ public class BlockManagerImpl implements BlockManager {
         // block length is used, And also on restart the blocks committed to DB
         // is only used to compute the bytes used. This is done to keep the
         // current behavior and avoid DB write during write chunk operation.
-        // Write UTs for this
         db.getStore().getMetadataTable().putWithBatch(batch, containerData.getBytesUsedKey(),
             containerData.getBytesUsed());
 
@@ -440,19 +439,6 @@ public class BlockManagerImpl implements BlockManager {
       }
     } finally {
       container.readUnlock();
-    }
-  }
-
-  @Override
-  public boolean blockExists(Container container, BlockID blockID) throws IOException {
-    KeyValueContainerData containerData = (KeyValueContainerData) container
-        .getContainerData();
-    try (DBHandle db = BlockUtils.getDB(containerData, config)) {
-      // This is a post condition that acts as a hint to the user.
-      // Should never fail.
-      Preconditions.checkNotNull(db, DB_NULL_ERR_MSG);
-      String blockKey = containerData.getBlockKey(blockID.getLocalID());
-      return db.getStore().getBlockDataTable().isExist(blockKey);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -150,7 +150,7 @@ public class FilePerBlockStrategy implements ChunkManager {
         .getContainerData();
 
     final File chunkFile = getChunkFile(container, blockID);
-    long len = info.getLen();
+    long chunkLength = info.getLen();
     long offset = info.getOffset();
 
     HddsVolume volume = containerData.getVolume();
@@ -183,19 +183,19 @@ public class FilePerBlockStrategy implements ChunkManager {
           + chunkFile.getName(), CHUNK_FILE_INCONSISTENCY);
     }
 
-    ChunkUtils.writeData(channel, chunkFile.getName(), data, offset, len, volume);
+    ChunkUtils.writeData(channel, chunkFile.getName(), data, offset, chunkLength, volume);
 
     // When overwriting, update the bytes used if the new length is greater than the old length
     // This is to ensure that the bytes used is updated correctly when overwriting a smaller chunk
     // with a larger chunk at the end of the block.
     if (overwrite) {
-      long fileLengthAfterWrite = offset + len;
+      long fileLengthAfterWrite = offset + chunkLength;
       if (fileLengthAfterWrite > fileLengthBeforeWrite) {
         containerData.incrBytesUsed(fileLengthAfterWrite - fileLengthBeforeWrite);
       }
     }
 
-    containerData.updateWriteStats(len, overwrite);
+    containerData.updateWriteStats(chunkLength, overwrite);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -179,15 +179,15 @@ public class FilePerBlockStrategy implements ChunkManager {
     try {
       fileLengthBeforeWrite = channel.size();
     } catch (IOException e) {
-      throw new StorageContainerException("IO error encountered while " +
-          "getting the file size for " + chunkFile.getName(), CHUNK_FILE_INCONSISTENCY);
+      throw new StorageContainerException("Encountered an error while getting the file size for "
+          + chunkFile.getName(), CHUNK_FILE_INCONSISTENCY);
     }
 
     ChunkUtils.writeData(channel, chunkFile.getName(), data, offset, len, volume);
 
     // When overwriting, update the bytes used if the new length is greater than the old length
     // This is to ensure that the bytes used is updated correctly when overwriting a smaller chunk
-    // with a larger chunk.
+    // with a larger chunk at the end of the block.
     if (overwrite) {
       long fileLengthAfterWrite = offset + len;
       if (fileLengthAfterWrite > fileLengthBeforeWrite) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -50,6 +50,17 @@ public interface BlockManager {
       throws IOException;
 
   /**
+   * Puts or overwrites a block to a closed container.
+   *
+   * @param container - Container for which block need to be added.
+   * @param data - Block Data.
+   * @param overwriteBcsId - To overwrite bcsId in the block data.
+   * @return length of the Block.
+   */
+  long putBlockForClosedContainer(Container container, BlockData data, boolean overwriteBcsId)
+          throws IOException;
+
+  /**
    * Gets an existing block.
    *
    * @param container - Container from which block needs to be fetched.
@@ -78,6 +89,15 @@ public interface BlockManager {
    */
   List<BlockData> listBlock(Container container, long startLocalID, int count)
       throws IOException;
+
+  /**
+   * Check if a block exists in the container.
+   *
+   * @param container - Container from which blocks need to be listed.
+   * @param blockID - BlockID of the Block.
+   * @return True if block exists, false otherwise.
+   */
+  boolean blockExists(Container container, BlockID blockID) throws IOException;
 
   /**
    * Returns last committed length of the block.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -59,7 +59,7 @@ public interface BlockManager {
    *
    * @param container      - Container for which block data need to be persisted.
    * @param data           - Block Data to be persisted (BlockData should have the chunks).
-   * @param overwriteBcsId - To overwrite bcsId of the block and container.
+   * @param overwriteBcsId - To overwrite bcsId of the container.
    */
   long putBlockForClosedContainer(Container container, BlockData data, boolean overwriteBcsId)
           throws IOException;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -18,10 +18,13 @@
 package org.apache.hadoop.ozone.container.keyvalue.interfaces;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 
 /**
  * BlockManager is for performing key related operations on the container.
@@ -50,12 +53,13 @@ public interface BlockManager {
       throws IOException;
 
   /**
-   * Puts or overwrites a block to a closed container.
+   * Persists the block data for a closed container. The block data should have all the chunks and bcsId.
+   * Overwrites the block if it already exists, The container's used bytes should be updated by the caller with
+   * {@link ChunkManager#writeChunk(Container, BlockID, ChunkInfo, ByteBuffer, DispatcherContext)}.
    *
-   * @param container - Container for which block need to be added.
-   * @param data - Block Data.
-   * @param overwriteBcsId - To overwrite bcsId in the block data.
-   * @return length of the Block.
+   * @param container      - Container for which block data need to be persisted.
+   * @param data           - Block Data to be persisted (BlockData should have the chunks).
+   * @param overwriteBcsId - To overwrite bcsId of the block and container.
    */
   long putBlockForClosedContainer(Container container, BlockData data, boolean overwriteBcsId)
           throws IOException;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -91,15 +91,6 @@ public interface BlockManager {
       throws IOException;
 
   /**
-   * Check if a block exists in the container.
-   *
-   * @param container - Container from which blocks need to be listed.
-   * @param blockID - BlockID of the Block.
-   * @return True if block exists, false otherwise.
-   */
-  boolean blockExists(Container container, BlockID blockID) throws IOException;
-
-  /**
    * Returns last committed length of the block.
    *
    * @param container - Container from which block need to be fetched.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -251,7 +251,7 @@ public class TestBlockManagerImpl {
       assertEquals(2, db.getStore().getMetadataTable().get(containerData.getBcsIdKey()));
 
       // 4. Put Block with bcsId = 1 < container bcsId, Overwrite BCS ID = true
-      // We are overwriting an existing block with lower bcsId than container bcdId. Container bcsId should not change
+      // We are overwriting an existing block with lower bcsId than container bcsId. Container bcsId should not change
       BlockData blockData3 = createBlockData(1L, 1L, 1, 0, 2048, 1);
       blockManager.putBlockForClosedContainer(keyValueContainer, blockData3, true);
       fromGetBlockData = blockManager.getBlock(keyValueContainer, blockData3.getBlockID());
@@ -261,7 +261,8 @@ public class TestBlockManagerImpl {
       assertEquals(3, db.getStore().getMetadataTable().get(containerData.getBlockCountKey()));
       assertEquals(2, db.getStore().getMetadataTable().get(containerData.getBcsIdKey()));
 
-      // Used Bytes is only update by writeChunk, so it should be 0 here.
+      // writeChunk updates the in-memory state of the used bytes, putBlock persists the in-memory state to the DB.
+      // We are only doing putBlock without writeChunk, the used bytes should be 0.
       assertEquals(0, db.getStore().getMetadataTable().get(containerData.getBytesUsedKey()));
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -236,7 +236,7 @@ public class TestBlockManagerImpl {
       assertEquals(1, db.getStore().getMetadataTable().get(containerData.getBcsIdKey()));
 
       // 3. Put Block with bcsId = 2, Overwrite = true
-      // This should succeed as we are overwriting the BcsId, The container BcsId should be updated to 3
+      // This should succeed as we are overwriting the BcsId, The container BcsId should be updated to 2
       // The block count should not change.
       blockManager.putBlockForClosedContainer(keyValueContainer, blockData2, true);
       fromGetBlockData = blockManager.getBlock(keyValueContainer, blockData2.getBlockID());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -50,6 +51,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -194,6 +196,52 @@ public class TestBlockManagerImpl {
     assertEquals(blockData.getMetadata().size(), fromGetBlockData.getMetadata()
         .size());
 
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testPutBlockForClosed(ContainerTestVersionInfo versionInfo)
+      throws Exception {
+    initTest(versionInfo);
+    assertEquals(0, keyValueContainer.getContainerData().getBlockCount());
+    // 1. Put Block with bcsId = 2, Overwrite = true
+    blockManager.putBlockForClosedContainer(keyValueContainer, blockData1, true);
+
+    BlockData fromGetBlockData;
+    //Check Container's bcsId
+    fromGetBlockData = blockManager.getBlock(keyValueContainer, blockData1.getBlockID());
+    assertEquals(1, keyValueContainer.getContainerData().getBlockCount());
+    assertEquals(1, keyValueContainer.getContainerData().getBlockCommitSequenceId());
+    assertEquals(1, fromGetBlockData.getBlockCommitSequenceId());
+
+    // 2. Put Block with bcsId = 3, Overwrite = false
+    BlockData blockData2 = createBlockData(1L, 3L, 1, 0, 2048, 2);
+    blockManager.putBlockForClosedContainer(keyValueContainer, blockData2, false);
+
+    // The block should be written, but we won't be able to read it, As BcsId < container's BcsId
+    // fails during block read.
+    Assertions.assertThrows(StorageContainerException.class, () -> blockManager
+        .getBlock(keyValueContainer, blockData2.getBlockID()));
+    assertEquals(2, keyValueContainer.getContainerData().getBlockCount());
+    // BcsId should still be 1, as the BcsId is not overwritten
+    assertEquals(1, keyValueContainer.getContainerData().getBlockCommitSequenceId());
+
+    // 3. Put Block with bcsId = 3, Overwrite = true
+    // This should succeed as we are overwriting the BcsId, The container BcsId should be updated to 3
+    // The block count should not change.
+    blockManager.putBlockForClosedContainer(keyValueContainer, blockData2, true);
+    fromGetBlockData = blockManager.getBlock(keyValueContainer, blockData2.getBlockID());
+    assertEquals(2, keyValueContainer.getContainerData().getBlockCount());
+    assertEquals(2, keyValueContainer.getContainerData().getBlockCommitSequenceId());
+    assertEquals(2, fromGetBlockData.getBlockCommitSequenceId());
+
+    // 4. Put Block with bcsId = 1 < container bcsId, Overwrite = true
+    // Container bcsId should not change
+    BlockData blockData3 = createBlockData(1L, 1L, 1, 0, 2048, 1);
+    blockManager.putBlockForClosedContainer(keyValueContainer, blockData3, true);
+    fromGetBlockData = blockManager.getBlock(keyValueContainer, blockData3.getBlockID());
+    assertEquals(3, keyValueContainer.getContainerData().getBlockCount());
+    assertEquals(2, keyValueContainer.getContainerData().getBlockCommitSequenceId());
+    assertEquals(1, fromGetBlockData.getBlockCommitSequenceId());
   }
 
   @ContainerTestVersionInfo.ContainerTest

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
@@ -225,38 +225,70 @@ public class TestFilePerBlockStrategy extends CommonChunkManagerTestCases {
     containerSet.addContainer(kvContainer);
     KeyValueHandler keyValueHandler = createKeyValueHandler(containerSet);
     List<ContainerProtos.ChunkInfo> chunkInfoList = new ArrayList<>();
-    chunkInfoList.add(getChunkInfo().getProtoBufMessage());
+    ChunkInfo info = new ChunkInfo(String.format("%d.data.%d", getBlockID().getLocalID(), 0), 0L, 20L);
+
+    chunkInfoList.add(info.getProtoBufMessage());
     BlockData putBlockData = new BlockData(getBlockID());
     putBlockData.setChunks(chunkInfoList);
+
+    ChunkBuffer chunkData = ContainerTestHelper.getData(20);
+    keyValueHandler.writeChunkForClosedContainer(info, getBlockID(), chunkData, kvContainer);
     keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 1L, true);
-    Assertions.assertEquals(containerData.getBlockCommitSequenceId(), 1L);
-    Assertions.assertEquals(containerData.getBlockCount(), 1L);
+    assertEquals(1L, containerData.getBlockCommitSequenceId());
+    assertEquals(1L, containerData.getBlockCount());
 
     try (DBHandle dbHandle = BlockUtils.getDB(containerData, new OzoneConfiguration())) {
       long localID = putBlockData.getLocalID();
       BlockData getBlockData = dbHandle.getStore().getBlockDataTable()
           .get(containerData.getBlockKey(localID));
       Assertions.assertTrue(blockDataEquals(putBlockData, getBlockData));
+      // Overwriting the same
+      assertEquals(20L, containerData.getBytesUsed());
+      assertEquals(20L, dbHandle.getStore().getMetadataTable().get(containerData.getBytesUsedKey()));
     }
 
     // Add another chunk and check the put block data
-    ChunkInfo newChunkInfo = new ChunkInfo(String.format("%d.data.%d", getBlockID()
-        .getLocalID(), 1L), 0, 20L);
+    ChunkInfo newChunkInfo = new ChunkInfo(String.format("%d.data.%d", getBlockID().getLocalID(), 1L), 20L, 20L);
     chunkInfoList.add(newChunkInfo.getProtoBufMessage());
     putBlockData.setChunks(chunkInfoList);
+
+    chunkData = ContainerTestHelper.getData(20);
+    keyValueHandler.writeChunkForClosedContainer(newChunkInfo, getBlockID(), chunkData, kvContainer);
     keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 2L, true);
-    Assertions.assertEquals(containerData.getBlockCommitSequenceId(), 2L);
-    Assertions.assertEquals(containerData.getBlockCount(), 1L);
+    assertEquals(2L, containerData.getBlockCommitSequenceId());
+    assertEquals(1L, containerData.getBlockCount());
 
     try (DBHandle dbHandle = BlockUtils.getDB(containerData, new OzoneConfiguration())) {
       long localID = putBlockData.getLocalID();
       BlockData getBlockData = dbHandle.getStore().getBlockDataTable()
           .get(containerData.getBlockKey(localID));
       Assertions.assertTrue(blockDataEquals(putBlockData, getBlockData));
+      assertEquals(40L, containerData.getBytesUsed());
+      assertEquals(40L, dbHandle.getStore().getMetadataTable().get(containerData.getBytesUsedKey()));
+    }
+
+    newChunkInfo = new ChunkInfo(String.format("%d.data.%d", getBlockID().getLocalID(), 1L), 20L, 30L);
+    chunkInfoList.remove(chunkInfoList.size() - 1);
+    chunkInfoList.add(newChunkInfo.getProtoBufMessage());
+    putBlockData.setChunks(chunkInfoList);
+
+    chunkData = ContainerTestHelper.getData(30);
+    keyValueHandler.writeChunkForClosedContainer(newChunkInfo, getBlockID(), chunkData, kvContainer);
+    keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 2L, true);
+    assertEquals(2L, containerData.getBlockCommitSequenceId());
+    assertEquals(1L, containerData.getBlockCount());
+
+    try (DBHandle dbHandle = BlockUtils.getDB(containerData, new OzoneConfiguration())) {
+      long localID = putBlockData.getLocalID();
+      BlockData getBlockData = dbHandle.getStore().getBlockDataTable()
+          .get(containerData.getBlockKey(localID));
+      Assertions.assertTrue(blockDataEquals(putBlockData, getBlockData));
+      assertEquals(50L, containerData.getBytesUsed());
+      assertEquals(50L, dbHandle.getStore().getMetadataTable().get(containerData.getBytesUsedKey()));
     }
 
     keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 2L, true);
-    Assertions.assertEquals(containerData.getBlockCommitSequenceId(), 2L);
+    assertEquals(2L, containerData.getBlockCommitSequenceId());
   }
 
   private boolean blockDataEquals(BlockData putBlockData, BlockData getBlockData) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
@@ -164,8 +164,8 @@ public class TestFilePerBlockStrategy extends CommonChunkManagerTestCases {
     ChunkBuffer.wrap(getData());
     Assertions.assertThrows(IOException.class, () -> keyValueHandler.writeChunkForClosedContainer(
         getChunkInfo(), getBlockID(), ChunkBuffer.wrap(getData()), keyValueContainer));
-    Assertions.assertThrows(IOException.class, () -> keyValueHandler.putBlockForClosedContainer(
-        null, keyValueContainer, new BlockData(getBlockID()), 0L));
+    Assertions.assertThrows(IOException.class, () -> keyValueHandler.putBlockForClosedContainer(keyValueContainer,
+            new BlockData(getBlockID()), 0L, true));
   }
 
   @Test
@@ -227,7 +227,8 @@ public class TestFilePerBlockStrategy extends CommonChunkManagerTestCases {
     List<ContainerProtos.ChunkInfo> chunkInfoList = new ArrayList<>();
     chunkInfoList.add(getChunkInfo().getProtoBufMessage());
     BlockData putBlockData = new BlockData(getBlockID());
-    keyValueHandler.putBlockForClosedContainer(chunkInfoList, kvContainer, putBlockData, 1L);
+    putBlockData.setChunks(chunkInfoList);
+    keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 1L, true);
     Assertions.assertEquals(containerData.getBlockCommitSequenceId(), 1L);
     Assertions.assertEquals(containerData.getBlockCount(), 1L);
 
@@ -242,7 +243,8 @@ public class TestFilePerBlockStrategy extends CommonChunkManagerTestCases {
     ChunkInfo newChunkInfo = new ChunkInfo(String.format("%d.data.%d", getBlockID()
         .getLocalID(), 1L), 0, 20L);
     chunkInfoList.add(newChunkInfo.getProtoBufMessage());
-    keyValueHandler.putBlockForClosedContainer(chunkInfoList, kvContainer, putBlockData, 2L);
+    putBlockData.setChunks(chunkInfoList);
+    keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 2L, true);
     Assertions.assertEquals(containerData.getBlockCommitSequenceId(), 2L);
     Assertions.assertEquals(containerData.getBlockCount(), 1L);
 
@@ -253,8 +255,7 @@ public class TestFilePerBlockStrategy extends CommonChunkManagerTestCases {
       Assertions.assertTrue(blockDataEquals(putBlockData, getBlockData));
     }
 
-    // Put block on bcsId <= containerBcsId should be a no-op
-    keyValueHandler.putBlockForClosedContainer(chunkInfoList, kvContainer, putBlockData, 2L);
+    keyValueHandler.putBlockForClosedContainer(kvContainer, putBlockData, 2L, true);
     Assertions.assertEquals(containerData.getBlockCommitSequenceId(), 2L);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `putBlock` call for `OPEN` container cannot be used for the `CLOSED` container and needs some modification to update `bscId` and remove changes that are only applicable to `OPEN` container such a pending put block cache, hsync support. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12397

## How was this patch tested?
Added Unit Test.
