### PR TITLE
HDDS-12648. Fix checkLeaderStatus in removeOMFromRatisRing and addOMToRatisRing

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -378,7 +378,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
       }
     }
     assertNotNull(followerOM);
-    assertSame(followerOM.getOmRatisServer().checkLeaderStatus(),
+    assertSame(followerOM.getOmRatisServer().getLeaderStatus(),
         OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER);
 
     OzoneManagerProtocolProtos.OMRequest writeRequest =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3051,7 +3051,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (null == omRatisServer) {
       return getRatisRolesException("Server is shutting down");
     }
-    String leaderReadiness = omRatisServer.checkLeaderStatus().name();
+    String leaderReadiness = omRatisServer.getLeaderStatus().name();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
       LOG.error(NO_LEADER_ERROR_MESSAGE);
@@ -4214,7 +4214,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   public boolean isLeaderReady() {
     final OzoneManagerRatisServer ratisServer = omRatisServer;
-    return ratisServer != null && ratisServer.checkLeaderStatus() == LEADER_AND_READY;
+    return ratisServer != null && ratisServer.getLeaderStatus() == LEADER_AND_READY;
   }
 
   /**
@@ -4225,7 +4225,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public void checkLeaderStatus() throws OMNotLeaderException,
       OMLeaderNotReadyException {
     OzoneManagerRatisServer.RaftServerStatus raftServerStatus =
-        omRatisServer.checkLeaderStatus();
+        omRatisServer.getLeaderStatus();
     RaftPeerId raftPeerId = omRatisServer.getRaftPeerId();
 
     switch (raftServerStatus) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -357,7 +357,6 @@ public final class OzoneManagerRatisServer {
     final List<RaftPeer> newPeersList = new ArrayList<>(raftPeerMap.values());
     newPeersList.add(newRaftPeer);
 
-    checkLeaderStatus();
     SetConfigurationRequest request = new SetConfigurationRequest(clientId,
         server.getId(), raftGroupId, nextCallId(), newPeersList);
 
@@ -390,7 +389,6 @@ public final class OzoneManagerRatisServer {
         .map(Map.Entry::getValue)
         .collect(Collectors.toList());
 
-    checkLeaderStatus();
     SetConfigurationRequest request = new SetConfigurationRequest(clientId,
         server.getId(), raftGroupId, nextCallId(), newPeersList);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -827,7 +827,7 @@ public final class OzoneManagerRatisServer {
    *
    * @return RaftServerStatus.
    */
-  public RaftServerStatus checkLeaderStatus() {
+  public RaftServerStatus getLeaderStatus() {
     final RaftServer.Division division = getServerDivision();
     if (division == null) {
       return RaftServerStatus.NOT_LEADER;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -186,7 +186,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
   private OMResponse submitReadRequestToOM(OMRequest request)
       throws ServiceException {
     // Check if this OM is the leader.
-    RaftServerStatus raftServerStatus = omRatisServer.checkLeaderStatus();
+    RaftServerStatus raftServerStatus = omRatisServer.getLeaderStatus();
     if (raftServerStatus == LEADER_AND_READY ||
         request.getCmdType().equals(PrepareStatus)) {
       return handler.handleReadRequest(request);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
@@ -122,7 +122,7 @@ public final class OmTestManagers {
         "scmTopologyClient", scmTopologyClient);
 
     om.start();
-    waitFor(() -> om.getOmRatisServer().checkLeaderStatus() == RaftServerStatus.LEADER_AND_READY,
+    waitFor(() -> om.getOmRatisServer().getLeaderStatus() == RaftServerStatus.LEADER_AND_READY,
         10, 10_000);
 
     rpcClient = OzoneClientFactory.getRpcClient(conf);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the checkLeaderStatus check does nothing, it return the leader status & ignores

https://github.com/apache/ozone/blob/57fda0c32704b76b78152f5b16bc9a7c923167ac/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java#L360

After checking the codebase, found there is no need for `OzoneManagerRatisServer#checkLeaderStatus`.
As it already performed the check before calling `omRatisServer.addOMToRatisRing(newOmNode)` and `omRatisServer.removeOMFromRatisRing(newOmNode)`
- https://github.com/apache/ozone/blob/1b0e912f53d139fc098bf057f7872774bdc7ca50/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java#L56

- https://github.com/apache/ozone/blob/1b0e912f53d139fc098bf057f7872774bdc7ca50/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java#L87


### Additional context

`OzoneManagerRatisUtils#checkLeaderStatus`:
https://github.com/apache/ozone/blob/6ebd5921f6087913ee1dfe100dd2806c9bb5c4ec/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java#L497-L505

`OzoneManager#checkLeaderStatus`:
https://github.com/apache/ozone/blob/6ebd5921f6087913ee1dfe100dd2806c9bb5c4ec/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java#L4220-L4240

`OzoneManagerRatisServer#checkLeaderStatus`:
https://github.com/apache/ozone/blob/6ebd5921f6087913ee1dfe100dd2806c9bb5c4ec/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java#L825-L841
 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12648

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14020769117