### PR TITLE
HDDS-12555. Combine containerMap and replicaMap in ContainerStateMap.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -17,16 +17,11 @@
 
 package org.apache.hadoop.hdds.scm.container;
 
-import static java.util.Comparator.reverseOrder;
 import static org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator.CONTAINER_ID;
-import static org.apache.hadoop.hdds.utils.CollectionUtils.findTopN;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -144,21 +139,20 @@ public class ContainerManagerImpl implements ContainerManager {
 
   @Override
   public List<ContainerInfo> getContainers(ReplicationType type) {
-    return toContainers(containerStateManager.getContainerIDs(type));
+    return containerStateManager.getContainerInfos(type);
   }
 
   @Override
   public List<ContainerInfo> getContainers(final ContainerID startID,
                                            final int count) {
     scmContainerManagerMetrics.incNumListContainersOps();
-    return toContainers(filterSortAndLimit(startID, count,
-        containerStateManager.getContainerIDs()));
+    return containerStateManager.getContainerInfos(startID, count);
   }
 
   @Override
   public List<ContainerInfo> getContainers(final LifeCycleState state) {
     scmContainerManagerMetrics.incNumListContainersOps();
-    return toContainers(containerStateManager.getContainerIDs(state));
+    return containerStateManager.getContainerInfos(state);
   }
 
   @Override
@@ -166,13 +160,12 @@ public class ContainerManagerImpl implements ContainerManager {
                                            final int count,
                                            final LifeCycleState state) {
     scmContainerManagerMetrics.incNumListContainersOps();
-    return toContainers(filterSortAndLimit(startID, count,
-        containerStateManager.getContainerIDs(state)));
+    return containerStateManager.getContainerInfos(state, startID, count);
   }
 
   @Override
   public int getContainerStateCount(final LifeCycleState state) {
-    return containerStateManager.getContainerIDs(state).size();
+    return containerStateManager.getContainerCount(state);
   }
 
   @Override
@@ -468,34 +461,5 @@ public class ContainerManagerImpl implements ContainerManager {
   @VisibleForTesting
   public SCMHAManager getSCMHAManager() {
     return haManager;
-  }
-
-  private static List<ContainerID> filterSortAndLimit(
-      ContainerID startID, int count, Set<ContainerID> set) {
-
-    if (ContainerID.MIN.equals(startID) && count >= set.size()) {
-      List<ContainerID> list = new ArrayList<>(set);
-      Collections.sort(list);
-      return list;
-    }
-
-    return findTopN(set, count, reverseOrder(),
-        id -> id.compareTo(startID) >= 0);
-  }
-
-  /**
-   * Returns a list of all containers identified by {@code ids}.
-   */
-  private List<ContainerInfo> toContainers(Collection<ContainerID> ids) {
-    List<ContainerInfo> containers = new ArrayList<>(ids.size());
-
-    for (ContainerID id : ids) {
-      ContainerInfo container = containerStateManager.getContainer(id);
-      if (container != null) {
-        containers.add(container);
-      }
-    }
-
-    return containers;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -54,6 +54,10 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     sequenceId = b.sequenceId;
   }
 
+  public ContainerID getContainerID() {
+    return containerID;
+  }
+
   /**
    * Returns the DatanodeDetails to which this replica belongs.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.container;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
@@ -103,22 +104,33 @@ public interface ContainerStateManager {
   boolean contains(ContainerID containerID);
 
   /**
-   * Returns the ID of all the managed containers.
+   * Get {@link ContainerInfo}s.
    *
-   * @return Set of {@link ContainerID}
+   * @param start the start {@link ContainerID} (inclusive)
+   * @param count the size limit
+   * @return a list of {@link ContainerInfo};
    */
-  Set<ContainerID> getContainerIDs();
+  List<ContainerInfo> getContainerInfos(ContainerID start, int count);
 
   /**
+   * Get {@link ContainerInfo}s for the given state.
    *
+   * @param start the start {@link ContainerID} (inclusive)
+   * @param count the size limit
+   * @return a list of {@link ContainerInfo};
    */
-  Set<ContainerID> getContainerIDs(LifeCycleState state);
+  List<ContainerInfo> getContainerInfos(LifeCycleState state, ContainerID start, int count);
 
+  /** @return all {@link ContainerInfo}s for the given state. */
+  List<ContainerInfo> getContainerInfos(LifeCycleState state);
 
   /**
-   * Returns the IDs of the Containers whose ReplicationType matches the given type.
+   * @return all {@link ContainerID}s for the given state.
    */
-  Set<ContainerID> getContainerIDs(ReplicationType type);
+  int getContainerCount(LifeCycleState state);
+
+  /** @return all {@link ContainerInfo}s for the given type. */
+  List<ContainerInfo> getContainerInfos(ReplicationType type);
 
   /**
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -32,13 +32,14 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QU
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_LOCK_STRIPE_SIZE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_LOCK_STRIPE_SIZE_DEFAULT;
 
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Striped;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -68,6 +69,7 @@ import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.common.statemachine.StateMachine;
 import org.apache.ratis.util.AutoCloseableLock;
+import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.function.CheckedConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -239,7 +241,7 @@ public final class ContainerStateManagerImpl
 
       while (iterator.hasNext()) {
         final ContainerInfo container = iterator.next().getValue();
-        Preconditions.checkNotNull(container);
+        Objects.requireNonNull(container, "container == null");
         containers.addContainer(container);
         if (container.getState() == LifeCycleState.OPEN) {
           try {
@@ -268,23 +270,37 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
-  public Set<ContainerID> getContainerIDs() {
+  public List<ContainerInfo> getContainerInfos(ContainerID start, int count) {
     try (AutoCloseableLock ignored = readLock()) {
-      return containers.getAllContainerIDs();
+      return containers.getContainerInfos(start, count);
     }
   }
 
   @Override
-  public Set<ContainerID> getContainerIDs(final LifeCycleState state) {
+  public List<ContainerInfo> getContainerInfos(LifeCycleState state, ContainerID start, int count) {
     try (AutoCloseableLock ignored = readLock()) {
-      return containers.getContainerIDsByState(state);
+      return containers.getContainerInfos(state, start, count);
     }
   }
 
   @Override
-  public Set<ContainerID> getContainerIDs(final ReplicationType type) {
+  public List<ContainerInfo> getContainerInfos(final LifeCycleState state) {
     try (AutoCloseableLock ignored = readLock()) {
-      return containers.getContainerIDsByType(type);
+      return containers.getContainerInfos(state);
+    }
+  }
+
+  @Override
+  public List<ContainerInfo> getContainerInfos(ReplicationType type) {
+    try (AutoCloseableLock ignored = readLock()) {
+      return containers.getContainerInfos(type);
+    }
+  }
+
+  @Override
+  public int getContainerCount(final LifeCycleState state) {
+    try (AutoCloseableLock ignored = readLock()) {
+      return containers.getContainerCount(state);
     }
   }
 
@@ -303,7 +319,7 @@ public final class ContainerStateManagerImpl
     // ClosedPipelineException once ClosedPipelineException is introduced
     // in PipelineManager.
 
-    Preconditions.checkNotNull(containerInfo);
+    Objects.requireNonNull(containerInfo, "containerInfo == null");
     final ContainerInfo container = ContainerInfo.fromProtobuf(containerInfo);
     final ContainerID containerID = container.containerID();
     final PipelineID pipelineID = container.getPipelineID();
@@ -403,7 +419,7 @@ public final class ContainerStateManagerImpl
   public void updateContainerReplica(final ContainerID id,
                                      final ContainerReplica replica) {
     try (AutoCloseableLock ignored = writeLock(id)) {
-      containers.updateContainerReplica(id, replica);
+      containers.updateContainerReplica(replica);
       // Clear any pending additions for this replica as we have now seen it.
       containerReplicaPendingOps.completeAddReplica(id,
           replica.getDatanodeDetails(), replica.getReplicaIndex());
@@ -413,8 +429,10 @@ public final class ContainerStateManagerImpl
   @Override
   public void removeContainerReplica(final ContainerID id,
                                      final ContainerReplica replica) {
+    //TODO remove ContainerID parameter
+    Preconditions.assertEquals(id, replica.getContainerID(), "containerID");
     try (AutoCloseableLock ignored = writeLock(id)) {
-      containers.removeContainerReplica(id, replica);
+      containers.removeContainerReplica(id, replica.getDatanodeDetails().getID());
       // Remove any pending delete replication operations for the deleted
       // replica.
       containerReplicaPendingOps.completeDeleteReplica(id,
@@ -601,9 +619,9 @@ public final class ContainerStateManagerImpl
     }
 
     public ContainerStateManager build() throws IOException {
-      Preconditions.checkNotNull(conf);
-      Preconditions.checkNotNull(pipelineMgr);
-      Preconditions.checkNotNull(table);
+      Objects.requireNonNull(conf, "conf == null");
+      Objects.requireNonNull(pipelineMgr, "pipelineMgr == null");
+      Objects.requireNonNull(table, "table == null");
 
       final ContainerStateManager csm = new ContainerStateManagerImpl(
           conf, pipelineMgr, table, transactionBuffer,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import java.util.EnumMap;
 import java.util.NavigableSet;
 import java.util.Objects;
+import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -136,6 +137,15 @@ public class ContainerAttribute<T extends Enum<T>> {
    */
   public NavigableSet<ContainerID> getCollection(T key) {
     return ImmutableSortedSet.copyOf(get(key));
+  }
+
+  public SortedSet<ContainerID> tailSet(T key, ContainerID start) {
+    Objects.requireNonNull(start, "start == null");
+    return get(key).tailSet(start);
+  }
+
+  public int count(T key) {
+    return get(key).size();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -18,20 +18,23 @@
 package org.apache.hadoop.hdds.scm.container.states;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
+import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,17 +75,107 @@ public class ContainerStateMap {
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerStateMap.class);
 
+  /**
+   * Two levels map.
+   * Outer container map: {@link ContainerID} -> {@link Entry} (info and replicas)
+   * Inner replica map: {@link DatanodeID} -> {@link ContainerReplica}
+   */
+  private static class ContainerMap {
+    private static class Entry {
+      private final ContainerInfo info;
+      private final Map<DatanodeID, ContainerReplica> replicas = new HashMap<>();
+
+      Entry(ContainerInfo info) {
+        this.info = info;
+      }
+
+      ContainerInfo getInfo() {
+        return info;
+      }
+
+      Set<ContainerReplica> getReplicas() {
+        return new HashSet<>(replicas.values());
+      }
+
+      ContainerReplica put(ContainerReplica r) {
+        return replicas.put(r.getDatanodeDetails().getID(), r);
+      }
+
+      ContainerReplica removeReplica(DatanodeID datanodeID) {
+        return replicas.remove(datanodeID);
+      }
+    }
+
+    private final NavigableMap<ContainerID, Entry> map = new TreeMap<>();
+
+    boolean contains(ContainerID id) {
+      return map.containsKey(id);
+    }
+
+    ContainerInfo getInfo(ContainerID id) {
+      final Entry entry = map.get(id);
+      return entry == null ? null : entry.getInfo();
+    }
+
+    List<ContainerInfo> getInfos(ContainerID start, int count) {
+      Objects.requireNonNull(start, "start == null");
+      Preconditions.assertTrue(count >= 0, "count < 0");
+      return map.tailMap(start).values().stream()
+          .map(Entry::getInfo)
+          .limit(count)
+          .collect(Collectors.toList());
+    }
+
+    Set<ContainerReplica> getReplicas(ContainerID id) {
+      Objects.requireNonNull(id, "id == null");
+      final Entry entry = map.get(id);
+      return entry == null ? null : entry.getReplicas();
+    }
+
+    /**
+     * Add if the given info not already in this map.
+     *
+     * @return true iff the given info is added.
+     */
+    boolean addIfAbsent(ContainerInfo info) {
+      Objects.requireNonNull(info, "info == null");
+      final ContainerID id = info.containerID();
+      if (map.containsKey(id)) {
+        return false; // already exist
+      }
+      final Entry previous = map.put(id, new Entry(info));
+      Preconditions.assertNull(previous, "previous");
+      return true;
+    }
+
+    ContainerReplica put(ContainerReplica replica) {
+      Objects.requireNonNull(replica, "replica == null");
+      final Entry entry = map.get(replica.getContainerID());
+      return entry == null ? null : entry.put(replica);
+    }
+
+    ContainerInfo remove(ContainerID id) {
+      Objects.requireNonNull(id, "id == null");
+      final Entry removed = map.remove(id);
+      return removed == null ? null : removed.getInfo();
+    }
+
+    ContainerReplica removeReplica(ContainerID containerID, DatanodeID datanodeID) {
+      Objects.requireNonNull(containerID, "containerID == null");
+      Objects.requireNonNull(datanodeID, "datanodeID == null");
+      final Entry entry = map.get(containerID);
+      return entry == null ? null : entry.removeReplica(datanodeID);
+    }
+  }
+
   private final ContainerAttribute<LifeCycleState> lifeCycleStateMap = new ContainerAttribute<>(LifeCycleState.class);
   private final ContainerAttribute<ReplicationType> typeMap = new ContainerAttribute<>(ReplicationType.class);
-  private final Map<ContainerID, ContainerInfo> containerMap;
-  private final Map<ContainerID, Set<ContainerReplica>> replicaMap;
+  private final ContainerMap containerMap = new ContainerMap();
 
   /**
    * Create a ContainerStateMap.
    */
   public ContainerStateMap() {
-    this.containerMap = new ConcurrentHashMap<>();
-    this.replicaMap = new ConcurrentHashMap<>();
   }
 
   @VisibleForTesting
@@ -94,24 +187,19 @@ public class ContainerStateMap {
    * Adds a ContainerInfo Entry in the ContainerStateMap.
    *
    * @param info - container info
-   * @throws SCMException - throws if create failed.
    */
-  public void addContainer(final ContainerInfo info)
-      throws SCMException {
-    Preconditions.checkNotNull(info, "Container Info cannot be null");
-    final ContainerID id = info.containerID();
-    if (!contains(id)) {
-      containerMap.put(id, info);
+  public void addContainer(final ContainerInfo info) {
+    Objects.requireNonNull(info, "info == null");
+    if (containerMap.addIfAbsent(info)) {
+      final ContainerID id = info.containerID();
       lifeCycleStateMap.insert(info.getState(), id);
       typeMap.insert(info.getReplicationType(), id);
-      replicaMap.put(id, Collections.emptySet());
-
-      LOG.trace("Container {} added to ContainerStateMap.", id);
+      LOG.trace("Added {}", info);
     }
   }
 
   public boolean contains(final ContainerID id) {
-    return containerMap.containsKey(id);
+    return containerMap.contains(id);
   }
 
   /**
@@ -120,15 +208,12 @@ public class ContainerStateMap {
    * @param id - ContainerID
    */
   public void removeContainer(final ContainerID id) {
-    Preconditions.checkNotNull(id, "ContainerID cannot be null");
-    if (contains(id)) {
-      // Should we revert back to the original state if any of the below
-      // remove operation fails?
-      final ContainerInfo info = containerMap.remove(id);
+    Objects.requireNonNull(id, "id == null");
+    final ContainerInfo info = containerMap.remove(id);
+    if (info != null) {
       lifeCycleStateMap.remove(info.getState(), id);
       typeMap.remove(info.getReplicationType(), id);
-      replicaMap.remove(id);
-      LOG.trace("Container {} removed from ContainerStateMap.", id);
+      LOG.trace("Removed {}", info);
     }
   }
 
@@ -139,7 +224,7 @@ public class ContainerStateMap {
    * @return container info, if found else null.
    */
   public ContainerInfo getContainerInfo(final ContainerID containerID) {
-    return containerMap.get(containerID);
+    return containerMap.getInfo(containerID);
   }
 
   /**
@@ -148,8 +233,8 @@ public class ContainerStateMap {
    */
   public Set<ContainerReplica> getContainerReplicas(
       final ContainerID containerID) {
-    Preconditions.checkNotNull(containerID);
-    return replicaMap.get(containerID);
+    Objects.requireNonNull(containerID, "containerID == null");
+    return containerMap.getReplicas(containerID);
   }
 
   /**
@@ -157,39 +242,18 @@ public class ContainerStateMap {
    * Logs a debug entry if a datanode is already added as replica for given
    * ContainerId.
    */
-  public void updateContainerReplica(final ContainerID containerID,
-      final ContainerReplica replica) {
-    Preconditions.checkNotNull(containerID);
-    if (contains(containerID)) {
-      final Set<ContainerReplica> newSet = createNewReplicaSet(containerID);
-      newSet.remove(replica);
-      newSet.add(replica);
-      replaceReplicaSet(containerID, newSet);
-    }
+  public void updateContainerReplica(ContainerReplica replica) {
+    Objects.requireNonNull(replica, "replica == null");
+    containerMap.put(replica);
   }
 
   /**
    * Remove a container Replica for given DataNode.
    */
-  public void removeContainerReplica(final ContainerID containerID,
-      final ContainerReplica replica) {
-    Preconditions.checkNotNull(containerID);
-    Preconditions.checkNotNull(replica);
-    if (contains(containerID)) {
-      final Set<ContainerReplica> newSet = createNewReplicaSet(containerID);
-      newSet.remove(replica);
-      replaceReplicaSet(containerID, newSet);
-    }
-  }
-
-  private Set<ContainerReplica> createNewReplicaSet(ContainerID containerID) {
-    Set<ContainerReplica> existingSet = replicaMap.get(containerID);
-    return existingSet == null ? new HashSet<>() : new HashSet<>(existingSet);
-  }
-
-  private void replaceReplicaSet(ContainerID containerID,
-      Set<ContainerReplica> newSet) {
-    replicaMap.put(containerID, Collections.unmodifiableSet(newSet));
+  public void removeContainerReplica(final ContainerID containerID, DatanodeID datanodeID) {
+    Objects.requireNonNull(containerID, "containerID == null");
+    Objects.requireNonNull(datanodeID, "datanodeID == null");
+    containerMap.removeReplica(containerID, datanodeID);
   }
 
   /**
@@ -205,7 +269,7 @@ public class ContainerStateMap {
     if (currentState == newState) { // state not changed
       return;
     }
-    final ContainerInfo currentInfo = containerMap.get(containerID);
+    final ContainerInfo currentInfo = containerMap.getInfo(containerID);
     if (currentInfo == null) { // container not found
       return;
     }
@@ -214,30 +278,39 @@ public class ContainerStateMap {
     currentInfo.setState(newState);
   }
 
-  public Set<ContainerID> getAllContainerIDs() {
-    return ImmutableSet.copyOf(containerMap.keySet());
+  public List<ContainerInfo> getContainerInfos(ContainerID start, int count) {
+    return containerMap.getInfos(start, count);
   }
 
   /**
-   * Returns Containers in the System by the Type.
    *
-   * @param type - Replication type -- StandAlone, Ratis etc.
-   * @return NavigableSet
+   * @param state the state of the {@link ContainerInfo}s
+   * @param start the start id
+   * @param count the maximum size of the returned list
+   * @return a list of {@link ContainerInfo}s sorted by {@link ContainerID}
    */
-  public NavigableSet<ContainerID> getContainerIDsByType(final ReplicationType type) {
-    Preconditions.checkNotNull(type);
-    return typeMap.getCollection(type);
+  public List<ContainerInfo> getContainerInfos(LifeCycleState state, ContainerID start, int count) {
+    Preconditions.assertTrue(count >= 0, "count < 0");
+    return lifeCycleStateMap.tailSet(state, start).stream()
+        .map(this::getContainerInfo)
+        .limit(count)
+        .collect(Collectors.toList());
   }
 
-  /**
-   * Returns Containers by State.
-   *
-   * @param state - State - Open, Closed etc.
-   * @return List of containers by state.
-   */
-  public NavigableSet<ContainerID> getContainerIDsByState(
-      final LifeCycleState state) {
-    Preconditions.checkNotNull(state);
-    return lifeCycleStateMap.getCollection(state);
+  public List<ContainerInfo> getContainerInfos(LifeCycleState state) {
+    return lifeCycleStateMap.getCollection(state).stream()
+        .map(this::getContainerInfo)
+        .collect(Collectors.toList());
+  }
+
+  public List<ContainerInfo> getContainerInfos(ReplicationType state) {
+    return typeMap.getCollection(state).stream()
+        .map(this::getContainerInfo)
+        .collect(Collectors.toList());
+  }
+
+  /** @return the number of containers for the given state. */
+  public int getContainerCount(LifeCycleState state) {
+    return lifeCycleStateMap.count(state);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
@@ -134,9 +136,6 @@ public class TestContainerStateManagerIntegration {
     assertNotNull(info);
 
     String newContainerOwner = "OZONE_NEW";
-    ContainerWithPipeline container2 = scm.getClientProtocolServer()
-        .allocateContainer(SCMTestUtils.getReplicationType(conf),
-            SCMTestUtils.getReplicationFactor(conf), newContainerOwner);
     ContainerInfo info2 = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, newContainerOwner,
             container1.getPipeline());
@@ -267,13 +266,15 @@ public class TestContainerStateManagerIntegration {
     }
   }
 
+  void assertContainerCount(LifeCycleState state, int expected) {
+    final int computed = containerStateManager.getContainerCount(state);
+    assertEquals(expected, computed);
+  }
+
   @Test
   public void testUpdateContainerState() throws IOException,
-      InvalidStateTransitionException, TimeoutException {
-    Set<ContainerID> containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.OPEN);
-    int containers = containerList == null ? 0 : containerList.size();
-    assertEquals(0, containers);
+      InvalidStateTransitionException {
+    assertContainerCount(LifeCycleState.OPEN, 0);
 
     // Allocate container1 and update its state from
     // OPEN -> CLOSING -> CLOSED -> DELETING -> DELETED
@@ -281,37 +282,20 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
-    containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.OPEN);
-    assertEquals(1, containerList.size());
+    final ContainerID id1 = container1.getContainerInfo().containerID();
+    assertContainerCount(LifeCycleState.OPEN, 1);
 
-    containerManager
-        .updateContainerState(container1.getContainerInfo().containerID(),
-            HddsProtos.LifeCycleEvent.FINALIZE);
-    containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.CLOSING);
-    assertEquals(1, containerList.size());
+    containerManager.updateContainerState(id1, LifeCycleEvent.FINALIZE);
+    assertContainerCount(LifeCycleState.CLOSING, 1);
 
-    containerManager
-        .updateContainerState(container1.getContainerInfo().containerID(),
-            HddsProtos.LifeCycleEvent.CLOSE);
-    containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.CLOSED);
-    assertEquals(1, containerList.size());
+    containerManager.updateContainerState(id1, LifeCycleEvent.CLOSE);
+    assertContainerCount(LifeCycleState.CLOSED, 1);
 
-    containerManager
-        .updateContainerState(container1.getContainerInfo().containerID(),
-            HddsProtos.LifeCycleEvent.DELETE);
-    containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETING);
-    assertEquals(1, containerList.size());
+    containerManager.updateContainerState(id1, LifeCycleEvent.DELETE);
+    assertContainerCount(LifeCycleState.DELETING, 1);
 
-    containerManager
-        .updateContainerState(container1.getContainerInfo().containerID(),
-            HddsProtos.LifeCycleEvent.CLEANUP);
-    containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(1, containerList.size());
+    containerManager.updateContainerState(id1, LifeCycleEvent.CLEANUP);
+    assertContainerCount(LifeCycleState.DELETED, 1);
 
     // Allocate container1 and update its state from
     // OPEN -> CLOSING -> CLOSED
@@ -328,9 +312,7 @@ public class TestContainerStateManagerIntegration {
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLOSE);
-    containerList = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.CLOSED);
-    assertEquals(1, containerList.size());
+    assertContainerCount(LifeCycleState.CLOSED, 1);
   }
 
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1144,6 +1144,11 @@ public class TestContainerEndpoint {
     return new ContainerWithPipeline(containerInfo, localPipeline);
   }
 
+  void assertContainerCount(HddsProtos.LifeCycleState state, int expected) {
+    final int computed = containerStateManager.getContainerCount(state);
+    assertEquals(expected, computed);
+  }
+
   @Test
   public void testGetSCMDeletedContainers() throws Exception {
     reconContainerManager.addNewContainer(
@@ -1161,9 +1166,7 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(102L),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    Set<ContainerID> containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(1, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
 
     reconContainerManager.updateContainerState(ContainerID.valueOf(103L),
         HddsProtos.LifeCycleEvent.FINALIZE);
@@ -1172,14 +1175,10 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(103L),
             HddsProtos.LifeCycleEvent.DELETE);
-    containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETING);
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(103L),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(2, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 2);
 
     Response scmDeletedContainers =
         containerEndpoint.getSCMDeletedContainers(2, 0);
@@ -1212,9 +1211,7 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(104L),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    Set<ContainerID> containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(1, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
 
     reconContainerManager.updateContainerState(ContainerID.valueOf(105L),
         HddsProtos.LifeCycleEvent.FINALIZE);
@@ -1226,9 +1223,7 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(105L),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(2, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 2);
 
     Response scmDeletedContainers =
         containerEndpoint.getSCMDeletedContainers(1, 0);
@@ -1258,9 +1253,7 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(106L),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    Set<ContainerID> containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(1, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
 
     reconContainerManager.updateContainerState(ContainerID.valueOf(107L),
         HddsProtos.LifeCycleEvent.FINALIZE);
@@ -1272,9 +1265,7 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(107L),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(2, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 2);
 
     Response scmDeletedContainers =
         containerEndpoint.getSCMDeletedContainers(2, 106L);
@@ -1554,16 +1545,12 @@ public class TestContainerEndpoint {
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(1),
             HddsProtos.LifeCycleEvent.DELETE);
-    Set<ContainerID> containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETING);
-    assertEquals(1, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETING, 1);
 
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(1),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(1, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
 
     List<ContainerInfo> deletedSCMContainers =
         reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
@@ -1603,9 +1590,7 @@ public class TestContainerEndpoint {
     // and then to DELETED
     updateContainerStateToDeleted(1);
 
-    Set<ContainerID> containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(1, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
 
     List<ContainerInfo> deletedSCMContainers =
         reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
@@ -1647,9 +1632,7 @@ public class TestContainerEndpoint {
     updateContainerStateToDeleted(1);
     updateContainerStateToDeleted(2);
 
-    Set<ContainerID> containerIDs = containerStateManager
-        .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    assertEquals(2, containerIDs.size());
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 2);
 
     List<ContainerInfo> deletedSCMContainers =
         reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerStateMap has two maps, containerMap and replicaMap.  Both of them has the same key type ContainerID.  They should be combined into one map for simplicity and efficiency.

## What is the link to the Apache JIRA

HDDS-12555.

## How was this patch tested?

Updating existing tests.