### PR TITLE
HDDS-12428. Avoid force closing OPEN/CLOSING replica of a CLOSED Container

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
@@ -92,7 +92,7 @@ public class MismatchedReplicasHandler extends AbstractCheck {
   /**
    * Returns the final expected closed state type based on the scm container state and the replica state.
    * @param replica replica to check for mismatch and if it should be closed
-   * @return non null closed state if the replica should be closed, else CLOSED/QUASI_CLOSED based on the replica's
+   * @return null if the replica should not be closed, else CLOSED/QUASI_CLOSED based on the replica's
    * state.
    */
   private ContainerReplicaProto.State getTransitionState(ContainerInfo container,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
@@ -326,4 +326,52 @@ public class TestMismatchedReplicasHandler {
     verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(containerInfo,
         differentSeqID.getDatanodeDetails(), true);
   }
+
+  @Test
+  public void testCloseCommandSentForMismatchedRatisReplicasWithIncorrectBCSID() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ratisReplicationConfig, 1, CLOSED, 1000);
+    ContainerReplica mismatch1 = ReplicationTestUtil.createContainerReplica(
+        containerInfo.containerID(), 0,
+        HddsProtos.NodeOperationalState.IN_SERVICE,
+        ContainerReplicaProto.State.OPEN, 99);
+    ContainerReplica mismatch2 = ReplicationTestUtil.createContainerReplica(
+        containerInfo.containerID(), 0,
+        HddsProtos.NodeOperationalState.IN_SERVICE,
+        ContainerReplicaProto.State.CLOSING, 999);
+    ContainerReplica mismatch3 = ReplicationTestUtil.createContainerReplica(
+        containerInfo.containerID(), 0,
+        HddsProtos.NodeOperationalState.IN_SERVICE,
+        ContainerReplicaProto.State.QUASI_CLOSED, 1000);
+    Set<ContainerReplica> containerReplicas = new HashSet<>();
+    containerReplicas.add(mismatch1);
+    containerReplicas.add(mismatch2);
+    containerReplicas.add(mismatch3);
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
+
+    // this handler always returns false so other handlers can fix issues
+    // such as under replication
+    assertFalse(handler.handle(request));
+    assertFalse(handler.handle(readRequest));
+
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch1.getDatanodeDetails(), false);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch2.getDatanodeDetails(), false);
+    // close command should not be sent for unhealthy replica
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch3.getDatanodeDetails(), true);
+  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
@@ -223,12 +223,12 @@ public class TestMismatchedReplicasHandler {
     assertFalse(handler.handle(readRequest));
 
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
-        containerInfo, mismatch1.getDatanodeDetails(), true);
+        containerInfo, mismatch1.getDatanodeDetails(), false);
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
-        containerInfo, mismatch2.getDatanodeDetails(), true);
+        containerInfo, mismatch2.getDatanodeDetails(), false);
     // close command should not be sent for unhealthy replica
     verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
-        containerInfo, mismatch3.getDatanodeDetails(), true);
+        containerInfo, mismatch3.getDatanodeDetails(), false);
   }
 
   /**
@@ -343,10 +343,15 @@ public class TestMismatchedReplicasHandler {
         containerInfo.containerID(), 0,
         HddsProtos.NodeOperationalState.IN_SERVICE,
         ContainerReplicaProto.State.QUASI_CLOSED, 1000);
+    ContainerReplica mismatch4 = ReplicationTestUtil.createContainerReplica(
+        containerInfo.containerID(), 0,
+        HddsProtos.NodeOperationalState.IN_SERVICE,
+        ContainerReplicaProto.State.CLOSING, 1000);
     Set<ContainerReplica> containerReplicas = new HashSet<>();
     containerReplicas.add(mismatch1);
     containerReplicas.add(mismatch2);
     containerReplicas.add(mismatch3);
+    containerReplicas.add(mismatch4);
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.emptyList())
         .setReport(new ReplicationManagerReport())
@@ -373,5 +378,7 @@ public class TestMismatchedReplicasHandler {
     // close command should not be sent for unhealthy replica
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
         containerInfo, mismatch3.getDatanodeDetails(), true);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch4.getDatanodeDetails(), false);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the container is in CLOSED state and the Replica state in SCM is OPEN/CLOSING state, we are force closing the Container without comparing the BCSID. We should not force close the replicas in OPEN/CLOSING state.
Changing the should close function to return the expected final state and setting force parameter based on the value returned.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12428?jql=text%20~%20%22force%20close%22

## How was this patch tested?
Adding unit tests.
