### PR TITLE
HDDS-12573. Pipeline#toString should separate ReplicaIndex from next node UUID

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -522,19 +522,20 @@ public final class Pipeline {
   @Override
   public String toString() {
     final StringBuilder b =
-        new StringBuilder(getClass().getSimpleName()).append("[");
+        new StringBuilder(getClass().getSimpleName()).append("{");
     b.append(" Id: ").append(id.getId());
-    b.append(", Nodes: ");
+    b.append(", Nodes: [");
     for (DatanodeDetails datanodeDetails : nodeStatus.keySet()) {
-      b.append(datanodeDetails);
-      b.append(" ReplicaIndex: ").append(this.getReplicaIndex(datanodeDetails));
+      b.append(" {").append(datanodeDetails);
+      b.append(", ReplicaIndex: ").append(this.getReplicaIndex(datanodeDetails)).append("},");
     }
+    b.append("]");
     b.append(", ReplicationConfig: ").append(replicationConfig);
     b.append(", State:").append(getPipelineState());
     b.append(", leaderId:").append(leaderId != null ? leaderId.toString() : "");
     b.append(", CreationTimestamp").append(getCreationTimestamp()
         .atZone(ZoneId.systemDefault()));
-    b.append("]");
+    b.append("}");
     return b.toString();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the replica node has 0 as thee first character, it is truncated in the leaderNode mapping.

```bash
# ozone admin pipeline list -fst OPEN -r THREE -t RATIS
Pipeline[ Id: fb8d88cb-5008-44ca-8c73-a1f0705efed1, Nodes: e751fa12-8be2-4ee4-9655-16ef7d8b1a69(ccycloud-4) ReplicaIndex: 0b63db24b-9d73-45ea-84eb-78dca9f54b6d(ccycloud-7) ReplicaIndex: 0026bcb44-214c-4f2a-8954-018e4230f695(ccycloud-1) ReplicaIndex: 0, ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:b63db24b-9d73-45ea-84eb-78dca9f54b6d, CreationTimestamp2025-03-12T15:48:25.146Z[UTC]]
Pipeline[ Id: 8861d89b-3b75-4e0d-9ba8-cc809959d268, Nodes: 6ab01d76-7290-4c58-919f-8a7e48f638ce(ccycloud-8) ReplicaIndex: 0926178e6-69a1-41de-97d1-a619d9c8cb8a(ccycloud-3) ReplicaIndex: 074fb71fd-9639-45da-b496-2fdf30379a70(ccycloud-2) ReplicaIndex: 0, ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:6ab01d76-7290-4c58-919f-8a7e48f638ce, CreationTimestamp2025-03-12T15:48:25.134Z[UTC]]
Pipeline[ Id: 88853822-a5ac-4481-98de-6439436d631d, Nodes: 6ab01d76-7290-4c58-919f-8a7e48f638ce(ccycloud-8) ReplicaIndex: 0926178e6-69a1-41de-97d1-a619d9c8cb8a(ccycloud-3) ReplicaIndex: 074fb71fd-9639-45da-b496-2fdf30379a70(ccycloud-2) ReplicaIndex: 0, ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:926178e6-69a1-41de-97d1-a619d9c8cb8a, CreationTimestamp2025-03-12T15:48:25.141Z[UTC]]
Pipeline[ Id: b2241b8d-3dc6-4c75-92bf-815d3af99b9c, Nodes: e751fa12-8be2-4ee4-9655-16ef7d8b1a69(ccycloud-4) ReplicaIndex: 0b63db24b-9d73-45ea-84eb-78dca9f54b6d(ccycloud-7) ReplicaIndex: 0026bcb44-214c-4f2a-8954-018e4230f695(ccycloud-1) ReplicaIndex: 0, ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:026bcb44-214c-4f2a-8954-018e4230f695, CreationTimestamp2025-03-12T15:48:25.145Z[UTC]]
```


Actually, it's not the leaderId. It has 8-4-4-4-12 pattern
It is defined as UUID.

```java
private UUID leaderId;
```

The ReplicaIndex on the other hand has 9-4-4-4-12
0b63db24b-9d73-45ea-84eb-78dca9f54b6d
```java
private final PipelineID id;
```

## What has been done?

Provide better message when calling Pipeline#toString

the new format is
```
Pipeline{ Id: 369f9e51-0e5b-46fb-a5c5-31b484330df9, Nodes: [ {d9203761-6030-4f68-a35a-0aed970bc8fd(localhost-234.166.195.186/234.166.195.186), ReplicaIndex: 4}, {3c62a069-e665-4170-8d36-cb082f1745ff(localhost-54.238.51.211/54.238.51.211), ReplicaIndex: 3}, {3294d85e-1965-4379-af66-7f3322b47df7(localhost-233.29.60.35/233.29.60.35), ReplicaIndex: 2}, {5bfe19fe-b114-4f7e-bbdf-7116fefde865(localhost-254.178.61.66/254.178.61.66), ReplicaIndex: 1}, {8c34105c-9c49-4ff3-8b76-0db340ed6419(localhost-152.24.191.163/152.24.191.163), ReplicaIndex: 0},], ReplicationConfig: EC{rs-3-2-1024k}, State:OPEN, leaderId:, CreationTimestamp2025-03-12T19:08:07.590510Z[Etc/UTC]}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12573

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/13819740728
