### PR TITLE
HDDS-12671. Include .editorconfig and .run in source tarball

### DIFF
--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -59,12 +59,20 @@
     <fileSet>
       <directory>.</directory>
       <includes>
+        <include>.editorconfig</include>
         <include>pom.xml</include>
         <include>README.md</include>
         <include>HISTORY.md</include>
         <include>SECURITY.md</include>
         <include>CONTRIBUTING.md</include>
       </includes>
+    </fileSet>
+    <fileSet>
+      <directory>.run</directory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
     </fileSet>
     <fileSet>
       <directory>dev-support</directory>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12365 added new files for developers, but they are missing from the source tarball.

https://issues.apache.org/jira/browse/HDDS-12671

## How was this patch tested?

```
$ mvn -Psrc -DskipRecon -DskipShade -DskipTests clean package
...

$ tar tzvf hadoop-ozone/dist/target/ozone-2.1.0-SNAPSHOT-src.tar.gz | grep -F -e .editorconfig -e .run
-rw------- root/root      2906 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.editorconfig
-rw------- root/root      1621 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/CsiServer.run.xml
-rw------- root/root      1699 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Datanode1-ha.run.xml
-rw------- root/root      1693 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Datanode1.run.xml
-rw------- root/root      2045 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Datanode2-ha.run.xml
-rw------- root/root      2039 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Datanode2.run.xml
-rw------- root/root      2045 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Datanode3-ha.run.xml
-rw------- root/root      2039 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Datanode3.run.xml
-rw------- root/root      1603 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/FreonStandalone.run.xml
-rw------- root/root      1816 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneFsShell-ha.run.xml
-rw------- root/root      1810 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneFsShell.run.xml
-rw------- root/root      1616 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneManager-ha.run.xml
-rw------- root/root      1610 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneManager.run.xml
-rw------- root/root      1627 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneManagerInit-ha.run.xml
-rw------- root/root      1621 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneManagerInit.run.xml
-rw------- root/root      1630 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneShell-ha.run.xml
-rw------- root/root      1624 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/OzoneShell.run.xml
-rw------- root/root      1747 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/PrimordialSCM-ha.run.xml
-rw------- root/root      1783 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/PrimordialSCMInit-ha.run.xml
-rw------- root/root      1602 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Recon-ha.run.xml
-rw------- root/root      1596 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Recon.run.xml
-rw------- root/root      1597 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/S3Gateway.run.xml
-rw------- root/root      1762 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Scm2-ha.run.xml
-rw------- root/root      1784 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Scm2Bootstrap-ha.run.xml
-rw------- root/root      1762 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Scm3-ha.run.xml
-rw------- root/root      1783 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/Scm3Bootstrap-ha.run.xml
-rw------- root/root      1625 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/ScmRoles.run.xml
-rw------- root/root      1665 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/StorageContainerManager.run.xml
-rw------- root/root      1676 2025-03-12 23:12 ozone-2.1.0-SNAPSHOT-src/.run/StorageContainerManagerInit.run.xml
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/14017034950