### PR TITLE
HDDS-12627. NodeStateMap may handle opStateExpiryEpochSeconds incorrectly.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -135,6 +135,16 @@ public final class NodeStatus implements Comparable<NodeStatus> {
     this.opStateExpiryEpochSeconds = opExpiryEpochSeconds;
   }
 
+  /** @return the status with the new health. */
+  public NodeStatus newNodeState(NodeState newHealth) {
+    return NodeStatus.valueOf(operationalState, newHealth, opStateExpiryEpochSeconds);
+  }
+
+  /** @return the status with the new op state and expiry epoch seconds. */
+  public NodeStatus newOperationalState(NodeOperationalState op, long opExpiryEpochSeconds) {
+    return NodeStatus.valueOf(op, health, opExpiryEpochSeconds);
+  }
+
   /** Is this node writeable ({@link NodeState#HEALTHY} and {@link NodeOperationalState#IN_SERVICE}) ? */
   public boolean isNodeWritable() {
     return health == HEALTHY && operationalState == IN_SERVICE;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found two bugs in NodeStateMap:

1. in updateNodeHealthState, it does not pass the updateNodeHealthState from the oldStatus to the newStatus, i.e. the newStatus will always have opStateExpiryEpochSeconds == 0.
2. in filterNodes, when both opState and health are non-null, the matched nodes must also have opStateExpiryEpochSeconds == 0, i.e. the non-zero opStateExpiryEpochSeconds won't be matched.

## What is the link to the Apache JIRA

HDDS-12627

## How was this patch tested?

Added new tests.