### PR TITLE
HDDS-12600. Lazily convert ACLs from protobuf in OmKeyInfo and OmDirectoryInfo

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -26,9 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -573,7 +571,7 @@ public final class OmKeyInfo extends WithParentObjectId
       return this;
     }
 
-    public Builder setAcls(Supplier<List<OzoneAcl>> listOfAcls) {
+    public Builder setAclsSupplier(Supplier<List<OzoneAcl>> listOfAcls) {
       if (listOfAcls != null) {
         this.acls = () -> {
           if (listOfAcls.get() != null) {
@@ -773,7 +771,7 @@ public final class OmKeyInfo extends WithParentObjectId
         .addAllTags(KeyValueUtil.getFromProtobuf(keyInfo.getTagsList()))
         .setFileEncryptionInfo(keyInfo.hasFileEncryptionInfo() ?
             OMPBHelper.convert(keyInfo.getFileEncryptionInfo()) : null)
-        .setAcls(() -> OzoneAclUtil.fromProtobuf(keyInfo.getAclsList()));
+        .setAclsSupplier(() -> OzoneAclUtil.fromProtobuf(keyInfo.getAclsList()));
     if (keyInfo.hasObjectID()) {
       builder.setObjectID(keyInfo.getObjectID());
     }
@@ -895,7 +893,7 @@ public final class OmKeyInfo extends WithParentObjectId
         .setDataSize(dataSize)
         .setReplicationConfig(replicationConfig)
         .setFileEncryptionInfo(encInfo)
-        .setAcls(() -> Lists.newArrayList(prevAcl.get()))
+        .setAclsSupplier(() -> Lists.newArrayList(prevAcl.get()))
         .setFileName(fileName)
         .setFile(isFile);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently on Deserialization of a bulky OmKeyInfo & OmDirectoryInfo takes a really long time if the key has too many Acls and a good amount of time is spent in the following function while converting a proto KeyInfo to Java OmKeyInfo
https://github.com/apache/ozone/blob/2f3150ab68183b8db61ee758c793fd4c1e1ee594/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java#L194
This patch proposes to lazily load the acl info if the object is going to be only read and in most of the flows these ACLs are never used and we end up wasting CPU in deserializing the entire ACL info.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12600

## How was this patch tested?
Existing unit tests & performance benchmarking in progress.