### PR TITLE
HDDS-12433. [DiskBalancer] Avoid selecting container which has container balancer or replication task already

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.ozone.container.diskbalancer.policy.ContainerChoosingPo
 import org.apache.hadoop.ozone.container.diskbalancer.policy.VolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.FileUtils;
@@ -103,14 +104,17 @@ public class DiskBalancerService extends BackgroundService {
   private final File diskBalancerInfoFile;
 
   private DiskBalancerServiceMetrics metrics;
+  private ReplicationSupervisor replicationSupervisor;
 
   public DiskBalancerService(OzoneContainer ozoneContainer,
       long serviceCheckInterval, long serviceCheckTimeout, TimeUnit timeUnit,
-      int workerSize, ConfigurationSource conf) throws IOException {
+      int workerSize, ConfigurationSource conf, ReplicationSupervisor replicationSupervisor)
+      throws IOException {
     super("DiskBalancerService", serviceCheckInterval, timeUnit, workerSize,
         serviceCheckTimeout);
     this.ozoneContainer = ozoneContainer;
     this.conf = conf;
+    this.replicationSupervisor = replicationSupervisor;
 
     String diskBalancerInfoPath = getDiskBalancerInfoPath();
     Preconditions.checkNotNull(diskBalancerInfoPath);
@@ -337,7 +341,7 @@ public class DiskBalancerService extends BackgroundService {
       }
       HddsVolume sourceVolume = pair.getLeft(), destVolume = pair.getRight();
       ContainerData toBalanceContainer = containerChoosingPolicy
-          .chooseContainer(ozoneContainer, sourceVolume, inProgressContainers);
+          .chooseContainer(ozoneContainer, sourceVolume, inProgressContainers, replicationSupervisor);
       if (toBalanceContainer != null) {
         queue.add(new DiskBalancerTask(toBalanceContainer, sourceVolume,
             destVolume));

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/ContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/ContainerChoosingPolicy.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 
 /**
  * This interface specifies the policy for choosing containers to balance.
@@ -32,5 +33,6 @@ public interface ContainerChoosingPolicy {
    * @return a Container
    */
   ContainerData chooseContainer(OzoneContainer ozoneContainer,
-      HddsVolume volume, Set<Long> inProgressContainerIDs);
+      HddsVolume volume, Set<Long> inProgressContainerIDs,
+      ReplicationSupervisor replicationSupervisor);
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -34,7 +34,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -96,6 +98,7 @@ import org.apache.hadoop.ozone.container.metadata.WitnessedContainerMetadataStor
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
+import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures.SchemaV3;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 import org.apache.hadoop.util.Timer;
@@ -140,6 +143,8 @@ public class OzoneContainer {
   private final ContainerMetrics metrics;
   private WitnessedContainerMetadataStore witnessedContainerMetadataStore;
 
+  private ReplicationSupervisor replicationSupervisor;
+
   enum InitializingStatus {
     UNINITIALIZED, INITIALIZING, INITIALIZED
   }
@@ -153,6 +158,7 @@ public class OzoneContainer {
    * @throws DiskOutOfSpaceException
    * @throws IOException
    */
+  @SuppressWarnings("checkstyle:methodlength")
   public OzoneContainer(HddsDatanodeService hddsDatanodeService,
       DatanodeDetails datanodeDetails, ConfigurationSource conf,
       StateContext context, CertificateClient certClient,
@@ -263,15 +269,24 @@ public class OzoneContainer {
             blockDeletingServiceWorkerSize, config,
             datanodeDetails.threadNamePrefix(),
             context.getParent().getReconfigurationHandler());
+    Clock clock = Clock.system(ZoneId.systemDefault());
 
     Duration diskBalancerSvcInterval = conf.getObject(
         DiskBalancerConfiguration.class).getDiskBalancerInterval();
     Duration diskBalancerSvcTimeout = conf.getObject(
         DiskBalancerConfiguration.class).getDiskBalancerTimeout();
+
+    replicationSupervisor = ReplicationSupervisor.newBuilder()
+        .stateContext(context)
+        .datanodeConfig(dnConf)
+        .replicationConfig(conf.getObject(ReplicationConfig.class))
+        .clock(clock)
+        .build();
+
     diskBalancerService =
         new DiskBalancerService(this, diskBalancerSvcInterval.toMillis(),
             diskBalancerSvcTimeout.toMillis(), TimeUnit.MILLISECONDS, 1,
-            config);
+            config, replicationSupervisor);
 
     Duration recoveringContainerScrubbingSvcInterval =
         dnConf.getRecoveringContainerScrubInterval();
@@ -659,6 +674,10 @@ public class OzoneContainer {
 
   public ReplicationServer getReplicationServer() {
     return replicationServer;
+  }
+
+  public ReplicationSupervisor getReplicationSupervisor() {
+    return replicationSupervisor;
   }
 
   public void compactDb() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -554,4 +554,8 @@ public final class ReplicationSupervisor {
     MutableRate rate = opsLatencyMs.get(metricsName);
     return rate != null ? (long) rate.lastStat().total() : 0;
   }
+
+  public Set<AbstractReplicationTask> getInFlightTasks() {
+    return inFlight;
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceTestImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 
 
 /**
@@ -41,10 +42,11 @@ public class DiskBalancerServiceTestImpl extends DiskBalancerService {
   private AtomicInteger numOfProcessed = new AtomicInteger(0);
 
   public DiskBalancerServiceTestImpl(OzoneContainer container,
-      int serviceInterval, ConfigurationSource conf, int threadCount)
+      int serviceInterval, ConfigurationSource conf,
+      int threadCount, ReplicationSupervisor supervisor)
       throws IOException {
     super(container, serviceInterval, SERVICE_TIMEOUT_IN_MILLISECONDS,
-        TimeUnit.MILLISECONDS, threadCount, conf);
+        TimeUnit.MILLISECONDS, threadCount, conf, supervisor);
   }
 
   public void runBalanceTasks() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDefaultContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDefaultContainerChoosingPolicy.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.diskbalancer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultContainerChoosingPolicy;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask;
+import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
+import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
+import org.apache.hadoop.ozone.container.replication.ReplicationTask;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test class for DefaultContainerChoosingPolicy.
+ */
+public class TestDefaultContainerChoosingPolicy {
+
+  private OzoneContainer ozoneContainer;
+  private ReplicationSupervisor replicationSupervisor;
+  private DefaultContainerChoosingPolicy containerChoosingPolicy;
+  private HddsVolume hddsVolume;
+  private ContainerController containerController;
+  private Collection<Container<?>> containers;
+  private Set<AbstractReplicationTask> inFlight;
+  private Set<Long> inProgressContainerIDs;
+
+  private static final AtomicLong CONTAINER_SEQ_ID = new AtomicLong(100);
+  private static final long CURRENT_TERM = 1;
+  private final AtomicReference<ContainerReplicator> replicatorRef = new AtomicReference<>();
+
+  @BeforeEach
+  public void init() {
+    ozoneContainer = mock(OzoneContainer.class);
+    replicationSupervisor = mock(ReplicationSupervisor.class);
+    containerChoosingPolicy = new DefaultContainerChoosingPolicy();
+    inProgressContainerIDs = ConcurrentHashMap.newKeySet();
+    hddsVolume = mock(HddsVolume.class);
+    containerController = mock(ContainerController.class);
+    when(ozoneContainer.getController()).thenReturn(containerController);
+    containers = new ArrayList<>();
+    inFlight = ConcurrentHashMap.newKeySet();
+  }
+
+  @Test
+  public void testChooseContainer() {
+    //container 103 -> inProgressContainerIds.
+    inProgressContainerIDs.add(103L);
+
+    // container 101, container 102 -> inFlight.
+    inFlight.add(createTask(101L));
+    inFlight.add(createTask(102L));
+
+    for (int i = 0; i < 6; i++) {
+      containers.add(createMockContainers());
+    }
+
+    when(replicationSupervisor.getInFlightTasks()).thenReturn(inFlight);
+    when(containerController.getContainers(hddsVolume))
+        .thenAnswer(i -> this.containers.iterator());
+
+    ContainerData result = containerChoosingPolicy.chooseContainer(ozoneContainer, hddsVolume,
+        inProgressContainerIDs, replicationSupervisor);
+
+    assertEquals(106L, result.getContainerID(),
+        "Only container 106 is choosen rest others are skipped");
+  }
+
+  private Container createMockContainers() {
+    KeyValueContainer container = mock(KeyValueContainer.class);
+
+    KeyValueContainerData data = mock(KeyValueContainerData.class);
+    long containerId = CONTAINER_SEQ_ID.incrementAndGet();
+    when(data.getContainerID()).thenReturn(containerId);
+
+    //container 104 -> is empty and all others are non-empty
+    if (containerId == 104L) {
+      when(data.isEmpty()).thenReturn(true);
+    } else {
+      when(data.isEmpty()).thenReturn(false);
+    }
+
+    //container 105 -> is not closed and all others are closed
+    if (containerId == 105L) {
+      when(data.isClosed()).thenReturn(false);
+    } else {
+      when(data.isClosed()).thenReturn(true);
+    }
+
+    when(container.getContainerData()).thenReturn(data);
+    return container;
+  }
+
+  private static ReplicateContainerCommand createCommand(long containerId) {
+    ReplicateContainerCommand cmd =
+        ReplicateContainerCommand.forTest(containerId);
+    cmd.setTerm(CURRENT_TERM);
+    return cmd;
+  }
+
+  private ReplicationTask createTask(long containerId) {
+    ReplicateContainerCommand cmd = createCommand(containerId);
+    return new ReplicationTask(cmd, replicatorRef.get());
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
@@ -106,7 +107,7 @@ public class TestDiskBalancerService {
             metrics, c -> {
         });
     DiskBalancerServiceTestImpl svc =
-        getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1);
+        getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1, null);
 
     // Set a low bandwidth to delay job
     svc.setShouldRun(true);
@@ -143,7 +144,7 @@ public class TestDiskBalancerService {
             metrics, c -> {
         });
     DiskBalancerServiceTestImpl svc =
-        getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1);
+        getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1, null);
 
     assertTrue(svc.getContainerChoosingPolicy()
         instanceof DefaultContainerChoosingPolicy);
@@ -163,11 +164,11 @@ public class TestDiskBalancerService {
   private DiskBalancerServiceTestImpl getDiskBalancerService(
       ContainerSet containerSet, ConfigurationSource config,
       KeyValueHandler keyValueHandler, ContainerController controller,
-      int threadCount) throws IOException {
+      int threadCount, ReplicationSupervisor replicationSupervisor) throws IOException {
     OzoneContainer ozoneContainer =
         mockDependencies(containerSet, keyValueHandler, controller);
     return new DiskBalancerServiceTestImpl(ozoneContainer, 1000, config,
-        threadCount);
+        threadCount, replicationSupervisor);
   }
 
   private OzoneContainer mockDependencies(ContainerSet containerSet,
@@ -180,6 +181,8 @@ public class TestDiskBalancerService {
     when(dispatcher.getHandler(any())).thenReturn(keyValueHandler);
     when(ozoneContainer.getVolumeSet()).thenReturn(volumeSet);
     when(ozoneContainer.getController()).thenReturn(controller);
+    ReplicationSupervisor supervisor = mock(ReplicationSupervisor.class);
+    when(ozoneContainer.getReplicationSupervisor()).thenReturn((supervisor));
     return ozoneContainer;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
If a container has push mode moving task already, there is chance that this container's replica will be deleted in future. Avoid selecting such state containers. Also avoid selecting empty container to move.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12433

## How was this patch tested?

Added a unit test for `DefaultContainerChoosingPolicy.java` in  `TestDefaultContainerChoosingPolicy` class.
