### PR TITLE
HDDS-12611. Snapshot creation is removing extra keys from AOS's DB

### DIFF
--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -121,6 +121,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
    *
    * @param volume - Volume name
    * @param bucket - Bucket name
+   * @return /volume/bucket/
    */
   String getBucketKeyPrefix(String volume, String bucket);
 
@@ -129,6 +130,8 @@ public interface OMMetadataManager extends DBStoreHAManager {
    *
    * @param volume - Volume name
    * @param bucket - Bucket name
+   * @return /volumeId/bucketId/
+   *    e.g. /-9223372036854772480/-9223372036854771968/
    */
   String getBucketKeyPrefixFSO(String volume, String bucket) throws IOException;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -42,7 +42,6 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager.getSnapshotRootPath;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotActive;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.dropColumnFamilyHandle;
-import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getOzonePathKeyForFso;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -499,8 +498,7 @@ public final class OmSnapshotManager implements AutoCloseable {
       String bucketName, BatchOperation batchOperation) throws IOException {
 
     // Range delete start key (inclusive)
-    final String keyPrefix = getOzonePathKeyForFso(omMetadataManager,
-        volumeName, bucketName);
+    final String keyPrefix = omMetadataManager.getBucketKeyPrefixFSO(volumeName, bucketName);
 
     try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
          iter = omMetadataManager.getDeletedDirTable().iterator(keyPrefix)) {
@@ -566,7 +564,7 @@ public final class OmSnapshotManager implements AutoCloseable {
 
     // Range delete start key (inclusive)
     final String keyPrefix =
-        omMetadataManager.getOzoneKey(volumeName, bucketName, "");
+        omMetadataManager.getBucketKeyPrefix(volumeName, bucketName);
 
     try (TableIterator<String,
         ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDirectoryCleaningService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDirectoryCleaningService.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.om.service;
 
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getDirectoryInfo;
-import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getOzonePathKeyForFso;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getPreviousSnapshot;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -207,7 +206,7 @@ public class SnapshotDirectoryCleaningService
                   .getKeyTable(bucketInfo.getBucketLayout());
             }
 
-            String dbBucketKeyForDir = getOzonePathKeyForFso(metadataManager,
+            String dbBucketKeyForDir = metadataManager.getBucketKeyPrefixFSO(
                 currSnapInfo.getVolumeName(), currSnapInfo.getBucketName());
             try (ReferenceCounted<OmSnapshot>
                      rcCurrOmSnapshot = omSnapshotManager.getActiveSnapshot(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -221,59 +220,14 @@ public final class SnapshotUtils {
       String volumeName,
       String bucketName
   ) throws IOException {
-    String keyPrefix = getOzonePathKey(volumeName, bucketName);
-    String keyPrefixFso = getOzonePathKeyForFso(omMetadataManager, volumeName,
-        bucketName);
+    String keyPrefix = omMetadataManager.getBucketKeyPrefix(volumeName, bucketName);
+    String keyPrefixFso = omMetadataManager.getBucketKeyPrefixFSO(volumeName, bucketName);
 
     Map<String, String> columnFamilyToPrefixMap = new HashMap<>();
     columnFamilyToPrefixMap.put(KEY_TABLE, keyPrefix);
     columnFamilyToPrefixMap.put(DIRECTORY_TABLE, keyPrefixFso);
     columnFamilyToPrefixMap.put(FILE_TABLE, keyPrefixFso);
     return columnFamilyToPrefixMap;
-  }
-
-  /**
-   * Helper method to generate /volumeName/bucketBucket/ DB key prefix from
-   * given volume name and bucket name as a prefix for legacy and OBS buckets.
-   * Follows:
-   * {@link OmMetadataManagerImpl#getOzonePathKey(long, long, long, String)}.
-   * <p>
-   * Note: Currently, this is only intended to be a special use case in
-   * Snapshot. If this is used elsewhere, consider moving this to
-   * {@link OMMetadataManager}.
-   *
-   * @param volumeName volume name
-   * @param bucketName bucket name
-   * @return /volumeName/bucketName/
-   */
-  public static String getOzonePathKey(String volumeName,
-                                       String bucketName) throws IOException {
-    return OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName +
-        OM_KEY_PREFIX;
-  }
-
-  /**
-   * Helper method to generate /volumeId/bucketId/ DB key prefix from given
-   * volume name and bucket name as a prefix for FSO buckets.
-   * Follows:
-   * {@link OmMetadataManagerImpl#getOzonePathKey(long, long, long, String)}.
-   * <p>
-   * Note: Currently, this is only intended to be a special use case in
-   * Snapshot. If this is used elsewhere, consider moving this to
-   * {@link OMMetadataManager}.
-   *
-   * @param volumeName volume name
-   * @param bucketName bucket name
-   * @return /volumeId/bucketId/
-   *    e.g. /-9223372036854772480/-9223372036854771968/
-   */
-  public static String getOzonePathKeyForFso(OMMetadataManager metadataManager,
-                                             String volumeName,
-                                             String bucketName)
-      throws IOException {
-    final long volumeId = metadataManager.getVolumeId(volumeName);
-    final long bucketId = metadataManager.getBucketId(volumeName, bucketName);
-    return OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId + OM_KEY_PREFIX;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
-import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateSnapshotResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -211,8 +210,7 @@ public class TestOMSnapshotCreateResponse {
     // Add deletedDirectoryTable key entries that "surround" the snapshot scope
     Set<String> sentinelKeys = new HashSet<>();
 
-    final String dbKeyPfx = SnapshotUtils.getOzonePathKeyForFso(
-            omMetadataManager, volumeName, bucketName);
+    final String dbKeyPfx = omMetadataManager.getBucketKeyPrefixFSO(volumeName, bucketName);
 
     // Calculate offset to bucketId's last character in dbKeyPfx.
     // First -1 for offset, second -1 for second to last char (before '/')


### PR DESCRIPTION
## What changes were proposed in this pull request?
On snapshot creation, the correct bucket prefix is not used to remove keys from `deletedTable` of AOS’s DB. Prefix does not end with `/ `([code](https://github.com/apache/ozone/blob/f7e9aedf49e005f219845f2911b92f66cec24bcf/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java#L568)) which means for snapshot creation on bucket `/vol1/buck1`, it will move all the keys belonging to bucket `/vol1/buck1` and buckets `/vol1/buck1[.*]`. And keys for buckets `/vol1/buck1[.*]` will be trapped inside the snapshot and never be reclaimed, causing orphan data blocks because `KeytDeletingService` and `SnapshotDeletingService` use the correct bucket prefix. 

This change includes:
- Remove keys from `deletedTable` by using the correct bucket prefix (ending with `/`). So that 
- Removed duplicate functions from SnapshotUtils and the same function everywhere.

## What is the link to the Apache JIRA
HDDS-12611

## How was this patch tested?
Existing test for now. Created HDDS-12612 to add through integration tests for HDDS-12611.
