### PR TITLE
HDDS-12644. Create factory method for OzoneAcl

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
@@ -56,7 +56,7 @@ import org.apache.ratis.util.MemoizedSupplier;
  * </ul>
  */
 @Immutable
-public class OzoneAcl {
+public final class OzoneAcl {
 
   private static final String ACL_SCOPE_REGEX = ".*\\[(ACCESS|DEFAULT)\\]";
   /**
@@ -64,7 +64,7 @@ public class OzoneAcl {
    * which is similar to Linux POSIX symbolic.
    */
   public static final OzoneAcl LINK_BUCKET_DEFAULT_ACL =
-      new OzoneAcl(IAccessAuthorizer.ACLIdentityType.WORLD, "", ACCESS, READ, WRITE);
+      OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.WORLD, "", ACCESS, READ, WRITE);
 
   private final ACLIdentityType type;
   private final String name;
@@ -77,12 +77,12 @@ public class OzoneAcl {
   @JsonIgnore
   private final Supplier<Integer> hashCodeMethod;
 
-  public OzoneAcl(ACLIdentityType type, String name, AclScope scope, ACLType... acls) {
-    this(type, name, scope, toInt(acls));
+  public static OzoneAcl of(ACLIdentityType type, String name, AclScope scope, ACLType... acls) {
+    return new OzoneAcl(type, name, scope, toInt(acls));
   }
 
-  public OzoneAcl(ACLIdentityType type, String name, AclScope scope, EnumSet<ACLType> acls) {
-    this(type, name, scope, toInt(acls));
+  public static OzoneAcl of(ACLIdentityType type, String name, AclScope scope, EnumSet<ACLType> acls) {
+    return new OzoneAcl(type, name, scope, toInt(acls));
   }
 
   private OzoneAcl(ACLIdentityType type, String name, AclScope scope, int acls) {
@@ -194,7 +194,7 @@ public class OzoneAcl {
 
     // TODO : Support sanitation of these user names by calling into
     // userAuth Interface.
-    return new OzoneAcl(aclType, parts[1], aclScope, acls);
+    return OzoneAcl.of(aclType, parts[1], aclScope, acls);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -68,10 +68,10 @@ public final class OzoneAclUtil {
     }
     List<OzoneAcl> listOfAcls = new ArrayList<>();
     // User ACL.
-    listOfAcls.add(new OzoneAcl(USER, ugi.getShortUserName(), ACCESS, userRights));
+    listOfAcls.add(OzoneAcl.of(USER, ugi.getShortUserName(), ACCESS, userRights));
     try {
       String groupName = ugi.getPrimaryGroupName();
-      listOfAcls.add(new OzoneAcl(GROUP, groupName, ACCESS, groupRights));
+      listOfAcls.add(OzoneAcl.of(GROUP, groupName, ACCESS, groupRights));
     } catch (IOException e) {
       // do nothing, since user has the permission, user can add ACL for selected groups later.
       LOG.warn("Failed to get primary group from user {}", ugi);
@@ -82,10 +82,10 @@ public final class OzoneAclUtil {
   public static List<OzoneAcl> getAclList(UserGroupInformation ugi, ACLType userPrivilege, ACLType groupPrivilege) {
     List<OzoneAcl> listOfAcls = new ArrayList<>();
     // User ACL.
-    listOfAcls.add(new OzoneAcl(USER, ugi.getShortUserName(), ACCESS, userPrivilege));
+    listOfAcls.add(OzoneAcl.of(USER, ugi.getShortUserName(), ACCESS, userPrivilege));
     try {
       String groupName = ugi.getPrimaryGroupName();
-      listOfAcls.add(new OzoneAcl(GROUP, groupName, ACCESS, groupPrivilege));
+      listOfAcls.add(OzoneAcl.of(GROUP, groupName, ACCESS, groupPrivilege));
     } catch (IOException e) {
       // do nothing, since user has the permission, user can add ACL for selected groups later.
       LOG.warn("Failed to get primary group from user {}", ugi);

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -76,7 +76,7 @@ public class TestOmBucketInfo {
         .setCreationTime(Time.now())
         .setIsVersionEnabled(false)
         .setStorageType(StorageType.ARCHIVE)
-        .setAcls(Collections.singletonList(new OzoneAcl(
+        .setAcls(Collections.singletonList(OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             "defaultUser",
             OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL
@@ -91,7 +91,7 @@ public class TestOmBucketInfo {
             + " to be equal");
 
     /* Reset acl & check not equal. */
-    omBucketInfo.setAcls(Collections.singletonList(new OzoneAcl(
+    omBucketInfo.setAcls(Collections.singletonList(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER,
         "newUser",
         OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL
@@ -108,7 +108,7 @@ public class TestOmBucketInfo {
         cloneBucketInfo.getAcls().get(0));
 
     /* Remove acl & check. */
-    omBucketInfo.removeAcl(new OzoneAcl(
+    omBucketInfo.removeAcl(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER,
         "newUser",
         OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL
@@ -124,7 +124,7 @@ public class TestOmBucketInfo {
         OmBucketInfo.newBuilder().setBucketName("bucket").setVolumeName("vol1")
             .setCreationTime(Time.now()).setIsVersionEnabled(false)
             .setStorageType(StorageType.ARCHIVE).setAcls(Collections
-                .singletonList(new OzoneAcl(
+                .singletonList(OzoneAcl.of(
                     IAccessAuthorizer.ACLIdentityType.USER,
                     "defaultUser", OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL
                 ))).build();
@@ -143,7 +143,7 @@ public class TestOmBucketInfo {
         .setCreationTime(Time.now())
         .setIsVersionEnabled(false)
         .setStorageType(StorageType.ARCHIVE)
-        .setAcls(Collections.singletonList(new OzoneAcl(
+        .setAcls(Collections.singletonList(OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             "defaultUser", OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL
         )))

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -181,7 +181,7 @@ public class TestOmKeyInfo {
       }
     }
 
-    key.setAcls(Arrays.asList(new OzoneAcl(
+    key.setAcls(Arrays.asList(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
         ACCESS, IAccessAuthorizer.ACLType.WRITE)));
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
@@ -43,7 +43,7 @@ public class TestOmVolumeArgs {
         .setObjectID(1L).setUpdateID(1L).setQuotaInBytes(Long.MAX_VALUE)
         .addMetadata("key1", "value1").addMetadata("key2", "value2")
         .addOzoneAcls(
-            new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "user1",
+            OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER, "user1",
                 ACCESS, IAccessAuthorizer.ACLType.READ)).build();
 
     OmVolumeArgs cloneVolumeArgs = omVolumeArgs.copyObject();
@@ -51,7 +51,7 @@ public class TestOmVolumeArgs {
     assertEquals(omVolumeArgs, cloneVolumeArgs);
 
     // add user acl to write.
-    omVolumeArgs.addAcl(new OzoneAcl(
+    omVolumeArgs.addAcl(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
         ACCESS, IAccessAuthorizer.ACLType.WRITE));
 
@@ -60,7 +60,7 @@ public class TestOmVolumeArgs {
         omVolumeArgs.getAcls().get(0));
 
     // Set user acl to Write_ACL.
-    omVolumeArgs.setAcls(Collections.singletonList(new OzoneAcl(
+    omVolumeArgs.setAcls(Collections.singletonList(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
         ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL)));
 
@@ -74,7 +74,7 @@ public class TestOmVolumeArgs {
     assertEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
-    omVolumeArgs.removeAcl(new OzoneAcl(
+    omVolumeArgs.removeAcl(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
         ACCESS, IAccessAuthorizer.ACLType.WRITE_ACL));
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
@@ -46,10 +46,10 @@ public class TestOzoneAclUtil {
   private static final List<OzoneAcl> DEFAULT_ACLS =
       getDefaultAcls();
 
-  private static final OzoneAcl USER1 = new OzoneAcl(USER, "user1",
+  private static final OzoneAcl USER1 = OzoneAcl.of(USER, "user1",
       ACCESS, ACLType.READ_ACL);
 
-  private static final OzoneAcl GROUP1 = new OzoneAcl(GROUP, "group1",
+  private static final OzoneAcl GROUP1 = OzoneAcl.of(GROUP, "group1",
       ACCESS, ACLType.ALL);
 
   @Test
@@ -59,7 +59,7 @@ public class TestOzoneAclUtil {
 
     // Add new permission to existing acl entry.
     OzoneAcl oldAcl = currentAcls.get(0);
-    OzoneAcl newAcl = new OzoneAcl(oldAcl.getType(), oldAcl.getName(),
+    OzoneAcl newAcl = OzoneAcl.of(oldAcl.getType(), oldAcl.getName(),
         ACCESS, ACLType.READ_ACL);
 
     addAndVerifyAcl(currentAcls, newAcl, true, DEFAULT_ACLS.size());
@@ -91,7 +91,7 @@ public class TestOzoneAclUtil {
 
     // Add new permission to existing acl entru.
     OzoneAcl oldAcl = currentAcls.get(0);
-    OzoneAcl newAcl = new OzoneAcl(oldAcl.getType(), oldAcl.getName(),
+    OzoneAcl newAcl = OzoneAcl.of(oldAcl.getType(), oldAcl.getName(),
         ACCESS, ACLType.READ_ACL);
 
     // Remove non existing acl entry
@@ -185,12 +185,12 @@ public class TestOzoneAclUtil {
     IAccessAuthorizer.ACLType[] userRights = aclConfig.getUserDefaultRights();
     IAccessAuthorizer.ACLType[] groupRights = aclConfig.getGroupDefaultRights();
 
-    OzoneAclUtil.addAcl(ozoneAcls, new OzoneAcl(USER,
+    OzoneAclUtil.addAcl(ozoneAcls, OzoneAcl.of(USER,
         ugi.getUserName(), ACCESS, userRights));
     //Group ACLs of the User
     List<String> userGroups = Arrays.asList(ugi.getGroupNames());
     userGroups.stream().forEach((group) -> OzoneAclUtil.addAcl(ozoneAcls,
-        new OzoneAcl(GROUP, group, ACCESS, groupRights)));
+        OzoneAcl.of(GROUP, group, ACCESS, groupRights)));
     return ozoneAcls;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1205,8 +1205,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     VolumeArgs volumeArgs = VolumeArgs.newBuilder()
         .setAdmin("admin")
         .setOwner("admin")
-        .addAcl(new OzoneAcl(ACLIdentityType.WORLD, "", ACCESS, aclRights))
-        .addAcl(new OzoneAcl(ACLIdentityType.USER, "admin", ACCESS, userRights))
+        .addAcl(OzoneAcl.of(ACLIdentityType.WORLD, "", ACCESS, aclRights))
+        .addAcl(OzoneAcl.of(ACLIdentityType.USER, "admin", ACCESS, userRights))
         .setQuotaInNamespace(1000)
         .setQuotaInBytes(Long.MAX_VALUE).build();
     // Sanity check
@@ -1240,8 +1240,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     // bucket acls have all access to admin and read+write+list access to world
     BucketArgs bucketArgs = new BucketArgs.Builder()
         .setOwner("admin")
-        .addAcl(new OzoneAcl(ACLIdentityType.WORLD, "", ACCESS, READ, WRITE, LIST))
-        .addAcl(new OzoneAcl(ACLIdentityType.USER, "admin", ACCESS, userRights))
+        .addAcl(OzoneAcl.of(ACLIdentityType.WORLD, "", ACCESS, READ, WRITE, LIST))
+        .addAcl(OzoneAcl.of(ACLIdentityType.USER, "admin", ACCESS, userRights))
         .setQuotaInNamespace(1000)
         .setQuotaInBytes(Long.MAX_VALUE).build();
 
@@ -1300,7 +1300,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
     ACLType[] userRights = aclConfig.getUserDefaultRights();
     // Construct ACL for world access
-    OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
+    OzoneAcl aclWorldAccess = OzoneAcl.of(ACLIdentityType.WORLD, "",
         ACCESS, userRights);
     // Construct VolumeArgs
     VolumeArgs volumeArgs = VolumeArgs.newBuilder()
@@ -2295,7 +2295,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
     ACLType[] userRights = aclConfig.getUserDefaultRights();
     // Construct ACL for world access
-    OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
+    OzoneAcl aclWorldAccess = OzoneAcl.of(ACLIdentityType.WORLD, "",
         ACCESS, userRights);
     // Construct VolumeArgs, set ACL to world access
     VolumeArgs volumeArgs = VolumeArgs.newBuilder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -217,13 +217,13 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       storageContainerLocationClient;
   private static String remoteUserName = "remoteUser";
   private static String remoteGroupName = "remoteGroup";
-  private static OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
+  private static OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
       DEFAULT, READ);
-  private static OzoneAcl defaultGroupAcl = new OzoneAcl(GROUP, remoteGroupName,
+  private static OzoneAcl defaultGroupAcl = OzoneAcl.of(GROUP, remoteGroupName,
       DEFAULT, READ);
-  private static OzoneAcl inheritedUserAcl = new OzoneAcl(USER, remoteUserName,
+  private static OzoneAcl inheritedUserAcl = OzoneAcl.of(USER, remoteUserName,
       ACCESS, READ);
-  private static OzoneAcl inheritedGroupAcl = new OzoneAcl(GROUP,
+  private static OzoneAcl inheritedGroupAcl = OzoneAcl.of(GROUP,
       remoteGroupName, ACCESS, READ);
   private static MessageDigest eTagProvider;
   private static Set<OzoneClient> ozoneClients = new HashSet<>();
@@ -399,10 +399,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           .setVolumeName(volumeName).setBucketName(bucketName)
           .setStoreType(OzoneObj.StoreType.OZONE)
           .setResType(OzoneObj.ResourceType.BUCKET).build();
-      store.addAcl(volumeObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
-      store.addAcl(volumeObj, new OzoneAcl(USER, "user2", ACCESS, ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "user2", ACCESS, ALL));
+      store.addAcl(volumeObj, OzoneAcl.of(USER, "user1", ACCESS, ALL));
+      store.addAcl(volumeObj, OzoneAcl.of(USER, "user2", ACCESS, ALL));
+      store.addAcl(bucketObj, OzoneAcl.of(USER, "user1", ACCESS, ALL));
+      store.addAcl(bucketObj, OzoneAcl.of(USER, "user2", ACCESS, ALL));
 
       createKeyForUser(volumeName, bucketName, key1, content, user1);
       createKeyForUser(volumeName, bucketName, key2, content, user2);
@@ -749,7 +749,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OzoneAcl userAcl = new OzoneAcl(USER, "test",
+    OzoneAcl userAcl = OzoneAcl.of(USER, "test",
         ACCESS, READ);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -783,7 +783,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OzoneAcl userAcl = new OzoneAcl(USER, "test",
+    OzoneAcl userAcl = OzoneAcl.of(USER, "test",
         ACCESS, ALL);
     ReplicationConfig repConfig = new ECReplicationConfig(3, 2);
     store.createVolume(volumeName);
@@ -823,7 +823,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     List<OzoneAcl> acls = new ArrayList<>();
-    acls.add(new OzoneAcl(USER, "test", ACCESS, ALL));
+    acls.add(OzoneAcl.of(USER, "test", ACCESS, ALL));
     OzoneBucket bucket = volume.getBucket(bucketName);
     for (OzoneAcl acl : acls) {
       assertTrue(bucket.addAcl(acl));
@@ -838,7 +838,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OzoneAcl userAcl = new OzoneAcl(USER, "test",
+    OzoneAcl userAcl = OzoneAcl.of(USER, "test",
         ACCESS, ALL);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -857,9 +857,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OzoneAcl userAcl = new OzoneAcl(USER, "test",
+    OzoneAcl userAcl = OzoneAcl.of(USER, "test",
         ACCESS, ALL);
-    OzoneAcl acl2 = new OzoneAcl(USER, "test1",
+    OzoneAcl acl2 = OzoneAcl.of(USER, "test1",
         ACCESS, ALL);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -923,10 +923,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OzoneAcl userAcl1 = new OzoneAcl(USER, "test", DEFAULT, READ);
+    OzoneAcl userAcl1 = OzoneAcl.of(USER, "test", DEFAULT, READ);
     UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
-    OzoneAcl currentUserAcl = new OzoneAcl(USER, currentUser.getShortUserName(), ACCESS, ALL);
-    OzoneAcl currentUserPrimaryGroupAcl = new OzoneAcl(GROUP, currentUser.getPrimaryGroupName(), ACCESS, READ, LIST);
+    OzoneAcl currentUserAcl = OzoneAcl.of(USER, currentUser.getShortUserName(), ACCESS, ALL);
+    OzoneAcl currentUserPrimaryGroupAcl = OzoneAcl.of(GROUP, currentUser.getPrimaryGroupName(), ACCESS, READ, LIST);
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(currentUser.getShortUserName())
         .setAdmin(currentUser.getShortUserName())
@@ -958,7 +958,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     assertEquals(ACCESS, bucketAcls.get(2).getAclScope());
 
     // link bucket
-    OzoneAcl userAcl2 = new OzoneAcl(USER, "test-link", DEFAULT, READ);
+    OzoneAcl userAcl2 = OzoneAcl.of(USER, "test-link", DEFAULT, READ);
     String linkBucketName =  "link-" + bucketName;
     builder = BucketArgs.newBuilder().setSourceVolume(volumeName).setSourceBucket(bucketName)
         .addAcl(currentUserAcl).addAcl(currentUserPrimaryGroupAcl).addAcl(userAcl2);
@@ -3168,10 +3168,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneBucket bucket = volume.getBucket(bucketName);
 
     // Add ACL on Bucket
-    OzoneAcl acl1 = new OzoneAcl(USER, "Monday", DEFAULT, ALL);
-    OzoneAcl acl2 = new OzoneAcl(USER, "Friday", DEFAULT, ALL);
-    OzoneAcl acl3 = new OzoneAcl(USER, "Jan", ACCESS, ALL);
-    OzoneAcl acl4 = new OzoneAcl(USER, "Feb", ACCESS, ALL);
+    OzoneAcl acl1 = OzoneAcl.of(USER, "Monday", DEFAULT, ALL);
+    OzoneAcl acl2 = OzoneAcl.of(USER, "Friday", DEFAULT, ALL);
+    OzoneAcl acl3 = OzoneAcl.of(USER, "Jan", ACCESS, ALL);
+    OzoneAcl acl4 = OzoneAcl.of(USER, "Feb", ACCESS, ALL);
     bucket.addAcl(acl1);
     bucket.addAcl(acl2);
     bucket.addAcl(acl3);
@@ -3205,8 +3205,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     try (OzoneClient client =
         remoteUser.doAs((PrivilegedExceptionAction<OzoneClient>)
             () -> OzoneClientFactory.getRpcClient(cluster.getConf()))) {
-      OzoneAcl acl5 = new OzoneAcl(USER, userName, DEFAULT, ACLType.READ);
-      OzoneAcl acl6 = new OzoneAcl(USER, userName, ACCESS, ACLType.READ);
+      OzoneAcl acl5 = OzoneAcl.of(USER, userName, DEFAULT, ACLType.READ);
+      OzoneAcl acl6 = OzoneAcl.of(USER, userName, ACCESS, ACLType.READ);
       OzoneObj volumeObj = OzoneObjInfo.Builder.newBuilder()
           .setVolumeName(volumeName).setStoreType(OzoneObj.StoreType.OZONE)
           .setResType(OzoneObj.ResourceType.VOLUME).build();
@@ -3229,10 +3229,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       assertEquals(ResultCodes.PERMISSION_DENIED, ome.getResult());
 
       // Add create permission for user, and try multi-upload init again
-      OzoneAcl acl7 = new OzoneAcl(USER, userName, DEFAULT, ACLType.CREATE);
-      OzoneAcl acl8 = new OzoneAcl(USER, userName, ACCESS, ACLType.CREATE);
-      OzoneAcl acl9 = new OzoneAcl(USER, userName, DEFAULT, WRITE);
-      OzoneAcl acl10 = new OzoneAcl(USER, userName, ACCESS, WRITE);
+      OzoneAcl acl7 = OzoneAcl.of(USER, userName, DEFAULT, ACLType.CREATE);
+      OzoneAcl acl8 = OzoneAcl.of(USER, userName, ACCESS, ACLType.CREATE);
+      OzoneAcl acl9 = OzoneAcl.of(USER, userName, DEFAULT, WRITE);
+      OzoneAcl acl10 = OzoneAcl.of(USER, userName, ACCESS, WRITE);
       store.addAcl(volumeObj, acl7);
       store.addAcl(volumeObj, acl8);
       store.addAcl(volumeObj, acl9);
@@ -3342,10 +3342,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           .setVolumeName(volumeName).setBucketName(bucketName)
           .setStoreType(OzoneObj.StoreType.OZONE)
           .setResType(OzoneObj.ResourceType.BUCKET).build();
-      store.addAcl(volumeObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
-      store.addAcl(volumeObj, new OzoneAcl(USER, "awsUser1", ACCESS, ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "awsUser1", ACCESS, ALL));
+      store.addAcl(volumeObj, OzoneAcl.of(USER, "user1", ACCESS, ALL));
+      store.addAcl(volumeObj, OzoneAcl.of(USER, "awsUser1", ACCESS, ALL));
+      store.addAcl(bucketObj, OzoneAcl.of(USER, "user1", ACCESS, ALL));
+      store.addAcl(bucketObj, OzoneAcl.of(USER, "awsUser1", ACCESS, ALL));
 
       // user1 MultipartUpload a key
       UserGroupInformation.setLoginUser(user1);
@@ -4069,7 +4069,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         .setStoreType(OzoneObj.StoreType.OZONE)
         .build();
 
-    OzoneAcl user1Acl = new OzoneAcl(USER, "user1", ACCESS, READ);
+    OzoneAcl user1Acl = OzoneAcl.of(USER, "user1", ACCESS, READ);
     assertTrue(store.addAcl(prefixObj, user1Acl));
 
     // get acl
@@ -4082,7 +4082,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     aclsGet = store.getAcl(prefixObj);
     assertEquals(0, aclsGet.size());
 
-    OzoneAcl group1Acl = new OzoneAcl(GROUP, "group1", ACCESS, ALL);
+    OzoneAcl group1Acl = OzoneAcl.of(GROUP, "group1", ACCESS, ALL);
     List<OzoneAcl> acls = new ArrayList<>();
     acls.add(user1Acl);
     acls.add(group1Acl);
@@ -4122,9 +4122,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     ACLType[] userRights = aclConfig.getUserDefaultRights();
     ACLType[] groupRights = aclConfig.getGroupDefaultRights();
 
-    listOfAcls.add(new OzoneAcl(USER, ugi.getShortUserName(), ACCESS, userRights));
+    listOfAcls.add(OzoneAcl.of(USER, ugi.getShortUserName(), ACCESS, userRights));
     //Group ACL of the User
-    listOfAcls.add(new OzoneAcl(GROUP, ugi.getPrimaryGroupName(), ACCESS, groupRights));
+    listOfAcls.add(OzoneAcl.of(GROUP, ugi.getPrimaryGroupName(), ACCESS, groupRights));
     return listOfAcls;
   }
 
@@ -4139,7 +4139,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     // Case:1 Add new acl permission to existing acl.
     if (!expectedAcls.isEmpty()) {
       OzoneAcl oldAcl = expectedAcls.get(0);
-      OzoneAcl newAcl = new OzoneAcl(oldAcl.getType(), oldAcl.getName(),
+      OzoneAcl newAcl = OzoneAcl.of(oldAcl.getType(), oldAcl.getName(),
           oldAcl.getAclScope(), ACLType.READ_ACL);
       // Verify that operation successful.
       assertTrue(store.addAcl(ozObj, newAcl));
@@ -4190,9 +4190,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     assertThat(finalNewAcls).containsAll(expectedAcls);
 
     // Reset acl's.
-    OzoneAcl ua = new OzoneAcl(USER, "userx",
+    OzoneAcl ua = OzoneAcl.of(USER, "userx",
         ACCESS, ACLType.READ_ACL);
-    OzoneAcl ug = new OzoneAcl(GROUP, "userx",
+    OzoneAcl ug = OzoneAcl.of(GROUP, "userx",
         ACCESS, ALL);
     store.setAcl(ozObj, Arrays.asList(ua, ug));
     newAcls = store.getAcl(ozObj);
@@ -4551,7 +4551,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         .setStoreType(OzoneObj.StoreType.OZONE)
         .build();
 
-    OzoneAcl ozoneAcl = new OzoneAcl(USER, remoteUserName, DEFAULT, WRITE);
+    OzoneAcl ozoneAcl = OzoneAcl.of(USER, remoteUserName, DEFAULT, WRITE);
 
     boolean result = store.addAcl(s3vVolume, ozoneAcl);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
@@ -80,10 +80,10 @@ public class TestOzoneRpcClientForAclAuditLog {
       LoggerFactory.getLogger(TestOzoneRpcClientForAclAuditLog.class);
   private static UserGroupInformation ugi;
   private static final OzoneAcl USER_ACL =
-      new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER,
+      OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER,
           "johndoe", ACCESS, IAccessAuthorizer.ACLType.ALL);
   private static final OzoneAcl USER_ACL_2 =
-      new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER,
+      OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER,
           "jane", ACCESS, IAccessAuthorizer.ACLType.ALL);
   private static List<OzoneAcl> aclListToAdd = new ArrayList<>();
   private static MiniOzoneCluster cluster = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -103,7 +103,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       //Get Acls
       ozoneBucket.getAcls();
       //Add Acls
-      OzoneAcl acl = new OzoneAcl(USER, "testuser",
+      OzoneAcl acl = OzoneAcl.of(USER, "testuser",
           DEFAULT, IAccessAuthorizer.ACLType.ALL);
       ozoneBucket.addAcl(acl);
     }
@@ -159,7 +159,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       assertThrows(Exception.class, () -> {
         OzoneVolume volume = client.getObjectStore().getVolume(VOLUME_NAME);
         OzoneBucket ozoneBucket = volume.getBucket("bucket1");
-        OzoneAcl acl = new OzoneAcl(USER, "testuser1",
+        OzoneAcl acl = OzoneAcl.of(USER, "testuser1",
             DEFAULT, IAccessAuthorizer.ACLType.ALL);
         ozoneBucket.addAcl(acl);
       }, "Add Acls as non-volume and non-bucket owner should fail");
@@ -181,7 +181,7 @@ public abstract class TestBucketOwner implements NonHATests.TestCase {
       //Get Acls
       ozoneBucket.getAcls();
       //Add Acls
-      OzoneAcl acl = new OzoneAcl(USER, "testuser2",
+      OzoneAcl acl = OzoneAcl.of(USER, "testuser2",
           DEFAULT, IAccessAuthorizer.ACLType.ALL);
       ozoneBucket.addAcl(acl);
       //Bucket Delete

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -527,7 +527,7 @@ public class TestKeyManagerImpl {
         .setStoreType(OzoneObj.StoreType.OZONE)
         .build();
 
-    OzoneAcl ozAcl1 = new OzoneAcl(ACLIdentityType.USER, "user1",
+    OzoneAcl ozAcl1 = OzoneAcl.of(ACLIdentityType.USER, "user1",
         ACCESS, ACLType.READ);
     writeClient.addAcl(ozPrefix1, ozAcl1);
 
@@ -536,13 +536,13 @@ public class TestKeyManagerImpl {
     assertEquals(ozAcl1, ozAclGet.get(0));
 
     List<OzoneAcl> acls = new ArrayList<>();
-    OzoneAcl ozAcl2 = new OzoneAcl(ACLIdentityType.USER, "admin", ACCESS, ACLType.ALL);
+    OzoneAcl ozAcl2 = OzoneAcl.of(ACLIdentityType.USER, "admin", ACCESS, ACLType.ALL);
 
-    OzoneAcl ozAcl3 = new OzoneAcl(ACLIdentityType.GROUP, "dev", ACCESS, READ, WRITE);
+    OzoneAcl ozAcl3 = OzoneAcl.of(ACLIdentityType.GROUP, "dev", ACCESS, READ, WRITE);
 
-    OzoneAcl ozAcl4 = new OzoneAcl(ACLIdentityType.GROUP, "dev", ACCESS, WRITE);
+    OzoneAcl ozAcl4 = OzoneAcl.of(ACLIdentityType.GROUP, "dev", ACCESS, WRITE);
 
-    OzoneAcl ozAcl5 = new OzoneAcl(ACLIdentityType.GROUP, "dev", ACCESS, READ);
+    OzoneAcl ozAcl5 = OzoneAcl.of(ACLIdentityType.GROUP, "dev", ACCESS, READ);
 
     acls.add(ozAcl2);
     acls.add(ozAcl3);
@@ -613,7 +613,7 @@ public class TestKeyManagerImpl {
 
     // Invalid prefix not ending with "/"
     String invalidPrefix = "invalid/pf";
-    OzoneAcl ozAcl1 = new OzoneAcl(ACLIdentityType.USER, "user1",
+    OzoneAcl ozAcl1 = OzoneAcl.of(ACLIdentityType.USER, "user1",
         ACCESS, ACLType.READ);
 
     OzoneObj ozInvalidPrefix = new OzoneObjInfo.Builder()
@@ -677,7 +677,7 @@ public class TestKeyManagerImpl {
         .setStoreType(OzoneObj.StoreType.OZONE)
         .build();
 
-    OzoneAcl ozAcl1 = new OzoneAcl(ACLIdentityType.USER, "user1",
+    OzoneAcl ozAcl1 = OzoneAcl.of(ACLIdentityType.USER, "user1",
         ACCESS, ACLType.READ);
     writeClient.addAcl(ozPrefix1, ozAcl1);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -690,7 +690,7 @@ public class TestOmMetrics {
     // Test getAcl, addAcl, setAcl, removeAcl
     List<OzoneAcl> acls = ozoneManager.getAcl(volObj);
     writeClient.addAcl(volObj,
-        new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "ozoneuser",
+        OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER, "ozoneuser",
             ACCESS, IAccessAuthorizer.ACLType.ALL));
     writeClient.setAcl(volObj, acls);
     writeClient.removeAcl(volObj, acls.get(0));
@@ -745,7 +745,7 @@ public class TestOmMetrics {
     OMMetrics metrics = ozoneManager.getMetrics();
     long initialValue = metrics.getNumAddAcl();
     objectStore.addAcl(volObj,
-        new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "ozoneuser",
+        OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER, "ozoneuser",
             ACCESS, IAccessAuthorizer.ACLType.ALL));
 
     assertEquals(initialValue + 1, metrics.getNumAddAcl());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -560,7 +560,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testAddBucketAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     OzoneObj ozoneObj = buildBucketObj(ozoneBucket);
@@ -572,7 +572,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testRemoveBucketAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     OzoneObj ozoneObj = buildBucketObj(ozoneBucket);
@@ -585,7 +585,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testSetBucketAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     OzoneObj ozoneObj = buildBucketObj(ozoneBucket);
@@ -617,7 +617,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testAddKeyAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    OzoneAcl userAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl userAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     String key = createKey(ozoneBucket);
@@ -631,7 +631,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testRemoveKeyAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    OzoneAcl userAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl userAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     String key = createKey(ozoneBucket);
@@ -646,7 +646,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testSetKeyAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    OzoneAcl userAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl userAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     String key = createKey(ozoneBucket);
@@ -662,7 +662,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
     String prefixName = RandomStringUtils.randomAlphabetic(5) + "/";
-    OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     OzoneObj ozoneObj = buildPrefixObj(ozoneBucket, prefixName);
@@ -675,9 +675,9 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
     String prefixName = RandomStringUtils.randomAlphabetic(5) + "/";
-    OzoneAcl userAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl userAcl = OzoneAcl.of(USER, remoteUserName,
         ACCESS, READ);
-    OzoneAcl userAcl1 = new OzoneAcl(USER, "remote",
+    OzoneAcl userAcl1 = OzoneAcl.of(USER, "remote",
         ACCESS, READ);
 
     OzoneObj ozoneObj = buildPrefixObj(ozoneBucket, prefixName);
@@ -707,7 +707,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
     String prefixName = RandomStringUtils.randomAlphabetic(5) + "/";
-    OzoneAcl defaultUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
     OzoneObj ozoneObj = buildPrefixObj(ozoneBucket, prefixName);
@@ -724,13 +724,13 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj srcObj = buildBucketObj(srcBucket);
 
     // Add ACL to the LINK and verify that it is added to the source bucket
-    OzoneAcl acl1 = new OzoneAcl(USER, "remoteUser1", DEFAULT, READ);
+    OzoneAcl acl1 = OzoneAcl.of(USER, "remoteUser1", DEFAULT, READ);
     boolean addAcl = getObjectStore().addAcl(linkObj, acl1);
     assertTrue(addAcl);
     assertEqualsAcls(srcObj, linkObj);
 
     // Add ACL to the SOURCE and verify that it from link
-    OzoneAcl acl2 = new OzoneAcl(USER, "remoteUser2", DEFAULT, WRITE);
+    OzoneAcl acl2 = OzoneAcl.of(USER, "remoteUser2", DEFAULT, WRITE);
     boolean addAcl2 = getObjectStore().addAcl(srcObj, acl2);
     assertTrue(addAcl2);
     assertEqualsAcls(srcObj, linkObj);
@@ -777,14 +777,14 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
     // Set ACL to the LINK and verify that it is set to the source bucket
     List<OzoneAcl> acl1 = Collections.singletonList(
-        new OzoneAcl(USER, "remoteUser1", DEFAULT, READ));
+        OzoneAcl.of(USER, "remoteUser1", DEFAULT, READ));
     boolean setAcl1 = getObjectStore().setAcl(linkObj, acl1);
     assertTrue(setAcl1);
     assertEqualsAcls(srcObj, linkObj);
 
     // Set ACL to the SOURCE and verify that it from link
     List<OzoneAcl> acl2 = Collections.singletonList(
-        new OzoneAcl(USER, "remoteUser2", DEFAULT, WRITE));
+        OzoneAcl.of(USER, "remoteUser2", DEFAULT, WRITE));
     boolean setAcl2 = getObjectStore().setAcl(srcObj, acl2);
     assertTrue(setAcl2);
     assertEqualsAcls(srcObj, linkObj);
@@ -800,12 +800,12 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj srcObj = buildKeyObj(srcBucket, key);
 
     String user1 = "remoteUser1";
-    OzoneAcl acl1 = new OzoneAcl(USER, user1, DEFAULT, READ);
+    OzoneAcl acl1 = OzoneAcl.of(USER, user1, DEFAULT, READ);
     testAddAcl(user1, linkObj, acl1);  // case1: set link acl
     assertEqualsAcls(srcObj, linkObj);
 
     String user2 = "remoteUser2";
-    OzoneAcl acl2 = new OzoneAcl(USER, user2, DEFAULT, READ);
+    OzoneAcl acl2 = OzoneAcl.of(USER, user2, DEFAULT, READ);
     testAddAcl(user2, srcObj, acl2);  // case2: set src acl
     assertEqualsAcls(srcObj, linkObj);
 
@@ -821,7 +821,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj linkObj = buildKeyObj(linkedBucket, key);
     OzoneObj srcObj = buildKeyObj(srcBucket, key);
     String user = "remoteUser1";
-    OzoneAcl acl = new OzoneAcl(USER, user, DEFAULT, READ);
+    OzoneAcl acl = OzoneAcl.of(USER, user, DEFAULT, READ);
     testRemoveAcl(user, linkObj, acl);
     assertEqualsAcls(srcObj, linkObj);
 
@@ -832,7 +832,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj linkObj2 = buildKeyObj(linkedBucket2, key2);
     OzoneObj srcObj2 = buildKeyObj(srcBucket2, key2);
     String user2 = "remoteUser2";
-    OzoneAcl acl2 = new OzoneAcl(USER, user2, DEFAULT, READ);
+    OzoneAcl acl2 = OzoneAcl.of(USER, user2, DEFAULT, READ);
     testRemoveAcl(user2, srcObj2, acl2);
     assertEqualsAcls(srcObj2, linkObj2);
 
@@ -847,12 +847,12 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj srcObj = buildKeyObj(srcBucket, key);
 
     String user1 = "remoteUser1";
-    OzoneAcl acl1 = new OzoneAcl(USER, user1, DEFAULT, READ);
+    OzoneAcl acl1 = OzoneAcl.of(USER, user1, DEFAULT, READ);
     testSetAcl(user1, linkObj, acl1);  // case1: set link acl
     assertEqualsAcls(srcObj, linkObj);
 
     String user2 = "remoteUser2";
-    OzoneAcl acl2 = new OzoneAcl(USER, user2, DEFAULT, READ);
+    OzoneAcl acl2 = OzoneAcl.of(USER, user2, DEFAULT, READ);
     testSetAcl(user2, srcObj, acl2);  // case2: set src acl
     assertEqualsAcls(srcObj, linkObj);
 
@@ -868,12 +868,12 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     createPrefix(linkObj);
 
     String user1 = "remoteUser1";
-    OzoneAcl acl1 = new OzoneAcl(USER, user1, DEFAULT, READ);
+    OzoneAcl acl1 = OzoneAcl.of(USER, user1, DEFAULT, READ);
     testAddAcl(user1, linkObj, acl1);  // case1: set link acl
     assertEqualsAcls(srcObj, linkObj);
 
     String user2 = "remoteUser2";
-    OzoneAcl acl2 = new OzoneAcl(USER, user2, DEFAULT, READ);
+    OzoneAcl acl2 = OzoneAcl.of(USER, user2, DEFAULT, READ);
     testAddAcl(user2, srcObj, acl2);  // case2: set src acl
     assertEqualsAcls(srcObj, linkObj);
 
@@ -891,7 +891,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     createPrefix(linkObj);
 
     String user = "remoteUser1";
-    OzoneAcl acl = new OzoneAcl(USER, user, DEFAULT, READ);
+    OzoneAcl acl = OzoneAcl.of(USER, user, DEFAULT, READ);
     testRemoveAcl(user, linkObj, acl);
     assertEqualsAcls(srcObj, linkObj);
 
@@ -904,7 +904,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     createPrefix(srcObj2);
 
     String user2 = "remoteUser2";
-    OzoneAcl acl2 = new OzoneAcl(USER, user2, DEFAULT, READ);
+    OzoneAcl acl2 = OzoneAcl.of(USER, user2, DEFAULT, READ);
     testRemoveAcl(user2, srcObj2, acl2);
     assertEqualsAcls(srcObj2, linkObj2);
 
@@ -920,12 +920,12 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     createPrefix(linkObj);
 
     String user1 = "remoteUser1";
-    OzoneAcl acl1 = new OzoneAcl(USER, user1, DEFAULT, READ);
+    OzoneAcl acl1 = OzoneAcl.of(USER, user1, DEFAULT, READ);
     testSetAcl(user1, linkObj, acl1);  // case1: set link acl
     assertEqualsAcls(srcObj, linkObj);
 
     String user2 = "remoteUser2";
-    OzoneAcl acl2 = new OzoneAcl(USER, user2, DEFAULT, READ);
+    OzoneAcl acl2 = OzoneAcl.of(USER, user2, DEFAULT, READ);
     testSetAcl(user2, srcObj, acl2);  // case2: set src acl
     assertEqualsAcls(srcObj, linkObj);
 
@@ -997,7 +997,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
       assertFalse(acls.isEmpty());
     }
 
-    OzoneAcl modifiedUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl modifiedUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, WRITE);
 
     List<OzoneAcl> newAcls = Collections.singletonList(modifiedUserAcl);
@@ -1030,7 +1030,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     assertFalse(addAcl);
 
     // Add an acl by changing acl type with same type, name and scope.
-    userAcl = new OzoneAcl(USER, remoteUserName,
+    userAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, WRITE);
     addAcl = objectStore.addAcl(ozoneObj, userAcl);
     assertTrue(addAcl);
@@ -1046,7 +1046,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
       objectStore.addAcl(ozoneObj, userAcl);
       // Add another arbitrary group ACL since the prefix will be removed when removing
       // the last ACL for the prefix and PREFIX_NOT_FOUND will be thrown
-      OzoneAcl groupAcl = new OzoneAcl(GROUP, "arbitrary-group", ACCESS, READ);
+      OzoneAcl groupAcl = OzoneAcl.of(GROUP, "arbitrary-group", ACCESS, READ);
       objectStore.addAcl(ozoneObj, groupAcl);
     }
     acls = objectStore.getAcl(ozoneObj);
@@ -1065,7 +1065,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     assertTrue(addAcl);
 
     // Just changed acl type here to write, rest all is same as defaultUserAcl.
-    OzoneAcl modifiedUserAcl = new OzoneAcl(USER, remoteUserName,
+    OzoneAcl modifiedUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, WRITE);
     addAcl = objectStore.addAcl(ozoneObj, modifiedUserAcl);
     assertTrue(addAcl);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -1073,7 +1073,7 @@ public abstract class TestOmSnapshot {
     key1 = createFileKeyWithPrefix(bucket, key1);
     createSnapshot(testVolumeName, testBucketName, snap1);
     OzoneObj keyObj = buildKeyObj(bucket, key1);
-    OzoneAcl userAcl = new OzoneAcl(USER, "user",
+    OzoneAcl userAcl = OzoneAcl.of(USER, "user",
         DEFAULT, WRITE);
     store.addAcl(keyObj, userAcl);
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclStorage.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclStorage.java
@@ -62,7 +62,7 @@ final class OzoneAclStorage {
         .mapToObj(a -> IAccessAuthorizer.ACLType.values()[a])
         .collect(Collectors.toList());
     EnumSet<IAccessAuthorizer.ACLType> aclSet = EnumSet.copyOf(aclTypeList);
-    return new OzoneAcl(ACLIdentityType.valueOf(protoAcl.getType().name()),
+    return OzoneAcl.of(ACLIdentityType.valueOf(protoAcl.getType().name()),
         protoAcl.getName(), AclScope.valueOf(protoAcl.getAclScope().name()), aclSet);
   }
 

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
@@ -73,7 +73,7 @@ public class TestOmPrefixInfo {
       OzoneAcl.AclScope scope) {
     return OmPrefixInfo.newBuilder()
         .setName(path)
-        .setAcls(new ArrayList<>(Collections.singletonList(new OzoneAcl(
+        .setAcls(new ArrayList<>(Collections.singletonList(OzoneAcl.of(
             identityType, identityString,
             scope, aclType))))
         .setObjectID(10)
@@ -97,7 +97,7 @@ public class TestOmPrefixInfo {
 
 
     // Change acls and check.
-    omPrefixInfo.addAcl(new OzoneAcl(
+    omPrefixInfo.addAcl(OzoneAcl.of(
         IAccessAuthorizer.ACLIdentityType.USER, username,
         ACCESS, IAccessAuthorizer.ACLType.READ));
 

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfoCodec.java
@@ -43,7 +43,7 @@ public class TestOmPrefixInfoCodec extends Proto2CodecTestBase<OmPrefixInfo> {
   public void testToAndFromPersistedFormat() throws IOException {
 
     List<OzoneAcl> acls = new LinkedList<>();
-    OzoneAcl ozoneAcl = new OzoneAcl(ACLIdentityType.USER,
+    OzoneAcl ozoneAcl = OzoneAcl.of(ACLIdentityType.USER,
         "hive", ACCESS, ACLType.ALL);
     acls.add(ozoneAcl);
     OmPrefixInfo opiSave = OmPrefixInfo.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4569,14 +4569,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // Provide ACLType of ALL which is default acl rights for user and group.
     List<OzoneAcl> listOfAcls = new ArrayList<>();
     //User ACL
-    listOfAcls.add(new OzoneAcl(ACLIdentityType.USER,
+    listOfAcls.add(OzoneAcl.of(ACLIdentityType.USER,
         userName, ACCESS, ACLType.ALL));
     //Group ACLs of the User
     List<String> userGroups = Arrays.asList(UserGroupInformation
         .createRemoteUser(userName).getGroupNames());
 
     userGroups.forEach((group) -> listOfAcls.add(
-        new OzoneAcl(ACLIdentityType.GROUP, group, ACCESS, ACLType.ALL)));
+        OzoneAcl.of(ACLIdentityType.GROUP, group, ACCESS, ACLType.ALL)));
 
     // Add ACLs
     for (OzoneAcl ozoneAcl : listOfAcls) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/TestOMPrefixAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/TestOMPrefixAclResponse.java
@@ -49,9 +49,9 @@ public class TestOMPrefixAclResponse extends TestOMKeyResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
-    final OzoneAcl user1 = new OzoneAcl(USER, "user1",
+    final OzoneAcl user1 = OzoneAcl.of(USER, "user1",
         ACCESS, ACLType.READ_ACL);
-    final OzoneAcl user2 = new OzoneAcl(USER, "user2",
+    final OzoneAcl user2 = OzoneAcl.of(USER, "user2",
         ACCESS, ACLType.WRITE);
     final String prefixName = "/vol/buck/prefix/";
     List<OzoneAcl> acls = Arrays.asList(user1, user2);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -241,9 +241,9 @@ public class TestOzoneNativeAuthorizer {
       String keyName, String prefixName, ACLType userRight,
       ACLType groupRight, boolean expectedResult) throws Exception {
     createAll(keyName, prefixName, userRight, groupRight, expectedResult);
-    OzoneAcl userAcl = new OzoneAcl(USER, testUgi.getUserName(),
+    OzoneAcl userAcl = OzoneAcl.of(USER, testUgi.getUserName(),
         ACCESS, parentDirUserAcl);
-    OzoneAcl groupAcl = new OzoneAcl(GROUP, !testUgi.getGroups().isEmpty() ?
+    OzoneAcl groupAcl = OzoneAcl.of(GROUP, !testUgi.getGroups().isEmpty() ?
         testUgi.getGroups().get(0) : "", ACCESS, parentDirGroupAcl);
     // Set access for volume.
     // We should directly add to table because old API's update to DB.
@@ -263,9 +263,9 @@ public class TestOzoneNativeAuthorizer {
       String keyName, String prefixName, ACLType userRight,
       ACLType groupRight, boolean expectedResult) throws Exception {
     createAll(keyName, prefixName, userRight, groupRight, expectedResult);
-    OzoneAcl userAcl = new OzoneAcl(USER, testUgi.getUserName(),
+    OzoneAcl userAcl = OzoneAcl.of(USER, testUgi.getUserName(),
         ACCESS, parentDirUserAcl);
-    OzoneAcl groupAcl = new OzoneAcl(GROUP, !testUgi.getGroups().isEmpty() ?
+    OzoneAcl groupAcl = OzoneAcl.of(GROUP, !testUgi.getGroups().isEmpty() ?
         testUgi.getGroups().get(0) : "", ACCESS, parentDirGroupAcl);
     // Set access for volume & bucket. We should directly add to table
     // because old API's update to DB.
@@ -293,9 +293,9 @@ public class TestOzoneNativeAuthorizer {
         .setStoreType(OZONE)
         .build();
 
-    OzoneAcl userAcl = new OzoneAcl(USER, testUgi.getUserName(),
+    OzoneAcl userAcl = OzoneAcl.of(USER, testUgi.getUserName(),
         ACCESS, parentDirUserAcl);
-    OzoneAcl groupAcl = new OzoneAcl(GROUP, !testUgi.getGroups().isEmpty() ?
+    OzoneAcl groupAcl = OzoneAcl.of(GROUP, !testUgi.getGroups().isEmpty() ?
         testUgi.getGroups().get(0) : "", ACCESS, parentDirGroupAcl);
     // Set access for volume & bucket. We should directly add to table
     // because old API's update to DB.
@@ -351,7 +351,7 @@ public class TestOzoneNativeAuthorizer {
      *    if user/group has access to them.
      */
     for (ACLType a1 : allAcls) {
-      OzoneAcl newAcl = new OzoneAcl(accessType, getAclName(accessType), ACCESS, a1
+      OzoneAcl newAcl = OzoneAcl.of(accessType, getAclName(accessType), ACCESS, a1
       );
 
       // Reset acls to only one right.
@@ -430,7 +430,7 @@ public class TestOzoneNativeAuthorizer {
           int type = RandomUtils.nextInt(0, 3);
           ACLIdentityType identityType = ACLIdentityType.values()[type];
           // Add remaining acls one by one and then check access.
-          OzoneAcl addAcl = new OzoneAcl(identityType,
+          OzoneAcl addAcl = OzoneAcl.of(identityType,
               getAclName(identityType), ACCESS, a2);
 
           // For volume and bucket update to cache. As Old API's update to

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -220,10 +220,10 @@ public class TestParentAcl {
         .setAclType(USER)
         .setAclRights(childAclType).build();
 
-    OzoneAcl childAcl = new OzoneAcl(USER,
+    OzoneAcl childAcl = OzoneAcl.of(USER,
         testUgi1.getUserName(), ACCESS, childAclType);
 
-    OzoneAcl parentAcl = new OzoneAcl(USER,
+    OzoneAcl parentAcl = OzoneAcl.of(USER,
         testUgi1.getUserName(), ACCESS, parentAclType);
 
     assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
@@ -251,7 +251,7 @@ public class TestParentAcl {
           child, requestContext));
 
       // add the volume acl (grand-parent), now key access is allowed.
-      OzoneAcl parentVolumeAcl = new OzoneAcl(USER,
+      OzoneAcl parentVolumeAcl = OzoneAcl.of(USER,
           testUgi1.getUserName(), ACCESS, READ);
       addVolumeAcl(child.getVolumeName(), parentVolumeAcl);
       assertTrue(nativeAuthorizer.checkAccess(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -489,12 +489,12 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
             .setQuotaInBytes(OzoneConsts.GB)
             .setQuotaInNamespace(1000)
             .setUsedNamespace(500)
-            .addOzoneAcls(new OzoneAcl(
+            .addOzoneAcls(OzoneAcl.of(
                 IAccessAuthorizer.ACLIdentityType.USER,
                 "TestUser2",
                 OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE
             ))
-            .addOzoneAcls(new OzoneAcl(
+            .addOzoneAcls(OzoneAcl.of(
                 IAccessAuthorizer.ACLIdentityType.USER,
                 "TestUser2",
                 OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.READ
@@ -505,7 +505,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol2")
         .setBucketName("bucketOne")
-        .addAcl(new OzoneAcl(
+        .addAcl(OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.GROUP,
             "TestGroup2",
             OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.WRITE
@@ -528,7 +528,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     OmBucketInfo bucketInfo2 = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol2")
         .setBucketName("bucketTwo")
-        .addAcl(new OzoneAcl(
+        .addAcl(OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.GROUP,
             "TestGroup2",
             OzoneAcl.AclScope.ACCESS, IAccessAuthorizer.ACLType.READ

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/common/CommonUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/common/CommonUtils.java
@@ -62,7 +62,7 @@ public class CommonUtils {
       OzoneAcl.AclScope scope) {
     return OmPrefixInfo.newBuilder()
         .setName(path)
-        .setAcls(new ArrayList<>(Collections.singletonList(new OzoneAcl(
+        .setAcls(new ArrayList<>(Collections.singletonList(OzoneAcl.of(
             identityType, identityString,
             scope, aclType))))
         .setObjectID(10)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -691,10 +691,10 @@ public class BucketEndpoint extends EndpointBase {
       }
       // Build ACL on Bucket
       EnumSet<IAccessAuthorizer.ACLType> aclsOnBucket = S3Acl.getOzoneAclOnBucketFromS3Permission(permission);
-      OzoneAcl defaultOzoneAcl = new OzoneAcl(
+      OzoneAcl defaultOzoneAcl = OzoneAcl.of(
           IAccessAuthorizer.ACLIdentityType.USER, part[1], OzoneAcl.AclScope.DEFAULT, aclsOnBucket
       );
-      OzoneAcl accessOzoneAcl = new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, part[1], ACCESS, aclsOnBucket);
+      OzoneAcl accessOzoneAcl = OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER, part[1], ACCESS, aclsOnBucket);
       ozoneAclList.add(defaultOzoneAcl);
       ozoneAclList.add(accessOzoneAcl);
     }
@@ -723,7 +723,7 @@ public class BucketEndpoint extends EndpointBase {
       // Build ACL on Volume
       EnumSet<IAccessAuthorizer.ACLType> aclsOnVolume =
           S3Acl.getOzoneAclOnVolumeFromS3Permission(permission);
-      OzoneAcl accessOzoneAcl = new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, part[1], ACCESS, aclsOnVolume);
+      OzoneAcl accessOzoneAcl = OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER, part[1], ACCESS, aclsOnVolume);
       ozoneAclList.add(accessOzoneAcl);
     }
     return ozoneAclList;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
@@ -226,11 +226,11 @@ public final class S3Acl {
       if (identityType != null && identityType.isSupported()) {
         String permission = grant.getPermission();
         EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnBucketFromS3Permission(permission);
-        OzoneAcl defaultOzoneAcl = new OzoneAcl(
+        OzoneAcl defaultOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.DEFAULT, acls
         );
-        OzoneAcl accessOzoneAcl = new OzoneAcl(
+        OzoneAcl accessOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.ACCESS, acls
         );
@@ -290,7 +290,7 @@ public final class S3Acl {
       if (identityType != null && identityType.isSupported()) {
         String permission = grant.getPermission();
         EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnVolumeFromS3Permission(permission);
-        OzoneAcl accessOzoneAcl = new OzoneAcl(
+        OzoneAcl accessOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.ACCESS, acls
         );

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorOm.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorOm.java
@@ -157,10 +157,10 @@ public class GeneratorOm extends BaseGenerator implements
         .setUpdateID(1L)
         .setQuotaInBytes(100L)
         .addOzoneAcls(
-            new OzoneAcl(IAccessAuthorizer.ACLIdentityType.WORLD, "",
+            OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.WORLD, "",
                 ACCESS, IAccessAuthorizer.ACLType.ALL))
         .addOzoneAcls(
-            new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, getUserId(),
+            OzoneAcl.of(IAccessAuthorizer.ACLIdentityType.USER, getUserId(),
                 ACCESS, IAccessAuthorizer.ACLType.ALL)
         ).build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace direct constructor usage of `OzoneAcl` with factory method.  This requires trivial, but somewhat large change.  It will make it easier to refactor the class later.

https://issues.apache.org/jira/browse/HDDS-12644

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13951163868