### PR TITLE
HDDS-12442. Add latency metrics for OM deletion services

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
 /**
@@ -150,6 +151,15 @@ public class OMPerformanceMetrics {
 
   @Metric(about = "ACLs check in getObjectTagging")
   private MutableRate getObjectTaggingAclCheckLatencyNs;
+
+  @Metric("Latency of DirectoryDeletingService")
+  private MutableGaugeLong latencyDirectoryDeletingService;
+
+  @Metric("Latency of KeyDeletingService")
+  private MutableGaugeLong latencyKeyDeletingService;
+
+  @Metric("Latency of OpenKeyCleanupService")
+  private MutableGaugeLong latencyOpenKeyCleanupService;
 
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);
@@ -298,5 +308,17 @@ public class OMPerformanceMetrics {
 
   public void addGetObjectTaggingLatencyNs(long latencyInNs) {
     getObjectTaggingAclCheckLatencyNs.add(latencyInNs);
+  }
+
+  public void setLatencyDirectoryDeletingService(long latencyInNs) {
+    latencyDirectoryDeletingService.set(latencyInNs);
+  }
+
+  public void setLatencyKeyDeletingService(long latencyInNs) {
+    latencyKeyDeletingService.set(latencyInNs);
+  }
+
+  public void setLatencyOpenKeyCleanupService(long latencyInNs) {
+    latencyOpenKeyCleanupService.set(latencyInNs);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -153,13 +153,13 @@ public class OMPerformanceMetrics {
   private MutableRate getObjectTaggingAclCheckLatencyNs;
 
   @Metric(about = "Latency of DirectoryDeletingService in ms")
-  private MutableGaugeLong latencyDirectoryDeletingService;
+  private MutableGaugeLong directoryDeletingServiceLatencyMs;
 
   @Metric(about = "Latency of KeyDeletingService in ms")
-  private MutableGaugeLong latencyKeyDeletingService;
+  private MutableGaugeLong keyDeletingServiceLatencyMs;
 
   @Metric(about = "Latency of OpenKeyCleanupService in ms")
-  private MutableGaugeLong latencyOpenKeyCleanupService;
+  private MutableGaugeLong openKeyCleanupServiceLatencyMs;
 
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);
@@ -310,15 +310,15 @@ public class OMPerformanceMetrics {
     getObjectTaggingAclCheckLatencyNs.add(latencyInNs);
   }
 
-  public void setLatencyDirectoryDeletingService(long latencyInNs) {
-    latencyDirectoryDeletingService.set(latencyInNs);
+  public void setDirectoryDeletingServiceLatencyMs(long latencyInMs) {
+    directoryDeletingServiceLatencyMs.set(latencyInMs);
   }
 
-  public void setLatencyKeyDeletingService(long latencyInNs) {
-    latencyKeyDeletingService.set(latencyInNs);
+  public void setKeyDeletingServiceLatencyMs(long latencyInMs) {
+    keyDeletingServiceLatencyMs.set(latencyInMs);
   }
 
-  public void setLatencyOpenKeyCleanupService(long latencyInNs) {
-    latencyOpenKeyCleanupService.set(latencyInNs);
+  public void setOpenKeyCleanupServiceLatencyMs(long latencyInMs) {
+    openKeyCleanupServiceLatencyMs.set(latencyInMs);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -152,13 +152,13 @@ public class OMPerformanceMetrics {
   @Metric(about = "ACLs check in getObjectTagging")
   private MutableRate getObjectTaggingAclCheckLatencyNs;
 
-  @Metric("Latency of DirectoryDeletingService")
+  @Metric(about = "Latency of DirectoryDeletingService in ms")
   private MutableGaugeLong latencyDirectoryDeletingService;
 
-  @Metric("Latency of KeyDeletingService")
+  @Metric(about = "Latency of KeyDeletingService in ms")
   private MutableGaugeLong latencyKeyDeletingService;
 
-  @Metric("Latency of OpenKeyCleanupService")
+  @Metric(about = "Latency of OpenKeyCleanupService in ms")
   private MutableGaugeLong latencyOpenKeyCleanupService;
 
   public void addLookupLatency(long latencyInNs) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -152,13 +152,13 @@ public class OMPerformanceMetrics {
   @Metric(about = "ACLs check in getObjectTagging")
   private MutableRate getObjectTaggingAclCheckLatencyNs;
 
-  @Metric(about = "Latency of DirectoryDeletingService in ms")
+  @Metric(about = "Latency of each iteration of DirectoryDeletingService in ms")
   private MutableGaugeLong directoryDeletingServiceLatencyMs;
 
-  @Metric(about = "Latency of KeyDeletingService in ms")
+  @Metric(about = "Latency of each iteration of KeyDeletingService in ms")
   private MutableGaugeLong keyDeletingServiceLatencyMs;
 
-  @Metric(about = "Latency of OpenKeyCleanupService in ms")
+  @Metric(about = "Latency of each iteration of OpenKeyCleanupService in ms")
   private MutableGaugeLong openKeyCleanupServiceLatencyMs;
 
   public void addLookupLatency(long latencyInNs) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -130,7 +130,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
       LOG.info("Blocks for {} (out of {}) keys are deleted from DB in {} ms. Limit per task is {}.",
           delCount, blockDeletionResults.size(), Time.monotonicNow() - purgeStartTime, limit);
     }
-    perfMetrics.setLatencyKeyDeletingService(Time.monotonicNowNanos() - startTime);
+    perfMetrics.setLatencyKeyDeletingService(Time.monotonicNow() - startTime);
     return delCount;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -130,7 +130,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
       LOG.info("Blocks for {} (out of {}) keys are deleted from DB in {} ms. Limit per task is {}.",
           delCount, blockDeletionResults.size(), Time.monotonicNow() - purgeStartTime, limit);
     }
-    perfMetrics.setLatencyKeyDeletingService(Time.monotonicNow() - startTime);
+    perfMetrics.setKeyDeletingServiceLatencyMs(Time.monotonicNow() - startTime);
     return delCount;
   }
 
@@ -420,7 +420,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
           dirNum, subdirDelNum, subFileNum, (subDirNum - subdirDelNum),
           timeTakenInIteration, rnCnt);
       metrics.incrementDirectoryDeletionTotalMetrics(dirNum + subdirDelNum, subDirNum, subFileNum);
-      perfMetrics.setLatencyDirectoryDeletingService(timeTakenInIteration);
+      perfMetrics.setDirectoryDeletingServiceLatencyMs(timeTakenInIteration);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
@@ -237,9 +237,11 @@ public class OpenKeyCleanupService extends BackgroundService {
         });
       }
 
+      long timeTaken = Time.monotonicNow() - startTime;
       LOG.info("Number of expired open keys submitted for deletion: {},"
               + " for commit: {}, cleanupLimit: {}, elapsed time: {}ms",
-          numOpenKeys, numHsyncKeys, cleanupLimitPerTask, Time.monotonicNow() - startTime);
+          numOpenKeys, numHsyncKeys, cleanupLimitPerTask, timeTaken);
+      ozoneManager.getPerfMetrics().setLatencyOpenKeyCleanupService(timeTaken);
       final int numKeys = numOpenKeys + numHsyncKeys;
       submittedOpenKeyCount.addAndGet(numKeys);
       return () -> numKeys;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OpenKeyCleanupService.java
@@ -241,7 +241,7 @@ public class OpenKeyCleanupService extends BackgroundService {
       LOG.info("Number of expired open keys submitted for deletion: {},"
               + " for commit: {}, cleanupLimit: {}, elapsed time: {}ms",
           numOpenKeys, numHsyncKeys, cleanupLimitPerTask, timeTaken);
-      ozoneManager.getPerfMetrics().setLatencyOpenKeyCleanupService(timeTaken);
+      ozoneManager.getPerfMetrics().setOpenKeyCleanupServiceLatencyMs(timeTaken);
       final int numKeys = numOpenKeys + numHsyncKeys;
       submittedOpenKeyCount.addAndGet(numKeys);
       return () -> numKeys;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds metrics in OM to measure how long each iteration of the deletion services are taking. Latency metrics for DirectoryDeletionService, KeyDeletingService, OpenKeyCleanupService are added.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12442

## How was this patch tested?

Tested manually using docker with prometheus:
<img width="1728" alt="Screenshot 2025-03-03 at 10 23 28 PM" src="https://github.com/user-attachments/assets/512a773f-114e-4020-82a9-58d330e73ba1" />
<img width="1728" alt="Screenshot 2025-03-03 at 10 23 18 PM" src="https://github.com/user-attachments/assets/6b9d914b-2fcf-43b0-92f5-3c0238288124" />