### PR TITLE
HDDS-12639. Add info for timeout exception

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
@@ -97,9 +98,17 @@ public class RunningDatanodeState implements DatanodeState {
         } else {
           heartbeatFrequency = context.getHeartbeatFrequency();
         }
-        ecs.submit(() -> endpoint.getExecutorService()
-            .submit(endpointTask)
-            .get(heartbeatFrequency, TimeUnit.MILLISECONDS));
+        ecs.submit(() -> {
+          try {
+            return endpoint.getExecutorService()
+                .submit(endpointTask)
+                .get(context.getHeartbeatFrequency(), TimeUnit.MILLISECONDS);
+          } catch (TimeoutException e) {
+            TimeoutException timeoutEx = new TimeoutException("Timeout occurred on endpoint: " + endpoint.getAddress());
+            timeoutEx.initCause(e);
+            throw timeoutEx;
+          }
+        });
       } else {
         // This can happen if a task is taking more time than the timeOut
         // specified for the task in await, and when it is completed the task
@@ -167,7 +176,12 @@ public class RunningDatanodeState implements DatanodeState {
         LOG.error("Error in executing end point task.", e);
         Thread.currentThread().interrupt();
       } catch (ExecutionException e) {
-        LOG.error("Error in executing end point task.", e);
+        Throwable cause = e.getCause();
+        if (cause instanceof TimeoutException) {
+          LOG.warn("Detected timeout: {}", cause.getMessage());
+        } else {
+          LOG.error("Error in executing end point task.", e);
+        }
       }
     }
     return DatanodeStateMachine.DatanodeStates.RUNNING;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When datanode can not connect to SCM or Recon, the following error will be throw, and the timeout exception can be reformat.

```
Error in executing end point task.
java.util.concurrent.ExecutionException: java.util.concurrent.TimeoutException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
	at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.computeNextContainerState(RunningDatanodeState.java:191)
	at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.await(RunningDatanodeState.java:231)
	at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.await(RunningDatanodeState.java:50)
	at org.apache.hadoop.ozone.container.common.statemachine.StateContext.execute(StateContext.java:641)
	at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.start(DatanodeStateMachine.java:281)
	at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.lambda$startDaemon$0(DatanodeStateMachine.java:472)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.TimeoutException
	at java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.lambda$execute$0(RunningDatanodeState.java:149)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	... 1 more 
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12639

## How was this patch tested?

Exception changed to the following format.
```
2025-03-19 09:59:20,675 [c4164728-1ffe-4d8d-b5ae-17367e5904e2-DatanodeStateMachineDaemonThread] WARN datanode.RunningDatanodeState: Detected timeout: Timeout occurred on endpoint: recon/<unresolved>:9891
```