### PR TITLE
HDDS-11735. Update ozone-default.xml for volume choosing policy

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -210,13 +210,12 @@
   </property>
   <property>
     <name>hdds.datanode.volume.choosing.policy</name>
-    <value/>
+    <value>org.apache.hadoop.ozone.container.common.volume.CapacityVolumeChoosingPolicy</value>
     <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
     <description>
-      The class name of the policy for choosing volumes in the list of
-      directories.  Defaults to
-      org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy.
-      This volume choosing policy selects volumes in a round-robin order.
+      The class name of the policy for choosing volumes in the list of directories.
+      Defaults to org.apache.hadoop.ozone.container.common.volume.CapacityVolumeChoosingPolicy.
+      This volume choosing policy randomly chooses volume with remaining space to satisfy the size constraints.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -215,7 +215,7 @@
     <description>
       The class name of the policy for choosing volumes in the list of directories.
       Defaults to org.apache.hadoop.ozone.container.common.volume.CapacityVolumeChoosingPolicy.
-      This volume choosing policy randomly chooses volume with remaining space to satisfy the size constraints.
+      This volume choosing policy randomly chooses two volumes with remaining space and then picks the one with lower utilization.
     </description>
   </property>
   <property>


### PR DESCRIPTION
## What changes were proposed in this pull request?
[HDDS-9273](https://issues.apache.org/jira/browse/HDDS-9273) changes the default volume choosing policy from `RoundRobinVolumeChoosingPolicy` to `CapacityVolumeChoosingPolicy`.

Update `ozone-default.xml` to reflect the new default value of `hdds.datanode.volume.choosing.policy` to `org.apache.hadoop.ozone.container.common.volume.CapacityVolumeChoosingPolicy`.

## What is the link to the Apache JIRA
[HDDS-11735](https://issues.apache.org/jira/browse/HDDS-11735)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/13920274839
