### PR TITLE
HDDS-11787. raft.server.log.appender.wait-time.min cannot be 0us

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmRatisServerConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmRatisServerConfig.java
@@ -35,7 +35,7 @@ import org.apache.ratis.server.RaftServerConfigKeys;
 public class ScmRatisServerConfig {
   /** @see RaftServerConfigKeys.Log.Appender#WAIT_TIME_MIN_KEY */
   @Config(key = "log.appender.wait-time.min",
-      defaultValue = "0ms",
+      defaultValue = "1ms",
       type = ConfigType.TIME,
       tags = {OZONE, SCM, RATIS, PERFORMANCE},
       description = "Minimum wait time between two appendEntries calls."

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -180,13 +180,13 @@ public class TestDatanodeConfiguration {
 
     final DatanodeRatisServerConfig ratisConf = conf.getObject(
         DatanodeRatisServerConfig.class);
-    assertEquals(0, ratisConf.getLogAppenderWaitTimeMin(),
+    assertEquals(1, ratisConf.getLogAppenderWaitTimeMin(),
         "getLogAppenderWaitTimeMin");
 
-    assertWaitTimeMin(TimeDuration.ZERO, conf);
-    ratisConf.setLogAppenderWaitTimeMin(1);
-    conf.setFromObject(ratisConf);
     assertWaitTimeMin(TimeDuration.ONE_MILLISECOND, conf);
+    ratisConf.setLogAppenderWaitTimeMin(2);
+    conf.setFromObject(ratisConf);
+    assertWaitTimeMin(TimeDuration.valueOf(2, TimeUnit.MILLISECONDS), conf);
   }
 
   static void assertWaitTimeMin(TimeDuration expected,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -193,13 +193,13 @@ public class DatanodeRatisServerConfig {
 
   /** @see RaftServerConfigKeys.Log.Appender#WAIT_TIME_MIN_KEY */
   @Config(key = "log.appender.wait-time.min",
-      defaultValue = "0us",
+      defaultValue = "1ms",
       type = ConfigType.TIME,
       tags = {OZONE, DATANODE, RATIS, PERFORMANCE},
       description = "The minimum wait time between two appendEntries calls. " +
           "In some error conditions, the leader may keep retrying " +
           "appendEntries. If it happens, increasing this value to, say, " +
-          "5us (microseconds) can help avoid the leader being too busy " +
+          "1ms (millisecond) can help avoid the leader being too busy " +
           "retrying."
   )
   private long logAppenderWaitTimeMin;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMConfiguration.java
@@ -200,14 +200,14 @@ class TestSCMConfiguration {
 
     final ScmRatisServerConfig scmRatisConfig = conf.getObject(
         ScmRatisServerConfig.class);
-    assertEquals(0, scmRatisConfig.getLogAppenderWaitTimeMin(),
+    assertEquals(1, scmRatisConfig.getLogAppenderWaitTimeMin(),
         "getLogAppenderWaitTimeMin");
 
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, tempDir.getPath());
 
     final RaftProperties p = RatisUtil.newRaftProperties(conf);
     final TimeDuration t = RaftServerConfigKeys.Log.Appender.waitTimeMin(p);
-    assertEquals(TimeDuration.ZERO, t,
+    assertEquals(TimeDuration.ONE_MILLISECOND, t,
         RaftServerConfigKeys.Log.Appender.WAIT_TIME_MIN_KEY);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmConf.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmConf.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
@@ -37,13 +38,13 @@ public class TestOmConf {
     final OzoneConfiguration conf = new OzoneConfiguration();
     final OzoneManagerRatisServerConfig ratisConf = conf.getObject(
         OzoneManagerRatisServerConfig.class);
-    assertEquals(0, ratisConf.getLogAppenderWaitTimeMin(),
+    assertEquals(1, ratisConf.getLogAppenderWaitTimeMin(),
         "getLogAppenderWaitTimeMin");
-    assertWaitTimeMin(TimeDuration.ZERO, conf);
-
-    ratisConf.setLogAppenderWaitTimeMin(1);
-    conf.setFromObject(ratisConf);
     assertWaitTimeMin(TimeDuration.ONE_MILLISECOND, conf);
+
+    ratisConf.setLogAppenderWaitTimeMin(2);
+    conf.setFromObject(ratisConf);
+    assertWaitTimeMin(TimeDuration.valueOf(2, TimeUnit.MILLISECONDS), conf);
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -413,7 +413,7 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
         .getRaftServer()
         .getProperties();
     final TimeDuration t = RaftServerConfigKeys.Log.Appender.waitTimeMin(p);
-    assertEquals(TimeDuration.ZERO, t,
+    assertEquals(TimeDuration.ONE_MILLISECOND, t,
         RaftServerConfigKeys.Log.Appender.WAIT_TIME_MIN_KEY);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServerConfig.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServerConfig.java
@@ -37,7 +37,7 @@ import org.apache.ratis.server.RaftServerConfigKeys;
 public class OzoneManagerRatisServerConfig {
   /** @see RaftServerConfigKeys.Log.Appender#WAIT_TIME_MIN_KEY */
   @Config(key = "log.appender.wait-time.min",
-      defaultValue = "0ms",
+      defaultValue = "1ms",
       type = ConfigType.TIME,
       tags = {OZONE, OM, RATIS, PERFORMANCE},
       description = "Minimum wait time between two appendEntries calls."


### PR DESCRIPTION
## What changes were proposed in this pull request?
OM, SCM and DN configures `raft.server.log.appender.wait-time.min` as `0us`/`0ms`. However Ratis accepts only positive values and will fall back to the default which is `1ms`. Update the defaultVaue to `1ms`.

## What is the link to the Apache JIRA
[HDDS-11787](https://issues.apache.org/jira/browse/HDDS-11787)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/13939399074