### PR TITLE
HDDS-12586. Ozone Recon - Containers page showing incorrect count for the number of keys for various unhealthy states of containers.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -421,7 +421,7 @@ public class ContainerEndpoint {
         long containerID = c.getContainerId();
         ContainerInfo containerInfo =
             containerManager.getContainer(ContainerID.valueOf(containerID));
-        long keyCount = containerInfo.getNumberOfKeys();
+        long keyCount = reconContainerMetadataManager.getKeyCountForContainer(containerID);
         UUID pipelineID = containerInfo.getPipelineID().getId();
         List<ContainerHistory> datanodes =
             containerManager.getLatestContainerHistory(containerID,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Containers page showing incorrect count for the number of keys for various unhealthy states of containers.

Currently the API picks the key count from org.apache.hadoop.hdds.scm.container.ContainerInfo#numberOfKeys which seems inconsistent. So to correctly showing the value, we should pick using ContainerKeyMapping info where recon maintains container to key mapping for each container.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12586

## How was this patch tested?
This patch is tested using junit and integration tests and using local docker cluster.
