### PR TITLE
HDDS-12531. Use AtomicFileOutputStream to write YAML files.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/YamlUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/YamlUtils.java
@@ -17,8 +17,15 @@
 
 package org.apache.hadoop.hdds.server;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import org.apache.ratis.util.AtomicFileOutputStream;
+import org.slf4j.Logger;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.inspector.TagInspector;
@@ -45,5 +52,15 @@ public final class YamlUtils {
     LoaderOptions loaderOptions = new LoaderOptions();
     loaderOptions.setTagInspector(tags);
     return new Yaml(loaderOptions);
+  }
+
+  public static void dump(Yaml yaml, Object data, File file, Logger log) throws IOException {
+    try (OutputStream out = new AtomicFileOutputStream(file);
+         OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+      yaml.dump(data, writer);
+    } catch (IOException e) {
+      log.warn("Failed to dump {}", data, e);
+      throw e;
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
@@ -20,10 +20,7 @@ package org.apache.hadoop.ozone.container.common.helpers;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -71,10 +68,8 @@ public final class DatanodeIdYaml {
     options.setDefaultFlowStyle(DumperOptions.FlowStyle.FLOW);
     Yaml yaml = new Yaml(options);
 
-    try (Writer writer = new OutputStreamWriter(
-        Files.newOutputStream(path.toPath()), StandardCharsets.UTF_8)) {
-      yaml.dump(getDatanodeDetailsYaml(datanodeDetails, conf), writer);
-    }
+    final DatanodeDetailsYaml data = getDatanodeDetailsYaml(datanodeDetails, conf);
+    YamlUtils.dump(yaml, data, path, LOG);
   }
 
   /**
@@ -228,6 +223,11 @@ public final class DatanodeIdYaml {
     public void setCurrentVersion(int version) {
       this.currentVersion = version;
     }
+
+    @Override
+    public String toString() {
+      return "DatanodeDetailsYaml(" + uuid + ", " + hostName + "/" + ipAddress + ")";
+    }
   }
 
   private static DatanodeDetailsYaml getDatanodeDetailsYaml(
@@ -268,7 +268,7 @@ public final class DatanodeIdYaml {
     }
 
     return new DatanodeDetailsYaml(
-        datanodeDetails.getUuid().toString(),
+        datanodeDetails.getUuidString(),
         datanodeDetails.getIpAddress(),
         datanodeDetails.getHostName(),
         datanodeDetails.getCertSerialId(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -80,9 +80,9 @@ public abstract class ContainerData {
   private boolean committedSpace;
 
   //ID of the pipeline where this container is created
-  private String originPipelineId;
+  private final String originPipelineId;
   //ID of the datanode where this container is created
-  private String originNodeId;
+  private final String originNodeId;
 
   /** parameters for read/write statistics on the container. **/
   private final AtomicLong readBytes;
@@ -667,4 +667,12 @@ public abstract class ContainerData {
     incrWriteBytes(bytesWritten);
   }
 
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + " #" + containerID
+        + " (" + state
+        + ", " + (isEmpty ? "empty" : "non-empty")
+        + ", ri=" + replicaIndex
+        + ", origin=[dn_" + originNodeId + ", pipeline_" + originPipelineId + "])";
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -294,8 +294,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     long containerId = containerData.getContainerID();
     try {
       tempContainerFile = createTempFile(containerFile);
-      ContainerDataYaml.createContainerFile(
-          ContainerType.KeyValueContainer, containerData, tempContainerFile);
+      ContainerDataYaml.createContainerFile(containerData, tempContainerFile);
 
       // NativeIO.renameTo is an atomic function. But it might fail if the
       // container file already exists. Hence, we handle the two cases

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeIdYaml.java
@@ -79,6 +79,8 @@ class TestDatanodeIdYaml {
   void testWriteReadAfterRatisDatastreamPortLayoutVersion(@TempDir File dir)
       throws IOException {
     DatanodeDetails original = MockDatanodeDetails.randomDatanodeDetails();
+    assertEquals(original.getUuid().toString(), original.getUuidString());
+
     File file = new File(dir, "datanode.yaml");
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.toString());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -89,8 +89,7 @@ public class TestContainerDataYaml {
     File containerFile = new File(testRoot, containerPath);
 
     // Create .container file with ContainerData
-    ContainerDataYaml.createContainerFile(ContainerProtos.ContainerType
-        .KeyValueContainer, keyValueContainerData, containerFile);
+    ContainerDataYaml.createContainerFile(keyValueContainerData, containerFile);
 
     //Check .container file exists or not.
     assertTrue(containerFile.exists());
@@ -140,8 +139,7 @@ public class TestContainerDataYaml {
     kvData.setState(ContainerProtos.ContainerDataProto.State.CLOSED);
 
 
-    ContainerDataYaml.createContainerFile(ContainerProtos.ContainerType
-            .KeyValueContainer, kvData, containerFile);
+    ContainerDataYaml.createContainerFile(kvData, containerFile);
 
     // Reading newly updated data from .container file
     kvData =  (KeyValueContainerData) ContainerDataYaml.readContainerFile(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
@@ -185,9 +185,7 @@ class TestContainerImporter {
   private File containerTarFile(
       long containerId, ContainerData containerData) throws IOException {
     File yamlFile = new File(tempDir, "container.yaml");
-    ContainerDataYaml.createContainerFile(
-        ContainerProtos.ContainerType.KeyValueContainer, containerData,
-        yamlFile);
+    ContainerDataYaml.createContainerFile(containerData, yamlFile);
     File tarFile = new File(tempDir,
         ContainerUtils.getContainerTarName(containerId));
     try (OutputStream output = Files.newOutputStream(tarFile.toPath())) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/UpgradeTask.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/UpgradeTask.java
@@ -345,9 +345,7 @@ public class UpgradeTask {
       result.setBackupContainerFilePath(bakFile.getAbsolutePath());
 
       // gen new v3 container data file
-      ContainerDataYaml.createContainerFile(
-          ContainerProtos.ContainerType.KeyValueContainer,
-          copyContainerData, originContainerFile);
+      ContainerDataYaml.createContainerFile(copyContainerData, originContainerFile);
 
       result.setNewContainerData(copyContainerData);
       result.setNewContainerFilePath(originContainerFile.getAbsolutePath());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use AtomicFileOutputStream to write YAML files and also clean up the code.

## What is the link to the Apache JIRA

HDDS-12531

## How was this patch tested?

Updating existing tests.