### PR TITLE
HDDS-12168. Create new Grafana panel to display cluster growth rate

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - Overall Metrics.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - Overall Metrics.json
@@ -2362,6 +2362,105 @@
       ],
       "title": "ratis_leader_election_timeoutCount{component=\"$component\"}",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 160
+      },
+      "id": 240,
+      "panels": [],
+      "title": "Cluster Health",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 160
+      },
+      "id": 240,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(scm_node_manager_total_used[1h])) * 100 / sum(scm_node_manager_total_used)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Growth Rate",
+      "type": "timeseries"
     }
   ],
   "refresh": "",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Introduced a new Cluster Health panel to the existing Grafana dashboard.
The growth rate is calculated dynamically based on Prometheus metrics, using the following PromQL query:
`sum(rate(scm_node_manager_total_used[1h])) * 100 / sum(scm_node_manager_total_used)`
Here 1h can be changed based on user selection, but default it will show in last 1 hour, what is the growth rate.

This is how the new panel looks like in the Grafana "Ozone - Overall Metrics" Dashboard 
<img width="477" alt="Screenshot 2025-02-27 at 10 52 12 AM" src="https://github.com/user-attachments/assets/4ae43281-6068-4867-bca4-94d066340eb0" />


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12168

## How was this patch tested?

Tested locally via docker by running a freon workload

Below is the successfully passed workflow
https://github.com/sreejasahithi/ozone/actions/runs/13559737886
