### PR TITLE
HDDS-12485. Repair tool should only print user warning for offline commands

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -53,8 +53,11 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
 
   @Override
   public final Void call() throws Exception {
+    final Component service = serviceToBeOffline();
     if (!dryRun) {
-      confirmUser();
+      if (service == null) { // offline tool
+        confirmUser();
+      }
     }
     if (isServiceStateOK()) {
       execute();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java
@@ -54,10 +54,8 @@ public abstract class RepairTool extends AbstractSubcommand implements Callable<
   @Override
   public final Void call() throws Exception {
     final Component service = serviceToBeOffline();
-    if (!dryRun) {
-      if (service == null) { // offline tool
-        confirmUser();
-      }
+    if (!dryRun && service != null) { // offline tool
+      confirmUser();
     }
     if (isServiceStateOK()) {
       execute();

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -23,6 +23,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
@@ -92,6 +93,29 @@ public class TestOzoneRepair {
         assertSubcommandOptionRecursively(sub);
       }
     }
+  }
+
+  @Test
+  void testOzoneRepairWhenUserIsRemindedSystemUserAndDeclinesToProceed() throws Exception {
+    OzoneRepair ozoneRepair = new OzoneRepair();
+    System.setIn(new ByteArrayInputStream("N".getBytes(DEFAULT_ENCODING)));
+
+    int res = ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
+    assertThat(res).isNotEqualTo(CommandLine.ExitCode.OK);
+    assertThat(err.toString(DEFAULT_ENCODING)).contains("Aborting command.");
+    // prompt should contain the current user name as well
+    assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
+  }
+
+  @Test
+  void testOzoneRepairWhenUserIsRemindedSystemUserAndAgreesToProceed() throws Exception {
+    OzoneRepair ozoneRepair = new OzoneRepair();
+    System.setIn(new ByteArrayInputStream("y".getBytes(DEFAULT_ENCODING)));
+
+    ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
+    assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_USER);
+    // prompt should contain the current user name as well
+    assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
   }
 
   /** Arguments for which confirmation prompt should not be displayed. */

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -23,7 +23,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
@@ -93,29 +92,6 @@ public class TestOzoneRepair {
         assertSubcommandOptionRecursively(sub);
       }
     }
-  }
-
-  @Test
-  void testOzoneRepairWhenUserIsRemindedSystemUserAndDeclinesToProceed() throws Exception {
-    OzoneRepair ozoneRepair = new OzoneRepair();
-    System.setIn(new ByteArrayInputStream("N".getBytes(DEFAULT_ENCODING)));
-
-    int res = ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
-    assertThat(res).isNotEqualTo(CommandLine.ExitCode.OK);
-    assertThat(err.toString(DEFAULT_ENCODING)).contains("Aborting command.");
-    // prompt should contain the current user name as well
-    assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
-  }
-
-  @Test
-  void testOzoneRepairWhenUserIsRemindedSystemUserAndAgreesToProceed() throws Exception {
-    OzoneRepair ozoneRepair = new OzoneRepair();
-    System.setIn(new ByteArrayInputStream("y".getBytes(DEFAULT_ENCODING)));
-
-    ozoneRepair.execute(new String[]{"om", "fso-tree", "--db", "/dev/null"});
-    assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_USER);
-    // prompt should contain the current user name as well
-    assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
   }
 
   /** Arguments for which confirmation prompt should not be displayed. */


### PR DESCRIPTION
## What changes were proposed in this pull request?
We should not print the [warning message](https://github.com/apache/ozone/blob/7ee359daab84842a52258cc8b7ef115fa0ed4cb6/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java#L31) about which user the command is running as, since it is only relevant for offline repair. The method [RepairTool#serviceToBeOffline](https://github.com/apache/ozone/blob/7ee359daab84842a52258cc8b7ef115fa0ed4cb6/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/RepairTool.java#L50) can be used to check whether the tool is online or offline and print the message accordingly.

## What is the link to the Apache JIRA
[HDDS-12485](https://issues.apache.org/jira/browse/HDDS-12485)

## How was this patch tested?
Manually test and CI
```shell
bash-5.1$ ozone repair om quota start 
Into call() in repair tool and the service = null
ATTENTION: Running as user hadoop. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? N
```
https://github.com/chiacyu/ozone/actions/runs/14019575387
