### PR TITLE
HDDS-12469. mark statemachine unhealthy for write operation timeout

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -632,7 +632,9 @@ public final class ScmConfigKeys {
 
   public static final String NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY =
       "net.topology.node.switch.mapping.impl";
-
+  public static final String HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL
+      = "hdds.container.ratis.statemachine.write.wait.interval";
+  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_DEFAULT = 10 * 1000L;
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -634,7 +634,7 @@ public final class ScmConfigKeys {
       "net.topology.node.switch.mapping.impl";
   public static final String HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL
       = "hdds.container.ratis.statemachine.write.wait.interval";
-  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_NS_DEFAULT = 10 * 60 * 1000_1000_1000L;
+  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_NS_DEFAULT = 10 * 60 * 1000_000_000L;
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -634,7 +634,7 @@ public final class ScmConfigKeys {
       "net.topology.node.switch.mapping.impl";
   public static final String HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL
       = "hdds.container.ratis.statemachine.write.wait.interval";
-  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_DEFAULT = 10 * 1000L;
+  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_DEFAULT = 10 * 60 * 1000L;
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -634,7 +634,7 @@ public final class ScmConfigKeys {
       "net.topology.node.switch.mapping.impl";
   public static final String HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL
       = "hdds.container.ratis.statemachine.write.wait.interval";
-  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_DEFAULT = 10 * 60 * 1000L;
+  public static final long HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_NS_DEFAULT = 10 * 60 * 1000_1000_1000L;
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3549,6 +3549,14 @@
     </description>
   </property>
   <property>
+    <name>hdds.container.ratis.statemachine.write.wait.interval</name>
+    <tag>OZONE, DATANODE</tag>
+    <value>10m</value>
+    <description>
+      Timeout for the write path for container blocks.
+    </description>
+  </property>
+  <property>
     <name>hdds.datanode.slow.op.warning.threshold</name>
     <tag>OZONE, DATANODE, PERFORMANCE</tag>
     <value>500ms</value>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -896,7 +896,7 @@ public class ContainerStateMachine extends BaseStateMachine {
    */
   @Override
   public CompletableFuture<Void> flush(long index) {
-    final SortedMap<Long, WriteFutures> head = writeChunkFutureMap.headMap(index + 1);
+    final SortedMap<Long, WriteFutures> head = writeChunkFutureMap.headMap(index, true);
     if (head.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -624,7 +624,7 @@ public class ContainerStateMachine extends BaseStateMachine {
             return result;
           } catch (Exception e) {
             LOG.error("{}: writeChunk writeStateMachineData failed: blockId" +
-                  "{} logIndex {} chunkName {}", getGroupId(), write.getBlockID(),
+                "{} logIndex {} chunkName {}", getGroupId(), write.getBlockID(),
                 entryIndex, write.getChunkData().getChunkName(), e);
             metrics.incNumWriteDataFails();
             // write chunks go in parallel. It's possible that one write chunk

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -688,7 +688,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     while (!writeChunkFutureMap.isEmpty()) {
       writeFutureContextEntry = writeChunkFutureMap.firstEntry();
       // there is a possibility of entry being removed before added in map, cleanup those
-      if (!writeFutureContextEntry.getValue().getWriteChunkFuture().isDone()) {
+      if (null == writeFutureContextEntry || !writeFutureContextEntry.getValue().getWriteChunkFuture().isDone()) {
         break;
       }
       writeChunkFutureMap.remove(writeFutureContextEntry.getKey());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -624,7 +624,7 @@ public class ContainerStateMachine extends BaseStateMachine {
             return result;
           } catch (Exception e) {
             LOG.error("{}: writeChunk writeStateMachineData failed: blockId" +
-                    "{} logIndex {} chunkName {}", getGroupId(), write.getBlockID(),
+                  "{} logIndex {} chunkName {}", getGroupId(), write.getBlockID(),
                 entryIndex, write.getChunkData().getChunkName(), e);
             metrics.incNumWriteDataFails();
             // write chunks go in parallel. It's possible that one write chunk
@@ -700,18 +700,14 @@ public class ContainerStateMachine extends BaseStateMachine {
         found = true;
       }
     }
-    if (null == writeFutureContextEntry) {
-      return;
-    }
     // validate for timeout in milli second
     long waitTime = Time.monotonicNowNanos() - writeFutureContextEntry.getValue().getStartTime();
     if (waitTime > writeChunkWaitMaxNs) {
-      LOG.error("Write chunk has taken {}ns crossing threshold {}ns for index {} groupId {}", waitTime,
-          writeChunkWaitMaxNs, writeFutureContextEntry.getKey(), getGroupId());
+      LOG.error("Write chunk has taken {}ns crossing threshold {}ns for index {} groupId {}, " +
+              "cancelling pending write chunk for this group", waitTime, writeChunkWaitMaxNs,
+          writeFutureContextEntry.getKey(), getGroupId());
       stateMachineHealthy.set(false);
       writeChunkFutureMap.forEach((key, value) -> {
-        LOG.error("Cancelling write chunk due to timeout {}ns crossing {}ns for index {}, groupId {}", waitTime,
-            writeChunkWaitMaxNs, key, getGroupId());
         value.getWriteChunkFuture().cancel(true);
       });
       throw new StorageContainerException("Write chunk has taken " + waitTime + "ns crossing threshold "

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -49,6 +49,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -301,8 +302,8 @@ public class ContainerStateMachine extends BaseStateMachine {
     this.waitOnBothFollowers = conf.getObject(
         DatanodeConfiguration.class).waitOnAllFollowers();
 
-    this.writeChunkWaitMaxMs = conf.getLong(ScmConfigKeys.HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL,
-        ScmConfigKeys.HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_DEFAULT);
+    this.writeChunkWaitMaxMs = conf.getTimeDuration(ScmConfigKeys.HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL,
+        ScmConfigKeys.HDDS_CONTAINER_RATIS_STATEMACHINE_WRITE_WAIT_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
   }
 
   private void validatePeers() throws IOException {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -30,8 +31,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -57,6 +60,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -262,5 +266,53 @@ abstract class TestContainerStateMachine {
     ContainerProtos.ContainerCommandResponseProto resp =
         ContainerProtos.ContainerCommandResponseProto.parseFrom(succcesfulTransaction.getContent());
     assertEquals(ContainerProtos.Result.SUCCESS, resp.getResult());
+  }
+
+  @Test
+  public void testWriteTimout() throws Exception {
+    RaftProtos.LogEntryProto entry = mock(RaftProtos.LogEntryProto.class);
+    when(entry.getTerm()).thenReturn(1L);
+    when(entry.getIndex()).thenReturn(1L);
+    RaftProtos.LogEntryProto entryNext = mock(RaftProtos.LogEntryProto.class);
+    when(entryNext.getTerm()).thenReturn(1L);
+    when(entryNext.getIndex()).thenReturn(2L);
+    TransactionContext trx = mock(TransactionContext.class);
+    ContainerStateMachine.Context context = mock(ContainerStateMachine.Context.class);
+    when(trx.getStateMachineContext()).thenReturn(context);
+    doAnswer(e -> {
+      try {
+        Thread.sleep(200000);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        throw ie;
+      }
+      return null;
+    }).when(dispatcher).dispatch(any(), any());
+
+    when(context.getRequestProto()).thenReturn(ContainerProtos.ContainerCommandRequestProto.newBuilder()
+        .setCmdType(ContainerProtos.Type.WriteChunk).setWriteChunk(
+            ContainerProtos.WriteChunkRequestProto.newBuilder().setData(ByteString.copyFromUtf8("Test Data"))
+                .setBlockID(
+                    ContainerProtos.DatanodeBlockID.newBuilder().setContainerID(1).setLocalID(1).build()).build())
+        .setContainerID(1)
+        .setDatanodeUuid(UUID.randomUUID().toString()).build());
+    AtomicReference<Throwable> throwable = new AtomicReference<>(null);
+    Function<Throwable, ? extends Message> throwableSetter = t -> {
+      throwable.set(t);
+      return null;
+    };
+    Field writeChunkWaitMaxMs = stateMachine.getClass().getDeclaredField("writeChunkWaitMaxMs");
+    writeChunkWaitMaxMs.setAccessible(true);
+    writeChunkWaitMaxMs.set(stateMachine, 1000);
+    CompletableFuture<Message> firstWrite = stateMachine.write(entry, trx);
+    Thread.sleep(2000);
+    CompletableFuture<Message> secondWrite = stateMachine.write(entryNext, trx);
+    firstWrite.exceptionally(throwableSetter).get();
+    assertNotNull(throwable.get());
+    assertInstanceOf(InterruptedException.class, throwable.get());
+
+    secondWrite.exceptionally(throwableSetter).get();
+    assertNotNull(throwable.get());
+    assertInstanceOf(IOException.class, throwable.get());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
@@ -301,9 +301,9 @@ abstract class TestContainerStateMachine {
       throwable.set(t);
       return null;
     };
-    Field writeChunkWaitMaxMs = stateMachine.getClass().getDeclaredField("writeChunkWaitMaxNs");
-    writeChunkWaitMaxMs.setAccessible(true);
-    writeChunkWaitMaxMs.set(stateMachine, 1000);
+    Field writeChunkWaitMaxNs = stateMachine.getClass().getDeclaredField("writeChunkWaitMaxNs");
+    writeChunkWaitMaxNs.setAccessible(true);
+    writeChunkWaitMaxNs.set(stateMachine, 1000_000_000);
     CompletableFuture<Message> firstWrite = stateMachine.write(entry, trx);
     Thread.sleep(2000);
     CompletableFuture<Message> secondWrite = stateMachine.write(entryNext, trx);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
@@ -301,7 +301,7 @@ abstract class TestContainerStateMachine {
       throwable.set(t);
       return null;
     };
-    Field writeChunkWaitMaxMs = stateMachine.getClass().getDeclaredField("writeChunkWaitMaxMs");
+    Field writeChunkWaitMaxMs = stateMachine.getClass().getDeclaredField("writeChunkWaitMaxNs");
     writeChunkWaitMaxMs.setAccessible(true);
     writeChunkWaitMaxMs.set(stateMachine, 1000);
     CompletableFuture<Message> firstWrite = stateMachine.write(entry, trx);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
@@ -313,6 +313,8 @@ abstract class TestContainerStateMachine {
 
     secondWrite.exceptionally(throwableSetter).get();
     assertNotNull(throwable.get());
-    assertInstanceOf(IOException.class, throwable.get());
+    assertInstanceOf(StorageContainerException.class, throwable.get());
+    StorageContainerException sce = (StorageContainerException) throwable.get();
+    assertEquals(ContainerProtos.Result.CONTAINER_INTERNAL_ERROR, sce.getResult());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. When same write log is retry and already existing operation in progress, return back existing future
2. Validate if write operation time crosses threshold, if crosses, mark statemachine as unhealthy

The trigger will be when next operation comes, check for existing operation if any timeout occurred. Here, lowest index checking should be enough as that is the first operation in-progress and to be completed for next one to be marked committed.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12469

## How was this patch tested?

- Unit test case added
- Impact via existing integration test
