### PR TITLE
HDDS-12435. [DiskBalancer] Add success move count and fail move count in status report

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -32,6 +32,8 @@ public class DiskBalancerInfo {
   private long bandwidthInMB;
   private int parallelThread;
   private DiskBalancerVersion version;
+  private long successCount;
+  private long failureCount;
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread) {
@@ -46,6 +48,18 @@ public class DiskBalancerInfo {
     this.bandwidthInMB = bandwidthInMB;
     this.parallelThread = parallelThread;
     this.version = version;
+  }
+
+  public DiskBalancerInfo(boolean shouldRun, double threshold,
+      long bandwidthInMB, int parallelThread, DiskBalancerVersion version,
+      long successCount, long failureCount) {
+    this.shouldRun = shouldRun;
+    this.threshold = threshold;
+    this.bandwidthInMB = bandwidthInMB;
+    this.parallelThread = parallelThread;
+    this.version = version;
+    this.successCount = successCount;
+    this.failureCount = failureCount;
   }
 
   public DiskBalancerInfo(boolean shouldRun,
@@ -78,6 +92,8 @@ public class DiskBalancerInfo {
         StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto.newBuilder();
     builder.setIsRunning(shouldRun);
     builder.setDiskBalancerConf(confProto);
+    builder.setSuccessMoveCount(successCount);
+    builder.setFailureMoveCount(failureCount);
     return builder.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -294,11 +294,6 @@ public class DiskBalancerService extends BackgroundService {
     this.version = version;
   }
 
-  public DiskBalancerInfo getDiskBalancerInfo() {
-    return new DiskBalancerInfo(shouldRun, threshold, bandwidthInMB,
-        parallelThread, version);
-  }
-
   public DiskBalancerReportProto getDiskBalancerReportProto() {
     DiskBalancerReportProto.Builder builder =
         DiskBalancerReportProto.newBuilder();
@@ -489,6 +484,11 @@ public class DiskBalancerService extends BackgroundService {
       deltaSizes.put(destVolume, deltaSizes.get(destVolume)
           - containerData.getBytesUsed());
     }
+  }
+
+  public DiskBalancerInfo getDiskBalancerInfo() {
+    return new DiskBalancerInfo(shouldRun, threshold, bandwidthInMB,
+        parallelThread, version, metrics.getSuccessCount(), metrics.getFailureCount());
   }
 
   private Path getDiskBalancerTmpDir(HddsVolume hddsVolume) {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -561,4 +561,6 @@ message DatanodeDiskBalancerInfoProto {
     required double currentVolumeDensitySum = 2;
     optional DiskBalancerRunningStatus runningStatus = 3;
     optional DiskBalancerConfigurationProto diskBalancerConf = 4;
+    optional uint64 successMoveCount = 5;
+    optional uint64 failureMoveCount = 6;
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -499,6 +499,8 @@ message DiskBalancerReportProto {
   required bool isRunning = 1;
   optional uint64 balancedBytes = 2;
   optional DiskBalancerConfigurationProto diskBalancerConf = 3;
+  optional uint64 successMoveCount = 4;
+  optional uint64 failureMoveCount = 5;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerRunningStatus;
 import org.apache.hadoop.hdds.scm.storage.DiskBalancerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,12 +29,12 @@ public class DiskBalancerStatus {
   public static final Logger LOG =
       LoggerFactory.getLogger(DiskBalancerStatus.class);
 
-  private boolean isRunning;
+  private DiskBalancerRunningStatus isRunning;
   private DiskBalancerConfiguration diskBalancerConfiguration;
   private long successMoveCount;
   private long failureMoveCount;
 
-  public DiskBalancerStatus(boolean isRunning, DiskBalancerConfiguration conf,
+  public DiskBalancerStatus(DiskBalancerRunningStatus isRunning, DiskBalancerConfiguration conf,
       long successMoveCount, long failureMoveCount) {
     this.isRunning = isRunning;
     this.diskBalancerConfiguration = conf;
@@ -41,7 +42,7 @@ public class DiskBalancerStatus {
     this.failureMoveCount = failureMoveCount;
   }
 
-  public boolean isRunning() {
+  public DiskBalancerRunningStatus getRunningStatus() {
     return isRunning;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -30,11 +30,15 @@ public class DiskBalancerStatus {
 
   private boolean isRunning;
   private DiskBalancerConfiguration diskBalancerConfiguration;
+  private long successMoveCount;
+  private long failureMoveCount;
 
-
-  public DiskBalancerStatus(boolean isRunning, DiskBalancerConfiguration conf) {
+  public DiskBalancerStatus(boolean isRunning, DiskBalancerConfiguration conf,
+      long successMoveCount, long failureMoveCount) {
     this.isRunning = isRunning;
     this.diskBalancerConfiguration = conf;
+    this.successMoveCount = successMoveCount;
+    this.failureMoveCount = failureMoveCount;
   }
 
   public boolean isRunning() {
@@ -43,5 +47,13 @@ public class DiskBalancerStatus {
 
   public DiskBalancerConfiguration getDiskBalancerConfiguration() {
     return diskBalancerConfiguration;
+  }
+
+  public long getSuccessMoveCount() {
+    return successMoveCount;
+  }
+
+  public long getFailureMoveCount() {
+    return failureMoveCount;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -60,27 +60,31 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
   private String generateStatus(
       List<HddsProtos.DatanodeDiskBalancerInfoProto> protos) {
     StringBuilder formatBuilder = new StringBuilder("Status result:%n" +
-        "%-50s %s %s %s %s %s%n");
+        "%-40s %-20s %-10s %-10s %-15s %-15s %-15s %-15s%n");
 
     List<String> contentList = new ArrayList<>();
     contentList.add("Datanode");
     contentList.add("VolumeDensity");
     contentList.add("Status");
-    contentList.add("Threshold");
+    contentList.add("Threshold(%)");
     contentList.add("BandwidthInMB");
-    contentList.add("ParallelThread");
+    contentList.add("Threads");
+    contentList.add("SuccessMove");
+    contentList.add("FailureMove");
 
     for (HddsProtos.DatanodeDiskBalancerInfoProto proto: protos) {
-      formatBuilder.append("%-50s %s %s %s %s %s%n");
+      formatBuilder.append("%-40s %-20s %-10s %-10s %-15s %-15s %-15s %-15s%n");
       contentList.add(proto.getNode().getHostName());
       contentList.add(String.valueOf(proto.getCurrentVolumeDensitySum()));
       contentList.add(proto.getRunningStatus().name());
       contentList.add(
-          String.valueOf(proto.getDiskBalancerConf().getThreshold()));
+          String.format("%.4f", proto.getDiskBalancerConf().getThreshold()));
       contentList.add(
           String.valueOf(proto.getDiskBalancerConf().getDiskBandwidthInMB()));
       contentList.add(
           String.valueOf(proto.getDiskBalancerConf().getParallelThread()));
+      contentList.add(String.valueOf(proto.getSuccessMoveCount()));
+      contentList.add(String.valueOf(proto.getFailureMoveCount()));
     }
 
     return String.format(formatBuilder.toString(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
As the status helps to reveal the disk balancer task state to user, add success move count and fail move count to status report.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12435

## How was this patch tested?

The patch was tested manually on docker cluster by checking diskbalancer status command.
```
bash-5.1$ ozone admin datanode diskbalancer status
Status result:
Datanode                                 VolumeDensity        Status     Threshold(%) BandwidthInMB   Threads         SuccessMove     FailureMove    
ozone-datanode-1.ozone_default           0.010688673650023704 RUNNING    0.0002       10              5               2               0              
ozone-datanode-2.ozone_default           0.02164608881687885  RUNNING    0.0002       10              5               3               0              
           
```
