### PR TITLE
HDDS-12583. Skip Fields in protobuf while deserializing protobuf

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -166,6 +166,19 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
       throws IOException;
 
   /**
+   * Returns the iterator for this metadata store.
+   * @param keyCodec
+   * @param valueCodec
+   * @param prefix
+   * @return MetaStoreIterator
+   * @throws IOException on failure.
+   */
+  default TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator(Codec<KEY> keyCodec, Codec<VALUE> valueCodec,
+                                                                      KEY prefix) throws IOException {
+    throw new NotImplementedException("iterator is not implemented");
+  }
+
+  /**
    * Returns a prefixed iterator for this metadata store.
    * @param prefix
    * @return MetaStoreIterator


### PR DESCRIPTION
Change-Id: I00f9f5d6b39e2d3e8a401b5ff55b7d35691f24ab

## What changes were proposed in this pull request?
Currently while deserializing really bulky KeyInfo/DirectoryInfo a lot of time is spent on just deserializing the proto and creating a java pojo and some iterations of these keys don't need bulky fields. We can actually skip deserializing these bulky optional fields while deserializing the proto itself.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12583

## How was this patch tested?
Adding unit tests wip