### PR TITLE
HDDS-11805. Replicate the ReplicationManager start and stop command

### DIFF
--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -485,6 +485,10 @@ message ContainerBalancerConfigurationProto {
     optional int64 moveReplicationTimeout = 20;
 }
 
+message ReplicationManagerConfigurationProto {
+    required bool isRunning = 1;
+}
+
 message TransferLeadershipRequestProto {
     required string newLeaderId = 1;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -288,48 +288,6 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
     }
   }
 
-  public void saveConfiguration(boolean isRunning)
-      throws IOException {
-    saveConfiguration(
-        ReplicationManagerConfigurationProto.newBuilder()
-            .setIsRunning(isRunning)
-            .build());
-  }
-
-  public boolean isRunning() {
-    try {
-      ReplicationManagerConfigurationProto proto =
-          readConfiguration(ReplicationManagerConfigurationProto.class);
-      if (proto == null) {
-        LOG.warn("Could not find persisted configuration for {} when checking" +
-            " if ReplicationManager is running. ReplicationManager should not " +
-            "run now.", this.getServiceName());
-        return false;
-      }
-      return proto.getIsRunning();
-    } catch (IOException e) {
-      LOG.warn("Could not read persisted configuration for checking if " +
-          "ReplicationManager is running. ReplicationManager should not run" +
-          " now.", e);
-      return false;
-    }
-  }
-
-  /**
-   * Returns true if the Replication Monitor Thread is running.
-   *
-   * @return true if running, false otherwise
-   */
-  public boolean canRun() {
-    if (!isRunning()) {
-      synchronized (this) {
-        return replicationMonitor != null
-            && replicationMonitor.isAlive();
-      }
-    }
-    return true;
-  }
-
   /**
    * Stops Replication Monitor thread.
    */
@@ -374,6 +332,48 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
     overReplicatedProcessorThread.setName(prefix + "OverReplicatedProcessor");
     overReplicatedProcessorThread.setDaemon(true);
     overReplicatedProcessorThread.start();
+  }
+
+  public void saveConfiguration(boolean isRunning)
+      throws IOException {
+    saveConfiguration(
+        ReplicationManagerConfigurationProto.newBuilder()
+            .setIsRunning(isRunning)
+            .build());
+  }
+
+  public boolean isRunning() {
+    try {
+      ReplicationManagerConfigurationProto proto =
+          readConfiguration(ReplicationManagerConfigurationProto.class);
+      if (proto == null) {
+        LOG.warn("Could not find persisted configuration for {} when checking" +
+            " if ReplicationManager is running. ReplicationManager should not " +
+            "run now.", this.getServiceName());
+        return false;
+      }
+      return proto.getIsRunning();
+    } catch (IOException e) {
+      LOG.warn("Could not read persisted configuration for checking if " +
+          "ReplicationManager is running. ReplicationManager should not run" +
+          " now.", e);
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if the Replication Monitor Thread is running.
+   *
+   * @return true if running, false otherwise
+   */
+  public boolean canRun() {
+    if (!isRunning()) {
+      synchronized (this) {
+        return replicationMonitor != null
+            && replicationMonitor.isAlive();
+      }
+    }
+    return true;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -361,11 +361,6 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
     }
   }
 
-  /**
-   * Returns true if the Replication Monitor Thread is running.
-   *
-   * @return true if running, false otherwise
-   */
   public boolean canRun() {
     if (!isRunning()) {
       synchronized (this) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -377,8 +377,10 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
       LOG.warn("No persisted configuration found for {} when checking operational status. " +
           "This may prevent the ReplicationManager from responding to manual start/stop commands. " +
           "Use its thread status to check if it is running.", this.getServiceName());
-      return replicationMonitor != null
-          && replicationMonitor.isAlive();
+      synchronized (this) {
+        return replicationMonitor != null
+            && replicationMonitor.isAlive();
+      }
     }
     return proto.getIsRunning();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -278,7 +278,7 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
    * Notice that if persist is true, it may fail with raft purpose exception.
    */
   public synchronized void start(boolean persist) {
-    if (!started()) {
+    if (!isRunning()) {
       LOG.info("Starting Replication Monitor Thread.");
       if (persist) {
         try {
@@ -366,25 +366,21 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
     }
   }
 
+   /**
+   * Returns true if the Replication Monitor Thread is running.
+   *
+   * @return true if running, false otherwise
+   */
   public boolean isRunning() {
     ReplicationManagerConfigurationProto proto = readConfiguration();
     if (proto == null) {
       LOG.warn("No persisted configuration found for {} when checking operational status. " +
           "This may prevent the ReplicationManager from responding to manual start/stop commands. " +
-          "Defaulting to running state.", this.getServiceName());
-      return true;
+          "Use its thread status to check if it is running.", this.getServiceName());
+      return replicationMonitor != null
+          && replicationMonitor.isAlive();
     }
     return proto.getIsRunning();
-  }
-
-  public boolean started() {
-    if (readConfiguration() == null || !isRunning()) {
-      synchronized (this) {
-        return replicationMonitor != null
-            && replicationMonitor.isAlive();
-      }
-    }
-    return true;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -268,7 +268,7 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
 
   @Override
   public void start() {
-    start(true);
+    start(false);
   }
 
   /**
@@ -277,7 +277,7 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
    * 
    * Notice that if persist is true, it may fail with raft purpose exception.
    */
-  private synchronized void start(boolean persist) {
+  public synchronized void start(boolean persist) {
     if (!started()) {
       LOG.info("Starting Replication Monitor Thread.");
       if (persist) {
@@ -349,7 +349,7 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
     overReplicatedProcessorThread.start();
   }
 
-  public void saveConfiguration(boolean isRunning)
+  protected void saveConfiguration(boolean isRunning)
       throws IOException {
     saveConfiguration(
         ReplicationManagerConfigurationProto.newBuilder()
@@ -357,7 +357,7 @@ public class ReplicationManager extends StatefulService implements ContainerRepl
             .build());
   }
 
-  private ReplicationManagerConfigurationProto readConfiguration() {
+  protected ReplicationManagerConfigurationProto readConfiguration() {
     try {
       return readConfiguration(ReplicationManagerConfigurationProto.class);
     } catch (IOException e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -68,7 +68,7 @@ public final class SCMContext {
    */
   private SafeModeStatus safeModeStatus;
 
-  private final OzoneStorageContainerManager scm;
+  private OzoneStorageContainerManager scm;
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   /**
@@ -132,6 +132,15 @@ public final class SCMContext {
     lock.writeLock().lock();
     try {
       this.finalizationCheckpoint = checkpoint;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public void setSCM(OzoneStorageContainerManager ozoneScm) {
+    lock.writeLock().lock();
+    try {
+      this.scm = ozoneScm;
     } finally {
       lock.writeLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMServiceManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMServiceManager.java
@@ -65,20 +65,6 @@ public final class SCMServiceManager {
   }
 
   /**
-   * Starts all running services.
-   */
-  public synchronized void start() {
-    for (SCMService service : services) {
-      LOG.debug("Starting service:{}.", service.getServiceName());
-      try {
-        service.start();
-      } catch (SCMServiceException e) {
-        LOG.warn("Could not start " + service.getServiceName(), e);
-      }
-    }
-  }
-
-  /**
    * Stops all running services.
    */
   public synchronized void stop() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/OzoneStorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/OzoneStorageContainerManager.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
+import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 
@@ -59,4 +60,6 @@ public interface OzoneStorageContainerManager {
   SCMNodeDetails getScmNodeDetails();
 
   ReconfigurationHandler getReconfigurationHandler();
+
+  StatefulServiceStateManager getStatefulServiceStateManager();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -964,7 +964,7 @@ public class SCMClientProtocolServer implements
     getScm().checkAdminAccess(getRemoteUser(), false);
     AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
         SCMAction.STOP_REPLICATION_MANAGER, null));
-    scm.getReplicationManager().stop();
+    scm.getReplicationManager().stop(true);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -956,7 +956,7 @@ public class SCMClientProtocolServer implements
     getScm().checkAdminAccess(getRemoteUser(), false);
     AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
         SCMAction.START_REPLICATION_MANAGER, null));
-    scm.getReplicationManager().start();
+    scm.getReplicationManager().start(true);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -692,6 +692,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     if (configurator.getScmContext() != null) {
       scmContext = configurator.getScmContext();
+      if (scmContext.getScm() == null) {
+        scmContext.setSCM(this);
+      }
     } else {
       // non-leader of term 0, in safe mode, preCheck not completed.
       scmContext = new SCMContext.Builder()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1999,6 +1999,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     return this.clusterMap;
   }
 
+  @Override
   public StatefulServiceStateManager getStatefulServiceStateManager() {
     return statefulServiceStateManager;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -803,6 +803,14 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     } else {
       scmBlockManager = new BlockManagerImpl(conf, scmConfig, this);
     }
+
+    statefulServiceStateManager = StatefulServiceStateManagerImpl.newBuilder()
+        .setStatefulServiceConfig(
+            scmMetadataStore.getStatefulServiceConfigTable())
+        .setSCMDBTransactionBuffer(scmHAManager.getDBTransactionBuffer())
+        .setRatisServer(scmHAManager.getRatisServer())
+        .build();
+
     if (configurator.getReplicationManager() != null) {
       replicationManager = configurator.getReplicationManager();
     }  else {
@@ -832,13 +840,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     scmDecommissionManager = new NodeDecommissionManager(conf, scmNodeManager, containerManager,
         scmContext, eventQueue, replicationManager);
-
-    statefulServiceStateManager = StatefulServiceStateManagerImpl.newBuilder()
-        .setStatefulServiceConfig(
-            scmMetadataStore.getStatefulServiceConfigTable())
-        .setSCMDBTransactionBuffer(scmHAManager.getDBTransactionBuffer())
-        .setRatisServer(scmHAManager.getRatisServer())
-        .build();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -256,7 +256,9 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testPersistConfiguration() {
+  public void testPersistConfiguration() throws IOException {
+    serviceToConfigMap.clear();
+    replicationManager = createDefaultReplicationManager();
     // replicationManager has started in the constructor
     assertTrue(replicationManager.isRunning());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -275,15 +276,18 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testManualStartStopAndPersist() throws IOException {
+  public void testPersistedStartStop() throws IOException {
     serviceToConfigMap.clear();
     replicationManager = createDefaultReplicationManager();
+    assertNull(replicationManager.readConfiguration());
     assertTrue(replicationManager.isRunning());
 
     replicationManager.stop(true);
+    assertNotNull(replicationManager.readConfiguration());
     assertFalse(replicationManager.isRunning());
 
-    replicationManager.start();
+    replicationManager.start(true);
+    assertNotNull(replicationManager.readConfiguration());
     assertTrue(replicationManager.isRunning());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -255,7 +255,7 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testIsRunning() {
+  public void testPersistConfiguration() {
     // replicationManager has started in the constructor
     assertTrue(replicationManager.isRunning());
 
@@ -275,12 +275,12 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testStartStop() throws IOException {
+  public void testManualStartStopAndPersist() throws IOException {
     serviceToConfigMap.clear();
     replicationManager = createDefaultReplicationManager();
     assertTrue(replicationManager.isRunning());
 
-    replicationManager.stop();
+    replicationManager.stop(true);
     assertFalse(replicationManager.isRunning());
 
     replicationManager.start();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -277,7 +277,7 @@ public class TestReplicationManager {
   @Test
   public void testStartStop() throws IOException {
     serviceToConfigMap.clear();
-    ReplicationManager replicationManager = createDefaultReplicationManager();
+    replicationManager = createDefaultReplicationManager();
     assertTrue(replicationManager.isRunning());
 
     replicationManager.stop();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -38,8 +38,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
-import org.apache.hadoop.hdds.scm.ha.SCMContext;
-import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB;
@@ -65,11 +63,8 @@ public class TestSCMClientProtocolServer {
   @BeforeEach
   void setUp(@TempDir File testDir) throws Exception {
     config = SCMTestUtils.getConf(testDir);
-    SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(SCMHAManagerStub.getInstance(true));
-    configurator.setScmContext(SCMContext.emptyContext());
     config.set(OZONE_READONLY_ADMINISTRATORS, "testUser");
-    scm = HddsTestUtils.getScm(config, configurator);
+    scm = HddsTestUtils.getScm(config);
     scm.start();
     scm.exitSafeMode();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOMSortDatanodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOMSortDatanodes.java
@@ -33,11 +33,8 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
-import org.apache.hadoop.hdds.scm.ha.SCMContext;
-import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
-import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.net.StaticMapping;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -94,10 +91,7 @@ public class TestOMSortDatanodes {
     config.set(StaticMapping.KEY_HADOOP_CONFIGURED_NODE_MAPPING,
         String.join(",", nodeMapping));
 
-    SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(SCMHAManagerStub.getInstance(true));
-    configurator.setScmContext(SCMContext.emptyContext());
-    scm = HddsTestUtils.getScm(config, configurator);
+    scm = HddsTestUtils.getScm(config);
     scm.start();
     scm.exitSafeMode();
     nodeManager = scm.getScmNodeManager();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -85,6 +85,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator;
+import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBTransactionBufferImpl;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
@@ -713,6 +714,11 @@ public class ReconStorageContainerManagerFacade
 
   @Override
   public ReconfigurationHandler getReconfigurationHandler() {
+    return null;
+  }
+
+  @Override
+  public StatefulServiceStateManager getStatefulServiceStateManager() {
     return null;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `ReplicationManager` start and stop command is only processed by the leader which will either start or stop the relevant threads as well as set the flag "running". However, if there is a leader change, the new SCM leader will not see the previous start / stop subcommand.

We can replicate this start and stop command to the followers so that each SCM has a consistent view of whether replication should run. 

Similar to ContainerBalancer, Make `ReplicationManager` implements `StatefulService`.

## What has been done?

- Only persist start/stop state with manual operation, exclude the SCM stop service and ReplicationManager constructor cases
- Make few change to make some existing tests pass
  - Set the scmContenxt.scm to SCM if it's null, This is used to prevent NPE for those test init scm with HddsTestUrils.getscm
  - remove ServiceManager#start as it's unused
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11805

## How was this patch tested?

CI:
~~https://github.com/peterxcli/ozone/actions/runs/13725399354~~
https://github.com/peterxcli/ozone/actions/runs/13727387381