### PR TITLE
HDDS-12295. Allow updating OM default replication config for tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
@@ -443,5 +444,15 @@ public final class TestHelper {
       MiniOzoneCluster cluster) throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> countReplicas(containerID, cluster) == count,
         200, 30000);
+  }
+
+  /** Helper to set config even if {@code value} is null, which
+   * {@link OzoneConfiguration#set(String, String) does not allow. */
+  public static void setConfig(OzoneConfiguration conf, String key, String value) {
+    if (value == null) {
+      conf.unset(key);
+    } else {
+      conf.set(key, value);
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReplicationConfigPreference.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReplicationConfigPreference.java
@@ -18,221 +18,156 @@
 package org.apache.hadoop.ozone.shell;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.google.common.collect.ImmutableMap;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.hadoop.hdds.cli.GenericCli;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
-import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
-import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.container.TestHelper;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
-import picocli.CommandLine;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test the order of Replication config resolution.
- *
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(100)
-public class TestReplicationConfigPreference {
+public abstract class TestReplicationConfigPreference implements NonHATests.TestCase {
 
-  private OzoneConfiguration conf = null;
+  private static final Logger LOG = LoggerFactory.getLogger(TestReplicationConfigPreference.class);
+
+  private static final String VOLUME_NAME = "vol-" + UUID.randomUUID();
+  private static final List<ReplicationConfig> REPLICATIONS = Arrays.asList(
+      null,
+      RatisReplicationConfig.getInstance(THREE),
+      new ECReplicationConfig(3, 2)
+  );
+  private static final List<String> CONFIG_KEYS = Arrays.asList(
+      OZONE_REPLICATION, OZONE_REPLICATION_TYPE,
+      OZONE_SERVER_DEFAULT_REPLICATION_KEY, OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY
+  );
+
   private MiniOzoneCluster cluster;
   private OzoneClient client;
-  private String omServiceId;
-  @TempDir
-  private Path path;
   private File testFile;
-  private static final String DEFAULT_BUCKET = "default";
-  private static final String RATIS_BUCKET = "ratis";
-  private static final String EC_BUCKET = "ecbucket";
-  private static final String DEFAULT_KEY = "defaultkey";
-  private static final String RATIS_KEY = "ratiskey";
-  private static final String EC_KEY = "eckey";
-  private String[] bucketList;
-  private String[] keyList;
-  private static int numOfOMs = 3;
-  private static final ReplicationConfig RATIS_REPL_CONF =
-      ReplicationConfig.fromProtoTypeAndFactor(RATIS, THREE);
-  private static final ReplicationConfig EC_REPL_CONF = new ECReplicationConfig(
-      3, 2, ECReplicationConfig.EcCodec.RS, (int) OzoneConsts.MB);
-
-  protected void startCluster()
-      throws Exception {
-    omServiceId = "om-service-test1";
-    MiniOzoneHAClusterImpl.Builder builder =
-        MiniOzoneCluster.newHABuilder(conf);
-    builder.setOMServiceId(omServiceId)
-        .setNumOfOzoneManagers(numOfOMs)
-        .setNumDatanodes(5);
-    cluster = builder.build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
-  }
+  private final Map<String, String> originalSettings = new HashMap<>();
+  private OzoneVolume volume;
 
   @BeforeAll
-  void init() throws Exception {
-    testFile = new File(path + OZONE_URI_DELIMITER + "testFile");
-    testFile.getParentFile().mkdirs();
-    testFile.createNewFile();
-    bucketList = new String[]{DEFAULT_BUCKET, RATIS_BUCKET, EC_BUCKET};
-    keyList = new String[]{DEFAULT_KEY, RATIS_KEY, EC_KEY};
+  void init(@TempDir Path path) throws Exception {
+    cluster = cluster();
+    client = cluster.newClient();
+
+    testFile = path.resolve("testFile").toFile();
+    FileUtils.createParentDirectories(testFile);
+    FileUtils.touch(testFile);
+
+    OzoneConfiguration conf = cluster.getOzoneManager().getConfiguration();
+    originalSettings.clear();
+    for (String key : CONFIG_KEYS) {
+      originalSettings.put(key, conf.get(key));
+      conf.unset(key);
+    }
+
+    TestDataUtil.createVolume(client, VOLUME_NAME);
+    volume = client.getObjectStore().getVolume(VOLUME_NAME);
   }
 
-  /**
-   * shutdown MiniOzoneCluster.
-   */
   @AfterAll
   void shutdown() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
+
+    OzoneConfiguration conf = cluster.getOzoneManager().getConfiguration();
+    originalSettings.forEach((k, v) -> TestHelper.setConfig(conf, k, v));
+  }
+
+  private static void execute(OzoneShell shell, List<String> args) {
+    LOG.info("ozone sh {}", String.join(" ", args));
+    shell.getCmd().execute(args.toArray(new String[0]));
+  }
+
+  private void createBucket(OzoneShell ozoneShell,
+      String bucketName,
+      ReplicationConfig replicationConfig
+  ) {
+    List<String> args = new ArrayList<>(Arrays.asList(
+        "bucket", "create",
+        VOLUME_NAME + "/" + bucketName
+    ));
+
+    addReplicationParameters(replicationConfig, args);
+
+    execute(ozoneShell, args);
+  }
+
+  private void createKey(OzoneShell ozoneShell,
+      String bucketName, String keyName,
+      ReplicationConfig replicationConfig
+  ) {
+    List<String> args = new ArrayList<>(Arrays.asList(
+        "key", "put",
+        VOLUME_NAME + "/" + bucketName + "/" + keyName,
+        testFile.getPath()));
+
+    addReplicationParameters(replicationConfig, args);
+
+    execute(ozoneShell, args);
+  }
+
+  private static void addReplicationParameters(ReplicationConfig replicationConfig, List<String> args) {
+    if (replicationConfig != null) {
+      args.addAll(Arrays.asList(
+          "--type", replicationConfig.getReplicationType().name(),
+          "--replication", replicationConfig.getReplication()
+      ));
     }
   }
 
-  private String getSetConfStringFromConf(String key) {
-    return String.format("--set=%s=%s", key, conf.get(key));
-  }
-
-  private String generateSetConfString(String key, String value) {
-    return String.format("--set=%s=%s", key, value);
-  }
-
-  /**
-   * Helper function to get a String array to be fed into OzoneShell.
-   * @param numOfArgs Additional number of arguments after the HA conf string,
-   *                  this translates into the number of empty array elements
-   *                  after the HA conf string.
-   * @return String array.
-   */
-  private String[] getHASetConfStrings(int numOfArgs) {
-    assert (numOfArgs >= 0);
-    String[] res = new String[1 + 1 + numOfOMs + numOfArgs];
-    final int indexOmServiceIds = 0;
-    final int indexOmNodes = 1;
-    final int indexOmAddressStart = 2;
-
-    res[indexOmServiceIds] = getSetConfStringFromConf(
-        OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY);
-
-    String omNodesKey = ConfUtils.addKeySuffixes(
-        OMConfigKeys.OZONE_OM_NODES_KEY, omServiceId);
-    String omNodesVal = conf.get(omNodesKey);
-    res[indexOmNodes] = generateSetConfString(omNodesKey, omNodesVal);
-
-    String[] omNodesArr = omNodesVal.split(",");
-    // Sanity check
-    assert (omNodesArr.length == numOfOMs);
-    for (int i = 0; i < numOfOMs; i++) {
-      res[indexOmAddressStart + i] =
-          getSetConfStringFromConf(ConfUtils.addKeySuffixes(
-              OMConfigKeys.OZONE_OM_ADDRESS_KEY, omServiceId, omNodesArr[i]));
-    }
-
-    return res;
-  }
-
-  /**
-   * Helper function to create a new set of arguments that contains HA configs.
-   * @param existingArgs Existing arguments to be fed into OzoneShell command.
-   * @return String array.
-   */
-  private String[] getHASetConfStrings(String[] existingArgs) {
-    // Get a String array populated with HA configs first
-    String[] res = getHASetConfStrings(existingArgs.length);
-
-    int indexCopyStart = res.length - existingArgs.length;
-    // Then copy the existing args to the returned String array
-    for (int i = 0; i < existingArgs.length; i++) {
-      res[indexCopyStart + i] = existingArgs[i];
-    }
-    return res;
-  }
-
-  private void execute(GenericCli shell, String[] args) {
-    CommandLine cmd = shell.getCmd();
-
-    // Since there is no elegant way to pass Ozone config to the shell,
-    // the idea is to use 'set' to place those OM HA configs.
-    String[] argsWithHAConf = getHASetConfStrings(args);
-
-    cmd.execute(argsWithHAConf);
-  }
-
-  protected void createAllKeys(OzoneShell ozoneShell,
-      String volumeName, String bucketName) {
-    execute(ozoneShell, new String[] {"key", "put", "o3://" + omServiceId
-          + "/" + volumeName + "/" + bucketName + "/" + DEFAULT_KEY,
-        testFile.getPath()});
-    execute(ozoneShell, new String[] {"key", "put", "o3://" + omServiceId
-          + "/" + volumeName + "/" + bucketName + "/" + RATIS_KEY,
-        testFile.getPath(),
-        "--type=" + RATIS_REPL_CONF.getReplicationType().name(),
-        "--replication=" + RATIS_REPL_CONF.getReplication()});
-    execute(ozoneShell, new String[] {"key", "put", "o3://" + omServiceId
-          + "/" + volumeName + "/" + bucketName + "/" + EC_KEY,
-        testFile.getPath(),
-        "--type=" + EC_REPL_CONF.getReplicationType().name(),
-        "--replication=" + EC_REPL_CONF.getReplication()});
-  }
-
-  protected void createAllBucketsAndKeys(Map<String, String> clientConf,
-                                                String volumeName) {
+  private OzoneShell createSubject(ReplicationConfig clientReplication) {
     OzoneShell ozoneShell = new OzoneShell();
-    if (clientConf != null) {
-      ozoneShell.setConfigurationOverrides(clientConf);
-    }
-    execute(ozoneShell, new String[] {"volume", "create", "o3://" + omServiceId
-          + "/" + volumeName});
-    execute(ozoneShell, new String[] {"bucket", "create", "o3://" + omServiceId
-          + "/" + volumeName + "/" + DEFAULT_BUCKET});
-    createAllKeys(ozoneShell, volumeName, DEFAULT_BUCKET);
 
-    ozoneShell = new OzoneShell();
-    if (clientConf != null) {
-      ozoneShell.setConfigurationOverrides(clientConf);
+    ImmutableMap.Builder<String, String> config = new ImmutableMap.Builder<>();
+    if (clientReplication != null) {
+      config.put(OZONE_REPLICATION_TYPE, clientReplication.getReplicationType().name());
+      config.put(OZONE_REPLICATION, clientReplication.getReplication());
     }
-    execute(ozoneShell, new String[] {"bucket", "create", "o3://" + omServiceId
-          + "/" + volumeName + "/" + RATIS_BUCKET,
-        "--type=" + RATIS_REPL_CONF.getReplicationType().name(),
-        "--replication=" + RATIS_REPL_CONF.getReplication()});
-    createAllKeys(ozoneShell, volumeName, RATIS_BUCKET);
+    config.put(OZONE_OM_ADDRESS_KEY, cluster().getConf().get(OZONE_OM_ADDRESS_KEY));
+    ozoneShell.setConfigurationOverrides(config.build());
 
-    ozoneShell = new OzoneShell();
-    if (clientConf != null) {
-      ozoneShell.setConfigurationOverrides(clientConf);
-    }
-    execute(ozoneShell, new String[] {"bucket", "create", "o3://" + omServiceId
-          + "/" + volumeName + "/" + EC_BUCKET,
-        "--type=" + EC_REPL_CONF.getReplicationType().name(),
-        "--replication=" + EC_REPL_CONF.getReplication()});
-    createAllKeys(ozoneShell, volumeName, EC_BUCKET);
+    return ozoneShell;
   }
 
   /**
@@ -245,122 +180,102 @@ public class TestReplicationConfigPreference {
    * 2. Bucket Replication Config
    * 3. Server Default replication config
    */
-  public void validateReplicationOrder(String volumeName,
-                                       String clientConfigReplType,
-                                       String clientConfigReplConfig,
-                                       String serverDefaultReplType,
-                                       String serverDefaultReplConfig) throws Exception {
+  private void validateReplicationOrder(
+      String bucketName, String keyName,
+      ReplicationConfig serverReplication,
+      ReplicationConfig clientReplication,
+      ReplicationConfig bucketReplication,
+      ReplicationConfig keyReplication
+  ) throws Exception {
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    assertEquals(bucketReplication, bucket.getReplicationConfig());
 
-    for (String b: bucketList) {
-      OzoneBucket bucket = client.getObjectStore().getVolume(volumeName)
-          .getBucket(b);
-      if (b.equals(DEFAULT_BUCKET)) {
-        assertNull(bucket.getReplicationConfig());
-      } else {
-        assertNotNull(bucket.getReplicationConfig());
-      }
+    OzoneKeyDetails key = bucket.getKey(keyName);
+    final ReplicationConfig expected;
+    if (keyReplication != null) {
+      // if client sets replication config during key creation then
+      // this replication config is used regardless of client configs or
+      // bucket replication or server defaults.
+      expected = keyReplication;
+    } else if (clientReplication != null) {
+      // if replication config are not passed as CLI params
+      // during key creation and bucket replication config is set then
+      // key uses bucket replication config
+      // unless replication config is available in client configs.
+      expected = clientReplication;
+    } else if (bucketReplication != null) {
+      // if replication config are not passed as CLI params
+      // during key creation and bucket replication config is set then
+      // key uses bucket replication config
+      expected = bucketReplication;
+    } else if (serverReplication != null) {
+      // If replication is not set in client configs then key uses
+      // server default replication config.
+      expected = serverReplication;
+    } else {
+      expected = RatisReplicationConfig.getInstance(THREE);
+    }
 
-      for (String k: keyList) {
-        OzoneKeyDetails key = bucket.getKey(k);
-        if (b.equals(DEFAULT_BUCKET) && k.equals(DEFAULT_KEY)) {
-          // if replication config are not passed as CLI params during bucket and
-          // key creation then key uses client configs.
-          // If replication is not set in client configs then key uses
-          // server default replication config.
-          if (clientConfigReplConfig != null) {
-            assertEquals(clientConfigReplType, key.getReplicationConfig()
-                .getReplicationType().name());
-            assertEquals(clientConfigReplConfig, key.getReplicationConfig()
-                .getReplication());
-          } else {
-            assertEquals(serverDefaultReplType, key.getReplicationConfig()
-                .getReplicationType().name());
-            assertEquals(serverDefaultReplConfig, key.getReplicationConfig()
-                .getReplication());
-          }
-        } else if (k.equals(DEFAULT_KEY)) {
-          // if replication config are not passed as CLI params
-          // during key creation and bucket replication config is set then
-          // key uses bucket replication config
-          // unless replication config is available in client configs.
-          if (clientConfigReplConfig != null) {
-            assertEquals(clientConfigReplType, key.getReplicationConfig()
-                .getReplicationType().name());
-            assertEquals(clientConfigReplConfig, key.getReplicationConfig()
-                .getReplication());
-          } else {
-            assertEquals(bucket.getReplicationConfig(),
-                key.getReplicationConfig());
-          }
-        } else if (k.equals(RATIS_KEY)) {
-          // if client sets replication config during key creation then
-          // this replication config is used regardless of client configs or
-          // bucket replication or server defaults.
-          assertEquals(RATIS_REPL_CONF, key.getReplicationConfig());
-        } else if (k.equals(EC_KEY)) {
-          assertEquals(EC_REPL_CONF, key.getReplicationConfig());
-        }
-      }
+    ReplicationConfig actual = key.getReplicationConfig();
+
+    assertEquals(expected, actual,
+        () -> "key: " + describe(keyReplication)
+            + " bucket: " + describe(bucketReplication)
+            + " client: " + describe(clientReplication)
+            + " server: " + describe(serverReplication)
+    );
+  }
+
+  private static String describe(ReplicationConfig config) {
+    return config != null
+        ? config.getReplicationType() + "/" + config.getReplication()
+        : "none";
+  }
+
+  private void updateReplicationInOM(ReplicationConfig replicationConfig) {
+    if (replicationConfig != null) {
+      updateReplicationInOM(replicationConfig.getReplicationType().name(), replicationConfig.getReplication());
+    } else {
+      updateReplicationInOM(null, null);
     }
   }
 
-  @Test
-  public void testReplicationOrderDefaultRatisCluster() throws Exception {
-    // Starting a cluster with server default replication type RATIS/THREE.
-    shutdown();
-    conf = new OzoneConfiguration();
-    startCluster();
-
-    // Replication configs are not set in Client configuration.
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    createAllBucketsAndKeys(null, volumeName);
-    validateReplicationOrder(volumeName, null, null,
-        RATIS_REPL_CONF.getReplicationType().name(),
-        RATIS_REPL_CONF.getReplication());
-
-    // Replication configs are set in Client configuration.
-    Map<String, String> clientConf = new HashMap<String, String>() {{
-        put(OZONE_REPLICATION_TYPE, EC_REPL_CONF.getReplicationType().name());
-        put(OZONE_REPLICATION, EC_REPL_CONF.getReplication());
-      }};
-    volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    createAllBucketsAndKeys(clientConf, volumeName);
-    validateReplicationOrder(volumeName,
-        EC_REPL_CONF.getReplicationType().name(),
-        EC_REPL_CONF.getReplication(),
-        RATIS_REPL_CONF.getReplicationType().name(),
-        RATIS_REPL_CONF.getReplication());
+  private void updateReplicationInOM(@Nullable String type, @Nullable String params) {
+    OzoneConfiguration conf = cluster.getOzoneManager().getConfiguration();
+    TestHelper.setConfig(conf, OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY, type);
+    TestHelper.setConfig(conf, OZONE_SERVER_DEFAULT_REPLICATION_KEY, params);
+    cluster.getOzoneManager().setReplicationFromConfig();
   }
 
-  @Test
-  public void testReplicationOrderDefaultECCluster() throws Exception {
-    // Starting a cluster with server default replication type EC.
-    shutdown();
-    conf = new OzoneConfiguration();
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
-        EC_REPL_CONF.getReplicationType().name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY,
-        EC_REPL_CONF.getReplication());
-    startCluster();
+  @ParameterizedTest
+  @MethodSource("replicationCombinations")
+  void test(
+      ReplicationConfig serverReplication,
+      ReplicationConfig clientReplication,
+      ReplicationConfig bucketReplication,
+      ReplicationConfig keyReplication
+  ) throws Exception {
+    updateReplicationInOM(serverReplication);
+    OzoneShell shell = createSubject(clientReplication);
+    String bucketName = "bucket-" + UUID.randomUUID();
+    String keyName = "key-" + UUID.randomUUID();
+    createBucket(shell, bucketName, bucketReplication);
+    createKey(shell, bucketName, keyName, keyReplication);
+    validateReplicationOrder(bucketName, keyName,
+        serverReplication, clientReplication, bucketReplication, keyReplication);
+  }
 
-    // Replication configs are not set in Client configuration.
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    createAllBucketsAndKeys(null, volumeName);
-    validateReplicationOrder(volumeName, null, null,
-        EC_REPL_CONF.getReplicationType().name(),
-        EC_REPL_CONF.getReplication());
-
-    // Replication configs are set in Client configuration.
-    Map<String, String> clientConf = new HashMap<String, String>() {{
-        put(OZONE_REPLICATION_TYPE, RATIS_REPL_CONF.getReplicationType().name());
-        put(OZONE_REPLICATION, RATIS_REPL_CONF.getReplication());
-      }};
-    volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    createAllBucketsAndKeys(clientConf, volumeName);
-    validateReplicationOrder(volumeName,
-        RATIS_REPL_CONF.getReplicationType().name(),
-        RATIS_REPL_CONF.getReplication(),
-        EC_REPL_CONF.getReplicationType().name(),
-        EC_REPL_CONF.getReplication());
+  public List<Arguments> replicationCombinations() {
+    List<Arguments> args = new ArrayList<>();
+    for (ReplicationConfig serverReplication : REPLICATIONS) {
+      for (ReplicationConfig clientReplication : REPLICATIONS) {
+        for (ReplicationConfig bucketReplication : REPLICATIONS) {
+          for (ReplicationConfig keyReplication : REPLICATIONS) {
+            args.add(Arguments.of(serverReplication, clientReplication, bucketReplication, keyReplication));
+          }
+        }
+      }
+    }
+    return args;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -17,8 +17,40 @@
 
 package org.apache.ozone.test;
 
+import org.apache.hadoop.fs.ozone.TestOzoneFSBucketLayout;
+import org.apache.hadoop.fs.ozone.TestOzoneFSInputStream;
+import org.apache.hadoop.fs.ozone.TestOzoneFSWithObjectStoreCreate;
+import org.apache.hadoop.fs.ozone.TestOzoneFileSystemMetrics;
+import org.apache.hadoop.fs.ozone.TestOzoneFileSystemMissingParent;
+import org.apache.hadoop.hdds.scm.TestAllocateContainer;
 import org.apache.hadoop.hdds.scm.TestContainerOperations;
+import org.apache.hadoop.hdds.scm.TestContainerReportWithKeys;
+import org.apache.hadoop.hdds.scm.TestContainerSmallFile;
+import org.apache.hadoop.hdds.scm.TestGetCommittedBlockLengthAndPutKey;
+import org.apache.hadoop.hdds.scm.TestSCMMXBean;
+import org.apache.hadoop.hdds.scm.TestSCMNodeManagerMXBean;
+import org.apache.hadoop.hdds.scm.TestXceiverClientManager;
+import org.apache.hadoop.hdds.scm.container.metrics.TestSCMContainerManagerMetrics;
+import org.apache.hadoop.hdds.scm.pipeline.TestNode2PipelineMap;
+import org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean;
+import org.apache.hadoop.hdds.scm.pipeline.TestSCMPipelineMetrics;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestCpuMetrics;
+import org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer;
+import org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks;
+import org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient;
+import org.apache.hadoop.ozone.om.TestListKeys;
+import org.apache.hadoop.ozone.om.TestListKeysWithFSO;
+import org.apache.hadoop.ozone.om.TestListStatus;
+import org.apache.hadoop.ozone.om.TestObjectStore;
+import org.apache.hadoop.ozone.om.TestObjectStoreWithFSO;
+import org.apache.hadoop.ozone.om.TestObjectStoreWithLegacyFS;
+import org.apache.hadoop.ozone.om.TestOmBlockVersioning;
+import org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes;
+import org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface;
+import org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration;
+import org.apache.hadoop.ozone.reconfig.TestOmReconfiguration;
+import org.apache.hadoop.ozone.reconfig.TestScmReconfiguration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 
@@ -38,7 +70,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneFSBucketLayout extends org.apache.hadoop.fs.ozone.TestOzoneFSBucketLayout {
+  class OzoneFSBucketLayout extends TestOzoneFSBucketLayout {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -46,7 +78,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneFSInputStream extends org.apache.hadoop.fs.ozone.TestOzoneFSInputStream {
+  class OzoneFSInputStream extends TestOzoneFSInputStream {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -54,7 +86,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneFSWithObjectStoreCreate extends org.apache.hadoop.fs.ozone.TestOzoneFSWithObjectStoreCreate {
+  class OzoneFSWithObjectStoreCreate extends TestOzoneFSWithObjectStoreCreate {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -62,7 +94,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneFileSystemMetrics extends org.apache.hadoop.fs.ozone.TestOzoneFileSystemMetrics {
+  class OzoneFileSystemMetrics extends TestOzoneFileSystemMetrics {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -70,7 +102,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneFileSystemMissingParent extends org.apache.hadoop.fs.ozone.TestOzoneFileSystemMissingParent {
+  class OzoneFileSystemMissingParent extends TestOzoneFileSystemMissingParent {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -78,7 +110,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class AllocateContainer extends org.apache.hadoop.hdds.scm.TestAllocateContainer {
+  class AllocateContainer extends TestAllocateContainer {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -94,7 +126,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ContainerReportWithKeys extends org.apache.hadoop.hdds.scm.TestContainerReportWithKeys {
+  class ContainerReportWithKeys extends TestContainerReportWithKeys {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -102,7 +134,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ContainerSmallFile extends org.apache.hadoop.hdds.scm.TestContainerSmallFile {
+  class ContainerSmallFile extends TestContainerSmallFile {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -110,7 +142,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class GetCommittedBlockLengthAndPutKey extends org.apache.hadoop.hdds.scm.TestGetCommittedBlockLengthAndPutKey {
+  class GetCommittedBlockLengthAndPutKey extends TestGetCommittedBlockLengthAndPutKey {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -118,7 +150,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class SCMMXBean extends org.apache.hadoop.hdds.scm.TestSCMMXBean {
+  class SCMMXBean extends TestSCMMXBean {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -126,7 +158,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class SCMNodeManagerMXBean extends org.apache.hadoop.hdds.scm.TestSCMNodeManagerMXBean {
+  class SCMNodeManagerMXBean extends TestSCMNodeManagerMXBean {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -134,7 +166,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class XceiverClientManager extends org.apache.hadoop.hdds.scm.TestXceiverClientManager {
+  class XceiverClientManager extends TestXceiverClientManager {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -142,7 +174,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class SCMContainerManagerMetrics extends org.apache.hadoop.hdds.scm.container.metrics.TestSCMContainerManagerMetrics {
+  class SCMContainerManagerMetrics extends TestSCMContainerManagerMetrics {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -150,7 +182,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class Node2PipelineMap extends org.apache.hadoop.hdds.scm.pipeline.TestNode2PipelineMap {
+  class Node2PipelineMap extends TestNode2PipelineMap {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -158,7 +190,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class PipelineManagerMXBean extends org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean {
+  class PipelineManagerMXBean extends TestPipelineManagerMXBean {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -166,7 +198,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class SCMPipelineMetrics extends org.apache.hadoop.hdds.scm.pipeline.TestSCMPipelineMetrics {
+  class SCMPipelineMetrics extends TestSCMPipelineMetrics {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -174,7 +206,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class CpuMetrics extends org.apache.hadoop.ozone.TestCpuMetrics {
+  class CpuMetrics extends TestCpuMetrics {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -182,7 +214,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class DiscardPreallocatedBlocks extends org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks {
+  class DiscardPreallocatedBlocks extends TestDiscardPreallocatedBlocks {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -190,7 +222,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class LeaseRecoverer extends org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer {
+  class LeaseRecoverer extends TestLeaseRecoverer {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -198,7 +230,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class BucketLayoutWithOlderClient extends org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient {
+  class BucketLayoutWithOlderClient extends TestBucketLayoutWithOlderClient {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -206,7 +238,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ListKeys extends org.apache.hadoop.ozone.om.TestListKeys {
+  class ListKeys extends TestListKeys {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -214,7 +246,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ListKeysWithFSO extends org.apache.hadoop.ozone.om.TestListKeysWithFSO {
+  class ListKeysWithFSO extends TestListKeysWithFSO {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -222,7 +254,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ListStatus extends org.apache.hadoop.ozone.om.TestListStatus {
+  class ListStatus extends TestListStatus {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -230,7 +262,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ObjectStore extends org.apache.hadoop.ozone.om.TestObjectStore {
+  class ObjectStore extends TestObjectStore {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -238,7 +270,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ObjectStoreWithFSO extends org.apache.hadoop.ozone.om.TestObjectStoreWithFSO {
+  class ObjectStoreWithFSO extends TestObjectStoreWithFSO {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -246,7 +278,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ObjectStoreWithLegacyFS extends org.apache.hadoop.ozone.om.TestObjectStoreWithLegacyFS {
+  class ObjectStoreWithLegacyFS extends TestObjectStoreWithLegacyFS {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -254,7 +286,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OmBlockVersioning extends org.apache.hadoop.ozone.om.TestOmBlockVersioning {
+  class OmBlockVersioning extends TestOmBlockVersioning {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -262,7 +294,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneManagerListVolumes extends org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes {
+  class OzoneManagerListVolumes extends TestOzoneManagerListVolumes {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -270,7 +302,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OzoneManagerRestInterface extends org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface {
+  class OzoneManagerRestInterface extends TestOzoneManagerRestInterface {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -278,7 +310,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class DatanodeReconfiguration extends org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration {
+  class DatanodeReconfiguration extends TestDatanodeReconfiguration {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -286,7 +318,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class OmReconfiguration extends org.apache.hadoop.ozone.reconfig.TestOmReconfiguration {
+  class OmReconfiguration extends TestOmReconfiguration {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();
@@ -294,7 +326,7 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   }
 
   @Nested
-  class ScmReconfiguration extends org.apache.hadoop.ozone.reconfig.TestScmReconfiguration {
+  class ScmReconfiguration extends TestScmReconfiguration {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface;
 import org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestOmReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestScmReconfiguration;
+import org.apache.hadoop.ozone.shell.TestReplicationConfigPreference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 
@@ -191,6 +192,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class PipelineManagerMXBean extends TestPipelineManagerMXBean {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ReplicationConfigPreference extends TestReplicationConfigPreference {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -451,7 +451,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private final int preallocateBlocksMax;
   private final boolean grpcBlockTokenEnabled;
   private final BucketLayout defaultBucketLayout;
-  private final ReplicationConfig defaultReplicationConfig;
+  private ReplicationConfig defaultReplicationConfig;
 
   private final boolean isS3MultiTenancyEnabled;
   private final boolean isStrictS3;
@@ -607,7 +607,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     // Validates the default server-side replication configs.
-    this.defaultReplicationConfig = getDefaultReplicationConfig();
+    setReplicationFromConfig();
     InetSocketAddress omNodeRpcAddr = omNodeDetails.getRpcAddress();
     // Honor property 'hadoop.security.token.service.use_ip'
     omRpcAddressTxt = new Text(SecurityUtil.buildTokenService(omNodeRpcAddr));
@@ -4480,18 +4480,22 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public ReplicationConfig getDefaultReplicationConfig() {
-    if (this.defaultReplicationConfig != null) {
-      return this.defaultReplicationConfig;
+    if (defaultReplicationConfig == null) {
+      setReplicationFromConfig();
     }
+    return defaultReplicationConfig;
+  }
 
+  public void setReplicationFromConfig() {
     final String replication = configuration.getTrimmed(
         OZONE_SERVER_DEFAULT_REPLICATION_KEY,
         OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT);
     final String type = configuration.getTrimmed(
         OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
         OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT);
-    return ReplicationConfig.parse(ReplicationType.valueOf(type),
+    defaultReplicationConfig = ReplicationConfig.parse(ReplicationType.valueOf(type),
         replication, configuration);
+    LOG.info("Set default replication in OM: {}/{} -> {}", type, replication, defaultReplicationConfig);
   }
 
   public BucketLayout getOMDefaultBucketLayout() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Allow updating server-default replication settings without restarting OM to speed up tests.  Cannot add to reconfiguration framework, because it applies property changes one by one, but these two settings must be changed at the same time (`EC/THREE` or `RATIS/rs-3-2-1024k` are invalid).  Later we may improve this by ignoring invalid configurations during the update.
- Add `TestReplicationConfigPreference` to `NonHATests` (using HA cluster is not really needed) and simplify it by refactoring to a single parameterized test, instead of using hard-coded bucket/key names for handling different scenarios.
- Add imports in `NonHATests` for all nested classes.

https://issues.apache.org/jira/browse/HDDS-12295

## How was this patch tested?

Before:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 81.36 s -- in org.apache.hadoop.ozone.shell.TestReplicationConfigPreference
```

After:

```
Tests run: 81, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.853 s -- in org.apache.ozone.test.NonHATests$ReplicationConfigPreference
```

https://github.com/adoroszlai/ozone/actions/runs/13548064424/job/37865190732#step:6:6714