### PR TITLE
HDDS-12619. Optimize Recon OM Container Mismatch API

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/SeekableIterator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/SeekableIterator.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * An {@link Iterator} that may hold resources until it is closed.
+ */
+public interface SeekableIterator<K, E> extends ClosableIterator<E> {
+  void seek(K position) throws IOException;
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
 import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistory;
+import org.apache.hadoop.ozone.util.SeekableIterator;
 
 /**
  * The Recon Container DB Service interface.
@@ -185,6 +186,9 @@ public interface ReconContainerMetadataManager {
    */
   Map<Long, ContainerMetadata> getContainers(int limit, long prevContainer)
       throws IOException;
+
+
+  SeekableIterator<Long, ContainerMetadata> getContainersIterator() throws IOException;
 
   /**
    * Delete an entry in the container DB.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -26,6 +26,7 @@ import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTab
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
@@ -54,6 +56,7 @@ import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistory;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistoryList;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
+import org.apache.hadoop.ozone.util.SeekableIterator;
 import org.apache.ozone.recon.schema.generated.tables.daos.GlobalStatsDao;
 import org.apache.ozone.recon.schema.generated.tables.pojos.GlobalStats;
 import org.jooq.Configuration;
@@ -431,53 +434,80 @@ public class ReconContainerMetadataManagerImpl
                                                     long prevContainer)
       throws IOException {
     Map<Long, ContainerMetadata> containers = new LinkedHashMap<>();
-    try (
-        TableIterator<ContainerKeyPrefix,
-            ? extends KeyValue<ContainerKeyPrefix, Integer>>
-            containerIterator = containerKeyTable.iterator()) {
-      ContainerKeyPrefix seekKey;
-      if (prevContainer > 0L) {
-        seekKey = ContainerKeyPrefix.get(prevContainer);
-        KeyValue<ContainerKeyPrefix,
-            Integer> seekKeyValue = containerIterator.seek(seekKey);
-        // Check if RocksDB was able to correctly seek to the given
-        // prevContainer containerId. If not, then return empty result
-        if (seekKeyValue != null &&
-            seekKeyValue.getKey().getContainerId() != prevContainer) {
-          return containers;
-        } else {
-          // seek to the prevContainer+1 containerID to start scan
-          seekKey = ContainerKeyPrefix.get(prevContainer + 1);
-          containerIterator.seek(seekKey);
-        }
-      }
-      while (containerIterator.hasNext()) {
-        KeyValue<ContainerKeyPrefix, Integer> keyValue =
-            containerIterator.next();
-        ContainerKeyPrefix containerKeyPrefix = keyValue.getKey();
-        Long containerID = containerKeyPrefix.getContainerId();
-        Integer numberOfKeys = keyValue.getValue();
-        List<Pipeline> pipelines =
-            getPipelines(containerKeyPrefix);
-
-        // break the loop if limit has been reached
-        // and one more new entity needs to be added to the containers map
-        if (containers.size() == limit &&
-            !containers.containsKey(containerID)) {
-          break;
-        }
-
-        // initialize containerMetadata with 0 as number of keys.
-        containers.computeIfAbsent(containerID, ContainerMetadata::new);
-        // increment number of keys for the containerID
-        ContainerMetadata containerMetadata = containers.get(containerID);
-        containerMetadata.setNumberOfKeys(containerMetadata.getNumberOfKeys() +
-            numberOfKeys);
-        containerMetadata.setPipelines(pipelines);
-        containers.put(containerID, containerMetadata);
+    try (SeekableIterator<Long, ContainerMetadata> containerIterator = getContainersIterator()) {
+      containerIterator.seek(prevContainer + 1);
+      while (containerIterator.hasNext() && ((limit < 0) || containers.size() < limit)) {
+        ContainerMetadata containerMetadata = containerIterator.next();
+        containers.put(containerMetadata.getContainerID(), containerMetadata);
       }
     }
     return containers;
+  }
+
+  @Override
+  public SeekableIterator<Long, ContainerMetadata> getContainersIterator()
+          throws IOException {
+    return new ContainerMetadataIterator();
+  }
+
+  private class ContainerMetadataIterator implements SeekableIterator<Long, ContainerMetadata> {
+    private TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix, Integer>> containerIterator;
+    private KeyValue<ContainerKeyPrefix, Integer> currentKey;
+
+    ContainerMetadataIterator()
+            throws IOException {
+      containerIterator = containerKeyTable.iterator();
+      currentKey = containerIterator.hasNext() ? containerIterator.next() : null;
+    }
+
+    @Override
+    public void seek(Long containerID) throws IOException {
+      ContainerKeyPrefix seekKey = ContainerKeyPrefix.get(containerID);
+      containerIterator.seek(seekKey);
+      currentKey = containerIterator.hasNext() ? containerIterator.next() : null;
+    }
+
+    @Override
+    public void close() {
+      try {
+        containerIterator.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return currentKey != null;
+    }
+
+    @Override
+    public ContainerMetadata next() {
+      try {
+        if (currentKey == null) {
+          return null;
+        }
+        Map<PipelineID, Pipeline> pipelines = new HashMap<>();
+        ContainerMetadata containerMetadata = new ContainerMetadata(currentKey.getKey().getContainerId());
+        do {
+          ContainerKeyPrefix containerKeyPrefix = this.currentKey.getKey();
+          containerMetadata.setNumberOfKeys(containerMetadata.getNumberOfKeys() + 1);
+          getPipelines(containerKeyPrefix).forEach(pipeline -> {
+            pipelines.putIfAbsent(pipeline.getId(), pipeline);
+          });
+          if (containerIterator.hasNext()) {
+            currentKey = containerIterator.next();
+          } else {
+            currentKey = null;
+          }
+        } while (currentKey != null &&
+                currentKey.getKey().getContainerId() == containerMetadata.getContainerID());
+        containerMetadata.setPipelines(new ArrayList<>(pipelines.values()));
+        return containerMetadata;
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
   }
 
   @Nonnull

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
@@ -365,8 +365,8 @@ public class TestReconContainerMetadataManagerImpl {
         reconContainerMetadataManager.getContainers(-1, 0L);
     assertEquals(2, containerMap.size());
 
-    assertEquals(3, containerMap.get(containerId).getNumberOfKeys());
-    assertEquals(3, containerMap.get(nextContainerId).getNumberOfKeys());
+    assertEquals(2, containerMap.get(containerId).getNumberOfKeys());
+    assertEquals(1, containerMap.get(nextContainerId).getNumberOfKeys());
 
     // test if limit works
     containerMap = reconContainerMetadataManager.getContainers(


### PR DESCRIPTION
Change-Id: I820e10912427c643b05d3e88a7c30094106fbd5a

## What changes were proposed in this pull request?
Currently the Container mismatch API in recon loads up the entire ContainerMetaData from ContainerKeyPrefix table and figures out the container mismatches between OM & SCM. The implication is that the ContainerKeyPrefix table will have as many keys as there there in OM. In case there are too many keys even for loading a small page too many containers would be brought into memory and the result would be eventually discarded because of the page size limit. Instead of this we should implement an container iterator for the containerKeyPrefix table which would iterate on containers sequentially in a sorted fashion along with the scm containerManager iterator and diff would be figured out based on the merging these 2 container list. We can save on a lot of iops & improve the latency of this api by a lot.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12619

## How was this patch tested?
Existing unit tests & adding more for the iterator