### PR TITLE
HDDS-12602. Intermittent failure in TestContainerStateMachine.testWriteFailure

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachine.java
@@ -123,6 +123,9 @@ abstract class TestContainerStateMachine {
     RaftProtos.LogEntryProto entry = mock(RaftProtos.LogEntryProto.class);
     when(entry.getTerm()).thenReturn(1L);
     when(entry.getIndex()).thenReturn(1L);
+    RaftProtos.LogEntryProto entryNext = mock(RaftProtos.LogEntryProto.class);
+    when(entryNext.getTerm()).thenReturn(1L);
+    when(entryNext.getIndex()).thenReturn(2L);
     TransactionContext trx = mock(TransactionContext.class);
     ContainerStateMachine.Context context = mock(ContainerStateMachine.Context.class);
     when(trx.getStateMachineContext()).thenReturn(context);
@@ -167,7 +170,7 @@ abstract class TestContainerStateMachine {
                     ContainerProtos.DatanodeBlockID.newBuilder().setContainerID(2).setLocalID(1).build()).build())
         .setContainerID(2)
         .setDatanodeUuid(UUID.randomUUID().toString()).build());
-    stateMachine.write(entry, trx).exceptionally(throwableSetter).get();
+    stateMachine.write(entryNext, trx).exceptionally(throwableSetter).get();
     verify(dispatcher, times(0)).dispatch(any(ContainerProtos.ContainerCommandRequestProto.class),
         any(DispatcherContext.class));
     assertInstanceOf(StorageContainerException.class, throwable.get());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineFollower.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineFollower.java
@@ -17,12 +17,9 @@
 
 package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
-import org.apache.ozone.test.tag.Flaky;
-
 /**
  * Test class to ContainerStateMachine class for follower.
  */
-@Flaky("HDDS-12602")
 public class TestContainerStateMachineFollower extends TestContainerStateMachine {
   public TestContainerStateMachineFollower() {
     super(false);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineLeader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineLeader.java
@@ -17,12 +17,9 @@
 
 package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
-import org.apache.ozone.test.tag.Flaky;
-
 /**
  * Test class to ContainerStateMachine class for leader.
  */
-@Flaky("HDDS-12602")
 public class TestContainerStateMachineLeader extends TestContainerStateMachine {
   public TestContainerStateMachineLeader() {
     super(true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.554 s <<< FAILURE! -- in org.apache.hadoop.ozone.container.common.transport.server.ratis.TestContainerStateMachineFollower
org.apache.hadoop.ozone.container.common.transport.server.ratis.TestContainerStateMachineFollower.testWriteFailure(boolean)[2] -- Time elapsed: 0.024 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <CONTAINER_UNHEALTHY> but was: <CONTAINER_INTERNAL_ERROR>
  ...
  at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
  at org.apache.hadoop.ozone.container.common.transport.server.ratis.TestContainerStateMachine.testWriteFailure(TestContainerStateMachine.java:175)
  at org.apache.hadoop.ozone.container.common.transport.server.ratis.TestContainerStateMachineFollower.testWriteFailure(TestContainerStateMachineFollower.java:23)
```

---

@chungen0126: The first write and the second write are writing to the same entry, causing them to interfere with each other. The first write has not yet been completed by the chunkExecutor when the second write is in progress, causing the second write to detect the first write's entry.

So use different entry with incremental index for SM to write wont get the [in-flight writeChunk future](https://github.com/peterxcli/ozone/blob/d5ee708619df15ace7a4007c80e5c5a2cff9a178/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java#L578-L581)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12602

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/13899997432

flaky test check:
https://github.com/peterxcli/ozone/actions/runs/13900193243