### PR TITLE
HDDS-12461. Bump Ranger to 2.6.0

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -267,6 +267,7 @@ Apache License 2.0
    ch.qos.reload4j:reload4j
    com.amazonaws:aws-java-sdk-core
    com.amazonaws:aws-java-sdk-kms
+   com.amazonaws:aws-java-sdk-logs
    com.amazonaws:aws-java-sdk-s3
    com.amazonaws:jmespath-java
    com.carrotsearch:hppc
@@ -276,6 +277,8 @@ Apache License 2.0
    com.fasterxml.jackson.dataformat:jackson-dataformat-cbor
    com.fasterxml.jackson.dataformat:jackson-dataformat-xml
    com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+   com.fasterxml.jackson.jaxrs:jackson-jaxrs-base
+   com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider
    com.fasterxml.jackson.module:jackson-module-jaxb-annotations
    com.fasterxml.woodstox:woodstox-core
    com.github.jnr:jnr-a64asm
@@ -316,6 +319,7 @@ Apache License 2.0
    commons-fileupload:commons-fileupload
    info.picocli:picocli
    info.picocli:picocli-shell-jline3
+   io.airlift:aircompressor
    io.dropwizard.metrics:metrics-core
    io.grpc:grpc-api
    io.grpc:grpc-context
@@ -397,6 +401,7 @@ Apache License 2.0
    org.apache.logging.log4j:log4j-api
    org.apache.logging.log4j:log4j-core
    org.apache.orc:orc-core
+   org.apache.orc:orc-shims
    org.apache.ranger:ranger-intg
    org.apache.ranger:ranger-plugin-classloader
    org.apache.ranger:ranger-plugin-audit
@@ -415,10 +420,6 @@ Apache License 2.0
    org.apache.thrift:libthrift
    org.apache.zookeeper:zookeeper
    org.apache.zookeeper:zookeeper-jute
-   org.codehaus.jackson:jackson-core-asl
-   org.codehaus.jackson:jackson-jaxrs
-   org.codehaus.jackson:jackson-mapper-asl
-   org.codehaus.jackson:jackson-xc
    org.eclipse.jetty:jetty-client
    org.eclipse.jetty:jetty-http
    org.eclipse.jetty:jetty-io

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -395,17 +395,6 @@ com.jolbox:bonecp
    This product includes software developed by
    Wallace Wadge (http://jolbox.com/).
 
-org.codehaus.jackson:jackson-mapper-asl
-====================
-
-This product currently only contains code developed by authors
-of specific components, as identified by the source code files;
-if such notes are missing files have been created by
-Tatu Saloranta.
-
-For additional credits (generally to people who reported problems)
-see CREDITS file.
-
 
 com.google.inject:guice
 ====================
@@ -431,32 +420,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 
-
-
-org.codehaus.jackson:jackson-xc
-====================
-
-This product currently only contains code developed by authors
-of specific components, as identified by the source code files;
-if such notes are missing files have been created by
-Tatu Saloranta.
-
-For additional credits (generally to people who reported problems)
-see CREDITS file.
-
-
-org.codehaus.jackson:jackson-jaxrs
-====================
-
-This product currently only contains code developed by authors
-of specific components, as identified by the source code files;
-if such notes are missing files have been created by
-Tatu Saloranta.
-
-For additional credits (generally to people who reported problems)
-see CREDITS file.
-
-
 com.google.inject.extensions:guice-servlet
 ====================
 
@@ -468,18 +431,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 
-
-
-org.codehaus.jackson:jackson-core-asl
-====================
-
-This product currently only contains code developed by authors
-of specific components, as identified by the source code files;
-if such notes are missing files have been created by
-Tatu Saloranta.
-
-For additional credits (generally to people who reported problems)
-see CREDITS file.
 
 
 org.bouncycastle:bcpkix-jdk18on

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -1,3 +1,4 @@
+share/ozone/lib/aircompressor.jar
 share/ozone/lib/animal-sniffer-annotations.jar
 share/ozone/lib/annotations.jar
 share/ozone/lib/annotations.jar
@@ -12,6 +13,7 @@ share/ozone/lib/aspectjrt.jar
 share/ozone/lib/aspectjweaver.jar
 share/ozone/lib/aws-java-sdk-core.jar
 share/ozone/lib/aws-java-sdk-kms.jar
+share/ozone/lib/aws-java-sdk-logs.jar
 share/ozone/lib/aws-java-sdk-s3.jar
 share/ozone/lib/bcpkix-jdk18on.jar
 share/ozone/lib/bcprov-jdk18on.jar
@@ -93,14 +95,13 @@ share/ozone/lib/httpmime.jar
 share/ozone/lib/istack-commons-runtime.jar
 share/ozone/lib/j2objc-annotations.jar
 share/ozone/lib/jackson-annotations.jar
-share/ozone/lib/jackson-core-asl.jar
 share/ozone/lib/jackson-core.jar
 share/ozone/lib/jackson-databind.jar
 share/ozone/lib/jackson-dataformat-cbor.jar
 share/ozone/lib/jackson-dataformat-xml.jar
 share/ozone/lib/jackson-datatype-jsr310.jar
-share/ozone/lib/jackson-jaxrs.jar
-share/ozone/lib/jackson-mapper-asl.jar
+share/ozone/lib/jackson-jaxrs-base.jar
+share/ozone/lib/jackson-jaxrs-json-provider.jar
 share/ozone/lib/jackson-module-jaxb-annotations.jar
 share/ozone/lib/jaeger-client.jar
 share/ozone/lib/jaeger-core.jar
@@ -215,6 +216,7 @@ share/ozone/lib/opentracing-noop.jar
 share/ozone/lib/opentracing-tracerresolver.jar
 share/ozone/lib/opentracing-util.jar
 share/ozone/lib/orc-core.jar
+share/ozone/lib/orc-shims.jar
 share/ozone/lib/osgi-resource-locator.jar
 share/ozone/lib/ozone-client.jar
 share/ozone/lib/ozone-cli-shell.jar

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -285,29 +285,6 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
-    <!-- Override ranger-intg jackson version -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-core-asl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-mapper-asl</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,6 @@
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.16</httpcore.version>
     <io.grpc.version>1.58.0</io.grpc.version>
-    <jackson-jaxr.version>1.9.13</jackson-jaxr.version>
-    <jackson1.version>1.9.13</jackson1.version>
     <jackson2-bom.version>2.16.2</jackson2-bom.version>
     <jacoco.version>0.8.12</jacoco.version>
     <jaeger.version>1.8.1</jaeger.version>
@@ -202,7 +200,7 @@
     <proto3.hadooprpc.protobuf.version>3.23.4</proto3.hadooprpc.protobuf.version>
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    <ranger.version>2.3.0</ranger.version>
+    <ranger.version>2.6.0</ranger.version>
     <ratis.thirdparty.version>1.0.6</ratis.thirdparty.version>
     <ratis.version>3.1.2</ratis.version>
     <re2j.version>1.7</re2j.version>
@@ -988,26 +986,6 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcutil-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-core-asl</artifactId>
-        <version>${jackson1.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-jaxrs</artifactId>
-        <version>${jackson-jaxr.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson1.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>stax2-api</artifactId>
-        <version>${stax2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Ranger to 2.6.0.

https://issues.apache.org/jira/browse/HDDS-12461

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/13968803766