### PR TITLE
HDDS-12496. Use TextFormat#shortDebugString to flatten proto message in SCMDatanodeProtocolServer.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -44,6 +44,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.protobuf.BlockingService;
 import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.TextFormat;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -285,7 +286,7 @@ public class SCMDatanodeProtocolServer implements
         auditMap.append(" encodedToken: \"").append(cmd.getEncodedToken()).append("\"");
         auditMap.append(" deadlineMsSinceEpoch: ").append(cmd.getDeadlineMsSinceEpoch());
       } else {
-        auditMap.append(cmd);
+        auditMap.append(TextFormat.shortDebugString(cmd));
       }
       auditMap.append(", ");
     }
@@ -308,7 +309,7 @@ public class SCMDatanodeProtocolServer implements
     boolean auditSuccess = true;
     Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("datanodeUUID", heartbeat.getDatanodeDetails().getUuid());
-    auditMap.put("command", flatten(constructCommandAuditMap(cmdResponses)));
+    auditMap.put("command", constructCommandAuditMap(cmdResponses));
     term.ifPresent(t -> auditMap.put("term", String.valueOf(t)));
     try {
       SCMHeartbeatResponseProto.Builder builder =
@@ -478,13 +479,6 @@ public class SCMDatanodeProtocolServer implements
         .withResult(AuditEventStatus.FAILURE)
         .withException(throwable)
         .build();
-  }
-
-  private static String flatten(String input) {
-    return input
-        .replaceAll(System.lineSeparator(), " ")
-        .trim()
-        .replaceAll(" +", " ");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use TextFormat#shortDebugString to flatten proto message in SCMDatanodeProtocolServer.


Currently we have a custom implementation to flatten the string generated by `proto#toString`, which is not required. We can use `TextFormat#shortDebugString` instead.

## What is the link to the Apache JIRA
HDDS-12496

## How was this patch tested?

CI Run: https://github.com/nandakumar131/ozone/actions/runs/13716111984

Output 
Before the change:
```
2025-03-04 17:08:46,166 | INFO  | SCMAudit | user=dn/dn@EXAMPLE.COM | ip=172.19.0.6 | op=SEND_HEARTBEAT {datanodeUUID=7c397365-5024-4a6a-bd66-2afd462f074e, term=2, command=[commandType: closePipelineCommand closePipelineCommandProto { pipelineID { id: "4ba00bcb-43bb-4f4c-9aec-e7ebb664b9f3" uuid128 { mostSigBits: 5449368516760915788 leastSigBits: -7283191497801549325 } } cmdId: 1741107361521 } term: 2 encodedToken: "" deadlineMsSinceEpoch: 0 ]} | ret=SUCCESS |
```

After the change:
```
2025-03-07 08:24:04,167 | INFO  | SCMAudit | user=hadoop | ip=172.18.0.3 | op=SEND_HEARTBEAT {datanodeUUID=92a882c6-625f-48fc-885d-9b45f5122f42, term=2, command=[commandType: closePipelineCommand closePipelineCommandProto { pipelineID { id: "1d42a265-2df1-49f7-95ea-cbc34b8a151b" uuid128 { mostSigBits: 2108426131008997879 leastSigBits: -7644073377861593829 } } cmdId: 1741335250559 } term: 2 encodedToken: "" deadlineMsSinceEpoch: 0]} | ret=SUCCESS |
```
