### PR TITLE
HDDS-12661. Standardize Maven module names

### DIFF
--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -22,8 +22,8 @@
   <artifactId>hdds-docs</artifactId>
   <version>2.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>Apache Ozone/HDDS Documentation</name>
-  <description>Apache Ozone/HDDS Documentation</description>
+  <name>Apache Ozone Documentation</name>
+  <description>Apache Ozone Documentation</description>
 
   <properties>
     <!-- no testable code in this module -->

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -23,8 +23,8 @@
   <artifactId>rocksdb-checkpoint-differ</artifactId>
   <version>2.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>RocksDB Checkpoint Differ</name>
-  <description>RocksDB Checkpoint Differ</description>
+  <name>Apache Ozone Checkpoint Differ for RocksDB</name>
+  <description>Apache Ozone Checkpoint Differ for RocksDB</description>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Please describe your PR in detail:
When compiling with maven, the summary at the end shows that most module names have the prefix Apache Ozone .
 
```
[INFO] Apache Ozone HDDS Hadoop Server dependencies ....... SUCCESS [  0.482 s]
[INFO] Apache Ozone HDDS RocksDB Tools .................... SUCCESS [  0.362 s]
[INFO] RocksDB Checkpoint Differ .......................... SUCCESS [  0.599 s]
[INFO] Apache Ozone HDDS Server Framework ................. SUCCESS [  2.509 s]
[INFO] Apache Ozone/HDDS Documentation .................... SUCCESS [ 51.698 s]
[INFO] Apache Ozone HDDS Container Service ................ SUCCESS [  2.711 s] 
```
Two modules do not follow the standard:
```
# notice the extra `/`
  <name>Apache Ozone/HDDS Documentation</name> 
  <description>Apache Ozone/HDDS Documentation</description> 

# no "Apache Ozone" prefix
  <name>RocksDB Checkpoint Differ</name> 
  <description>RocksDB Checkpoint Differ</description>  
```

This PR standardizes the module names

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12661

## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/13997984010
```java
[INFO] Apache Ozone Checkpoint Differ for RocksDB ......... SUCCESS [  0.706 s]
[INFO] Apache Ozone HDDS Server Framework ................. SUCCESS [  2.215 s]
[INFO] Apache Ozone Documentation ......................... SUCCESS [  3.868 s]
```