### PR TITLE
HDDS-12348. Reuse `TestDataUtil.createKey` method

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -418,7 +418,7 @@ public class TestOzoneFSWithObjectStoreCreate {
                                   byte[] input)
       throws Exception {
     
-    createKey(ozoneBucket, key, new String(input));
+    createKey(ozoneBucket, key, new String(input, UTF_8));
 
     // Read the key with given key name.
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -424,7 +424,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   }
 
   private void readKey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
-      throws Exception{
+      throws Exception {
 
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -414,13 +414,18 @@ public class TestOzoneFSWithObjectStoreCreate {
     assertEquals(keys, outputKeys);
   }
 
-  private void createAndAssertKey(OzoneBucket ozoneBucket, String key, int length,
-                                  byte[] input)
+  private void createAndAssertKey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
       throws Exception {
     
-    createKey(ozoneBucket, key, new String(input, UTF_8));
-
+    createKey(ozoneBucket, key, input);
     // Read the key with given key name.
+    readKey(ozoneBucket, key, length, input);
+
+  }
+
+  private void readKey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
+      throws Exception{
+
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];
     ozoneInputStream.read(read, 0, length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.OzoneConsts.MD5_HASH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -366,9 +367,9 @@ public class TestOzoneFSWithObjectStoreCreate {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte)96);
 
-    createKey(ozoneBucket, key1, 10, input);
-    createKey(ozoneBucket, key2, 10, input);
-    createKey(ozoneBucket, key3, 10, input);
+    createAndAssertKey(ozoneBucket, key1, 10, input);
+    createAndAssertKey(ozoneBucket, key2, 10, input);
+    createAndAssertKey(ozoneBucket, key3, 10, input);
 
     // Iterator with key name as prefix.
 
@@ -413,16 +414,11 @@ public class TestOzoneFSWithObjectStoreCreate {
     assertEquals(keys, outputKeys);
   }
 
-  private void createKey(OzoneBucket ozoneBucket, String key, int length,
-      byte[] input)
+  private void createAndAssertKey(OzoneBucket ozoneBucket, String key, int length,
+                                  byte[] input)
       throws Exception {
-
-    OzoneOutputStream ozoneOutputStream =
-        ozoneBucket.createKey(key, length);
-
-    ozoneOutputStream.write(input);
-    ozoneOutputStream.write(input, 0, 10);
-    ozoneOutputStream.close();
+    
+    createKey(ozoneBucket, key, new String(input));
 
     // Read the key with given key name.
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -108,13 +108,14 @@ public final class TestDataUtil {
   public static void createKey(OzoneBucket bucket, String keyName,
                                String content) throws IOException {
     createKey(bucket, keyName, ReplicationFactor.ONE,
-        ReplicationType.RATIS, content);
+        ReplicationType.RATIS, content.getBytes(UTF_8));
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,
                                byte[] content) throws IOException {
     createKey(bucket, keyName, ReplicationFactor.ONE,
-        ReplicationType.RATIS, new String(content, UTF_8));
+        ReplicationType.RATIS, content);
+
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,
@@ -122,7 +123,21 @@ public final class TestDataUtil {
       throws IOException {
     ReplicationConfig repConfig = ReplicationConfig
         .fromTypeAndFactor(repType, repFactor);
-    createKey(bucket, keyName, repConfig, new String(content, UTF_8));
+    try (OutputStream stream = bucket
+        .createKey(keyName, content.length, repConfig,
+            new HashMap<>())) {
+      stream.write(content);
+    }
+  }
+
+  public static void createKey(OzoneBucket bucket, String keyName,
+                               ReplicationConfig repConfig, byte[] content)
+      throws IOException {
+    try (OutputStream stream = bucket
+        .createKey(keyName, content.length, repConfig,
+            new HashMap<>())) {
+      stream.write(content);
+    }
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,
@@ -130,17 +145,13 @@ public final class TestDataUtil {
       throws IOException {
     ReplicationConfig repConfig = ReplicationConfig
         .fromTypeAndFactor(repType, repFactor);
-    createKey(bucket, keyName, repConfig, content);
+    createKey(bucket, keyName, repConfig, content.getBytes(UTF_8));
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,
       ReplicationConfig repConfig, String content)
       throws IOException {
-    try (OutputStream stream = bucket
-        .createKey(keyName, content.length(), repConfig,
-            new HashMap<>())) {
-      stream.write(content.getBytes(UTF_8));
-    }
+    createKey(bucket, keyName, repConfig, content.getBytes(UTF_8));
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -109,6 +110,20 @@ public final class TestDataUtil {
                                String content) throws IOException {
     createKey(bucket, keyName, ReplicationFactor.ONE,
         ReplicationType.RATIS, content);
+  }
+
+  public static void createKey(OzoneBucket bucket, String keyName,
+                               byte[] content) throws IOException {
+    createKey(bucket, keyName, ReplicationFactor.ONE,
+        ReplicationType.RATIS, new String(content));
+  }
+
+  public static void createKey(OzoneBucket bucket, String keyName,
+                               ReplicationFactor repFactor, ReplicationType repType, byte[] content)
+      throws IOException {
+    ReplicationConfig repConfig = ReplicationConfig
+        .fromTypeAndFactor(repType, repFactor);
+    createKey(bucket, keyName, repConfig, new String(content, UTF_8));
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -115,7 +115,7 @@ public final class TestDataUtil {
   public static void createKey(OzoneBucket bucket, String keyName,
                                byte[] content) throws IOException {
     createKey(bucket, keyName, ReplicationFactor.ONE,
-        ReplicationType.RATIS, new String(content));
+        ReplicationType.RATIS, new String(content, UTF_8));
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
+import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -92,8 +93,9 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
           .getVolume(VOLUME_NAME);
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create
-      createKey(ozoneBucket, "key1", 10, new byte[10]);
-      createKey(ozoneBucket, "key2", 10, new byte[10]);
+      byte[] bytes = new byte[10];
+      createKey(ozoneBucket, "key1", new String(bytes));
+      createKey(ozoneBucket, "key2", new String(bytes));
       //Key Delete
       ozoneBucket.deleteKey("key1");
       //Bucket Delete
@@ -118,7 +120,8 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       assertThrows(Exception.class, () -> {
         OzoneVolume volume = client.getObjectStore().getVolume(VOLUME_NAME);
         OzoneBucket ozoneBucket = volume.getBucket("bucket1");
-        createKey(ozoneBucket, "key3", 10, new byte[10]);
+        byte[] bytes = new byte[10];
+        createKey(ozoneBucket, "key3", new String(bytes));
       }, "Create key as non-volume and non-bucket owner should fail");
     }
     //Key Delete - should fail
@@ -174,7 +177,8 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       OzoneVolume volume = client.getObjectStore().getVolume(VOLUME_NAME);
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create
-      createKey(ozoneBucket, "key2", 10, new byte[10]);
+      byte[] bytes = new byte[10];
+      createKey(ozoneBucket, "key2",new String(bytes));
       //Key Delete
       ozoneBucket.deleteKey("key2");
       //List Keys
@@ -207,13 +211,5 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
     OzoneObj obj = OzoneObjInfo.Builder.newBuilder().setVolumeName(volumeName)
         .setResType(OzoneObj.ResourceType.VOLUME).setStoreType(OZONE).build();
     assertTrue(store.setAcl(obj, OzoneAcl.parseAcls(aclString)));
-  }
-
-  private void createKey(OzoneBucket ozoneBucket, String key, int length,
-       byte[] input) throws Exception {
-    OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(key, length);
-    ozoneOutputStream.write(input);
-    ozoneOutputStream.write(input, 0, 10);
-    ozoneOutputStream.close();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -178,7 +178,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create
       byte[] bytes = new byte[10];
-      createKey(ozoneBucket, "key2", new String(bytes));
+      createKey(ozoneBucket, "key2", new String(bytes, StandardCharsets.UTF_8));
       //Key Delete
       ozoneBucket.deleteKey("key2");
       //List Keys

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -93,8 +94,8 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create
       byte[] bytes = new byte[10];
-      createKey(ozoneBucket, "key1", new String(bytes));
-      createKey(ozoneBucket, "key2", new String(bytes));
+      createKey(ozoneBucket, "key1", new String(bytes, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, "key2", new String(bytes, StandardCharsets.UTF_8));
       //Key Delete
       ozoneBucket.deleteKey("key1");
       //Bucket Delete
@@ -120,7 +121,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
         OzoneVolume volume = client.getObjectStore().getVolume(VOLUME_NAME);
         OzoneBucket ozoneBucket = volume.getBucket("bucket1");
         byte[] bytes = new byte[10];
-        createKey(ozoneBucket, "key3", new String(bytes));
+        createKey(ozoneBucket, "key3", new String(bytes, StandardCharsets.UTF_8));
       }, "Create key as non-volume and non-bucket owner should fail");
     }
     //Key Delete - should fail

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -93,9 +92,8 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
           .getVolume(VOLUME_NAME);
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create
-      byte[] bytes = new byte[10];
-      createKey(ozoneBucket, "key1", new String(bytes, StandardCharsets.UTF_8));
-      createKey(ozoneBucket, "key2", new String(bytes, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, "key1", new byte[10]);
+      createKey(ozoneBucket, "key2", new byte[10]);
       //Key Delete
       ozoneBucket.deleteKey("key1");
       //Bucket Delete
@@ -120,8 +118,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       assertThrows(Exception.class, () -> {
         OzoneVolume volume = client.getObjectStore().getVolume(VOLUME_NAME);
         OzoneBucket ozoneBucket = volume.getBucket("bucket1");
-        byte[] bytes = new byte[10];
-        createKey(ozoneBucket, "key3", new String(bytes, StandardCharsets.UTF_8));
+        createKey(ozoneBucket, "key3", new byte[10]);
       }, "Create key as non-volume and non-bucket owner should fail");
     }
     //Key Delete - should fail
@@ -176,9 +173,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
     try (OzoneClient client = cluster().newClient()) {
       OzoneVolume volume = client.getObjectStore().getVolume(VOLUME_NAME);
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
-      //Key Create
-      byte[] bytes = new byte[10];
-      createKey(ozoneBucket, "key2", new String(bytes, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, "key2", new byte[10]);
       //Key Delete
       ozoneBucket.deleteKey("key2");
       //List Keys

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -177,7 +177,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create
       byte[] bytes = new byte[10];
-      createKey(ozoneBucket, "key2",new String(bytes));
+      createKey(ozoneBucket, "key2", new String(bytes));
       //Key Delete
       ozoneBucket.deleteKey("key2");
       //List Keys

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -375,7 +377,8 @@ public abstract class TestListKeys implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, key, ReplicationFactor.THREE, ReplicationType.RATIS,
+          new String(input, StandardCharsets.UTF_8));
 
       // Read the key with given key name.
       OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -375,7 +375,7 @@ public abstract class TestListKeys implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input));
+      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
 
       // Read the key with given key name.
       OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -384,7 +384,7 @@ public abstract class TestListKeys implements NonHATests.TestCase {
   }
 
   private static void readkey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
-  throws Exception{
+      throws Exception {
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];
     ozoneInputStream.read(read, 0, length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -377,16 +377,19 @@ public abstract class TestListKeys implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, ReplicationFactor.THREE, ReplicationType.RATIS,
-          new String(input, StandardCharsets.UTF_8));
-
+      createKey(ozoneBucket, key, ReplicationFactor.THREE, ReplicationType.RATIS, input);
       // Read the key with given key name.
-      OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
-      byte[] read = new byte[length];
-      ozoneInputStream.read(read, 0, length);
-      ozoneInputStream.close();
-
-      assertEquals(new String(input, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
+      readkey(ozoneBucket, key, length, input);
     }
+  }
+
+  private static void readkey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
+  throws Exception{
+    OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
+    byte[] read = new byte[length];
+    ozoneInputStream.read(read, 0, length);
+    ozoneInputStream.close();
+
+    assertEquals(new String(input, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om;
 import static com.google.common.collect.Lists.newLinkedList;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LIST_CACHE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
+import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
@@ -41,7 +42,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
@@ -147,7 +147,7 @@ public abstract class TestListKeys implements NonHATests.TestCase {
     keys.add("a1/b3/e2/e21.tx");
     keys.add("a1/b3/e3/e31.tx");
 
-    createKeys(ozoneBucket, keys);
+    createAndAssertKeys(ozoneBucket, keys);
 
     ozoneBucket.createDirectory("a1/b4/");
   }
@@ -369,32 +369,21 @@ public abstract class TestListKeys implements NonHATests.TestCase {
     assertEquals(keys, outputKeysList);
   }
 
-  private static void createKeys(OzoneBucket ozoneBucket, List<String> keys)
+  private static void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
     int length = 10;
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, 10, input);
+      createKey(ozoneBucket, key, new String(input));
+
+      // Read the key with given key name.
+      OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
+      byte[] read = new byte[length];
+      ozoneInputStream.read(read, 0, length);
+      ozoneInputStream.close();
+
+      assertEquals(new String(input, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
     }
-  }
-
-  private static void createKey(OzoneBucket ozoneBucket, String key, int length,
-      byte[] input) throws Exception {
-
-    OzoneOutputStream ozoneOutputStream =
-        ozoneBucket.createKey(key, length);
-
-    ozoneOutputStream.write(input);
-    ozoneOutputStream.write(input, 0, 10);
-    ozoneOutputStream.close();
-
-    // Read the key with given key name.
-    OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
-    byte[] read = new byte[length];
-    ozoneInputStream.read(read, 0, length);
-    ozoneInputStream.close();
-
-    assertEquals(new String(input, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -657,7 +657,7 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
   }
 
   private static void readkey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
-      throws Exception{
+      throws Exception {
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];
     ozoneInputStream.read(read, 0, length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -647,7 +647,7 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input));
+      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
 
       // Read the key with given key name.
       OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -647,7 +649,8 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, key, ReplicationFactor.THREE,
+          ReplicationType.RATIS, new String(input, StandardCharsets.UTF_8));
 
       // Read the key with given key name.
       OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -650,16 +650,19 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
       createKey(ozoneBucket, key, ReplicationFactor.THREE,
-          ReplicationType.RATIS, new String(input, StandardCharsets.UTF_8));
-
+          ReplicationType.RATIS, input);
       // Read the key with given key name.
-      OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
-      byte[] read = new byte[length];
-      ozoneInputStream.read(read, 0, length);
-      ozoneInputStream.close();
-
-      assertEquals(new String(input, StandardCharsets.UTF_8),
-          new String(read, StandardCharsets.UTF_8));
+      readkey(ozoneBucket, key, length, input);
     }
+  }
+
+  private static void readkey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
+      throws Exception{
+    OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
+    byte[] read = new byte[length];
+    ozoneInputStream.read(read, 0, length);
+    ozoneInputStream.close();
+
+    assertEquals(new String(input, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -516,7 +517,9 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte)96);
 
-    createAndAssertKeys(ozoneBucket, keys);
+    createAndAssertKeys(ozoneBucket, Collections.singletonList(key1));
+    createAndAssertKeys(ozoneBucket, Collections.singletonList(key2));
+    createAndAssertKeys(ozoneBucket, Collections.singletonList(key3));
 
     // Iterator with key name as prefix.
     Iterator<? extends OzoneKey> ozoneKeyIterator =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -566,7 +566,7 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input));
+      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
 
       // Read the key with given key name.
       OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -562,10 +562,11 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
 
   private void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
-    int length = 10;
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte) 96);
     for (String key : keys) {
+      int length = 10;
+      byte[] input = new byte[length];
+      Arrays.fill(input, (byte) 96);
+
       createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
 
       // Read the key with given key name.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -571,7 +571,7 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
   }
 
   private void readKey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
-      throws Exception{
+      throws Exception {
 
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -516,12 +516,9 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte)96);
 
-    createKey(ozoneBucket, key1, 10, input);
-    createKey(ozoneBucket, key2, 10, input);
-    createKey(ozoneBucket, key3, 10, input);
+    createAndAssertKeys(ozoneBucket, keys);
 
     // Iterator with key name as prefix.
-
     Iterator<? extends OzoneKey> ozoneKeyIterator =
             ozoneBucket.listKeys("/dir1//", null);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -251,7 +250,7 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
       byte[] input = new byte[length];
       Arrays.fill(input, (byte) 96);
       String keyName = UUID.randomUUID().toString();
-      createKey(ozoneBucket, keyName, new String(input, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, keyName, input);
       obj = OzoneObjInfo.Builder.newBuilder().setVolumeName(volume.getName())
           .setBucketName(ozoneBucket.getName()).setKeyName(keyName)
           .setResType(OzoneObj.ResourceType.KEY).setStoreType(OZONE).build();
@@ -335,7 +334,7 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
+      createKey(ozoneBucket, key, input);
       setKeyAcl(objectStore, ozoneBucket.getVolumeName(), ozoneBucket.getName(),
           key, aclWorldAll);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -250,7 +251,7 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
       byte[] input = new byte[length];
       Arrays.fill(input, (byte) 96);
       String keyName = UUID.randomUUID().toString();
-      createKey(ozoneBucket, keyName, new String(input));
+      createKey(ozoneBucket, keyName, new String(input, StandardCharsets.UTF_8));
       obj = OzoneObjInfo.Builder.newBuilder().setVolumeName(volume.getName())
           .setBucketName(ozoneBucket.getName()).setKeyName(keyName)
           .setResType(OzoneObj.ResourceType.KEY).setStoreType(OZONE).build();
@@ -334,7 +335,7 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, new String(input));
+      createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
       setKeyAcl(objectStore, ozoneBucket.getVolumeName(), ozoneBucket.getName(),
           key, aclWorldAll);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om;
 
+import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,7 +38,6 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
@@ -250,7 +250,7 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
       byte[] input = new byte[length];
       Arrays.fill(input, (byte) 96);
       String keyName = UUID.randomUUID().toString();
-      createKey(ozoneBucket, keyName, length, input);
+      createKey(ozoneBucket, keyName, new String(input));
       obj = OzoneObjInfo.Builder.newBuilder().setVolumeName(volume.getName())
           .setBucketName(ozoneBucket.getName()).setKeyName(keyName)
           .setResType(OzoneObj.ResourceType.KEY).setStoreType(OZONE).build();
@@ -334,19 +334,10 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
     byte[] input = new byte[length];
     Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, 10, input);
+      createKey(ozoneBucket, key, new String(input));
       setKeyAcl(objectStore, ozoneBucket.getVolumeName(), ozoneBucket.getName(),
           key, aclWorldAll);
     }
   }
-
-  private void createKey(OzoneBucket ozoneBucket, String key, int length,
-      byte[] input) throws Exception {
-    OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(key, length);
-    ozoneOutputStream.write(input);
-    ozoneOutputStream.write(input, 0, 10);
-    ozoneOutputStream.close();
-  }
-
 }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -366,7 +366,7 @@ public abstract class TestOmSnapshotFileSystem {
   }
 
   private void readkey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
-      throws Exception{
+      throws Exception {
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];
     ozoneInputStream.read(read, 0, length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -360,7 +360,7 @@ public abstract class TestOmSnapshotFileSystem {
   private void createKey(OzoneBucket ozoneBucket, String key, int length,
                          byte[] input) throws Exception {
 
-    TestDataUtil.createKey(ozoneBucket, key, new String(input));
+    TestDataUtil.createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
 
     // Read the key with given key name.
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -361,12 +361,7 @@ public abstract class TestOmSnapshotFileSystem {
   private void createKey(OzoneBucket ozoneBucket, String key, int length,
                          byte[] input) throws Exception {
 
-    OzoneOutputStream ozoneOutputStream =
-        ozoneBucket.createKey(key, length);
-
-    ozoneOutputStream.write(input);
-    ozoneOutputStream.write(input, 0, 10);
-    ozoneOutputStream.close();
+    TestDataUtil.createKey(ozoneBucket, key, new String(input));
 
     // Read the key with given key name.
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -76,7 +76,6 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -360,9 +360,13 @@ public abstract class TestOmSnapshotFileSystem {
   private void createKey(OzoneBucket ozoneBucket, String key, int length,
                          byte[] input) throws Exception {
 
-    TestDataUtil.createKey(ozoneBucket, key, new String(input, StandardCharsets.UTF_8));
-
+    TestDataUtil.createKey(ozoneBucket, key, input);
     // Read the key with given key name.
+    readkey(ozoneBucket, key, length, input);
+  }
+
+  private void readkey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
+      throws Exception{
     OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
     byte[] read = new byte[length];
     ozoneInputStream.read(read, 0, length);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `TestDataUtil.createKey`  can be reused in many places to reduce the code redundancy, please take a look, thanks!

## What is the link to the Apache JIRA
[HDDS-12348](https://issues.apache.org/jira/browse/HDDS-12348)

## How was this patch tested?
It can test by CI.
