### PR TITLE
HDDS-12582. TypedTable support using different codec

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.lang3.ClassUtils;
 
 /**
@@ -61,6 +62,7 @@ public final class CodecRegistry {
     }
 
     <T> Codec<T> get(Class<T> clazz) {
+      Objects.requireNonNull(clazz, "clazz == null");
       final Codec<?> codec = map.get(clazz);
       return (Codec<T>) codec;
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -74,6 +74,19 @@ public interface DBStore extends Closeable, BatchOperationHandler {
       TableCache.CacheType cacheType) throws IOException;
 
   /**
+   * Gets table store with implict key/value conversion.
+   *
+   * @param name - table name
+   * @param keyCodec - key codec
+   * @param valueCodec - value codec
+   * @param cacheType - cache type
+   * @return - Table Store
+   * @throws IOException
+   */
+  <KEY, VALUE> TypedTable<KEY, VALUE> getTable(
+      String name, Codec<KEY> keyCodec, Codec<VALUE> valueCodec, TableCache.CacheType cacheType) throws IOException;
+
+  /**
    * Lists the Known list of Tables in a DB.
    *
    * @return List of Tables, in case of Rocks DB and LevelDB we will return at

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -301,6 +301,12 @@ public class RDBStore implements DBStore {
   }
 
   @Override
+  public <K, V> TypedTable<K, V> getTable(
+      String name, Codec<K> keyCodec, Codec<V> valueCodec, TableCache.CacheType cacheType) throws IOException {
+    return new TypedTable<>(getTable(name), keyCodec, valueCodec, cacheType);
+  }
+
+  @Override
   public <K, V> Table<K, V> getTable(String name,
       Class<K> keyType, Class<V> valueType,
       TableCache.CacheType cacheType) throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -161,8 +161,7 @@ public class PartialTableCache<KEY, VALUE> implements TableCache<KEY, VALUE> {
     CacheValue<VALUE> cachevalue = cache.get(cachekey);
     statsRecorder.recordValue(cachevalue);
     if (cachevalue == null) {
-      return new CacheResult<>(CacheResult.CacheStatus.MAY_EXIST,
-            null);
+      return (CacheResult<VALUE>) MAY_EXIST;
     } else {
       if (cachevalue.getCacheValue() != null) {
         return new CacheResult<>(CacheResult.CacheStatus.EXISTS, cachevalue);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability.Evolving;
 @Private
 @Evolving
 public interface TableCache<KEY, VALUE> {
+  CacheResult<?> MAY_EXIST = new CacheResult<>(CacheResult.CacheStatus.MAY_EXIST, null);
 
   /**
    * Return the value for the key if it is present, otherwise return null.
@@ -113,7 +114,8 @@ public interface TableCache<KEY, VALUE> {
   enum CacheType {
     FULL_CACHE, //  This mean's the table maintains full cache. Cache and DB
     // state are same.
-    PARTIAL_CACHE // This is partial table cache, cache state is partial state
+    PARTIAL_CACHE, // This is partial table cache, cache state is partial state
     // compared to DB state.
+    NO_CACHE
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableNoCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableNoCache.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
+import org.apache.hadoop.hdds.annotation.InterfaceStability.Evolving;
+
+/**
+ * Dummy cache implementation for the table, means key/value are not cached. 
+ * @param <KEY>
+ * @param <VALUE>
+ */
+@Private
+@Evolving
+public final class TableNoCache<KEY, VALUE> implements TableCache<KEY, VALUE> {
+  public static final CacheStats EMPTY_STAT = new CacheStats(0, 0, 0);
+
+  private static final TableCache<?, ?> NO_CACHE_INSTANCE = new TableNoCache<>();
+  public static <K, V> TableCache<K, V> instance() {
+    return (TableCache<K, V>) NO_CACHE_INSTANCE;
+  }
+
+  private TableNoCache() {
+  }
+
+  @Override
+  public CacheValue<VALUE> get(CacheKey<KEY> cachekey) {
+    return null;
+  }
+
+  @Override
+  public void loadInitial(CacheKey<KEY> key, CacheValue<VALUE> value) {
+  }
+
+  @Override
+  public void put(CacheKey<KEY> cacheKey, CacheValue<VALUE> value) {
+  }
+
+  @Override
+  public void cleanup(List<Long> epochs) {
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public Iterator<Map.Entry<CacheKey<KEY>, CacheValue<VALUE>>> iterator() {
+    return Collections.emptyIterator();
+  }
+
+  @VisibleForTesting
+  @Override
+  public void evictCache(List<Long> epochs) {
+  }
+
+  @Override
+  public CacheResult<VALUE> lookup(CacheKey<KEY> cachekey) {
+    return (CacheResult<VALUE>) MAY_EXIST;
+  }
+
+  @VisibleForTesting
+  @Override
+  public NavigableMap<Long, Set<CacheKey<KEY>>> getEpochEntries() {
+    return Collections.emptyNavigableMap();
+  }
+
+  @Override
+  public CacheStats getStats() {
+    return EMPTY_STAT;
+  }
+
+  @Override
+  public CacheType getCacheType() {
+    return CacheType.NO_CACHE;
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.protobuf.ByteString;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,6 +42,7 @@ import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.junit.jupiter.api.AfterEach;
@@ -68,7 +70,8 @@ public class TestRDBTableStore {
           "First", "Second", "Third",
           "Fourth", "Fifth",
           "Sixth", "Seventh",
-          "Eighth", "Ninth");
+          "Eighth", "Ninth",
+          "Ten");
   private final List<String> prefixedFamilies = Arrays.asList(
       "PrefixFirst",
       "PrefixTwo", "PrefixThree",
@@ -301,6 +304,19 @@ public class TestRDBTableStore {
 
       //then
       assertNull(testTable.get(key));
+    }
+  }
+
+  @Test
+  public void putGetTypedTableCodec() throws Exception {
+    try (Table<String, String> testTable = rdbStore.getTable("Ten", String.class, String.class)) {
+      testTable.put("test1", "123");
+      assertFalse(testTable.isEmpty());
+      assertEquals("123", testTable.get("test1"));
+    }
+    try (Table<String, ByteString> testTable = rdbStore.getTable("Ten",
+        StringCodec.get(), ByteStringCodec.get(), TableCache.CacheType.NO_CACHE)) {
+      assertEquals("123", testTable.get("test1").toStringUtf8());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

can create TypedTable with custom key and value Codec, this will be used for customized codec where it may be required to avoid some field for performance.

Also added TABLE_NO_CACHE type caching, so that TypedTable becomes light-weight in creation and operation; and complexity / threads present PARTIAL_TABLE_CACHE class can be avoided.

Sample:
1. 
```
// Use basic type for value codec like ByteString, and no conversion to protobuf

Table<String, ByteString> tbl3 = store.getTable(FILE_TABLE, String.class, ByteString.class,
          StringCodec.get(), ByteStringCodec.get(), TableCache.CacheType.NO_CACHE);
```
2. 
```
// Use only conversion to protobuf type, but not Ozone object deserialization

Table<String, KeyInfo> tbl4 = store.getTable(FILE_TABLE, String.class, KeyInfo.class,
          StringCodec.get(), Proto2Codec.get(KeyInfo.getDefaultInstance()), TableCache.CacheType.NO_CACHE);
```
3. 
```
// custom deserialization, with conversion of KeyInfo protobuf to OmKeyInfo not having Acl as part of getFromProtobufNoAcl()

Codec<OmKeyInfo> customCodec = new DelegatedCodec<>(
        Proto2Codec.get(KeyInfo.getDefaultInstance()),
        OmKeyInfo::getFromProtobufNoAcl,
        k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION),
        OmKeyInfo.class);

Table<String, OmKeyInfo> tbl2 = store.getTable(FILE_TABLE, String.class, OmKeyInfo.class,
          StringCodec.get(), customCodec, TableCache.CacheType.NO_CACHE);
```

Based on different codec and usecase, performance can be achieved,

```
-- Time in nano second for de
Time taken: 500751424541, cnt: 38790291, one task: 12909, msg:defaultTable
Time taken: 351664795250, cnt: 38790291, one task: 9065, msg:skip acl in omObject
Time taken: 102017933083, cnt: 38790291, one task: 2629, msg:byteString
Time taken: 296334535250, cnt: 38790291, one task: 7639, msg:only KeyInfo

for byte[] of KeyInfo proto in rocksdb:
byteString value type: takes 2.6k ns
OMKeyInfo value type: takes 13k ns
OMKeyInfo value type (skip acl): takes 9k ns

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12582

## How was this patch tested?

- no impact of existing flow, will be covered impact by existing test
