### PR TITLE
HDDS-12590. Used db name as the threadNamePrefix.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -107,7 +107,6 @@ public final class DBStoreBuilder {
   // number in request to avoid increase in heap memory.
   private long maxDbUpdatesSizeThreshold;
   private Integer maxNumberOfOpenFiles = null;
-  private String threadNamePrefix = "";
 
   /**
    * Create DBStoreBuilder from a generic DBDefinition.
@@ -233,7 +232,7 @@ public final class DBStoreBuilder {
       return new RDBStore(dbFile, rocksDBOption, statistics, writeOptions, tableConfigs,
           registry.build(), openReadOnly, maxFSSnapshots, dbJmxBeanNameName,
           enableCompactionDag, maxDbUpdatesSizeThreshold, createCheckpointDirs,
-          configuration, threadNamePrefix, enableRocksDbMetrics);
+          configuration, enableRocksDbMetrics);
     } finally {
       tableConfigs.forEach(TableConfig::close);
     }
@@ -320,11 +319,6 @@ public final class DBStoreBuilder {
 
   public DBStoreBuilder setMaxNumberOfOpenFiles(Integer maxNumberOfOpenFiles) {
     this.maxNumberOfOpenFiles = maxNumberOfOpenFiles;
-    return this;
-  }
-
-  public DBStoreBuilder setThreadNamePrefix(String prefix) {
-    this.threadNamePrefix = prefix;
     return this;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -74,7 +74,6 @@ public class RDBStore implements DBStore {
   private final long maxDbUpdatesSizeThreshold;
   private final ManagedDBOptions dbOptions;
   private final ManagedStatistics statistics;
-  private final String threadNamePrefix;
 
   @SuppressWarnings("parameternumber")
   public RDBStore(File dbFile, ManagedDBOptions dbOptions, ManagedStatistics statistics,
@@ -83,11 +82,10 @@ public class RDBStore implements DBStore {
                   String dbJmxBeanName, boolean enableCompactionDag,
                   long maxDbUpdatesSizeThreshold,
                   boolean createCheckpointDirs,
-                  ConfigurationSource configuration, String threadNamePrefix,
+                  ConfigurationSource configuration,
                   boolean enableRocksDBMetrics)
 
       throws IOException {
-    this.threadNamePrefix = threadNamePrefix;
     Preconditions.checkNotNull(dbFile, "DB file location cannot be null");
     Preconditions.checkNotNull(families);
     Preconditions.checkArgument(!families.isEmpty());
@@ -306,8 +304,7 @@ public class RDBStore implements DBStore {
   public <K, V> Table<K, V> getTable(String name,
       Class<K> keyType, Class<V> valueType,
       TableCache.CacheType cacheType) throws IOException {
-    return new TypedTable<>(getTable(name), codecRegistry, keyType,
-        valueType, cacheType, threadNamePrefix);
+    return new TypedTable<>(getTable(name), codecRegistry, keyType, valueType, cacheType);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -62,7 +62,7 @@ public class TestRDBStore {
       throws IOException {
     return new RDBStore(dbFile, options, null, new ManagedWriteOptions(), families,
         CodecRegistry.newBuilder().build(), false, 1000, null, false,
-        maxDbUpdatesSizeThreshold, true, null, "", true);
+        maxDbUpdatesSizeThreshold, true, null, true);
   }
 
   public static final int MAX_DB_UPDATES_SIZE_THRESHOLD = 80;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The actual value of threadNamePrefix parameter in the db/table related classes is always an empty string.  Let's simply use the db name as threadNamePrefix and remove the parameter.

## What is the link to the Apache JIRA

HDDS-12590

## How was this patch tested?

By existing tests