### PR TITLE
HDDS-12622. Refactor minFreeSpace calculation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -59,14 +59,6 @@ public final class HddsConfigKeys {
   public static final String HDDS_DATANODE_VOLUME_CHOOSING_POLICY =
       "hdds.datanode.volume.choosing.policy";
 
-  public static final String HDDS_DATANODE_VOLUME_MIN_FREE_SPACE =
-      "hdds.datanode.volume.min.free.space";
-  public static final String HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT =
-      "5GB";
-
-  public static final String HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT =
-      "hdds.datanode.volume.min.free.space.percent";
-
   public static final String HDDS_DB_PROFILE = "hdds.db.profile";
 
   // Once a container usage crosses this threshold, it is eligible for

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -219,17 +219,6 @@
     </description>
   </property>
   <property>
-    <name>hdds.datanode.volume.min.free.space</name>
-    <value>5GB</value>
-    <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
-    <description>
-      This determines the free space to be used for closing containers
-      When the difference between volume capacity and used reaches this number,
-      containers that reside on this volume will be closed and no new containers
-      would be allocated on this volume.
-    </description>
-  </property>
-  <property>
     <name>hdds.container.ratis.enabled</name>
     <value>false</value>
     <tag>OZONE, MANAGEMENT, PIPELINE, RATIS</tag>

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigType.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigType.java
@@ -168,6 +168,18 @@ public enum ConfigType {
         Config config) {
       target.setDouble(key, (double) value);
     }
+  },
+  FLOAT {
+    @Override
+    Float parse(String value, Config config, Class<?> type, String key) {
+      return Float.parseFloat(value);
+    }
+
+    @Override
+    void set(ConfigurationTarget target, String key, Object value,
+        Config config) {
+      target.setFloat(key, (float) value);
+    }
   };
 
   abstract Object parse(String value, Config config, Class<?> type, String key)

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
@@ -39,6 +39,10 @@ public interface ConfigurationTarget {
     set(name, Double.toString(value));
   }
 
+  default void setFloat(String name, float value) {
+    set(name, Float.toString(value));
+  }
+
   default void setBoolean(String name, boolean value) {
     set(name, Boolean.toString(value));
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -112,7 +112,6 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   private ContainerMetrics metrics;
   private final TokenVerifier tokenVerifier;
   private long slowOpThresholdNs;
-  private VolumeUsage.MinFreeSpaceCalculator freeSpaceCalculator;
 
   /**
    * Constructs an OzoneContainer that receives calls from
@@ -146,7 +145,6 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
             LOG,
             HddsUtils::processForDebug,
             HddsUtils::processForDebug);
-    this.freeSpaceCalculator = new VolumeUsage.MinFreeSpaceCalculator(conf);
   }
 
   @Override
@@ -619,7 +617,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
       SpaceUsageSource usage = volume.getCurrentUsage();
-      long volumeFreeSpaceToSpare = freeSpaceCalculator.get(usage.getCapacity());
+      long volumeFreeSpaceToSpare = volume.getFreeSpaceToSpare(usage.getCapacity());
       return !VolumeUsage.hasVolumeEnoughSpace(usage.getAvailable(), volume.getCommittedBytes(), 0,
           volumeFreeSpaceToSpare);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -19,12 +19,10 @@ package org.apache.hadoop.ozone.container.common.impl;
 
 import java.io.IOException;
 import org.apache.hadoop.fs.StorageType;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageTypeProto;
 import org.apache.hadoop.ozone.container.common.interfaces.StorageLocationReportMXBean;
-import org.apache.hadoop.ozone.container.common.volume.VolumeUsage;
 
 /**
  * Storage location stats of datanodes that provide back store for containers.
@@ -168,11 +166,6 @@ public final class StorageLocationReport implements
    * @throws IOException In case, the storage type specified is invalid.
    */
   public StorageReportProto getProtoBufMessage() throws IOException {
-    return getProtoBufMessage(null);
-  }
-
-  public StorageReportProto getProtoBufMessage(ConfigurationSource conf)
-      throws IOException {
     StorageReportProto.Builder srb = StorageReportProto.newBuilder();
     return srb.setStorageUuid(getId())
         .setCapacity(getCapacity())
@@ -182,8 +175,7 @@ public final class StorageLocationReport implements
         .setStorageType(getStorageTypeProto())
         .setStorageLocation(getStorageLocation())
         .setFailed(isFailed())
-        .setFreeSpaceToSpare(conf != null ?
-            new VolumeUsage.MinFreeSpaceCalculator(conf).get(getCapacity()) : 0)
+        .setFreeSpaceToSpare(getFreeSpaceToSpare())
         .build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
@@ -44,8 +44,7 @@ public class AvailableSpaceFilter implements Predicate<HddsVolume> {
     long free = usage.getAvailable();
     long committed = vol.getCommittedBytes();
     long available = free - committed;
-    long volumeFreeSpaceToSpare =
-        new VolumeUsage.MinFreeSpaceCalculator(vol.getConf()).get(volumeCapacity);
+    long volumeFreeSpaceToSpare = vol.getFreeSpaceToSpare(volumeCapacity);
     boolean hasEnoughSpace = VolumeUsage.hasVolumeEnoughSpace(free, committed,
         requiredSpace, volumeFreeSpaceToSpare);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
-import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.utils.RawDB;
@@ -142,7 +141,6 @@ public class HddsVolume extends StorageVolume {
       volumeIOStats = null;
       volumeInfoMetrics = new VolumeInfoMetrics(b.getVolumeRootStr(), this);
     }
-
   }
 
   @Override
@@ -264,14 +262,13 @@ public class HddsVolume extends StorageVolume {
       throws Exception {
     VolumeCheckResult result = super.check(unused);
 
-    DatanodeConfiguration df = getConf().getObject(DatanodeConfiguration.class);
     if (isDbLoadFailure()) {
       LOG.warn("Volume {} failed to access RocksDB: RocksDB parent directory is null, " +
           "the volume might not have been loaded properly.", getStorageDir());
       return VolumeCheckResult.FAILED;
     }
     if (result != VolumeCheckResult.HEALTHY ||
-        !df.getContainerSchemaV3Enabled() || !isDbLoaded()) {
+        !getDatanodeConfig().getContainerSchemaV3Enabled() || !isDbLoaded()) {
       return result;
     }
 
@@ -303,6 +300,10 @@ public class HddsVolume extends StorageVolume {
    */
   public long getCommittedBytes() {
     return committedBytes.get();
+  }
+
+  public long getFreeSpaceToSpare(long volumeCapacity) {
+    return getDatanodeConfig().getMinFreeSpace(volumeCapacity);
   }
 
   public void setDbVolume(DbVolume dbVolume) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -469,6 +469,7 @@ public class MutableVolumeSet implements VolumeSet {
         long remaining = 0;
         long capacity = 0;
         long committed = 0;
+        long spare = 0;
         String rootDir = "";
         failed = true;
         if (volumeInfo.isPresent()) {
@@ -478,8 +479,9 @@ public class MutableVolumeSet implements VolumeSet {
             scmUsed = usage.getUsedSpace();
             remaining = usage.getAvailable();
             capacity = usage.getCapacity();
-            committed = (volume instanceof HddsVolume) ?
-                ((HddsVolume) volume).getCommittedBytes() : 0;
+            HddsVolume hddsVolume = volume instanceof HddsVolume ? (HddsVolume) volume : null;
+            committed = hddsVolume != null ? hddsVolume.getCommittedBytes() : 0;
+            spare = hddsVolume != null ? hddsVolume.getFreeSpaceToSpare(capacity) : 0;
             failed = false;
           } catch (UncheckedIOException ex) {
             LOG.warn("Failed to get scmUsed and remaining for container " +
@@ -500,6 +502,7 @@ public class MutableVolumeSet implements VolumeSet {
             .setRemaining(remaining)
             .setScmUsed(scmUsed)
             .setCommitted(committed)
+            .setFreeSpaceToSpare(spare)
             .setStorageType(volume.getStorageType());
         StorageLocationReport r = builder.build();
         reports[counter++] = r;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -115,7 +115,8 @@ public abstract class StorageVolume
   private long cTime;             // creation time of the file system state
   private int layoutVersion;      // layout version of the storage data
 
-  private ConfigurationSource conf;
+  private final ConfigurationSource conf;
+  private final DatanodeConfiguration dnConf;
 
   private final File storageDir;
   private String workingDirName;
@@ -150,10 +151,9 @@ public abstract class StorageVolume
       this.state = VolumeState.NOT_INITIALIZED;
       this.clusterID = b.clusterID;
       this.datanodeUuid = b.datanodeUuid;
-      this.conf = b.conf;
 
-      DatanodeConfiguration dnConf =
-          conf.getObject(DatanodeConfiguration.class);
+      this.conf = b.conf;
+      this.dnConf = conf.getObject(DatanodeConfiguration.class);
       this.ioTestCount = dnConf.getVolumeIOTestCount();
       this.ioFailureTolerance = dnConf.getVolumeIOFailureTolerance();
       this.ioTestSlidingWindow = new LinkedList<>();
@@ -167,6 +167,8 @@ public abstract class StorageVolume
       this.state = VolumeState.FAILED;
       this.ioTestCount = 0;
       this.ioFailureTolerance = 0;
+      this.conf = null;
+      this.dnConf = null;
     }
   }
 
@@ -527,6 +529,10 @@ public abstract class StorageVolume
 
   public ConfigurationSource getConf() {
     return conf;
+  }
+
+  public DatanodeConfiguration getDatanodeConfig() {
+    return dnConf;
   }
 
   public void failVolume() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -17,9 +17,6 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT;
@@ -31,7 +28,6 @@ import java.util.Collection;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageSize;
-import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.fs.CachingSpaceUsageSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckParams;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
@@ -126,58 +122,6 @@ public class VolumeUsage {
 
   public long getReservedBytes() {
     return reservedInBytes;
-  }
-
-  /**
-   * Convenience class to calculate minimum free space.
-   */
-  public static class MinFreeSpaceCalculator {
-    private final boolean minFreeSpaceConfigured;
-    private final boolean minFreeSpacePercentConfigured;
-    private final long freeSpace;
-    private float freeSpacePercent;
-    private final long defaultFreeSpace;
-    public MinFreeSpaceCalculator(ConfigurationSource conf) {
-      // cache these values to avoid repeated lookups
-      minFreeSpaceConfigured = conf.isConfigured(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE);
-      minFreeSpacePercentConfigured = conf.isConfigured(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT);
-      freeSpace = (long)conf.getStorageSize(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
-          HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT, StorageUnit.BYTES);
-      if (minFreeSpacePercentConfigured) {
-        freeSpacePercent = Float.parseFloat(
-            conf.get(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT));
-      }
-      StorageSize measure = StorageSize.parse(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT);
-      double byteValue = measure.getUnit().toBytes(measure.getValue());
-      defaultFreeSpace = (long)StorageUnit.BYTES.fromBytes(byteValue);
-    }
-
-    /**
-     * If 'hdds.datanode.volume.min.free.space' is defined,
-     * it will be honored first. If it is not defined and
-     * 'hdds.datanode.volume.min.free.space' is defined, it will honor this
-     * else it will fall back to 'hdds.datanode.volume.min.free.space.default'
-     */
-    public long get(long capacity) {
-      if (minFreeSpaceConfigured && minFreeSpacePercentConfigured) {
-        LOG.error(
-            "Both {} and {} are set. Set either one, not both. If both are set,"
-                + "it will use default value which is {} as min free space",
-            HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
-            HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
-            HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT);
-        return defaultFreeSpace;
-      }
-
-      if (minFreeSpaceConfigured) {
-        return freeSpace;
-      } else if (minFreeSpacePercentConfigured) {
-        return (long) (capacity * freeSpacePercent);
-      }
-      // either properties are not configured,then return
-      // HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT
-      return defaultFreeSpace;
-    }
   }
 
   public static boolean hasVolumeEnoughSpace(long volumeAvailableSpace,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -606,7 +606,7 @@ public class OzoneContainer {
             NodeReportProto.newBuilder();
 
     for (StorageLocationReport report : reports) {
-      nrb.addStorageReport(report.getProtoBufMessage(config));
+      nrb.addStorageReport(report.getProtoBufMessage());
     }
 
     StorageLocationReport[] metaReports = metaVolumeSet.getStorageReport();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.conf.StorageUnit;
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
@@ -245,7 +244,7 @@ public class TestHddsDispatcher {
       ContainerLayoutVersion layoutVersion) throws Exception {
     String testDirPath = testDir.getPath();
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setStorageSize(HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
+    conf.setStorageSize(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
         100.0, StorageUnit.BYTES);
     DatanodeDetails dd = randomDatanodeDetails();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.getDefaultFreeSpace;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
@@ -44,11 +45,15 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test for {@link DatanodeConfiguration}.
  */
 public class TestDatanodeConfiguration {
+
+  private static final long[] CAPACITIES = {100_000, 1_000_000, 10_000_000};
 
   @Test
   public void acceptsValidValues() {
@@ -149,6 +154,7 @@ public class TestDatanodeConfiguration {
   public void isCreatedWitDefaultValues() {
     // GIVEN
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.unset(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE); // set in ozone-site.xml
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -170,6 +176,65 @@ public class TestDatanodeConfiguration {
         subject.getDiskCheckTimeout());
     assertEquals(BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT,
         subject.getBlockDeleteCommandWorkerInterval());
+    assertEquals(DatanodeConfiguration.getDefaultFreeSpace(), subject.getMinFreeSpace());
+    assertEquals(DatanodeConfiguration.MIN_FREE_SPACE_UNSET, subject.getMinFreeSpaceRatio());
+  }
+
+  @Test
+  void rejectsInvalidMinFreeSpaceRatio() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setFloat(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT, 1.5f);
+
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    assertEquals(DatanodeConfiguration.MIN_FREE_SPACE_UNSET, subject.getMinFreeSpaceRatio());
+  }
+
+  @Test
+  void usesDefaultFreeSpaceIfBothMinFreeSpacePropertiesSet() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setLong(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE, 10000);
+    conf.setFloat(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT, .5f);
+
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    assertEquals(DatanodeConfiguration.getDefaultFreeSpace(), subject.getMinFreeSpace());
+    assertEquals(DatanodeConfiguration.MIN_FREE_SPACE_UNSET, subject.getMinFreeSpaceRatio());
+
+    for (long capacity : CAPACITIES) {
+      assertEquals(getDefaultFreeSpace(), subject.getMinFreeSpace(capacity));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {1_000, 10_000, 100_000})
+  void usesFixedMinFreeSpace(long bytes) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setLong(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE, bytes);
+
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    assertEquals(bytes, subject.getMinFreeSpace());
+    assertEquals(DatanodeConfiguration.MIN_FREE_SPACE_UNSET, subject.getMinFreeSpaceRatio());
+
+    for (long capacity : CAPACITIES) {
+      assertEquals(bytes, subject.getMinFreeSpace(capacity));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 10, 100})
+  void calculatesMinFreeSpaceRatio(int percent) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.unset(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE); // set in ozone-site.xml
+    conf.setFloat(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT, percent / 100.0f);
+
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    assertEquals(percent / 100.0f, subject.getMinFreeSpaceRatio());
+    for (long capacity : CAPACITIES) {
+      assertEquals(capacity * percent / 100, subject.getMinFreeSpace(capacity));
+    }
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
@@ -17,10 +17,10 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,11 +30,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import org.apache.hadoop.conf.StorageUnit;
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -196,21 +196,18 @@ public class TestReservedVolumeSpace {
   public void testMinFreeSpaceCalculator() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     double minSpace = 100.0;
-    conf.setStorageSize(HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
+    conf.setStorageSize(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
         minSpace, StorageUnit.BYTES);
-    VolumeUsage.MinFreeSpaceCalculator calc = new VolumeUsage.MinFreeSpaceCalculator(conf);
     long capacity = 1000;
-    assertEquals(minSpace, calc.get(capacity));
+    assertEquals(minSpace, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
 
     conf.setFloat(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT, 0.01f);
-    calc = new VolumeUsage.MinFreeSpaceCalculator(conf);
     // default is 5GB
-    assertEquals(5L * 1024 * 1024 * 1024, calc.get(capacity));
+    assertEquals(5L * 1024 * 1024 * 1024, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
 
     // capacity * 1% = 10
     conf.unset(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE);
-    calc = new VolumeUsage.MinFreeSpaceCalculator(conf);
-    assertEquals(10, calc.get(capacity));
+    assertEquals(10, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
   }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig;
 import org.apache.hadoop.hdds.server.http.HttpServer2;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.s3.S3GatewayConfigKeys;
@@ -129,7 +130,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY,
         ScmConfigKeys.OZONE_SCM_HA_PREFIX,
         S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED,
-        HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
+        DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
         OzoneConfigKeys.HDDS_SCM_CLIENT_RPC_TIME_OUT,
         OzoneConfigKeys.HDDS_SCM_CLIENT_MAX_RETRY_TIMEOUT,
         OzoneConfigKeys.HDDS_SCM_CLIENT_FAILOVER_MAX_RETRY


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor calculation of `minFreeSpace` for datanode volume.

Currently it is done by `MinFreeSpaceCalculator`, which exists only to avoid repeated lookup of the config setting needed for the calculation.  Of its 3 different usages, `AvailableSpaceFilter` and `StorageLocationReport` both create a new instance for each calculation, which defeats the purpose of storing config values.  Sharing the same instance of `MinFreeSpaceCalculator` from `HddsDispatcher` would require extensive changes.

This PR moves the definition of config properties, as well as validation and calculation, to `DatanodeConfiguration`, which I think is a better fit than `MinFreeSpaceCalculator`.  Config objects are for storing configs, they have methods for validation, and this specific type is already used by `HddsVolume` and related code.

In follow-up patch we can go further, and pass `DatanodeConfiguration` to the volumes via the builder.

https://issues.apache.org/jira/browse/HDDS-12622

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13965703068