### PR TITLE
HDDS-12557. Added progress indicator for checkpoint tarball in leader OM

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -620,18 +620,20 @@ public final class HddsServerUtil {
     }
   }
 
-  public static void includeFile(File file, String entryName,
+  public static long includeFile(File file, String entryName,
                                  ArchiveOutputStream archiveOutputStream)
       throws IOException {
     ArchiveEntry archiveEntry =
         archiveOutputStream.createArchiveEntry(file, entryName);
     archiveOutputStream.putArchiveEntry(archiveEntry);
+    long bytesWritten;
     try (InputStream fis = Files.newInputStream(file.toPath())) {
-      IOUtils.copy(fis, archiveOutputStream);
+      bytesWritten = IOUtils.copy(fis, archiveOutputStream);
       archiveOutputStream.flush();
     } finally {
       archiveOutputStream.closeArchiveEntry();
     }
+    return bytesWritten;
   }
 
   // Mark tarball completed.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -324,8 +324,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             counters.getFileCounter().get(),
             (includeSnapshotData ? ", snapshots: " + totalSnapshots : ""));
       } catch (Exception e) {
-        LOG.error("Could not determine estimated size of transfer to " +
-            "Checkpoint Tarball Stream", e);
+        LOG.error("Could not estimate size of transfer to Checkpoint Tarball Stream.", e);
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -303,7 +303,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
     // Log estimated total data transferred on first request.
     if (sstFilesToExclude.isEmpty()) {
-      logTotals(checkpoint, includeSnapshotData);
+      logEstimatedTarballSize(checkpoint, includeSnapshotData);
     }
 
     // Get the active fs files.
@@ -338,7 +338,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         compactionLogDir.getOriginalDir().toPath());
   }
 
-  private void logTotals(
+  private void logEstimatedTarballSize(
       DBCheckpoint checkpoint, boolean includeSnapshotData) {
     try {
       Counters.PathCounters counters = Counters.longPathCounters();


### PR DESCRIPTION
## What changes were proposed in this pull request?

No logs to indicate checkpoint tarball in leader OM. 
Added logs to provide an initial estimate of the amount of data, number of files and snapshots to be transferred in the tarball stream.
Added progress indicator logs every 30s detailing # sst files and size of data trasferred per request. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12557

## How was this patch tested?

Manually tested with docker with a progress log interval of `500ms`
Leader OM: 
```
INFO om.OMDBCheckpointServlet: Estimates for Checkpoint Tarball Stream - Data size: 64190 KB, SST files: 48317, snapshots: 300
INFO om.OMDBCheckpointServlet: Transferred 91266 KB, #files 2774 to checkpoint tarball stream... // Will print every 30s. 
INFO om.OMDBCheckpointServlet: Completed transfer of 106103 KB, #files 3183 to checkpoint tarball stream. Checkpoint tarball is complete. // excluding hard links.
```

As usual the follower tracks the amount of data transferred
Follower OM:
```
INFO ratis_snapshot.OmRatisSnapshotProvider: Downloading latest checkpoint from Leader OM om1. Checkpoint: om.db-om1-1742344843952.tar URL: http://om1:9874/dbCheckpoint?includeSnapshotData=true&flushBeforeCheckpoint=true
INFO ratis_snapshot.OmRatisSnapshotProvider: Download completed for 'om.db-om1-1742344843952.tar'. Total size: 116045 KB
```

