### PR TITLE
HDDS-12465. Intermittent failure in TestOzoneFileSystemMetrics

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -62,6 +62,9 @@ public abstract class TestOzoneFileSystemMetrics implements NonHATests.TestCase 
 
   @BeforeAll
   void init() throws Exception {
+    cluster().getOzoneManager().getKeyManager().getDeletingService().suspend();
+    cluster().getOzoneManager().getKeyManager().getDirDeletingService().suspend();
+
     client = cluster().newClient();
 
     OmConfig omConfig = cluster().getOzoneManager().getConfig();
@@ -81,6 +84,8 @@ public abstract class TestOzoneFileSystemMetrics implements NonHATests.TestCase 
   void cleanup() {
     IOUtils.closeQuietly(client, fs);
     cluster().getOzoneManager().getConfig().setFrom(originalOmConfig);
+    cluster().getOzoneManager().getKeyManager().getDeletingService().resume();
+    cluster().getOzoneManager().getKeyManager().getDirDeletingService().resume();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/ClusterForTests.java
@@ -20,7 +20,6 @@ package org.apache.ozone.test;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LEASE_SOFT_LIMIT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -70,7 +69,6 @@ public abstract class ClusterForTests<C extends MiniOzoneCluster> {
     conf.setBoolean("ozone.client.hbase.enhancements.allowed", true);
     conf.setBoolean(OZONE_FS_HSYNC_ENABLED, true);
     conf.setTimeDuration(OZONE_OM_LEASE_SOFT_LIMIT, 0, TimeUnit.SECONDS);
-    conf.setInt(OZONE_KEY_DELETING_LIMIT_PER_TASK, 0);
 
     return conf;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suspend key and dir deleting services for the duration of `TestOzoneFileSystemMetrics` to fix intermittent failure:

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.395 s <<< FAILURE! -- in org.apache.ozone.test.NonHATests$OzoneFileSystemMetrics
org.apache.ozone.test.NonHATests$OzoneFileSystemMetrics.testFileOps -- Time elapsed: 3.278 s <<< FAILURE!
AssertionFailedError: expected: <230> but was: <198>
	at org.apache.hadoop.fs.ozone.TestOzoneFileSystemMetrics.testOzoneFileCommit(TestOzoneFileSystemMetrics.java:134)
	at org.apache.hadoop.fs.ozone.TestOzoneFileSystemMetrics.testFileOps(TestOzoneFileSystemMetrics.java:93)
```

https://issues.apache.org/jira/browse/HDDS-12465

## How was this patch tested?

Passed 10x10 runs:
https://github.com/adoroszlai/ozone/actions/runs/13999277200