### PR TITLE
HDDS-12437. [DiskBalancer] Estimate the total size pending to move before disk usage becomes even

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -157,6 +157,16 @@ public class HddsVolume extends StorageVolume {
     }
   }
 
+  public long getTotalCapacity() {
+    File volumeDir = getStorageDir();
+    return volumeDir.getTotalSpace();
+  }
+
+  public long getFreeSpace() {
+    File volumeDir = getStorageDir();
+    return volumeDir.getFreeSpace();
+  }
+
   @Override
   public void createTmpDirs(String workDirName) throws IOException {
     super.createTmpDirs(workDirName);
@@ -496,3 +506,4 @@ public class HddsVolume extends StorageVolume {
     }
   }
 }
+

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -157,16 +157,6 @@ public class HddsVolume extends StorageVolume {
     }
   }
 
-  public long getTotalCapacity() {
-    File volumeDir = getStorageDir();
-    return volumeDir.getTotalSpace();
-  }
-
-  public long getFreeSpace() {
-    File volumeDir = getStorageDir();
-    return volumeDir.getFreeSpace();
-  }
-
   @Override
   public void createTmpDirs(String workDirName) throws IOException {
     super.createTmpDirs(workDirName);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -496,4 +496,3 @@ public class HddsVolume extends StorageVolume {
     }
   }
 }
-

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -34,6 +34,7 @@ public class DiskBalancerInfo {
   private DiskBalancerVersion version;
   private long successCount;
   private long failureCount;
+  private long totalDataPendingToMove;
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread) {
@@ -52,7 +53,7 @@ public class DiskBalancerInfo {
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread, DiskBalancerVersion version,
-      long successCount, long failureCount) {
+      long successCount, long failureCount, long totalDataPendingToMove) {
     this.shouldRun = shouldRun;
     this.threshold = threshold;
     this.bandwidthInMB = bandwidthInMB;
@@ -60,6 +61,7 @@ public class DiskBalancerInfo {
     this.version = version;
     this.successCount = successCount;
     this.failureCount = failureCount;
+    this.totalDataPendingToMove = totalDataPendingToMove;
   }
 
   public DiskBalancerInfo(boolean shouldRun,
@@ -94,6 +96,7 @@ public class DiskBalancerInfo {
     builder.setDiskBalancerConf(confProto);
     builder.setSuccessMoveCount(successCount);
     builder.setFailureMoveCount(failureCount);
+    builder.setEstimatedTotalSizePendingToMove(totalDataPendingToMove);
     return builder.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -51,6 +51,7 @@ public class DiskBalancerInfo {
     this.version = version;
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread, DiskBalancerVersion version,
       long successCount, long failureCount, long totalDataPendingToMove) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -34,7 +34,7 @@ public class DiskBalancerInfo {
   private DiskBalancerVersion version;
   private long successCount;
   private long failureCount;
-  private long totalDataPendingToMove;
+  private long bytesToMove;
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread) {
@@ -54,7 +54,7 @@ public class DiskBalancerInfo {
   @SuppressWarnings("checkstyle:ParameterNumber")
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread, DiskBalancerVersion version,
-      long successCount, long failureCount, long totalDataPendingToMove) {
+      long successCount, long failureCount, long bytesToMove) {
     this.shouldRun = shouldRun;
     this.threshold = threshold;
     this.bandwidthInMB = bandwidthInMB;
@@ -62,7 +62,7 @@ public class DiskBalancerInfo {
     this.version = version;
     this.successCount = successCount;
     this.failureCount = failureCount;
-    this.totalDataPendingToMove = totalDataPendingToMove;
+    this.bytesToMove = bytesToMove;
   }
 
   public DiskBalancerInfo(boolean shouldRun,
@@ -97,7 +97,7 @@ public class DiskBalancerInfo {
     builder.setDiskBalancerConf(confProto);
     builder.setSuccessMoveCount(successCount);
     builder.setFailureMoveCount(failureCount);
-    builder.setEstimatedTotalSizePendingToMove(totalDataPendingToMove);
+    builder.setBytesToMove(bytesToMove);
     return builder.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -103,7 +103,6 @@ public class DiskBalancerService extends BackgroundService {
   private final File diskBalancerInfoFile;
 
   private DiskBalancerServiceMetrics metrics;
-  private long queueSize;
   private long bytesToMove;
 
   public DiskBalancerService(OzoneContainer ozoneContainer,
@@ -353,9 +352,10 @@ public class DiskBalancerService extends BackgroundService {
 
     if (queue.isEmpty()) {
       metrics.incrIdleLoopNoAvailableVolumePairCount();
+    } else {
+      bytesToMove = calculateBytesToMove(volumeSet);
     }
-    queueSize = queue.size();
-    bytesToMove = calculateBytesToMove(volumeSet);
+
     return queue;
   }
 
@@ -515,14 +515,6 @@ public class DiskBalancerService extends BackgroundService {
 
   public long calculateBytesToMove(MutableVolumeSet inputVolumeSet) {
     long bytesPendingToMove = 0;
-
-    if (queueSize == 0) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("No available Volume pair to perform move.");
-      }
-      return bytesPendingToMove;
-    }
-
     long totalUsedSpace = 0;
     long totalCapacity = 0;
 
@@ -579,10 +571,6 @@ public class DiskBalancerService extends BackgroundService {
 
   public VolumeChoosingPolicy getVolumeChoosingPolicy() {
     return volumeChoosingPolicy;
-  }
-
-  public void setQueueSize(long queueSize) {
-    this.queueSize = queueSize;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -507,7 +507,8 @@ public class DiskBalancerService extends BackgroundService {
 
   public DiskBalancerInfo getDiskBalancerInfo() {
     return new DiskBalancerInfo(shouldRun, threshold, bandwidthInMB,
-        parallelThread, version, metrics.getSuccessCount(), metrics.getFailureCount(), estimatedTotalSizePendingToMove());
+        parallelThread, version, metrics.getSuccessCount(),
+        metrics.getFailureCount(), estimatedTotalSizePendingToMove());
   }
 
   private long estimatedTotalSizePendingToMove() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -515,7 +515,9 @@ public class DiskBalancerService extends BackgroundService {
     long totalDataPendingToMove = 0;
 
     if (queueSize == 0) {
-      LOG.debug("No available Volume pair to perform move.");
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("No available Volume pair to perform move.");
+      }
       return totalDataPendingToMove;
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -355,7 +355,7 @@ public class DiskBalancerService extends BackgroundService {
       metrics.incrIdleLoopNoAvailableVolumePairCount();
     }
     queueSize = queue.size();
-    bytesToMove = calculateBytesToMove();
+    bytesToMove = calculateBytesToMove(volumeSet);
     return queue;
   }
 
@@ -513,7 +513,7 @@ public class DiskBalancerService extends BackgroundService {
         metrics.getFailureCount(), bytesToMove);
   }
 
-  private long calculateBytesToMove() {
+  public long calculateBytesToMove(MutableVolumeSet inputVolumeSet) {
     long bytesPendingToMove = 0;
 
     if (queueSize == 0) {
@@ -526,7 +526,7 @@ public class DiskBalancerService extends BackgroundService {
     long totalUsedSpace = 0;
     long totalCapacity = 0;
 
-    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList())) {
+    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(inputVolumeSet.getVolumesList())) {
       totalUsedSpace += volume.getCurrentUsage().getUsedSpace();
       totalCapacity += volume.getCurrentUsage().getCapacity();
     }
@@ -541,7 +541,7 @@ public class DiskBalancerService extends BackgroundService {
     double upperLimit = datanodeUtilization + thresholdFraction;
 
     // Calculate excess data in overused volumes
-    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList())) {
+    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(inputVolumeSet.getVolumesList())) {
       long usedSpace = volume.getCurrentUsage().getUsedSpace();
       long capacity = volume.getCurrentUsage().getCapacity();
       double volumeUtilization = (double) usedSpace / capacity;
@@ -579,10 +579,6 @@ public class DiskBalancerService extends BackgroundService {
 
   public VolumeChoosingPolicy getVolumeChoosingPolicy() {
     return volumeChoosingPolicy;
-  }
-
-  public long getBytesToMove() {
-    return calculateBytesToMove();
   }
 
   public void setQueueSize(long queueSize) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -234,7 +234,7 @@ public class TestDiskBalancerService {
     DiskBalancerServiceTestImpl svc =
         getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1);
 
-    long totalCapacity = volumes.isEmpty()? 0 : volumes.get(0).getCurrentUsage().getCapacity();
+    long totalCapacity = volumes.isEmpty() ? 0 : volumes.get(0).getCurrentUsage().getCapacity();
     long expectedBytesToMove = (long) Math.ceil(
         (totalCapacity * expectedBytesToMovePercent) / 100.0 * totalOverUtilisedVolumes);
 

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -563,5 +563,5 @@ message DatanodeDiskBalancerInfoProto {
     optional DiskBalancerConfigurationProto diskBalancerConf = 4;
     optional uint64 successMoveCount = 5;
     optional uint64 failureMoveCount = 6;
-    optional int64 estimatedTotalSizePendingToMove = 7;
+    optional uint64 estimatedTotalSizePendingToMove = 7;
 }

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -563,5 +563,5 @@ message DatanodeDiskBalancerInfoProto {
     optional DiskBalancerConfigurationProto diskBalancerConf = 4;
     optional uint64 successMoveCount = 5;
     optional uint64 failureMoveCount = 6;
-    optional uint64 estimatedTotalSizePendingToMove = 7;
+    optional uint64 bytesToMove = 7;
 }

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -563,4 +563,5 @@ message DatanodeDiskBalancerInfoProto {
     optional DiskBalancerConfigurationProto diskBalancerConf = 4;
     optional uint64 successMoveCount = 5;
     optional uint64 failureMoveCount = 6;
+    optional int64 estimatedTotalSizePendingToMove = 7;
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -501,6 +501,7 @@ message DiskBalancerReportProto {
   optional DiskBalancerConfigurationProto diskBalancerConf = 3;
   optional uint64 successMoveCount = 4;
   optional uint64 failureMoveCount = 5;
+  optional int64 estimatedTotalSizePendingToMove = 6;
 }
 
 /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -501,7 +501,7 @@ message DiskBalancerReportProto {
   optional DiskBalancerConfigurationProto diskBalancerConf = 3;
   optional uint64 successMoveCount = 4;
   optional uint64 failureMoveCount = 5;
-  optional int64 estimatedTotalSizePendingToMove = 6;
+  optional uint64 estimatedTotalSizePendingToMove = 6;
 }
 
 /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -501,7 +501,7 @@ message DiskBalancerReportProto {
   optional DiskBalancerConfigurationProto diskBalancerConf = 3;
   optional uint64 successMoveCount = 4;
   optional uint64 failureMoveCount = 5;
-  optional uint64 estimatedTotalSizePendingToMove = 6;
+  optional uint64 bytesToMove = 6;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -268,7 +268,7 @@ public class DiskBalancerManager {
             .setRunningStatus(status.getRunningStatus())
             .setSuccessMoveCount(status.getSuccessMoveCount())
             .setFailureMoveCount(status.getFailureMoveCount())
-            .setEstimatedTotalSizePendingToMove(status.getEstimatedTotalSizePendingToMove());
+            .setBytesToMove(status.getBytesToMove());
     if (status.getRunningStatus() != DiskBalancerRunningStatus.UNKNOWN) {
       builder.setDiskBalancerConf(statusMap.get(dn)
           .getDiskBalancerConfiguration().toProtobufBuilder());
@@ -327,10 +327,10 @@ public class DiskBalancerManager {
             new DiskBalancerConfiguration();
     long successMoveCount = reportProto.getSuccessMoveCount();
     long failureMoveCount = reportProto.getFailureMoveCount();
-    long estimatedTotalSizePendingToMove = reportProto.getEstimatedTotalSizePendingToMove();
+    long bytesToMove = reportProto.getBytesToMove();
     statusMap.put(dn, new DiskBalancerStatus(
         isRunning ? DiskBalancerRunningStatus.RUNNING : DiskBalancerRunningStatus.STOPPED,
-        diskBalancerConfiguration, successMoveCount, failureMoveCount, estimatedTotalSizePendingToMove));
+        diskBalancerConfiguration, successMoveCount, failureMoveCount, bytesToMove));
     if (reportProto.hasBalancedBytes()) {
       balancedBytesMap.put(dn, reportProto.getBalancedBytes());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -267,7 +267,8 @@ public class DiskBalancerManager {
             .setCurrentVolumeDensitySum(volumeDensitySum)
             .setRunningStatus(status.getRunningStatus())
             .setSuccessMoveCount(status.getSuccessMoveCount())
-            .setFailureMoveCount(status.getFailureMoveCount());
+            .setFailureMoveCount(status.getFailureMoveCount())
+            .setEstimatedTotalSizePendingToMove(status.getEstimatedTotalSizePendingToMove());
     if (status.getRunningStatus() != DiskBalancerRunningStatus.UNKNOWN) {
       builder.setDiskBalancerConf(statusMap.get(dn)
           .getDiskBalancerConfiguration().toProtobufBuilder());
@@ -306,13 +307,14 @@ public class DiskBalancerManager {
 
   private DiskBalancerStatus getStatus(DatanodeDetails datanodeDetails) {
     return statusMap.computeIfAbsent(datanodeDetails,
-        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN, new DiskBalancerConfiguration(), 0, 0));
+        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN,
+            new DiskBalancerConfiguration(), 0, 0, 0));
   }
 
   @VisibleForTesting
   public void addRunningDatanode(DatanodeDetails datanodeDetails) {
     statusMap.put(datanodeDetails, new DiskBalancerStatus(DiskBalancerRunningStatus.RUNNING,
-        new DiskBalancerConfiguration(), 0, 0));
+        new DiskBalancerConfiguration(), 0, 0, 0));
   }
 
   public void processDiskBalancerReport(DiskBalancerReportProto reportProto,
@@ -325,9 +327,10 @@ public class DiskBalancerManager {
             new DiskBalancerConfiguration();
     long successMoveCount = reportProto.getSuccessMoveCount();
     long failureMoveCount = reportProto.getFailureMoveCount();
+    long estimatedTotalSizePendingToMove = reportProto.getEstimatedTotalSizePendingToMove();
     statusMap.put(dn, new DiskBalancerStatus(
         isRunning ? DiskBalancerRunningStatus.RUNNING : DiskBalancerRunningStatus.STOPPED,
-        diskBalancerConfiguration, successMoveCount, failureMoveCount));
+        diskBalancerConfiguration, successMoveCount, failureMoveCount, estimatedTotalSizePendingToMove));
     if (reportProto.hasBalancedBytes()) {
       balancedBytesMap.put(dn, reportProto.getBalancedBytes());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerRunningStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
@@ -61,6 +60,7 @@ public class DiskBalancerManager {
   private Map<DatanodeDetails, DiskBalancerStatus> statusMap;
   private Map<DatanodeDetails, Long> balancedBytesMap;
   private boolean useHostnames;
+  private long totalDataPendingToMove;
 
   /**
    * Constructs DiskBalancer Manager.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerRunningStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -60,7 +60,6 @@ public class DiskBalancerManager {
   private Map<DatanodeDetails, DiskBalancerStatus> statusMap;
   private Map<DatanodeDetails, Long> balancedBytesMap;
   private boolean useHostnames;
-  private long totalDataPendingToMove;
 
   /**
    * Constructs DiskBalancer Manager.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -33,15 +33,15 @@ public class DiskBalancerStatus {
   private DiskBalancerConfiguration diskBalancerConfiguration;
   private long successMoveCount;
   private long failureMoveCount;
-  private long estimatedTotalSizePendingToMove;
+  private long bytesToMove;
 
   public DiskBalancerStatus(DiskBalancerRunningStatus isRunning, DiskBalancerConfiguration conf,
-      long successMoveCount, long failureMoveCount, long estimatedTotalSizePendingToMove) {
+      long successMoveCount, long failureMoveCount, long bytesToMove) {
     this.isRunning = isRunning;
     this.diskBalancerConfiguration = conf;
     this.successMoveCount = successMoveCount;
     this.failureMoveCount = failureMoveCount;
-    this.estimatedTotalSizePendingToMove = estimatedTotalSizePendingToMove;
+    this.bytesToMove = bytesToMove;
   }
 
   public DiskBalancerRunningStatus getRunningStatus() {
@@ -60,7 +60,7 @@ public class DiskBalancerStatus {
     return failureMoveCount;
   }
 
-  public long getEstimatedTotalSizePendingToMove() {
-    return estimatedTotalSizePendingToMove;
+  public long getBytesToMove() {
+    return bytesToMove;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -33,13 +33,15 @@ public class DiskBalancerStatus {
   private DiskBalancerConfiguration diskBalancerConfiguration;
   private long successMoveCount;
   private long failureMoveCount;
+  private long estimatedTotalSizePendingToMove;
 
   public DiskBalancerStatus(DiskBalancerRunningStatus isRunning, DiskBalancerConfiguration conf,
-      long successMoveCount, long failureMoveCount) {
+      long successMoveCount, long failureMoveCount, long estimatedTotalSizePendingToMove) {
     this.isRunning = isRunning;
     this.diskBalancerConfiguration = conf;
     this.successMoveCount = successMoveCount;
     this.failureMoveCount = failureMoveCount;
+    this.estimatedTotalSizePendingToMove = estimatedTotalSizePendingToMove;
   }
 
   public DiskBalancerRunningStatus getRunningStatus() {
@@ -56,5 +58,9 @@ public class DiskBalancerStatus {
 
   public long getFailureMoveCount() {
     return failureMoveCount;
+  }
+
+  public long getEstimatedTotalSizePendingToMove() {
+    return estimatedTotalSizePendingToMove;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -60,7 +60,7 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
   private String generateStatus(
       List<HddsProtos.DatanodeDiskBalancerInfoProto> protos) {
     StringBuilder formatBuilder = new StringBuilder("Status result:%n" +
-        "%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s%n");
+        "%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s %-12s%n");
 
     List<String> contentList = new ArrayList<>();
     contentList.add("Datanode");
@@ -71,11 +71,13 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
     contentList.add("Threads");
     contentList.add("SuccessMove");
     contentList.add("FailureMove");
+    contentList.add("EstBytesToMove(MB)");
     contentList.add("EstTimeLeft(min)");
 
     for (HddsProtos.DatanodeDiskBalancerInfoProto proto: protos) {
-      formatBuilder.append("%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s%n");
-      double estimatedTimeLeft = calculateEstimatedTimeLeft(proto);
+      formatBuilder.append("%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s %-12s%n");
+      long estimatedTimeLeft = calculateEstimatedTimeLeft(proto);
+      long bytesToMoveMB = proto.getBytesToMove() / (1024 * 1024);
 
       contentList.add(proto.getNode().getHostName());
       contentList.add(String.format("%.18f", proto.getCurrentVolumeDensitySum()));
@@ -88,20 +90,28 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
           String.valueOf(proto.getDiskBalancerConf().getParallelThread()));
       contentList.add(String.valueOf(proto.getSuccessMoveCount()));
       contentList.add(String.valueOf(proto.getFailureMoveCount()));
-      contentList.add(estimatedTimeLeft >= 0 ? String.format("%.2f", estimatedTimeLeft) : "N/A");
+      contentList.add(String.valueOf(bytesToMoveMB));
+      contentList.add(estimatedTimeLeft >= 0 ? String.valueOf(estimatedTimeLeft) : "N/A");
     }
+
+    formatBuilder.append("%nNote: Estimated time left is calculated" +
+        " based on the estimated bytes to move and the configured disk bandwidth.");
 
     return String.format(formatBuilder.toString(),
         contentList.toArray(new String[0]));
   }
 
-  private double calculateEstimatedTimeLeft(HddsProtos.DatanodeDiskBalancerInfoProto proto) {
-    long estimatedDataPendingToMove = proto.getEstimatedTotalSizePendingToMove();
-    double bandwidth = proto.getDiskBalancerConf().getDiskBandwidthInMB();
+  private long calculateEstimatedTimeLeft(HddsProtos.DatanodeDiskBalancerInfoProto proto) {
+    long bytesToMove = proto.getBytesToMove();
+
+    if (bytesToMove == 0) {
+      return 0;
+    }
+    long bandwidth = proto.getDiskBalancerConf().getDiskBandwidthInMB();
 
     // Convert estimated data from bytes to MB
-    double estimatedDataPendingMB = estimatedDataPendingToMove / (1024.0 * 1024.0);
+    double estimatedDataPendingMB = bytesToMove / (1024.0 * 1024.0);
     double estimatedTimeLeft = (bandwidth > 0) ? (estimatedDataPendingMB / bandwidth) / 60 : -1;
-    return estimatedTimeLeft;
+    return (long) Math.ceil(estimatedTimeLeft);
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -60,7 +60,7 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
   private String generateStatus(
       List<HddsProtos.DatanodeDiskBalancerInfoProto> protos) {
     StringBuilder formatBuilder = new StringBuilder("Status result:%n" +
-        "%-40s %-20s %-10s %-10s %-15s %-15s %-15s %-15s %-15s%n");
+        "%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s%n");
 
     List<String> contentList = new ArrayList<>();
     contentList.add("Datanode");
@@ -74,11 +74,11 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
     contentList.add("EstTimeLeft(min)");
 
     for (HddsProtos.DatanodeDiskBalancerInfoProto proto: protos) {
-      formatBuilder.append("%-40s %-20s %-10s %-10s %-15s %-15s %-15s %-15s %-15s%n");
+      formatBuilder.append("%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s%n");
       double estimatedTimeLeft = calculateEstimatedTimeLeft(proto);
 
       contentList.add(proto.getNode().getHostName());
-      contentList.add(String.valueOf(proto.getCurrentVolumeDensitySum()));
+      contentList.add(String.format("%.18f", proto.getCurrentVolumeDensitySum()));
       contentList.add(proto.getRunningStatus().name());
       contentList.add(
           String.format("%.4f", proto.getDiskBalancerConf().getThreshold()));

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
@@ -100,8 +100,8 @@ public class TestDiskBalancerSubCommand {
 
     statusCmd.execute(scmClient);
 
-    // 2 Headers + 10 results
-    assertEquals(12, newLineCount(outContent.toString(DEFAULT_ENCODING)));
+    // 2 Headers + 10 results + 1 note
+    assertEquals(13, newLineCount(outContent.toString(DEFAULT_ENCODING)));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
It will be an estimation value, due to there are other activities going on, such as block deletion, new container creation, container replica deletion, new data ingestion.

This value will be an indicator for roughly how much time are still needed for the disk usage to become even.

Should Include this value in status report too.

The estimated time pending before disk usage become even is given for the happy path in status report.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12437

## How was this patch tested?
Unit Test is written for the function in `testDiskBalancerService#testCalculateBytesToMove`.

Tested it manually by running locally on docker-cluster.

```
bash-5.1$ ozone admin datanode diskbalancer status
Status result:
Datanode                            VolumeDensity             Status          Threshold(%)    BandwidthInMB   Threads      SuccessMove  FailureMove  EstBytesToMove(MB) EstTimeLeft(min)
ozone-datanode-2.ozone_default      0.001334742544789370      RUNNING         0.0002          10              5            5            0            816                2           
ozone-datanode-1.ozone_default      0.001486062001891789      RUNNING         0.0002          10              5            5            0            3185               6           

Note: Estimated time left is calculated based on the estimated bytes to move and the configured disk bandwidth.
```
```
bash-5.1$ ozone admin datanode diskbalancer status
Status result:
Datanode                            VolumeDensity             Status          Threshold(%)    BandwidthInMB   Threads      SuccessMove  FailureMove  EstBytesToMove(MB) EstTimeLeft(min)
ozone-datanode-2.ozone_default      0.001334742544789370      RUNNING         0.0002          10              5            8            2            683                2           
ozone-datanode-1.ozone_default      0.001486062001891789      RUNNING         0.0002          10              5            5            3            763                2           

Note: Estimated time left is calculated based on the estimated bytes to move and the configured disk bandwidth.
```
