### PR TITLE
HDDS-12521. The robot prints error messages in the Console

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/lib/os.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/lib/os.robot
@@ -15,6 +15,7 @@
 
 *** Settings ***
 Library     OperatingSystem
+Library     String
 
 *** Keywords ***
 Execute

--- a/hadoop-ozone/dist/src/main/smoketest/lib/os.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/lib/os.robot
@@ -30,6 +30,10 @@ Execute And Ignore Error
 Execute and checkrc
     [arguments]                     ${command}                  ${expected_error_code}
     ${rc}                           ${output} =                 Run And Return Rc And Output           ${command}
+    ${PRINT_ERROR_ON_FAILURE} =     Get Environment Variable    PRINT_ERROR_ON_FAILURE     True
+    ${PRINT_ERROR_ON_FAILURE} =     Convert To Lower Case       ${PRINT_ERROR_ON_FAILURE}
+    Run Keyword If                  ${rc} != 0 and '${PRINT_ERROR_ON_FAILURE}' == 'true'
+    ...                             Log To Console   \n\n[ERROR] Command failed: ${command}\nOutput: ${output}\n\nReturn code: ${rc}\n
     Log                             ${output}
     Should Be Equal As Integers     ${rc}                       ${expected_error_code}
     [return]                        ${output}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make robot tests print error messages in the Console instead of just outputting ’1! = 0‘.
In this way, we can see the error message directly in CI.

Example

```robot
*** Test cases ***

Test hadoop dfs
    ${dir} =          Format FS URL         ${SCHEME}     ${volume}    ${bucket}
    ${random} =        Generate Random String  5  [NUMBERS]
    ${result} =        Execute                    hdfs dfs1 -put /opt/hadoop/NOTICE.txt ${dir}/${PREFIX}-${random}
```
output:
```bash
==============================================================================
hadoop-2.10.2-hadoopfs-o3fs :: Test ozone fs with hadoopfs                    
==============================================================================
Test hadoop dfs                                                       

[ERROR] Command failed: hdfs dfs1 -put /opt/hadoop/NOTICE.txt o3fs://bucket1.volume1.om//ozone-31953
Output: Error: Could not find or load main class dfs1

Return code: 1

| FAIL |
1 != 0
------------------------------------------------------------------------------
hadoop-2.10.2-hadoopfs-o3fs :: Test ozone fs with hadoopfs            | FAIL |
1 critical test, 0 passed, 1 failed
1 test total, 0 passed, 1 failed
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12521

## How was this patch tested?

manual Test in local

