### PR TITLE
HDDS-12411. Make hdds-client compliant with PMD.FieldDeclarationsShouldBeAtStartOfClass

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -35,20 +35,7 @@ import org.slf4j.LoggerFactory;
 @ConfigGroup(prefix = "ozone.client")
 public class OzoneClientConfig {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(OzoneClientConfig.class);
-
-  /**
-   * Enum for indicating what mode to use when combining chunk and block
-   * checksums to define an aggregate FileChecksum. This should be considered
-   * a client-side runtime option rather than a persistent property of any
-   * stored metadata, which is why this is not part of ChecksumOpt, which
-   * deals with properties of files at rest.
-   */
-  public enum ChecksumCombineMode {
-    MD5MD5CRC,  // MD5 of block checksums, which are MD5 over chunk CRCs
-    COMPOSITE_CRC  // Block/chunk-independent composite CRC
-  }
+  private static final Logger LOG = LoggerFactory.getLogger(OzoneClientConfig.class);
 
   @Config(key = "stream.buffer.flush.size",
       defaultValue = "16MB",
@@ -558,5 +545,17 @@ public class OzoneClientConfig {
 
   public int getMaxConcurrentWritePerKey() {
     return this.maxConcurrentWritePerKey;
+  }
+
+  /**
+   * Enum for indicating what mode to use when combining chunk and block
+   * checksums to define an aggregate FileChecksum. This should be considered
+   * a client-side runtime option rather than a persistent property of any
+   * stored metadata, which is why this is not part of ChecksumOpt, which
+   * deals with properties of files at rest.
+   */
+  public enum ChecksumCombineMode {
+    MD5MD5CRC,  // MD5 of block checksums, which are MD5 over chunk CRCs
+    COMPOSITE_CRC  // Block/chunk-independent composite CRC
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientCreator.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientCreator.java
@@ -32,10 +32,6 @@ import org.apache.hadoop.ozone.OzoneSecurityUtil;
 public class XceiverClientCreator implements XceiverClientFactory {
   private static ErrorInjector errorInjector;
 
-  public static void enableErrorInjection(ErrorInjector injector) {
-    errorInjector = injector;
-  }
-
   private final ConfigurationSource conf;
   private final boolean topologyAwareRead;
   private final ClientTrustManager trustManager;
@@ -55,6 +51,10 @@ public class XceiverClientCreator implements XceiverClientFactory {
     if (securityEnabled) {
       Preconditions.checkNotNull(trustManager);
     }
+  }
+
+  public static void enableErrorInjection(ErrorInjector injector) {
+    errorInjector = injector;
   }
 
   public boolean isSecurityEnabled() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -70,28 +70,7 @@ import org.slf4j.LoggerFactory;
  * The underlying RPC mechanism can be chosen via the constructor.
  */
 public final class XceiverClientRatis extends XceiverClientSpi {
-  public static final Logger LOG =
-      LoggerFactory.getLogger(XceiverClientRatis.class);
-
-  public static XceiverClientRatis newXceiverClientRatis(
-      org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
-      ConfigurationSource ozoneConf) {
-    return newXceiverClientRatis(pipeline, ozoneConf, null, null);
-  }
-
-  public static XceiverClientRatis newXceiverClientRatis(
-      org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
-      ConfigurationSource ozoneConf, ClientTrustManager trustManager, ErrorInjector errorInjector) {
-    final String rpcType = ozoneConf
-        .get(ScmConfigKeys.HDDS_CONTAINER_RATIS_RPC_TYPE_KEY,
-            ScmConfigKeys.HDDS_CONTAINER_RATIS_RPC_TYPE_DEFAULT);
-    final RetryPolicy retryPolicy = RatisHelper.createRetryPolicy(ozoneConf);
-    final GrpcTlsConfig tlsConfig = RatisHelper.createTlsClientConfig(new
-        SecurityConfig(ozoneConf), trustManager);
-    return new XceiverClientRatis(pipeline,
-        SupportedRpcType.valueOfIgnoreCase(rpcType),
-        retryPolicy, tlsConfig, ozoneConf, errorInjector);
-  }
+  public static final Logger LOG = LoggerFactory.getLogger(XceiverClientRatis.class);
 
   private final Pipeline pipeline;
   private final RpcType rpcType;
@@ -141,6 +120,26 @@ public final class XceiverClientRatis extends XceiverClientSpi {
           new Throwable("TRACE"));
     }
     this.errorInjector = errorInjector;
+  }
+
+  public static XceiverClientRatis newXceiverClientRatis(
+      org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
+      ConfigurationSource ozoneConf) {
+    return newXceiverClientRatis(pipeline, ozoneConf, null, null);
+  }
+
+  public static XceiverClientRatis newXceiverClientRatis(
+      org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
+      ConfigurationSource ozoneConf, ClientTrustManager trustManager, ErrorInjector errorInjector) {
+    final String rpcType = ozoneConf
+        .get(ScmConfigKeys.HDDS_CONTAINER_RATIS_RPC_TYPE_KEY,
+            ScmConfigKeys.HDDS_CONTAINER_RATIS_RPC_TYPE_DEFAULT);
+    final RetryPolicy retryPolicy = RatisHelper.createRetryPolicy(ozoneConf);
+    final GrpcTlsConfig tlsConfig = RatisHelper.createTlsClientConfig(new
+        SecurityConfig(ozoneConf), trustManager);
+    return new XceiverClientRatis(pipeline,
+        SupportedRpcType.valueOfIgnoreCase(rpcType),
+        retryPolicy, tlsConfig, ozoneConf, errorInjector);
   }
 
   private long updateCommitInfosMap(RaftClientReply reply, RaftProtos.ReplicationLevel level) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -48,10 +48,6 @@ import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
 public final class HddsClientUtils {
-
-  private HddsClientUtils() {
-  }
-
   private static final List<Class<? extends Exception>> EXCEPTION_LIST =
       ImmutableList.<Class<? extends Exception>>builder()
           .add(TimeoutException.class)
@@ -63,6 +59,9 @@ public final class HddsClientUtils {
           // does not succeed
           .add(NotReplicatedException.class)
           .build();
+
+  private HddsClientUtils() {
+  }
 
   private static void doNameChecks(String resName, String resType) {
     if (resName == null) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -62,8 +62,10 @@ import org.slf4j.LoggerFactory;
  */
 public class BlockInputStream extends BlockExtendedInputStream {
 
-  public static final Logger LOG =
-      LoggerFactory.getLogger(BlockInputStream.class);
+  public static final Logger LOG = LoggerFactory.getLogger(BlockInputStream.class);
+
+  private static final List<Validator> VALIDATORS =
+      ContainerProtocolCalls.toValidatorList((request, response) -> validate(response));
 
   private final BlockID blockID;
   private long length;
@@ -299,10 +301,6 @@ public class BlockInputStream extends BlockExtendedInputStream {
         .build();
     pipelineRef.set(readPipeline);
   }
-
-  private static final List<Validator> VALIDATORS
-      = ContainerProtocolCalls.toValidatorList(
-          (request, response) -> validate(response));
 
   private static void validate(ContainerCommandResponseProto response)
       throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Code for the hdds-client made compliant with PMD.FieldDeclarationsShouldBeAtStartOfClass verification rule.
It is done before enabling the rule itself to prevent us reviewing a very huge PR. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12411

## How was this patch tested?

Patch tested using standard verification pipeline.