### PR TITLE
HDDS-12551. Replace dnsToUuidMap with dnsToDnIdMap in SCMNodeManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -152,6 +152,7 @@ public class SCMNodeManager implements NodeManager {
    * Constructs SCM machine Manager.
    */
   public SCMNodeManager(
+
       OzoneConfiguration conf,
       SCMStorageConfig scmStorageConfig,
       EventPublisher eventPublisher,
@@ -1741,7 +1742,7 @@ public class SCMNodeManager implements NodeManager {
     datanodeIDS.forEach(datanodeID -> {
       try {
         List<DatanodeDetails> datanodeDetails = allNodes.stream().
-            filter(node -> node.getID().getID().equals(datanodeID.getID())).
+            filter(node -> node.getID().equals(datanodeID)).
             collect(Collectors.toList());
         results.addAll(datanodeDetails);
       } catch (Exception e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -53,6 +53,7 @@ import javax.management.ObjectName;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -126,7 +127,7 @@ public class SCMNodeManager implements NodeManager {
   private final NetworkTopology clusterMap;
   private final Function<String, String> nodeResolver;
   private final boolean useHostname;
-  private final Map<String, Set<UUID>> dnsToUuidMap = new ConcurrentHashMap<>();
+  private final Map<String, Set<DatanodeID>> dnsToDnIdMap = new ConcurrentHashMap<>();
   private final int numPipelinesPerMetadataVolume;
   private final int heavyNodeCriteria;
   private final HDDSLayoutVersionManager scmLayoutVersionManager;
@@ -409,7 +410,7 @@ public class SCMNodeManager implements NodeManager {
       datanodeDetails.setNetworkLocation(networkLocation);
     }
 
-    final UUID uuid = datanodeDetails.getUuid();
+    final DatanodeID dnId = datanodeDetails.getID();
     if (!isNodeRegistered(datanodeDetails)) {
       try {
         clusterMap.add(datanodeDetails);
@@ -417,7 +418,7 @@ public class SCMNodeManager implements NodeManager {
         // Check that datanode in nodeStateManager has topology parent set
         DatanodeDetails dn = nodeStateManager.getNode(datanodeDetails);
         Preconditions.checkState(dn.getParent() != null);
-        addToDnsToUuidMap(uuid, ipAddress, hostName);
+        addToDnsToDnIdMap(dnId, ipAddress, hostName);
         // Updating Node Report, as registration is successful
         processNodeReport(datanodeDetails, nodeReport);
         LOG.info("Registered datanode: {}", datanodeDetails.toDebugString());
@@ -436,7 +437,7 @@ public class SCMNodeManager implements NodeManager {
       try {
         final DatanodeInfo oldNode = nodeStateManager.getNode(datanodeDetails);
         if (updateDnsToUuidMap(oldNode.getHostName(), oldNode.getIpAddress(),
-            hostName, ipAddress, uuid)) {
+            hostName, ipAddress, dnId)) {
           LOG.info("Updating datanode {} from {} to {}",
                   datanodeDetails.getUuidString(),
                   oldNode,
@@ -472,23 +473,23 @@ public class SCMNodeManager implements NodeManager {
    * and each host can have multiple addresses,
    * this is a many to many mapping.
    *
-   * @param uuid the UUID of the registered node.
+   * @param datanodeID the DataNodeID of the registered node.
    * @param addresses hostname and/or IP of the node
    */
-  private synchronized void addToDnsToUuidMap(UUID uuid, String... addresses) {
+  private synchronized void addToDnsToDnIdMap(DatanodeID datanodeID, String... addresses) {
     for (String addr : addresses) {
       if (!Strings.isNullOrEmpty(addr)) {
-        dnsToUuidMap.computeIfAbsent(addr, k -> ConcurrentHashMap.newKeySet())
-            .add(uuid);
+        dnsToDnIdMap.computeIfAbsent(addr, k -> ConcurrentHashMap.newKeySet())
+            .add(datanodeID);
       }
     }
   }
 
-  private synchronized void removeFromDnsToUuidMap(UUID uuid, String address) {
+  private synchronized void removeFromDnsToUuidMap(DatanodeID datanodeID, String address) {
     if (address != null) {
-      Set<UUID> dnSet = dnsToUuidMap.get(address);
-      if (dnSet != null && dnSet.remove(uuid) && dnSet.isEmpty()) {
-        dnsToUuidMap.remove(address);
+      Set<DatanodeID> dnSet = dnsToDnIdMap.get(address);
+      if (dnSet != null && dnSet.remove(datanodeID) && dnSet.isEmpty()) {
+        dnsToDnIdMap.remove(address);
       }
     }
   }
@@ -496,18 +497,18 @@ public class SCMNodeManager implements NodeManager {
   private boolean updateDnsToUuidMap(
       String oldHostName, String oldIpAddress,
       String newHostName, String newIpAddress,
-      UUID uuid) {
+      DatanodeID datanodeID) {
     final boolean ipChanged = !Objects.equals(oldIpAddress, newIpAddress);
     final boolean hostNameChanged = !Objects.equals(oldHostName, newHostName);
     if (ipChanged || hostNameChanged) {
       synchronized (this) {
         if (ipChanged) {
-          removeFromDnsToUuidMap(uuid, oldIpAddress);
-          addToDnsToUuidMap(uuid, newIpAddress);
+          removeFromDnsToUuidMap(datanodeID, oldIpAddress);
+          addToDnsToDnIdMap(datanodeID, newIpAddress);
         }
         if (hostNameChanged) {
-          removeFromDnsToUuidMap(uuid, oldHostName);
-          addToDnsToUuidMap(uuid, newHostName);
+          removeFromDnsToUuidMap(datanodeID, oldHostName);
+          addToDnsToDnIdMap(datanodeID, newHostName);
         }
       }
     }
@@ -1725,24 +1726,29 @@ public class SCMNodeManager implements NodeManager {
    */
   @Override
   public List<DatanodeDetails> getNodesByAddress(String address) {
+    List<DatanodeDetails> allNodes = getAllNodes();
     List<DatanodeDetails> results = new LinkedList<>();
     if (Strings.isNullOrEmpty(address)) {
       LOG.warn("address is null");
       return results;
     }
-    Set<UUID> uuids = dnsToUuidMap.get(address);
-    if (uuids == null) {
+    Set<DatanodeID> datanodeIDS = dnsToDnIdMap.get(address);
+    if (datanodeIDS == null) {
       LOG.debug("Cannot find node for address {}", address);
       return results;
     }
 
-    for (UUID uuid : uuids) {
+    datanodeIDS.forEach(datanodeID -> {
       try {
-        results.add(nodeStateManager.getNode(uuid));
-      } catch (NodeNotFoundException e) {
-        LOG.warn("Cannot find node for uuid {}", uuid);
+        allNodes.forEach(node -> {
+          if (node.getID().getID().equals(datanodeID.getID())) {
+            results.add(node);
+          }
+        });
+      } catch(Exception e) {
+        LOG.warn("Cannot find node for uuid {}", datanodeID);
       }
-    }
+    });
     return results;
   }
 
@@ -1845,7 +1851,7 @@ public class SCMNodeManager implements NodeManager {
           clusterMap.remove(datanodeDetails);
         }
         nodeStateManager.removeNode(datanodeDetails);
-        removeFromDnsToUuidMap(datanodeDetails.getUuid(), datanodeDetails.getIpAddress());
+        removeFromDnsToUuidMap(datanodeDetails.getID(), datanodeDetails.getIpAddress());
         final List<SCMCommand<?>> cmdList = getCommandQueue(datanodeDetails.getUuid());
         LOG.info("Clearing command queue of size {} for DN {}", cmdList.size(), datanodeDetails);
       } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1745,7 +1745,7 @@ public class SCMNodeManager implements NodeManager {
             results.add(node);
           }
         });
-      } catch(Exception e) {
+      } catch (Exception e) {
         LOG.warn("Cannot find node for uuid {}", datanodeID);
       }
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?
In `SCMNodeManager`, we maintain `DNS` to `Datanode` mapping. This is currently using `UUID` to represent `Datanode`, we can replace the `UUID` with `DatanodeID`.

## What is the link to the Apache JIRA
[HDDS-12551](https://issues.apache.org/jira/browse/HDDS-12551)

## How was this patch tested?
It can test by CI.