### PR TITLE
HDDS-12584. Optimize Recon OmTableInsightTask row count logic

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -100,6 +100,11 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public long getExactKeyCount() throws IOException {
+    return table.getExactKeyCount();
+  }
+
+  @Override
   public boolean isExist(KEY key) throws IOException {
     return table.isExist(key);
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -246,6 +246,17 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
+  public long getExactKeyCount() throws IOException {
+    try (TableIterator<byte[], KeyValue<byte[], byte[]>> iterator = iterator()) {
+      int keyCount = 0;
+      for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
+        keyCount++;
+      }
+      return keyCount;
+    }
+  }
+
+  @Override
   public List<KeyValue<byte[], byte[]>> getRangeKVs(byte[] startKey,
       int count, byte[] prefix,
       MetadataKeyFilters.MetadataKeyFilter... filters)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -246,17 +246,6 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
-  public long getExactKeyCount() throws IOException {
-    try (TableIterator<byte[], KeyValue<byte[], byte[]>> iterator = iterator()) {
-      int keyCount = 0;
-      for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
-        keyCount++;
-      }
-      return keyCount;
-    }
-  }
-
-  @Override
   public List<KeyValue<byte[], byte[]>> getRangeKVs(byte[] startKey,
       int count, byte[] prefix,
       MetadataKeyFilters.MetadataKeyFilter... filters)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -188,6 +188,15 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   long getEstimatedKeyCount() throws IOException;
 
   /**
+   * Returns the exact key count of this Table.
+   * @return Exact key count of this Table
+   * @throws IOException on failure
+   */
+  default long getExactKeyCount() throws IOException {
+    return getEstimatedKeyCount();
+  }
+
+  /**
    * Add entry to the table cache.
    *
    * If the cacheKey already exists, it will override the entry.
@@ -325,10 +334,6 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    * @throws IOException
    */
   void loadFromFile(File externalFile) throws IOException;
-
-  default Table<byte[], byte[]> getRawTable() {
-    throw new NotImplementedException("getRawTable is not implemented");
-  }
 
   /**
    * Class used to represent the key and value pair of a db entry.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -326,6 +326,10 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    */
   void loadFromFile(File externalFile) throws IOException;
 
+  default Table<byte[], byte[]> getRawTable() {
+    throw new NotImplementedException("getRawTable is not implemented");
+  }
+
   /**
    * Class used to represent the key and value pair of a db entry.
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -188,12 +188,20 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   long getEstimatedKeyCount() throws IOException;
 
   /**
-   * Returns the exact key count of this Table.
+   * Count the number of keys in this table.  Note: this operation may be expensive, prefer
+   * {@link #getEstimatedKeyCount()}.
+   *
    * @return Exact key count of this Table
    * @throws IOException on failure
    */
   default long getExactKeyCount() throws IOException {
-    return getEstimatedKeyCount();
+    try (TableIterator<?, ?> iterator = iterator()) {
+      long keyCount = 0;
+      for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
+        keyCount++;
+      }
+      return keyCount;
+    }
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -543,6 +543,11 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public Table<byte[], byte[]> getRawTable() {
+    return rawTable;
+  }
+
+  @Override
   public void cleanupCache(List<Long> epochs) {
     cache.cleanup(epochs);
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -456,25 +456,12 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     return rawTable.getEstimatedKeyCount();
   }
 
-  /**
-   * Returns the exact key count of column family.
-   *
-   * @return keyCount
-   * @throws IOException
-   */
   @Override
   public long getExactKeyCount() throws IOException {
     if (cache.getCacheType() == CacheType.FULL_CACHE) {
       return cache.size();
     }
-    try (TableIterator<byte[], KeyValue<byte[], byte[]>> iterator
-             = rawTable.iterator()) {
-      int keyCount = 0;
-      for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
-        keyCount++;
-      }
-      return keyCount;
-    }
+    return rawTable.getExactKeyCount();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -456,6 +456,27 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     return rawTable.getEstimatedKeyCount();
   }
 
+  /**
+   * Returns the exact key count of column family.
+   *
+   * @return keyCount
+   * @throws IOException
+   */
+  @Override
+  public long getExactKeyCount() throws IOException {
+    if (cache.getCacheType() == CacheType.FULL_CACHE) {
+      return cache.size();
+    }
+    try (TableIterator<byte[], KeyValue<byte[], byte[]>> iterator
+             = rawTable.iterator()) {
+      int keyCount = 0;
+      for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
+        keyCount++;
+      }
+      return keyCount;
+    }
+  }
+
   @Override
   public void close() throws Exception {
     rawTable.close();
@@ -540,11 +561,6 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   @Override
   public void loadFromFile(File externalFile) throws IOException {
     rawTable.loadFromFile(externalFile);
-  }
-
-  @Override
-  public Table<byte[], byte[]> getRawTable() {
-    return rawTable;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
@@ -100,6 +100,11 @@ public final class InMemoryTestTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public long getExactKeyCount() {
+    return map.size();
+  }
+
+  @Override
   public List<? extends KeyValue<KEY, VALUE>> getRangeKVs(KEY startKey, int count, KEY prefix,
                                                           MetadataKeyFilters.MetadataKeyFilter... filters)
       throws IOException, IllegalArgumentException {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -25,7 +25,6 @@ import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.using;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -126,12 +125,7 @@ public class OmTableInsightTask implements ReconOmTask {
                 details.getRight());
           }
         } else {
-          try (
-              TableIterator<String, ? extends Table.KeyValue<String, ?>> rawTableIterator
-                  = table.getRawTable().iterator()) {
-            long count = Iterators.size(rawTableIterator);
-            objectCountMap.put(getTableCountKeyFromTable(tableName), count);
-          }
+          objectCountMap.put(getTableCountKeyFromTable(tableName), table.getExactKeyCount());
         }
       } catch (IOException ioEx) {
         LOG.error("Unable to populate Table Count in Recon DB.", ioEx);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to use rawTable iterator to avoid de-serializing of proto to heavy objects when iterating table to get table rows count. This will improve performance when there are large number of omkeyinfo objects in OM metadata and large ACL list.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12584

## How was this patch tested?
This patch is tested manually using docker and running existing junit and integration tests.
