### PR TITLE
HDDS-12408. Create mixin for ContainerID list parameters

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/ItemsFromStdin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/ItemsFromStdin.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.cli;
+
+import static java.util.Collections.unmodifiableList;
+
+import jakarta.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Scanner;
+
+/** Parameter for specifying list of items, reading from stdin if "-" is given as first item. */
+public abstract class ItemsFromStdin implements Iterable<String> {
+
+  protected static final String FORMAT_DESCRIPTION =
+      ": one or more, separated by spaces. To read from stdin, specify '-' and supply one item per line.";
+
+  private List<String> items;
+
+  protected void setItems(List<String> arguments) {
+    items = readItemsFromStdinIfNeeded(arguments);
+  }
+
+  public List<String> getItems() {
+    return unmodifiableList(items);
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<String> iterator() {
+    return items.iterator();
+  }
+
+  public int size() {
+    return items.size();
+  }
+
+  private static List<String> readItemsFromStdinIfNeeded(List<String> parameters) {
+    if (parameters.isEmpty() || !"-".equals(parameters.iterator().next())) {
+      return parameters;
+    }
+
+    List<String> items = new ArrayList<>();
+    Scanner scanner = new Scanner(System.in, StandardCharsets.UTF_8.name());
+    while (scanner.hasNextLine()) {
+      items.add(scanner.nextLine().trim());
+    }
+    return items;
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerIDParameters.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerIDParameters.java
@@ -15,25 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdds.scm.cli.datanode;
+package org.apache.hadoop.hdds.scm.cli.container;
 
 import java.util.List;
 import org.apache.hadoop.hdds.cli.ItemsFromStdin;
 import picocli.CommandLine;
 
-/** Parameter for specifying list of hostnames. */
+/** Parameter for specifying list of container IDs. */
 @CommandLine.Command
-public class HostNameParameters extends ItemsFromStdin {
+public class ContainerIDParameters extends ItemsFromStdin {
 
-  @CommandLine.Parameters(description = "Host names" + FORMAT_DESCRIPTION,
+  @CommandLine.Parameters(description = "Container IDs" + FORMAT_DESCRIPTION,
       arity = "1..*",
-      paramLabel = "<host name>")
-  public void setHostNames(List<String> arguments) {
+      paramLabel = "<container ID>")
+  public void setContainerIDs(List<String> arguments) {
     setItems(arguments);
   }
-
-  public List<String> getHostNames() {
-    return getItems();
-  }
-
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -43,7 +42,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
 
 /**
  * This is the handler that process container info command.
@@ -60,40 +58,20 @@ public class InfoSubcommand extends ScmSubcommand {
       description = "Format output as JSON")
   private boolean json;
 
-  @Parameters(description = "One or more container IDs separated by spaces. " +
-      "To read from stdin, specify '-' and supply the container IDs " +
-      "separated by newlines.",
-      arity = "1..*",
-      paramLabel = "<container ID>")
-  private String[] containerList;
+  @CommandLine.Mixin
+  private ContainerIDParameters containerList;
 
   private boolean multiContainer = false;
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     boolean first = true;
-    boolean stdin = false;
-    if (containerList.length > 1) {
-      multiContainer = true;
-    } else if (containerList[0].equals("-")) {
-      stdin = true;
-      // Assume multiple containers if reading from stdin
-      multiContainer = true;
-    }
+    multiContainer = containerList.size() > 1;
 
     printHeader();
-    if (stdin) {
-      Scanner scanner = new Scanner(System.in, "UTF-8");
-      while (scanner.hasNextLine()) {
-        String id = scanner.nextLine().trim();
-        printOutput(scmClient, id, first);
-        first = false;
-      }
-    } else {
-      for (String id : containerList) {
-        printOutput(scmClient, id, first);
-        first = false;
-      }
+    for (String id : containerList) {
+      printOutput(scmClient, id, first);
+      first = false;
     }
     printFooter();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Generalize `HostNameParameters` to allow various parameters to be supplied via stdin.  Reuse in `ozone admin container info` for container ID list.

Avoid duplicate parsing of arguments in `Shell`, because the first one consumes inputs from stdin, and the command hangs waiting for further input.

https://issues.apache.org/jira/browse/HDDS-12408

## How was this patch tested?

Tested in `ozone` compose environment:

```bash
$ ozone freon ockg -n1 -t1
...

$ ozone admin container close 1

$ ozone freon ockg -n1 -t1
...

$ ozone admin container info -
1
2
^D

Container id: 1
...

Container id: 2
...

$ ozone admin container info --json - <<EOF | jq -r '.[].containerInfo.containerID'
> 1
> 2
> EOF
1
2

$ ozone admin container info --json 1 2 | jq -r '.[].containerInfo.containerID'
1
2
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/13520031977