### PR TITLE
HDDS-12432. [DiskBalancer] Respect property "hdds.datanode.disk.balancer.max.disk.throughputInMBPerSec"

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -363,21 +363,19 @@ public class DiskBalancerService extends BackgroundService {
   private boolean shouldDelay() {
     // We should wait for next AvailableTime.
     if (Time.monotonicNow() <= nextAvailableTime.get()) {
-      LOG.info("Skipping balancing as nextAvailableTime ({}) is in the future", nextAvailableTime.get());
+      LOG.info("Skipping balancing until nextAvailableTime ({})", nextAvailableTime.get());
       return true;
     }
     // Calculate the next AvailableTime based on bandwidth
-    LOG.info("Bytes balanced to find the next avaliable time {} MB", balancedBytesInLastWindow.get() / (1024 * 1024));
     long bytesBalanced = balancedBytesInLastWindow.getAndSet(0L);
-    LOG.info("balanced bytes in last window after resetting it {} MB", balancedBytesInLastWindow.get() / (1024 * 1024));
     final int megaByte = 1024 * 1024;
 
     // converting disk bandwidth in byte/millisec
     float bytesPerMillisec = bandwidthInMB * megaByte / 1000f;
-    long delayMillis = (long) (bytesBalanced / bytesPerMillisec);
-    LOG.info("Bytes balanced: {} MB, Calculated delay: {} ms ({} sec)",
-        bytesBalanced / megaByte, delayMillis, delayMillis / 1000);
-    nextAvailableTime.set(Time.monotonicNow() + delayMillis);
+    long delayInMillisec = (long) (bytesBalanced / bytesPerMillisec);
+    nextAvailableTime.set(Time.monotonicNow() + delayInMillisec);
+    LOG.debug("Bytes balanced: {} MB, Calculated delay: {} ms ({} sec)",
+        bytesBalanced / megaByte, delayInMillisec, delayInMillisec / 1000);
     return false;
   }
 
@@ -451,7 +449,6 @@ public class DiskBalancerService extends BackgroundService {
         oldContainer.getContainerData().getVolume()
             .decrementUsedSpace(containerSize);
         balancedBytesInLastWindow.addAndGet(containerSize);
-        LOG.info("sum of balanced bytes in the last window {} MB", balancedBytesInLastWindow.get() / (1024 * 1024));
         metrics.incrSuccessCount(1);
         metrics.incrSuccessBytes(containerSize);
       } catch (IOException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current DiskBalancerService#balancedBytesInLastWindow is always 0. Throttling configuration "hdds.datanode.disk.balancer.max.disk.throughputInMBPerSec" is not respected.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12432

## How was this patch tested?

The patch was tested manually on docker cluster by adding log for debugging.
```
2025-03-04 12:46:23 2025-03-04 07:16:23,611 [DiskBalancerService#3] INFO diskbalancer.DiskBalancerService: Skipping balancing until nextAvailableTime (8628818)
2025-03-04 12:46:23 2025-03-04 07:16:23,611 [47aaddad-75cb-42a0-8e02-cde1309ca6d2-BlockDeletingService#2] INFO interfaces.ContainerDeletionChoosingPolicyTemplate: Chosen 0/5000 blocks from 0 candidate containers.
2025-03-04 12:47:23 2025-03-04 07:17:23,611 [DiskBalancerService#3] INFO diskbalancer.DiskBalancerService: Skipping balancing until nextAvailableTime (8628818)
2025-03-04 12:47:23 2025-03-04 07:17:23,611 [47aaddad-75cb-42a0-8e02-cde1309ca6d2-BlockDeletingService#2] INFO interfaces.ContainerDeletionChoosingPolicyTemplate: Chosen 0/5000 blocks from 0 candidate containers.
2025-03-04 12:48:23 2025-03-04 07:18:23,610 [DiskBalancerService#3] INFO diskbalancer.DiskBalancerService: Skipping balancing until nextAvailableTime (8628818)
2025-03-04 12:48:23 2025-03-04 07:18:23,610 [47aaddad-75cb-42a0-8e02-cde1309ca6d2-BlockDeletingService#2] INFO interfaces.ContainerDeletionChoosingPolicyTemplate: Chosen 0/5000 blocks from 0 candidate containers.
```
