### PR TITLE
HDDS-12626. Move the compare method in NodeStatus to ECPipelineProvider.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
  */
 public final class NodeStatus {
   /** For the {@link NodeStatus} objects with {@link #opStateExpiryEpochSeconds} == 0. */
-  private static final Map<NodeOperationalState, Map<NodeState, NodeStatus>> CONSTANT_MAP;
+  private static final Map<NodeOperationalState, Map<NodeState, NodeStatus>> CONSTANTS;
   static {
     final Map<NodeOperationalState, Map<NodeState, NodeStatus>> map = new EnumMap<>(NodeOperationalState.class);
     for (NodeOperationalState op : NodeOperationalState.values()) {
@@ -55,16 +55,20 @@ public final class NodeStatus {
       }
       map.put(op, Collections.unmodifiableMap(healthMap));
     }
-    CONSTANT_MAP = Collections.unmodifiableMap(map);
+    CONSTANTS = Collections.unmodifiableMap(map);
   }
 
   /** @return a {@link NodeStatus} object with {@link #opStateExpiryEpochSeconds} == 0. */
   public static NodeStatus valueOf(NodeOperationalState op, NodeState health) {
-    return CONSTANT_MAP.get(op).get(health);
+    Objects.requireNonNull(op, "op == null");
+    Objects.requireNonNull(health, "health == null");
+    return CONSTANTS.get(op).get(health);
   }
 
   /** @return a {@link NodeStatus} object. */
   public static NodeStatus valueOf(NodeOperationalState op, NodeState health, long opExpiryEpochSeconds) {
+    Objects.requireNonNull(op, "op == null");
+    Objects.requireNonNull(health, "health == null");
     return opExpiryEpochSeconds == 0 ? valueOf(op, health)
         : new NodeStatus(health, op, opExpiryEpochSeconds);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
  * <p>
  * This class is value-based.
  */
-public final class NodeStatus implements Comparable<NodeStatus> {
+public final class NodeStatus {
   /** For the {@link NodeStatus} objects with {@link #opStateExpiryEpochSeconds} == 0. */
   private static final Map<NodeOperationalState, Map<NodeState, NodeStatus>> CONSTANT_MAP;
   static {
@@ -55,7 +55,7 @@ public final class NodeStatus implements Comparable<NodeStatus> {
       }
       map.put(op, healthMap);
     }
-    CONSTANT_MAP = map;
+    CONSTANT_MAP = Collections.unmodifiableMap(map);
   }
 
   /** @return a {@link NodeStatus} object with {@link #opStateExpiryEpochSeconds} == 0. */
@@ -242,17 +242,5 @@ public final class NodeStatus implements Comparable<NodeStatus> {
   public String toString() {
     return "OperationalState: " + operationalState
         + "(expiry: " + opStateExpiryEpochSeconds + "s), Health: " + health;
-  }
-
-  @Override
-  public int compareTo(NodeStatus o) {
-    int order = Boolean.compare(o.isHealthy(), isHealthy());
-    if (order == 0) {
-      order = Boolean.compare(isDead(), o.isDead());
-    }
-    if (order == 0) {
-      order = operationalState.compareTo(o.operationalState);
-    }
-    return order;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -53,7 +53,7 @@ public final class NodeStatus {
       for (NodeState health : NodeState.values()) {
         healthMap.put(health, new NodeStatus(health, op, 0));
       }
-      map.put(op, healthMap);
+      map.put(op, Collections.unmodifiableMap(healthMap));
     }
     CONSTANT_MAP = Collections.unmodifiableMap(map);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -60,16 +60,14 @@ public final class NodeStatus {
 
   /** @return a {@link NodeStatus} object with {@link #opStateExpiryEpochSeconds} == 0. */
   public static NodeStatus valueOf(NodeOperationalState op, NodeState health) {
-    Objects.requireNonNull(op, "op == null");
-    Objects.requireNonNull(health, "health == null");
-    return CONSTANTS.get(op).get(health);
+    return valueOf(op, health, 0);
   }
 
   /** @return a {@link NodeStatus} object. */
   public static NodeStatus valueOf(NodeOperationalState op, NodeState health, long opExpiryEpochSeconds) {
     Objects.requireNonNull(op, "op == null");
     Objects.requireNonNull(health, "health == null");
-    return opExpiryEpochSeconds == 0 ? valueOf(op, health)
+    return opExpiryEpochSeconds == 0 ? CONSTANTS.get(op).get(health)
         : new NodeStatus(health, op, opExpiryEpochSeconds);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -244,7 +244,8 @@ public final class NodeStatus {
 
   @Override
   public String toString() {
-    return "OperationalState: " + operationalState
-        + "(expiry: " + opStateExpiryEpochSeconds + "s), Health: " + health;
+    final String expiry = opStateExpiryEpochSeconds == 0 ? "no expiry"
+        : "expiry: " + opStateExpiryEpochSeconds + "s";
+    return operationalState + "(" + expiry + ")-" + health;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeAlreadyExistsException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeAlreadyExistsException.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.hdds.scm.node.states;
 
+import org.apache.hadoop.hdds.protocol.DatanodeID;
+
 /**
  * This exception represents that there is already a node added to NodeStateMap
  * with same UUID.
@@ -34,12 +36,8 @@ public class NodeAlreadyExistsException extends NodeException {
   /**
    * Constructs an {@code NodeAlreadyExistsException} with the specified
    * detail message.
-   *
-   * @param message
-   *        The detail message (which is saved for later retrieval
-   *        by the {@link #getMessage()} method)
    */
-  public NodeAlreadyExistsException(String message) {
-    super(message);
+  public NodeAlreadyExistsException(DatanodeID datanodeID) {
+    super("Datanode " + datanodeID + " already exists");
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeAlreadyExistsException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeAlreadyExistsException.java
@@ -34,8 +34,7 @@ public class NodeAlreadyExistsException extends NodeException {
   }
 
   /**
-   * Constructs an {@code NodeAlreadyExistsException} with the specified
-   * detail message.
+   * Constructs an {@code NodeAlreadyExistsException} with the given {@link DatanodeID}.
    */
   public NodeAlreadyExistsException(DatanodeID datanodeID) {
     super("Datanode " + datanodeID + " already exists");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -80,7 +80,7 @@ public class NodeStateMap {
     try {
       final DatanodeID id = datanodeDetails.getID();
       if (nodeMap.containsKey(id)) {
-        throw new NodeAlreadyExistsException("Node UUID: " + id);
+        throw new NodeAlreadyExistsException(id);
       }
       nodeMap.put(id, new DatanodeInfo(datanodeDetails, nodeStatus,
           layoutInfo));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, NodeStatus implements Comparable but the implementation of the compareTo method is very specific to the use case in ECPipelineProvider but not a natural order. It is better to move the implementation to ECPipelineProvider.

## What is the link to the Apache JIRA

HDDS-12626

## How was this patch tested?

By updating existing tests.