### PR TITLE
HDDS-12448. Avoid using Jackson1

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -57,7 +58,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ratis.protocol.ClientId;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -487,7 +487,7 @@ public class QuotaRepairTask {
       status.put("errorMsg", errorMsg);
       status.put("bucketCountDiffMap", bucketCountDiffMap);
       try {
-        return new ObjectMapper().writeValueAsString(status);
+        return JsonUtils.toJsonString(status);
       } catch (IOException e) {
         LOG.error("error in generating status", e);
         return "{}";

--- a/pom.xml
+++ b/pom.xml
@@ -1683,6 +1683,17 @@
                       <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
                     </excludedSourceRoots>
                   </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Use Jackson 2 (com.fasterxml.jackson)</reason>
+                    <bannedImports>
+                      <bannedImport>org.codehaus.jackson.**</bannedImport>
+                    </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dependency on `org.codehaus.jackson` (Jackson v1) is only for Ranger, should not be used in Ozone itself.

- replace usage in `QuotaRepairTask`
- ban import

https://issues.apache.org/jira/browse/HDDS-12448

## How was this patch tested?

Tested import ban without the fix in `QuotaRepairTask`:

```
[ERROR] Banned imports detected:
[ERROR] 
[ERROR] Reason: Use Jackson 2 (com.fasterxml.jackson)
[ERROR] 	in hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
[ERROR] 		org.codehaus.jackson.map.ObjectMapper 	(Line: 60, Matched by: org.codehaus.jackson.**)
```

Existing tests: `TestOzoneRepairShell`, `TestQuotaRepairTask`.

CI:
https://github.com/adoroszlai/ozone/actions/runs/13602780164