### PR TITLE
HDDS-12655. Optimize Recon Container Mismatch API while getting containerInfos & ContainerMetadata

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/SeekableIterator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/SeekableIterator.java
@@ -25,4 +25,6 @@ import java.util.Iterator;
  */
 public interface SeekableIterator<K, E> extends ClosableIterator<E> {
   void seek(K position) throws IOException;
+
+  K peekNextKey();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -106,12 +106,6 @@ public interface ContainerManager extends Closeable {
    */
   Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID startID);
 
-  /**
-   * Return the container iterator.
-   * @return
-   */
-  Iterator<ContainerInfo> getContainerInfoIterator();
-
 
   List<ContainerInfo> getContainers(ReplicationType type);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.hdds.scm.container;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
@@ -71,6 +73,44 @@ public interface ContainerManager extends Closeable {
    * @return a list of container.
    */
   List<ContainerInfo> getContainers(ContainerID startID, int count);
+
+  /**
+   * Returns the containers iterator with startID.
+   *
+   * @param startID start containerID, >=0,
+   * start searching at the head if 0.
+   *
+   * @return an iterator of container.
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator(ContainerID startID);
+
+  /**
+   * Returns the containers iterator with startID and filters the values in iterator.
+   *
+   * @param startID start containerID, >=0,
+   * start searching at the head if 0.
+   * @param filter predicate value
+   *
+   * @return an iterator of container.
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator(ContainerID startID, Predicate<ContainerInfo> filter);
+
+  /**
+   * Returns the containers iterator in a certain state with startID.
+   *
+   * @param state LifeCycleState of the container.
+   * @param startID start containerID, >=0,
+   * start searching at the head if 0.
+   *
+   * @return an iterator of container.
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID startID);
+
+  /**
+   * Return the container iterator.
+   * @return
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator();
 
 
   List<ContainerInfo> getContainers(ReplicationType type);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -31,6 +31,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -148,6 +149,28 @@ public class ContainerManagerImpl implements ContainerManager {
     scmContainerManagerMetrics.incNumListContainersOps();
     return containerStateManager.getContainerInfos(startID, count);
   }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID startID) {
+    return containerStateManager.getContainerInfoIterator(state, startID);
+  }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator(ContainerID startID,
+                                                          Predicate<ContainerInfo> filter) {
+    return containerStateManager.getContainerInfoIterator(startID, filter);
+  }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator(ContainerID startID) {
+    return getContainerInfoIterator(startID, (Predicate<ContainerInfo>)  null);
+  }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator() {
+    return getContainerInfoIterator(ContainerID.MIN);
+  }
+
 
   @Override
   public List<ContainerInfo> getContainers(final LifeCycleState state) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -167,12 +167,6 @@ public class ContainerManagerImpl implements ContainerManager {
   }
 
   @Override
-  public Iterator<ContainerInfo> getContainerInfoIterator() {
-    return getContainerInfoIterator(ContainerID.MIN);
-  }
-
-
-  @Override
   public List<ContainerInfo> getContainers(final LifeCycleState state) {
     scmContainerManagerMetrics.incNumListContainersOps();
     return containerStateManager.getContainerInfos(state);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -128,14 +128,6 @@ public interface ContainerStateManager {
    * @param start the start {@link ContainerID} (inclusive)
    * @return an iterator of {@link ContainerInfo};
    */
-  Iterator<ContainerInfo> getContainerInfoIterator(ContainerID start);
-
-  /**
-   * Get {@link ContainerInfo}s for the given state.
-   *
-   * @param start the start {@link ContainerID} (inclusive)
-   * @return an iterator of {@link ContainerInfo};
-   */
   Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID start);
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.hdds.scm.container;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
@@ -111,6 +113,30 @@ public interface ContainerStateManager {
    * @return a list of {@link ContainerInfo};
    */
   List<ContainerInfo> getContainerInfos(ContainerID start, int count);
+
+  /**
+   * Get {@link ContainerInfo}s for the given state.
+   *
+   * @param start the start {@link ContainerID} (inclusive)
+   * @return an iterator of {@link ContainerInfo};
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator(ContainerID start, Predicate<ContainerInfo> predicate);
+
+  /**
+   * Get {@link ContainerInfo}s for the given state.
+   *
+   * @param start the start {@link ContainerID} (inclusive)
+   * @return an iterator of {@link ContainerInfo};
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator(ContainerID start);
+
+  /**
+   * Get {@link ContainerInfo}s for the given state.
+   *
+   * @param start the start {@link ContainerID} (inclusive)
+   * @return an iterator of {@link ContainerInfo};
+   */
+  Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID start);
 
   /**
    * Get {@link ContainerInfo}s for the given state.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -283,11 +283,6 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
-  public Iterator<ContainerInfo> getContainerInfoIterator(ContainerID start) {
-    return getContainerInfoIterator(start, null);
-  }
-
-  @Override
   public Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID start) {
     return containers.getContainerInfoIterator(state, start);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -36,6 +36,7 @@ import com.google.common.util.concurrent.Striped;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -44,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -273,6 +275,21 @@ public final class ContainerStateManagerImpl
     try (AutoCloseableLock ignored = readLock()) {
       return containers.getContainerInfos(start, count);
     }
+  }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator(ContainerID start, Predicate<ContainerInfo> predicate) {
+    return containers.getContainerInfoIterator(start, predicate);
+  }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator(ContainerID start) {
+    return getContainerInfoIterator(start, null);
+  }
+
+  @Override
+  public Iterator<ContainerInfo> getContainerInfoIterator(LifeCycleState state, ContainerID start) {
+    return containers.getContainerInfoIterator(state, start);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -603,7 +603,7 @@ public class ContainerEndpoint {
           } else if (scmContainerID == null || omContainerID.compareTo(scmContainerID) < 0) {
             ContainerMetadata omContainer = omContainers.next();
             if (omContainer.getNumberOfKeys() > 0) {
-              notSCMContainers.add(omContainers.next());
+              notSCMContainers.add(omContainer);
             }
           } else {
             scmContainerInfo = scmNonDeletedContainers.hasNext() ? scmNonDeletedContainers.next() : null;
@@ -728,7 +728,10 @@ public class ContainerEndpoint {
         Long omContainerID = omContainers.peekNextKey();
         Long scmContainerID = scmContainerInfo.getContainerID();
         if (scmContainerID.equals(omContainerID)) {
-          omContainersDeletedInSCM.add(omContainers.next());
+          ContainerMetadata containerMetadata = omContainers.next();
+          if (containerMetadata.getNumberOfKeys() > 0) {
+            omContainersDeletedInSCM.add(omContainers.next());
+          }
           scmContainerInfo = deletedStateSCMContainers.hasNext() ? deletedStateSCMContainers.next() : null;
         } else if (scmContainerID.compareTo(omContainerID) < 0) {
           scmContainerInfo = deletedStateSCMContainers.hasNext() ? deletedStateSCMContainers.next() : null;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -29,7 +29,6 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -584,29 +583,28 @@ public class ContainerEndpoint {
         new ArrayList<>();
     Long minContainerID = prevKey + 1;
     Iterator<ContainerInfo> scmNonDeletedContainers =
-            containerManager.getContainers().stream()
-                    .filter(containerInfo -> (containerInfo.getContainerID() >= minContainerID))
-                    .filter(containerInfo -> containerInfo.getState() != HddsProtos.LifeCycleState.DELETED)
-                    .sorted(Comparator.comparingLong(ContainerInfo::getContainerID)).iterator();
-    ContainerInfo scmContainerInfo = scmNonDeletedContainers.hasNext() ?
-            scmNonDeletedContainers.next() : null;
+            containerManager.getContainerInfoIterator(ContainerID.valueOf(minContainerID),
+              containerInfo -> containerInfo.getState() != HddsProtos.LifeCycleState.DELETED);
+    ContainerInfo scmContainerInfo = scmNonDeletedContainers.hasNext() ? scmNonDeletedContainers.next() : null;
     DataFilter dataFilter = DataFilter.fromValue(missingIn.toUpperCase());
     try (SeekableIterator<Long, ContainerMetadata> omContainers =
-                 reconContainerMetadataManager.getContainersIterator()) {
+           reconContainerMetadataManager.getContainersIterator()) {
       omContainers.seek(minContainerID);
-      ContainerMetadata containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
+
       switch (dataFilter) {
       case SCM:
         List<ContainerMetadata> notSCMContainers = new ArrayList<>();
-        while (containerMetadata != null && notSCMContainers.size() < limit) {
-          Long omContainerID = containerMetadata.getContainerID();
+        while (omContainers.hasNext() && notSCMContainers.size() < limit) {
+          Long omContainerID = omContainers.peekNextKey();
           Long scmContainerID = scmContainerInfo == null ? null : scmContainerInfo.getContainerID();
           if (omContainerID.equals(scmContainerID)) {
-            containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
+            omContainers.seek(omContainerID + 1);
             scmContainerInfo = scmNonDeletedContainers.hasNext() ? scmNonDeletedContainers.next() : null;
           } else if (scmContainerID == null || omContainerID.compareTo(scmContainerID) < 0) {
-            notSCMContainers.add(containerMetadata);
-            containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
+            ContainerMetadata omContainer = omContainers.next();
+            if (omContainer.getNumberOfKeys() > 0) {
+              notSCMContainers.add(omContainers.next());
+            }
           } else {
             scmContainerInfo = scmNonDeletedContainers.hasNext() ? scmNonDeletedContainers.next() : null;
           }
@@ -628,19 +626,16 @@ public class ContainerEndpoint {
       case OM:
         List<ContainerInfo> nonOMContainers = new ArrayList<>();
         while (scmContainerInfo != null && nonOMContainers.size() < limit) {
-          Long omContainerID = containerMetadata == null ? null : containerMetadata.getContainerID();
+          Long omContainerID = omContainers.peekNextKey();
           Long scmContainerID = scmContainerInfo.getContainerID();
           if (scmContainerID.equals(omContainerID)) {
             scmContainerInfo = scmNonDeletedContainers.hasNext() ? scmNonDeletedContainers.next() : null;
-            containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
+            omContainers.seek(scmContainerInfo == null ? (omContainerID + 1) : scmContainerInfo.getContainerID());
           } else if (omContainerID == null || scmContainerID.compareTo(omContainerID) < 0) {
             nonOMContainers.add(scmContainerInfo);
             scmContainerInfo = scmNonDeletedContainers.hasNext() ? scmNonDeletedContainers.next() : null;
           } else {
-            //Seeking directly to SCM containerId sequential read is just wasteful here if there are too many values
-            // to be read in b/w omContainerID & scmContainerID since (omContainerId<scmContainerID)
-            omContainers.seek(scmContainerID);
-            containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
+            omContainers.seek(scmContainerInfo.getContainerID());
           }
         }
 
@@ -721,30 +716,25 @@ public class ContainerEndpoint {
       limit = Integer.MAX_VALUE;
     }
     long minContainerID = prevKey + 1;
-    Iterator<ContainerInfo> deletedStateSCMContainers = containerManager.getContainers().stream()
-        .filter(containerInfo -> containerInfo.getContainerID() >= minContainerID)
-        .filter(containerInfo -> containerInfo.getState() == HddsProtos.LifeCycleState.DELETED)
-        .sorted(Comparator.comparingLong(ContainerInfo::getContainerID)).iterator();
+    Iterator<ContainerInfo> deletedStateSCMContainers = containerManager.getContainerInfoIterator(
+        HddsProtos.LifeCycleState.DELETED, ContainerID.valueOf(minContainerID));
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList;
     try (SeekableIterator<Long, ContainerMetadata> omContainers =
            reconContainerMetadataManager.getContainersIterator()) {
       ContainerInfo scmContainerInfo = deletedStateSCMContainers.hasNext() ? deletedStateSCMContainers.next() : null;
-      ContainerMetadata containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
       List<ContainerMetadata> omContainersDeletedInSCM = new ArrayList<>();
-      while (containerMetadata != null && scmContainerInfo != null
+      while (omContainers.hasNext() && scmContainerInfo != null
         && omContainersDeletedInSCM.size() < limit) {
-        Long omContainerID = containerMetadata.getContainerID();
+        Long omContainerID = omContainers.peekNextKey();
         Long scmContainerID = scmContainerInfo.getContainerID();
         if (scmContainerID.equals(omContainerID)) {
-          omContainersDeletedInSCM.add(containerMetadata);
+          omContainersDeletedInSCM.add(omContainers.next());
           scmContainerInfo = deletedStateSCMContainers.hasNext() ? deletedStateSCMContainers.next() : null;
-          containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
         } else if (scmContainerID.compareTo(omContainerID) < 0) {
           scmContainerInfo = deletedStateSCMContainers.hasNext() ? deletedStateSCMContainers.next() : null;
         } else {
           // Seek directly to scmContainerId iterating sequentially is very wasteful here.
           omContainers.seek(scmContainerID);
-          containerMetadata = omContainers.hasNext() ? omContainers.next() : null;
         }
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -511,10 +511,12 @@ public class ReconContainerMetadataManagerImpl
 
         ContainerMetadata containerMetadata = new ContainerMetadata(currentKey.getKey());
         if (currentMetadata == null || currentKey.getKey() != currentMetadata.getKey().getContainerId()) {
-          LOG.error("ContainerMetaData and containerIDs count do not match for container Id: {}. Container Count " +
-              "Table has {} counts and container Metadata doesn't have container and next containerId is {}",
-              currentKey.getKey(), currentMetadata.getKey().getContainerId(),
-              currentMetadata.getKey().getContainerId());
+          if (currentKey.getValue() > 0) {
+            Long containerID = currentMetadata == null ? null : currentMetadata.getKey().getContainerId();
+            LOG.error("ContainerMetaData and containerIDs count do not match for container Id: {}. Container Count " +
+                "Table has {} counts and container Metadata doesn't have container and next containerId is {}",
+                currentKey.getKey(), currentKey.getValue(), containerID);
+          }
           currentKey = containerIterator.hasNext() ? containerIterator.next() : null;
           if (currentKey != null) {
             seek(currentKey.getKey());
@@ -535,6 +537,11 @@ public class ReconContainerMetadataManagerImpl
                  currentMetadata.getKey().getContainerId() == containerMetadata.getContainerID());
         containerMetadata.setNumberOfKeys(count);
         containerMetadata.setPipelines(new ArrayList<>(pipelines.values()));
+        if (currentKey.getValue() != count) {
+          LOG.error("ContainerMetaData and containerIDs count do not match for container Id: {}. Container Count " +
+              "Table has {} counts and container Metadata only has {} keys",
+              currentKey.getKey(), currentKey.getValue(), count);
+        }
         currentKey = containerIterator.hasNext() ? containerIterator.next() : null;
         return containerMetadata;
       } catch (IOException e) {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
@@ -714,7 +714,7 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
     cancelDeletedKeysSignal = controller
     request.then(deletedKeysResponse => {
       let deletedContainerKeys = [];
-      deletedContainerKeys = deletedKeysResponse?.data?.containers ?? [];
+      deletedContainerKeys = deletedKeysResponse?.data?.containerDiscrepancyInfo ?? [];
       this.setState({
         loading: false,
         deletedContainerKeysDataSource: deletedContainerKeys


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the mismatch api instead of looking into the containerKeyCountTable looks into containerKeyPrefix table which means more number of keys have to be looked into while getting mismatched container. The proposal here is to look into the containerKeyCountTable for checking the presence of the container and only look into the containerKeyPrefixTable if and only if the containerMetadata for container is needed to be returned.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12655

## How was this patch tested?
Existing unit tests