### PR TITLE
HDDS-12483. Quasi Closed Stuck should have 2 replicas of each origin

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckReplicaCount.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+
+/**
+ * Class to count the replicas in a quasi-closed stuck container.
+ */
+public class QuasiClosedStuckReplicaCount {
+
+  private final Map<UUID, Set<ContainerReplica>> replicasByOrigin = new HashMap<>();
+  private final Map<UUID, Set<ContainerReplica>> inServiceReplicasByOrigin = new HashMap<>();
+  private final Map<UUID, Set<ContainerReplica>> maintenanceReplicasByOrigin = new HashMap<>();
+  private boolean hasOutOfServiceReplicas = false;
+  private int minHealthyForMaintenance;
+
+  public QuasiClosedStuckReplicaCount(Set<ContainerReplica> replicas, int minHealthyForMaintenance) {
+    this.minHealthyForMaintenance = minHealthyForMaintenance;
+    for (ContainerReplica r : replicas) {
+      replicasByOrigin.computeIfAbsent(r.getOriginDatanodeId(), k -> new HashSet<>()).add(r);
+      HddsProtos.NodeOperationalState opState = r.getDatanodeDetails().getPersistedOpState();
+      if (opState == HddsProtos.NodeOperationalState.IN_SERVICE) {
+        inServiceReplicasByOrigin.computeIfAbsent(r.getOriginDatanodeId(), k -> new HashSet<>()).add(r);
+      } else if (opState == HddsProtos.NodeOperationalState.IN_MAINTENANCE
+          || opState == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE) {
+        maintenanceReplicasByOrigin.computeIfAbsent(r.getOriginDatanodeId(), k -> new HashSet<>()).add(r);
+        hasOutOfServiceReplicas = true;
+      } else {
+        hasOutOfServiceReplicas = true;
+      }
+    }
+  }
+
+  public boolean hasOutOfServiceReplicas() {
+    return hasOutOfServiceReplicas;
+  }
+
+  public boolean isUnderReplicated() {
+    // If there is only a single origin, we expect 3 copies, otherwise we expect 2 copies of each origin
+    if (replicasByOrigin.size() == 1) {
+      UUID origin = replicasByOrigin.keySet().iterator().next();
+      Set<ContainerReplica> inService = inServiceReplicasByOrigin.get(origin);
+      if (inService == null) {
+        return true;
+      }
+      if (inService.size() >= 3) {
+        return false;
+      }
+      // If it is less than 3, we need to check for maintenance copies.
+      Set<ContainerReplica> maintenance = maintenanceReplicasByOrigin.get(origin);
+      int maintenanceCount = maintenance == null ? 0 : maintenance.size();
+
+      return inService.size() < minHealthyForMaintenance || inService.size() + maintenanceCount < 3;
+    }
+
+    // If there are multiple origins, we expect 2 copies of each origin
+    // For maintenance, we expect 1 copy of each origin and ignore the minHealthyForMaintenance parameter
+    for (UUID origin : replicasByOrigin.keySet()) {
+      Set<ContainerReplica> replicas = inServiceReplicasByOrigin.get(origin);
+      if (replicas == null) {
+        return true;
+      }
+      Set<ContainerReplica> maintenance = maintenanceReplicasByOrigin.get(origin);
+      int maintenanceCount = maintenance == null ? 0 : maintenance.size();
+      if (replicas.size() + maintenanceCount < 2) {
+        return true;
+      }
+    }
+    // If we have 2 copies of each origin, we are not under-replicated
+    return false;
+  }
+
+  /**
+   * Returns True is the container is over-replicated. This means that if we have a single origin, there are more than
+   * 3 copies. If we have multiple origins, there are more than 2 copies of each origin.
+   * The over replication check ignore maintenance replicas. The container may become over replicated when maintenance
+   * ends.
+   *
+   * @return True if the container is over-replicated, otherwise false
+   */
+  public boolean isOverReplicated() {
+    // If there is only a single origin, we expect 3 copies, otherwise we expect 2 copies of each origin
+    if (replicasByOrigin.size() == 1) {
+      UUID origin = replicasByOrigin.keySet().iterator().next();
+      Set<ContainerReplica> inService = inServiceReplicasByOrigin.get(origin);
+      return inService != null && inService.size() > 3;
+    }
+
+    // If there are multiple origins, we expect 2 copies of each origin
+    for (UUID origin : replicasByOrigin.keySet()) {
+      Set<ContainerReplica> replicas = inServiceReplicasByOrigin.get(origin);
+      if (replicas != null && replicas.size() > 2) {
+        return true;
+      }
+    }
+    // If we have 2 copies or less of each origin, we are not over-replicated
+    return false;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to correct under replicated QuasiClosed Stuck Ratis containers.
+ */
+public class QuasiClosedStuckUnderReplicationHandler implements UnhealthyReplicationHandler {
+  public static final Logger LOG = LoggerFactory.getLogger(QuasiClosedStuckUnderReplicationHandler.class);
+
+  private final PlacementPolicy placementPolicy;
+  private final ReplicationManager replicationManager;
+  private final long currentContainerSize;
+  private final ReplicationManagerMetrics metrics;
+
+  public QuasiClosedStuckUnderReplicationHandler(final PlacementPolicy placementPolicy,
+      final ConfigurationSource conf, final ReplicationManager replicationManager) {
+    this.placementPolicy = placementPolicy;
+    this.currentContainerSize = (long) conf.getStorageSize(ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
+    this.replicationManager = replicationManager;
+    this.metrics = replicationManager.getMetrics();
+  }
+
+  @Override
+  public int processAndSendCommands(Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,
+      ContainerHealthResult result, int remainingMaintenanceRedundancy) throws IOException {
+    ContainerInfo containerInfo = result.getContainerInfo();
+    LOG.debug("Handling under replicated QuasiClosed Stuck Ratis container {}", containerInfo);
+
+    int pendingAdd = 0;
+    for (ContainerReplicaOp op : pendingOps) {
+      if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
+        pendingAdd++;
+      }
+    }
+
+    if (pendingAdd > 0) {
+      LOG.debug("Container {} has pending add operations. No more replication will be scheduled until they complete",
+          containerInfo);
+      return 0;
+    }
+
+    QuasiClosedStuckReplicaCount replicaCount =
+        new QuasiClosedStuckReplicaCount(replicas, remainingMaintenanceRedundancy);
+
+    List<QuasiClosedStuckReplicaCount.UnderReplicatedOrigin> underReplicatedOrigins
+        = replicaCount.getUnderReplicatedReplicas();
+
+    if (underReplicatedOrigins.isEmpty()) {
+      LOG.debug("Container {} is not under replicated", containerInfo);
+      return 0;
+    }
+
+    // Schedule Replicas for the under replicated origins.
+    int totalRequiredReplicas = 0;
+    int totalCommandsSent = 0;
+    IOException firstException = null;
+    List<ContainerReplicaOp> mutablePendingOps = new ArrayList<>(pendingOps);
+    for (QuasiClosedStuckReplicaCount.UnderReplicatedOrigin origin : underReplicatedOrigins) {
+      totalRequiredReplicas += origin.getAdditionalRequired();
+      List<DatanodeDetails> targets;
+      try {
+        targets = getTargets(containerInfo, replicas, origin.getAdditionalRequired(), mutablePendingOps);
+      } catch (SCMException e) {
+        if (firstException == null) {
+          firstException = e;
+        }
+        LOG.warn("Cannot replicate container {} because no suitable targets were found.", containerInfo, e);
+        continue;
+      }
+
+      List<DatanodeDetails> sourceDatanodes = origin.getSources().stream()
+          .map(ContainerReplica::getDatanodeDetails)
+          .collect(Collectors.toList());
+      for (DatanodeDetails target : targets) {
+        try {
+          replicationManager.sendThrottledReplicationCommand(containerInfo, sourceDatanodes, target, 0);
+          // Add the pending op, so we exclude the node for subsequent origins
+          mutablePendingOps.add(ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.ADD, target, 0));
+          totalCommandsSent++;
+        } catch (CommandTargetOverloadedException e) {
+          LOG.warn("Cannot replicate container {} because target {} is overloaded.", containerInfo, target);
+          if (firstException == null) {
+            firstException = e;
+          }
+        }
+      }
+    }
+
+    if (firstException != null || totalCommandsSent < totalRequiredReplicas) {
+      // Some commands were not sent as expected (not enough nodes found or overloaded nodes), so we just rethrow
+      // the first exception we encountered.
+      LOG.info("A command was not sent for all required new replicas for container {}. Total sent {}, required {} ",
+          containerInfo, totalCommandsSent, totalRequiredReplicas);
+      metrics.incrPartialReplicationTotal();
+      if (firstException != null) {
+        throw firstException;
+      } else {
+        throw new InsufficientDatanodesException(totalRequiredReplicas, totalCommandsSent);
+      }
+    }
+    return totalCommandsSent;
+  }
+
+  private List<DatanodeDetails> getTargets(ContainerInfo containerInfo,
+      Set<ContainerReplica> replicas, int additionalRequired, List<ContainerReplicaOp> pendingOps) throws IOException {
+    LOG.debug("Need {} target datanodes for container {}. Current replicas: {}.",
+        additionalRequired, containerInfo, replicas);
+
+    ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
+        ReplicationManagerUtil.getExcludedAndUsedNodes(containerInfo, new ArrayList<>(replicas), Collections.emptySet(),
+            pendingOps, replicationManager);
+
+    List<DatanodeDetails> excluded = excludedAndUsedNodes.getExcludedNodes();
+    List<DatanodeDetails> used = excludedAndUsedNodes.getUsedNodes();
+
+    LOG.debug("UsedList: {}, size {}. ExcludeList: {}, size: {}. ",
+        used, used.size(), excluded, excluded.size());
+
+    return ReplicationManagerUtil.getTargetDatanodes(placementPolicy,
+        additionalRequired, used, excluded, currentContainerSize, containerInfo);
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.hdds.scm.container.replication.health.HealthCheck;
 import org.apache.hadoop.hdds.scm.container.replication.health.MismatchedReplicasHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.OpenContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.QuasiClosedContainerHandler;
+import org.apache.hadoop.hdds.scm.container.replication.health.QuasiClosedStuckReplicationCheck;
 import org.apache.hadoop.hdds.scm.container.replication.health.RatisReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.RatisUnhealthyReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.VulnerableUnhealthyReplicasHandler;
@@ -262,6 +263,7 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
         .addNext(new MismatchedReplicasHandler(this))
         .addNext(new EmptyContainerHandler(this))
         .addNext(new DeletingContainerHandler(this))
+        .addNext(new QuasiClosedStuckReplicationCheck())
         .addNext(ecReplicationCheckHandler)
         .addNext(ratisReplicationCheckHandler)
         .addNext(new ClosedWithUnhealthyReplicasHandler(this))

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedContainerHandler.java
@@ -86,6 +86,17 @@ public class QuasiClosedContainerHandler extends AbstractCheck {
   }
 
   /**
+   * Returns true if the container is stuck in QUASI_CLOSED state, otherwise false.
+   * @param container The container to check
+   * @param replicas Set of ContainerReplicas
+   * @return true if the container is stuck in QUASI_CLOSED state, otherwise false
+   */
+  public static boolean isQuasiClosedStuck(final ContainerInfo container,
+      final Set<ContainerReplica> replicas) {
+    return !canForceCloseContainer(container, replicas);
+  }
+
+  /**
    * Returns true if more than 50% of the container replicas with unique
    * originNodeId are in QUASI_CLOSED state.
    *
@@ -93,7 +104,7 @@ public class QuasiClosedContainerHandler extends AbstractCheck {
    * @param replicas Set of ContainerReplicas
    * @return true if we can force close the container, false otherwise
    */
-  private boolean canForceCloseContainer(final ContainerInfo container,
+  private static boolean canForceCloseContainer(final ContainerInfo container,
       final Set<ContainerReplica> replicas) {
     final int replicationFactor =
         container.getReplicationConfig().getRequiredNodes();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedStuckReplicationCheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedStuckReplicationCheck.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
+
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
+import org.apache.hadoop.hdds.scm.container.replication.QuasiClosedStuckReplicaCount;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to check for the replication of the replicas in quasi-closed stuck containers. As we want to maintain
+ * as much data and information as possible, the rule for QC stuck container is to maintain 2 copies of each origin
+ * if there is more than 1 origin. If there is only 1 origin, then we need to maintain 3 copies.
+ */
+public class QuasiClosedStuckReplicationCheck  extends AbstractCheck {
+  public static final Logger LOG = LoggerFactory.getLogger(QuasiClosedStuckReplicationCheck.class);
+
+  @Override
+  public boolean handle(ContainerCheckRequest request) {
+    if (request.getContainerInfo().getState() != QUASI_CLOSED) {
+      return false;
+    }
+    if (!QuasiClosedContainerHandler.isQuasiClosedStuck(request.getContainerInfo(), request.getContainerReplicas())) {
+      return false;
+    }
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(
+        request.getContainerReplicas(), request.getMaintenanceRedundancy());
+    int pendingAdd = 0;
+    int pendingDelete = 0;
+    for (ContainerReplicaOp op : request.getPendingOps()) {
+      if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
+        pendingAdd++;
+      } else if (op.getOpType() == ContainerReplicaOp.PendingOpType.DELETE) {
+        pendingDelete++;
+      }
+    }
+
+    if (request.getContainerReplicas().isEmpty()) {
+      // If there are no replicas, then mark as missing and return.
+      request.getReport().incrementAndSample(
+          ReplicationManagerReport.HealthState.MISSING, request.getContainerInfo().containerID());
+      return true;
+    }
+
+    if (replicaCount.isUnderReplicated()) {
+      LOG.debug("Container {} is quasi-closed-stuck under-replicated", request.getContainerInfo());
+      request.getReport().incrementAndSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+          request.getContainerInfo().containerID());
+      if (pendingAdd == 0) {
+        // Only queue if there are no pending adds, as that could correct the under replication.
+        LOG.debug("Queueing under-replicated health result for container {}", request.getContainerInfo());
+        ContainerHealthResult.UnderReplicatedHealthResult underReplicatedHealthResult =
+            new ContainerHealthResult.UnderReplicatedHealthResult(request.getContainerInfo(), 1,
+                replicaCount.hasOutOfServiceReplicas(), false, false);
+        request.getReplicationQueue().enqueue(underReplicatedHealthResult);
+      }
+      return true;
+    }
+
+    if (replicaCount.isOverReplicated()) {
+      LOG.debug("Container {} is quasi-closed-stuck over-replicated", request.getContainerInfo());
+      request.getReport().incrementAndSample(ReplicationManagerReport.HealthState.OVER_REPLICATED,
+          request.getContainerInfo().containerID());
+      if (pendingDelete == 0) {
+        // Only queue if there are no pending deletes which could correct the over replication
+        LOG.debug("Queueing over-replicated health result for container {}", request.getContainerInfo());
+        ContainerHealthResult.OverReplicatedHealthResult overReplicatedHealthResult =
+            new ContainerHealthResult.OverReplicatedHealthResult(request.getContainerInfo(), 1, false);
+        request.getReplicationQueue().enqueue(overReplicatedHealthResult);
+      }
+      return true;
+    }
+    return false;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -125,6 +125,19 @@ public final class ReplicationTestUtil {
     return replicas;
   }
 
+  public static Set<ContainerReplica> createReplicasWithOriginAndOpState(
+      ContainerID containerID, ContainerReplicaProto.State replicaState,
+      Pair<UUID, HddsProtos.NodeOperationalState>... nodes) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    UUID originNodeId = MockDatanodeDetails.randomDatanodeDetails().getUuid();
+    for (Pair<UUID, HddsProtos.NodeOperationalState> i : nodes) {
+      replicas.add(createContainerReplica(
+          containerID, 0, i.getRight(), replicaState, 123L, 1234L,
+          MockDatanodeDetails.randomDatanodeDetails(), i.getLeft()));
+    }
+    return replicas;
+  }
+
   public static ContainerReplica createContainerReplica(ContainerID containerID,
       int replicaIndex, HddsProtos.NodeOperationalState opState,
       ContainerReplicaProto.State replicaState) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckReplicaCount.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED;
+import static org.apache.ratis.util.Preconditions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Set;
+import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the QuasiClosedStuckReplicaCount class.
+ */
+public class TestQuasiClosedStuckReplicaCount {
+
+  private UUID origin1;
+  private UUID origin2;
+  private UUID origin3;
+
+  @BeforeEach
+  public void setUp() {
+    origin1 = UUID.randomUUID();
+    origin2 = UUID.randomUUID();
+    origin3 = UUID.randomUUID();
+  }
+
+  @Test
+  public void testCorrectlyReplicationWithThreeOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE),
+        Pair.of(origin3, IN_SERVICE), Pair.of(origin3, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testCorrectReplicationWithTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testCorrectReplicationWithOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationWithThreeOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE),
+        Pair.of(origin3, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationWithTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationWithOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testOverReplicationWithThreeOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE),
+        Pair.of(origin3, IN_SERVICE), Pair.of(origin3, IN_SERVICE), Pair.of(origin3, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertTrue(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testOverReplicationWithTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertTrue(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testOverReplicationWithOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin1, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertTrue(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationDueToDecommissionWithThreeOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, DECOMMISSIONING),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE),
+        Pair.of(origin3, IN_SERVICE), Pair.of(origin3, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationDueToDecommissionWithTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, DECOMMISSIONING),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationDueToDecommissionWithOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, DECOMMISSIONING));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testNoOverReplicationWithOutOfServiceReplicasWithThreeOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, DECOMMISSIONED),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE),
+        Pair.of(origin3, IN_SERVICE), Pair.of(origin3, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testNoOverReplicationWithOutOfServiceReplicasWithTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, DECOMMISSIONED),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testNoOverReplicationWithOutOfServiceReplicasWithOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin1, DECOMMISSIONED));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationWithMaintenanceWithOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, ENTERING_MAINTENANCE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+
+    replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, ENTERING_MAINTENANCE), Pair.of(origin1, ENTERING_MAINTENANCE));
+
+    replicaCount = new QuasiClosedStuckReplicaCount(replicas, 2);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testUnderReplicationWithMaintenanceWithTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, ENTERING_MAINTENANCE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+
+    replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, ENTERING_MAINTENANCE), Pair.of(origin1, ENTERING_MAINTENANCE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertTrue(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+
+    replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, ENTERING_MAINTENANCE), Pair.of(origin1, ENTERING_MAINTENANCE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testNoOverReplicationWithExcessMaintenanceReplicasTwoOrigins() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_MAINTENANCE),
+        Pair.of(origin2, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+  @Test
+  public void testNoOverReplicationWithExcessMaintenanceReplicasOneOrigin() {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(
+        ContainerID.valueOf(1), QUASI_CLOSED,
+        Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+        Pair.of(origin1, IN_MAINTENANCE));
+
+    QuasiClosedStuckReplicaCount replicaCount = new QuasiClosedStuckReplicaCount(replicas, 1);
+    assertFalse(replicaCount.isUnderReplicated());
+    assertFalse(replicaCount.isOverReplicated());
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
@@ -167,7 +167,6 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
     assertThrows(CommandTargetOverloadedException.class, () ->
         handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1));
     assertEquals(1, commandsSent.size());
-    assertEquals(1, metrics.getPartialReplicationTotal());
   }
 
   @Test
@@ -200,7 +199,6 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
     assertThrows(InsufficientDatanodesException.class, () ->
         handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1));
     assertEquals(1, commandsSent.size());
-    assertEquals(1, metrics.getPartialReplicationTotal());
   }
 
   private ContainerHealthResult.UnderReplicatedHealthResult getUnderReplicatedHealthResult() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test for QuasiClosedStuckUnderReplicationHandler.
+ */
+public class TestQuasiClosedStuckUnderReplicationHandler {
+
+  private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG = RatisReplicationConfig.getInstance(THREE);
+  private ContainerInfo container;
+  private NodeManager nodeManager;
+  private OzoneConfiguration conf;
+  private ReplicationManager replicationManager;
+  private ReplicationManagerMetrics metrics;
+  private PlacementPolicy policy;
+  private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
+  private QuasiClosedStuckUnderReplicationHandler handler;
+
+
+  @BeforeEach
+  void setup(@TempDir File testDir) throws NodeNotFoundException,
+      CommandTargetOverloadedException, NotLeaderException {
+    container = ReplicationTestUtil.createContainer(
+        HddsProtos.LifeCycleState.QUASI_CLOSED, RATIS_REPLICATION_CONFIG);
+
+    nodeManager = mock(NodeManager.class);
+    conf = SCMTestUtils.getConf(testDir);
+    policy = ReplicationTestUtil
+        .getSimpleTestPlacementPolicy(nodeManager, conf);
+    replicationManager = mock(ReplicationManager.class);
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.setBoolean("hdds.scm.replication.push", true);
+    when(replicationManager.getConfig())
+        .thenReturn(ozoneConfiguration.getObject(
+            ReplicationManager.ReplicationManagerConfiguration.class));
+    metrics = ReplicationManagerMetrics.create(replicationManager);
+    when(replicationManager.getMetrics()).thenReturn(metrics);
+
+    /*
+      Return NodeStatus with NodeOperationalState as specified in
+      DatanodeDetails, and NodeState as HEALTHY.
+    */
+    when(
+        replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenAnswer(invocationOnMock -> {
+          DatanodeDetails dn = invocationOnMock.getArgument(0);
+          return new NodeStatus(dn.getPersistedOpState(),
+              HddsProtos.NodeState.HEALTHY);
+        });
+
+    commandsSent = new HashSet<>();
+    ReplicationTestUtil.mockRMSendThrottleReplicateCommand(
+        replicationManager, commandsSent, new AtomicBoolean(false));
+    ReplicationTestUtil.mockRMSendDatanodeCommand(replicationManager,
+        commandsSent);
+    ReplicationTestUtil.mockRMSendDeleteCommand(replicationManager,
+        commandsSent);
+    handler = new QuasiClosedStuckUnderReplicationHandler(policy, conf,
+        replicationManager);
+  }
+
+  @Test
+  public void testReturnsZeroIfNotUnderReplicated() throws IOException {
+    UUID origin = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    int count = handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1);
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void testNoCommandsScheduledIfPendingOps() throws IOException {
+    UUID origin = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
+    List<ContainerReplicaOp> pendingOps = new ArrayList<>();
+    pendingOps.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.ADD, MockDatanodeDetails.randomDatanodeDetails(), 0));
+
+    int count = handler.processAndSendCommands(replicas, pendingOps, getUnderReplicatedHealthResult(), 1);
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void testCommandScheduledForUnderReplicatedContainer() throws IOException {
+    UUID origin = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    int count = handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1);
+    assertEquals(2, count);
+    ReplicationTestUtil.mockRMSendThrottleReplicateCommand(replicationManager, commandsSent, new AtomicBoolean(true));
+  }
+
+  @Test
+  public void testOverloadedExceptionContinuesAndThrows() throws NotLeaderException, CommandTargetOverloadedException {
+    UUID origin1 = UUID.randomUUID();
+    UUID origin2 = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin2, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    ReplicationTestUtil.mockRMSendThrottleReplicateCommand(replicationManager, commandsSent, new AtomicBoolean(true));
+
+    assertThrows(CommandTargetOverloadedException.class, () ->
+        handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1));
+    assertEquals(1, commandsSent.size());
+    assertEquals(1, metrics.getPartialReplicationTotal());
+  }
+
+  @Test
+  public void testInsufficientNodesExceptionThrown() {
+    UUID origin1 = UUID.randomUUID();
+    UUID origin2 = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin2, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager, conf);
+    handler = new QuasiClosedStuckUnderReplicationHandler(policy, conf, replicationManager);
+
+    assertThrows(SCMException.class, () ->
+        handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1));
+    assertEquals(0, commandsSent.size());
+  }
+
+  @Test
+  public void testPartialReplicationExceptionThrown() {
+    UUID origin1 = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    policy = ReplicationTestUtil.getInsufficientNodesTestPlacementPolicy(nodeManager, conf, 2);
+    handler = new QuasiClosedStuckUnderReplicationHandler(policy, conf, replicationManager);
+
+    assertThrows(InsufficientDatanodesException.class, () ->
+        handler.processAndSendCommands(replicas, Collections.emptyList(), getUnderReplicatedHealthResult(), 1));
+    assertEquals(1, commandsSent.size());
+    assertEquals(1, metrics.getPartialReplicationTotal());
+  }
+
+  private ContainerHealthResult.UnderReplicatedHealthResult getUnderReplicatedHealthResult() {
+    ContainerHealthResult.UnderReplicatedHealthResult
+        healthResult = mock(ContainerHealthResult.UnderReplicatedHealthResult.class);
+    when(healthResult.getContainerInfo()).thenReturn(container);
+    return healthResult;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -471,63 +471,6 @@ public class TestReplicationManager {
     assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
-  @Test
-  public void testQuasiClosedContainerWithVulnerableUnhealthyReplica()
-      throws IOException, NodeNotFoundException {
-    RatisReplicationConfig ratisRepConfig =
-        RatisReplicationConfig.getInstance(THREE);
-    long sequenceID = 10;
-    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
-        HddsProtos.LifeCycleState.QUASI_CLOSED, sequenceID);
-
-    // this method creates replicas with same origin id and zero sequence id
-    Set<ContainerReplica> replicas =
-        createReplicasWithSameOrigin(container.containerID(),
-            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
-    replicas.add(createContainerReplica(container.containerID(), 0,
-        IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY, sequenceID));
-    ContainerReplica decommissioning =
-        createContainerReplica(container.containerID(), 0, DECOMMISSIONING,
-            ContainerReplicaProto.State.UNHEALTHY, sequenceID);
-    replicas.add(decommissioning);
-    storeContainerAndReplicas(container, replicas);
-    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
-        .thenAnswer(invocation -> {
-          DatanodeDetails dn = invocation.getArgument(0);
-          if (dn.equals(decommissioning.getDatanodeDetails())) {
-            return new NodeStatus(DECOMMISSIONING, HddsProtos.NodeState.HEALTHY);
-          }
-
-          return NodeStatus.inServiceHealthy();
-        });
-
-    replicationManager.processContainer(container, repQueue, repReport);
-    assertEquals(1, repReport.getStat(
-        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    assertEquals(0, repReport.getStat(
-        ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    assertEquals(1, repQueue.underReplicatedQueueSize());
-    assertEquals(0, repQueue.overReplicatedQueueSize());
-
-    when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
-        anyLong())).thenAnswer(invocation -> ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails()));
-    when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
-        .thenAnswer(invocation -> {
-          Map<SCMCommandProto.Type, Integer> map = new HashMap<>();
-          map.put(SCMCommandProto.Type.replicateContainerCommand, 0);
-          map.put(SCMCommandProto.Type.reconstructECContainersCommand, 0);
-          return map;
-        });
-    RatisUnderReplicationHandler handler =
-        new RatisUnderReplicationHandler(ratisPlacementPolicy, configuration, replicationManager);
-
-    handler.processAndSendCommands(replicas, Collections.emptyList(), repQueue.dequeueUnderReplicatedContainer(), 2);
-    assertEquals(1, commandsSent.size());
-    Pair<UUID, SCMCommand<?>> command = commandsSent.iterator().next();
-    assertEquals(SCMCommandProto.Type.replicateContainerCommand, command.getValue().getType());
-    assertEquals(decommissioning.getDatanodeDetails().getUuid(), command.getKey());
-  }
-
   /**
    * When there is Quasi Closed Replica with incorrect sequence id
    * for a Closed container, it's treated as unhealthy and deleted.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -528,67 +528,6 @@ public class TestReplicationManager {
     assertEquals(decommissioning.getDatanodeDetails().getUuid(), command.getKey());
   }
 
-
-  /**
-   * There is a QUASI_CLOSED container with some UNHEALTHY replicas on unique origin nodes. If the datanode hosting
-   * one such replica is being taken offline, then the UNHEALTHY replica needs to be replicated to another node.
-   */
-  @Test
-  public void testQuasiClosedContainerWithUnhealthyReplicaOnDecommissioningNodeWithUniqueOrigin()
-      throws IOException, NodeNotFoundException {
-    RatisReplicationConfig ratisRepConfig =
-        RatisReplicationConfig.getInstance(THREE);
-    // create a QUASI_CLOSED container with 3 QUASI_CLOSED replicas on same origin, and 1 UNHEALTHY on unique origin
-    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
-        HddsProtos.LifeCycleState.QUASI_CLOSED);
-    Set<ContainerReplica> replicas =
-        createReplicasWithSameOrigin(container.containerID(),
-            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
-    ContainerReplica unhealthy =
-        createContainerReplica(container.containerID(), 0, DECOMMISSIONING,
-            ContainerReplicaProto.State.UNHEALTHY);
-    replicas.add(unhealthy);
-    storeContainerAndReplicas(container, replicas);
-    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
-        .thenAnswer(invocation -> {
-          DatanodeDetails dn = invocation.getArgument(0);
-          if (dn.equals(unhealthy.getDatanodeDetails())) {
-            return new NodeStatus(DECOMMISSIONING, HddsProtos.NodeState.HEALTHY);
-          }
-
-          return NodeStatus.inServiceHealthy();
-        });
-
-    // the container should be under replicated and queued to under replication queue
-    replicationManager.processContainer(container, repQueue, repReport);
-    assertEquals(1, repReport.getStat(
-        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    assertEquals(0, repReport.getStat(
-        ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    assertEquals(1, repQueue.underReplicatedQueueSize());
-    assertEquals(0, repQueue.overReplicatedQueueSize());
-
-    // next, this test sets up some mocks to test if RatisUnderReplicationHandler will handle this container correctly
-    when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
-        anyLong())).thenAnswer(invocation -> ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails()));
-    when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
-        .thenAnswer(invocation -> {
-          Map<SCMCommandProto.Type, Integer> map = new HashMap<>();
-          map.put(SCMCommandProto.Type.replicateContainerCommand, 0);
-          map.put(SCMCommandProto.Type.reconstructECContainersCommand, 0);
-          return map;
-        });
-    RatisUnderReplicationHandler handler =
-        new RatisUnderReplicationHandler(ratisPlacementPolicy, configuration, replicationManager);
-
-    handler.processAndSendCommands(replicas, Collections.emptyList(), repQueue.dequeueUnderReplicatedContainer(), 2);
-    assertEquals(1, commandsSent.size());
-    Pair<UUID, SCMCommand<?>> command = commandsSent.iterator().next();
-    // a replicate command should have been sent for the UNHEALTHY replica
-    assertEquals(SCMCommandProto.Type.replicateContainerCommand, command.getValue().getType());
-    assertEquals(unhealthy.getDatanodeDetails().getUuid(), command.getKey());
-  }
-
   /**
    * When there is Quasi Closed Replica with incorrect sequence id
    * for a Closed container, it's treated as unhealthy and deleted.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -463,11 +463,11 @@ public class TestReplicationManager {
     storeContainerAndReplicas(container, replicas);
 
     replicationManager.processContainer(container, repQueue, repReport);
-    assertEquals(0, repReport.getStat(
+    assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     assertEquals(0, repReport.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.underReplicatedQueueSize());
     assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Tests for the QuasiClosedStuckReplicationCheck class.
+ */
+public class TestQuasiClosedStuckReplicationCheck {
+
+  private QuasiClosedStuckReplicationCheck handler;
+  private final UUID origin1 = UUID.randomUUID();
+  private final UUID origin2 = UUID.randomUUID();
+  private final UUID origin3 = UUID.randomUUID();
+  private ReplicationManagerReport report;
+  private ReplicationQueue queue;
+
+  @BeforeEach
+  public void setup() {
+    handler = new QuasiClosedStuckReplicationCheck();
+    report = new ReplicationManagerReport();
+    queue = new ReplicationQueue();
+  }
+
+  @Test
+  public void testClosedContainerReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE));
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertFalse(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testQuasiClosedNotStuckReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin2, IN_SERVICE), Pair.of(origin3, IN_SERVICE));
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertFalse(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+
+  }
+
+  @Test
+  public void testCorrectlyReplicated() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE));
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertFalse(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+
+  }
+
+  @Test
+  public void testNoReplicasReturnsTrue() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = new HashSet<>();
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertTrue(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(1, report.getStat(ReplicationManagerReport.HealthState.MISSING));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testUnderReplicatedIsQueued() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE));
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertTrue(handler.handle(request));
+    assertEquals(1, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.MISSING));
+    assertEquals(1, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testUnderReplicatedWithPendingAddIsNotQueued() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE));
+
+    List<ContainerReplicaOp> pendingOps = new ArrayList<>();
+    pendingOps.add(new ContainerReplicaOp(
+        ContainerReplicaOp.PendingOpType.ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE));
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .setPendingOps(pendingOps)
+        .build();
+
+    assertTrue(handler.handle(request));
+    assertEquals(1, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.MISSING));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testOverReplicatedIsQueued() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+            Pair.of(origin1, IN_SERVICE));
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertTrue(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(1, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.MISSING));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(1, queue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testOverReplicatedWithPendingDeleteIsNotQueued() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE),
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin1, IN_SERVICE));
+
+    List<ContainerReplicaOp> pendingOps = new ArrayList<>();
+    pendingOps.add(new ContainerReplicaOp(
+        ContainerReplicaOp.PendingOpType.DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE));
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .setPendingOps(pendingOps)
+        .build();
+
+    assertTrue(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(1, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.MISSING));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
@@ -109,7 +109,32 @@ public class TestQuasiClosedStuckReplicationCheck {
     assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
     assertEquals(0, queue.underReplicatedQueueSize());
     assertEquals(0, queue.overReplicatedQueueSize());
+  }
 
+  @Test
+  public void testQuasiClosedStuckWithOpenReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE), 1, QUASI_CLOSED);
+
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.QUASI_CLOSED,
+            Pair.of(origin1, IN_SERVICE), Pair.of(origin2, IN_SERVICE));
+    containerReplicas.addAll(ReplicationTestUtil
+        .createReplicasWithOriginAndOpState(containerInfo.containerID(), State.OPEN,
+            Pair.of(origin3, IN_SERVICE)));
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReplicationQueue(queue)
+        .build();
+
+    assertFalse(handler.handle(request));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, queue.underReplicatedQueueSize());
+    assertEquals(0, queue.overReplicatedQueueSize());
   }
 
   @Test
@@ -133,7 +158,6 @@ public class TestQuasiClosedStuckReplicationCheck {
     assertEquals(0, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
     assertEquals(0, queue.underReplicatedQueueSize());
     assertEquals(0, queue.overReplicatedQueueSize());
-
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -28,7 +28,7 @@
       { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"},
       { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 12, "isEmpty": false, "origin": "o2"}
     ],
-    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
     "checkCommands": [],
     "commands": []
   },
@@ -108,7 +108,7 @@
       { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
       { "state": "UNHEALTHY",    "index": 0,   "datanode": "d4", "sequenceId": 11, "isEmpty": false, "origin": "o3"}
     ],
-    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
     "commands": []
   }

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -133,5 +133,19 @@
       { "type": "replicateContainerCommand", "datanode": "d4" },
       { "type": "replicateContainerCommand", "datanode": "d4" }
     ]
+  },
+  { "description": "Quasi-Closed 3 on one origin 2 unhealthy with 1 decommissioning", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 11,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "UNHEALTHY",    "index": 0,   "datanode": "d4", "sequenceId": 11, "isEmpty": false, "origin": "o3", "operationalState": "DECOMMISSIONING"},
+      { "state": "UNHEALTHY",    "index": 0,   "datanode": "d5", "sequenceId": 11, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": [
+      { "type": "replicateContainerCommand"}
+    ]
   }
 ]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -19,7 +19,8 @@
     "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
     "checkCommands": [],
     "commands": [
-      { "type": "replicateContainerCommand" }
+      { "type": "replicateContainerCommand", "datanode": "d1" },
+      { "type": "replicateContainerCommand", "datanode": "d2" }
     ]
   },
   { "description": "Quasi-closed with 3 replicas 2 origins", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
@@ -30,7 +31,9 @@
     ],
     "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1},
     "checkCommands": [],
-    "commands": []
+    "commands": [
+      { "type": "replicateContainerCommand", "datanode": "d1" }
+    ]
   },
   { "description": "Quasi-closed with 3 replicas 3 origins", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
     "replicas": [
@@ -98,7 +101,9 @@
     "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
     "commands": [
-      { "type": "replicateContainerCommand" }
+      { "type": "replicateContainerCommand", "datanode": "d1" },
+      { "type": "replicateContainerCommand", "datanode": "d2" },
+      { "type": "replicateContainerCommand", "datanode": "d3" }
     ]
   },
   { "description": "Quasi-Closed with 3 QC and one unhealthy", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 11,
@@ -110,6 +115,9 @@
     ],
     "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
-    "commands": []
+    "commands": [
+      { "type": "replicateContainerCommand", "datanode": "d1" },
+      { "type": "replicateContainerCommand", "datanode": "d4" }
+    ]
   }
 ]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -119,5 +119,19 @@
       { "type": "replicateContainerCommand", "datanode": "d1" },
       { "type": "replicateContainerCommand", "datanode": "d4" }
     ]
+  },
+  { "description": "Quasi-Closed 3 on one origin 1 unhealthy decommissioning", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 11,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "UNHEALTHY",    "index": 0,   "datanode": "d4", "sequenceId": 11, "isEmpty": false, "origin": "o3", "operationalState": "DECOMMISSIONING"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": [
+      { "type": "replicateContainerCommand", "datanode": "d4" },
+      { "type": "replicateContainerCommand", "datanode": "d4" }
+    ]
   }
 ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the change to ensure Quasi Closed replicas only move to CLOSED when all 3 origin are present, some new edge cases appeared where some replicas do not get full replication.

After some discussion we decided on the following for Quasi Closed Stuck containers:

1. If there is only 1 origin available, create 3 copies of it.

2. If there are 2 or more origins, maintain 2 copies of each origin.

In the worse case, which is:

Origin: 1, bcsid:10, State: Quasi_Closed
Origin: 2, bcsid:10, State: Quasi_Closed
Origin: 3, bcsid:11, State: Unhealthy

This cannot move to closed as the highest BCSID is unhealthy, so 6 replicas will be maintained in the system - 2 from each origin.

This PR solves this issue by introducing a new replication check handler for QC Stuck containers which runs before the existing Ratis Under Replicated Handler.

When under replication is identified a new QuasiClosedStuckUnderReplicationHandler is introduced to process it separately from the existing under replication flow.

Implementing in this way, isolates the special handling into their own code units, and avoids making changing to existing handles which could result in unexpected side effects in complex areas.

Note a followup PR will be required for Over Replication handling.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12483

## How was this patch tested?

New unit and RM scenario tests added / modified.
