### PR TITLE
HDDS-12436. [DiskBalancer] Add metrics for time spent by container move

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -480,7 +480,7 @@ public class DiskBalancerService extends BackgroundService {
         metrics.incrFailureCount();
       } finally {
         // Stop timing for successful move
-        if(moveSucceeded){
+        if (moveSucceeded) {
           long endTime = Time.monotonicNow();
           metrics.getMoveSuccessTime().add(endTime - startTime);
         }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -392,6 +392,8 @@ public class DiskBalancerService extends BackgroundService {
 
     @Override
     public BackgroundTaskResult call() {
+      //start time
+      long startTime = System.currentTimeMillis();
       long containerId = containerData.getContainerID();
       boolean destVolumeIncreased = false;
       Path diskBalancerTmpDir = null, diskBalancerDestDir = null;
@@ -446,9 +448,18 @@ public class DiskBalancerService extends BackgroundService {
         }
         oldContainer.getContainerData().getVolume()
             .decrementUsedSpace(containerSize);
+
+        // Stop timing
+        long endTime = System.currentTimeMillis();
+        metrics.addMoveSuccessTime(endTime - startTime);
+        LOG.info("Max success time spent on container move in (s) : {} ", metrics.getMoveSuccessTime() / 1000.0);
         metrics.incrSuccessCount(1);
         metrics.incrSuccessBytes(containerSize);
       } catch (IOException e) {
+        // Stop timing
+        long endTime = System.currentTimeMillis();
+        metrics.addMoveFailureTime(endTime - startTime);
+        LOG.info("Max failure time spent on container move in (s) : {} ", metrics.getMoveFailureTime() / 1000.0);
         if (diskBalancerTmpDir != null) {
           try {
             Files.deleteIfExists(diskBalancerTmpDir);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -451,15 +451,10 @@ public class DiskBalancerService extends BackgroundService {
 
         // Stop timing
         long endTime = System.currentTimeMillis();
-        metrics.addMoveSuccessTime(endTime - startTime);
-        LOG.info("Max success time spent on container move in (s) : {} ", metrics.getMoveSuccessTime() / 1000.0);
+        metrics.getMoveSuccessTime().add(endTime - startTime);
         metrics.incrSuccessCount(1);
         metrics.incrSuccessBytes(containerSize);
       } catch (IOException e) {
-        // Stop timing
-        long endTime = System.currentTimeMillis();
-        metrics.addMoveFailureTime(endTime - startTime);
-        LOG.info("Max failure time spent on container move in (s) : {} ", metrics.getMoveFailureTime() / 1000.0);
         if (diskBalancerTmpDir != null) {
           try {
             Files.deleteIfExists(diskBalancerTmpDir);
@@ -481,6 +476,9 @@ public class DiskBalancerService extends BackgroundService {
         if (destVolumeIncreased) {
           destVolume.decrementUsedSpace(containerSize);
         }
+        // Stop timing
+        long endTime = System.currentTimeMillis();
+        metrics.getMoveFailureTime().add(endTime - startTime);
         metrics.incrFailureCount();
       } finally {
         postCall();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceMetrics.java
@@ -143,8 +143,8 @@ public final class DiskBalancerServiceMetrics {
     buffer.append("successCount = " + successCount.value()).append("\t")
         .append("successBytes = " + successBytes.value()).append("\t")
         .append("failureCount = " + failureCount.value()).append("\t")
-        .append("moveSuccessTime = ").append(moveSuccessTime.lastStat().mean()).append("\t")
-        .append("moveFailureTime = ").append(moveFailureTime.lastStat().mean()).append("\t")
+        .append("moveSuccessTime = " + moveSuccessTime.lastStat().mean()).append("\t")
+        .append("moveFailureTime = " + moveFailureTime.lastStat().mean()).append("\t")
         .append("idleLoopNoAvailableVolumePairCount = " +
             idleLoopNoAvailableVolumePairCount.value()).append("\t")
         .append("idleLoopExceedsBandwidthCount = " +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceMetrics.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
-import org.apache.hadoop.metrics2.lib.MutableStat;
+import org.apache.hadoop.metrics2.lib.MutableRate;
 
 /**
  * Metrics related to DiskBalancer Service running on Datanode.
@@ -45,10 +45,10 @@ public final class DiskBalancerServiceMetrics {
   private MutableCounterLong failureCount;
 
   @Metric(about = "The time spent on successful container moves.")
-  private MutableStat moveSuccessTime;
+  private MutableRate moveSuccessTime;
 
   @Metric(about = "The time spent on failed container moves.")
-  private MutableStat moveFailureTime;
+  private MutableRate moveFailureTime;
 
   @Metric(about = "The number of total running loop")
   private MutableCounterLong runningLoopCount;
@@ -93,14 +93,6 @@ public final class DiskBalancerServiceMetrics {
     this.failureCount.incr();
   }
 
-  public void addMoveSuccessTime(long time) {
-    this.moveSuccessTime.add(time);
-  }
-
-  public void addMoveFailureTime(long time) {
-    this.moveFailureTime.add(time);
-  }
-
   public void incrRunningLoopCount() {
     this.runningLoopCount.incr();
   }
@@ -137,12 +129,12 @@ public final class DiskBalancerServiceMetrics {
     return idleLoopExceedsBandwidthCount.value();
   }
 
-  public double getMoveSuccessTime() {
-    return moveSuccessTime.lastStat().max();
+  public MutableRate getMoveSuccessTime() {
+    return moveSuccessTime;
   }
 
-  public double getMoveFailureTime() {
-    return moveFailureTime.lastStat().max();
+  public MutableRate getMoveFailureTime() {
+    return moveFailureTime;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceMetrics.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableStat;
 
 /**
  * Metrics related to DiskBalancer Service running on Datanode.
@@ -42,6 +43,12 @@ public final class DiskBalancerServiceMetrics {
 
   @Metric(about = "The number of failed balance job.")
   private MutableCounterLong failureCount;
+
+  @Metric(about = "The time spent on successful container moves.")
+  private MutableStat moveSuccessTime;
+
+  @Metric(about = "The time spent on failed container moves.")
+  private MutableStat moveFailureTime;
 
   @Metric(about = "The number of total running loop")
   private MutableCounterLong runningLoopCount;
@@ -86,6 +93,14 @@ public final class DiskBalancerServiceMetrics {
     this.failureCount.incr();
   }
 
+  public void addMoveSuccessTime(long time) {
+    this.moveSuccessTime.add(time);
+  }
+
+  public void addMoveFailureTime(long time) {
+    this.moveFailureTime.add(time);
+  }
+
   public void incrRunningLoopCount() {
     this.runningLoopCount.incr();
   }
@@ -122,12 +137,22 @@ public final class DiskBalancerServiceMetrics {
     return idleLoopExceedsBandwidthCount.value();
   }
 
+  public double getMoveSuccessTime() {
+    return moveSuccessTime.lastStat().max();
+  }
+
+  public double getMoveFailureTime() {
+    return moveFailureTime.lastStat().max();
+  }
+
   @Override
   public String toString() {
     StringBuffer buffer = new StringBuffer();
     buffer.append("successCount = " + successCount.value()).append("\t")
         .append("successBytes = " + successBytes.value()).append("\t")
         .append("failureCount = " + failureCount.value()).append("\t")
+        .append("moveSuccessTime = ").append(moveSuccessTime.lastStat().mean()).append("\t")
+        .append("moveFailureTime = ").append(moveFailureTime.lastStat().mean()).append("\t")
         .append("idleLoopNoAvailableVolumePairCount = " +
             idleLoopNoAvailableVolumePairCount.value()).append("\t")
         .append("idleLoopExceedsBandwidthCount = " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add metrics in DiskBalancerServiceMetrics to record the time spent on container move, for both success and failure case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12436

## How was this patch tested?

The patch was tested manually by running docker cluster and seeing the results at JMX endpoint and prometheus. At prometheus endpoint by querying for `disk_balancer_service_metrics_move_success_time_avg_time` and `disk_balancer_service_metrics_move_failure_time_avg_time` it shows the change in graph curves and the average time taken for the successful and failure moves respectively.
```
"name" : "Hadoop:service=HddsDatanode,name=DiskBalancerServiceMetrics",
    "modelerType" : "DiskBalancerServiceMetrics",
    "tag.Context" : "dfs",
    "tag.Hostname" : "2757e35f9c78",
    "FailureCount" : 6,
    "IdleLoopExceedsBandwidthCount" : 0,
    "IdleLoopNoAvailableVolumePairCount" : 0,
    "MoveFailureTimeNumOps" : 6,
    "MoveFailureTimeAvgTime" : 0.0,
    "MoveSuccessTimeNumOps" : 7,
    "MoveSuccessTimeAvgTime" : 0.0,
    "RunningLoopCount" : 10,
    "SuccessBytes" : 10412359680,
    "SuccessCount" : 7
```

