### PR TITLE
HDDS-12443. Intermittent failure in TestContainerBalancerSubCommand

### DIFF
--- a/hadoop-hdds/tools/pom.xml
+++ b/hadoop-hdds/tools/pom.xml
@@ -140,6 +140,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
@@ -69,7 +70,9 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
       System.out.println("ContainerBalancer is Running.");
 
       if (verbose) {
-        System.out.printf("Started at: %s %s%n", dateTime.toLocalDate(), dateTime.toLocalTime());
+        System.out.printf("Started at: %s %s%n",
+            dateTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE),
+            dateTime.toLocalTime().format(DateTimeFormatter.ISO_LOCAL_TIME));
         Duration balancingDuration = Duration.between(startedAtInstant, OffsetDateTime.now());
         System.out.printf("Balancing duration: %s%n%n", getPrettyDuration(balancingDuration));
         System.out.println(getConfigurationPrettyString(balancerStatusInfo.getConfiguration()));

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -47,23 +47,23 @@ import picocli.CommandLine;
  */
 class TestContainerBalancerSubCommand {
 
-  public static final Pattern DURATION = Pattern.compile(
+  private static final Pattern DURATION = Pattern.compile(
       "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
-  public static final Pattern FAILED_TO_START = Pattern.compile(
+  private static final Pattern FAILED_TO_START = Pattern.compile(
       "^Failed\\sto\\sstart\\sContainer\\sBalancer.");
-  public static final Pattern IS_NOT_RUNNING = Pattern.compile(
+  private static final Pattern IS_NOT_RUNNING = Pattern.compile(
       "^ContainerBalancer\\sis\\sNot\\sRunning.");
   private static final Pattern IS_RUNNING = Pattern.compile(
       "^ContainerBalancer\\sis\\sRunning.$", Pattern.MULTILINE);
-  public static final Pattern STARTED_AT = Pattern.compile(
+  private static final Pattern STARTED_AT = Pattern.compile(
       "^Started at: (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})$", Pattern.MULTILINE);
-  public static final Pattern STARTED_SUCCESSFULLY = Pattern.compile(
+  private static final Pattern STARTED_SUCCESSFULLY = Pattern.compile(
       "^Container\\sBalancer\\sstarted\\ssuccessfully.");
-  public static final Pattern WAITING_TO_STOP = Pattern.compile(
+  private static final Pattern WAITING_TO_STOP = Pattern.compile(
       "^Sending\\sstop\\scommand.\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
       "Container\\sBalancer\\sstopped.");
 
-  public static final String BALANCER_CONFIG_OUTPUT = "Container Balancer Configuration values:\n" +
+  private static final String BALANCER_CONFIG_OUTPUT = "Container Balancer Configuration values:\n" +
       "Key                                                Value\n" +
       "Threshold                                          10.0\n" +
       "Max Datanodes to Involve per Iteration(percent)    20\n" +

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -238,8 +238,6 @@ class TestContainerBalancerSubCommand {
     //test status is running
     when(scmClient.getContainerBalancerStatusInfo()).thenReturn(statusInfoResponseProto);
     statusCmd.execute(scmClient);
-    String output = out.get();
-    assertThat(output).containsPattern(IS_RUNNING);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -258,7 +256,6 @@ class TestContainerBalancerSubCommand {
         "Container IDs to Exclude from Balancing            None\n" +
         "Datanodes Specified to be Balanced                 None\n" +
         "Datanodes Excluded from Balancing                  None";
-    assertThat(output).doesNotContain(balancerConfigOutput);
 
     String currentIterationOutput =
         "Current iteration info:\n" +
@@ -278,9 +275,11 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 30 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
-    assertThat(output).doesNotContain(currentIterationOutput);
 
-    assertThat(output).doesNotContain("Iteration history list:");
+    assertThat(out.get()).containsPattern(IS_RUNNING)
+        .doesNotContain(balancerConfigOutput)
+        .doesNotContain(currentIterationOutput)
+        .doesNotContain("Iteration history list:");
   }
 
   @Test
@@ -298,10 +297,6 @@ class TestContainerBalancerSubCommand {
     CommandLine c = new CommandLine(statusCmd);
     c.parseArgs("--verbose", "--history");
     statusCmd.execute(scmClient);
-    String output = out.get();
-    assertThat(output).containsPattern(IS_RUNNING);
-    assertThat(output).containsPattern(STARTED_AT);
-    assertThat(output).containsPattern(DURATION);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -320,9 +315,6 @@ class TestContainerBalancerSubCommand {
         "Container IDs to Exclude from Balancing            None\n" +
         "Datanodes Specified to be Balanced                 None\n" +
         "Datanodes Excluded from Balancing                  None";
-    assertThat(output).contains(balancerConfigOutput);
-
-    assertThat(output).contains("Iteration history list:");
     String firstHistoryIterationOutput =
         "Key                                                Value\n" +
         "Iteration number                                   3\n" +
@@ -340,7 +332,6 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 30 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
-    assertThat(output).contains(firstHistoryIterationOutput);
 
     String secondHistoryIterationOutput =
         "Key                                                Value\n" +
@@ -359,7 +350,15 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 15 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 15 GB";
-    assertThat(output).contains(secondHistoryIterationOutput);
+
+    assertThat(out.get())
+        .containsPattern(IS_RUNNING)
+        .containsPattern(STARTED_AT)
+        .containsPattern(DURATION)
+        .contains(balancerConfigOutput)
+        .contains("Iteration history list:")
+        .contains(firstHistoryIterationOutput)
+        .contains(secondHistoryIterationOutput);
   }
 
   @Test
@@ -377,10 +376,6 @@ class TestContainerBalancerSubCommand {
     CommandLine c = new CommandLine(statusCmd);
     c.parseArgs("--verbose");
     statusCmd.execute(scmClient);
-    String output = out.get();
-    assertThat(output).containsPattern(IS_RUNNING);
-    assertThat(output).containsPattern(STARTED_AT);
-    assertThat(output).containsPattern(DURATION);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -399,7 +394,6 @@ class TestContainerBalancerSubCommand {
         "Container IDs to Exclude from Balancing            None\n" +
         "Datanodes Specified to be Balanced                 None\n" +
         "Datanodes Excluded from Balancing                  None";
-    assertThat(output).contains(balancerConfigOutput);
 
     String currentIterationOutput =
         "Current iteration info:\n" +
@@ -419,9 +413,14 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 30 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
-    assertThat(output).contains(currentIterationOutput);
 
-    assertThat(output).doesNotContain("Iteration history list:");
+    assertThat(out.get())
+        .containsPattern(IS_RUNNING)
+        .containsPattern(STARTED_AT)
+        .containsPattern(DURATION)
+        .contains(balancerConfigOutput)
+        .contains(currentIterationOutput)
+        .doesNotContain("Iteration history list:");
   }
 
   @Test
@@ -436,8 +435,7 @@ class TestContainerBalancerSubCommand {
             .build());
 
     statusCmd.execute(scmClient);
-    String output = out.get();
-    assertThat(output).containsPattern(IS_NOT_RUNNING);
+    assertThat(out.get()).containsPattern(IS_NOT_RUNNING);
   }
 
   @Test
@@ -452,8 +450,7 @@ class TestContainerBalancerSubCommand {
 
     statusCmd.execute(scmClient);
 
-    String output = out.get();
-    assertThat(output).containsPattern(IS_NOT_RUNNING);
+    assertThat(out.get()).containsPattern(IS_NOT_RUNNING);
   }
 
   @Test
@@ -461,8 +458,7 @@ class TestContainerBalancerSubCommand {
     ScmClient scmClient = mock(ScmClient.class);
     stopCmd.execute(scmClient);
 
-    String output = out.get();
-    assertThat(output).containsPattern(WAITING_TO_STOP);
+    assertThat(out.get()).containsPattern(WAITING_TO_STOP);
   }
 
   @Test
@@ -478,8 +474,7 @@ class TestContainerBalancerSubCommand {
                 .build());
     startCmd.execute(scmClient);
 
-    String output = out.get();
-    assertThat(output).containsPattern(STARTED_SUCCESSFULLY);
+    assertThat(out.get()).containsPattern(STARTED_SUCCESSFULLY);
   }
 
   @Test
@@ -495,8 +490,7 @@ class TestContainerBalancerSubCommand {
             .build());
     startCmd.execute(scmClient);
 
-    String output = out.get();
-    assertThat(output).containsPattern(FAILED_TO_START);
+    assertThat(out.get()).containsPattern(FAILED_TO_START);
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -18,8 +18,7 @@
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import static org.apache.hadoop.ozone.OzoneConsts.GB;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +29,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoProto;
@@ -233,8 +231,7 @@ class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sRunning.");
     String output = outContent.toString(DEFAULT_ENCODING);
-    Matcher m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -253,7 +250,7 @@ class TestContainerBalancerSubCommand {
         "Container IDs to Exclude from Balancing            None\n" +
         "Datanodes Specified to be Balanced                 None\n" +
         "Datanodes Excluded from Balancing                  None";
-    assertFalse(output.contains(balancerConfigOutput));
+    assertThat(output).doesNotContain(balancerConfigOutput);
 
     String currentIterationOutput =
         "Current iteration info:\n" +
@@ -273,9 +270,9 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 30 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
-    assertFalse(output.contains(currentIterationOutput));
+    assertThat(output).doesNotContain(currentIterationOutput);
 
-    assertFalse(output.contains("Iteration history list:"));
+    assertThat(output).doesNotContain("Iteration history list:");
   }
 
   @Test
@@ -296,18 +293,15 @@ class TestContainerBalancerSubCommand {
     String output = outContent.toString(DEFAULT_ENCODING);
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sRunning.$", Pattern.MULTILINE);
-    Matcher m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     p = Pattern.compile(
         "^Started at: (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})$", Pattern.MULTILINE);
-    m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     p = Pattern.compile(
         "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
-    m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -326,9 +320,9 @@ class TestContainerBalancerSubCommand {
         "Container IDs to Exclude from Balancing            None\n" +
         "Datanodes Specified to be Balanced                 None\n" +
         "Datanodes Excluded from Balancing                  None";
-    assertTrue(output.contains(balancerConfigOutput));
+    assertThat(output).contains(balancerConfigOutput);
 
-    assertTrue(output.contains("Iteration history list:"));
+    assertThat(output).contains("Iteration history list:");
     String firstHistoryIterationOutput =
         "Key                                                Value\n" +
         "Iteration number                                   3\n" +
@@ -346,7 +340,7 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 30 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
-    assertTrue(output.contains(firstHistoryIterationOutput));
+    assertThat(output).contains(firstHistoryIterationOutput);
 
     String secondHistoryIterationOutput =
         "Key                                                Value\n" +
@@ -365,7 +359,7 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 15 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 15 GB";
-    assertTrue(output.contains(secondHistoryIterationOutput));
+    assertThat(output).contains(secondHistoryIterationOutput);
   }
 
   @Test
@@ -386,18 +380,15 @@ class TestContainerBalancerSubCommand {
     String output = outContent.toString(DEFAULT_ENCODING);
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sRunning.$", Pattern.MULTILINE);
-    Matcher m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     p = Pattern.compile(
         "^Started at: (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})$", Pattern.MULTILINE);
-    m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     p = Pattern.compile(
         "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
-    m = p.matcher(output);
-    assertTrue(m.find());
+    assertThat(output).containsPattern(p);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -416,7 +407,7 @@ class TestContainerBalancerSubCommand {
         "Container IDs to Exclude from Balancing            None\n" +
         "Datanodes Specified to be Balanced                 None\n" +
         "Datanodes Excluded from Balancing                  None";
-    assertTrue(output.contains(balancerConfigOutput));
+    assertThat(output).contains(balancerConfigOutput);
 
     String currentIterationOutput =
         "Current iteration info:\n" +
@@ -436,9 +427,9 @@ class TestContainerBalancerSubCommand {
         "Exited data from nodes                             \n" +
         "b8b9c511-c30f-4933-8938-2f272e307070 -> 30 GB\n" +
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
-    assertTrue(output.contains(currentIterationOutput));
+    assertThat(output).contains(currentIterationOutput);
 
-    assertFalse(output.contains("Iteration history list:"));
+    assertThat(output).doesNotContain("Iteration history list:");
   }
 
   @Test
@@ -455,8 +446,8 @@ class TestContainerBalancerSubCommand {
     statusCmd.execute(scmClient);
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sNot\\sRunning.");
-    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).containsPattern(p);
   }
 
   @Test
@@ -473,8 +464,8 @@ class TestContainerBalancerSubCommand {
 
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sNot\\sRunning.");
-    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).containsPattern(p);
   }
 
   @Test
@@ -486,8 +477,8 @@ class TestContainerBalancerSubCommand {
         "\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
         "Container\\sBalancer\\sstopped.");
 
-    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).containsPattern(p);
   }
 
   @Test
@@ -505,8 +496,8 @@ class TestContainerBalancerSubCommand {
 
     Pattern p = Pattern.compile("^Container\\sBalancer\\sstarted" +
         "\\ssuccessfully.");
-    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).containsPattern(p);
   }
 
   @Test
@@ -525,8 +516,8 @@ class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile("^Failed\\sto\\sstart\\sContainer" +
         "\\sBalancer.");
 
-    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).containsPattern(p);
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -47,6 +47,22 @@ import picocli.CommandLine;
  */
 class TestContainerBalancerSubCommand {
 
+  public static final Pattern DURATION = Pattern.compile(
+      "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
+  public static final Pattern FAILED_TO_START = Pattern.compile(
+      "^Failed\\sto\\sstart\\sContainer\\sBalancer.");
+  public static final Pattern IS_NOT_RUNNING = Pattern.compile(
+      "^ContainerBalancer\\sis\\sNot\\sRunning.");
+  private static final Pattern IS_RUNNING = Pattern.compile(
+      "^ContainerBalancer\\sis\\sRunning.$", Pattern.MULTILINE);
+  public static final Pattern STARTED_AT = Pattern.compile(
+      "^Started at: (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})$", Pattern.MULTILINE);
+  public static final Pattern STARTED_SUCCESSFULLY = Pattern.compile(
+      "^Container\\sBalancer\\sstarted\\ssuccessfully.");
+  public static final Pattern WAITING_TO_STOP = Pattern.compile(
+      "^Sending\\sstop\\scommand.\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
+      "Container\\sBalancer\\sstopped.");
+
   private ContainerBalancerStopSubcommand stopCmd;
   private ContainerBalancerStartSubcommand startCmd;
   private ContainerBalancerStatusSubcommand statusCmd;
@@ -222,10 +238,8 @@ class TestContainerBalancerSubCommand {
     //test status is running
     when(scmClient.getContainerBalancerStatusInfo()).thenReturn(statusInfoResponseProto);
     statusCmd.execute(scmClient);
-    Pattern p = Pattern.compile(
-        "^ContainerBalancer\\sis\\sRunning.");
     String output = out.get();
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(IS_RUNNING);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -285,17 +299,9 @@ class TestContainerBalancerSubCommand {
     c.parseArgs("--verbose", "--history");
     statusCmd.execute(scmClient);
     String output = out.get();
-    Pattern p = Pattern.compile(
-        "^ContainerBalancer\\sis\\sRunning.$", Pattern.MULTILINE);
-    assertThat(output).containsPattern(p);
-
-    p = Pattern.compile(
-        "^Started at: (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})$", Pattern.MULTILINE);
-    assertThat(output).containsPattern(p);
-
-    p = Pattern.compile(
-        "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(IS_RUNNING);
+    assertThat(output).containsPattern(STARTED_AT);
+    assertThat(output).containsPattern(DURATION);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -372,17 +378,9 @@ class TestContainerBalancerSubCommand {
     c.parseArgs("--verbose");
     statusCmd.execute(scmClient);
     String output = out.get();
-    Pattern p = Pattern.compile(
-        "^ContainerBalancer\\sis\\sRunning.$", Pattern.MULTILINE);
-    assertThat(output).containsPattern(p);
-
-    p = Pattern.compile(
-        "^Started at: (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})$", Pattern.MULTILINE);
-    assertThat(output).containsPattern(p);
-
-    p = Pattern.compile(
-        "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(IS_RUNNING);
+    assertThat(output).containsPattern(STARTED_AT);
+    assertThat(output).containsPattern(DURATION);
 
     String balancerConfigOutput =
         "Container Balancer Configuration values:\n" +
@@ -438,10 +436,8 @@ class TestContainerBalancerSubCommand {
             .build());
 
     statusCmd.execute(scmClient);
-    Pattern p = Pattern.compile(
-        "^ContainerBalancer\\sis\\sNot\\sRunning.");
     String output = out.get();
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(IS_NOT_RUNNING);
   }
 
   @Test
@@ -456,10 +452,8 @@ class TestContainerBalancerSubCommand {
 
     statusCmd.execute(scmClient);
 
-    Pattern p = Pattern.compile(
-        "^ContainerBalancer\\sis\\sNot\\sRunning.");
     String output = out.get();
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(IS_NOT_RUNNING);
   }
 
   @Test
@@ -467,12 +461,8 @@ class TestContainerBalancerSubCommand {
     ScmClient scmClient = mock(ScmClient.class);
     stopCmd.execute(scmClient);
 
-    Pattern p = Pattern.compile("^Sending\\sstop\\scommand." +
-        "\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
-        "Container\\sBalancer\\sstopped.");
-
     String output = out.get();
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(WAITING_TO_STOP);
   }
 
   @Test
@@ -488,10 +478,8 @@ class TestContainerBalancerSubCommand {
                 .build());
     startCmd.execute(scmClient);
 
-    Pattern p = Pattern.compile("^Container\\sBalancer\\sstarted" +
-        "\\ssuccessfully.");
     String output = out.get();
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(STARTED_SUCCESSFULLY);
   }
 
   @Test
@@ -507,11 +495,8 @@ class TestContainerBalancerSubCommand {
             .build());
     startCmd.execute(scmClient);
 
-    Pattern p = Pattern.compile("^Failed\\sto\\sstart\\sContainer" +
-        "\\sBalancer.");
-
     String output = out.get();
-    assertThat(output).containsPattern(p);
+    assertThat(output).containsPattern(FAILED_TO_START);
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -63,6 +63,23 @@ class TestContainerBalancerSubCommand {
       "^Sending\\sstop\\scommand.\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
       "Container\\sBalancer\\sstopped.");
 
+  public static final String BALANCER_CONFIG_OUTPUT = "Container Balancer Configuration values:\n" +
+      "Key                                                Value\n" +
+      "Threshold                                          10.0\n" +
+      "Max Datanodes to Involve per Iteration(percent)    20\n" +
+      "Max Size to Move per Iteration                     0GB\n" +
+      "Max Size Entering Target per Iteration             26GB\n" +
+      "Max Size Leaving Source per Iteration              26GB\n" +
+      "Number of Iterations                               3\n" +
+      "Time Limit for Single Container's Movement         65min\n" +
+      "Time Limit for Single Container's Replication      50min\n" +
+      "Interval between each Iteration                    0min\n" +
+      "Whether to Enable Network Topology                 false\n" +
+      "Whether to Trigger Refresh Datanode Usage Info     false\n" +
+      "Container IDs to Exclude from Balancing            None\n" +
+      "Datanodes Specified to be Balanced                 None\n" +
+      "Datanodes Excluded from Balancing                  None";
+
   private ContainerBalancerStopSubcommand stopCmd;
   private ContainerBalancerStartSubcommand startCmd;
   private ContainerBalancerStatusSubcommand statusCmd;
@@ -239,24 +256,6 @@ class TestContainerBalancerSubCommand {
     when(scmClient.getContainerBalancerStatusInfo()).thenReturn(statusInfoResponseProto);
     statusCmd.execute(scmClient);
 
-    String balancerConfigOutput =
-        "Container Balancer Configuration values:\n" +
-        "Key                                                Value\n" +
-        "Threshold                                          10.0\n" +
-        "Max Datanodes to Involve per Iteration(percent)    20\n" +
-        "Max Size to Move per Iteration                     0GB\n" +
-        "Max Size Entering Target per Iteration             26GB\n" +
-        "Max Size Leaving Source per Iteration              26GB\n" +
-        "Number of Iterations                               3\n" +
-        "Time Limit for Single Container's Movement         65min\n" +
-        "Time Limit for Single Container's Replication      50min\n" +
-        "Interval between each Iteration                    0min\n" +
-        "Whether to Enable Network Topology                 false\n" +
-        "Whether to Trigger Refresh Datanode Usage Info     false\n" +
-        "Container IDs to Exclude from Balancing            None\n" +
-        "Datanodes Specified to be Balanced                 None\n" +
-        "Datanodes Excluded from Balancing                  None";
-
     String currentIterationOutput =
         "Current iteration info:\n" +
         "Key                                                Value\n" +
@@ -277,7 +276,7 @@ class TestContainerBalancerSubCommand {
         "7bd99815-47e7-4015-bc61-ca6ef6dfd130 -> 18 GB";
 
     assertThat(out.get()).containsPattern(IS_RUNNING)
-        .doesNotContain(balancerConfigOutput)
+        .doesNotContain(BALANCER_CONFIG_OUTPUT)
         .doesNotContain(currentIterationOutput)
         .doesNotContain("Iteration history list:");
   }
@@ -298,23 +297,6 @@ class TestContainerBalancerSubCommand {
     c.parseArgs("--verbose", "--history");
     statusCmd.execute(scmClient);
 
-    String balancerConfigOutput =
-        "Container Balancer Configuration values:\n" +
-        "Key                                                Value\n" +
-        "Threshold                                          10.0\n" +
-        "Max Datanodes to Involve per Iteration(percent)    20\n" +
-        "Max Size to Move per Iteration                     0GB\n" +
-        "Max Size Entering Target per Iteration             26GB\n" +
-        "Max Size Leaving Source per Iteration              26GB\n" +
-        "Number of Iterations                               3\n" +
-        "Time Limit for Single Container's Movement         65min\n" +
-        "Time Limit for Single Container's Replication      50min\n" +
-        "Interval between each Iteration                    0min\n" +
-        "Whether to Enable Network Topology                 false\n" +
-        "Whether to Trigger Refresh Datanode Usage Info     false\n" +
-        "Container IDs to Exclude from Balancing            None\n" +
-        "Datanodes Specified to be Balanced                 None\n" +
-        "Datanodes Excluded from Balancing                  None";
     String firstHistoryIterationOutput =
         "Key                                                Value\n" +
         "Iteration number                                   3\n" +
@@ -355,7 +337,7 @@ class TestContainerBalancerSubCommand {
         .containsPattern(IS_RUNNING)
         .containsPattern(STARTED_AT)
         .containsPattern(DURATION)
-        .contains(balancerConfigOutput)
+        .contains(BALANCER_CONFIG_OUTPUT)
         .contains("Iteration history list:")
         .contains(firstHistoryIterationOutput)
         .contains(secondHistoryIterationOutput);
@@ -376,24 +358,6 @@ class TestContainerBalancerSubCommand {
     CommandLine c = new CommandLine(statusCmd);
     c.parseArgs("--verbose");
     statusCmd.execute(scmClient);
-
-    String balancerConfigOutput =
-        "Container Balancer Configuration values:\n" +
-        "Key                                                Value\n" +
-        "Threshold                                          10.0\n" +
-        "Max Datanodes to Involve per Iteration(percent)    20\n" +
-        "Max Size to Move per Iteration                     0GB\n" +
-        "Max Size Entering Target per Iteration             26GB\n" +
-        "Max Size Leaving Source per Iteration              26GB\n" +
-        "Number of Iterations                               3\n" +
-        "Time Limit for Single Container's Movement         65min\n" +
-        "Time Limit for Single Container's Replication      50min\n" +
-        "Interval between each Iteration                    0min\n" +
-        "Whether to Enable Network Topology                 false\n" +
-        "Whether to Trigger Refresh Datanode Usage Info     false\n" +
-        "Container IDs to Exclude from Balancing            None\n" +
-        "Datanodes Specified to be Balanced                 None\n" +
-        "Datanodes Excluded from Balancing                  None";
 
     String currentIterationOutput =
         "Current iteration info:\n" +
@@ -418,7 +382,7 @@ class TestContainerBalancerSubCommand {
         .containsPattern(IS_RUNNING)
         .containsPattern(STARTED_AT)
         .containsPattern(DURATION)
-        .contains(balancerConfigOutput)
+        .contains(BALANCER_CONFIG_OUTPUT)
         .contains(currentIterationOutput)
         .doesNotContain("Iteration history list:");
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent test failure:

```
Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.411 s <<< FAILURE! - in org.apache.hadoop.hdds.scm.cli.datanode.TestContainerBalancerSubCommand
org.apache.hadoop.hdds.scm.cli.datanode.TestContainerBalancerSubCommand.testContainerBalancerStatusInfoSubcommandVerboseHistory  Time elapsed: 0.127 s  <<< FAILURE!
AssertionFailedError: expected: <true> but was: <false>
  ...
  at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
  at org.apache.hadoop.hdds.scm.cli.datanode.TestContainerBalancerSubCommand.testContainerBalancerStatusInfoSubcommandVerboseHistory(TestContainerBalancerSubCommand.java:305)
```

which occurs if balancer happens to be started at the start of the minute (`:00` seconds).  It is caused by relying on `LocalTime.toString()`, which omits 0 seconds from output, but the test expects it in HH:MM:SS format.

Reproduced the problem in `flaky-test-check`:
https://github.com/adoroszlai/ozone/actions/runs/13592212498/job/38002149684#step:7:858

The problem can be consistently reproduced by applying tweak:

```diff
--- hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -173,7 +173,7 @@ private static ContainerBalancerStatusInfoResponseProto getContainerBalancerStat
     return ContainerBalancerStatusInfoResponseProto.newBuilder()
             .setIsRunning(true)
             .setContainerBalancerStatusInfo(ContainerBalancerStatusInfoProto.newBuilder()
-                .setStartedAt(OffsetDateTime.now().toEpochSecond())
+                .setStartedAt(OffsetDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.MINUTES).toEpochSecond())
                 .setConfiguration(config.toProtobufBuilder().setShouldRun(true))
                 .addAllIterationsStatusInfo(
                     Arrays.asList(iteration1StatusInfo, iteration2StatusInfo, iteration3StatusInfo)
```

It is fixed by using ISO formatter instead of `toString()`.

Also improve `TestContainerBalancerSubCommand`:

- change assertions to `assertThat` to show expected and actual input
- reduce duplication

https://issues.apache.org/jira/browse/HDDS-12443

## How was this patch tested?

Verified that the test passes even with the tweak, plus an additional change needed to avoid flakiness caused by the tweak itself:

```diff
--- hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -48,7 +48,7 @@
 class TestContainerBalancerSubCommand {
 
   private static final Pattern DURATION = Pattern.compile(
-      "^Balancing duration: \\d{1}s$", Pattern.MULTILINE);
+      "^Balancing duration: \\d+s$", Pattern.MULTILINE);
   private static final Pattern FAILED_TO_START = Pattern.compile(
       "^Failed\\sto\\sstart\\sContainer\\sBalancer.");
   private static final Pattern IS_NOT_RUNNING = Pattern.compile(
@@ -199,7 +199,7 @@ private static ContainerBalancerStatusInfoResponseProto getContainerBalancerStat
     return ContainerBalancerStatusInfoResponseProto.newBuilder()
             .setIsRunning(true)
             .setContainerBalancerStatusInfo(ContainerBalancerStatusInfoProto.newBuilder()
-                .setStartedAt(OffsetDateTime.now().toEpochSecond())
+                .setStartedAt(OffsetDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.MINUTES).toEpochSecond())
                 .setConfiguration(config.toProtobufBuilder().setShouldRun(true))
                 .addAllIterationsStatusInfo(
                     Arrays.asList(iteration1StatusInfo, iteration2StatusInfo, iteration3StatusInfo)
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/13593432908
