### PR TITLE
HDDS-12566. Handle Over replication of Quasi Closed Stuck containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckOverReplicationHandler.java
@@ -75,7 +75,7 @@ public class QuasiClosedStuckOverReplicationHandler implements UnhealthyReplicat
     int totalCommandsSent = 0;
     IOException firstException = null;
     for (QuasiClosedStuckReplicaCount.MisReplicatedOrigin origin : misReplicatedOrigins) {
-      List<ContainerReplica> sortedReplicas = getEligibleReplicas(origin.getSources());
+      List<ContainerReplica> sortedReplicas = getSortedReplicas(origin.getSources());
       for (int i = 0; i < origin.getReplicaDelta(); i++) {
         try {
           replicationManager.sendThrottledDeleteCommand(
@@ -99,7 +99,7 @@ public class QuasiClosedStuckOverReplicationHandler implements UnhealthyReplicat
     return totalCommandsSent;
   }
 
-  private List<ContainerReplica> getEligibleReplicas(
+  private List<ContainerReplica> getSortedReplicas(
       Set<ContainerReplica> replicas) {
     // sort replicas so that they can be selected in a deterministic way
     return replicas.stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckOverReplicationHandler.java
@@ -22,8 +22,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 
 /**
  * Class to correct over replicated QuasiClosed Stuck Ratis containers.
@@ -50,7 +52,7 @@ public class QuasiClosedStuckOverReplicationHandler implements UnhealthyReplicat
 
     int pendingDelete = 0;
     for (ContainerReplicaOp op : pendingOps) {
-      if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
+      if (op.getOpType() == ContainerReplicaOp.PendingOpType.DELETE) {
         pendingDelete++;
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckOverReplicationHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+
+/**
+ * Class to correct over replicated QuasiClosed Stuck Ratis containers.
+ */
+public class QuasiClosedStuckOverReplicationHandler implements UnhealthyReplicationHandler {
+
+
+  public QuasiClosedStuckOverReplicationHandler(final PlacementPolicy placementPolicy,
+      final ConfigurationSource conf, final ReplicationManager replicationManager) {
+  }
+
+  @Override
+  public int processAndSendCommands(Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,
+      ContainerHealthResult result, int remainingMaintenanceRedundancy)
+      throws IOException {
+    return 0;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -253,8 +253,7 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
         ratisContainerPlacement, conf, this);
     quasiClosedStuckUnderReplicationHandler =
         new QuasiClosedStuckUnderReplicationHandler(ratisContainerPlacement, conf, this);
-    quasiClosedStuckOverReplicationHandler =
-        new QuasiClosedStuckOverReplicationHandler(ratisContainerPlacement, conf, this);
+    quasiClosedStuckOverReplicationHandler = new QuasiClosedStuckOverReplicationHandler(this);
     underReplicatedProcessor =
         new UnderReplicatedProcessor(this, rmConf::getUnderReplicatedInterval);
     overReplicatedProcessor =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -788,7 +788,7 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
       handler = ecOverReplicationHandler;
     } else {
       if (QuasiClosedStuckReplicationCheck.shouldHandleAsQuasiClosedStuck(result.getContainerInfo(), replicas)) {
-        handler = quasiClosedStuckUnderReplicationHandler;
+        handler = quasiClosedStuckOverReplicationHandler;
       } else {
         handler = ratisOverReplicationHandler;
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -504,9 +504,29 @@ public final class ReplicationTestUtil {
    * @param commandsSent Set to add the command to rather than sending it.
    */
   public static void mockRMSendThrottledDeleteCommand(ReplicationManager mock,
-      Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent)
+                                                      Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent)
+      throws NotLeaderException, CommandTargetOverloadedException {
+    mockRMSendThrottledDeleteCommand(mock, commandsSent, new AtomicBoolean(false));
+  }
+
+  /**
+   * Given a Mockito mock of ReplicationManager, this method will mock the
+   * sendThrottledDeleteCommand method so that it adds the command created to
+   * the commandsSent set.
+   * @param mock Mock of ReplicationManager
+   * @param commandsSent Set to add the command to rather than sending it.
+   * @param throwOverloaded If the atomic boolean is true, throw a
+   *                        CommandTargetOverloadedException and set the boolean
+   *                        to false, instead of creating the replicate command.
+   */
+  public static void mockRMSendThrottledDeleteCommand(ReplicationManager mock,
+      Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent, AtomicBoolean throwOverloaded)
       throws NotLeaderException, CommandTargetOverloadedException {
     doAnswer((Answer<Void>) invocationOnMock -> {
+      if (throwOverloaded.get()) {
+        throwOverloaded.set(false);
+        throw new CommandTargetOverloadedException("Overloaded");
+      }
       ContainerInfo containerInfo = invocationOnMock.getArgument(0);
       int replicaIndex = invocationOnMock.getArgument(1);
       DatanodeDetails target = invocationOnMock.getArgument(2);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test for QuasiClosedStuckOverReplicationHandler.
+ */
+public class TestQuasiClosedStuckOverReplicationHandler {
+
+  private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG = RatisReplicationConfig.getInstance(THREE);
+  private ContainerInfo container;
+  private NodeManager nodeManager;
+  private OzoneConfiguration conf;
+  private ReplicationManager replicationManager;
+  private ReplicationManagerMetrics metrics;
+  private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
+  private QuasiClosedStuckOverReplicationHandler handler;
+
+  @BeforeEach
+  void setup(@TempDir File testDir) throws NodeNotFoundException,
+      CommandTargetOverloadedException, NotLeaderException {
+    container = ReplicationTestUtil.createContainer(
+        HddsProtos.LifeCycleState.QUASI_CLOSED, RATIS_REPLICATION_CONFIG);
+
+    nodeManager = mock(NodeManager.class);
+    conf = SCMTestUtils.getConf(testDir);
+    replicationManager = mock(ReplicationManager.class);
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.setBoolean("hdds.scm.replication.push", true);
+    when(replicationManager.getConfig())
+        .thenReturn(ozoneConfiguration.getObject(
+            ReplicationManager.ReplicationManagerConfiguration.class));
+    metrics = ReplicationManagerMetrics.create(replicationManager);
+    when(replicationManager.getMetrics()).thenReturn(metrics);
+
+    /*
+      Return NodeStatus with NodeOperationalState as specified in
+      DatanodeDetails, and NodeState as HEALTHY.
+    */
+    when(
+        replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenAnswer(invocationOnMock -> {
+          DatanodeDetails dn = invocationOnMock.getArgument(0);
+          return new NodeStatus(dn.getPersistedOpState(),
+              HddsProtos.NodeState.HEALTHY);
+        });
+
+    commandsSent = new HashSet<>();
+    ReplicationTestUtil.mockRMSendThrottledDeleteCommand(
+        replicationManager, commandsSent);
+    handler = new QuasiClosedStuckOverReplicationHandler(replicationManager);
+  }
+
+  @Test
+  public void testReturnsZeroIfNotOverReplicated() throws IOException {
+    UUID origin = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    int count = handler.processAndSendCommands(replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 1);
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void testNoCommandsScheduledIfPendingOps() throws IOException {
+    UUID origin = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
+    List<ContainerReplicaOp> pendingOps = new ArrayList<>();
+    pendingOps.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0));
+
+    int count = handler.processAndSendCommands(replicas, pendingOps, getOverReplicatedHealthResult(), 1);
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void testCommandScheduledForOverReplicatedContainer() throws IOException {
+    UUID origin = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    int count = handler.processAndSendCommands(replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 1);
+    assertEquals(1, count);
+    SCMCommand<?> command = commandsSent.iterator().next().getRight();
+    assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.deleteContainerCommand, command.getType());
+  }
+
+  @Test
+  public void testOverloadedExceptionContinuesAndThrows() throws NotLeaderException, CommandTargetOverloadedException {
+    UUID origin1 = UUID.randomUUID();
+    UUID origin2 = UUID.randomUUID();
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
+        Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin2, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin2, HddsProtos.NodeOperationalState.IN_SERVICE),
+        Pair.of(origin2, HddsProtos.NodeOperationalState.IN_SERVICE));
+
+    ReplicationTestUtil.mockRMSendThrottledDeleteCommand(replicationManager, commandsSent, new AtomicBoolean(true));
+
+    assertThrows(CommandTargetOverloadedException.class, () ->
+        handler.processAndSendCommands(replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 1));
+    assertEquals(1, commandsSent.size());
+  }
+
+
+  private ContainerHealthResult.OverReplicatedHealthResult getOverReplicatedHealthResult() {
+    ContainerHealthResult.OverReplicatedHealthResult
+        healthResult = mock(ContainerHealthResult.OverReplicatedHealthResult.class);
+    when(healthResult.getContainerInfo()).thenReturn(container);
+    return healthResult;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,15 +41,12 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test for QuasiClosedStuckOverReplicationHandler.
@@ -59,21 +55,17 @@ public class TestQuasiClosedStuckOverReplicationHandler {
 
   private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG = RatisReplicationConfig.getInstance(THREE);
   private ContainerInfo container;
-  private NodeManager nodeManager;
-  private OzoneConfiguration conf;
   private ReplicationManager replicationManager;
   private ReplicationManagerMetrics metrics;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
   private QuasiClosedStuckOverReplicationHandler handler;
 
   @BeforeEach
-  void setup(@TempDir File testDir) throws NodeNotFoundException,
+  void setup() throws NodeNotFoundException,
       CommandTargetOverloadedException, NotLeaderException {
     container = ReplicationTestUtil.createContainer(
         HddsProtos.LifeCycleState.QUASI_CLOSED, RATIS_REPLICATION_CONFIG);
 
-    nodeManager = mock(NodeManager.class);
-    conf = SCMTestUtils.getConf(testDir);
     replicationManager = mock(ReplicationManager.class);
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setBoolean("hdds.scm.replication.push", true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -550,7 +550,7 @@ public class TestReplicationManagerScenarios {
   public static class ExpectedCommands {
     private SCMCommandProto.Type type;
     private String datanode;
-    private Set<DatanodeDetails> expectedDatanodes = new HashSet<>();
+    private Set<DatanodeDetails> expectedDatanodes;
 
     public void setDatanode(String datanode) {
       this.datanode = datanode;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -130,6 +130,7 @@ public class TestReplicationManagerScenarios {
 
   private static List<Scenario> loadTestsInFile(URI testFile)
       throws IOException {
+    System.out.println("Loading test file: " + testFile);
     ObjectReader reader = new ObjectMapper().readerFor(Scenario.class);
     try (InputStream stream = testFile.toURL().openStream()) {
       try (MappingIterator<Scenario> iterator = reader.readValues(stream)) {
@@ -332,11 +333,10 @@ public class TestReplicationManagerScenarios {
       boolean found = false;
       for (Pair<UUID, SCMCommand<?>> command : commandsSent) {
         if (command.getRight().getType() == expectedCommand.getType()) {
-          DatanodeDetails targetDatanode = expectedCommand.getTargetDatanode();
-          if (targetDatanode != null) {
+          if (expectedCommand.hasExpectedDatanode()) {
             // We need to assert against the command the datanode is sent to
             DatanodeDetails commandDatanode = findDatanodeFromUUID(command.getKey());
-            if (commandDatanode != null && commandDatanode.equals(targetDatanode)) {
+            if (commandDatanode != null && expectedCommand.isTargetExpected(commandDatanode)) {
               found = true;
               commandsSent.remove(command);
               break;
@@ -550,6 +550,7 @@ public class TestReplicationManagerScenarios {
   public static class ExpectedCommands {
     private SCMCommandProto.Type type;
     private String datanode;
+    private Set<DatanodeDetails> expectedDatanodes = new HashSet<>();
 
     public void setDatanode(String datanode) {
       this.datanode = datanode;
@@ -564,15 +565,33 @@ public class TestReplicationManagerScenarios {
       return type;
     }
 
-    public DatanodeDetails getTargetDatanode() {
+    public boolean hasExpectedDatanode() {
+      createExpectedDatanodes();
+      return !expectedDatanodes.isEmpty();
+    }
+
+    public boolean isTargetExpected(DatanodeDetails dn) {
+      createExpectedDatanodes();
+      return expectedDatanodes.contains(dn);
+    }
+
+    private void createExpectedDatanodes() {
+      if (expectedDatanodes != null) {
+        return;
+      }
+      this.expectedDatanodes = new HashSet<>();
       if (datanode == null) {
-        return null;
+        return;
       }
-      DatanodeDetails datanodeDetails = DATANODE_ALIASES.get(this.datanode);
-      if (datanodeDetails == null) {
-        fail("Unable to find a datanode for the alias: " + datanode + " in the expected commands.");
+      String[] nodes = datanode.split("\\|");
+      for (String n : nodes) {
+        DatanodeDetails dn = DATANODE_ALIASES.get(n);
+        if (dn != null) {
+          expectedDatanodes.add(dn);
+        } else {
+          fail("Expected datanode not found: " + datanode);
+        }
       }
-      return datanodeDetails;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -252,5 +252,18 @@
     "commands": [
       { "type": "deleteContainerCommand" }
     ]
+  },
+  { "description": "Quasi-Closed stuck two origins over replicated with stale", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1", "healthState": "STALE" },
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d4", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d5", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d6", "sequenceId": 10, "isEmpty": false, "origin": "o2", "healthState": "STALE" }
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": []
   }
 ]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -181,5 +181,76 @@
     "commands": [
       { "type": "replicateContainerCommand"}
     ]
+  },
+  { "description": "Quasi-Closed stuck one origin over replicated", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d4", "sequenceId": 10, "isEmpty": false, "origin": "o1"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": [
+      { "type": "deleteContainerCommand" }
+    ]
+  },
+  { "description": "Quasi-Closed stuck two origins over replicated", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d4", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d5", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d6", "sequenceId": 10, "isEmpty": false, "origin": "o2"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": [
+      { "type": "deleteContainerCommand" },
+      { "type": "deleteContainerCommand" }
+    ]
+  },
+  { "description": "Quasi-Closed stuck two origins not over replicated with maintenance", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1", "operationalState": "IN_MAINTENANCE" },
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d4", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d5", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d6", "sequenceId": 10, "isEmpty": false, "origin": "o2", "operationalState": "IN_MAINTENANCE"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": []
+  },
+  { "description": "Quasi-Closed stuck two origins not over replicated with decommission", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1", "operationalState": "DECOMMISSIONED" },
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d4", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d5", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d6", "sequenceId": 10, "isEmpty": false, "origin": "o2", "operationalState": "DECOMMISSIONED"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": []
+  },
+  { "description": "Quasi-Closed stuck two origins over replicated with maintenance", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
+    "replicas": [
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d1", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d2", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d3", "sequenceId": 10, "isEmpty": false, "origin": "o1"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d4", "sequenceId": 10, "isEmpty": false, "origin": "o1", "operationalState": "IN_MAINTENANCE" },
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d5", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d6", "sequenceId": 10, "isEmpty": false, "origin": "o2"},
+      { "state": "QUASI_CLOSED", "index": 0,   "datanode": "d7", "sequenceId": 10, "isEmpty": false, "origin": "o2", "operationalState": "IN_MAINTENANCE"}
+    ],
+    "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
+    "checkCommands": [],
+    "commands": [
+      { "type": "deleteContainerCommand" }
+    ]
   }
 ]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/quasi_closed.json
@@ -179,8 +179,7 @@
     "expectation": { "underReplicated": 1, "underReplicatedQueue": 1, "overReplicated": 0, "overReplicatedQueue":  0, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
     "commands": [
-      { "type": "replicateContainerCommand"}
-    ]
+      { "type": "replicateContainerCommand", "datanode": "d4|d5" }]
   },
   { "description": "Quasi-Closed stuck one origin over replicated", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
     "replicas": [
@@ -192,7 +191,7 @@
     "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
     "commands": [
-      { "type": "deleteContainerCommand" }
+      { "type": "deleteContainerCommand", "datanode": "d1|d2|d3|d4" }
     ]
   },
   { "description": "Quasi-Closed stuck two origins over replicated", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
@@ -207,8 +206,8 @@
     "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
     "commands": [
-      { "type": "deleteContainerCommand" },
-      { "type": "deleteContainerCommand" }
+      { "type": "deleteContainerCommand", "datanode": "d1|d2|d3" },
+      { "type": "deleteContainerCommand", "datanode": "d4|d5|d6" }
     ]
   },
   { "description": "Quasi-Closed stuck two origins not over replicated with maintenance", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,
@@ -250,7 +249,7 @@
     "expectation": { "underReplicated": 0, "underReplicatedQueue": 0, "overReplicated": 1, "overReplicatedQueue":  1, "quasiClosedStuck": 1, "unhealthy": 0 },
     "checkCommands": [],
     "commands": [
-      { "type": "deleteContainerCommand" }
+      { "type": "deleteContainerCommand", "datanode": "d1|d2|d3" }
     ]
   },
   { "description": "Quasi-Closed stuck two origins over replicated with stale", "containerState": "QUASI_CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 10,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR follows on from [HDDS-12483](https://issues.apache.org/jira/browse/HDDS-12483), which added under replication handling for quasi-closed suck containers. In that PR, we ensure that each origin has 2 copies, or 3 copies if there is a single origin. 

This PR handles over replication of quasi-closed stuck containers so the replica count is reduced to 2 per origin if the container has more than that.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12566

## How was this patch tested?

New tests added.