### PR TITLE
HDDS-12382. Fix other spotbugs warnings

### DIFF
--- a/hadoop-hdds/client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/client/dev-support/findbugsExcludeFile.xml
@@ -15,21 +15,10 @@
    limitations under the License.
 -->
 <FindBugsFilter>
-  <!-- Test -->
   <Match>
     <Class name="org.apache.hadoop.hdds.scm.storage.ByteArrayReader"></Class>
     <Bug pattern="EI_EXPOSE_REP2" /> <!-- "Deep copy byte[] has bad impact on performance" -->
   </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.storage.TestBufferPool"></Class>
-    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.storage.TestChunkInputStream"></Class>
-    <Bug pattern="RR_NOT_CHECKED" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.storage.TestBlockInputStream"></Class>
-    <Bug pattern="RR_NOT_CHECKED" />
-  </Match>
+
+  <!-- Test -->
 </FindBugsFilter>

--- a/hadoop-hdds/client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/client/dev-support/findbugsExcludeFile.xml
@@ -19,6 +19,4 @@
     <Class name="org.apache.hadoop.hdds.scm.storage.ByteArrayReader"></Class>
     <Bug pattern="EI_EXPOSE_REP2" /> <!-- "Deep copy byte[] has bad impact on performance" -->
   </Match>
-
-  <!-- Test -->
 </FindBugsFilter>

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -204,7 +204,8 @@ public class TestBlockInputStream {
     // the read should result in 3 ChunkInputStream reads
     seekAndVerify(50);
     byte[] b = new byte[200];
-    blockStream.read(b, 0, 200);
+    int bytesRead = blockStream.read(b, 0, 200);
+    assertEquals(200, bytesRead, "Expected to read 200 bytes");
     matchWithInputData(b, 50, 200);
 
     // The new position of the blockInputStream should be the last index read
@@ -252,12 +253,14 @@ public class TestBlockInputStream {
     // Seek to a position and read data
     seekAndVerify(50);
     byte[] b1 = new byte[100];
-    blockStream.read(b1, 0, 100);
+    int bytesRead1 = blockStream.read(b1, 0, 100);
+    assertEquals(100, bytesRead1, "Expected to read 100 bytes");
     matchWithInputData(b1, 50, 100);
 
     // Next read should start from the position of the last read + 1 i.e. 100
     byte[] b2 = new byte[100];
-    blockStream.read(b2, 0, 100);
+    int bytesRead2 = blockStream.read(b2, 0, 100);
+    assertEquals(100, bytesRead2, "Expected to read 100 bytes");
     matchWithInputData(b2, 150, 100);
   }
 
@@ -280,7 +283,8 @@ public class TestBlockInputStream {
       assertFalse(isRefreshed.get());
       seekAndVerify(50);
       byte[] b = new byte[200];
-      blockInputStreamWithRetry.read(b, 0, 200);
+      int bytesRead = blockInputStreamWithRetry.read(b, 0, 200);
+      assertEquals(200, bytesRead, "Expected to read 200 bytes");
       assertThat(logCapturer.getOutput()).contains("Retry read after");
       assertTrue(isRefreshed.get());
     }
@@ -388,7 +392,12 @@ public class TestBlockInputStream {
 
       // WHEN
       assertThrows(ex.getClass(),
-          () -> subject.read(new byte[len], 0, len));
+          () -> {
+            byte[] buffer = new byte[len];
+            int bytesRead = subject.read(buffer, 0, len);
+            // This line should never be reached due to the exception
+            assertEquals(len, bytesRead);
+          });
 
       // THEN
       verify(refreshFunction, never()).apply(blockID);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -133,7 +133,8 @@ public class TestChunkInputStream {
   @Test
   public void testFullChunkRead() throws Exception {
     byte[] b = new byte[CHUNK_SIZE];
-    chunkStream.read(b, 0, CHUNK_SIZE);
+    int bytesRead = chunkStream.read(b, 0, CHUNK_SIZE);
+    assertEquals(CHUNK_SIZE, bytesRead, "Expected to read full chunk size");
     matchWithInputData(b, 0, CHUNK_SIZE);
   }
 
@@ -142,7 +143,8 @@ public class TestChunkInputStream {
     int len = CHUNK_SIZE / 2;
     byte[] b = new byte[len];
 
-    chunkStream.read(b, 0, len);
+    int bytesRead = chunkStream.read(b, 0, len);
+    assertEquals(len, bytesRead, "Expected to read half chunk size");
 
     matchWithInputData(b, 0, len);
 
@@ -169,7 +171,8 @@ public class TestChunkInputStream {
     // copying chunk data from index 20 to 59 into the buffers (checksum
     // boundaries).
     byte[] b = new byte[30];
-    chunkStream.read(b, 0, 30);
+    int bytesRead = chunkStream.read(b, 0, 30);
+    assertEquals(30, bytesRead, "Expected to read 30 bytes");
     matchWithInputData(b, 25, 30);
     matchWithInputData(chunkStream.getReadByteBuffers(), 20, 40);
 
@@ -194,7 +197,8 @@ public class TestChunkInputStream {
     // released and hence chunkPosition updated with current position of chunk.
     seekAndVerify(25);
     b = new byte[15];
-    chunkStream.read(b, 0, 15);
+    int bytesRead2 = chunkStream.read(b, 0, 15);
+    assertEquals(15, bytesRead2, "Expected to read 15 bytes");
     matchWithInputData(b, 25, 15);
     assertEquals(40, chunkStream.getChunkPosition());
   }
@@ -204,19 +208,22 @@ public class TestChunkInputStream {
     // Seek to a position and read data
     seekAndVerify(50);
     byte[] b1 = new byte[20];
-    chunkStream.read(b1, 0, 20);
+    int bytesRead1 = chunkStream.read(b1, 0, 20);
+    assertEquals(20, bytesRead1, "Expected to read 20 bytes");
     matchWithInputData(b1, 50, 20);
 
     // Next read should start from the position of the last read + 1 i.e. 70
     byte[] b2 = new byte[20];
-    chunkStream.read(b2, 0, 20);
+    int bytesRead2 = chunkStream.read(b2, 0, 20);
+    assertEquals(20, bytesRead2, "Expected to read 20 bytes");
     matchWithInputData(b2, 70, 20);
   }
 
   @Test
   public void testUnbuffered() throws Exception {
     byte[] b1 = new byte[20];
-    chunkStream.read(b1, 0, 20);
+    int bytesRead = chunkStream.read(b1, 0, 20);
+    assertEquals(20, bytesRead, "Expected to read 20 bytes");
     matchWithInputData(b1, 0, 20);
 
     chunkStream.unbuffer();
@@ -225,7 +232,8 @@ public class TestChunkInputStream {
 
     // Next read should start from the position of the last read + 1 i.e. 20
     byte[] b2 = new byte[20];
-    chunkStream.read(b2, 0, 20);
+    int bytesRead2 = chunkStream.read(b2, 0, 20);
+    assertEquals(20, bytesRead2, "Expected to read 20 bytes");
     matchWithInputData(b2, 20, 20);
   }
 

--- a/hadoop-hdds/framework/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/framework/dev-support/findbugsExcludeFile.xml
@@ -21,12 +21,4 @@
   </Match>
 
   <!-- Test -->
-  <Match>
-    <Class name="org.apache.hadoop.hdds.server.http.TestRatisDropwizardExports"></Class>
-    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.utils.BufferedMetricsCollector$BufferedMetricsRecordBuilderImpl"></Class>
-    <Bug pattern="URF_UNREAD_FIELD" />
-  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/framework/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/framework/dev-support/findbugsExcludeFile.xml
@@ -19,6 +19,4 @@
     <Class name="org.apache.hadoop.hdds.utils.ProtocolMessageMetrics"></Class>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
   </Match>
-
-  <!-- Test -->
 </FindBugsFilter>

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -64,7 +64,7 @@ public class TestRatisDropwizardExports {
         new RatisDropwizardExports(dropWizardMetricRegistry);
 
     CollectorRegistry collector = new CollectorRegistry();
-    collector.register(new RatisDropwizardExports(dropWizardMetricRegistry));
+    collector.register(exports);
 
     //export metrics to the string
     StringWriter writer = new StringWriter();

--- a/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
@@ -18,6 +18,4 @@
   <Match>
     <Package name="org.apache.hadoop.hdds.protocol.proto"/>
   </Match>
-
-  <!-- Test -->
 </FindBugsFilter>

--- a/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
@@ -18,42 +18,6 @@
   <Match>
     <Package name="org.apache.hadoop.hdds.protocol.proto"/>
   </Match>
+
   <!-- Test -->
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.TestHddsServerUtil" />
-    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.TestStorageContainerManagerHttpServer" />
-    <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.block.TestBlockManager" />
-    <Bug pattern="REC_CATCH_EXCEPTION" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.container.MockNodeManager" />
-    <Bug pattern="URF_UNREAD_FIELD" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.node.TestDatanodeAdminMonitor" />
-    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.node.TestSCMNodeManager" />
-    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.server.TestSCMSecurityProtocolServer" />
-    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.metadata.TestSCMTransactionInfoCodec"/>
-    <Bug pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.container.replication.ReplicationManager"/>
-    <Field name="metrics" />
-    <Bug pattern="IS2_INCONSISTENT_SYNC" />
-  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -52,7 +52,7 @@ public class TestStorageContainerManagerHttpServer {
   @BeforeAll
   public static void setUp() throws Exception {
     File ozoneMetadataDirectory = new File(baseDir, "metadata");
-    ozoneMetadataDirectory.mkdirs();
+    assertTrue(ozoneMetadataDirectory.mkdirs());
     conf = new OzoneConfiguration();
     keystoresDir = baseDir.getAbsolutePath();
     sslConfDir = KeyStoreTestUtil.getClasspathDir(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -1643,8 +1643,8 @@ public class TestSCMNodeManager {
         Thread.sleep(100);
       }
 
-      final long expectedScmUsed = usedPerHeartbeat * (heartbeatCount - 1);
-      final long expectedRemaining = capacity - expectedScmUsed;
+      long expectedScmUsed = usedPerHeartbeat * (heartbeatCount - 1);
+      long expectedRemaining = capacity - expectedScmUsed;
 
       GenericTestUtils.waitFor(
           () -> nodeManager.getStats().getScmUsed().get() == expectedScmUsed,

--- a/hadoop-ozone/httpfsgateway/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/httpfsgateway/dev-support/findbugsExcludeFile.xml
@@ -35,7 +35,6 @@
     <Method name="closeFileSystem" />
     <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
   </Match>
-  <Match>
-    <Source name="~.*Test.*\.java" />
-  </Match>
+
+  <!-- Test -->
 </FindBugsFilter>

--- a/hadoop-ozone/httpfsgateway/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/httpfsgateway/dev-support/findbugsExcludeFile.xml
@@ -35,6 +35,4 @@
     <Method name="closeFileSystem" />
     <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
   </Match>
-
-  <!-- Test -->
 </FindBugsFilter>

--- a/hadoop-ozone/httpfsgateway/src/test/java/org/apache/ozone/fs/http/server/metrics/TestHttpFSMetrics.java
+++ b/hadoop-ozone/httpfsgateway/src/test/java/org/apache/ozone/fs/http/server/metrics/TestHttpFSMetrics.java
@@ -19,6 +19,7 @@ package org.apache.ozone.fs.http.server.metrics;
 
 import static org.apache.ozone.lib.service.hadoop.FileSystemAccessService.FILE_SYSTEM_SERVICE_CREATED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,8 +49,12 @@ import org.junit.jupiter.api.io.TempDir;
  * Test class for HttpFSServerMetrics.
  */
 public class TestHttpFSMetrics {
-  private static final FileSystem mockFs = mock(FileSystem.class);
-  private static final FSDataOutputStream fsDataOutputStream = mock(FSDataOutputStream.class);
+  private static FileSystem mockFs = mock(FileSystem.class);
+  private static FSDataOutputStream fsDataOutputStream = mock(FSDataOutputStream.class);
+
+  /**
+   * Mock FileSystemAccessService.
+   */
   public static class MockFileSystemAccessService extends FileSystemAccessService {
     @Override
     protected FileSystem createFileSystem(Configuration namenodeConf) throws IOException {
@@ -70,11 +76,11 @@ public class TestHttpFSMetrics {
   @BeforeAll
   static void init(@TempDir File dir) throws Exception {
     File tempDir = new File(dir, "temp");
-    tempDir.mkdirs();
+    assertTrue(tempDir.mkdirs());
     File logDir = new File(dir, "log");
-    logDir.mkdirs();
+    assertTrue(logDir.mkdirs());
     File confDir = new File(dir, "conf");
-    confDir.mkdirs();
+    assertTrue(confDir.mkdirs());
     System.setProperty("httpfs.home.dir", dir.getAbsolutePath());
   }
 
@@ -89,7 +95,7 @@ public class TestHttpFSMetrics {
 
     fsAccess = HttpFSServerWebApp.get().get(FileSystemAccess.class);
     metrics = HttpFSServerWebApp.getMetrics();
-    ugi = UserGroupInformation.createUserForTesting("testuser", new String[] { "testgroup" });
+    ugi = UserGroupInformation.createUserForTesting("testuser", new String[] {"testgroup"});
   }
 
   @AfterEach
@@ -106,7 +112,7 @@ public class TestHttpFSMetrics {
     long initialBytesWritten = metrics.getBytesWritten();
 
     FSOperations.FSCreate createOp = new FSOperations.FSCreate(
-        new ByteArrayInputStream("test".getBytes()),
+        new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)),
         "/test.txt",
         (short) 0644,
         true,
@@ -128,7 +134,7 @@ public class TestHttpFSMetrics {
     long initialBytesWritten = metrics.getBytesWritten();
 
     FSOperations.FSAppend appendOp = new FSOperations.FSAppend(
-        new ByteArrayInputStream("test".getBytes()),
+        new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)),
         "/test.txt");
 
     when(mockFs.append(isA(Path.class), isA(Integer.class))).thenReturn(fsDataOutputStream);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.genconf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -233,7 +234,7 @@ public class TestGenerateOzoneRequiredConfigurations {
    */
   @Test
   public void genconfFailureByInsufficientPermissions(@TempDir File tempPath) throws Exception {
-    tempPath.setReadOnly();
+    assertTrue(tempPath.setReadOnly());
     String[] args = new String[]{tempPath.getAbsolutePath()};
     executeWithException(args, "Insufficient permission.");
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

```java
M B RR: org.apache.hadoop.hdds.scm.storage.TestBlockInputStream.lambda$testReadNotRetriedOnOtherException$5(BlockInputStream, int) ignores result of org.apache.hadoop.hdds.scm.storage.BlockInputStream.read(byte[], int, int)  At TestBlockInputStream.java:[line 391]
M B RR: org.apache.hadoop.hdds.scm.storage.TestBlockInputStream.testRead() ignores result of org.apache.hadoop.hdds.scm.storage.BlockInputStream.read(byte[], int, int)  At TestBlockInputStream.java:[line 207]
M B RR: org.apache.hadoop.hdds.scm.storage.TestBlockInputStream.testRefreshPipelineFunction() ignores result of org.apache.hadoop.hdds.scm.storage.BlockInputStream.read(byte[], int, int)  At TestBlockInputStream.java:[line 283]
M B RR: org.apache.hadoop.hdds.scm.storage.TestBlockInputStream.testSeekAndRead() ignores result of org.apache.hadoop.hdds.scm.storage.BlockInputStream.read(byte[], int, int)  At TestBlockInputStream.java:[line 255]
M B RR: org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.testFullChunkRead() ignores result of org.apache.hadoop.hdds.scm.storage.DummyChunkInputStream.read(byte[], int, int)  At TestChunkInputStream.java:[line 136]
M B RR: org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.testPartialChunkRead() ignores result of org.apache.hadoop.hdds.scm.storage.DummyChunkInputStream.read(byte[], int, int)  At TestChunkInputStream.java:[line 145]
M B RR: org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.testSeek() ignores result of org.apache.hadoop.hdds.scm.storage.DummyChunkInputStream.read(byte[], int, int)  At TestChunkInputStream.java:[line 172]
M B RR: org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.testSeekAndRead() ignores result of org.apache.hadoop.hdds.scm.storage.DummyChunkInputStream.read(byte[], int, int)  At TestChunkInputStream.java:[line 207]
M B RR: org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.testUnbuffered() ignores result of org.apache.hadoop.hdds.scm.storage.DummyChunkInputStream.read(byte[], int, int)  At TestChunkInputStream.java:[line 219]
H D DLS: Dead store to exports in org.apache.hadoop.hdds.server.http.TestRatisDropwizardExports.export()  At TestRatisDropwizardExports.java:[line 63]
M B RV: Exceptional return value of java.io.File.mkdirs() ignored in org.apache.hadoop.hdds.scm.TestStorageContainerManagerHttpServer.setUp()  At TestStorageContainerManagerHttpServer.java:[line 55]
M D DLS: Dead store to expectedScmUsed in org.apache.hadoop.hdds.scm.node.TestSCMNodeManager.testScmNodeReportUpdate()  At TestSCMNodeManager.java:[line 1646]
M B RV: Exceptional return value of java.io.File.setReadOnly() ignored in org.apache.hadoop.ozone.genconf.TestGenerateOzoneRequiredConfigurations.genconfFailureByInsufficientPermissions(File)  At TestGenerateOzoneRequiredConfigurations.java:[line 236]
H I Dm: Found reliance on default encoding in org.apache.ozone.fs.http.server.metrics.TestHttpFSMetrics.testFsAppend(): String.getBytes()  At TestHttpFSMetrics.java:[line 131]
H I Dm: Found reliance on default encoding in org.apache.ozone.fs.http.server.metrics.TestHttpFSMetrics.testFsCreate(): String.getBytes()  At TestHttpFSMetrics.java:[line 109]
M B RV: Exceptional return value of java.io.File.mkdirs() ignored in org.apache.ozone.fs.http.server.metrics.TestHttpFSMetrics.init(File)  At TestHttpFSMetrics.java:[line 73]
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12382

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/13518022566