### PR TITLE
HDDS-12500. Do not skip JUnit tests in post-commit runs

### DIFF
--- a/hadoop-ozone/dev-support/checks/_post_process.sh
+++ b/hadoop-ozone/dev-support/checks/_post_process.sh
@@ -26,13 +26,13 @@
 # - $REPORT_FILE should be defined
 # - Maven output should be saved in $REPORT_DIR/output.log
 
-# script failed, but report file is empty (does not reflect failure)
-if [[ ${rc} -ne 0 ]] && [[ ! -s "${REPORT_FILE}" ]]; then
-  # do we know what to look for?
+if [[ ! -s "${REPORT_FILE}" ]]; then
+  # check if there are errors in the log
   if [[ -n "${ERROR_PATTERN:-}" ]]; then
     grep -m25 "${ERROR_PATTERN}" "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
   fi
-  if [[ ! -s "${REPORT_FILE}" ]]; then
+  # script failed, but report file is empty (does not reflect failure)
+  if [[ ${rc} -ne 0 ]] && [[ ! -s "${REPORT_FILE}" ]]; then
     echo "Unknown failure, check output.log" > "${REPORT_FILE}"
   fi
 fi

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -40,7 +40,7 @@ fi
 if [[ "${FAIL_FAST}" == "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-fast -Dsurefire.skipAfterFailureCount=1"
 else
-  MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-at-end"
+  MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-never"
 fi
 
 # apply module access args (for Java 9+)

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -107,5 +107,5 @@ if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
   mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec -Dscan=false
 fi
 
-ERROR_PATTERN="\[ERROR\]"
+ERROR_PATTERN="BUILD FAILURE"
 source "${DIR}/_post_process.sh"

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -50,8 +50,10 @@ if [[ -f hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh ]]; then
   ozone_java_setup
 fi
 
+mvn ${MAVEN_OPTIONS} clean
+
 if [[ ${ITERATIONS} -gt 1 ]] && [[ ${OZONE_REPO_CACHED} == "false" ]]; then
-  mvn ${MAVEN_OPTIONS} -DskipTests clean install
+  mvn ${MAVEN_OPTIONS} -DskipTests install
 fi
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/${CHECK}"}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`mvn --fail-at-end` skips tests in dependent modules.  We should use `mvn --fail-never` to run as many tests as possible.  This applies only to post-commit test run, PR run should still `--fail-fast`.

Also: perform `mvn clean` before running tests to avoid confusion due to leftover classes and results (useful for local runs).

https://issues.apache.org/jira/browse/HDDS-12500

## How was this patch tested?

No failures:

```bash
$ ./hadoop-ozone/dev-support/checks/integration.sh -am -pl :hdds-config
...
[INFO] BUILD SUCCESS

$ echo $?
0

$ wc -l target/integration/summary.txt
0 target/integration/summary.txt
```

Introduced compile failure:

```bash
$ ./hadoop-ozone/dev-support/checks/integration.sh -am -pl :hdds-config
...
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileAppender.java:[42,5] cannot find symbol
  symbol:   method ssertThat(java.lang.String)
  location: class org.apache.hadoop.hdds.conf.TestConfigFileAppender
[INFO] 1 error
...
[INFO] BUILD FAILURE
...
[INFO] Build failures were ignored.

$ echo $?
1

$ wc -l target/integration/summary.txt
1 target/integration/summary.txt

$ cat target/integration/summary.txt
[INFO] BUILD FAILURE
```

Introduced test failure:

```bash
$ ./hadoop-ozone/dev-support/checks/integration.sh -am -pl :hdds-config
...
[ERROR] org.apache.hadoop.hdds.conf.TestConfigFileAppender.testInit -- Time elapsed: 0.086 s <<< FAILURE!
java.lang.AssertionError: 
...
[INFO] BUILD FAILURE
...
[INFO] Build failures were ignored.

$ echo $?
1

$ wc -l target/integration/summary.txt
1 target/integration/summary.txt

$ cat target/integration/summary.txt
org.apache.hadoop.hdds.conf.TestConfigFileAppender
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/13723920090