### PR TITLE
HDDS-12630. Enable GitHub Discussions in asf.yml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,3 +37,6 @@ github:
     squash_commit_message: PR_TITLE
     merge:   false
     rebase:  false
+  features:
+    # Enable discussions
+    discussions: true


### PR DESCRIPTION

## What changes were proposed in this pull request?

ASF moving to `.asf.yml` to manage GitHub Features.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12630

## How was this patch tested?

If GitHub Discussions continue to show up :-)
