### PR TITLE
HDDS-12621. Change NodeStatus to value-based.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -338,11 +338,9 @@ public class NodeStateManager implements Runnable, Closeable {
       LOG.info("Updating nodeOperationalState on registration as the " +
               "datanode has a persisted state of {} and expiry of {}",
           dnOpState, dn.getPersistedOpStateExpiryEpochSec());
-      return new NodeStatus(dnOpState, state,
-          dn.getPersistedOpStateExpiryEpochSec());
+      return NodeStatus.valueOf(dnOpState, state, dn.getPersistedOpStateExpiryEpochSec());
     } else {
-      return new NodeStatus(
-          NodeOperationalState.IN_SERVICE, state);
+      return NodeStatus.valueOf(NodeOperationalState.IN_SERVICE, state);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -17,101 +17,134 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
-import com.google.common.collect.ImmutableSet;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.DEAD;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY_READONLY;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.STALE;
+
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 
 /**
- * This class is used to capture the current status of a datanode. This
- * includes its health (healthy, stale or dead) and its operation status (
- * in_service, decommissioned and maintenance mode) along with the expiry time
- * for the operational state (used with maintenance mode).
+ * The status of a datanode including {@link NodeState}, {@link NodeOperationalState}
+ * and the expiry time for the operational state,
+ * where the expiry time is used in maintenance mode.
+ * <p>
+ * This class is value-based.
  */
-public class NodeStatus implements Comparable<NodeStatus> {
+public final class NodeStatus implements Comparable<NodeStatus> {
+  /** For the {@link NodeStatus} objects with {@link #opStateExpiryEpochSeconds} == 0. */
+  private static final Map<NodeOperationalState, Map<NodeState, NodeStatus>> CONSTANT_MAP;
+  static {
+    final Map<NodeOperationalState, Map<NodeState, NodeStatus>> map = new EnumMap<>(NodeOperationalState.class);
+    for (NodeOperationalState op : NodeOperationalState.values()) {
+      final EnumMap<NodeState, NodeStatus> healthMap = new EnumMap<>(NodeState.class);
+      for (NodeState health : NodeState.values()) {
+        healthMap.put(health, new NodeStatus(health, op, 0));
+      }
+      map.put(op, healthMap);
+    }
+    CONSTANT_MAP = map;
+  }
 
-  private static final Set<HddsProtos.NodeOperationalState>
-      MAINTENANCE_STATES = ImmutableSet.copyOf(EnumSet.of(
-          HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
-          HddsProtos.NodeOperationalState.IN_MAINTENANCE
-      ));
+  /** @return a {@link NodeStatus} object with {@link #opStateExpiryEpochSeconds} == 0. */
+  public static NodeStatus valueOf(NodeOperationalState op, NodeState health) {
+    return CONSTANT_MAP.get(op).get(health);
+  }
 
-  private static final Set<HddsProtos.NodeOperationalState>
-      DECOMMISSION_STATES = ImmutableSet.copyOf(EnumSet.of(
-          HddsProtos.NodeOperationalState.DECOMMISSIONING,
-          HddsProtos.NodeOperationalState.DECOMMISSIONED
-      ));
+  /** @return a {@link NodeStatus} object. */
+  public static NodeStatus valueOf(NodeOperationalState op, NodeState health, long opExpiryEpochSeconds) {
+    return opExpiryEpochSeconds == 0 ? valueOf(op, health)
+        : new NodeStatus(health, op, opExpiryEpochSeconds);
+  }
 
-  private static final Set<HddsProtos.NodeOperationalState>
-      OUT_OF_SERVICE_STATES = ImmutableSet.copyOf(EnumSet.of(
-          HddsProtos.NodeOperationalState.DECOMMISSIONING,
-          HddsProtos.NodeOperationalState.DECOMMISSIONED,
-          HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
-          HddsProtos.NodeOperationalState.IN_MAINTENANCE
-      ));
-
-  public static Set<HddsProtos.NodeOperationalState> maintenanceStates() {
+  private static final Set<NodeOperationalState> MAINTENANCE_STATES = Collections.unmodifiableSet(
+      EnumSet.of(ENTERING_MAINTENANCE, IN_MAINTENANCE));
+  /**
+   * @return the set consists of {@link NodeOperationalState#ENTERING_MAINTENANCE}
+   *                         and {@link NodeOperationalState#IN_MAINTENANCE}.
+   */
+  public static Set<NodeOperationalState> maintenanceStates() {
     return MAINTENANCE_STATES;
   }
 
-  public static Set<HddsProtos.NodeOperationalState> decommissionStates() {
+  private static final Set<NodeOperationalState> DECOMMISSION_STATES = Collections.unmodifiableSet(
+      EnumSet.of(DECOMMISSIONING, DECOMMISSIONED));
+  /**
+   * @return the set consists of {@link NodeOperationalState#DECOMMISSIONING}
+   *                         and {@link NodeOperationalState#DECOMMISSIONED}.
+   */
+  public static Set<NodeOperationalState> decommissionStates() {
     return DECOMMISSION_STATES;
   }
 
-  public static Set<HddsProtos.NodeOperationalState> outOfServiceStates() {
+  private static final Set<NodeOperationalState> OUT_OF_SERVICE_STATES = Collections.unmodifiableSet(
+      EnumSet.of(DECOMMISSIONING, DECOMMISSIONED, ENTERING_MAINTENANCE, IN_MAINTENANCE));
+  /**
+   * @return the set consists of {@link NodeOperationalState#DECOMMISSIONING},
+   *                             {@link NodeOperationalState#DECOMMISSIONED},
+   *                             {@link NodeOperationalState#ENTERING_MAINTENANCE}
+   *                         and {@link NodeOperationalState#IN_MAINTENANCE}.
+   */
+  public static Set<NodeOperationalState> outOfServiceStates() {
     return OUT_OF_SERVICE_STATES;
   }
 
-  private HddsProtos.NodeOperationalState operationalState;
-  private HddsProtos.NodeState health;
-  private long opStateExpiryEpochSeconds;
-
-  public NodeStatus(HddsProtos.NodeOperationalState operationalState,
-                    HddsProtos.NodeState health) {
-    this.operationalState = operationalState;
-    this.health = health;
-    this.opStateExpiryEpochSeconds = 0;
-  }
-
-  public NodeStatus(HddsProtos.NodeOperationalState operationalState,
-                    HddsProtos.NodeState health,
-                    long opStateExpireEpocSeconds) {
-    this.operationalState = operationalState;
-    this.health = health;
-    this.opStateExpiryEpochSeconds = opStateExpireEpocSeconds;
-  }
-
+  private static final NodeStatus IN_SERVICE_HEALTHY = valueOf(IN_SERVICE, HEALTHY);
+  /** @return the status of {@link NodeOperationalState#IN_SERVICE} and {@link NodeState#HEALTHY}. */
   public static NodeStatus inServiceHealthy() {
-    return new NodeStatus(HddsProtos.NodeOperationalState.IN_SERVICE,
-        HddsProtos.NodeState.HEALTHY);
+    return IN_SERVICE_HEALTHY;
   }
 
+  private static final NodeStatus IN_SERVICE_HEALTHY_READONLY = valueOf(IN_SERVICE, HEALTHY_READONLY);
+  /** @return the status of {@link NodeOperationalState#IN_SERVICE} and {@link NodeState#HEALTHY_READONLY}. */
   public static NodeStatus inServiceHealthyReadOnly() {
-    return new NodeStatus(HddsProtos.NodeOperationalState.IN_SERVICE,
-        HddsProtos.NodeState.HEALTHY_READONLY);
+    return IN_SERVICE_HEALTHY_READONLY;
   }
 
+  private static final NodeStatus IN_SERVICE_STALE = NodeStatus.valueOf(IN_SERVICE, STALE);
+  /** @return the status of {@link NodeOperationalState#IN_SERVICE} and {@link NodeState#STALE}. */
   public static NodeStatus inServiceStale() {
-    return new NodeStatus(HddsProtos.NodeOperationalState.IN_SERVICE,
-        HddsProtos.NodeState.STALE);
+    return IN_SERVICE_STALE;
   }
 
+  private static final NodeStatus IN_SERVICE_DEAD = NodeStatus.valueOf(IN_SERVICE, DEAD);
+  /** @return the status of {@link NodeOperationalState#IN_SERVICE} and {@link NodeState#DEAD}. */
   public static NodeStatus inServiceDead() {
-    return new NodeStatus(HddsProtos.NodeOperationalState.IN_SERVICE,
-        HddsProtos.NodeState.DEAD);
+    return IN_SERVICE_DEAD;
   }
 
+  private final NodeState health;
+  private final NodeOperationalState operationalState;
+  private final long opStateExpiryEpochSeconds;
+
+  private NodeStatus(NodeState health, NodeOperationalState op, long opExpiryEpochSeconds) {
+    this.health = health;
+    this.operationalState = op;
+    this.opStateExpiryEpochSeconds = opExpiryEpochSeconds;
+  }
+
+  /** Is this node writeable ({@link NodeState#HEALTHY} and {@link NodeOperationalState#IN_SERVICE}) ? */
   public boolean isNodeWritable() {
-    return health == HddsProtos.NodeState.HEALTHY &&
-        operationalState == HddsProtos.NodeOperationalState.IN_SERVICE;
+    return health == HEALTHY && operationalState == IN_SERVICE;
   }
 
-  public HddsProtos.NodeState getHealth() {
+  public NodeState getHealth() {
     return health;
   }
 
-  public HddsProtos.NodeOperationalState getOperationalState() {
+  public NodeOperationalState getOperationalState() {
     return operationalState;
   }
 
@@ -119,102 +152,68 @@ public class NodeStatus implements Comparable<NodeStatus> {
     return opStateExpiryEpochSeconds;
   }
 
+  /** Is the op expired? */
   public boolean operationalStateExpired() {
-    if (0 == opStateExpiryEpochSeconds) {
-      return false;
-    }
-    return System.currentTimeMillis() / 1000 >= opStateExpiryEpochSeconds;
+    return opStateExpiryEpochSeconds != 0
+        && System.currentTimeMillis() >= 1000 * opStateExpiryEpochSeconds;
   }
 
+  /** @return true iff the node is {@link NodeOperationalState#IN_SERVICE}. */
   public boolean isInService() {
-    return operationalState == HddsProtos.NodeOperationalState.IN_SERVICE;
+    return operationalState == IN_SERVICE;
   }
 
   /**
-   * Returns true if the nodeStatus indicates the node is in any decommission
-   * state.
-   *
-   * @return True if the node is in any decommission state, false otherwise
+   * @return true iff the node is {@link NodeOperationalState#DECOMMISSIONING}
+   *                           or {@link NodeOperationalState#DECOMMISSIONED}.
    */
   public boolean isDecommission() {
     return DECOMMISSION_STATES.contains(operationalState);
   }
 
-  /**
-   * Returns true if the node is currently decommissioning.
-   *
-   * @return True if the node is decommissioning, false otherwise
-   */
+  /** @return true iff the node is {@link NodeOperationalState#DECOMMISSIONING}. */
   public boolean isDecommissioning() {
-    return operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONING;
+    return operationalState == DECOMMISSIONING;
   }
 
-  /**
-   * Returns true if the node is decommissioned.
-   *
-   * @return True if the node is decommissioned, false otherwise
-   */
+  /** @return true iff the node is {@link NodeOperationalState#DECOMMISSIONED}. */
   public boolean isDecommissioned() {
-    return operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONED;
+    return operationalState == DECOMMISSIONED;
   }
 
   /**
-   * Returns true if the node is in any maintenance state.
-   *
-   * @return True if the node is in any maintenance state, false otherwise
+   * @return true iff the node is {@link NodeOperationalState#ENTERING_MAINTENANCE}
+   *                           or {@link NodeOperationalState#IN_MAINTENANCE}.
    */
   public boolean isMaintenance() {
-    return MAINTENANCE_STATES.contains(operationalState);
+    return maintenanceStates().contains(operationalState);
   }
 
-  /**
-   * Returns true if the node is currently entering maintenance.
-   *
-   * @return True if the node is entering maintenance, false otherwise
-   */
+  /** @return true iff the node is {@link NodeOperationalState#ENTERING_MAINTENANCE}. */
   public boolean isEnteringMaintenance() {
-    return operationalState
-        == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
+    return operationalState == ENTERING_MAINTENANCE;
   }
 
-  /**
-   * Returns true if the node is currently in maintenance.
-   *
-   * @return True if the node is in maintenance, false otherwise.
-   */
+  /** @return true iff the node is {@link NodeOperationalState#IN_MAINTENANCE}. */
   public boolean isInMaintenance() {
-    return operationalState == HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+    return operationalState == IN_MAINTENANCE;
   }
 
-  /**
-   * Returns true if the nodeStatus is healthy or healthy_readonly (ie not stale
-   * or dead) and false otherwise.
-   *
-   * @return True if the node is healthy or healthy_readonly, false otherwise.
-   */
+  /** @return true iff this node is {@link NodeState#HEALTHY} or {@link NodeState#HEALTHY_READONLY}. */
   public boolean isHealthy() {
-    return health == HddsProtos.NodeState.HEALTHY
-        || health == HddsProtos.NodeState.HEALTHY_READONLY;
+    return health == HEALTHY
+        || health == HEALTHY_READONLY;
   }
 
-  /**
-   * Returns true if the nodeStatus is either healthy or stale and false
-   * otherwise.
-   *
-   * @return True is the node is Healthy or Stale, false otherwise.
-   */
+  /** @return true iff this node is {@link NodeState#HEALTHY} or {@link NodeState#STALE}. */
   public boolean isAlive() {
-    return health == HddsProtos.NodeState.HEALTHY
-        || health == HddsProtos.NodeState.STALE;
+    return health == HEALTHY
+        || health == STALE;
   }
 
-  /**
-   * Returns true if the nodeStatus is dead and false otherwise.
-   *
-   * @return True is the node is Dead, false otherwise.
-   */
+  /** @return true iff the node is {@link NodeState#DEAD}. */
   public boolean isDead() {
-    return health == HddsProtos.NodeState.DEAD;
+    return health == DEAD;
   }
 
   @Override
@@ -228,13 +227,10 @@ public class NodeStatus implements Comparable<NodeStatus> {
     if (getClass() != obj.getClass()) {
       return false;
     }
-    NodeStatus other = (NodeStatus) obj;
-    if (this.operationalState == other.operationalState &&
-        this.health == other.health
-        && this.opStateExpiryEpochSeconds == other.opStateExpiryEpochSeconds) {
-      return true;
-    }
-    return false;
+    final NodeStatus that = (NodeStatus) obj;
+    return this.operationalState == that.operationalState
+        && this.health == that.health
+        && this.opStateExpiryEpochSeconds == that.opStateExpiryEpochSeconds;
   }
 
   @Override
@@ -244,8 +240,8 @@ public class NodeStatus implements Comparable<NodeStatus> {
 
   @Override
   public String toString() {
-    return "OperationalState: " + operationalState + " Health: " + health +
-        " OperationStateExpiry: " + opStateExpiryEpochSeconds;
+    return "OperationalState: " + operationalState
+        + "(expiry: " + opStateExpiryEpochSeconds + "s), Health: " + health;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -146,8 +146,7 @@ public class NodeStateMap {
       lock.writeLock().lock();
       DatanodeInfo dn = getNodeInfoUnsafe(nodeId);
       NodeStatus oldStatus = dn.getNodeStatus();
-      NodeStatus newStatus = new NodeStatus(
-          oldStatus.getOperationalState(), newHealth);
+      NodeStatus newStatus = NodeStatus.valueOf(oldStatus.getOperationalState(), newHealth);
       dn.setNodeStatus(newStatus);
       return newStatus;
     } finally {
@@ -170,8 +169,7 @@ public class NodeStateMap {
       lock.writeLock().lock();
       DatanodeInfo dn = getNodeInfoUnsafe(nodeId);
       NodeStatus oldStatus = dn.getNodeStatus();
-      NodeStatus newStatus = new NodeStatus(
-          newOpState, oldStatus.getHealth(), opStateExpiryEpochSeconds);
+      NodeStatus newStatus = NodeStatus.valueOf(newOpState, oldStatus.getHealth(), opStateExpiryEpochSeconds);
       dn.setNodeStatus(newStatus);
       return newStatus;
     } finally {
@@ -440,7 +438,7 @@ public class NodeStateMap {
   private List<DatanodeInfo> filterNodes(
       NodeOperationalState opState, NodeState health) {
     if (opState != null && health != null) {
-      return filterNodes(matching(new NodeStatus(opState, health)));
+      return filterNodes(matching(NodeStatus.valueOf(opState, health)));
     }
     if (opState != null) {
       return filterNodes(matching(opState));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -130,7 +130,7 @@ public class SimpleMockNodeManager implements NodeManager {
       throw new NodeNotFoundException();
     }
     dni.setNodeStatus(
-        new NodeStatus(
+        NodeStatus.valueOf(
             newState, dni.getNodeStatus().getHealth(), opStateExpiryEpocSec));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -148,7 +148,7 @@ public class TestMoveManager {
     assertMoveFailsWith(REPLICATION_FAIL_NODE_UNHEALTHY,
         containerInfo.containerID());
 
-    nodes.put(src, new NodeStatus(
+    nodes.put(src, NodeStatus.valueOf(
         HddsProtos.NodeOperationalState.DECOMMISSIONING,
         HddsProtos.NodeState.HEALTHY));
     nodes.put(tgt, NodeStatus.inServiceHealthy());
@@ -156,7 +156,7 @@ public class TestMoveManager {
         containerInfo.containerID());
 
     nodes.put(src, NodeStatus.inServiceHealthy());
-    nodes.put(tgt, new NodeStatus(
+    nodes.put(tgt, NodeStatus.valueOf(
         HddsProtos.NodeOperationalState.DECOMMISSIONING,
         HddsProtos.NodeState.HEALTHY));
     assertMoveFailsWith(REPLICATION_FAIL_NODE_NOT_IN_SERVICE,
@@ -463,7 +463,7 @@ public class TestMoveManager {
   public void testMoveCompleteSrcNotInService() throws Exception {
     CompletableFuture<MoveManager.MoveResult> res = setupSuccessfulMove();
 
-    nodes.put(src, new NodeStatus(
+    nodes.put(src, NodeStatus.valueOf(
         HddsProtos.NodeOperationalState.DECOMMISSIONING,
         HddsProtos.NodeState.HEALTHY));
     ContainerReplicaOp op = new ContainerReplicaOp(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -616,7 +616,7 @@ public class TestSCMContainerPlacementRackAware {
     setup(datanodeCount);
     // Set all the nodes to out of service
     for (DatanodeInfo dn : dnInfos) {
-      dn.setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
+      dn.setNodeStatus(NodeStatus.valueOf(DECOMMISSIONED, HEALTHY));
     }
 
     for (int i = 0; i < 10; i++) {
@@ -632,7 +632,7 @@ public class TestSCMContainerPlacementRackAware {
         // ok, as there is only 1 IN_SERVICE node and with the retry logic we
         // may never find it.
       }
-      dnInfos.get(index).setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
+      dnInfos.get(index).setNodeStatus(NodeStatus.valueOf(DECOMMISSIONED, HEALTHY));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -826,7 +826,7 @@ public class TestSCMContainerPlacementRackScatter {
     setup(datanodeCount);
 
     // DN 5 is out of service
-    dnInfos.get(5).setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
+    dnInfos.get(5).setNodeStatus(NodeStatus.valueOf(DECOMMISSIONED, HEALTHY));
 
     // SCM should have detected that DN 5 is dead
     cluster.remove(datanodes.get(5));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -92,11 +92,9 @@ public class TestECOverReplicationHandler {
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
           if (staleNode != null && staleNode.equals(dd)) {
-            return new NodeStatus(dd.getPersistedOpState(),
-                HddsProtos.NodeState.STALE, 0);
+            return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.STALE);
           }
-          return new NodeStatus(dd.getPersistedOpState(),
-              HddsProtos.NodeState.HEALTHY, 0);
+          return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
         });
 
     commandsSent = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -131,8 +131,7 @@ public class TestECUnderReplicationHandler {
     nodeManager = new MockNodeManager(true, 10) {
       @Override
       public NodeStatus getNodeStatus(DatanodeDetails dd) {
-        return new NodeStatus(
-            dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY, 0);
+        return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
       }
     };
     replicationManager = mock(ReplicationManager.class);
@@ -146,8 +145,7 @@ public class TestECUnderReplicationHandler {
     when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
-          return new NodeStatus(dd.getPersistedOpState(),
-              HddsProtos.NodeState.HEALTHY, 0);
+          return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
         });
 
     commandsSent = new HashSet<>();
@@ -392,11 +390,10 @@ public class TestECUnderReplicationHandler {
       @Override
       public NodeStatus getNodeStatus(DatanodeDetails dd) {
         if (dd.equals(deadMaintenance.getDatanodeDetails())) {
-          return new NodeStatus(dd.getPersistedOpState(),
+          return NodeStatus.valueOf(dd.getPersistedOpState(),
               HddsProtos.NodeState.DEAD);
         }
-        return new NodeStatus(
-            dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY, 0);
+        return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
       }
     };
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -86,8 +86,8 @@ public abstract class TestMisReplicationHandler {
     when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
-          return new NodeStatus(dd.getPersistedOpState(),
-              HddsProtos.NodeState.HEALTHY, 0);
+          return NodeStatus.valueOf(dd.getPersistedOpState(),
+              HddsProtos.NodeState.HEALTHY);
         });
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
@@ -85,7 +85,7 @@ public class TestQuasiClosedStuckOverReplicationHandler {
         replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
-          return new NodeStatus(dn.getPersistedOpState(),
+          return NodeStatus.valueOf(dn.getPersistedOpState(),
               HddsProtos.NodeState.HEALTHY);
         });
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
@@ -98,7 +98,7 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
         replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
-          return new NodeStatus(dn.getPersistedOpState(),
+          return NodeStatus.valueOf(dn.getPersistedOpState(),
               HddsProtos.NodeState.HEALTHY);
         });
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -94,8 +94,7 @@ public class TestRatisOverReplicationHandler {
     when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
-          return new NodeStatus(dd.getPersistedOpState(),
-              HddsProtos.NodeState.HEALTHY, 0);
+          return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
         });
 
     commandsSent = new HashSet<>();
@@ -208,8 +207,7 @@ public class TestRatisOverReplicationHandler {
     when(replicationManager.getNodeStatus(eq(staleNode)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
-          return new NodeStatus(dd.getPersistedOpState(),
-              HddsProtos.NodeState.STALE, 0);
+          return NodeStatus.valueOf(dd.getPersistedOpState(), HddsProtos.NodeState.STALE);
         });
 
     testProcessing(replicas, Collections.emptyList(),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -115,7 +115,7 @@ public class TestRatisUnderReplicationHandler {
         replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
-          return new NodeStatus(dn.getPersistedOpState(),
+          return NodeStatus.valueOf(dn.getPersistedOpState(),
               HddsProtos.NodeState.HEALTHY);
         });
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -447,7 +447,7 @@ public class TestReplicationManagerScenarios {
     public ContainerReplica buildContainerReplica() {
       createDatanodeDetails();
       createOrigin();
-      NODE_STATUS_MAP.put(datanodeDetails, new NodeStatus(operationalState, healthState));
+      NODE_STATUS_MAP.put(datanodeDetails, NodeStatus.valueOf(operationalState, healthState));
       datanodeDetails.setPersistedOpState(operationalState);
 
       ContainerReplica.ContainerReplicaBuilder builder = new ContainerReplica.ContainerReplicaBuilder();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -105,7 +105,7 @@ public class TestReplicationManagerUtil {
           final DatanodeDetails dn = invocation.getArgument(0);
           for (ContainerReplica r : replicas) {
             if (r.getDatanodeDetails().equals(dn)) {
-              return new NodeStatus(
+              return NodeStatus.valueOf(
                   r.getDatanodeDetails().getPersistedOpState(),
                   HddsProtos.NodeState.HEALTHY);
             }
@@ -189,7 +189,7 @@ public class TestReplicationManagerUtil {
           final DatanodeDetails dn = invocation.getArgument(0);
           for (ContainerReplica r : replicas) {
             if (r.getDatanodeDetails().equals(dn)) {
-              return new NodeStatus(
+              return NodeStatus.valueOf(
                   r.getDatanodeDetails().getPersistedOpState(),
                   HddsProtos.NodeState.HEALTHY);
             }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestVulnerableUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestVulnerableUnhealthyReplicasHandler.java
@@ -148,7 +148,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
-            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+            return NodeStatus.valueOf(DECOMMISSIONING, HEALTHY);
           }
           return NodeStatus.inServiceHealthy();
         });
@@ -191,7 +191,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
-            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+            return NodeStatus.valueOf(DECOMMISSIONING, HEALTHY);
           }
           return NodeStatus.inServiceHealthy();
         });
@@ -219,7 +219,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
-            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+            return NodeStatus.valueOf(DECOMMISSIONING, HEALTHY);
           }
           return NodeStatus.inServiceHealthy();
         });
@@ -250,7 +250,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
-            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+            return NodeStatus.valueOf(DECOMMISSIONING, HEALTHY);
           }
           return NodeStatus.inServiceHealthy();
         });

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -115,7 +115,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     // Ensure the node has some pipelines
     nodeManager.setPipelines(dn1, 2);
@@ -154,7 +154,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     // Add the node to the monitor. By default we have zero pipelines and
@@ -173,7 +173,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setContainers(dn1, generateContainers(3));
@@ -236,7 +236,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     // create 3 QUASI_CLOSED replicas with containerID 1 and same origin ID
@@ -307,7 +307,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING, HddsProtos.NodeState.HEALTHY));
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING, HddsProtos.NodeState.HEALTHY));
 
     // create a container and 3 QUASI_CLOSED replicas with containerID 1 and same origin ID
     ContainerID containerID = ContainerID.valueOf(1);
@@ -364,7 +364,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setContainers(dn1, generateContainers(3));
@@ -393,7 +393,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setContainers(dn1, generateContainers(1));
@@ -451,7 +451,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setContainers(dn1, generateContainers(3));
@@ -475,7 +475,7 @@ public class TestDatanodeAdminMonitor {
     // Set the node to dead, and then the workflow should get aborted, setting
     // the node state back to IN_SERVICE on the next run.
     nodeManager.setNodeStatus(dn1,
-        new NodeStatus(IN_SERVICE,
+        NodeStatus.valueOf(IN_SERVICE,
             HddsProtos.NodeState.HEALTHY));
     monitor.run();
     assertEquals(0, monitor.getTrackedNodeCount());
@@ -488,7 +488,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setContainers(dn1, generateContainers(3));
@@ -512,7 +512,7 @@ public class TestDatanodeAdminMonitor {
     // Set the node to dead, and then the workflow should get aborted, setting
     // the node state back to IN_SERVICE.
     nodeManager.setNodeStatus(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.DEAD));
     monitor.run();
     assertEquals(0, monitor.getTrackedNodeCount());
@@ -525,7 +525,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException, ContainerNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     nodeManager.setContainers(dn1, generateContainers(3));
     DatanodeAdminMonitorTestUtil
@@ -554,7 +554,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(ENTERING_MAINTENANCE,
+        NodeStatus.valueOf(ENTERING_MAINTENANCE,
             HddsProtos.NodeState.HEALTHY));
 
     // Add the node to the monitor, it should transiting to
@@ -585,7 +585,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(ENTERING_MAINTENANCE,
+        NodeStatus.valueOf(ENTERING_MAINTENANCE,
             HddsProtos.NodeState.HEALTHY));
     // Ensure the node has some pipelines
     nodeManager.setPipelines(dn1, 2);
@@ -611,7 +611,7 @@ public class TestDatanodeAdminMonitor {
       throws ContainerNotFoundException, NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(ENTERING_MAINTENANCE,
+        NodeStatus.valueOf(ENTERING_MAINTENANCE,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setContainers(dn1, generateContainers(3));
@@ -646,7 +646,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(ENTERING_MAINTENANCE,
+        NodeStatus.valueOf(ENTERING_MAINTENANCE,
             HddsProtos.NodeState.HEALTHY));
 
     // Add the node to the monitor, it should transiting to
@@ -658,7 +658,7 @@ public class TestDatanodeAdminMonitor {
 
     // Set the node dead and ensure the workflow does not end
     NodeStatus status = nodeManager.getNodeStatus(dn1);
-    nodeManager.setNodeStatus(dn1, new NodeStatus(
+    nodeManager.setNodeStatus(dn1, NodeStatus.valueOf(
         status.getOperationalState(), HddsProtos.NodeState.DEAD));
 
     // Running the monitor again causes the node to remain in maintenance
@@ -672,7 +672,7 @@ public class TestDatanodeAdminMonitor {
       throws NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(ENTERING_MAINTENANCE,
+        NodeStatus.valueOf(ENTERING_MAINTENANCE,
             HddsProtos.NodeState.HEALTHY));
 
     // Add the node to the monitor, it should transiting to
@@ -696,7 +696,7 @@ public class TestDatanodeAdminMonitor {
 
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     Set<ContainerID> containers = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -1044,7 +1044,7 @@ public class TestNodeDecommissionManager {
     }
     for (DatanodeDetails datanode : dns) {
       if (datanode.equals(dn)) {
-        return new NodeStatus(datanode.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
+        return NodeStatus.valueOf(datanode.getPersistedOpState(), HddsProtos.NodeState.HEALTHY);
       }
     }
     return null;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
@@ -85,7 +85,7 @@ public class TestNodeDecommissionMetrics {
   public void testDecommMonitorCollectTrackedNodes() {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(ENTERING_MAINTENANCE,
+        NodeStatus.valueOf(ENTERING_MAINTENANCE,
             HddsProtos.NodeState.HEALTHY));
     monitor.startMonitoring(dn1);
     monitor.run();
@@ -100,7 +100,7 @@ public class TestNodeDecommissionMetrics {
   public void testDecommMonitorCollectRecommissionNodes() {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
     nodeManager.register(dn1,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     monitor.startMonitoring(dn1);
     monitor.run();
@@ -122,7 +122,7 @@ public class TestNodeDecommissionMetrics {
         "datanode_host1",
         "/r1/ng1");
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     // Ensure the node has some pipelines
     nodeManager.setPipelines(dn1, 2);
@@ -155,7 +155,7 @@ public class TestNodeDecommissionMetrics {
         "datanode_host1",
         "/r1/ng1");
     nodeManager.register(dn1,
-        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        NodeStatus.valueOf(HddsProtos.NodeOperationalState.DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     Set<ContainerID> containers = new HashSet<>();
@@ -195,7 +195,7 @@ public class TestNodeDecommissionMetrics {
         "datanode_host1",
         "/r1/ng1");
     nodeManager.register(dn1,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     Set<ContainerID> containers = new HashSet<>();
     containers.add(ContainerID.valueOf(1));
@@ -233,7 +233,7 @@ public class TestNodeDecommissionMetrics {
         "datanode_host1",
         "/r1/ng1");
     nodeManager.register(dn1,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     Set<ContainerID> containers = new HashSet<>();
     containers.add(ContainerID.valueOf(1));
@@ -269,10 +269,10 @@ public class TestNodeDecommissionMetrics {
     DatanodeDetails dn2 = MockDatanodeDetails.randomDatanodeDetails();
 
     nodeManager.register(dn1,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     nodeManager.register(dn2,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     Set<ContainerID> containersDn1 = new HashSet<>();
@@ -312,10 +312,10 @@ public class TestNodeDecommissionMetrics {
     DatanodeDetails dn2 = MockDatanodeDetails.randomDatanodeDetails();
 
     nodeManager.register(dn1,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
     nodeManager.register(dn2,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setPipelines(dn1, 2);
@@ -334,7 +334,7 @@ public class TestNodeDecommissionMetrics {
     DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
 
     nodeManager.register(dn1,
-        new NodeStatus(DECOMMISSIONING,
+        NodeStatus.valueOf(DECOMMISSIONING,
             HddsProtos.NodeState.HEALTHY));
 
     nodeManager.setPipelines(dn1, 2);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStatus.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStatus.java
@@ -40,27 +40,27 @@ class TestNodeStatus {
   @ParameterizedTest
   @EnumSource
   void readOnly(HddsProtos.NodeOperationalState state) {
-    assertEquals(0, new NodeStatus(state, HEALTHY)
-        .compareTo(new NodeStatus(state, HEALTHY_READONLY)));
+    assertEquals(0, NodeStatus.valueOf(state, HEALTHY)
+        .compareTo(NodeStatus.valueOf(state, HEALTHY_READONLY)));
   }
 
   @Test
   void healthyFirst() {
     assertThat(0).isGreaterThan(inServiceHealthy().compareTo(inServiceStale()));
     assertThat(0).isLessThan(inServiceDead().compareTo(inServiceHealthy()));
-    assertThat(0).isGreaterThan(new NodeStatus(ENTERING_MAINTENANCE, HEALTHY).compareTo(
+    assertThat(0).isGreaterThan(NodeStatus.valueOf(ENTERING_MAINTENANCE, HEALTHY).compareTo(
         inServiceStale()
     ));
     assertThat(0).isLessThan(inServiceStale().compareTo(
-        new NodeStatus(DECOMMISSIONING, HEALTHY)
+        NodeStatus.valueOf(DECOMMISSIONING, HEALTHY)
     ));
   }
 
   @Test
   void inServiceFirst() {
     assertThat(0).isGreaterThan(inServiceHealthy().compareTo(
-        new NodeStatus(ENTERING_MAINTENANCE, HEALTHY)));
-    assertThat(0).isLessThan(new NodeStatus(DECOMMISSIONING, HEALTHY).compareTo(
+        NodeStatus.valueOf(ENTERING_MAINTENANCE, HEALTHY)));
+    assertThat(0).isLessThan(NodeStatus.valueOf(DECOMMISSIONING, HEALTHY).compareTo(
         inServiceHealthy()
     ));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/states/TestNodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/states/TestNodeStateMap.java
@@ -81,7 +81,7 @@ public class TestNodeStateMap {
     NodeStatus status = NodeStatus.inServiceHealthy();
     map.addNode(dn, status, null);
 
-    NodeStatus expectedStatus = new NodeStatus(
+    NodeStatus expectedStatus = NodeStatus.valueOf(
         NodeOperationalState.DECOMMISSIONING,
         NodeState.HEALTHY, 999);
     NodeStatus returnedStatus = map.updateNodeOperationalState(
@@ -166,7 +166,7 @@ public class TestNodeStateMap {
       NodeOperationalState opState, NodeState health
   )
       throws NodeAlreadyExistsException {
-    NodeStatus status = new NodeStatus(opState, health);
+    NodeStatus status = NodeStatus.valueOf(opState, health);
     map.addNode(dn, status, null);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -137,10 +137,10 @@ public class TestECPipelineProvider {
         .thenReturn(NodeStatus.inServiceDead());
     DatanodeDetails dead2 = iterator.next().getDatanodeDetails();
     when(nodeManager.getNodeStatus(dead2))
-        .thenReturn(new NodeStatus(IN_MAINTENANCE, DEAD));
+        .thenReturn(NodeStatus.valueOf(IN_MAINTENANCE, DEAD));
     DatanodeDetails dead3 = iterator.next().getDatanodeDetails();
     when(nodeManager.getNodeStatus(dead3))
-        .thenReturn(new NodeStatus(DECOMMISSIONED, DEAD));
+        .thenReturn(NodeStatus.valueOf(DECOMMISSIONED, DEAD));
     Set<DatanodeDetails> deadNodes = ImmutableSet.of(dead, dead2, dead3);
 
     Pipeline pipeline = provider.createForRead(ecConf, replicas);
@@ -166,7 +166,7 @@ public class TestECPipelineProvider {
       DatanodeDetails decomNode = MockDatanodeDetails.randomDatanodeDetails();
       replicas.add(replica.toBuilder().setDatanodeDetails(decomNode).build());
       when(nodeManager.getNodeStatus(decomNode))
-          .thenReturn(new NodeStatus(DECOMMISSIONING, HEALTHY));
+          .thenReturn(NodeStatus.valueOf(DECOMMISSIONING, HEALTHY));
       decomNodes.add(decomNode);
 
       DatanodeDetails staleNode = MockDatanodeDetails.randomDatanodeDetails();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -238,7 +238,7 @@ public class ReplicationNodeManagerMock implements NodeManager {
       throws NodeNotFoundException {
     NodeStatus currentStatus = nodeStateMap.get(dd);
     if (currentStatus != null) {
-      nodeStateMap.put(dd, new NodeStatus(newState, currentStatus.getHealth(),
+      nodeStateMap.put(dd, NodeStatus.valueOf(newState, currentStatus.getHealth(),
           opStateExpiryEpocSec));
     } else {
       throw new NodeNotFoundException();


### PR DESCRIPTION
## What changes were proposed in this pull request?

All the fields in NodeStatus won't be changed. We should change it to a value-based class. The main changes are:
- adding valueOf(..) methods,
- hiding the constructors, and
- replace the constructor calls

We also add a `CONSTANT_MAP` for storing all the NodeStatus objects with opStateExpiryEpochSeconds == 0.

## What is the link to the Apache JIRA

HDDS-12621

## How was this patch tested?

By updating existing tests.