### PR TITLE
HDDS-12614. Configurable java version in flaky-test-check with default to 21

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -61,7 +61,7 @@ env:
   RATIS_REPO: ${{ github.event.inputs.ratis-repo }}
   RATIS_VERSION: ${{ github.event.inputs.ratis-ref }}
   JAVA_VERSION: ${{ github.event.inputs.java-version }}
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations) || '' }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}-java{5}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations, inputs.java-version) || '' }}
 jobs:
   prepare-job:
     runs-on: ubuntu-24.04

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -48,6 +48,10 @@ on:
         description: Ratis ref (branch, tag or commit SHA)
         default: ''
         required: false
+      java-version:
+        description: Java version to use
+        default: '21'
+        required: true
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   TEST_CLASS: ${{ github.event.inputs.test-class}}
@@ -56,6 +60,7 @@ env:
   FAIL_FAST: ${{ github.event.inputs.fail-fast }}
   RATIS_REPO: ${{ github.event.inputs.ratis-repo }}
   RATIS_VERSION: ${{ github.event.inputs.ratis-ref }}
+  JAVA_VERSION: ${{ github.event.inputs.java-version }}
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations) || '' }}
 jobs:
   prepare-job:
@@ -112,7 +117,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: ${{ github.event.inputs.java-version }}
       - name: Build (most) of Ozone
         run: |
           args="-DskipRecon -DskipShade -Dmaven.javadoc.skip=true"
@@ -176,7 +181,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: ${{ github.event.inputs.java-version }}
       - name: Execute tests
         run: |
           if [[ -e "${{ steps.download-ozone-repo.outputs.download-path }}" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just noticed that flaky-test-check ci workflow still use java 8 to run.
Currently, main ci test run with java 21. We should align to it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12614

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/13883456997

trigger flaky-test-check:
- java 21: https://github.com/peterxcli/ozone/actions/runs/13883465124
  ![image](https://github.com/user-attachments/assets/232284f5-2122-4703-b5f1-76c24d1c8294)
- java 8: https://github.com/peterxcli/ozone/actions/runs/13883472806
  ![image](https://github.com/user-attachments/assets/9f2a41fb-6125-4055-8feb-f66510101db6)


