### PR TITLE
HDDS-12666. Remove -SNAPSHOT from OZONE_CURRENT_VERSION in upgrade test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -33,6 +33,9 @@ source "${_testlib_dir}/../smoketest/testlib.sh"
 : ${OZONE_COMPOSE_RUNNING:=false}
 : ${SCM:=scm}
 
+# version is used in bucket name, which does not allow uppercase
+export OZONE_CURRENT_VERSION="$(echo "${ozone.version}" | sed -e 's/-SNAPSHOT//' | tr '[:upper:]' '[:lower:]')"
+
 # create temp directory for test data; only once, even if testlib.sh is sourced again
 if [[ -z "${TEST_DATA_DIR:-}" ]] && [[ "${KEEP_RUNNING:-false}" == "false" ]]; then
   export TEST_DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}"/robot-data-XXXXXX)"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/README.md
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/README.md
@@ -27,9 +27,8 @@ an older release of Ozone and a later release (which may be the local build).
     - To do this, uncomment all lines that contain `run_test` in the *test.sh* file, and execute *test.sh* either locally or on GitHub actions.
 
 2. After the release is finished and its docker image is published, add the new version to the test matrix.
-    1. Change the `OZONE_CURRENT_VERSION` variable to `OZONE_CURRENT_VERSION=<newly-released-version>`.
-    2. Comment out all `run_test` lines in *test.sh*.
-    3. Add a new line: `run_test ha non-rolling-upgrade <newly-released-version> "$OZONE_CURRENT_VERSION"` before the commented out lines.
+    1. Comment out all `run_test` lines in *test.sh*.
+    2. Add a new line: `run_test ha non-rolling-upgrade <newly-released-version> "$OZONE_CURRENT_VERSION"` before the commented out lines.
 
 ## Important Notes on Test Scope
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -35,7 +35,6 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-export OZONE_CURRENT_VERSION="${ozone.version}"
 run_test ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.4.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -19,8 +19,7 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
 
-# version is used in bucket name, which does not allow uppercase
-current_version="$(echo "${ozone.version}" | sed -e 's/-SNAPSHOT//' | tr '[:upper:]' '[:lower:]')"
+current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
 old_versions="1.1.0 1.2.1 1.3.0 1.4.0 1.4.1" # container is needed for each version in clients.yaml
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After HDDS-11333, we no longer have to manually update Ozone version number in xcompat and upgrade test scripts.  However, upgrade test also uses version number in directory names.  Any callbacks for the current version have to be in a directory exactly matching `ozone.version`, including `-SNAPSHOT`.  As part of the release process `-SNAPSHOT` is removed from `ozone.version`, and prior to this PR, the directory would also need to be renamed before the release.  To avoid that, this PR tweaks upgrade test to remove `-SNAPSHOT` from `OZONE_CURRENT_VERSION`.  Similar problem was fixed for xcompat test in HDDS-11134.

Also, remove obsolete step from upgrade test's documentation related to having to update `OZONE_CURRENT_VERSION` (this could have been removed by HDDS-11333).

https://issues.apache.org/jira/browse/HDDS-12666

## How was this patch tested?

Before:

```
--- RUNNING NON-ROLLING UPGRADE TEST FROM 1.4.1 TO 2.1.0-SNAPSHOT ---
```

After:

```
--- RUNNING NON-ROLLING UPGRADE TEST FROM 1.4.1 TO 2.1.0 ---
```

https://github.com/adoroszlai/ozone/actions/runs/14007718255/job/39223856263