### PR TITLE
HDDS-12505. Use Mockito doReturn() in `hadoop-hdds/client`

### DIFF
--- a/hadoop-hdds/client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/client/dev-support/findbugsExcludeFile.xml
@@ -19,4 +19,16 @@
     <Class name="org.apache.hadoop.hdds.scm.storage.ByteArrayReader"></Class>
     <Bug pattern="EI_EXPOSE_REP2" /> <!-- "Deep copy byte[] has bad impact on performance" -->
   </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.scm.storage.DummyBlockInputStreamWithRetry"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+  </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.scm.storage.TestBlockInputStream"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+  </Match>
+  <Match>
+    <Class name="org.apache.hadoop.ozone.client.io.TestBlockInputStreamFactoryImpl"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.List;
@@ -63,7 +63,7 @@ final class DummyBlockInputStreamWithRetry
           try {
             BlockLocationInfo blockLocationInfo = mock(BlockLocationInfo.class);
             Pipeline mockPipeline = MockPipeline.createPipeline(1);
-            when(blockLocationInfo.getPipeline()).thenReturn(mockPipeline);
+            doReturn(mockPipeline).when(blockLocationInfo.getPipeline());
             return blockLocationInfo;
           } catch (IOException e) {
             throw new RuntimeException(e);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.security.token.Token;
  * A dummy BlockInputStream with pipeline refresh function to mock read
  * block call to DN.
  */
-@SuppressWarnings("java:S1854")
+@SuppressWarnings("ResultOfMethodCallIgnored")
 final class DummyBlockInputStreamWithRetry
     extends DummyBlockInputStream {
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.security.token.Token;
  * A dummy BlockInputStream with pipeline refresh function to mock read
  * block call to DN.
  */
+@SuppressWarnings("java:S1854")
 final class DummyBlockInputStreamWithRetry
     extends DummyBlockInputStream {
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -63,7 +63,7 @@ final class DummyBlockInputStreamWithRetry
           try {
             BlockLocationInfo blockLocationInfo = mock(BlockLocationInfo.class);
             Pipeline mockPipeline = MockPipeline.createPipeline(1);
-            doReturn(mockPipeline).when(blockLocationInfo.getPipeline());
+            doReturn(mockPipeline).when(blockLocationInfo).getPipeline();
             return blockLocationInfo;
           } catch (IOException e) {
             throw new RuntimeException(e);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.security.token.Token;
  * A dummy BlockInputStream with pipeline refresh function to mock read
  * block call to DN.
  */
-@SuppressWarnings("java:S2201")
 final class DummyBlockInputStreamWithRetry
     extends DummyBlockInputStream {
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.security.token.Token;
  * A dummy BlockInputStream with pipeline refresh function to mock read
  * block call to DN.
  */
-@SuppressWarnings("ResultOfMethodCallIgnored")
+@SuppressWarnings("java:S2201")
 final class DummyBlockInputStreamWithRetry
     extends DummyBlockInputStream {
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -293,7 +293,7 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @SuppressWarnings("java:S2201")
   void refreshesPipelineOnReadFailure(IOException ex) throws Exception {
     // GIVEN
     Pipeline pipeline = MockPipeline.createSingleNodePipeline();
@@ -407,7 +407,7 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @SuppressWarnings("java:S2201")
   public void testRefreshOnReadFailureAfterUnbuffer(IOException ex)
       throws Exception {
     // GIVEN

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -293,7 +293,6 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
-  @SuppressWarnings("java:S2201")
   void refreshesPipelineOnReadFailure(IOException ex) throws Exception {
     // GIVEN
     Pipeline pipeline = MockPipeline.createSingleNodePipeline();
@@ -407,7 +406,6 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
-  @SuppressWarnings("java:S2201")
   public void testRefreshOnReadFailureAfterUnbuffer(IOException ex)
       throws Exception {
     // GIVEN

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -293,7 +293,7 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
-  @SuppressWarnings("java:S1854")
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   void refreshesPipelineOnReadFailure(IOException ex) throws Exception {
     // GIVEN
     Pipeline pipeline = MockPipeline.createSingleNodePipeline();
@@ -407,7 +407,7 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
-  @SuppressWarnings("java:S1854")
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testRefreshOnReadFailureAfterUnbuffer(IOException ex)
       throws Exception {
     // GIVEN

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -297,18 +297,18 @@ public class TestBlockInputStream {
     // GIVEN
     Pipeline pipeline = MockPipeline.createSingleNodePipeline();
     BlockLocationInfo blockLocationInfo = mock(BlockLocationInfo.class);
-    doReturn(pipeline).when(blockLocationInfo.getPipeline());
+    doReturn(pipeline).when(blockLocationInfo).getPipeline();
     Pipeline newPipeline = MockPipeline.createSingleNodePipeline();
     BlockLocationInfo newBlockLocationInfo = mock(BlockLocationInfo.class);
 
     testRefreshesPipelineOnReadFailure(ex, blockLocationInfo,
         id -> newBlockLocationInfo);
 
-    doReturn(newPipeline).when(newBlockLocationInfo.getPipeline());
+    doReturn(newPipeline).when(newBlockLocationInfo).getPipeline();
     testRefreshesPipelineOnReadFailure(ex, blockLocationInfo,
         id -> blockLocationInfo);
 
-    doReturn(null).when(newBlockLocationInfo.getPipeline());
+    doReturn(null).when(newBlockLocationInfo).getPipeline();
     testRefreshesPipelineOnReadFailure(ex, blockLocationInfo,
         id -> newBlockLocationInfo);
   }
@@ -359,7 +359,7 @@ public class TestBlockInputStream {
     if (succeedOnRetry) {
       stubbing.thenReturn(len);
     }
-    doReturn((long) len).when(stream.getRemaining());
+    doReturn((long) len).when(stream).getRemaining();
     return stream;
   }
 
@@ -415,13 +415,13 @@ public class TestBlockInputStream {
     XceiverClientFactory clientFactory = mock(XceiverClientFactory.class);
     XceiverClientSpi client = mock(XceiverClientSpi.class);
     BlockLocationInfo blockLocationInfo = mock(BlockLocationInfo.class);
-    doReturn(client).when(clientFactory.acquireClientForReadData(pipeline));
+    doReturn(client).when(clientFactory).acquireClientForReadData(pipeline);
 
     final int len = 200;
     final ChunkInputStream stream = throwingChunkInputStream(ex, len, true);
 
-    doReturn(blockLocationInfo).when(refreshFunction.apply(blockID));
-    doReturn(newPipeline).when(blockLocationInfo.getPipeline());
+    doReturn(blockLocationInfo).when(refreshFunction).apply(blockID);
+    doReturn(newPipeline).when(blockLocationInfo).getPipeline();
 
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setChecksumVerify(false);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -293,14 +293,15 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
+  @SuppressWarnings("java:S1854")
   void refreshesPipelineOnReadFailure(IOException ex) throws Exception {
     // GIVEN
     Pipeline pipeline = MockPipeline.createSingleNodePipeline();
     BlockLocationInfo blockLocationInfo = mock(BlockLocationInfo.class);
-    doReturn(pipeline).when(blockLocationInfo).getPipeline();
     Pipeline newPipeline = MockPipeline.createSingleNodePipeline();
     BlockLocationInfo newBlockLocationInfo = mock(BlockLocationInfo.class);
 
+    doReturn(pipeline).when(blockLocationInfo).getPipeline();
     testRefreshesPipelineOnReadFailure(ex, blockLocationInfo,
         id -> newBlockLocationInfo);
 
@@ -406,6 +407,7 @@ public class TestBlockInputStream {
 
   @ParameterizedTest
   @MethodSource("exceptionsTriggersRefresh")
+  @SuppressWarnings("java:S1854")
   public void testRefreshOnReadFailureAfterUnbuffer(IOException ex)
       throws Exception {
     // GIVEN

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -71,6 +70,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.OngoingStubbing;
 import org.slf4j.event.Level;
 
 /**
@@ -353,9 +353,11 @@ public class TestBlockInputStream {
   private static ChunkInputStream throwingChunkInputStream(IOException ex,
       int len, boolean succeedOnRetry) throws IOException {
     final ChunkInputStream stream = mock(ChunkInputStream.class);
-    doThrow(ex).doReturn(len).when(stream.read(any(), anyInt(), anyInt()));
+    OngoingStubbing<Integer> stubbing =
+        when(stream.read(any(), anyInt(), anyInt()))
+            .thenThrow(ex);
     if (succeedOnRetry) {
-      doReturn(len).when(stream).read(any(), anyInt(), anyInt());
+      stubbing.thenReturn(len);
     }
     doReturn((long) len).when(stream.getRemaining());
     return stream;

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.scm.storage;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -157,8 +157,7 @@ class TestBlockOutputStreamCorrectness {
     final Pipeline pipeline = MockPipeline.createRatisPipeline();
 
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
-    when(xcm.acquireClient(any()))
-        .thenReturn(new MockXceiverClientSpi(pipeline));
+    doReturn(new MockXceiverClientSpi(pipeline)).when(xcm.acquireClient(any()));
 
     OzoneClientConfig config = new OzoneClientConfig();
     config.setStreamBufferSize(4 * 1024 * 1024);
@@ -186,8 +185,7 @@ class TestBlockOutputStreamCorrectness {
   private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
       ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline) throws IOException {
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
-    when(xcm.acquireClient(any()))
-        .thenReturn(new MockXceiverClientSpi(pipeline));
+    doReturn(new MockXceiverClientSpi(pipeline)).when(xcm.acquireClient(any()));
 
     ContainerClientMetrics clientMetrics = ContainerClientMetrics.acquire();
     StreamBufferArgs streamBufferArgs =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -157,7 +157,7 @@ class TestBlockOutputStreamCorrectness {
     final Pipeline pipeline = MockPipeline.createRatisPipeline();
 
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
-    doReturn(new MockXceiverClientSpi(pipeline)).when(xcm.acquireClient(any()));
+    doReturn(new MockXceiverClientSpi(pipeline)).when(xcm).acquireClient(any());
 
     OzoneClientConfig config = new OzoneClientConfig();
     config.setStreamBufferSize(4 * 1024 * 1024);
@@ -185,7 +185,7 @@ class TestBlockOutputStreamCorrectness {
   private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
       ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline) throws IOException {
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
-    doReturn(new MockXceiverClientSpi(pipeline)).when(xcm.acquireClient(any()));
+    doReturn(new MockXceiverClientSpi(pipeline)).when(xcm).acquireClient(any());
 
     ContainerClientMetrics clientMetrics = ContainerClientMetrics.acquire();
     StreamBufferArgs streamBufferArgs =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -244,19 +245,16 @@ public class TestChunkInputStream {
     Pipeline newPipeline = MockPipeline.createSingleNodePipeline();
 
     Token<?> token = mock(Token.class);
-    when(token.encodeToUrlString())
-        .thenReturn("oldToken");
+    doReturn("oldToken").when(token.encodeToUrlString());
     Token<?> newToken = mock(Token.class);
-    when(newToken.encodeToUrlString())
-        .thenReturn("newToken");
+    doReturn("newToken").when(newToken.encodeToUrlString());
 
     AtomicReference<Pipeline> pipelineRef = new AtomicReference<>(pipeline);
     AtomicReference<Token<?>> tokenRef = new AtomicReference<>(token);
 
     XceiverClientFactory clientFactory = mock(XceiverClientFactory.class);
     XceiverClientSpi client = mock(XceiverClientSpi.class);
-    when(clientFactory.acquireClientForReadData(any()))
-        .thenReturn(client);
+    doReturn(client).when(clientFactory.acquireClientForReadData(any()));
     ArgumentCaptor<ContainerCommandRequestProto> requestCaptor =
         ArgumentCaptor.forClass(ContainerCommandRequestProto.class);
     when(client.getPipeline())

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -245,16 +245,16 @@ public class TestChunkInputStream {
     Pipeline newPipeline = MockPipeline.createSingleNodePipeline();
 
     Token<?> token = mock(Token.class);
-    doReturn("oldToken").when(token.encodeToUrlString());
+    doReturn("oldToken").when(token).encodeToUrlString();
     Token<?> newToken = mock(Token.class);
-    doReturn("newToken").when(newToken.encodeToUrlString());
+    doReturn("newToken").when(newToken).encodeToUrlString();
 
     AtomicReference<Pipeline> pipelineRef = new AtomicReference<>(pipeline);
     AtomicReference<Token<?>> tokenRef = new AtomicReference<>(token);
 
     XceiverClientFactory clientFactory = mock(XceiverClientFactory.class);
     XceiverClientSpi client = mock(XceiverClientSpi.class);
-    doReturn(client).when(clientFactory.acquireClientForReadData(any()));
+    doReturn(client).when(clientFactory).acquireClientForReadData(any());
     ArgumentCaptor<ContainerCommandRequestProto> requestCaptor =
         ArgumentCaptor.forClass(ContainerCommandRequestProto.class);
     when(client.getPipeline())

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -51,7 +51,7 @@ public class TestBlockInputStreamFactoryImpl {
   private OzoneConfiguration conf = new OzoneConfiguration();
 
   @Test
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @SuppressWarnings("java:S2201")
   public void testNonECGivesBlockInputStream() throws IOException {
     BlockInputStreamFactory factory = new BlockInputStreamFactoryImpl();
     ReplicationConfig repConfig =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -51,7 +51,6 @@ public class TestBlockInputStreamFactoryImpl {
   private OzoneConfiguration conf = new OzoneConfiguration();
 
   @Test
-  @SuppressWarnings("java:S2201")
   public void testNonECGivesBlockInputStream() throws IOException {
     BlockInputStreamFactory factory = new BlockInputStreamFactoryImpl();
     ReplicationConfig repConfig =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -51,6 +51,7 @@ public class TestBlockInputStreamFactoryImpl {
   private OzoneConfiguration conf = new OzoneConfiguration();
 
   @Test
+  @SuppressWarnings("java:S1854")
   public void testNonECGivesBlockInputStream() throws IOException {
     BlockInputStreamFactory factory = new BlockInputStreamFactoryImpl();
     ReplicationConfig repConfig =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -60,7 +60,7 @@ public class TestBlockInputStreamFactoryImpl {
         1024 * 1024 * 10);
     Pipeline pipeline = Mockito.spy(blockInfo.getPipeline());
     blockInfo.setPipeline(pipeline);
-    doReturn(1).when(pipeline.getReplicaIndex(any(DatanodeDetails.class)));
+    doReturn(1).when(pipeline).getReplicaIndex(any(DatanodeDetails.class));
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setChecksumVerify(true);
     BlockExtendedInputStream stream =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -51,7 +51,7 @@ public class TestBlockInputStreamFactoryImpl {
   private OzoneConfiguration conf = new OzoneConfiguration();
 
   @Test
-  @SuppressWarnings("java:S1854")
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testNonECGivesBlockInputStream() throws IOException {
     BlockInputStreamFactory factory = new BlockInputStreamFactoryImpl();
     ReplicationConfig repConfig =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.client.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,7 +60,7 @@ public class TestBlockInputStreamFactoryImpl {
         1024 * 1024 * 10);
     Pipeline pipeline = Mockito.spy(blockInfo.getPipeline());
     blockInfo.setPipeline(pipeline);
-    Mockito.when(pipeline.getReplicaIndex(any(DatanodeDetails.class))).thenReturn(1);
+    doReturn(1).when(pipeline.getReplicaIndex(any(DatanodeDetails.class)));
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setChecksumVerify(true);
     BlockExtendedInputStream stream =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently we're  using `thenReturn()` statements in the tests, we should change it with `doReturn()`.

## What is the link to the Apache JIRA
[HDDS-12505](https://issues.apache.org/jira/browse/HDDS-12505)

## How was this patch tested?
Tested by CI.
