### PR TITLE
HDDS-12341. Share cluster in client tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -20,32 +20,24 @@ package org.apache.hadoop.ozone.client.rpc;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
-import org.apache.hadoop.hdds.scm.OzoneClientConfig;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
@@ -55,56 +47,40 @@ import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests Close Container Exception handling by Ozone Client.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestCloseContainerHandlingByClient {
+public abstract class TestCloseContainerHandlingByClient implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf = new OzoneConfiguration();
-  private static OzoneClient client;
-  private static ObjectStore objectStore;
-  private static int chunkSize;
-  private static int blockSize;
-  private static String volumeName;
-  private static String bucketName;
-  private static String keyString;
+  private MiniOzoneCluster cluster;
+  private OzoneClient client;
+  private ObjectStore objectStore;
+  private int chunkSize;
+  private int blockSize;
+  private String volumeName;
+  private String bucketName;
+  private String keyString;
 
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   *
-   * @throws IOException
-   */
   @BeforeAll
-  public static void init() throws Exception {
-    chunkSize = (int) OzoneConsts.MB;
-    blockSize = 4 * chunkSize;
+  void init() throws Exception {
+    chunkSize = (int) cluster().getConf().getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY, 1024 * 1024, StorageUnit.BYTES);
+    blockSize = (int) cluster().getConf().getStorageSize(OZONE_SCM_BLOCK_SIZE, 4 * chunkSize, StorageUnit.BYTES);
 
-    OzoneClientConfig config = conf.getObject(OzoneClientConfig.class);
-    config.setChecksumType(ChecksumType.NONE);
-    conf.setFromObject(config);
-
-    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
-    conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 1);
-    conf.setQuietMode(false);
-    conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 4,
-        StorageUnit.MB);
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
-    cluster.waitForClusterToBeReady();
-    //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getRpcClient(conf);
+    cluster = cluster();
+    client = cluster().newClient();
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
-    volumeName = "closecontainerexceptionhandlingtest";
-    bucketName = volumeName;
+    volumeName = "vol-" + UUID.randomUUID();
+    bucketName = "bucket";
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
@@ -113,15 +89,9 @@ public class TestCloseContainerHandlingByClient {
     return UUID.randomUUID().toString();
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
@@ -17,200 +17,92 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
+import static org.apache.hadoop.ozone.container.TestHelper.createStreamKey;
+import static org.apache.hadoop.ozone.container.TestHelper.getDatanodeService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.UUID;
+import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ReplicationType;
-import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.conf.StorageUnit;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
-import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.ClientConfigForTesting;
-import org.apache.hadoop.ozone.HddsDatanodeService;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.KeyDataStreamOutput;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
-import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.apache.ozone.test.NonHATests;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests the containerStateMachine stream handling.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
-public class TestContainerStateMachineStream {
-  private MiniOzoneCluster cluster;
-  private OzoneConfiguration conf = new OzoneConfiguration();
+public abstract class TestContainerStateMachineStream implements NonHATests.TestCase {
   private OzoneClient client;
   private ObjectStore objectStore;
   private String volumeName;
   private String bucketName;
+  private int chunkSize;
 
-  private static final int CHUNK_SIZE = 100;
-  private static final int FLUSH_SIZE = 2 * CHUNK_SIZE;
-  private static final int MAX_FLUSH_SIZE = 2 * FLUSH_SIZE;
-  private static final int BLOCK_SIZE = 2 * MAX_FLUSH_SIZE;
+  @BeforeAll
+  void setup() throws Exception {
+    chunkSize = (int) cluster().getConf().getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY, 1024 * 1024, StorageUnit.BYTES);
 
-  /**
-   * Create a MiniDFSCluster for testing.
-   *
-   * @throws IOException
-   */
-  @BeforeEach
-  public void setup() throws Exception {
-    conf = new OzoneConfiguration();
-
-    OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
-    clientConfig.setStreamBufferFlushDelay(false);
-    conf.setFromObject(clientConfig);
-
-    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
-        TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 200,
-        TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 200, TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 200,
-        TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 30, TimeUnit.SECONDS);
-    conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 1,
-        TimeUnit.SECONDS);
-
-    RatisClientConfig ratisClientConfig =
-        conf.getObject(RatisClientConfig.class);
-    ratisClientConfig.setWriteRequestTimeout(Duration.ofSeconds(10));
-    ratisClientConfig.setWatchRequestTimeout(Duration.ofSeconds(10));
-    conf.setFromObject(ratisClientConfig);
-
-    DatanodeRatisServerConfig ratisServerConfig =
-        conf.getObject(DatanodeRatisServerConfig.class);
-    ratisServerConfig.setRequestTimeOut(Duration.ofSeconds(3));
-    ratisServerConfig.setWatchTimeOut(Duration.ofSeconds(10));
-    conf.setFromObject(ratisServerConfig);
-
-    RatisClientConfig.RaftConfig raftClientConfig =
-        conf.getObject(RatisClientConfig.RaftConfig.class);
-    raftClientConfig.setRpcRequestTimeout(Duration.ofSeconds(3));
-    raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(10));
-    conf.setFromObject(raftClientConfig);
-
-    ClientConfigForTesting.newBuilder(StorageUnit.BYTES)
-        .setDataStreamMinPacketSize(1024)
-        .setBlockSize(BLOCK_SIZE)
-        .setChunkSize(CHUNK_SIZE)
-        .setStreamBufferFlushSize(FLUSH_SIZE)
-        .setStreamBufferMaxSize(MAX_FLUSH_SIZE)
-        .applyTo(conf);
-
-    conf.setLong(OzoneConfigKeys.HDDS_RATIS_SNAPSHOT_THRESHOLD_KEY, 1);
-    conf.setQuietMode(false);
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(3)
-        .build();
-    cluster.waitForClusterToBeReady();
-    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
-    //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getRpcClient(conf);
+    client = cluster().newClient();
     objectStore = client.getObjectStore();
 
-    volumeName = "testcontainerstatemachinestream";
+    volumeName = "vol-" + UUID.randomUUID();
     bucketName = "teststreambucket";
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);
-
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
-  @AfterEach
-  public void shutdown() {
+  @AfterAll
+  void shutdown() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, +1})
+  void testContainerStateMachineForStreaming(int offset) throws Exception {
+    final int size = chunkSize + offset;
+
+    final List<OmKeyLocationInfo> locationInfoList;
+    try (OzoneDataStreamOutput key = createStreamKey("key" + offset, ReplicationType.RATIS, size,
+        objectStore, volumeName, bucketName)) {
+
+      byte[] data = ContainerTestHelper.generateData(size, true);
+      key.write(ByteBuffer.wrap(data));
+      key.flush();
+
+      locationInfoList = assertInstanceOf(KeyDataStreamOutput.class, key.getByteBufStreamOutput())
+          .getLocationInfoList();
     }
-  }
-
-  @Test
-  public void testContainerStateMachineForStreaming() throws Exception {
-    long size = CHUNK_SIZE + 1;
-
-    OzoneDataStreamOutput key = TestHelper.createStreamKey(
-        "ozone-stream-test.txt", ReplicationType.RATIS, size, objectStore,
-        volumeName, bucketName);
-
-    byte[] data = ContainerTestHelper.generateData((int) size, true);
-    key.write(ByteBuffer.wrap(data));
-    key.flush();
-
-    KeyDataStreamOutput streamOutput =
-        (KeyDataStreamOutput) key.getByteBufStreamOutput();
-    List<OmKeyLocationInfo> locationInfoList =
-        streamOutput.getLocationInfoList();
-
-    key.close();
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
 
-    long bytesUsed = dn.getDatanodeStateMachine()
-        .getContainer().getContainerSet()
-        .getContainer(omKeyLocationInfo.getContainerID()).
-        getContainerData().getBytesUsed();
+    long bytesUsed = getDatanodeService(omKeyLocationInfo, cluster())
+        .getDatanodeStateMachine()
+        .getContainer()
+        .getContainerSet()
+        .getContainer(omKeyLocationInfo.getContainerID())
+        .getContainerData()
+        .getBytesUsed();
 
-    assertEquals(bytesUsed, size);
-  }
-
-
-  @Test
-  public void testContainerStateMachineForStreamingSmallFile()
-      throws Exception {
-    long size = CHUNK_SIZE - 1;
-
-    OzoneDataStreamOutput key = TestHelper.createStreamKey(
-        "ozone-stream-test-small-file.txt", ReplicationType.RATIS, size,
-        objectStore, volumeName, bucketName);
-
-    byte[] data = ContainerTestHelper.generateData((int) size, true);
-    key.write(ByteBuffer.wrap(data));
-    key.flush();
-
-    KeyDataStreamOutput streamOutput =
-        (KeyDataStreamOutput) key.getByteBufStreamOutput();
-    List<OmKeyLocationInfo> locationInfoList =
-        streamOutput.getLocationInfoList();
-    key.close();
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-
-    long bytesUsed = dn.getDatanodeStateMachine()
-        .getContainer().getContainerSet()
-        .getContainer(omKeyLocationInfo.getContainerID()).
-        getContainerData().getBytesUsed();
-
-    assertEquals(bytesUsed, size);
+    assertThat(bytesUsed)
+        // container may have previous data
+        .isGreaterThanOrEqualTo(size);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,7 +34,6 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -44,8 +42,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatusLight;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -54,33 +51,14 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Main purpose of this test is with OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION
  * set/unset key create/read works properly or not for buckets
  * with/without versioning.
- * TODO: can be merged with other test class
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TestOzoneRpcClientWithKeyLatestVersion {
-
-  private MiniOzoneCluster cluster;
-
-  @BeforeAll
-  void setup() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setInt(OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .build();
-    cluster.waitForClusterToBeReady();
-  }
-
-  @AfterAll
-  void tearDown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-  }
+public abstract class TestOzoneRpcClientWithKeyLatestVersion implements NonHATests.TestCase {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testWithGetLatestVersion(boolean getLatestVersionOnly) throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration(cluster.getConf());
+    OzoneConfiguration conf = new OzoneConfiguration(cluster().getConf());
     conf.setBoolean(OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION,
         getLatestVersionOnly);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
@@ -20,6 +20,7 @@ package org.apache.ozone.test;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LEASE_SOFT_LIMIT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +70,7 @@ public abstract class ClusterForTests<C extends MiniOzoneCluster> {
     conf.setBoolean("ozone.client.hbase.enhancements.allowed", true);
     conf.setBoolean(OZONE_FS_HSYNC_ENABLED, true);
     conf.setTimeDuration(OZONE_OM_LEASE_SOFT_LIMIT, 0, TimeUnit.SECONDS);
+    conf.setInt(OZONE_KEY_DELETING_LIMIT_PER_TASK, 0);
 
     return conf;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer;
 import org.apache.hadoop.ozone.client.rpc.TestCloseContainerHandlingByClient;
 import org.apache.hadoop.ozone.client.rpc.TestContainerStateMachineStream;
 import org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks;
+import org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithKeyLatestVersion;
 import org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient;
 import org.apache.hadoop.ozone.om.TestListKeys;
 import org.apache.hadoop.ozone.om.TestListKeysWithFSO;
@@ -330,6 +331,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class OzoneManagerRestInterface extends TestOzoneManagerRestInterface {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class OzoneRpcClientWithKeyLatestVersion extends TestOzoneRpcClientWithKeyLatestVersion {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestCpuMetrics;
 import org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer;
 import org.apache.hadoop.ozone.client.rpc.TestCloseContainerHandlingByClient;
+import org.apache.hadoop.ozone.client.rpc.TestContainerStateMachineStream;
 import org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks;
 import org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient;
 import org.apache.hadoop.ozone.om.TestListKeys;
@@ -217,6 +218,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class CloseContainerHandlingByClient extends TestCloseContainerHandlingByClient {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ContainerStateMachineStream extends TestContainerStateMachineStream {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer;
 import org.apache.hadoop.ozone.client.rpc.TestCloseContainerHandlingByClient;
 import org.apache.hadoop.ozone.client.rpc.TestContainerStateMachineStream;
 import org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks;
+import org.apache.hadoop.ozone.client.rpc.TestOzoneClientMultipartUploadWithFSO;
 import org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithKeyLatestVersion;
 import org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient;
 import org.apache.hadoop.ozone.om.TestListKeys;
@@ -71,6 +72,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
   /** Test cases for non-HA cluster should implement this. */
   public interface TestCase {
     MiniOzoneCluster cluster();
+  }
+
+  @Nested
+  class OzoneClientMultipartUploadWithFSO extends TestOzoneClientMultipartUploadWithFSO {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
   }
 
   @Nested

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.scm.pipeline.TestSCMPipelineMetrics;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestCpuMetrics;
 import org.apache.hadoop.ozone.admin.om.lease.TestLeaseRecoverer;
+import org.apache.hadoop.ozone.client.rpc.TestCloseContainerHandlingByClient;
 import org.apache.hadoop.ozone.client.rpc.TestDiscardPreallocatedBlocks;
 import org.apache.hadoop.ozone.om.TestBucketLayoutWithOlderClient;
 import org.apache.hadoop.ozone.om.TestListKeys;
@@ -208,6 +209,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class SCMPipelineMetrics extends TestSCMPipelineMetrics {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class CloseContainerHandlingByClient extends TestCloseContainerHandlingByClient {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up some client integration tests by using shared cluster.

Also, fix intermittent failure caused by background key deletion (HDDS-12465), because it become more frequent with these new tests added.

https://issues.apache.org/jira/browse/HDDS-12341

## How was this patch tested?

Before:

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 66.09 s -- in org.apache.hadoop.ozone.client.rpc.TestCloseContainerHandlingByClient
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 66.91 s -- in org.apache.hadoop.ozone.client.rpc.TestContainerStateMachineStream
Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.65 s -- in org.apache.hadoop.ozone.client.rpc.TestOzoneClientMultipartUploadWithFSO
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.03 s -- in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithKeyLatestVersion
```

After:

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.18 s -- in org.apache.ozone.test.NonHATests$CloseContainerHandlingByClient
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.233 s -- in org.apache.ozone.test.NonHATests$ContainerStateMachineStream
Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.208 s -- in org.apache.ozone.test.NonHATests$OzoneClientMultipartUploadWithFSO
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.539 s -- in org.apache.ozone.test.NonHATests$OzoneRpcClientWithKeyLatestVersion
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/13979021418