### PR TITLE
HDDS-12527. Separate S3 Gateway from MiniOzoneCluster

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
@@ -86,7 +87,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       List<HddsDatanodeService> hddsDatanodes,
       String clusterPath,
       ReconServer reconServer) {
-    super(conf, scmConfigurator, hddsDatanodes, reconServer);
+    super(conf, scmConfigurator, hddsDatanodes, reconServer, emptyList());
     this.omhaService = omhaService;
     this.scmhaService = scmhaService;
     this.clusterMetaPath = clusterPath;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/S3GatewayService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/S3GatewayService.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3;
+
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.ratis.util.Preconditions;
+
+/** S3 Gateway for {@link MiniOzoneCluster}. */
+public class S3GatewayService implements MiniOzoneCluster.Service {
+
+  private static final String[] NO_ARGS = new String[0];
+
+  private Gateway s3g;
+
+  @Override
+  public void start(OzoneConfiguration conf) throws Exception {
+    Preconditions.assertNull(s3g, "S3 Gateway already started");
+    configureS3G(new OzoneConfiguration(conf));
+    s3g = new Gateway();
+    s3g.execute(NO_ARGS);
+  }
+
+  @Override
+  public void stop() throws Exception {
+    Preconditions.assertNotNull(s3g, "S3 Gateway not running");
+    s3g.stop();
+    // TODO (HDDS-11539): Remove this workaround once the @PreDestroy issue is fixed
+    OzoneClientCache.closeClient();
+  }
+
+  @Override
+  public String toString() {
+    final Gateway instance = s3g;
+    return instance != null
+        ? "S3Gateway(http=" + instance.getHttpAddress() + ", https=" + instance.getHttpsAddress() + ")"
+        : "S3Gateway";
+  }
+
+  public OzoneConfiguration getConf() {
+    return OzoneConfigurationHolder.configuration();
+  }
+
+  private void configureS3G(OzoneConfiguration conf) {
+    OzoneConfigurationHolder.resetConfiguration();
+
+    conf.set(S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY,  localhostWithFreePort());
+    conf.set(S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY, localhostWithFreePort());
+
+    OzoneConfigurationHolder.setConfiguration(conf);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -102,6 +102,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.s3.S3ClientFactory;
+import org.apache.hadoop.ozone.s3.S3GatewayService;
 import org.apache.ozone.test.OzoneTestBase;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -182,12 +183,13 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
    * @throws Exception exception thrown when waiting for the cluster to be ready.
    */
   static void startCluster(OzoneConfiguration conf) throws Exception {
+    S3GatewayService s3g = new S3GatewayService();
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .includeS3G(true)
+        .addService(s3g)
         .setNumDatanodes(5)
         .build();
     cluster.waitForClusterToBeReady();
-    s3Client = new S3ClientFactory(cluster.getConf()).createS3Client();
+    s3Client = new S3ClientFactory(s3g.getConf()).createS3Client();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -40,6 +40,7 @@ import javax.xml.bind.DatatypeConverter;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.s3.S3ClientFactory;
+import org.apache.hadoop.ozone.s3.S3GatewayService;
 import org.apache.ozone.test.OzoneTestBase;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -88,12 +89,13 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
    * @throws Exception exception thrown when waiting for the cluster to be ready.
    */
   static void startCluster(OzoneConfiguration conf) throws Exception {
+    S3GatewayService s3g = new S3GatewayService();
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .includeS3G(true)
+        .addService(s3g)
         .setNumDatanodes(5)
         .build();
     cluster.waitForClusterToBeReady();
-    s3Client = new S3ClientFactory(cluster.getConf()).createS3ClientV2();
+    s3Client = new S3ClientFactory(s3g.getConf()).createS3ClientV2();
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove S3 Gateway-specific details from `MiniOzoneCluster`, hiding it behind a more generic `Service` interface.

This allows moving S3 tests to a separate module in a follow-up (HDDS-12528).

https://issues.apache.org/jira/browse/HDDS-12527

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13808975185