### PR TITLE
HDDS-12458. Show safemode rules status irrespective of whether SCM is in safe mode in verbose mode.

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
@@ -46,16 +46,16 @@ public class SafeModeCheckSubcommand extends ScmSubcommand {
     // Output data list
     if (execReturn) {
       System.out.println("SCM is in safe mode.");
-      if (verbose) {
-        for (Map.Entry<String, Pair<Boolean, String>> entry :
-            scmClient.getSafeModeRuleStatuses().entrySet()) {
-          Pair<Boolean, String> value = entry.getValue();
-          System.out.printf("validated:%s, %s, %s%n",
-              value.getLeft(), entry.getKey(), value.getRight());
-        }
-      }
     } else {
       System.out.println("SCM is out of safe mode.");
+    }
+    if (verbose) {
+      for (Map.Entry<String, Pair<Boolean, String>> entry :
+          scmClient.getSafeModeRuleStatuses().entrySet()) {
+        Pair<Boolean, String> value = entry.getValue();
+        System.out.printf("validated:%s, %s, %s%n",
+            value.getLeft(), entry.getKey(), value.getRight());
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Show safemode rules status irrespective of whether SCM is in safe mode in verbose mode.
When --verbose is passed , it should show safemode status irrespective of safemode.
This can help in situations where someone force exits safe mode and is trying to track progress.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12548

## How was this patch tested?
Tried it out on a docker compose cluster.
```
bash-5.1$ ozone admin safemode status
SCM is in safe mode.
bash-5.1$ ozone admin safemode exit
SCM exit safe mode successfully.
bash-5.1$ ozone admin safemode status
SCM is out of safe mode.
bash-5.1$ ozone admin safemode status --verbose
SCM is out of safe mode.
validated:false, DataNodeSafeModeRule, registered datanodes (=0) >= required datanodes (=1)
validated:true, HealthyPipelineSafeModeRule, healthy Ratis/THREE pipelines (=0) >= healthyPipelineThresholdCount (=0)
validated:true, ContainerSafeModeRule, 100.00% of [Ratis] Containers(0 / 0) with at least one reported replica (=1.00) >= safeModeCutoff (=0.99);
100.00% of [EC] Containers(0 / 0) with at least N reported replica (=1.00) >= safeModeCutoff (=0.99);
validated:true, AtleastOneDatanodeReportedRule, reported Ratis/THREE pipelines with at least one datanode (=0) >= threshold (=0)
```