### PR TITLE
HDDS-12620. Fix OM Mismatch Deleted Container API

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/SeekableIterator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/SeekableIterator.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * An {@link Iterator} that may hold resources until it is closed.
+ */
+public interface SeekableIterator<K, E> extends ClosableIterator<E> {
+  void seek(K position) throws IOException;
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
 import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistory;
+import org.apache.hadoop.ozone.util.SeekableIterator;
 
 /**
  * The Recon Container DB Service interface.
@@ -185,6 +186,9 @@ public interface ReconContainerMetadataManager {
    */
   Map<Long, ContainerMetadata> getContainers(int limit, long prevContainer)
       throws IOException;
+
+
+  SeekableIterator<Long, ContainerMetadata> getContainersIterator() throws IOException;
 
   /**
    * Delete an entry in the container DB.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -26,6 +26,7 @@ import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTab
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
@@ -54,6 +56,7 @@ import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistory;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistoryList;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
+import org.apache.hadoop.ozone.util.SeekableIterator;
 import org.apache.ozone.recon.schema.generated.tables.daos.GlobalStatsDao;
 import org.apache.ozone.recon.schema.generated.tables.pojos.GlobalStats;
 import org.jooq.Configuration;
@@ -431,53 +434,80 @@ public class ReconContainerMetadataManagerImpl
                                                     long prevContainer)
       throws IOException {
     Map<Long, ContainerMetadata> containers = new LinkedHashMap<>();
-    try (
-        TableIterator<ContainerKeyPrefix,
-            ? extends KeyValue<ContainerKeyPrefix, Integer>>
-            containerIterator = containerKeyTable.iterator()) {
-      ContainerKeyPrefix seekKey;
-      if (prevContainer > 0L) {
-        seekKey = ContainerKeyPrefix.get(prevContainer);
-        KeyValue<ContainerKeyPrefix,
-            Integer> seekKeyValue = containerIterator.seek(seekKey);
-        // Check if RocksDB was able to correctly seek to the given
-        // prevContainer containerId. If not, then return empty result
-        if (seekKeyValue != null &&
-            seekKeyValue.getKey().getContainerId() != prevContainer) {
-          return containers;
-        } else {
-          // seek to the prevContainer+1 containerID to start scan
-          seekKey = ContainerKeyPrefix.get(prevContainer + 1);
-          containerIterator.seek(seekKey);
-        }
-      }
-      while (containerIterator.hasNext()) {
-        KeyValue<ContainerKeyPrefix, Integer> keyValue =
-            containerIterator.next();
-        ContainerKeyPrefix containerKeyPrefix = keyValue.getKey();
-        Long containerID = containerKeyPrefix.getContainerId();
-        Integer numberOfKeys = keyValue.getValue();
-        List<Pipeline> pipelines =
-            getPipelines(containerKeyPrefix);
-
-        // break the loop if limit has been reached
-        // and one more new entity needs to be added to the containers map
-        if (containers.size() == limit &&
-            !containers.containsKey(containerID)) {
-          break;
-        }
-
-        // initialize containerMetadata with 0 as number of keys.
-        containers.computeIfAbsent(containerID, ContainerMetadata::new);
-        // increment number of keys for the containerID
-        ContainerMetadata containerMetadata = containers.get(containerID);
-        containerMetadata.setNumberOfKeys(containerMetadata.getNumberOfKeys() +
-            numberOfKeys);
-        containerMetadata.setPipelines(pipelines);
-        containers.put(containerID, containerMetadata);
+    try (SeekableIterator<Long, ContainerMetadata> containerIterator = getContainersIterator()) {
+      containerIterator.seek(prevContainer + 1);
+      while (containerIterator.hasNext() && ((limit < 0) || containers.size() < limit)) {
+        ContainerMetadata containerMetadata = containerIterator.next();
+        containers.put(containerMetadata.getContainerID(), containerMetadata);
       }
     }
     return containers;
+  }
+
+  @Override
+  public SeekableIterator<Long, ContainerMetadata> getContainersIterator()
+          throws IOException {
+    return new ContainerMetadataIterator();
+  }
+
+  private class ContainerMetadataIterator implements SeekableIterator<Long, ContainerMetadata> {
+    private TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix, Integer>> containerIterator;
+    private KeyValue<ContainerKeyPrefix, Integer> currentKey;
+
+    ContainerMetadataIterator()
+            throws IOException {
+      containerIterator = containerKeyTable.iterator();
+      currentKey = containerIterator.hasNext() ? containerIterator.next() : null;
+    }
+
+    @Override
+    public void seek(Long containerID) throws IOException {
+      ContainerKeyPrefix seekKey = ContainerKeyPrefix.get(containerID);
+      containerIterator.seek(seekKey);
+      currentKey = containerIterator.hasNext() ? containerIterator.next() : null;
+    }
+
+    @Override
+    public void close() {
+      try {
+        containerIterator.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return currentKey != null;
+    }
+
+    @Override
+    public ContainerMetadata next() {
+      try {
+        if (currentKey == null) {
+          return null;
+        }
+        Map<PipelineID, Pipeline> pipelines = new HashMap<>();
+        ContainerMetadata containerMetadata = new ContainerMetadata(currentKey.getKey().getContainerId());
+        do {
+          ContainerKeyPrefix containerKeyPrefix = this.currentKey.getKey();
+          containerMetadata.setNumberOfKeys(containerMetadata.getNumberOfKeys() + 1);
+          getPipelines(containerKeyPrefix).forEach(pipeline -> {
+            pipelines.putIfAbsent(pipeline.getId(), pipeline);
+          });
+          if (containerIterator.hasNext()) {
+            currentKey = containerIterator.next();
+          } else {
+            currentKey = null;
+          }
+        } while (currentKey != null &&
+                currentKey.getKey().getContainerId() == containerMetadata.getContainerID());
+        containerMetadata.setPipelines(new ArrayList<>(pipelines.values()));
+        return containerMetadata;
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
   }
 
   @Nonnull

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1584,6 +1584,48 @@ public class TestContainerEndpoint {
   }
 
   @Test
+  public void testGetOmContainersDeletedInSCMPagination() throws Exception {
+    Map<Long, ContainerMetadata> omContainers =
+      reconContainerMetadataManager.getContainers(-1, 0);
+    putContainerInfos(2);
+    List<ContainerInfo> scmContainers = reconContainerManager.getContainers();
+    assertEquals(omContainers.size(), scmContainers.size());
+    // Update container state of Container Id 2 to CLOSING to CLOSED
+    // and then to DELETED
+    updateContainerStateToDeleted(2);
+
+    assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
+
+    List<ContainerInfo> deletedSCMContainers =
+      reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
+    assertEquals(1, deletedSCMContainers.size());
+
+    Response omContainersDeletedInSCMResponse =
+      containerEndpoint.getOmContainersDeletedInSCM(1, 0);
+    assertNotNull(omContainersDeletedInSCMResponse);
+
+    Map<String, Object> responseMap =
+      (Map<String, Object>) omContainersDeletedInSCMResponse.getEntity();
+
+    // Fetch the ContainerDiscrepancyInfo list from the response
+    List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
+      (List<ContainerDiscrepancyInfo>) responseMap.get(
+        "containerDiscrepancyInfo");
+    assertEquals(1, containerDiscrepancyInfoList.size());
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) responseMap.get("lastKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+        containerDiscrepancyInfoList.size() - 1).getContainerID(),
+      responsePrevKey);
+    assertEquals(2, responsePrevKey);
+
+    assertEquals(omContainers.get(2L).getNumberOfKeys(), containerDiscrepancyInfoList.get(0)
+      .getNumberOfKeys());
+    assertEquals(1, containerDiscrepancyInfoList.size());
+  }
+
+
+  @Test
   public void testGetOmContainersDeletedInSCMLimitParam() throws Exception {
     Map<Long, ContainerMetadata> omContainers =
         reconContainerMetadataManager.getContainers(-1, 0);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1585,8 +1585,7 @@ public class TestContainerEndpoint {
 
   @Test
   public void testGetOmContainersDeletedInSCMPagination() throws Exception {
-    Map<Long, ContainerMetadata> omContainers =
-      reconContainerMetadataManager.getContainers(-1, 0);
+    Map<Long, ContainerMetadata> omContainers = reconContainerMetadataManager.getContainers(-1, 0);
     putContainerInfos(2);
     List<ContainerInfo> scmContainers = reconContainerManager.getContainers();
     assertEquals(omContainers.size(), scmContainers.size());
@@ -1596,31 +1595,26 @@ public class TestContainerEndpoint {
 
     assertContainerCount(HddsProtos.LifeCycleState.DELETED, 1);
 
-    List<ContainerInfo> deletedSCMContainers =
-      reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
+    List<ContainerInfo> deletedSCMContainers = reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
     assertEquals(1, deletedSCMContainers.size());
 
     Response omContainersDeletedInSCMResponse =
-      containerEndpoint.getOmContainersDeletedInSCM(1, 0);
+        containerEndpoint.getOmContainersDeletedInSCM(1, 0);
     assertNotNull(omContainersDeletedInSCMResponse);
 
-    Map<String, Object> responseMap =
-      (Map<String, Object>) omContainersDeletedInSCMResponse.getEntity();
+    Map<String, Object> responseMap = (Map<String, Object>) omContainersDeletedInSCMResponse.getEntity();
 
     // Fetch the ContainerDiscrepancyInfo list from the response
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-      (List<ContainerDiscrepancyInfo>) responseMap.get(
-        "containerDiscrepancyInfo");
+        (List<ContainerDiscrepancyInfo>) responseMap.get("containerDiscrepancyInfo");
     assertEquals(1, containerDiscrepancyInfoList.size());
     // Check the prevKey is set correct in the response
     long responsePrevKey = (long) responseMap.get("lastKey");
-    assertEquals(containerDiscrepancyInfoList.get(
-        containerDiscrepancyInfoList.size() - 1).getContainerID(),
-      responsePrevKey);
+    assertEquals(containerDiscrepancyInfoList.get(containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
     assertEquals(2, responsePrevKey);
 
-    assertEquals(omContainers.get(2L).getNumberOfKeys(), containerDiscrepancyInfoList.get(0)
-      .getNumberOfKeys());
+    assertEquals(omContainers.get(2L).getNumberOfKeys(), containerDiscrepancyInfoList.get(0).getNumberOfKeys());
     assertEquals(1, containerDiscrepancyInfoList.size());
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
@@ -365,8 +365,8 @@ public class TestReconContainerMetadataManagerImpl {
         reconContainerMetadataManager.getContainers(-1, 0L);
     assertEquals(2, containerMap.size());
 
-    assertEquals(3, containerMap.get(containerId).getNumberOfKeys());
-    assertEquals(3, containerMap.get(nextContainerId).getNumberOfKeys());
+    assertEquals(2, containerMap.get(containerId).getNumberOfKeys());
+    assertEquals(1, containerMap.get(nextContainerId).getNumberOfKeys());
 
     // test if limit works
     containerMap = reconContainerMetadataManager.getContainers(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the Container mismatch API in recon loads up the first few ContainerMetaData records  from ContainerKeyPrefix table. Then from the scm containerManager all deleted containers are iterated and checked against the records loaded from containerPrefixTable. If a deletedContainer is not present in the loaded list the results turn out to be empty even though there could be some records present in the containerPrefixTable in the next few pages. This could lead to a wrong result by setting the lastKey to null in case it couldn't find any records corresponding to a deletedContainer.

Consider this example:

ContainerPrefixTable has containerIds

1..100 1000-1100

SCM has deletedContainerId

1000-1050

Now if an api call is made with lastKey as 50 and limit as 50

Now from the ContainerPrefix Table we would load only records 50-100

From SCM ContainerManager we would load deleted Containers 1000-1050

Since there is no intersection b/w these 2 containers then deletedContainers would never get loaded and would always be empty.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12620

## How was this patch tested?
Existing Unit tests and adding more for the above case. 
