### PR TITLE
HDDS-11513. All deletion configurations should be configurable without restart

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTPS;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClientWithMaxRetry;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
@@ -291,6 +293,10 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
                   this::reconfigBlockDeleteThreadMax)
               .register(OZONE_BLOCK_DELETING_SERVICE_WORKERS,
                   this::reconfigDeletingServiceWorkers)
+              .register(OZONE_BLOCK_DELETING_SERVICE_INTERVAL,
+                  this::reconfigBlockDeletingServiceInterval)
+              .register(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT,
+                  this::reconfigBlockDeletingServiceTimeout)
               .register(REPLICATION_STREAMS_LIMIT_KEY,
                   this::reconfigReplicationStreamsLimit);
 
@@ -673,6 +679,22 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
 
     getDatanodeStateMachine().getContainer().getReplicationServer()
         .setPoolSize(Integer.parseInt(value));
+    return value;
+  }
+
+  private String reconfigBlockDeletingServiceInterval(String value) {
+    getConf().set(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, value);
+
+    getDatanodeStateMachine().getContainer().getBlockDeletingService()
+        .setBlockDeletingServiceInterval(value);
+    return value;
+  }
+
+  private String reconfigBlockDeletingServiceTimeout(String value) {
+    getConf().set(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT, value);
+
+    getDatanodeStateMachine().getContainer().getBlockDeletingService()
+        .setBlockDeletingServiceTimeout(value);
     return value;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.common.helpers.BlockDeletingServiceMetrics;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDeletionChoosingPolicy;
@@ -64,6 +65,8 @@ public class BlockDeletingService extends BackgroundService {
   private static final int TASK_PRIORITY_DEFAULT = 1;
 
   private final Duration blockDeletingMaxLockHoldingTime;
+  private String blockDeletingServiceInterval;
+  private String blockDeletingServiceTimeout;
 
   @VisibleForTesting
   public BlockDeletingService(
@@ -99,6 +102,12 @@ public class BlockDeletingService extends BackgroundService {
     this.blockDeletingMaxLockHoldingTime =
         dnConf.getBlockDeletingMaxLockHoldingTime();
     metrics = BlockDeletingServiceMetrics.create();
+    this.blockDeletingServiceInterval = conf.get(
+        OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL,
+        OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL_DEFAULT);
+    this.blockDeletingServiceTimeout = conf.get(
+        OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT,
+        OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT);
   }
 
   /**
@@ -270,6 +279,20 @@ public class BlockDeletingService extends BackgroundService {
 
   public int getBlockLimitPerInterval() {
     return dnConf.getBlockDeletionLimit();
+  }
+
+  public String getBlockDeletingServiceInterval() {
+    return blockDeletingServiceInterval;
+  }
+  public void setBlockDeletingServiceInterval(String blockDeletingServiceInterval) {
+    this.blockDeletingServiceInterval = blockDeletingServiceInterval;
+  }
+
+  public String getBlockDeletingServiceTimeout() {
+    return blockDeletingServiceTimeout;
+  }
+  public void setBlockDeletingServiceTimeout(String blockDeletingServiceTimeout) {
+    this.blockDeletingServiceTimeout = blockDeletingServiceTimeout;
   }
 
   private static class BlockDeletingTaskBuilder {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.reconfig;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_BLOCK_DELETE_THREAD_MAX;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_STREAMS_LIMIT_KEY;
@@ -49,6 +51,8 @@ public abstract class TestDatanodeReconfiguration extends ReconfigurationTestBas
     Set<String> expected = ImmutableSet.<String>builder()
         .add(HDDS_DATANODE_BLOCK_DELETE_THREAD_MAX)
         .add(OZONE_BLOCK_DELETING_SERVICE_WORKERS)
+        .add(OZONE_BLOCK_DELETING_SERVICE_INTERVAL)
+        .add(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT)
         .add(REPLICATION_STREAMS_LIMIT_KEY)
         .addAll(new DatanodeConfiguration().reconfigurableProperties())
         .build();
@@ -90,6 +94,26 @@ public abstract class TestDatanodeReconfiguration extends ReconfigurationTestBas
     getFirstDatanode().getReconfigurationHandler().reconfigurePropertyImpl(
         OZONE_BLOCK_DELETING_SERVICE_WORKERS, String.valueOf(newValue));
     assertEquals(newValue, executor.getCorePoolSize());
+  }
+
+  @Test
+  void blockDeletingServiceInterval() throws ReconfigurationException {
+    //Initial string is 1m
+    getFirstDatanode().getReconfigurationHandler().reconfigurePropertyImpl(
+        OZONE_BLOCK_DELETING_SERVICE_INTERVAL, "2m");
+
+    assertEquals("2m", getFirstDatanode().getDatanodeStateMachine().getContainer()
+        .getBlockDeletingService().getBlockDeletingServiceInterval());
+  }
+
+  @Test
+  void blockDeletingServiceTimeout() throws ReconfigurationException {
+    //Initial string is 300000ms
+    getFirstDatanode().getReconfigurationHandler().reconfigurePropertyImpl(
+        OZONE_BLOCK_DELETING_SERVICE_TIMEOUT, "350000ms");
+
+    assertEquals("350000ms", getFirstDatanode().getDatanodeStateMachine().getContainer()
+        .getBlockDeletingService().getBlockDeletingServiceTimeout());
   }
 
   @ParameterizedTest

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.ozone.reconfig;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
@@ -51,6 +53,8 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
         .add(OZONE_KEY_DELETING_LIMIT_PER_TASK)
         .add(OZONE_OM_VOLUME_LISTALL_ALLOWED)
         .add(OZONE_READONLY_ADMINISTRATORS)
+        .add(OZONE_DIR_DELETING_SERVICE_INTERVAL)
+        .add(OZONE_THREAD_NUMBER_DIR_DELETION)
         .addAll(new OmConfig().reconfigurableProperties())
         .build();
 
@@ -119,6 +123,25 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
     getSubject().reconfigurePropertyImpl(OZONE_OM_VOLUME_LISTALL_ALLOWED, newValue);
 
     assertEquals(OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT, cluster().getOzoneManager().getAllowListAllVolumes());
+  }
+
+  @Test
+  void dirDeletingServiceInterval() throws ReconfigurationException {
+    //Initial string is 1m
+    getSubject().reconfigurePropertyImpl(OZONE_DIR_DELETING_SERVICE_INTERVAL, "2m");
+
+    assertEquals("2m", cluster().getOzoneManager().
+        getKeyManager().getDirDeletingService().getDirDeletingServiceInterval());
+  }
+
+  @Test
+  void threadNumberDirDeletion() throws ReconfigurationException {
+    int initialNum = cluster().getOzoneManager().getKeyManager().getDirDeletingService().getThreadNumberDirDeletion();
+
+    getSubject().reconfigurePropertyImpl(OZONE_THREAD_NUMBER_DIR_DELETION, String.valueOf(initialNum + 10));
+
+    assertEquals(initialNum + 10, cluster().getOzoneManager().
+        getKeyManager().getDirDeletingService().getThreadNumberDirDeletion());
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -80,6 +80,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   private int ratisByteLimit;
   private final AtomicBoolean suspended;
   private AtomicBoolean isRunningOnAOS;
+  private String dirDeletingServiceInterval;
+  private int threadNumberDirDeletion;
 
   private final DeletedDirSupplier deletedDirSupplier;
 
@@ -99,6 +101,12 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     this.suspended = new AtomicBoolean(false);
     this.isRunningOnAOS = new AtomicBoolean(false);
     this.dirDeletingCorePoolSize = dirDeletingServiceCorePoolSize;
+    this.dirDeletingServiceInterval = configuration.get(
+        OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL,
+        OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL_DEFAULT);
+    this.threadNumberDirDeletion = configuration.getInt(
+        OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION,
+        OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION_DEFAULT);
     deletedDirSupplier = new DeletedDirSupplier();
     taskCount.set(0);
   }
@@ -344,6 +352,22 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   public KeyValue<String, OmKeyInfo> getPendingDeletedDirInfo()
       throws IOException {
     return deletedDirSupplier.get();
+  }
+
+  public String getDirDeletingServiceInterval() {
+    return dirDeletingServiceInterval;
+  }
+
+  public void setDirDeletingServiceInterval(String dirDeletingServiceInterval) {
+    this.dirDeletingServiceInterval = dirDeletingServiceInterval;
+  }
+
+  public int getThreadNumberDirDeletion() {
+    return threadNumberDirDeletion;
+  }
+
+  public void setThreadNumberDirDeletion(int threadNumberDirDeletion) {
+    this.threadNumberDirDeletion = threadNumberDirDeletion;
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The following deletion related configurations are now dynamically reconfigurable without requiring a restart. 
This allows for easy tuning of deletion in response to logs and metrics.

OM:
- ozone.directory.deleting.service.interval
- ozone.thread.number.dir.deletion 

DATANODE:
- ozone.block.deleting.service.interval 
- ozone.block.deleting.service.timeout   

## What is the link to the Apache JIRA
[HDDS-11513](https://issues.apache.org/jira/browse/HDDS-11513)

## How was this patch tested?
OM:
- List all OM reconfigurable properties
```
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 properties
OM: Node [om:9862] Reconfigurable properties:
ozone.administrators
ozone.directory.deleting.service.interval
ozone.key.deleting.limit.per.task
ozone.om.server.list.max.size
ozone.om.volume.listall.allowed
ozone.readonly.administrators
ozone.thread.number.dir.deletion
```
- Reconfigured `ozone.directory.deleting.service.interval` successfully
```
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 start     
OM: Started reconfiguration task on node [om:9862].
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: started at Tue Mar 04 05:51:56 UTC 2025 and finished at Tue Mar 04 05:51:56 UTC 2025.
SUCCESS: Changed property ozone.directory.deleting.service.interval
        From: "1m"
        To: "2m"
```
- Reconfigured `ozone.thread.number.dir.deletion` successfully
```
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 start     
OM: Started reconfiguration task on node [om:9862].
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: started at Tue Mar 04 06:41:19 UTC 2025 and finished at Tue Mar 04 06:41:19 UTC 2025.
SUCCESS: Changed property ozone.thread.number.dir.deletion
        From: ""
        To: "20"
```
- Error case when `ozone.thread.number.dir.deletion` value is negative.
```
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 start     
OM: Started reconfiguration task on node [om:9862].
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: started at Tue Mar 04 07:07:08 UTC 2025 and finished at Tue Mar 04 07:07:08 UTC 2025.
FAILED: Change property ozone.thread.number.dir.deletion
        From: ""
        To: "-20"
        Error: ozone.thread.number.dir.deletion cannot be negative..
```

DATANODE:
- List all DN reconfigurable properties
```
bash-5.1$ ozone admin reconfig --service=DATANODE --address=datanode:19864 properties
DN: Node [datanode:19864] Reconfigurable properties:
hdds.datanode.block.delete.threads.max
hdds.datanode.block.deleting.limit.per.interval
hdds.datanode.replication.streams.limit
ozone.block.deleting.service.interval
ozone.block.deleting.service.timeout
ozone.block.deleting.service.workers
```
- Reconfigured `ozone.block.deleting.service.interval` and `ozone.block.deleting.service.timeout` successfully
```
bash-5.1$ ozone admin reconfig --service=DATANODE --address=datanode:19864 start     
DN: Started reconfiguration task on node [datanode:19864].
bash-5.1$ ozone admin reconfig --service=DATANODE --address=datanode:19864 status
DN: Reconfiguring status for node [datanode:19864]: started at Tue Mar 04 05:50:29 UTC 2025 and finished at Tue Mar 04 05:50:29 UTC 2025.
SUCCESS: Changed property ozone.block.deleting.service.interval
        From: "1m"
        To: "2m"
SUCCESS: Changed property ozone.block.deleting.service.timeout
        From: "300000ms"
        To: "350000ms"
```