### PR TITLE
HDDS-12668. HSync upgrade test failure

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -38,7 +38,9 @@ OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
+OZONE-SITE.XML_ozone.client.hbase.enhancements.allowed=true
 OZONE-SITE.XML_ozone.fs.hsync.enabled=true
+OZONE-SITE.XML_ozone.hbase.enhancements.allowed=true
 
 # If SCM sends container close commands as part of upgrade finalization while
 # datanodes are doing a leader election, all 3 replicas may end up in the

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/2.0.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/2.0.0/callback.sh
@@ -26,6 +26,6 @@ with_this_version_pre_finalized() {
 
 with_this_version_finalized() {
   execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
-  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-hsync" debug/ozone-debug-lease-recovery.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-hsync" admincli/lease-recovery.robot
   execute_robot_test "$SCM" -N "${OUTPUT_NAME}-freon-hsync" freon/hsync.robot
 }

--- a/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
@@ -45,10 +45,10 @@ Freon DFSG
 Test HSync lease recover prior to finalization
     Create volume bucket and put key
     ${o3fs_path} =  Format FS URL          o3fs     ${VOLUME}    ${BUCKET}    ${KEY}
-    ${result} =     Execute and checkrc    ozone debug recover --path=${o3fs_path}    255
+    ${result} =     Execute and checkrc    ozone admin om lease recover --path=${o3fs_path}    255
                     Should contain  ${result}  It belongs to the layout feature HBASE_SUPPORT, whose layout version is 7
     ${ofs_path} =   Format FS URL          ofs      ${VOLUME}    ${BUCKET}    ${KEY}
-    ${result} =     Execute and checkrc    ozone debug recover --path=${ofs_path}    255
+    ${result} =     Execute and checkrc    ozone admin om lease recover --path=${ofs_path}    255
                     Should contain  ${result}  It belongs to the layout feature HBASE_SUPPORT, whose layout version is 7
 
 Generate key for o3fs by HSYNC prior to finalization


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix failures in HSync upgrade test.

1. HDDS-12029 renamed `ozone debug recover` to `ozone admin om lease recover`, but missed its usage in upgrade test.

2. HSync is disabled in test cluster, so pre-finalization test fails, as client falls back to `flush()`, instead of hitting server with unsupported request:

```
Generate key for o3fs by HSYNC prior to finalization                  | FAIL |
0 != 255
```

```
Running command 'ozone freon dfsg -n 1000 --sync HSYNC -s 10240 --path o3fs://upgrade-hsync-bucket.upgrade-hsync-volume.omservice/ --buffer 1024 --copy-buffer 1024 -p dfsg
${rc} = 0
${output} = ...
2025-03-22 11:27:53,163 [shutdown-hook-0] INFO freon.BaseFreonGenerator: Successful executions: 1000
```

https://issues.apache.org/jira/browse/HDDS-12668

## How was this patch tested?

Together with HDDS-12662 on top of `ozone-2.0` branch:
https://github.com/adoroszlai/ozone/actions/runs/14008344769/job/39225283363