### PR TITLE
HDDS-12565. Treat volumeFreeSpaceToSpare as reserved space

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -619,13 +619,9 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
       SpaceUsageSource usage = volume.getCurrentUsage();
-      long volumeCapacity = usage.getCapacity();
-      long volumeFreeSpaceToSpare =
-          freeSpaceCalculator.get(volumeCapacity);
-      long volumeFree = usage.getAvailable();
-      long volumeCommitted = volume.getCommittedBytes();
-      long volumeAvailable = volumeFree - volumeCommitted;
-      return (volumeAvailable <= volumeFreeSpaceToSpare);
+      long volumeFreeSpaceToSpare = freeSpaceCalculator.get(usage.getCapacity());
+      return !VolumeUsage.hasVolumeEnoughSpace(usage.getAvailable(), volume.getCommittedBytes(), 0,
+          volumeFreeSpaceToSpare);
     }
     return false;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -184,8 +184,7 @@ public class VolumeUsage {
                                              long volumeCommittedBytesCount,
                                              long requiredSpace,
                                              long volumeFreeSpaceToSpare) {
-    return (volumeAvailableSpace - volumeCommittedBytesCount) >
-        (requiredSpace + volumeFreeSpaceToSpare);
+    return (volumeAvailableSpace - volumeCommittedBytesCount - volumeFreeSpaceToSpare) > requiredSpace;
   }
 
   private static long getReserved(ConfigurationSource conf, String rootDir,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -185,7 +185,7 @@ public class VolumeUsage {
                                              long requiredSpace,
                                              long volumeFreeSpaceToSpare) {
     return (volumeAvailableSpace - volumeCommittedBytesCount) >
-        Math.max(requiredSpace, volumeFreeSpaceToSpare);
+        (requiredSpace + volumeFreeSpaceToSpare);
   }
 
   private static long getReserved(ConfigurationSource conf, String rootDir,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -252,9 +252,9 @@ public class TestHddsDispatcher {
     HddsVolume.Builder volumeBuilder =
         new HddsVolume.Builder(testDirPath).datanodeUuid(dd.getUuidString())
             .conf(conf).usageCheckFactory(MockSpaceUsageCheckFactory.NONE);
-    // state of cluster : available (140) > 100  ,datanode volume
+    // state of cluster : available (160) > 100  ,datanode volume
     // utilisation threshold not yet reached. container creates are successful.
-    AtomicLong usedSpace = new AtomicLong(360);
+    AtomicLong usedSpace = new AtomicLong(340);
     SpaceUsageSource spaceUsage = MockSpaceUsageSource.of(500, usedSpace);
 
     SpaceUsageCheckFactory factory = MockSpaceUsageCheckFactory.of(
@@ -268,6 +268,7 @@ public class TestHddsDispatcher {
       ContainerSet containerSet = newContainerSet();
       StateContext context = ContainerTestUtils.getMockContext(dd, conf);
       // create a 50 byte container
+      // available (160) > 100 (min free space) + 50 (container size)
       KeyValueContainerData containerData = new KeyValueContainerData(1L,
           layoutVersion,
           50, UUID.randomUUID().toString(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

`VolumeUsage#hasVolumeEnoughSpace` should treat volumeFreeSpaceToSpare as reserved space.
Currently it's allowed to allocate space from `volumeFreeSpaceToSpare`.
```java
public static boolean hasVolumeEnoughSpace(long volumeAvailableSpace,
                                           long volumeCommittedBytesCount,
                                           long requiredSpace,
                                           long volumeFreeSpaceToSpare) {
  return (volumeAvailableSpace - volumeCommittedBytesCount) >
      Math.max(requiredSpace, volumeFreeSpaceToSpare);
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12565

## How was this patch tested?

CI:
~~https://github.com/peterxcli/ozone/actions/runs/13868674388~~
~~https://github.com/peterxcli/ozone/actions/runs/13869299568~~
https://github.com/peterxcli/ozone/actions/runs/13917800381