### PR TITLE
HDDS-12617. Use DatanodeID as keys in NodeStateMap.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -377,8 +377,8 @@ public class NodeStateManager implements Runnable, Closeable {
     return getNode(datanodeDetails.getID());
   }
 
-  public DatanodeInfo getNode(DatanodeID uuid) throws NodeNotFoundException {
-    return nodeStateMap.getNodeInfo(uuid);
+  public DatanodeInfo getNode(DatanodeID datanodeID) throws NodeNotFoundException {
+    return nodeStateMap.getNodeInfo(datanodeID);
   }
 
   /**
@@ -713,14 +713,14 @@ public class NodeStateManager implements Runnable, Closeable {
    * synchronization or side effects.
    * @return - set of containerIDs
    */
-  public Set<ContainerID> getContainers(DatanodeID uuid)
+  public Set<ContainerID> getContainers(DatanodeID datanodeID)
       throws NodeNotFoundException {
-    return nodeStateMap.getContainers(uuid);
+    return nodeStateMap.getContainers(datanodeID);
   }
 
-  public int getContainerCount(DatanodeID uuid)
+  public int getContainerCount(DatanodeID datanodeID)
       throws NodeNotFoundException {
-    return nodeStateMap.getContainerCount(uuid);
+    return nodeStateMap.getContainerCount(datanodeID);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -43,6 +43,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
@@ -309,12 +310,11 @@ public class NodeStateManager implements Runnable, Closeable {
       LayoutVersionProto layoutInfo) throws NodeAlreadyExistsException {
     NodeStatus newNodeStatus = newNodeStatus(datanodeDetails, layoutInfo);
     nodeStateMap.addNode(datanodeDetails, newNodeStatus, layoutInfo);
-    UUID dnID = datanodeDetails.getUuid();
     try {
       updateLastKnownLayoutVersion(datanodeDetails, layoutInfo);
     } catch (NodeNotFoundException ex) {
-      LOG.error("Inconsistent NodeStateMap! Datanode with ID {} was " +
-          "added but not found in  map: {}", dnID, nodeStateMap);
+      throw new IllegalStateException("Inconsistent NodeStateMap! Datanode "
+          + datanodeDetails.getID() + " was added but not found in map: " + nodeStateMap);
     }
   }
 
@@ -374,11 +374,10 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public DatanodeInfo getNode(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    return getNode(datanodeDetails.getUuid());
+    return getNode(datanodeDetails.getID());
   }
 
-  public DatanodeInfo getNode(UUID uuid)
-      throws NodeNotFoundException {
+  public DatanodeInfo getNode(DatanodeID uuid) throws NodeNotFoundException {
     return nodeStateMap.getNodeInfo(uuid);
   }
 
@@ -389,7 +388,7 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public void updateLastHeartbeatTime(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    nodeStateMap.getNodeInfo(datanodeDetails.getUuid())
+    nodeStateMap.getNodeInfo(datanodeDetails.getID())
         .updateLastHeartbeatTime();
   }
 
@@ -403,7 +402,7 @@ public class NodeStateManager implements Runnable, Closeable {
   public void updateLastKnownLayoutVersion(DatanodeDetails datanodeDetails,
                                       LayoutVersionProto layoutInfo)
       throws NodeNotFoundException {
-    nodeStateMap.getNodeInfo(datanodeDetails.getUuid())
+    nodeStateMap.getNodeInfo(datanodeDetails.getID())
         .updateLastKnownLayoutVersion(layoutInfo);
   }
 
@@ -417,8 +416,7 @@ public class NodeStateManager implements Runnable, Closeable {
   public void updateNode(DatanodeDetails datanodeDetails,
                          LayoutVersionProto layoutInfo)
           throws NodeNotFoundException {
-    DatanodeInfo datanodeInfo =
-            nodeStateMap.getNodeInfo(datanodeDetails.getUuid());
+    final DatanodeInfo datanodeInfo = nodeStateMap.getNodeInfo(datanodeDetails.getID());
     NodeStatus newNodeStatus = newNodeStatus(datanodeDetails, layoutInfo);
     LOG.info("updating node {} from {} to {} with status {}",
             datanodeDetails.getUuidString(),
@@ -440,7 +438,7 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    return nodeStateMap.getNodeStatus(datanodeDetails.getUuid());
+    return nodeStateMap.getNodeStatus(datanodeDetails.getID());
   }
 
   /**
@@ -582,12 +580,12 @@ public class NodeStateManager implements Runnable, Closeable {
   public void setNodeOperationalState(DatanodeDetails dn,
       NodeOperationalState newState,
       long stateExpiryEpochSec)  throws NodeNotFoundException {
-    DatanodeInfo dni = nodeStateMap.getNodeInfo(dn.getUuid());
+    final DatanodeID id = dn.getID();
+    final DatanodeInfo dni = nodeStateMap.getNodeInfo(id);
     NodeStatus oldStatus = dni.getNodeStatus();
     if (oldStatus.getOperationalState() != newState ||
         oldStatus.getOpStateExpiryEpochSeconds() != stateExpiryEpochSec) {
-      nodeStateMap.updateNodeOperationalState(
-          dn.getUuid(), newState, stateExpiryEpochSec);
+      nodeStateMap.updateNodeOperationalState(id, newState, stateExpiryEpochSec);
       // This will trigger an event based on the nodes health when the
       // operational state changes. Eg a node that was IN_MAINTENANCE goes
       // to IN_SERVICE + HEALTHY. This will trigger the HEALTHY node event to
@@ -680,56 +678,47 @@ public class NodeStateManager implements Runnable, Closeable {
 
   /**
    * Adds the given container to the specified datanode.
-   *
-   * @param uuid - datanode uuid
-   * @param containerId - containerID
    * @throws NodeNotFoundException - if datanode is not known. For new datanode
    *                        use addDatanodeInContainerMap call.
    */
-  public void addContainer(final UUID uuid,
+  public void addContainer(final DatanodeID datanodeID,
                            final ContainerID containerId)
       throws NodeNotFoundException {
-    nodeStateMap.addContainer(uuid, containerId);
+    nodeStateMap.addContainer(datanodeID, containerId);
   }
 
   /**
    * Removes the given container from the specified datanode.
-   *
-   * @param uuid - datanode uuid
-   * @param containerId - containerID
    * @throws NodeNotFoundException - if datanode is not known. For new datanode
    *                        use addDatanodeInContainerMap call.
    */
-  public void removeContainer(final UUID uuid,
+  public void removeContainer(final DatanodeID datanodeID,
                            final ContainerID containerId)
       throws NodeNotFoundException {
-    nodeStateMap.removeContainer(uuid, containerId);
+    nodeStateMap.removeContainer(datanodeID, containerId);
   }
 
   /**
    * Update set of containers available on a datanode.
-   * @param uuid - DatanodeID
-   * @param containerIds - Set of containerIDs
    * @throws NodeNotFoundException - if datanode is not known.
    */
-  public void setContainers(UUID uuid, Set<ContainerID> containerIds)
+  public void setContainers(DatanodeID datanodeID, Set<ContainerID> containerIds)
       throws NodeNotFoundException {
-    nodeStateMap.setContainers(uuid, containerIds);
+    nodeStateMap.setContainers(datanodeID, containerIds);
   }
 
   /**
    * Return set of containerIDs available on a datanode. This is a copy of the
    * set which resides inside NodeStateMap and hence can be modified without
    * synchronization or side effects.
-   * @param uuid - DatanodeID
    * @return - set of containerIDs
    */
-  public Set<ContainerID> getContainers(UUID uuid)
+  public Set<ContainerID> getContainers(DatanodeID uuid)
       throws NodeNotFoundException {
     return nodeStateMap.getContainers(uuid);
   }
 
-  public int getContainerCount(UUID uuid)
+  public int getContainerCount(DatanodeID uuid)
       throws NodeNotFoundException {
     return nodeStateMap.getContainerCount(uuid);
   }
@@ -792,7 +781,7 @@ public class NodeStateManager implements Runnable, Closeable {
     try {
       List<DatanodeInfo> nodes = nodeStateMap.getDatanodeInfos(null, HEALTHY);
       for (DatanodeInfo node : nodes) {
-        nodeStateMap.updateNodeHealthState(node.getUuid(),
+        nodeStateMap.updateNodeHealthState(node.getID(),
             HEALTHY_READONLY);
         if (state2EventMap.containsKey(HEALTHY_READONLY)) {
           // At this point pipeline creation is already frozen and the node's
@@ -860,7 +849,7 @@ public class NodeStateManager implements Runnable, Closeable {
 
     try {
       for (DatanodeInfo node : nodeStateMap.getAllDatanodeInfos()) {
-        NodeStatus status = nodeStateMap.getNodeStatus(node.getUuid());
+        NodeStatus status = nodeStateMap.getNodeStatus(node.getID());
         switch (status.getHealth()) {
         case HEALTHY:
           updateNodeLayoutVersionState(node, layoutMisMatchCondition, status,
@@ -967,7 +956,7 @@ public class NodeStateManager implements Runnable, Closeable {
         NodeState newHealthState = nodeHealthSM.
             getNextState(status.getHealth(), lifeCycleEvent);
         NodeStatus newStatus =
-            nodeStateMap.updateNodeHealthState(node.getUuid(), newHealthState);
+            nodeStateMap.updateNodeHealthState(node.getID(), newHealthState);
         fireHealthStateEvent(newStatus.getHealth(), node);
       }
     } catch (InvalidStateTransitionException e) {
@@ -1006,7 +995,7 @@ public class NodeStateManager implements Runnable, Closeable {
         NodeState newHealthState = nodeHealthSM.getNextState(status.getHealth(),
             lifeCycleEvent);
         NodeStatus newStatus =
-            nodeStateMap.updateNodeHealthState(node.getUuid(), newHealthState);
+            nodeStateMap.updateNodeHealthState(node.getID(), newHealthState);
         fireHealthStateEvent(newStatus.getHealth(), node);
       }
     } catch (InvalidStateTransitionException e) {
@@ -1086,7 +1075,7 @@ public class NodeStateManager implements Runnable, Closeable {
     return healthCheckFuture;
   }
 
-  protected void removeNode(DatanodeDetails datanodeDetails) {
-    nodeStateMap.removeNode(datanodeDetails);
+  protected void removeNode(DatanodeID datanodeID) {
+    nodeStateMap.removeNode(datanodeID);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1587,14 +1587,14 @@ public class SCMNodeManager implements NodeManager {
   public void addContainer(final DatanodeDetails datanodeDetails,
       final ContainerID containerId)
       throws NodeNotFoundException {
-    nodeStateManager.addContainer(datanodeDetails.getUuid(), containerId);
+    nodeStateManager.addContainer(datanodeDetails.getID(), containerId);
   }
 
   @Override
   public void removeContainer(final DatanodeDetails datanodeDetails,
                            final ContainerID containerId)
       throws NodeNotFoundException {
-    nodeStateManager.removeContainer(datanodeDetails.getUuid(), containerId);
+    nodeStateManager.removeContainer(datanodeDetails.getID(), containerId);
   }
 
   /**
@@ -1608,8 +1608,7 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public void setContainers(DatanodeDetails datanodeDetails,
       Set<ContainerID> containerIds) throws NodeNotFoundException {
-    nodeStateManager.setContainers(datanodeDetails.getUuid(),
-        containerIds);
+    nodeStateManager.setContainers(datanodeDetails.getID(), containerIds);
   }
 
   /**
@@ -1623,12 +1622,12 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public Set<ContainerID> getContainers(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    return nodeStateManager.getContainers(datanodeDetails.getUuid());
+    return nodeStateManager.getContainers(datanodeDetails.getID());
   }
 
   public int getContainerCount(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    return nodeStateManager.getContainerCount(datanodeDetails.getUuid());
+    return nodeStateManager.getContainerCount(datanodeDetails.getID());
   }
 
   public int getPipeLineCount(DatanodeDetails datanodeDetails)
@@ -1711,7 +1710,7 @@ public class SCMNodeManager implements NodeManager {
     }
 
     try {
-      return nodeStateManager.getNode(uuid);
+      return nodeStateManager.getNode(DatanodeID.of(uuid));
     } catch (NodeNotFoundException e) {
       LOG.warn("Cannot find node for uuid {}", uuid);
       return null;
@@ -1850,7 +1849,7 @@ public class SCMNodeManager implements NodeManager {
         if (clusterMap.contains(datanodeDetails)) {
           clusterMap.remove(datanodeDetails);
         }
-        nodeStateManager.removeNode(datanodeDetails);
+        nodeStateManager.removeNode(datanodeDetails.getID());
         removeFromDnsToDnIdMap(datanodeDetails.getID(), datanodeDetails.getIpAddress());
         final List<SCMCommand<?>> cmdList = getCommandQueue(datanodeDetails.getUuid());
         LOG.info("Clearing command queue of size {} for DN {}", cmdList.size(), datanodeDetails);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeNotFoundException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeNotFoundException.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.hdds.scm.node.states;
 
+import org.apache.hadoop.hdds.protocol.DatanodeID;
+
 /**
  * This exception represents that the node that is being accessed does not
  * exist in NodeStateMap.
@@ -33,15 +35,10 @@ public class NodeNotFoundException extends NodeException {
   }
 
   /**
-   * Constructs an {@code NodeNotFoundException} with the specified
-   * detail message.
-   *
-   * @param message
-   *        The detail message (which is saved for later retrieval
-   *        by the {@link #getMessage()} method)
+   * Constructs an {@code NodeNotFoundException} with the given {@link DatanodeID}.
    */
-  public NodeNotFoundException(String message) {
-    super(message);
+  public NodeNotFoundException(DatanodeID datanodeID) {
+    super("Datanode " + datanodeID + " not found");
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -25,11 +25,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
@@ -50,11 +50,11 @@ public class NodeStateMap {
   /**
    * Node id to node info map.
    */
-  private final Map<UUID, DatanodeInfo> nodeMap = new HashMap<>();
+  private final Map<DatanodeID, DatanodeInfo> nodeMap = new HashMap<>();
   /**
    * Node to set of containers on the node.
    */
-  private final Map<UUID, Set<ContainerID>> nodeToContainer = new HashMap<>();
+  private final Map<DatanodeID, Set<ContainerID>> nodeToContainer = new HashMap<>();
 
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -78,7 +78,7 @@ public class NodeStateMap {
       throws NodeAlreadyExistsException {
     lock.writeLock().lock();
     try {
-      UUID id = datanodeDetails.getUuid();
+      final DatanodeID id = datanodeDetails.getID();
       if (nodeMap.containsKey(id)) {
         throw new NodeAlreadyExistsException("Node UUID: " + id);
       }
@@ -92,16 +92,12 @@ public class NodeStateMap {
 
   /**
    * Removes a node from NodeStateMap.
-   *
-   * @param datanodeDetails DatanodeDetails
-   *
    */
-  public void removeNode(DatanodeDetails datanodeDetails) {
+  public void removeNode(DatanodeID datanodeID) {
     lock.writeLock().lock();
     try {
-      UUID uuid = datanodeDetails.getUuid();
-      nodeMap.remove(uuid);
-      nodeToContainer.remove(uuid);
+      nodeMap.remove(datanodeID);
+      nodeToContainer.remove(datanodeID);
     } finally {
       lock.writeLock().unlock();
     }
@@ -121,9 +117,9 @@ public class NodeStateMap {
           throws NodeNotFoundException {
     lock.writeLock().lock();
     try {
-      UUID id = datanodeDetails.getUuid();
+      final DatanodeID id = datanodeDetails.getID();
       if (!nodeMap.containsKey(id)) {
-        throw new NodeNotFoundException("Node UUID: " + id);
+        throw new NodeNotFoundException(id);
       }
       nodeMap.put(id, new DatanodeInfo(datanodeDetails, nodeStatus,
               layoutInfo));
@@ -140,10 +136,10 @@ public class NodeStateMap {
    *
    * @throws NodeNotFoundException if the node is not present
    */
-  public NodeStatus updateNodeHealthState(UUID nodeId, NodeState newHealth)
+  public NodeStatus updateNodeHealthState(DatanodeID nodeId, NodeState newHealth)
       throws NodeNotFoundException {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       DatanodeInfo dn = getNodeInfoUnsafe(nodeId);
       NodeStatus oldStatus = dn.getNodeStatus();
       NodeStatus newStatus = new NodeStatus(
@@ -163,11 +159,11 @@ public class NodeStateMap {
    *
    * @throws NodeNotFoundException if the node is not present
    */
-  public NodeStatus updateNodeOperationalState(UUID nodeId,
+  public NodeStatus updateNodeOperationalState(DatanodeID nodeId,
       NodeOperationalState newOpState, long opStateExpiryEpochSeconds)
       throws NodeNotFoundException {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       DatanodeInfo dn = getNodeInfoUnsafe(nodeId);
       NodeStatus oldStatus = dn.getNodeStatus();
       NodeStatus newStatus = new NodeStatus(
@@ -180,51 +176,22 @@ public class NodeStateMap {
   }
 
   /**
-   * Returns DatanodeInfo for the given node id.
-   *
-   * @param uuid Node Id
-   *
-   * @return DatanodeInfo of the node
-   *
+   * @return the info for the given node id.
    * @throws NodeNotFoundException if the node is not present
    */
-  public DatanodeInfo getNodeInfo(UUID uuid) throws NodeNotFoundException {
+  public DatanodeInfo getNodeInfo(DatanodeID datanodeID) throws NodeNotFoundException {
     lock.readLock().lock();
     try {
-      return getNodeInfoUnsafe(uuid);
+      return getNodeInfoUnsafe(datanodeID);
     } finally {
       lock.readLock().unlock();
     }
   }
 
-  /**
-   * Returns the list of node ids which match the desired operational state
-   * and health. Passing a null for either value is equivalent to a wild card.
-   *
-   * Therefore, passing opState = null, health=stale will return all stale nodes
-   * regardless of their operational state.
-   *
-   * @param opState
-   * @param health
-   * @return The list of nodes matching the given states
-   */
-  public List<UUID> getNodes(NodeOperationalState opState, NodeState health) {
-    ArrayList<UUID> nodes = new ArrayList<>();
-    for (DatanodeInfo dn : filterNodes(opState, health)) {
-      nodes.add(dn.getUuid());
-    }
-    return nodes;
-  }
-
-  /**
-   * Returns the list of all the node ids.
-   *
-   * @return list of all the node ids
-   */
-  public List<UUID> getAllNodes() {
+  public int getNodeCount() {
+    lock.readLock().lock();
     try {
-      lock.readLock().lock();
-      return new ArrayList<>(nodeMap.keySet());
+      return nodeMap.size();
     } finally {
       lock.readLock().unlock();
     }
@@ -287,13 +254,10 @@ public class NodeStateMap {
    * Therefore, passing opState=null, health=stale will count all stale nodes
    * regardless of their operational state.
    *
-   * @param opState
-   * @param health
-   *
    * @return Number of nodes in the specified state
    */
   public int getNodeCount(NodeOperationalState opState, NodeState health) {
-    return getNodes(opState, health).size();
+    return filterNodes(opState, health).size();
   }
 
   /**
@@ -313,21 +277,16 @@ public class NodeStateMap {
   /**
    * Returns the current state of the node.
    *
-   * @param uuid node id
+   * @param datanodeID node id
    *
    * @return NodeState
    *
    * @throws NodeNotFoundException if the node is not found
    */
-  public NodeStatus getNodeStatus(UUID uuid) throws NodeNotFoundException {
+  public NodeStatus getNodeStatus(DatanodeID datanodeID) throws NodeNotFoundException {
     lock.readLock().lock();
     try {
-      DatanodeInfo dn = nodeMap.get(uuid);
-      if (dn == null) {
-        throw new NodeNotFoundException("Node not found in node map." +
-            " UUID: " + uuid);
-      }
-      return dn.getNodeStatus();
+      return getNodeInfoUnsafe(datanodeID).getNodeStatus();
     } finally {
       lock.readLock().unlock();
     }
@@ -335,62 +294,54 @@ public class NodeStateMap {
 
   /**
    * Adds the given container to the specified datanode.
-   *
-   * @param uuid - datanode uuid
-   * @param containerId - containerID
    * @throws NodeNotFoundException - if datanode is not known. For new datanode
    *                        use addDatanodeInContainerMap call.
    */
-  public void addContainer(final UUID uuid,
+  public void addContainer(final DatanodeID datanodeID,
                            final ContainerID containerId)
       throws NodeNotFoundException {
     lock.writeLock().lock();
     try {
-      checkIfNodeExist(uuid);
-      nodeToContainer.get(uuid).add(containerId);
+      getExisting(datanodeID).add(containerId);
     } finally {
       lock.writeLock().unlock();
     }
   }
 
-  public void setContainers(UUID uuid, Set<ContainerID> containers)
+  public void setContainers(DatanodeID id, Set<ContainerID> containers)
       throws NodeNotFoundException {
     lock.writeLock().lock();
     try {
-      checkIfNodeExist(uuid);
-      nodeToContainer.put(uuid, containers);
+      getExisting(id);
+      nodeToContainer.put(id, containers);
     } finally {
       lock.writeLock().unlock();
     }
   }
 
-  public Set<ContainerID> getContainers(UUID uuid)
+  public Set<ContainerID> getContainers(DatanodeID id)
       throws NodeNotFoundException {
     lock.readLock().lock();
     try {
-      checkIfNodeExist(uuid);
-      return new HashSet<>(nodeToContainer.get(uuid));
+      return new HashSet<>(getExisting(id));
     } finally {
       lock.readLock().unlock();
     }
   }
 
-  public int getContainerCount(UUID uuid) throws NodeNotFoundException {
+  public int getContainerCount(DatanodeID datanodeID) throws NodeNotFoundException {
     lock.readLock().lock();
     try {
-      checkIfNodeExist(uuid);
-      return nodeToContainer.get(uuid).size();
+      return getExisting(datanodeID).size();
     } finally {
       lock.readLock().unlock();
     }
   }
 
-  public void removeContainer(UUID uuid, ContainerID containerID) throws
-      NodeNotFoundException {
+  public void removeContainer(DatanodeID datanodeID, ContainerID containerID) throws NodeNotFoundException {
     lock.writeLock().lock();
     try {
-      checkIfNodeExist(uuid);
-      nodeToContainer.get(uuid).remove(containerID);
+      getExisting(datanodeID).remove(containerID);
     } finally {
       lock.writeLock().unlock();
     }
@@ -418,15 +369,15 @@ public class NodeStateMap {
   }
 
   /**
-   * Throws NodeNotFoundException if the Node for given id doesn't exist.
-   *
-   * @param uuid Node UUID
+   * @return the container set mapping to the given id.
    * @throws NodeNotFoundException If the node is missing.
    */
-  private void checkIfNodeExist(UUID uuid) throws NodeNotFoundException {
-    if (!nodeToContainer.containsKey(uuid)) {
-      throw new NodeNotFoundException("Node UUID: " + uuid);
+  private Set<ContainerID> getExisting(DatanodeID id) throws NodeNotFoundException {
+    final Set<ContainerID> containers = nodeToContainer.get(id);
+    if (containers == null) {
+      throw new NodeNotFoundException(id);
     }
+    return containers;
   }
 
   /**
@@ -469,9 +420,12 @@ public class NodeStateMap {
     return result;
   }
 
-  private @Nonnull DatanodeInfo getNodeInfoUnsafe(@Nonnull UUID uuid) throws NodeNotFoundException {
-    checkIfNodeExist(uuid);
-    return nodeMap.get(uuid);
+  private @Nonnull DatanodeInfo getNodeInfoUnsafe(@Nonnull DatanodeID id) throws NodeNotFoundException {
+    final DatanodeInfo info = nodeMap.get(id);
+    if (info == null) {
+      throw new NodeNotFoundException(id);
+    }
+    return info;
   }
 
   private static Predicate<DatanodeInfo> matching(NodeStatus status) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -428,7 +428,7 @@ public class MockNodeManager implements NodeManager {
     } else if (deadNodes.contains(dd)) {
       return NodeStatus.inServiceDead();
     } else {
-      throw new NodeNotFoundException();
+      throw new NodeNotFoundException(dd.getID());
     }
   }
 
@@ -640,7 +640,7 @@ public class MockNodeManager implements NodeManager {
     try {
       node2ContainerMap.setContainersForDatanode(uuid.getUuid(), containerIds);
     } catch (SCMException e) {
-      throw new NodeNotFoundException(e.getMessage());
+      throw new NodeNotFoundException(uuid.getID());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -127,7 +127,7 @@ public class SimpleMockNodeManager implements NodeManager {
       throws NodeNotFoundException {
     DatanodeInfo dni = nodeMap.get(dn.getUuid());
     if (dni == null) {
-      throw new NodeNotFoundException();
+      throw new NodeNotFoundException(dn.getID());
     }
     dni.setNodeStatus(
         new NodeStatus(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -110,7 +110,7 @@ public class TestReplicationManagerUtil {
                   HddsProtos.NodeState.HEALTHY);
             }
           }
-          throw new NodeNotFoundException(dn.getUuidString());
+          throw new NodeNotFoundException(dn.getID());
         });
 
     ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
@@ -194,7 +194,7 @@ public class TestReplicationManagerUtil {
                   HddsProtos.NodeState.HEALTHY);
             }
           }
-          throw new NodeNotFoundException(dn.getUuidString());
+          throw new NodeNotFoundException(dn.getID());
         });
 
     ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -193,7 +193,7 @@ public class TestContainerPlacement {
       for (DatanodeDetails datanodeDetails : datanodes) {
         UUID dnId = datanodeDetails.getUuid();
         DatanodeInfo datanodeInfo = scmNodeManager.getNodeStateManager()
-            .getNode(dnId);
+            .getNode(datanodeDetails.getID());
         StorageContainerDatanodeProtocolProtos.StorageReportProto report =
             HddsTestUtils
                 .createStorageReport(dnId,
@@ -231,9 +231,8 @@ public class TestContainerPlacement {
             SCMTestUtils.getReplicationFactor(conf).getNumber()) {
           break;
         }
-        UUID dnId = datanodeDetails.getUuid();
         DatanodeInfo datanodeInfo = scmNodeManager.getNodeStateManager()
-            .getNode(dnId);
+            .getNode(datanodeDetails.getID());
         addReplica(container, datanodeInfo);
         replicaCount++;
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -1040,7 +1040,7 @@ public class TestNodeDecommissionManager {
 
   private NodeStatus getNodeOpState(DatanodeDetails dn, List<DatanodeDetails> dns) throws NodeNotFoundException {
     if (dn.equals(dns.get(0))) {
-      throw new NodeNotFoundException();
+      throw new NodeNotFoundException(dn.getID());
     }
     for (DatanodeDetails datanode : dns) {
       if (datanode.equals(dn)) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -274,16 +274,16 @@ public class TestNodeStateManager {
     DatanodeDetails dn = generateDatanode();
     nsm.addNode(dn, UpgradeUtils.defaultLayoutVersionProto());
 
-    nsm.addContainer(dn.getUuid(), ContainerID.valueOf(1));
-    nsm.addContainer(dn.getUuid(), ContainerID.valueOf(2));
+    nsm.addContainer(dn.getID(), ContainerID.valueOf(1));
+    nsm.addContainer(dn.getID(), ContainerID.valueOf(2));
 
-    Set<ContainerID> containerSet = nsm.getContainers(dn.getUuid());
+    Set<ContainerID> containerSet = nsm.getContainers(dn.getID());
     assertEquals(2, containerSet.size());
     assertThat(containerSet).contains(ContainerID.valueOf(1));
     assertThat(containerSet).contains(ContainerID.valueOf(2));
 
-    nsm.removeContainer(dn.getUuid(), ContainerID.valueOf(2));
-    containerSet = nsm.getContainers(dn.getUuid());
+    nsm.removeContainer(dn.getID(), ContainerID.valueOf(2));
+    containerSet = nsm.getContainers(dn.getID());
     assertEquals(1, containerSet.size());
     assertThat(containerSet).contains(ContainerID.valueOf(1));
     assertThat(containerSet).doesNotContain(ContainerID.valueOf(2));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -241,7 +241,7 @@ public class ReplicationNodeManagerMock implements NodeManager {
       nodeStateMap.put(dd, new NodeStatus(newState, currentStatus.getHealth(),
           opStateExpiryEpocSec));
     } else {
-      throw new NodeNotFoundException();
+      throw new NodeNotFoundException(dd.getID());
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -270,7 +270,7 @@ public class NodeEndpoint {
   private boolean preChecksSuccess(DatanodeDetails nodeByUuid, Map<String, String> failedNodeErrorResponseMap)
       throws NodeNotFoundException {
     if (null == nodeByUuid) {
-      throw new NodeNotFoundException("Node  not found !!!");
+      throw new NodeNotFoundException();
     }
     NodeStatus nodeStatus = null;
     AtomicBoolean isContainerOrPipeLineOpen = new AtomicBoolean(false);


### PR DESCRIPTION
## What changes were proposed in this pull request?

NodeStateMap currently uses UUID as keys. It is better to replace it with DatanodeID.

## What is the link to the Apache JIRA

HDDS-12617

## How was this patch tested?

By updating existing tests.