### PR TITLE
HDDS-12601. Ozone Recon - Unknown tar ball cleanup for Recon OM DB snapshot.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -63,6 +63,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -555,6 +556,7 @@ public class ReconUtils {
             }
           } catch (NumberFormatException nfEx) {
             log.warn("Unknown file found in Recon DB dir : {}", fileName);
+            FileUtils.deleteQuietly(snapshotFile);
           }
         }
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -408,7 +408,6 @@ public class OzoneManagerServiceProviderImpl
       // Untar the checkpoint file.
       Path untarredDbDir = Paths.get(omSnapshotDBParentDir.getAbsolutePath(), snapshotFileName);
       reconUtils.untarCheckpointFile(targetFile, untarredDbDir);
-      FileUtils.deleteQuietly(targetFile);
 
       // Validate the presence of required SST files
       File[] sstFiles = untarredDbDir.toFile().listFiles((dir, name) -> name.endsWith(".sst"));
@@ -430,6 +429,8 @@ public class OzoneManagerServiceProviderImpl
       LOG.error("Unable to obtain Ozone Manager DB Snapshot. ", e);
       reconContext.updateHealthStatus(new AtomicBoolean(false));
       reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+    } finally {
+      FileUtils.deleteQuietly(targetFile);
     }
     return null;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to address tar ball cleanup issue.
When Recon start or restart, it check for existing OM DB snapshot file, so if there is some old tar file left out in recon om db directory location, there is a possibility that it will be left out forever occupying the disk space and needs cleanup if tar ball is huge in size.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12601

## How was this patch tested?
This patch was tested manually using local docker cluster,