### PR TITLE
HDDS-12537. Selective checks: skip tests for PMD ruleset change

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -99,6 +99,17 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=true
 }
 
+@test "java test + pmd change" {
+  run dev-support/ci/selective_ci_checks.sh 250bd5f317
+
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compile=true
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-integration-tests=true
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "integration and unit: java change" {
   run dev-support/ci/selective_ci_checks.sh 9aebf6e25
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -487,6 +487,7 @@ function get_count_misc_files() {
         "\.txt$"
         "\.md$"
         "findbugsExcludeFile.xml"
+        "pmd-ruleset.xml"
         "/NOTICE$"
         "^hadoop-ozone/dist/src/main/compose/common/grafana/dashboards"
     )


### PR DESCRIPTION
## What changes were proposed in this pull request?

`pmd-ruleset.xml` should not count as "core file", i.e. it should not trigger all checks, only PMD.

https://issues.apache.org/jira/browse/HDDS-12537

## How was this patch tested?

Added test case in bats test.  (The specific commit also changed integration tests, thus few other tests are also expected to be triggered.)

https://github.com/adoroszlai/ozone/actions/runs/13771453603/job/38510823407#step:13:33