### PR TITLE
HDDS-12585. Recon ContainerHealthTask ConstraintViolationException error handling.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -136,7 +136,7 @@ public class ContainerHealthSchemaManager {
           // Log the error and just update other fields of the existing record
           // in case of ConstraintViolationException being actually thrown.
           unhealthyContainersDao.update(rec);
-          LOG.error("Error while inserting unhealthy container record: {}", rec,
+          LOG.debug("Error while inserting unhealthy container record: {}", rec,
               dataAccessException);
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to handle ContainerHealthTask ConstraintViolationException during the running of ContainerHealthTask.

Currently ContainerHealthTask gets aborted when "pk_container_id" ConstraintViolationException being thrown on UNHEALTHY_CONTAINERS table. Since this is a composite key and task should not be aborted , rather Recon's container health task should update the other fields of table if "pk_container_id" ConstraintViolationException being thrown on UNHEALTHY_CONTAINERS table.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12585

## How was this patch tested?
This patch is tested using existing junit and integration tests and running in local docker cluster.
