### PR TITLE
HDDS-12303. Move ozone.om.user.max.volume into OmConfig

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -651,18 +651,6 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.user.max.volume</name>
-    <value>1024</value>
-    <tag>OM, MANAGEMENT</tag>
-    <description>
-      The maximum number of volumes a user can have on a cluster.Increasing or
-      decreasing this number has no real impact on ozone cluster. This is
-      defined only for operational purposes. Only an administrator can create a
-      volume, once a volume is created there are no restrictions on the number
-      of buckets or keys inside each bucket a user can create.
-    </description>
-  </property>
-  <property>
     <name>ozone.om.db.dirs</name>
     <value/>
     <tag>OZONE, OM, STORAGE, PERFORMANCE</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -112,9 +112,6 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_VOLUME_LISTALL_ALLOWED =
       "ozone.om.volume.listall.allowed";
   public static final boolean OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT = true;
-  public static final String OZONE_OM_USER_MAX_VOLUME =
-      "ozone.om.user.max.volume";
-  public static final int OZONE_OM_USER_MAX_VOLUME_DEFAULT = 1024;
 
   public static final String OZONE_KEY_DELETING_LIMIT_PER_TASK =
       "ozone.key.deleting.limit.per.task";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OmConfig.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OmConfig.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
@@ -54,6 +55,18 @@ public class OmConfig extends ReconfigurableConfig {
   )
   private long maxListSize;
 
+  @Config(
+      key = "user.max.volume",
+      defaultValue = "1024",
+      description = "The maximum number of volumes a user can have on a cluster.Increasing or " +
+          "decreasing this number has no real impact on ozone cluster. This is " +
+          "defined only for operational purposes. Only an administrator can create a " +
+          "volume, once a volume is created there are no restrictions on the number " +
+          "of buckets or keys inside each bucket a user can create.",
+      tags = { ConfigTag.OM, ConfigTag.MANAGEMENT }
+  )
+  private int maxUserVolumeCount;
+
   public boolean isFileSystemPathEnabled() {
     return fileSystemPathEnabled;
   }
@@ -71,11 +84,23 @@ public class OmConfig extends ReconfigurableConfig {
     validate();
   }
 
+  public int getMaxUserVolumeCount() {
+    return maxUserVolumeCount;
+  }
+
+  public void setMaxUserVolumeCount(int newValue) {
+    maxUserVolumeCount = newValue;
+    validate();
+  }
+
   @PostConstruct
   public void validate() {
     if (maxListSize <= 0) {
       maxListSize = Defaults.SERVER_LIST_MAX_SIZE;
     }
+
+    Preconditions.checkArgument(this.maxUserVolumeCount > 0,
+        Keys.USER_MAX_VOLUME + " value should be greater than zero");
   }
 
   public OmConfig copy() {
@@ -87,6 +112,7 @@ public class OmConfig extends ReconfigurableConfig {
   public void setFrom(OmConfig other) {
     fileSystemPathEnabled = other.fileSystemPathEnabled;
     maxListSize = other.maxListSize;
+    maxUserVolumeCount = other.maxUserVolumeCount;
   }
 
   /**
@@ -95,6 +121,7 @@ public class OmConfig extends ReconfigurableConfig {
   public static final class Keys {
     public static final String ENABLE_FILESYSTEM_PATHS = "ozone.om.enable.filesystem.paths";
     public static final String SERVER_LIST_MAX_SIZE = "ozone.om.server.list.max.size";
+    public static final String USER_MAX_VOLUME = "ozone.om.user.max.volume";
   }
 
   /**

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/TestOmConfig.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/TestOmConfig.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -53,6 +54,14 @@ class TestOmConfig {
   }
 
   @Test
+  void throwsOnInvalidMaxUserVolume() {
+    MutableConfigurationSource conf = new OzoneConfiguration();
+    conf.setInt(OmConfig.Keys.USER_MAX_VOLUME, 0);
+
+    assertThrows(IllegalArgumentException.class, () -> conf.getObject(OmConfig.class));
+  }
+
+  @Test
   void testCopy() {
     MutableConfigurationSource conf = new OzoneConfiguration();
     OmConfig original = conf.getObject(OmConfig.class);
@@ -69,6 +78,7 @@ class TestOmConfig {
     OmConfig updated = conf.getObject(OmConfig.class);
     updated.setFileSystemPathEnabled(!updated.isFileSystemPathEnabled());
     updated.setMaxListSize(updated.getMaxListSize() + 1);
+    updated.setMaxUserVolumeCount(updated.getMaxUserVolumeCount() + 1);
 
     subject.setFrom(updated);
 
@@ -78,6 +88,7 @@ class TestOmConfig {
   private static void assertConfigEquals(OmConfig expected, OmConfig actual) {
     assertEquals(expected.getMaxListSize(), actual.getMaxListSize());
     assertEquals(expected.isFileSystemPathEnabled(), actual.isFileSystemPathEnabled());
+    assertEquals(expected.getMaxUserVolumeCount(), actual.getMaxUserVolumeCount());
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -69,8 +69,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_READ_THREADPOOL_D
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_READ_THREADPOOL_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_S3_GPRC_SERVER_ENABLED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_S3_GRPC_SERVER_ENABLED_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT;
@@ -438,9 +436,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private final ReplicationConfigValidator replicationConfigValidator;
 
   private boolean allowListAllVolumes;
-  // Adding parameters needed for VolumeRequests here, so that during request
-  // execution, we can get from ozoneManager.
-  private final long maxUserVolumeCount;
 
   private int minMultipartUploadPartSize = OzoneConsts.OM_MULTIPART_MIN_SIZE;
 
@@ -549,10 +544,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.threadPrefix = omNodeDetails.threadNamePrefix();
     loginOMUserIfSecurityEnabled(conf);
     setInstanceVariablesFromConf();
-    this.maxUserVolumeCount = conf.getInt(OZONE_OM_USER_MAX_VOLUME,
-        OZONE_OM_USER_MAX_VOLUME_DEFAULT);
-    Preconditions.checkArgument(this.maxUserVolumeCount > 0,
-        OZONE_OM_USER_MAX_VOLUME + " value should be greater than zero");
 
     if (omStorage.getState() != StorageState.INITIALIZED) {
       throw new OMException("OM not initialized, current OM storage state: "
@@ -4206,7 +4197,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @return maxUserVolumeCount
    */
   public long getMaxUserVolumeCount() {
-    return maxUserVolumeCount;
+    return config.getMaxUserVolumeCount();
   }
   /**
    * Return true, if the current OM node is leader and in ready state to


### PR DESCRIPTION
## What changes were proposed in this pull request?

To take advantage of the type safety and reduced boilerplate offered by configuration objects ([HDDS-1466](https://issues.apache.org/jira/browse/HDDS-1466)), this PR moves the definition of the ozone.om.user.max.volume parameter into OmConfig, and updates its single usage accordingly.

In addition to the steps described on [HDDS-12303](https://issues.apache.org/jira/browse/HDDS-12303), the following changes are also made:

- Removing the definition from ozone-default.xml, as it is now generated from the annotations.
- Removing the configuration key and default from OMConfigKeys, as there are no usages left.
- Removing the now unused imports from OzoneManager.
- Adding the full configuration key to OmConfig to allow keeping the validation unchanged in a straightforward way.
- Including the new member in copy() and setFrom(), with the rationale that if they are offered as such, they should be complete. (Even though they seem to be intended for use in specific tests that make no changes to the parameter.)
- Adding a setter for the new member to allow updating TestOmConfig.testSetFrom().
- Updating the assertion corresponding to said update.
- Adding a unit test to cover the validation moved to OmConfig.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12303

## How was this patch tested?

- Manually: Starting an OM in IntelliJ, and checking the value and source returned by its /conf endpoint. This was done before and after removing the parameter from ozone-default.xml, and after specifying a non-default value in ozone-site.xml.
- New and updated unit tests as described above.
- CI on fork: https://github.com/octachoron/ozone/actions/runs/13849087215
