### PR TITLE
HDDS-12476. Add TestDataUtil#createKey variant with small random content

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -402,7 +402,7 @@ public abstract class TestOzoneFSWithObjectStoreCreate implements NonHATests.Tes
   private void createAndAssertKey(OzoneBucket ozoneBucket, String key, int length)
       throws Exception {
     
-    byte[] input = createKey(ozoneBucket, key, length);
+    byte[] input = TestDataUtil.createStringKey(ozoneBucket, key, length);
     // Read the key with given key name.
     readKey(ozoneBucket, key, length, input);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -21,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.OzoneConsts.MD5_HASH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
-import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -352,13 +352,9 @@ public abstract class TestOzoneFSWithObjectStoreCreate implements NonHATests.Tes
     keys.add(OmUtils.normalizeKey(key2, false));
     keys.add(OmUtils.normalizeKey(key3, false));
 
-    int length = 10;
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte)96);
-
-    createAndAssertKey(ozoneBucket, key1, 10, input);
-    createAndAssertKey(ozoneBucket, key2, 10, input);
-    createAndAssertKey(ozoneBucket, key3, 10, input);
+    createAndAssertKey(ozoneBucket, key1, 10);
+    createAndAssertKey(ozoneBucket, key2, 10);
+    createAndAssertKey(ozoneBucket, key3, 10);
 
     // Iterator with key name as prefix.
 
@@ -403,10 +399,10 @@ public abstract class TestOzoneFSWithObjectStoreCreate implements NonHATests.Tes
     assertEquals(keys, outputKeys);
   }
 
-  private void createAndAssertKey(OzoneBucket ozoneBucket, String key, int length, byte[] input)
+  private void createAndAssertKey(OzoneBucket ozoneBucket, String key, int length)
       throws Exception {
     
-    createKey(ozoneBucket, key, input);
+    byte[] input = createKey(ozoneBucket, key, length);
     // Read the key with given key name.
     readKey(ozoneBucket, key, length, input);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -102,6 +103,14 @@ public final class TestDataUtil {
     objectStore.createVolume(volumeName, volumeArgs);
     return objectStore.getVolume(volumeName);
 
+  }
+
+  public static byte[] createKey(OzoneBucket bucket,
+                                 String keyName, int length) throws IOException{
+    byte[] content = RandomStringUtils.random(length, 0, 0
+        , true, true, null, new SecureRandom()).getBytes(UTF_8);
+    createKey(bucket, keyName, content);
+    return content;
   }
 
   public static void createKey(OzoneBucket bucket, String keyName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -106,9 +106,9 @@ public final class TestDataUtil {
   }
 
   public static byte[] createKey(OzoneBucket bucket,
-                                 String keyName, int length) throws IOException{
-    byte[] content = RandomStringUtils.random(length, 0, 0
-        , true, true, null, new SecureRandom()).getBytes(UTF_8);
+                                 String keyName, int length) throws IOException {
+    byte[] content = RandomStringUtils.random(length, 0, 0,
+        true, true, null, new SecureRandom()).getBytes(UTF_8);
     createKey(bucket, keyName, content);
     return content;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -105,10 +105,9 @@ public final class TestDataUtil {
 
   }
 
-  public static byte[] createKey(OzoneBucket bucket,
-                                 String keyName, int length) throws IOException {
-    byte[] content = RandomStringUtils.random(length, 0, 0,
-        true, true, null, new SecureRandom()).getBytes(UTF_8);
+  public static byte[] createStringKey(OzoneBucket bucket, String keyName, int length)
+      throws IOException {
+    byte[] content = RandomStringUtils.secure().nextAlphanumeric(length).getBytes(UTF_8);
     createKey(bucket, keyName, content);
     return content;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -371,13 +371,10 @@ public abstract class TestListKeys implements NonHATests.TestCase {
 
   private static void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
-    int length = 10;
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, input);
+      byte[] input = createKey(ozoneBucket, key, 10);
       // Read the key with given key name.
-      readkey(ozoneBucket, key, length, input);
+      readkey(ozoneBucket, key, 10, input);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om;
 import static com.google.common.collect.Lists.newLinkedList;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LIST_CACHE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
-import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.of;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -372,7 +372,7 @@ public abstract class TestListKeys implements NonHATests.TestCase {
   private static void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
     for (String key : keys) {
-      byte[] input = createKey(ozoneBucket, key, 10);
+      byte[] input = TestDataUtil.createStringKey(ozoneBucket, key, 10);
       // Read the key with given key name.
       readkey(ozoneBucket, key, 10, input);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.om;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LIST_CACHE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
-import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -643,13 +642,10 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
 
   private static void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
-    int length = 10;
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, input);
+      byte[] input = createKey(ozoneBucket, key, 10);
       // Read the key with given key name.
-      readkey(ozoneBucket, key, length, input);
+      readkey(ozoneBucket, key, 10, input);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -643,7 +643,7 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
   private static void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
     for (String key : keys) {
-      byte[] input = createKey(ozoneBucket, key, 10);
+      byte[] input = TestDataUtil.createStringKey(ozoneBucket, key, 10);
       // Read the key with given key name.
       readkey(ozoneBucket, key, 10, input);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
-import static org.apache.hadoop.ozone.TestDataUtil.createKey;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -560,7 +560,7 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
       throws Exception {
 
     for (String key : keys) {
-      byte[] input = createKey(ozoneBucket, key, 10);
+      byte[] input = TestDataUtil.createStringKey(ozoneBucket, key, 10);
       // Read the key with given key name.
       readKey(ozoneBucket, key, 10, input);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -559,14 +559,10 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
   private void createAndAssertKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
 
-    int length = 10;
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte) 96);
-
     for (String key : keys) {
-      createKey(ozoneBucket, key, input);
+      byte[] input = createKey(ozoneBucket, key, 10);
       // Read the key with given key name.
-      readKey(ozoneBucket, key, length, input);
+      readKey(ozoneBucket, key, 10, input);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -333,7 +334,7 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
     String aclWorldAll = "world::a";
 
     for (String key : keys) {
-      createKey(ozoneBucket, key, 10);
+      TestDataUtil.createStringKey(ozoneBucket, key, 10);
       setKeyAcl(objectStore, ozoneBucket.getVolumeName(), ozoneBucket.getName(),
           key, aclWorldAll);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -329,12 +329,11 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
 
   private void createKeys(ObjectStore objectStore, OzoneBucket ozoneBucket,
       List<String> keys) throws Exception {
-    int length = 10;
+
     String aclWorldAll = "world::a";
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte) 96);
+
     for (String key : keys) {
-      createKey(ozoneBucket, key, input);
+      createKey(ozoneBucket, key, 10);
       setKeyAcl(objectStore, ozoneBucket.getVolumeName(), ozoneBucket.getName(),
           key, aclWorldAll);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -357,7 +357,7 @@ public abstract class TestOmSnapshotFileSystem {
   private void createKey(OzoneBucket ozoneBucket, String key, int length)
       throws Exception {
 
-    byte[] input = TestDataUtil.createKey(ozoneBucket, key, length);
+    byte[] input = TestDataUtil.createStringKey(ozoneBucket, key, length);
     // Read the key with given key name.
     readkey(ozoneBucket, key, length, input);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -349,18 +349,15 @@ public abstract class TestOmSnapshotFileSystem {
 
   private void createKeys(OzoneBucket ozoneBucket, List<String> keys)
       throws Exception {
-    int length = 10;
-    byte[] input = new byte[length];
-    Arrays.fill(input, (byte) 96);
     for (String key : keys) {
-      createKey(ozoneBucket, key, 10, input);
+      createKey(ozoneBucket, key, 10);
     }
   }
 
-  private void createKey(OzoneBucket ozoneBucket, String key, int length,
-                         byte[] input) throws Exception {
+  private void createKey(OzoneBucket ozoneBucket, String key, int length)
+      throws Exception {
 
-    TestDataUtil.createKey(ozoneBucket, key, input);
+    byte[] input = TestDataUtil.createKey(ozoneBucket, key, length);
     // Read the key with given key name.
     readkey(ozoneBucket, key, length, input);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Several callers of `TestDataUtil#createKey` just want to write some data, without any interest in the content being written. The goal of this task is to create a variant of the method which generates some small random `byte[] content` instead of accepting it via parameter. To let the caller verify data (e.g. via `readKey`), this variant of `createKey` should return the random content it generated. Please take a look, thanks!
## What is the link to the Apache JIRA
[HDDS-12476](https://issues.apache.org/jira/browse/HDDS-12476)
## How was this patch tested?
Tested by CI.
