### PR TITLE
HDDS-6856. HA aware reads from Snapshots

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -54,6 +54,9 @@ public enum OzoneManagerVersion implements ComponentVersion {
 
   S3_LIST_MULTIPART_UPLOADS_PAGINATION(11,
       "OzoneManager version that supports S3 list multipart uploads API with pagination"),
+
+  SNAPSHOT_READ_FROM_NON_LEADER(12, "OzoneManager version that supports " +
+      "snapshot read operations from non-leader"),
     
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/InfoSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/InfoSnapshotHandler.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.shell.snapshot;
 
 import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.shell.Handler;
@@ -39,6 +40,11 @@ public class InfoSnapshotHandler extends Handler {
       index = "1", arity = "1")
   private String snapshotName;
 
+  @CommandLine.Option(
+      names = {"-n", "--node-id"},
+      description = "The id of OM node to get the snapshot information from")
+  private String omNodeId;
+
   @Override
   protected OzoneAddress getAddress() {
     return snapshotPath.getValue();
@@ -50,8 +56,14 @@ public class InfoSnapshotHandler extends Handler {
     String volumeName = snapshotPath.getValue().getVolumeName();
     String bucketName = snapshotPath.getValue().getBucketName();
 
-    OzoneSnapshot ozoneSnapshot = client.getObjectStore()
-        .getSnapshotInfo(volumeName, bucketName, snapshotName);
+    OzoneSnapshot ozoneSnapshot;
+    if (StringUtils.isEmpty(omNodeId)) {
+      ozoneSnapshot = client.getObjectStore()
+          .getSnapshotInfo(volumeName, bucketName, snapshotName);
+    } else {
+      ozoneSnapshot = client.getObjectStore()
+          .getSnapshotInfo(volumeName, bucketName, snapshotName, omNodeId);
+    }
 
     if (isVerbose()) {
       err().printf("Snapshot info for snapshot: %s under o3://%s/%s %n ",

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/InfoSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/InfoSnapshotHandler.java
@@ -41,7 +41,7 @@ public class InfoSnapshotHandler extends Handler {
   private String snapshotName;
 
   @CommandLine.Option(
-      names = {"-n", "--node-id"},
+      names = {"-n", "--om-node-id"},
       description = "The id of OM node to get the snapshot information from")
   private String omNodeId;
 

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
@@ -51,7 +51,7 @@ public class ListSnapshotDiffHandler extends Handler {
 
   @CommandLine.Option(
       names = {"-n", "--om-node-id"},
-      description = "The id of OM node to get the snapshot information from")
+      description = "The id of OM node to list snapshotDiff jobs from")
   private String omNodeId;
 
   @Override

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.shell.snapshot;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneSnapshotDiff;
 import org.apache.hadoop.ozone.shell.Handler;
@@ -48,6 +49,11 @@ public class ListSnapshotDiffHandler extends Handler {
       defaultValue = "false")
   private boolean listAll;
 
+  @CommandLine.Option(
+      names = {"-n", "--om-node-id"},
+      description = "The id of OM node to get the snapshot information from")
+  private String omNodeId;
+
   @Override
   protected OzoneAddress getAddress() {
     return snapshotPath.getValue();
@@ -60,9 +66,14 @@ public class ListSnapshotDiffHandler extends Handler {
     String volumeName = snapshotPath.getValue().getVolumeName();
     String bucketName = snapshotPath.getValue().getBucketName();
 
-    List<OzoneSnapshotDiff> jobList =
-        client.getObjectStore().listSnapshotDiffJobs(
-            volumeName, bucketName, jobStatus, listAll);
+    List<OzoneSnapshotDiff> jobList;
+    if (StringUtils.isEmpty(omNodeId)) {
+      jobList = client.getObjectStore().listSnapshotDiffJobs(
+          volumeName, bucketName, jobStatus, listAll);
+    } else {
+      jobList = client.getObjectStore().listSnapshotDiffJobs(
+          volumeName, bucketName, jobStatus, listAll, omNodeId);
+    }
 
     int counter = printAsJsonArray(jobList.iterator(),
         jobList.size());

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.shell.snapshot;
 
 import java.io.IOException;
 import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.shell.Handler;
@@ -42,6 +43,11 @@ public class ListSnapshotHandler extends Handler {
   @CommandLine.Mixin
   private ListOptions listOptions;
 
+  @CommandLine.Option(
+      names = {"-n", "--om-node-id"},
+      description = "The id of OM node to ist the snapshots from")
+  private String omNodeId;
+
   @Override
   protected OzoneAddress getAddress() {
     return snapshotPath.getValue();
@@ -53,9 +59,17 @@ public class ListSnapshotHandler extends Handler {
     String volumeName = snapshotPath.getValue().getVolumeName();
     String bucketName = snapshotPath.getValue().getBucketName();
 
-    Iterator<OzoneSnapshot> snapshotInfos = client.getObjectStore()
-        .listSnapshot(volumeName, bucketName, listOptions.getPrefix(),
-            listOptions.getStartItem());
+    Iterator<OzoneSnapshot> snapshotInfos;
+    if (StringUtils.isEmpty(omNodeId)) {
+      snapshotInfos = client.getObjectStore()
+          .listSnapshot(volumeName, bucketName, listOptions.getPrefix(),
+              listOptions.getStartItem());
+    } else {
+      snapshotInfos = client.getObjectStore()
+          .listSnapshot(volumeName, bucketName, listOptions.getPrefix(),
+              listOptions.getStartItem(), omNodeId);
+    }
+
     int counter = printAsJsonArray(snapshotInfos, listOptions.getLimit());
     if (isVerbose()) {
       err().printf("Found : %d snapshots for o3://%s/%s %n", counter,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -94,7 +94,7 @@ public class SnapshotDiffHandler extends Handler {
 
   @CommandLine.Option(
       names = {"-n", "--om-node-id"},
-      description = "The id of OM node to get the snapshot information from")
+      description = "The id of OM node to get the snapshot diff from")
   private String omNodeId;
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -604,6 +604,22 @@ public class ObjectStore {
   }
 
   /**
+   * Returns snapshot info for volume/bucket snapshot path.
+   * @param volumeName volume name
+   * @param bucketName bucket name
+   * @param snapshotName snapshot name
+   * @param omNodeId OM node ID to get the snapshot info
+   * @return snapshot info for volume/bucket snapshot path.
+   * @throws IOException
+   */
+  public OzoneSnapshot getSnapshotInfo(String volumeName,
+                                       String bucketName,
+                                       String snapshotName,
+                                       String omNodeId) throws IOException {
+    return proxy.getSnapshotInfo(volumeName, bucketName, snapshotName, omNodeId);
+  }
+
+  /**
    * List snapshots in a volume/bucket.
    * @param volumeName     volume name
    * @param bucketName     bucket name

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -728,6 +728,36 @@ public class ObjectStore {
   }
 
   /**
+   * Get the differences between two snapshots.
+   * @param volumeName Name of the volume to which the snapshot bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param token to get the index to return diff report from.
+   * @param pageSize maximum entries returned to the report.
+   * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param disableNativeDiff request to force diff to perform diffs without
+   *                           native lib
+   * @param omNodeId OM node ID to send the snapshot diff request.
+   * @return the difference report between two snapshots
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  @SuppressWarnings("parameternumber")
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize,
+                                           boolean forceFullDiff,
+                                           boolean disableNativeDiff,
+                                           String omNodeId)
+      throws IOException {
+    return proxy.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+        token, pageSize, forceFullDiff, disableNativeDiff, omNodeId);
+  }
+
+  /**
    * Cancel the snap diff jobs.
    * @param volumeName Name of the volume to which the snapshot bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong
@@ -746,6 +776,26 @@ public class ObjectStore {
   }
 
   /**
+   * Cancel the snap diff jobs.
+   * @param volumeName Name of the volume to which the snapshot bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param omNodeId OM node ID to send the cancel snapshot diff jobs request.
+   * @return the success if cancel succeeds.
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  public CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       String omNodeId)
+      throws IOException {
+    return proxy.cancelSnapshotDiff(volumeName, bucketName, fromSnapshot,
+        toSnapshot, omNodeId);
+  }
+
+  /**
    * Get a list of the SnapshotDiff jobs for a bucket based on the JobStatus.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong
@@ -761,5 +811,25 @@ public class ObjectStore {
       throws IOException {
     return proxy.listSnapshotDiffJobs(volumeName,
         bucketName, jobStatus, listAll);
+  }
+
+  /**
+   * Get a list of the SnapshotDiff jobs for a bucket based on the JobStatus.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param jobStatus JobStatus to be used to filter the snapshot diff jobs
+   * @param listAll Option to specify whether to list all jobs or not
+   * @param omNodeId OM node ID to get the list of SnapshotDiff jobs from
+   * @return a list of SnapshotDiffJob objects from the specified OM node
+   * @throws IOException in case there is a failure while getting a response.
+   */
+  public List<OzoneSnapshotDiff> listSnapshotDiffJobs(String volumeName,
+                                                      String bucketName,
+                                                      String jobStatus,
+                                                      boolean listAll,
+                                                      String omNodeId)
+      throws IOException {
+    return proxy.listSnapshotDiffJobs(volumeName,
+        bucketName, jobStatus, listAll, omNodeId);
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1260,6 +1260,28 @@ public interface ClientProtocol {
       throws IOException;
 
   /**
+   * Get the differences between two snapshots.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param token to get the index to return diff report from.
+   * @param pageSize maximum entries returned to the report.
+   * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param omNodeId OM node ID to send the snapshot diff request.
+   * @return the difference report between two snapshots
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  @SuppressWarnings("parameternumber")
+  SnapshotDiffResponse snapshotDiff(String volumeName, String bucketName,
+                                    String fromSnapshot, String toSnapshot,
+                                    String token, int pageSize,
+                                    boolean forceFullDiff,
+                                    boolean disableNativeDiff,
+                                    String omNodeId)
+      throws IOException;
+
+  /**
    * Cancel snapshot diff job.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong
@@ -1275,6 +1297,23 @@ public interface ClientProtocol {
       throws IOException;
 
   /**
+   * Cancel snapshot diff job.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param omNodeId OM node ID to send the cancel snapshot diff jobs request.
+   * @return the success if cancel succeeds.
+   * @throws IOException in case of any exception while cancelling snap diff job
+   */
+  CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
+                                                String bucketName,
+                                                String fromSnapshot,
+                                                String toSnapshot,
+                                                String omNodeId)
+      throws IOException;
+
+  /**
    * Get a list of the SnapshotDiff jobs for a bucket based on the JobStatus.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong
@@ -1287,6 +1326,23 @@ public interface ClientProtocol {
                                                String bucketName,
                                                String jobStatus,
                                                boolean listAll)
+      throws IOException;
+
+  /**
+   * Get a list of the SnapshotDiff jobs for a bucket based on the JobStatus.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param jobStatus JobStatus to be used to filter the snapshot diff jobs
+   * @param listAll Option to specify whether to list all jobs or not
+   * @param omNodeId OM node ID to get the list of SnapshotDiff jobs from
+   * @return a list of SnapshotDiffJob objects
+   * @throws IOException in case there is a failure while getting a response.
+   */
+  List<OzoneSnapshotDiff> listSnapshotDiffJobs(String volumeName,
+                                               String bucketName,
+                                               String jobStatus,
+                                               boolean listAll,
+                                               String omNodeId)
       throws IOException;
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1202,6 +1202,20 @@ public interface ClientProtocol {
                                 String snapshotName) throws IOException;
 
   /**
+   * Returns snapshot info for volume/bucket snapshot path.
+   * @param volumeName volume name
+   * @param bucketName bucket name
+   * @param snapshotName snapshot name
+   * @param omNodeId OM node ID to get the snapshot info from
+   * @return snapshot info for volume/bucket snapshot path.
+   * @throws IOException
+   */
+  OzoneSnapshot getSnapshotInfo(String volumeName,
+                                String bucketName,
+                                String snapshotName,
+                                String omNodeId) throws IOException;
+
+  /**
    * Create an image of the current compaction log DAG in the OM.
    * @param fileNamePrefix  file name prefix of the image file.
    * @param graphType       type of node name to use in the graph image.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1240,6 +1240,21 @@ public interface ClientProtocol {
       String prevSnapshot, int maxListResult) throws IOException;
 
   /**
+   * List snapshots in a volume/bucket.
+   * @param volumeName     volume name
+   * @param bucketName     bucket name
+   * @param snapshotPrefix snapshot prefix to match
+   * @param prevSnapshot   snapshots will be listed after this snapshot name
+   * @param maxListResult  max number of snapshots to return
+   * @param omNodeId       OM node ID to get the list of snapshots from
+   * @return list of snapshots for volume/bucket path.
+   * @throws IOException
+   */
+  ListSnapshotResponse listSnapshot(
+      String volumeName, String bucketName, String snapshotPrefix,
+      String prevSnapshot, int maxListResult, String omNodeId) throws IOException;
+
+  /**
    * Get the differences between two snapshots.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1077,6 +1077,28 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize,
+                                           boolean forceFullDiff,
+                                           boolean disableNativeDiff,
+                                           String omNodeId)
+      throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
+        "OM node ID can't be null or empty.");
+    return ozoneManagerClient.snapshotDiff(volumeName, bucketName,
+        fromSnapshot, toSnapshot, token, pageSize, forceFullDiff,
+        disableNativeDiff, omNodeId);
+  }
+
+  @Override
   public CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
                                                        String bucketName,
                                                        String fromSnapshot,
@@ -1095,6 +1117,27 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       String omNodeId)
+      throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(fromSnapshot),
+        "fromSnapshot can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(toSnapshot),
+        "toSnapshot can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
+        "OM node ID can't be null or empty.");
+    return ozoneManagerClient.cancelSnapshotDiff(volumeName, bucketName,
+        fromSnapshot, toSnapshot, omNodeId);
+  }
+
+  @Override
   public List<OzoneSnapshotDiff> listSnapshotDiffJobs(String volumeName,
                                                     String bucketName,
                                                     String jobStatus,
@@ -1107,6 +1150,22 @@ public class RpcClient implements ClientProtocol {
 
     return ozoneManagerClient.listSnapshotDiffJobs(
         volumeName, bucketName, jobStatus, listAll).stream()
+        .map(OzoneSnapshotDiff::fromSnapshotDiffJob)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<OzoneSnapshotDiff> listSnapshotDiffJobs(String volumeName, String bucketName, String jobStatus,
+      boolean listAll, String omNodeId) throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
+        "OM node ID can't be null or empty.");
+
+    return ozoneManagerClient.listSnapshotDiffJobs(
+            volumeName, bucketName, jobStatus, listAll, omNodeId).stream()
         .map(OzoneSnapshotDiff::fromSnapshotDiffJob)
         .collect(Collectors.toList());
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1021,6 +1021,30 @@ public class RpcClient implements ClientProtocol {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public OzoneSnapshot getSnapshotInfo(String volumeName,
+                                       String bucketName,
+                                       String snapshotName,
+                                       String omNodeId) throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(snapshotName),
+        "snapshot name can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
+        "OM node ID can't be null or empty.");
+    if (omVersion.compareTo(OzoneManagerVersion.SNAPSHOT_READ_FROM_NON_LEADER) < 0) {
+      throw new IOException("OzoneManager does not snapshot read from non-leader OM.");
+    }
+    SnapshotInfo snapshotInfo = ozoneManagerClient.getSnapshotInfo(volumeName,
+        bucketName, snapshotName, omNodeId);
+    return OzoneSnapshot.fromSnapshotInfo(snapshotInfo);
+  }
+
+  /**
    * Create an image of the current compaction log DAG in the OM.
    * @param fileNamePrefix  file name prefix of the image file.
    * @param graphType       type of node name to use in the graph image.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1192,6 +1192,32 @@ public class RpcClient implements ClientProtocol {
   }
 
   /**
+   * List snapshots in a volume/bucket.
+   * @param volumeName     volume name
+   * @param bucketName     bucket name
+   * @param snapshotPrefix snapshot prefix to match
+   * @param prevSnapshot   snapshots will be listed after this snapshot name
+   * @param maxListResult  max number of snapshots to return
+   * @param omNodeId       OM node ID to get the list of snapshots from
+   * @return list of snapshots for volume/bucket path.
+   * @throws IOException
+   */
+  @Override
+  public ListSnapshotResponse listSnapshot(
+      String volumeName, String bucketName, String snapshotPrefix,
+      String prevSnapshot, int maxListResult, String omNodeId) throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
+        "OM node ID can't be null or empty.");
+
+    return ozoneManagerClient.listSnapshot(volumeName, bucketName, snapshotPrefix,
+        prevSnapshot, maxListResult, omNodeId);
+  }
+
+  /**
    * Assign admin role to an accessId in a tenant.
    * @param accessId access ID.
    * @param tenantId tenant name.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1037,7 +1037,7 @@ public class RpcClient implements ClientProtocol {
     Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
         "OM node ID can't be null or empty.");
     if (omVersion.compareTo(OzoneManagerVersion.SNAPSHOT_READ_FROM_NON_LEADER) < 0) {
-      throw new IOException("OzoneManager does not snapshot read from non-leader OM.");
+      throw new IOException("OzoneManager does not support snapshot read from non-leader OM.");
     }
     SnapshotInfo snapshotInfo = ozoneManagerClient.getSnapshotInfo(volumeName,
         bucketName, snapshotName, omNodeId);
@@ -1093,6 +1093,9 @@ public class RpcClient implements ClientProtocol {
         "bucket can't be null or empty.");
     Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
         "OM node ID can't be null or empty.");
+    if (omVersion.compareTo(OzoneManagerVersion.SNAPSHOT_READ_FROM_NON_LEADER) < 0) {
+      throw new IOException("OzoneManager does not support snapshot diff from non-leader OM.");
+    }
     return ozoneManagerClient.snapshotDiff(volumeName, bucketName,
         fromSnapshot, toSnapshot, token, pageSize, forceFullDiff,
         disableNativeDiff, omNodeId);
@@ -1133,6 +1136,9 @@ public class RpcClient implements ClientProtocol {
         "toSnapshot can't be null or empty.");
     Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
         "OM node ID can't be null or empty.");
+    if (omVersion.compareTo(OzoneManagerVersion.SNAPSHOT_READ_FROM_NON_LEADER) < 0) {
+      throw new IOException("OzoneManager does not support cancel snapshot diff from non-leader OM.");
+    }
     return ozoneManagerClient.cancelSnapshotDiff(volumeName, bucketName,
         fromSnapshot, toSnapshot, omNodeId);
   }
@@ -1163,7 +1169,9 @@ public class RpcClient implements ClientProtocol {
         "bucket can't be null or empty.");
     Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
         "OM node ID can't be null or empty.");
-
+    if (omVersion.compareTo(OzoneManagerVersion.SNAPSHOT_READ_FROM_NON_LEADER) < 0) {
+      throw new IOException("OzoneManager does not support cancel snapshot diff from non-leader OM.");
+    }
     return ozoneManagerClient.listSnapshotDiffJobs(
             volumeName, bucketName, jobStatus, listAll, omNodeId).stream()
         .map(OzoneSnapshotDiff::fromSnapshotDiffJob)
@@ -1212,7 +1220,9 @@ public class RpcClient implements ClientProtocol {
         "bucket can't be null or empty.");
     Preconditions.checkArgument(StringUtils.isNotBlank(omNodeId),
         "OM node ID can't be null or empty.");
-
+    if (omVersion.compareTo(OzoneManagerVersion.SNAPSHOT_READ_FROM_NON_LEADER) < 0) {
+      throw new IOException("OzoneManager does not support list snapshots from non-leader OM.");
+    }
     return ozoneManagerClient.listSnapshot(volumeName, bucketName, snapshotPrefix,
         prevSnapshot, maxListResult, omNodeId);
   }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockOmTransport.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockOmTransport.java
@@ -147,6 +147,11 @@ public class MockOmTransport implements OmTransport {
     }
   }
 
+  @Override
+  public OMResponse submitRequest(String omNodeId, OMRequest payload) throws IOException {
+    return submitRequest(payload);
+  }
+
   private OzoneManagerProtocolProtos.AllocateBlockResponse allocateBlock(
       OzoneManagerProtocolProtos.AllocateBlockRequest allocateBlockRequest) {
     Iterator<? extends OzoneManagerProtocolProtos.KeyLocation> iterator =

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
@@ -133,10 +133,10 @@ public class HadoopRpcOMFailoverProxyProvider<T> extends
   /**
    * Creates proxy object.
    */
-  protected ProxyInfo createOMProxy(String nodeId) {
+  protected ProxyInfo<T> createOMProxy(String nodeId) {
     OMProxyInfo omProxyInfo = omProxyInfos.get(nodeId);
     InetSocketAddress address = omProxyInfo.getAddress();
-    ProxyInfo proxyInfo;
+    ProxyInfo<T> proxyInfo;
     try {
       T proxy = createOMProxy(address);
       // Create proxyInfo here, to make it work with all Hadoop versions.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcSingleOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcSingleOMFailoverProxyProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A failover proxy provider implementation which does nothing in the
+ * event of OM failover, and always returns the same proxy object. In case of OM failover,
+ * client will keep retrying to connect to the same OM node.
+ */
+public class HadoopRpcSingleOMFailoverProxyProvider<T> extends
+    SingleOMFailoverProxyProviderBase<T> {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(HadoopRpcSingleOMFailoverProxyProvider.class);
+
+  private final Text delegationTokenService;
+  private OMProxyInfo omProxyInfo;
+
+  // HadoopRpcOMFailoverProxyProvider, on encountering certain exception,
+  // will immediately fail. It only communicates with a single OM, regardless
+  // whether there are other OMs in the OM service.
+  public HadoopRpcSingleOMFailoverProxyProvider(ConfigurationSource configuration,
+                                                UserGroupInformation ugi,
+                                                String omServiceId,
+                                                String omNodeId,
+                                                Class<T> protocol) throws IOException {
+    super(configuration, ugi, omServiceId, omNodeId, protocol);
+    this.delegationTokenService = computeDelegationTokenService();
+  }
+
+  @Override
+  protected void loadOMClientConfig(ConfigurationSource config, String omSvcId, String omNodeId) throws IOException {
+    String rpcAddrKey = ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, omSvcId, omNodeId);
+    String rpcAddrStr = OmUtils.getOmRpcAddress(config, rpcAddrKey);
+    if (rpcAddrStr == null) {
+      throw new IllegalArgumentException("Could not find any configured " +
+          "addresses for OM. Please configure the system with "
+          + OZONE_OM_ADDRESS_KEY);
+    }
+
+    this.omProxyInfo =  new OMProxyInfo(omSvcId, omNodeId, rpcAddrStr);
+    if (omProxyInfo.getAddress() == null) {
+      LOG.error("Failed to create OM proxy for {} at address {}",
+          omNodeId, rpcAddrStr);
+      throw new IllegalArgumentException("Could not find any configured " +
+          "addresses for OM. Please configure the system with "
+          + OZONE_OM_ADDRESS_KEY);
+    }
+    setOmProxy(createOMProxy());
+  }
+
+  /**
+   * Creates proxy object.
+   */
+  protected ProxyInfo<T> createOMProxy() {
+    InetSocketAddress address = omProxyInfo.getAddress();
+    ProxyInfo<T> proxyInfo;
+    try {
+      T proxy = createOMProxy(address);
+      // Create proxyInfo here, to make it work with all Hadoop versions.
+      proxyInfo = new ProxyInfo<>(proxy, omProxyInfo.toString());
+
+    } catch (IOException ioe) {
+      LOG.error("{} Failed to create RPC proxy to OM at {}",
+          this.getClass().getSimpleName(), address, ioe);
+      throw new RuntimeException(ioe);
+    }
+    return proxyInfo;
+  }
+
+  public Text getCurrentProxyDelegationToken() {
+    return delegationTokenService;
+  }
+
+  protected Text computeDelegationTokenService() {
+    String address = null;
+    Text dtService = omProxyInfo.getDelegationTokenService();
+
+    // During client object creation when one of the OM configured address
+    // in unreachable, dtService can be null.
+    if (dtService != null) {
+      address = dtService.toString();
+    }
+
+    if (address != null) {
+      return new Text(address);
+    } else {
+      // If all OM addresses is unresolvable, set dt service to null. Let
+      // this fail in later step when during connection setup.
+      return null;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    ProxyInfo<T> proxyInfo = getProxy();
+    if (proxyInfo != null) {
+      RPC.stopProxy(proxyInfo.proxy);
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.ha;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ServiceException;
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -59,8 +58,7 @@ import org.slf4j.LoggerFactory;
  * multiple OMs to connect to. In case of OM failover, client can try
  * connecting to another OM node from the list of proxies.
  */
-public abstract class OMFailoverProxyProviderBase<T> implements
-    FailoverProxyProvider<T>, Closeable {
+public abstract class OMFailoverProxyProviderBase<T> implements FailoverProxyProvider<T> {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(OMFailoverProxyProviderBase.class);
@@ -83,11 +81,11 @@ public abstract class OMFailoverProxyProviderBase<T> implements
   // before attempting to contact all the OMs again. For other exceptions
   // such as LeaderNotReadyException, the same OM is contacted again with a
   // linearly increasing wait time.
-  private Set<String> attemptedOMs = new HashSet<>();
+  private final Set<String> attemptedOMs = new HashSet<>();
   private String lastAttemptedOM;
   private int numAttemptsOnSameOM = 0;
   private final long waitBetweenRetries;
-  private Set<String> accessControlExceptionOMs = new HashSet<>();
+  private final Set<String> accessControlExceptionOMs = new HashSet<>();
   private boolean performFailoverDone;
 
   private final UserGroupInformation ugi;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/SingleOMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/SingleOMFailoverProxyProviderBase.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.apache.hadoop.ozone.om.ha.OMFailoverProxyProviderBase.getLeaderNotReadyException;
+import static org.apache.hadoop.ozone.om.ha.OMFailoverProxyProviderBase.getNotLeaderException;
+
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
+import org.apache.hadoop.io.retry.FailoverProxyProvider;
+import org.apache.hadoop.io.retry.RetryPolicies;
+import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.io.retry.RetryPolicy.RetryAction.RetryDecision;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
+import org.apache.hadoop.security.AccessControlException;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.SecretManager;
+import org.apache.ratis.protocol.exceptions.StateMachineException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of {@link FailoverProxyProvider} which does nothing in the
+ * event of OM failover, and always returns the same proxy object. In case of OM failover,
+ * client will keep retrying to connect to the same OM node.
+ */
+public abstract class SingleOMFailoverProxyProviderBase<T> implements FailoverProxyProvider<T> {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(SingleOMFailoverProxyProviderBase.class);
+
+  private final ConfigurationSource conf;
+  private final Class<T> protocolClass;
+
+  private final String omServiceId;
+  private final String omNodeId;
+  private ProxyInfo<T> omProxy;
+
+  private final long waitBetweenRetries;
+
+  private final UserGroupInformation ugi;
+
+  public SingleOMFailoverProxyProviderBase(ConfigurationSource configuration, UserGroupInformation ugi,
+                                           String omServiceId, String omNodeId, Class<T> protocol) throws IOException {
+    this.conf = configuration;
+    this.protocolClass = protocol;
+    this.omServiceId = omServiceId;
+    this.omNodeId = omNodeId;
+    this.ugi = ugi;
+
+    waitBetweenRetries = conf.getLong(
+        OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT);
+
+    loadOMClientConfig(conf, omServiceId, omNodeId);
+    Preconditions.checkNotNull(omProxy);
+  }
+
+  protected abstract void loadOMClientConfig(ConfigurationSource config, String omSvcId,
+                                             String omNodeID) throws IOException;
+
+  /**
+   * Get the protocol proxy for provided address.
+   * @param omAddress An instance of {@link InetSocketAddress} which contains the address to connect
+   * @return the proxy connection to the address and the set of methods supported by the server at the address
+   * @throws IOException if any error occurs while trying to get the proxy
+   */
+  protected T createOMProxy(InetSocketAddress omAddress) throws IOException {
+    Configuration hadoopConf =
+        LegacyHadoopConfigurationSource.asHadoopConfiguration(getConf());
+
+    // TODO: Post upgrade to Protobuf 3.x we need to use ProtobufRpcEngine2
+    RPC.setProtocolEngine(hadoopConf, getInterface(), ProtobufRpcEngine.class);
+
+    // Ensure we fail immediately in case of OM exceptions
+    RetryPolicy connectionRetryPolicy = RetryPolicies.failoverOnNetworkException(0);
+
+    return (T) RPC.getProtocolProxy(
+        getInterface(),
+        RPC.getProtocolVersion(protocolClass),
+        omAddress,
+        ugi,
+        hadoopConf,
+        NetUtils.getDefaultSocketFactory(hadoopConf),
+        (int) OmUtils.getOMClientRpcTimeOut(getConf()),
+        connectionRetryPolicy
+    ).getProxy();
+  }
+
+  @Override
+  public ProxyInfo<T> getProxy() {
+    return omProxy;
+  }
+
+  @Override
+  public final Class<T> getInterface() {
+    return protocolClass;
+  }
+
+  protected synchronized boolean shouldRetryAgain(Exception ex) {
+    Throwable unwrappedException = HddsUtils.getUnwrappedException(ex);
+    if (unwrappedException instanceof AccessControlException ||
+        unwrappedException instanceof SecretManager.InvalidToken ||
+        HddsUtils.shouldNotFailoverOnRpcException(unwrappedException)) {
+      // Unlike OMFailoverProxyProviderBase which will retry all OMs first,
+      // AccessControlException will not be retried for single-OM case.
+      return false;
+    } else if (ex instanceof StateMachineException) {
+      StateMachineException smEx = (StateMachineException) ex;
+      Throwable cause = smEx.getCause();
+      if (cause instanceof OMException) {
+        OMException omEx = (OMException) cause;
+        // Do not retry if the operation was blocked because the OM was
+        // prepared.
+        return omEx.getResult() !=
+            OMException.ResultCodes.NOT_SUPPORTED_OPERATION_WHEN_PREPARED;
+      }
+    }
+    return true;
+  }
+
+  public synchronized long getWaitTime() {
+    return waitBetweenRetries;
+  }
+
+  public RetryPolicy getRetryPolicy(int maxRetries) {
+    RetryPolicy retryPolicy = new RetryPolicy() {
+      @Override
+      public RetryAction shouldRetry(Exception exception, int retries,
+          int failovers, boolean isIdempotentOrAtMostOnce)
+          throws Exception {
+
+        if (LOG.isDebugEnabled()) {
+          if (exception.getCause() != null) {
+            LOG.debug("RetryProxy: OM {}: {}: {}", omNodeId,
+                exception.getCause().getClass().getSimpleName(),
+                exception.getCause().getMessage());
+          } else {
+            LOG.debug("RetryProxy: OM {}: {}", omNodeId,
+                exception.getMessage());
+          }
+        }
+
+        if (exception instanceof ServiceException) {
+          OMNotLeaderException notLeaderException =
+              getNotLeaderException(exception);
+          if (notLeaderException != null) {
+            // This means that the OM node is a follower and it does not allow this particular
+            // request to go through. We should fail this immediately since the OM does not
+            // allow the request to non-leader to go through.
+            return RetryAction.FAIL;
+          }
+
+          OMLeaderNotReadyException leaderNotReadyException =
+              getLeaderNotReadyException(exception);
+          if (leaderNotReadyException != null) {
+            // Retry on same OM again as leader OM is not ready.
+            // Failing over to same OM so that wait time between retries is
+            // incremented
+            return getRetryAction(RetryDecision.RETRY, retries);
+          }
+        }
+
+        if (!shouldRetryAgain(exception)) {
+          return RetryAction.FAIL; // do not retry
+        }
+        return getRetryAction(RetryDecision.RETRY, retries);
+      }
+
+      private RetryAction getRetryAction(RetryDecision fallbackAction, int retries) {
+        if (retries < maxRetries) {
+          return new RetryAction(fallbackAction, getWaitTime());
+        } else {
+          LOG.error("Failed to connect to OM node: {}. Attempted {} retries.",
+              omNodeId, retries);
+          return RetryAction.FAIL;
+        }
+      }
+    };
+
+    return retryPolicy;
+  }
+
+  @Override
+  public final synchronized void performFailover(T currentProxy) {
+    // Do nothing since this proxy provider does not failover to other OM
+  }
+
+  protected ConfigurationSource getConf() {
+    return conf;
+  }
+
+  protected synchronized void setOmProxy(ProxyInfo<T> omProxy) {
+    this.omProxy = omProxy;
+  }
+
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/SingleOMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/SingleOMFailoverProxyProviderBase.java
@@ -61,7 +61,6 @@ public abstract class SingleOMFailoverProxyProviderBase<T> implements FailoverPr
   private final ConfigurationSource conf;
   private final Class<T> protocolClass;
 
-  private final String omServiceId;
   private final String omNodeId;
   private ProxyInfo<T> omProxy;
 
@@ -73,7 +72,6 @@ public abstract class SingleOMFailoverProxyProviderBase<T> implements FailoverPr
                                            String omServiceId, String omNodeId, Class<T> protocol) throws IOException {
     this.conf = configuration;
     this.protocolClass = protocol;
-    this.omServiceId = omServiceId;
     this.omNodeId = omNodeId;
     this.ugi = ugi;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -775,7 +775,7 @@ public interface OzoneManagerProtocol
    * @param volumeName volume name
    * @param bucketName bucket name
    * @param snapshotName snapshot name
-   * @param omNodeId OM node ID to get the snapshot info from
+   * @param omNodeId OM node ID to get the snapshot info from, if unspecified will get from OM leader
    * @return snapshot info for volume/bucket snapshot path.
    * @throws IOException
    */
@@ -844,6 +844,34 @@ public interface OzoneManagerProtocol
   }
 
   /**
+   * Get the differences between two snapshots.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param token to get the index to return diff report from.
+   * @param pageSize maximum entries returned to the report.
+   * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param omNodeId OM node ID to send the snapshot diff request.
+   * @return the difference report between two snapshots
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  @SuppressWarnings("parameternumber")
+  default SnapshotDiffResponse snapshotDiff(String volumeName,
+                                            String bucketName,
+                                            String fromSnapshot,
+                                            String toSnapshot,
+                                            String token,
+                                            int pageSize,
+                                            boolean forceFullDiff,
+                                            boolean disableNativeDiff,
+                                            String omNodeId)
+      throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
    * Cancel snapshot diff job.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong
@@ -862,6 +890,26 @@ public interface OzoneManagerProtocol
   }
 
   /**
+   * Cancel snapshot diff job.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param omNodeId OM node ID to send the cancel snapshot diff jobs request
+   * @return the success if cancel succeeds.
+   * @throws IOException in case of any exception while cancelling snap diff job
+   */
+  default CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
+                                                        String bucketName,
+                                                        String fromSnapshot,
+                                                        String toSnapshot,
+                                                        String omNodeId)
+      throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
    * Get a list of the SnapshotDiff jobs for a bucket based on the JobStatus.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong
@@ -873,6 +921,25 @@ public interface OzoneManagerProtocol
                                                      String bucketName,
                                                      String jobStatus,
                                                      boolean listAll)
+      throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
+   * Get a list of the SnapshotDiff jobs for a bucket based on the JobStatus.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param jobStatus JobStatus to be used to filter the snapshot diff jobs
+   * @param omNodeId OM node ID to get the list of SnapshotDiff jobs from, if unspecified will get from OM leader
+   * @return a list of SnapshotDiffJob objects
+   * @throws IOException in case there is a failure while getting a response.
+   */
+  default List<SnapshotDiffJob> listSnapshotDiffJobs(String volumeName,
+                                                     String bucketName,
+                                                     String jobStatus,
+                                                     boolean listAll,
+                                                     String omNodeId)
       throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented");

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -771,6 +771,23 @@ public interface OzoneManagerProtocol
   }
 
   /**
+   * Returns snapshot info for volume/bucket snapshot path.
+   * @param volumeName volume name
+   * @param bucketName bucket name
+   * @param snapshotName snapshot name
+   * @param omNodeId OM node ID to get the snapshot info from
+   * @return snapshot info for volume/bucket snapshot path.
+   * @throws IOException
+   */
+  default SnapshotInfo getSnapshotInfo(String volumeName,
+                                       String bucketName,
+                                       String snapshotName,
+                                       String omNodeId) throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
    * Create an image of the current compaction log DAG in the OM.
    * @param fileNamePrefix  file name prefix of the image file.
    * @param graphType       type of node name to use in the graph image.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -818,6 +818,24 @@ public interface OzoneManagerProtocol
   }
 
   /**
+   * List snapshots in a volume/bucket.
+   * @param volumeName     volume name
+   * @param bucketName     bucket name
+   * @param snapshotPrefix snapshot prefix to match
+   * @param prevSnapshot   snapshots will be listed after this snapshot name
+   * @param maxListResult  max number of snapshots to return
+   * @param omNodeId       OM node ID to get the list of snapshots from
+   * @return list of snapshots for volume/bucket path.
+   * @throws IOException
+   */
+  default ListSnapshotResponse listSnapshot(
+      String volumeName, String bucketName, String snapshotPrefix,
+      String prevSnapshot, int maxListResult, String omNodeId) throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
    * Get the differences between two snapshots.
    * @param volumeName Name of the volume to which the snapshotted bucket belong
    * @param bucketName Name of the bucket to which the snapshots belong

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -210,6 +210,11 @@ public class GrpcOmTransport implements OmTransport {
     return resp.get();
   }
 
+  @Override
+  public OMResponse submitRequest(String omNodeId, OMRequest payload) throws IOException {
+    throw new UnsupportedOperationException("gRPC client does not support submitting a request to a specific OM node");
+  }
+
   private Exception unwrapException(Exception ex) {
     Exception grpcException = null;
     try {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/Hadoop3OmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/Hadoop3OmTransport.java
@@ -17,10 +17,16 @@
 
 package org.apache.hadoop.ozone.om.protocolPB;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
@@ -28,9 +34,11 @@ import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
+import org.apache.hadoop.ozone.om.ha.HadoopRpcSingleOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -45,18 +53,25 @@ public class Hadoop3OmTransport implements OmTransport {
    */
   private static final RpcController NULL_RPC_CONTROLLER = null;
 
-  private final HadoopRpcOMFailoverProxyProvider omFailoverProxyProvider;
+  private final String omServiceId;
 
+  // This RPC proxy is used for requests made for OM leader.
+  private final HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> omFailoverProxyProvider;
   private final OzoneManagerProtocolPB rpcProxy;
+
+  // This RPC proxy is used for requests made for a specific OM node.
+  private final Map<String, HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB>> omFailoverProxyProviders;
+  private final Map<String, OzoneManagerProtocolPB> rpcProxies;
 
   public Hadoop3OmTransport(ConfigurationSource conf,
       UserGroupInformation ugi, String omServiceId) throws IOException {
+    this.omServiceId = omServiceId;
 
     RPC.setProtocolEngine(OzoneConfiguration.of(conf),
         OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
 
-    this.omFailoverProxyProvider = new HadoopRpcOMFailoverProxyProvider(
+    this.omFailoverProxyProvider = new HadoopRpcOMFailoverProxyProvider<>(
             conf, ugi, omServiceId, OzoneManagerProtocolPB.class);
 
     int maxFailovers = conf.getInt(
@@ -64,6 +79,19 @@ public class Hadoop3OmTransport implements OmTransport {
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT);
 
     this.rpcProxy = createRetryProxy(omFailoverProxyProvider, maxFailovers);
+
+    Map<String, OzoneManagerProtocolPB> rpcProxiesMap = new HashMap<>();
+    Map<String, HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB>>
+        omFailoverProxyProvidersMap = new HashMap<>();
+    Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf, omServiceId);
+    for (String omNodeId : omNodeIds) {
+      HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> singleOMFailoverProxyProvider =
+          new HadoopRpcSingleOMFailoverProxyProvider<>(conf, ugi, omServiceId, omNodeId, OzoneManagerProtocolPB.class);
+      omFailoverProxyProvidersMap.putIfAbsent(omNodeId, singleOMFailoverProxyProvider);
+      rpcProxiesMap.putIfAbsent(omNodeId, createRetryProxy(singleOMFailoverProxyProvider, maxFailovers));
+    }
+    this.omFailoverProxyProviders = Collections.unmodifiableMap(omFailoverProxyProvidersMap);
+    this.rpcProxies = Collections.unmodifiableMap(rpcProxiesMap);
   }
 
   @Override
@@ -92,6 +120,23 @@ public class Hadoop3OmTransport implements OmTransport {
   }
 
   @Override
+  public OMResponse submitRequest(String omNodeId, OMRequest payload) throws IOException {
+    try {
+      OzoneManagerProtocolPB singleRpcProxy = rpcProxies.get(omNodeId);
+      if (singleRpcProxy == null) {
+        throw new IOException(String.format("Could not find any configured client for OM node %s in service %s. " +
+            "Please configure the system with %s", omNodeId, omServiceId, OZONE_OM_ADDRESS_KEY));
+      }
+      if (!payload.hasOmNodeId()) {
+        payload = payload.toBuilder().setOmNodeId(omNodeId).build();
+      }
+      return singleRpcProxy.submitRequest(NULL_RPC_CONTROLLER, payload);
+    } catch (ServiceException e) {
+      throw new IOException("Could not connect to OM node " + omNodeId);
+    }
+  }
+
+  @Override
   public Text getDelegationTokenService() {
     return omFailoverProxyProvider.getCurrentProxyDelegationToken();
   }
@@ -103,22 +148,39 @@ public class Hadoop3OmTransport implements OmTransport {
    * is not the leader OM.
    */
   private OzoneManagerProtocolPB createRetryProxy(
-      HadoopRpcOMFailoverProxyProvider failoverProxyProvider,
+      HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> failoverProxyProvider,
       int maxFailovers) {
 
-    OzoneManagerProtocolPB proxy = (OzoneManagerProtocolPB) RetryProxy.create(
+    return (OzoneManagerProtocolPB) RetryProxy.create(
         OzoneManagerProtocolPB.class, failoverProxyProvider,
         failoverProxyProvider.getRetryPolicy(maxFailovers));
-    return proxy;
+  }
+
+  /**
+   * Creates a {@link RetryProxy} encapsulating the
+   * {@link HadoopRpcSingleOMFailoverProxyProvider}. The retry proxy fails over on
+   * network exception.
+   */
+  private OzoneManagerProtocolPB createRetryProxy(
+      HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> singleOMFailoverProxyProvider,
+      int maxRetry) {
+
+    return (OzoneManagerProtocolPB) RetryProxy.create(
+        OzoneManagerProtocolPB.class, singleOMFailoverProxyProvider,
+        singleOMFailoverProxyProvider.getRetryPolicy(maxRetry));
   }
 
   @VisibleForTesting
-  public HadoopRpcOMFailoverProxyProvider getOmFailoverProxyProvider() {
+  public HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> getOmFailoverProxyProvider() {
     return omFailoverProxyProvider;
   }
 
   @Override
   public void close() throws IOException {
     omFailoverProxyProvider.close();
+    for (HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> failoverProxyProvider
+        : omFailoverProxyProviders.values()) {
+      failoverProxyProvider.close();
+    }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransport.java
@@ -33,6 +33,11 @@ public interface OmTransport {
   OMResponse submitRequest(OMRequest payload) throws IOException;
 
   /**
+   * The main method to send out the request on the defined transport to a specific OM node.
+   */
+  OMResponse submitRequest(String omNodeId, OMRequest payload) throws IOException;
+
+  /**
    * Return the addresses of the Ozone Managers, used for delegation token.
    */
   Text getDelegationTokenService();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransport.java
@@ -34,6 +34,7 @@ public interface OmTransport {
 
   /**
    * The main method to send out the request on the defined transport to a specific OM node.
+   * Note that this request will not failover to another OM node in case of failure.
    */
   OMResponse submitRequest(String omNodeId, OMRequest payload) throws IOException;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1320,19 +1320,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   @Override
   public SnapshotInfo getSnapshotInfo(String volumeName, String bucketName,
                                       String snapshotName) throws IOException {
-    final SnapshotInfoRequest.Builder requestBuilder =
-        SnapshotInfoRequest.newBuilder()
-            .setVolumeName(volumeName)
-            .setBucketName(bucketName)
-            .setSnapshotName(snapshotName);
-
-    final OMRequest omRequest = createOMRequest(Type.GetSnapshotInfo)
-        .setSnapshotInfoRequest(requestBuilder)
-        .build();
-    final OMResponse omResponse = submitRequest(omRequest);
-    handleError(omResponse);
-    return SnapshotInfo.getFromProtobuf(omResponse.getSnapshotInfoResponse()
-        .getSnapshotInfo());
+    return getSnapshotInfo(volumeName, bucketName, snapshotName, null);
   }
 
 
@@ -1342,18 +1330,18 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   @Override
   public SnapshotInfo getSnapshotInfo(String volumeName, String bucketName,
                                       String snapshotName, String omNodeId) throws IOException {
-    Preconditions.checkNotNull(omNodeId);
     final SnapshotInfoRequest.Builder requestBuilder =
         SnapshotInfoRequest.newBuilder()
             .setVolumeName(volumeName)
             .setBucketName(bucketName)
             .setSnapshotName(snapshotName);
 
-    final OMRequest omRequest = createOMRequest(Type.GetSnapshotInfo)
-        .setSnapshotInfoRequest(requestBuilder)
-        .setOmNodeId(omNodeId)
-        .build();
-    final OMResponse omResponse = submitRequest(omRequest);
+    final OMRequest.Builder omRequest = createOMRequest(Type.GetSnapshotInfo)
+        .setSnapshotInfoRequest(requestBuilder);
+    if (!StringUtils.isBlank(omNodeId)) {
+      omRequest.setOmNodeId(omNodeId);
+    }
+    final OMResponse omResponse = submitRequest(omRequest.build());
     handleError(omResponse);
     return SnapshotInfo.getFromProtobuf(omResponse.getSnapshotInfoResponse()
         .getSnapshotInfo());
@@ -1443,6 +1431,24 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                            boolean forceFullDiff,
                                            boolean disableNativeDiff)
       throws IOException {
+    return snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot, token,
+        pageSize, forceFullDiff, disableNativeDiff, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize,
+                                           boolean forceFullDiff,
+                                           boolean disableNativeDiff,
+                                           String omNodeId)
+      throws IOException {
     final OzoneManagerProtocolProtos.SnapshotDiffRequest.Builder
         requestBuilder =
         OzoneManagerProtocolProtos.SnapshotDiffRequest.newBuilder()
@@ -1458,10 +1464,14 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       requestBuilder.setToken(token);
     }
 
-    final OMRequest omRequest = createOMRequest(Type.SnapshotDiff)
-        .setSnapshotDiffRequest(requestBuilder)
-        .build();
-    final OMResponse omResponse = submitRequest(omRequest);
+    final OMRequest.Builder omRequest = createOMRequest(Type.SnapshotDiff)
+        .setSnapshotDiffRequest(requestBuilder);
+
+    if (!StringUtils.isBlank(omNodeId)) {
+      omRequest.setOmNodeId(omNodeId);
+    }
+
+    final OMResponse omResponse = submitRequest(omRequest.build());
     handleError(omResponse);
     OzoneManagerProtocolProtos.SnapshotDiffResponse diffResponse =
         omResponse.getSnapshotDiffResponse();
@@ -1482,6 +1492,15 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                                        String fromSnapshot,
                                                        String toSnapshot)
       throws IOException {
+    return cancelSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName, String bucketName,
+      String fromSnapshot, String toSnapshot, String omNodeId) throws IOException {
     final OzoneManagerProtocolProtos.CancelSnapshotDiffRequest.Builder
         requestBuilder =
         OzoneManagerProtocolProtos.CancelSnapshotDiffRequest.newBuilder()
@@ -1490,11 +1509,14 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .setFromSnapshot(fromSnapshot)
             .setToSnapshot(toSnapshot);
 
-    final OMRequest omRequest = createOMRequest(Type.CancelSnapshotDiff)
-        .setCancelSnapshotDiffRequest(requestBuilder)
-        .build();
+    final OMRequest.Builder omRequest = createOMRequest(Type.CancelSnapshotDiff)
+        .setCancelSnapshotDiffRequest(requestBuilder);
 
-    final OMResponse omResponse = submitRequest(omRequest);
+    if (!StringUtils.isBlank(omNodeId)) {
+      omRequest.setOmNodeId(omNodeId);
+    }
+
+    final OMResponse omResponse = submitRequest(omRequest.build());
     handleError(omResponse);
     OzoneManagerProtocolProtos.CancelSnapshotDiffResponse diffResponse =
         omResponse.getCancelSnapshotDiffResponse();
@@ -1511,6 +1533,15 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                                     String jobStatus,
                                                     boolean listAll)
       throws IOException {
+    return listSnapshotDiffJobs(volumeName, bucketName, jobStatus, listAll, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<SnapshotDiffJob> listSnapshotDiffJobs(String volumeName, String bucketName, String jobStatus,
+                                                    boolean listAll, String omNodeId) throws IOException {
     final OzoneManagerProtocolProtos
         .ListSnapshotDiffJobRequest.Builder requestBuilder =
         OzoneManagerProtocolProtos
@@ -1520,10 +1551,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .setJobStatus(jobStatus)
             .setListAll(listAll);
 
-    final OMRequest omRequest = createOMRequest(Type.ListSnapshotDiffJobs)
-        .setListSnapshotDiffJobRequest(requestBuilder)
-        .build();
-    final OMResponse omResponse = submitRequest(omRequest);
+    final OMRequest.Builder omRequest = createOMRequest(Type.ListSnapshotDiffJobs)
+        .setListSnapshotDiffJobRequest(requestBuilder);
+    if (!StringUtils.isBlank(omNodeId)) {
+      omRequest.setOmNodeId(omNodeId);
+    }
+    final OMResponse omResponse = submitRequest(omRequest.build());
     handleError(omResponse);
     return omResponse.getListSnapshotDiffJobResponse()
         .getSnapshotDiffJobList().stream()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1378,6 +1378,16 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   public ListSnapshotResponse listSnapshot(
       String volumeName, String bucketName, String snapshotPrefix,
       String prevSnapshot, int maxListResult) throws IOException {
+    return listSnapshot(volumeName, bucketName, snapshotPrefix, prevSnapshot, maxListResult, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ListSnapshotResponse listSnapshot(
+      String volumeName, String bucketName, String snapshotPrefix,
+      String prevSnapshot, int maxListResult, String omNodeId) throws IOException {
     final OzoneManagerProtocolProtos.ListSnapshotRequest.Builder
         requestBuilder =
         OzoneManagerProtocolProtos.ListSnapshotRequest.newBuilder()
@@ -1393,10 +1403,14 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       requestBuilder.setPrefix(snapshotPrefix);
     }
 
-    final OMRequest omRequest = createOMRequest(Type.ListSnapshot)
-        .setListSnapshotRequest(requestBuilder)
-        .build();
-    final OMResponse omResponse = submitRequest(omRequest);
+    final OMRequest.Builder omRequest = createOMRequest(Type.ListSnapshot)
+        .setListSnapshotRequest(requestBuilder);
+
+    if (StringUtils.isNotBlank(omNodeId)) {
+      omRequest.setOmNodeId(omNodeId);
+    }
+
+    final OMResponse omResponse = submitRequest(omRequest.build());
     handleError(omResponse);
     OzoneManagerProtocolProtos.ListSnapshotResponse response = omResponse.getListSnapshotResponse();
     List<SnapshotInfo> snapshotInfos = response

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestSingleOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestSingleOMFailoverProxyProvider.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.protobuf.RpcController;
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.retry.RetryProxy;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.security.AccessControlException;
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+/**
+ * Tests SingleOMFailoverProxyProvider behaviour.
+ */
+public class TestSingleOMFailoverProxyProvider {
+  private static final String OM_SERVICE_ID = "om-service-test1";
+  private static final String NODE_ID_BASE_STR = "omNode-";
+  private static final String DUMMY_NODE_ADDR = "0.0.0.0:8080";
+  private static final Map<String, MockSingleFailoverProxyProvider>
+      MOCK_PROVIDERS = new HashMap<>();
+  // Configure the retries to speed up the tests
+  private static final int MAX_ATTEMPTS = 5;
+  private static final long WAIT_BETWEEN_RETRIES = 100L;
+  private static final int NUM_OF_NODES = 3;
+  private Exception testException;
+
+  @BeforeEach
+  void init() throws Exception {
+    OzoneConfiguration config = new OzoneConfiguration();
+    config.setInt(OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY, MAX_ATTEMPTS);
+    config.setLong(OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY, WAIT_BETWEEN_RETRIES);
+
+    StringJoiner allNodeIds = new StringJoiner(",");
+    for (int i = 1; i <= NUM_OF_NODES; i++) {
+      String nodeId = NODE_ID_BASE_STR + i;
+      config.set(ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, OM_SERVICE_ID,
+          nodeId), DUMMY_NODE_ADDR);
+      allNodeIds.add(nodeId);
+      MOCK_PROVIDERS.put(nodeId, new MockSingleFailoverProxyProvider(config, nodeId));
+    }
+    config.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID),
+        allNodeIds.toString());
+  }
+
+  @Test
+  public void testAccessControlExceptionNoFailover() throws IOException {
+    testException = new AccessControlException();
+
+    GenericTestUtils.setLogLevel(SingleOMFailoverProxyProviderBase.LOG, Level.DEBUG);
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
+        .captureLogs(SingleOMFailoverProxyProviderBase.LOG);
+
+    MockSingleFailoverProxyProvider singleFailoverProxyProvider = MOCK_PROVIDERS.get(NODE_ID_BASE_STR + "1");
+
+    OzoneManagerProtocolPB proxy = (OzoneManagerProtocolPB) RetryProxy
+        .create(OzoneManagerProtocolPB.class, singleFailoverProxyProvider,
+            singleFailoverProxyProvider.getRetryPolicy(MAX_ATTEMPTS));
+
+    ServiceException serviceException = assertThrows(ServiceException.class,
+        () -> proxy.submitRequest(null, null));
+
+    // Fail immediately for AccessControlException
+    assertThat(serviceException).hasCauseInstanceOf(AccessControlException.class);
+    assertThat(logCapturer.getOutput()).contains(
+        getRetryProxyDebugMsg(NODE_ID_BASE_STR + "1"));
+    assertThat(logCapturer.getOutput()).doesNotContain(
+        getRetryProxyDebugMsg(NODE_ID_BASE_STR + "2"));
+    assertThat(logCapturer.getOutput()).doesNotContain(
+        getRetryProxyDebugMsg(NODE_ID_BASE_STR + "3"));
+  }
+
+  @Test
+  public void testNotLeaderExceptionNoFailover() {
+    OMNotLeaderException omNotLeaderException = new OMNotLeaderException(RaftPeerId.valueOf(NODE_ID_BASE_STR + "1"),
+        RaftPeerId.valueOf(NODE_ID_BASE_STR + "2"), null);
+    testException = new RemoteException(omNotLeaderException.getClass().getName(), omNotLeaderException.getMessage());
+
+
+    GenericTestUtils.setLogLevel(SingleOMFailoverProxyProviderBase.LOG, Level.DEBUG);
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
+        .captureLogs(SingleOMFailoverProxyProviderBase.LOG);
+
+    MockSingleFailoverProxyProvider singleFailoverProxyProvider = MOCK_PROVIDERS.get(NODE_ID_BASE_STR + "1");
+
+    OzoneManagerProtocolPB proxy = (OzoneManagerProtocolPB) RetryProxy
+        .create(OzoneManagerProtocolPB.class, singleFailoverProxyProvider,
+            singleFailoverProxyProvider.getRetryPolicy(MAX_ATTEMPTS));
+
+    ServiceException serviceException = assertThrows(ServiceException.class,
+        () -> proxy.submitRequest(null, null));
+
+    // Fail immediately for OMNotLeaderException
+    assertThat(serviceException).hasCauseInstanceOf(RemoteException.class);
+    assertThat(logCapturer.getOutput()).contains(getRetryProxyDebugMsg(NODE_ID_BASE_STR + "1"));
+    assertThat(logCapturer.getOutput()).doesNotContain(getRetryProxyDebugMsg(NODE_ID_BASE_STR + "2"));
+    assertThat(logCapturer.getOutput()).doesNotContain(getRetryProxyDebugMsg(NODE_ID_BASE_STR + "3"));
+  }
+
+  @Test
+  public void testLeaderNotReadyException() {
+    OMLeaderNotReadyException omLeaderNotReadyException = new OMLeaderNotReadyException(
+        NODE_ID_BASE_STR + "1 is Leader but not ready to process request yet.");
+    testException = new RemoteException(omLeaderNotReadyException.getClass().getName(),
+        omLeaderNotReadyException.getMessage());
+
+    GenericTestUtils.setLogLevel(SingleOMFailoverProxyProviderBase.LOG, Level.DEBUG);
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
+        .captureLogs(SingleOMFailoverProxyProviderBase.LOG);
+
+    MockSingleFailoverProxyProvider singleFailoverProxyProvider = MOCK_PROVIDERS.get(NODE_ID_BASE_STR + "1");
+
+    OzoneManagerProtocolPB proxy = (OzoneManagerProtocolPB) RetryProxy
+        .create(OzoneManagerProtocolPB.class, singleFailoverProxyProvider,
+            singleFailoverProxyProvider.getRetryPolicy(MAX_ATTEMPTS));
+
+    ServiceException serviceException = assertThrows(ServiceException.class,
+        () -> proxy.submitRequest(null, null));
+
+
+    assertThat(serviceException).hasCauseInstanceOf(RemoteException.class);
+    // Will retry up until max attempts
+    for (int i = 0; i < MAX_ATTEMPTS; i++) {
+      assertThat(logCapturer.getOutput()).contains(getRetryProxyDebugMsg(NODE_ID_BASE_STR + "1"));
+    }
+    assertThat(logCapturer.getOutput()).doesNotContain(getRetryProxyDebugMsg(NODE_ID_BASE_STR + "2"));
+    assertThat(logCapturer.getOutput()).doesNotContain(getRetryProxyDebugMsg(NODE_ID_BASE_STR + "3"));
+  }
+
+  private String getRetryProxyDebugMsg(String omNodeId) {
+    return "RetryProxy: OM " + omNodeId + ": " +
+        testException.getClass().getSimpleName() + ": " +
+        testException.getMessage();
+  }
+
+  private static final class MockOzoneManagerProtocol
+      implements OzoneManagerProtocolPB {
+
+    private final String omNodeId;
+    // Exception to throw when submitMockRequest is called
+    private final Supplier<Exception> exception;
+
+    private MockOzoneManagerProtocol(String nodeId, Supplier<Exception> ex) {
+      omNodeId = nodeId;
+      exception = ex;
+    }
+
+    @Override
+    public OMResponse submitRequest(RpcController controller,
+                                    OzoneManagerProtocolProtos.OMRequest request) throws ServiceException {
+      throw new ServiceException("ServiceException of type " +
+          exception.getClass() + " for " + omNodeId, exception.get());
+    }
+  }
+
+  private final class MockSingleFailoverProxyProvider extends
+      HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> {
+
+    private final String omNodeId;
+
+    private MockSingleFailoverProxyProvider(ConfigurationSource configuration, String omNodeId) throws IOException {
+      super(configuration, null, null, omNodeId, OzoneManagerProtocolPB.class);
+      this.omNodeId = omNodeId;
+    }
+
+    @Override
+    protected ProxyInfo<OzoneManagerProtocolPB> createOMProxy() {
+      return new ProxyInfo<>(new MockOzoneManagerProtocol(omNodeId, () -> testException), omNodeId);
+    }
+
+    @Override
+    protected void loadOMClientConfig(ConfigurationSource conf, String omSvcId, String nodeId) throws IOException {
+      setOmProxy(createOMProxy());
+    }
+
+    @Override
+    protected Text computeDelegationTokenService() {
+      return null;
+    }
+  }
+}

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -49,3 +49,4 @@ execute_robot_test ${SCM} freon
 execute_robot_test ${SCM} -v USERNAME:httpfs httpfs
 
 execute_robot_test ${SCM} omha/om-roles.robot
+execute_robot_test ${SCM} --exclude pre-finalized-snapshot-tests snapshot

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -54,5 +54,3 @@ source "$COMPOSE_DIR/../common/replicas-test.sh"
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-o3fs-bucket ozonefs/ozonefs.robot
 
 execute_robot_test s3g grpc/grpc-om-s3-metrics.robot
-
-execute_robot_test scm --exclude pre-finalized-snapshot-tests snapshot

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
@@ -58,14 +58,14 @@ Snapshot List
                      Should contain      ${result}       SNAPSHOT_ACTIVE
 
 Snapshot Info
-   ${result} =       Execute             ozone sh snapshot info /${VOLUME}/${BUCKET}
+   ${result} =       Execute             ozone sh snapshot info /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE}
                      Should contain      echo '${result}' | jq '.volumeName'        ${VOLUME}
                      Should contain      echo '${result}' | jq '.bucketName'        ${BUCKET}
                      Should contain      echo '${result}' | jq '.name'              ${SNAPSHOT_ONE}
                      Should contain      echo '${result}' | jq '.snapshotStatus'    SNAPSHOT_ACTIVE
 
-   ${followerOM} =   Get One OM Follower Nod
-   ${result} =       Execute             ozone sh snapshot info /${VOLUME}/${BUCKET} --om-node-id ${followerOM}
+   ${followerOM} =   Get One OM Follower Node
+   ${result} =       Execute             ozone sh snapshot info /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} --om-node-id ${followerOM}
                      Should contain      echo '${result}' | jq '.volumeName'        ${VOLUME}
                      Should contain      echo '${result}' | jq '.bucketName'        ${BUCKET}
                      Should contain      echo '${result}' | jq '.name'              ${SNAPSHOT_ONE}
@@ -87,12 +87,12 @@ Snapshot Diff
 
     ${followerOM} =  Get One OM Follower Node
     ${result} =      Execute                       ozone sh snapshot ls /${VOLUME}/${BUCKET} --om-node-id ${followerOM}
-                     Wait Until Keyword Succeeds   30sec   5sec   Should contain      ${result}       ${SNAPSHOT_TWO}}
+                     Wait Until Keyword Succeeds   30sec   5sec   Should contain      ${result}       ${SNAPSHOT_TWO}
                      Should contain      ${result}       SNAPSHOT_ACTIVE
 
     ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO} --om-node-id ${followerOM}
                     Should contain      ${result}       Snapshot diff job is IN_PROGRESS
-    ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+    ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO} --om-node-id ${followerOM}
                     Should contain      ${result}       +    ${KEY_TWO}
                     Should contain      ${result}       +    ${KEY_THREE}
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
@@ -358,7 +358,6 @@ public class TestOzoneManagerHASnapshot {
 
     // Create snapshot (write operation) should be directed to leader
     store.createSnapshot(volumeName, bucketName, snapshotName);
-    List<OzoneManager> ozoneManagers = cluster.getOzoneManagersList();
 
     OzoneManager omLeader = cluster.getOMLeader();
     assertNotNull(omLeader);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -179,6 +179,13 @@ message OMRequest {
 
   optional LayoutVersion layoutVersion = 6;
 
+  // If omNodeID is specified, this means that this client request is specifically
+  // made to the particular OM node, regardless whether the OM node is a leader.
+  // OM needs to rejects the request if the omNodeID is not equal to its own node ID.
+  // If omNodeID is not specified, this means that this client request is expected
+  // to be sent to the leader.
+  optional string omNodeId = 7;
+
   optional CreateVolumeRequest              createVolumeRequest            = 11;
   optional SetVolumePropertyRequest         setVolumePropertyRequest       = 12;
   optional CheckVolumeAccessRequest         checkVolumeAccessRequest       = 13;

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/Hadoop27RpcTransport.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/Hadoop27RpcTransport.java
@@ -17,9 +17,15 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
@@ -27,9 +33,11 @@ import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
+import org.apache.hadoop.ozone.om.ha.HadoopRpcSingleOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -43,26 +51,45 @@ public class Hadoop27RpcTransport implements OmTransport {
 
   private static final RpcController NULL_RPC_CONTROLLER = null;
 
+  private final String omServiceId;
+
+  // This RPC proxy is used for requests made for OM leader.
+  private final HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> omFailoverProxyProvider;
   private final OzoneManagerProtocolPB rpcProxy;
 
-  private final HadoopRpcOMFailoverProxyProvider omFailoverProxyProvider;
+  // This RPC proxy is used for requests made for a specific OM node.
+  private final Map<String, HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB>> omFailoverProxyProviders;
+  private final Map<String, OzoneManagerProtocolPB> rpcProxies;
 
   public Hadoop27RpcTransport(ConfigurationSource conf,
       UserGroupInformation ugi, String omServiceId) throws IOException {
+    this.omServiceId = omServiceId;
 
     RPC.setProtocolEngine(OzoneConfiguration.of(conf),
         OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
 
-    this.omFailoverProxyProvider = new HadoopRpcOMFailoverProxyProvider(
+    this.omFailoverProxyProvider = new HadoopRpcOMFailoverProxyProvider<>(
             conf, ugi, omServiceId, OzoneManagerProtocolPB.class);
 
     int maxFailovers = conf.getInt(
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT);
 
-    rpcProxy = createRetryProxy(omFailoverProxyProvider, maxFailovers);
+    this.rpcProxy = createRetryProxy(omFailoverProxyProvider, maxFailovers);
 
+    Map<String, OzoneManagerProtocolPB> rpcProxiesMap = new HashMap<>();
+    Map<String, HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB>>
+        omFailoverProxyProvidersMap = new HashMap<>();
+    Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf, omServiceId);
+    for (String omNodeId : omNodeIds) {
+      HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> singleOMFailoverProxyProvider =
+          new HadoopRpcSingleOMFailoverProxyProvider<>(conf, ugi, omServiceId, omNodeId, OzoneManagerProtocolPB.class);
+      omFailoverProxyProvidersMap.putIfAbsent(omNodeId, singleOMFailoverProxyProvider);
+      rpcProxiesMap.putIfAbsent(omNodeId, createRetryProxy(singleOMFailoverProxyProvider, maxFailovers));
+    }
+    this.omFailoverProxyProviders = Collections.unmodifiableMap(omFailoverProxyProvidersMap);
+    this.rpcProxies = Collections.unmodifiableMap(rpcProxiesMap);
   }
 
   @Override
@@ -91,6 +118,23 @@ public class Hadoop27RpcTransport implements OmTransport {
   }
 
   @Override
+  public OMResponse submitRequest(String omNodeId, OMRequest payload) throws IOException {
+    try {
+      OzoneManagerProtocolPB singleRpcProxy = rpcProxies.get(omNodeId);
+      if (singleRpcProxy == null) {
+        throw new IOException(String.format("Could not find any configured client for OM node %s in service %s. " +
+            "Please configure the system with %s", omNodeId, omServiceId, OZONE_OM_ADDRESS_KEY));
+      }
+      if (!payload.hasOmNodeId()) {
+        payload = payload.toBuilder().setOmNodeId(omNodeId).build();
+      }
+      return singleRpcProxy.submitRequest(NULL_RPC_CONTROLLER, payload);
+    } catch (ServiceException e) {
+      throw new IOException("Could not connect to OM node " + omNodeId);
+    }
+  }
+
+  @Override
   public Text getDelegationTokenService() {
     return null;
   }
@@ -101,18 +145,35 @@ public class Hadoop27RpcTransport implements OmTransport {
    * network exception or if the current proxy is not the leader OM.
    */
   private OzoneManagerProtocolPB createRetryProxy(
-      HadoopRpcOMFailoverProxyProvider failoverProxyProvider,
+      HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> failoverProxyProvider,
       int maxFailovers) {
 
-    OzoneManagerProtocolPB proxy = (OzoneManagerProtocolPB) RetryProxy.create(
+    return (OzoneManagerProtocolPB) RetryProxy.create(
         OzoneManagerProtocolPB.class, failoverProxyProvider,
         failoverProxyProvider.getRetryPolicy(maxFailovers));
-    return proxy;
+  }
+
+  /**
+   * Creates a {@link RetryProxy} encapsulating the
+   * {@link HadoopRpcSingleOMFailoverProxyProvider}. The retry proxy fails over on
+   * network exception.
+   */
+  private OzoneManagerProtocolPB createRetryProxy(
+      HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> singleOMFailoverProxyProvider,
+      int maxRetry) {
+
+    return (OzoneManagerProtocolPB) RetryProxy.create(
+        OzoneManagerProtocolPB.class, singleOMFailoverProxyProvider,
+        singleOMFailoverProxyProvider.getRetryPolicy(maxRetry));
   }
 
   @Override
   public void close() throws IOException {
     omFailoverProxyProvider.close();
+    for (HadoopRpcSingleOMFailoverProxyProvider<OzoneManagerProtocolPB> failoverProxyProvider
+        : omFailoverProxyProviders.values()) {
+      failoverProxyProvider.close();
+    }
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -748,6 +748,13 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public SnapshotDiffResponse snapshotDiff(String volumeName, String bucketName, String fromSnapshot,
+                                           String toSnapshot, String token, int pageSize, boolean forceFullDiff,
+                                           boolean disableNativeDiff, String omNodeId) throws IOException {
+    return null;
+  }
+
+  @Override
   public CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
                                                        String bucketName,
                                                        String fromSnapshot,
@@ -757,9 +764,26 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public CancelSnapshotDiffResponse cancelSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       String omNodeId)
+      throws IOException {
+    return null;
+  }
+
+  @Override
   public List<OzoneSnapshotDiff> listSnapshotDiffJobs(
       String volumeName, String bucketName,
       String jobStatus, boolean listAll) {
+    return null;
+  }
+
+  @Override
+  public List<OzoneSnapshotDiff> listSnapshotDiffJobs(
+      String volumeName, String bucketName, String jobStatus,
+      boolean listAll, String omNodeId) {
     return null;
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -723,6 +723,12 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public OzoneSnapshot getSnapshotInfo(String volumeName, String bucketName, String snapshotName,
+                                       String omNodeId) throws IOException {
+    return null;
+  }
+
+  @Override
   public String printCompactionLogDag(String fileNamePrefix,
                                       String graphType) throws IOException {
     return null;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -708,7 +708,13 @@ public class ClientProtocolStub implements ClientProtocol {
       String prevSnapshot, int maxListResult) throws IOException {
     return null;
   }
-  
+
+  @Override
+  public ListSnapshotResponse listSnapshot(String volumeName, String bucketName, String snapshotPrefix,
+       String prevSnapshot, int maxListResult, String omNodeId) throws IOException {
+    return null;
+  }
+
   @Override
   public void deleteSnapshot(String volumeName,
       String bucketName, String snapshotName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds a support for Ozone client to be able to do read-only snapshot operations (GetSnapshotInfo, ListSnapshots, SnapshotDiff, ListSnapshotDiffJobs) from non-leader OM. For example, currently Snapdiff request will always go to the current OM leader. The leader will start a Snapdiff job if it does not exist yet and once it's finished, the user can rerun the snapdiff command again to receive the snapshot diffs returned by the Snapdiff job. However, if there is a OM leader change and another snapshot diff is called, the new OM leader needs to start the Snapdiff job again and the client will receive that the snapdiff is not ready yet, although it was ready at the previous leader.

This adds the following features
- Single (no-failover) proxy implementation to pick a specific OM node to get snapshot from `SingleOMFailoverProxyProviderBase`
- Supports for non-leader OM node to serve snapshot-related reads
  - This is supported by adding a new `omNodeId` proto field which if set means that the OM request is intended for the particular OM node 
- Ozone snapshot shell supports to read snapshots from followers

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6856

## How was this patch tested?

Unit test (proxy provider implementation), integration test (Ozone client), and acceptance test (Ozone shell).