### PR TITLE
[Snapshot] HDDS-8007. Add more detailed stages for SnapDiff job progress tracking

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
@@ -55,6 +56,9 @@ public class SnapshotDiffJob {
   // is FAILED.
   private String reason;
 
+  // Represents current status of the job if the job is in IN_PROGRESS state.
+  private List<String> activities;
+
   // Default constructor for Jackson Serializer.
   public SnapshotDiffJob() {
 
@@ -70,7 +74,8 @@ public class SnapshotDiffJob {
                          String toSnapshot,
                          boolean forceFullDiff,
                          boolean disableNativeDiff,
-                         long totalDiffEntries) {
+                         long totalDiffEntries,
+                         List<String> activities) {
     this.creationTime = creationTime;
     this.jobId = jobId;
     this.status = jobStatus;
@@ -82,6 +87,7 @@ public class SnapshotDiffJob {
     this.disableNativeDiff = disableNativeDiff;
     this.totalDiffEntries = totalDiffEntries;
     this.reason = StringUtils.EMPTY;
+    this.activities = activities;
   }
 
   public String getJobId() {
@@ -172,6 +178,18 @@ public class SnapshotDiffJob {
     this.disableNativeDiff = disableNativeDiffVal;
   }
 
+  public List<String> getActivities() {
+    return activities;
+  }
+
+  public void setActivities(List<String> activities) {
+    this.activities = activities;
+  }
+
+  public void addActivity(String activity){
+    this.activities.add(activity);
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("creationTime : ").append(creationTime)
@@ -209,7 +227,8 @@ public class SnapshotDiffJob {
           Objects.equals(this.forceFullDiff, otherJob.forceFullDiff) &&
           Objects.equals(this.totalDiffEntries, otherJob.totalDiffEntries) &&
           Objects.equals(this.disableNativeDiff, otherJob.disableNativeDiff)
-          && Objects.equals(this.reason, otherJob.reason);
+          && Objects.equals(this.reason, otherJob.reason) &&
+          Objects.equals(this.activities, otherJob.activities);
     }
     return false;
   }
@@ -218,7 +237,7 @@ public class SnapshotDiffJob {
   public int hashCode() {
     return Objects.hash(creationTime, jobId, status, volume, bucket,
         fromSnapshot, toSnapshot, forceFullDiff, disableNativeDiff,
-        totalDiffEntries, reason);
+        totalDiffEntries, reason, activities);
   }
 
   public SnapshotDiffJobProto toProtoBuf() {
@@ -233,6 +252,7 @@ public class SnapshotDiffJob {
         .setForceFullDiff(forceFullDiff)
         .setDisableNativeDiff(disableNativeDiff)
         .setTotalDiffEntries(totalDiffEntries)
+        .addAllActivities(activities)
         .build();
   }
 
@@ -248,7 +268,8 @@ public class SnapshotDiffJob {
         diffJobProto.getToSnapshot(),
         diffJobProto.getForceFullDiff(),
         diffJobProto.getDisableNativeDiff(),
-        diffJobProto.getTotalDiffEntries());
+        diffJobProto.getTotalDiffEntries(),
+        diffJobProto.getActivitiesList());
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffResponse.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.snapshot;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotDiffResponse.JobStatusProto;
+import java.util.List;
 
 /**
  * POJO for Snapshot Diff Response.
@@ -49,6 +50,7 @@ public class SnapshotDiffResponse {
   private final JobStatus jobStatus;
   private final long waitTimeInMs;
   private final String reason;
+  private List<String> activities;
 
   public SnapshotDiffResponse(final SnapshotDiffReportOzone snapshotDiffReport,
                               final JobStatus jobStatus,
@@ -85,6 +87,10 @@ public class SnapshotDiffResponse {
     return reason;
   }
 
+  public void setActivities(List<String> activities) {
+    this.activities = activities;
+  }
+
   @Override
   public String toString() {
     StringBuilder str = new StringBuilder();
@@ -112,6 +118,19 @@ public class SnapshotDiffResponse {
           .append(". Please retry after ")
           .append(waitTimeInMs)
           .append(" ms.\n");
+      if (activities != null && !activities.isEmpty()) {
+        str.append("Activities: [");
+        for (int i = 0; i < activities.size(); i++) {
+          String activity = activities.get(i);
+          str.append("{")
+              .append(", op : ").append(activity)
+              .append("}");
+          if (i < activities.size() - 1) {
+            str.append(", "); // Add comma except for the last element
+          }
+        }
+        str.append("]");
+      }
     }
     return str.toString();
   }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -912,6 +912,7 @@ message SnapshotDiffJobProto {
   optional uint64 totalDiffEntries = 9;
   optional string message = 10;
   optional bool disableNativeDiff = 11;
+  repeated string activities = 12;
 }
 
 message OzoneObj {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDiffCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDiffCleanupService.java
@@ -299,7 +299,8 @@ public class TestSnapshotDiffCleanupService {
     String jobKey = fromSnapshot + DELIMITER + toSnapshot;
 
     SnapshotDiffJob job = new SnapshotDiffJob(creationTime, jobId, jobStatus,
-        volume, bucket, fromSnapshot, toSnapshot, false, false, noOfEntries);
+        volume, bucket, fromSnapshot, toSnapshot, false, false, noOfEntries,
+        new ArrayList<>());
 
     db.get().put(jobTableCfh, codecRegistry.asRawData(jobKey),
         codecRegistry.asRawData(job));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -303,7 +303,8 @@ public class TestSnapshotDiffManager {
 
       SnapshotDiffJob diffJob = new SnapshotDiffJob(System.currentTimeMillis(),
           UUID.randomUUID().toString(), jobStatus, VOLUME_NAME, BUCKET_NAME,
-          baseSnapshotName, targetSnapshotName, false, false, 0);
+          baseSnapshotName, targetSnapshotName, false, false, 0,
+          new ArrayList<>());
 
       snapshotNames.add(targetSnapshotName);
       snapshotInfoList.add(targetSnapshot);
@@ -705,7 +706,7 @@ public class TestSnapshotDiffManager {
           Optional.of(newParentIds),
           ImmutableMap.of(OmMetadataManagerImpl.DIRECTORY_TABLE, "",
               OmMetadataManagerImpl.KEY_TABLE, "",
-              OmMetadataManagerImpl.FILE_TABLE, ""));
+              OmMetadataManagerImpl.FILE_TABLE, ""),"");
 
       try (ClosableIterator<Map.Entry<byte[], byte[]>> oldObjectIdIter =
                oldObjectIdKeyMap.iterator()) {
@@ -856,7 +857,7 @@ public class TestSnapshotDiffManager {
       assertEquals(100, totalDiffEntries);
       SnapshotDiffJob snapshotDiffJob = new SnapshotDiffJob(0, "jobId",
           JobStatus.DONE, "vol", "buck", "fs", "ts", false,
-          true, diffMap.size());
+          true, diffMap.size(), new ArrayList<>());
       SnapshotDiffReportOzone snapshotDiffReportOzone =
           snapshotDiffManager.createPageResponse(snapshotDiffJob, "vol",
               "buck", "fs", "ts",
@@ -917,11 +918,11 @@ public class TestSnapshotDiffManager {
 
     SnapshotDiffJob snapshotDiffJob = new SnapshotDiffJob(0, testJobId,
         JobStatus.DONE, "vol", "buck", "fs", "ts", false,
-        true, totalNumberOfRecords);
+        true, totalNumberOfRecords, new ArrayList<>());
 
     SnapshotDiffJob snapshotDiffJob2 = new SnapshotDiffJob(0, testJobId2,
         JobStatus.DONE, "vol", "buck", "fs", "ts", false,
-        true, totalNumberOfRecords);
+        true, totalNumberOfRecords, new ArrayList<>());
 
     db.get().put(snapDiffJobTable,
         codecRegistry.asRawData(testJobId),
@@ -1066,7 +1067,7 @@ public class TestSnapshotDiffManager {
     String jobId = UUID.randomUUID().toString();
     SnapshotDiffJob snapshotDiffJob = new SnapshotDiffJob(0L,
         jobId, jobStatus, volumeName, bucketName,
-        fromSnapshotName, toSnapshotName, true, false, 10);
+        fromSnapshotName, toSnapshotName, true, false, 10, new ArrayList<>());
 
     snapDiffJobMap.put(diffJobKey, snapshotDiffJob);
 
@@ -1558,7 +1559,7 @@ public class TestSnapshotDiffManager {
         .getSSTFileListForSnapshot(any(OmSnapshot.class), anyList());
 
     doNothing().when(spy).addToObjectIdMap(eq(keyInfoTable), eq(keyInfoTable),
-        any(), anyBoolean(), any(), any(), any(), any(), any(), anyMap());
+        any(), anyBoolean(), any(), any(), any(), any(), any(), anyMap(),anyString());
     doNothing().when(spy).checkReportsIntegrity(any(), anyInt(), anyInt());
 
     doReturn(10L).when(spy).generateDiffReport(anyString(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds a field "activities" in the SnapshotDiffJob response that records/logs the various stages of the diff computation.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8007

## How was this patch tested?
Tried out and verified the persistence of these logs in the DB. 
Here is how the snapDiff db looked for a job

```bash
c59e8806-364e-49c7-9505-a4e41e070930-19c4a25e-531b-4d18-9805-bf17d5365127 ==> {
  "creationTime": 1741169298085,
  "jobId": "09f3cc5b-1c2e-48e4-9f4d-6ff7ac6743a0",
  "status": "DONE",
  "volume": "vol1",
  "bucket": "buck1",
  "fromSnapshot": "snap1",
  "toSnapshot": "snap2",
  "forceFullDiff": false,
  "totalDiffEntries": 101,
  "reason": "",
  "activities": [
    "Wed Mar 05 10:08:18 UTC 2025 : Candidate Key Generation : Generating the ObjectId-Key Map",
    "Wed Mar 05 10:08:18 UTC 2025 : Computing Delta SST File Set",
    "Wed Mar 05 10:08:18 UTC 2025 : Computed Delta SST File Set, Total count = 3",
    "Wed Mar 05 10:08:18 UTC 2025 : Completed processing 0 number of keys",
    "Wed Mar 05 10:08:18 UTC 2025 : Completed processing 100 number of keys",
    "Wed Mar 05 10:08:18 UTC 2025 : Completed processing 200 number of keys",
    "Wed Mar 05 10:08:18 UTC 2025 : Candidate Key Generation : Generating the ObjectId-Key Map for Directory Keys",
    "Wed Mar 05 10:08:18 UTC 2025 : Computing Delta SST File Set",
    "Wed Mar 05 10:08:18 UTC 2025 : Computed Delta SST File Set, Total count = 3",
    "Wed Mar 05 10:08:18 UTC 2025 : Completed processing 0 number of keys",
    "Wed Mar 05 10:08:18 UTC 2025 : Completed processing 100 number of keys",
    "Wed Mar 05 10:08:18 UTC 2025 : Final Stage : Generating and storing the Diff Report"
  ],
  "nativeDiffDisabled": false
}
```
