### PR TITLE
HDDS-12418. Remove healthyReplicaCountAdapter from RatisContainerReplicaCount

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -191,17 +191,11 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    * Total healthy replicas = 3 = 1 matching + 2 mismatched replicas
    */
   public int getHealthyReplicaCount() {
-    return healthyReplicaCount + healthyReplicaCountAdapter()
-        + decommissionCount + maintenanceCount;
+    return healthyReplicaCount + decommissionCount + maintenanceCount;
   }
 
   public int getUnhealthyReplicaCount() {
-    return unhealthyReplicaCount + getUnhealthyReplicaCountAdapter()
-        + unhealthyDecommissionCount + unhealthyMaintenanceCount;
-  }
-
-  protected int getUnhealthyReplicaCountAdapter() {
-    return 0;
+    return unhealthyReplicaCount + unhealthyDecommissionCount + unhealthyMaintenanceCount;
   }
 
   public int getMisMatchedReplicaCount() {
@@ -213,19 +207,11 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
   }
 
   private int getAvailableReplicas() {
-    int available = healthyReplicaCount + healthyReplicaCountAdapter();
+    int available = healthyReplicaCount;
     if (considerUnhealthy) {
-      available += unhealthyReplicaCount + getUnhealthyReplicaCountAdapter();
+      available += unhealthyReplicaCount;
     }
     return available;
-  }
-
-  /**
-   * The new replication manager now does not consider replicas with
-   * UNHEALTHY state when counting sufficient replication.
-   */
-  protected int healthyReplicaCountAdapter() {
-    return 0;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

healthyReplicaCountAdapter is not used since LegacyReplicationManager and LegacyRatisContainerReplicaCount were removed in [HDDS-11759](https://issues.apache.org/jira/browse/HDDS-11759).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12418

## How was this patch tested?

CI:
~~https://github.com/peterxcli/ozone/actions/runs/13544826903~~
https://github.com/peterxcli/ozone/actions/runs/13544880973