### PR TITLE
HDDS-12546. [DiskBalancer] Display bytesMoved instead of VolumeDensity in status output

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -35,6 +35,7 @@ public class DiskBalancerInfo {
   private long successCount;
   private long failureCount;
   private long bytesToMove;
+  private long balancedBytes;
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread) {
@@ -54,7 +55,7 @@ public class DiskBalancerInfo {
   @SuppressWarnings("checkstyle:ParameterNumber")
   public DiskBalancerInfo(boolean shouldRun, double threshold,
       long bandwidthInMB, int parallelThread, DiskBalancerVersion version,
-      long successCount, long failureCount, long bytesToMove) {
+      long successCount, long failureCount, long bytesToMove, long balancedBytes) {
     this.shouldRun = shouldRun;
     this.threshold = threshold;
     this.bandwidthInMB = bandwidthInMB;
@@ -63,6 +64,7 @@ public class DiskBalancerInfo {
     this.successCount = successCount;
     this.failureCount = failureCount;
     this.bytesToMove = bytesToMove;
+    this.balancedBytes = balancedBytes;
   }
 
   public DiskBalancerInfo(boolean shouldRun,
@@ -98,6 +100,7 @@ public class DiskBalancerInfo {
     builder.setSuccessMoveCount(successCount);
     builder.setFailureMoveCount(failureCount);
     builder.setBytesToMove(bytesToMove);
+    builder.setBalancedBytes(balancedBytes);
     return builder.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -300,7 +300,6 @@ public class DiskBalancerService extends BackgroundService {
     DiskBalancerReportProto.Builder builder =
         DiskBalancerReportProto.newBuilder();
     return builder.setIsRunning(shouldRun)
-        .setBalancedBytes(totalBalancedBytes.get())
         .setDiskBalancerConf(
             HddsProtos.DiskBalancerConfigurationProto.newBuilder()
                 .setThreshold(threshold)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -85,6 +85,7 @@ public class DiskBalancerService extends BackgroundService {
 
   private DiskBalancerVersion version;
 
+  private AtomicLong totalBalancedBytes = new AtomicLong(0L);
   private AtomicLong balancedBytesInLastWindow = new AtomicLong(0L);
   private AtomicLong nextAvailableTime = new AtomicLong(Time.monotonicNow());
 
@@ -299,6 +300,7 @@ public class DiskBalancerService extends BackgroundService {
     DiskBalancerReportProto.Builder builder =
         DiskBalancerReportProto.newBuilder();
     return builder.setIsRunning(shouldRun)
+        .setBalancedBytes(totalBalancedBytes.get())
         .setDiskBalancerConf(
             HddsProtos.DiskBalancerConfigurationProto.newBuilder()
                 .setThreshold(threshold)
@@ -456,6 +458,7 @@ public class DiskBalancerService extends BackgroundService {
         balancedBytesInLastWindow.addAndGet(containerSize);
         metrics.incrSuccessCount(1);
         metrics.incrSuccessBytes(containerSize);
+        totalBalancedBytes.addAndGet(containerSize);
       } catch (IOException e) {
         moveSucceeded = false;
         if (diskBalancerTmpDir != null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -85,7 +85,6 @@ public class DiskBalancerService extends BackgroundService {
 
   private DiskBalancerVersion version;
 
-  private AtomicLong totalBalancedBytes = new AtomicLong(0L);
   private AtomicLong balancedBytesInLastWindow = new AtomicLong(0L);
   private AtomicLong nextAvailableTime = new AtomicLong(Time.monotonicNow());
 
@@ -512,7 +511,7 @@ public class DiskBalancerService extends BackgroundService {
   public DiskBalancerInfo getDiskBalancerInfo() {
     return new DiskBalancerInfo(shouldRun, threshold, bandwidthInMB,
         parallelThread, version, metrics.getSuccessCount(),
-        metrics.getFailureCount(), bytesToMove);
+        metrics.getFailureCount(), bytesToMove, metrics.getSuccessBytes());
   }
 
   public long calculateBytesToMove(MutableVolumeSet inputVolumeSet) {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -564,5 +564,5 @@ message DatanodeDiskBalancerInfoProto {
     optional uint64 successMoveCount = 5;
     optional uint64 failureMoveCount = 6;
     optional uint64 bytesToMove = 7;
-    optional uint64 balancedBytes = 8;
+    optional uint64 bytesMoved = 8;
 }

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -564,4 +564,5 @@ message DatanodeDiskBalancerInfoProto {
     optional uint64 successMoveCount = 5;
     optional uint64 failureMoveCount = 6;
     optional uint64 bytesToMove = 7;
+    optional uint64 balancedBytes = 8;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -269,6 +269,8 @@ public class DiskBalancerManager {
             .setSuccessMoveCount(status.getSuccessMoveCount())
             .setFailureMoveCount(status.getFailureMoveCount())
             .setBytesToMove(status.getBytesToMove());
+            .setFailureMoveCount(status.getFailureMoveCount())
+            .setBalancedBytes(status.getBalancedBytes());
     if (status.getRunningStatus() != DiskBalancerRunningStatus.UNKNOWN) {
       builder.setDiskBalancerConf(statusMap.get(dn)
           .getDiskBalancerConfiguration().toProtobufBuilder());
@@ -307,8 +309,7 @@ public class DiskBalancerManager {
 
   private DiskBalancerStatus getStatus(DatanodeDetails datanodeDetails) {
     return statusMap.computeIfAbsent(datanodeDetails,
-        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN,
-            new DiskBalancerConfiguration(), 0, 0, 0));
+        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN, new DiskBalancerConfiguration(), 0, 0, 0));
   }
 
   @VisibleForTesting
@@ -328,6 +329,7 @@ public class DiskBalancerManager {
     long successMoveCount = reportProto.getSuccessMoveCount();
     long failureMoveCount = reportProto.getFailureMoveCount();
     long bytesToMove = reportProto.getBytesToMove();
+    long balancedBytes = reportProto.getBalancedBytes();
     statusMap.put(dn, new DiskBalancerStatus(
         isRunning ? DiskBalancerRunningStatus.RUNNING : DiskBalancerRunningStatus.STOPPED,
         diskBalancerConfiguration, successMoveCount, failureMoveCount, bytesToMove));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -269,7 +269,7 @@ public class DiskBalancerManager {
             .setSuccessMoveCount(status.getSuccessMoveCount())
             .setFailureMoveCount(status.getFailureMoveCount())
             .setBytesToMove(status.getBytesToMove())
-            .setBalancedBytes(status.getBalancedBytes());
+            .setBytesMoved(status.getBalancedBytes());
     if (status.getRunningStatus() != DiskBalancerRunningStatus.UNKNOWN) {
       builder.setDiskBalancerConf(statusMap.get(dn)
           .getDiskBalancerConfiguration().toProtobufBuilder());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -268,8 +268,7 @@ public class DiskBalancerManager {
             .setRunningStatus(status.getRunningStatus())
             .setSuccessMoveCount(status.getSuccessMoveCount())
             .setFailureMoveCount(status.getFailureMoveCount())
-            .setBytesToMove(status.getBytesToMove());
-            .setFailureMoveCount(status.getFailureMoveCount())
+            .setBytesToMove(status.getBytesToMove())
             .setBalancedBytes(status.getBalancedBytes());
     if (status.getRunningStatus() != DiskBalancerRunningStatus.UNKNOWN) {
       builder.setDiskBalancerConf(statusMap.get(dn)
@@ -309,13 +308,13 @@ public class DiskBalancerManager {
 
   private DiskBalancerStatus getStatus(DatanodeDetails datanodeDetails) {
     return statusMap.computeIfAbsent(datanodeDetails,
-        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN, new DiskBalancerConfiguration(), 0, 0, 0));
+        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN, new DiskBalancerConfiguration(), 0, 0, 0, 0));
   }
 
   @VisibleForTesting
   public void addRunningDatanode(DatanodeDetails datanodeDetails) {
     statusMap.put(datanodeDetails, new DiskBalancerStatus(DiskBalancerRunningStatus.RUNNING,
-        new DiskBalancerConfiguration(), 0, 0, 0));
+        new DiskBalancerConfiguration(), 0, 0, 0, 0));
   }
 
   public void processDiskBalancerReport(DiskBalancerReportProto reportProto,
@@ -332,7 +331,7 @@ public class DiskBalancerManager {
     long balancedBytes = reportProto.getBalancedBytes();
     statusMap.put(dn, new DiskBalancerStatus(
         isRunning ? DiskBalancerRunningStatus.RUNNING : DiskBalancerRunningStatus.STOPPED,
-        diskBalancerConfiguration, successMoveCount, failureMoveCount, bytesToMove));
+        diskBalancerConfiguration, successMoveCount, failureMoveCount, bytesToMove, balancedBytes));
     if (reportProto.hasBalancedBytes()) {
       balancedBytesMap.put(dn, reportProto.getBalancedBytes());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -37,12 +37,13 @@ public class DiskBalancerStatus {
   private long balancedBytes;
 
   public DiskBalancerStatus(DiskBalancerRunningStatus isRunning, DiskBalancerConfiguration conf,
-      long successMoveCount, long failureMoveCount, long bytesToMove) {
+      long successMoveCount, long failureMoveCount, long bytesToMove, long balancedBytes) {
     this.isRunning = isRunning;
     this.diskBalancerConfiguration = conf;
     this.successMoveCount = successMoveCount;
     this.failureMoveCount = failureMoveCount;
     this.bytesToMove = bytesToMove;
+    this.balancedBytes = balancedBytes;
   }
 
   public DiskBalancerRunningStatus getRunningStatus() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -34,6 +34,7 @@ public class DiskBalancerStatus {
   private long successMoveCount;
   private long failureMoveCount;
   private long bytesToMove;
+  private long balancedBytes;
 
   public DiskBalancerStatus(DiskBalancerRunningStatus isRunning, DiskBalancerConfiguration conf,
       long successMoveCount, long failureMoveCount, long bytesToMove) {
@@ -62,5 +63,9 @@ public class DiskBalancerStatus {
 
   public long getBytesToMove() {
     return bytesToMove;
+  }
+
+  public long getBalancedBytes() {
+    return balancedBytes;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -60,27 +60,26 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
   private String generateStatus(
       List<HddsProtos.DatanodeDiskBalancerInfoProto> protos) {
     StringBuilder formatBuilder = new StringBuilder("Status result:%n" +
-        "%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s %-12s%n");
+        "%-35s %-15s %-15s %-15s %-12s %-12s %-12s %-15s %-15s %-15s%n");
 
     List<String> contentList = new ArrayList<>();
     contentList.add("Datanode");
-    contentList.add("BalancedBytes");
     contentList.add("Status");
     contentList.add("Threshold(%)");
     contentList.add("BandwidthInMB");
     contentList.add("Threads");
     contentList.add("SuccessMove");
     contentList.add("FailureMove");
+    contentList.add("BytesMoved(MB)");
     contentList.add("EstBytesToMove(MB)");
     contentList.add("EstTimeLeft(min)");
 
     for (HddsProtos.DatanodeDiskBalancerInfoProto proto: protos) {
-      formatBuilder.append("%-35s %-25s %-15s %-15s %-15s %-12s %-12s %-12s %-12s %-12s%n");
+      formatBuilder.append("%-35s %-15s %-15s %-15s %-12s %-12s %-12s %-15s %-15s %-15s%n");
       long estimatedTimeLeft = calculateEstimatedTimeLeft(proto);
       long bytesToMoveMB = proto.getBytesToMove() / (1024 * 1024);
 
       contentList.add(proto.getNode().getHostName());
-      contentList.add(String.valueOf(proto.getBalancedBytes()));
       contentList.add(proto.getRunningStatus().name());
       contentList.add(
           String.format("%.4f", proto.getDiskBalancerConf().getThreshold()));
@@ -90,6 +89,7 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
           String.valueOf(proto.getDiskBalancerConf().getParallelThread()));
       contentList.add(String.valueOf(proto.getSuccessMoveCount()));
       contentList.add(String.valueOf(proto.getFailureMoveCount()));
+      contentList.add(String.valueOf(proto.getBytesMoved() / (1024 * 1024)));
       contentList.add(String.valueOf(bytesToMoveMB));
       contentList.add(estimatedTimeLeft >= 0 ? String.valueOf(estimatedTimeLeft) : "N/A");
     }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -64,7 +64,7 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
 
     List<String> contentList = new ArrayList<>();
     contentList.add("Datanode");
-    contentList.add("VolumeDensity");
+    contentList.add("BalancedBytes");
     contentList.add("Status");
     contentList.add("Threshold(%)");
     contentList.add("BandwidthInMB");
@@ -80,7 +80,7 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
       long bytesToMoveMB = proto.getBytesToMove() / (1024 * 1024);
 
       contentList.add(proto.getNode().getHostName());
-      contentList.add(String.format("%.18f", proto.getCurrentVolumeDensitySum()));
+      contentList.add(String.valueOf(proto.getBalancedBytes()));
       contentList.add(proto.getRunningStatus().name());
       contentList.add(
           String.format("%.4f", proto.getDiskBalancerConf().getThreshold()));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -77,7 +77,8 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
     for (HddsProtos.DatanodeDiskBalancerInfoProto proto: protos) {
       formatBuilder.append("%-35s %-15s %-15s %-15s %-12s %-12s %-12s %-15s %-15s %-15s%n");
       long estimatedTimeLeft = calculateEstimatedTimeLeft(proto);
-      long bytesToMoveMB = proto.getBytesToMove() / (1024 * 1024);
+      long bytesMovedMB = (long) Math.ceil(proto.getBytesMoved() / (1024.0 * 1024.0));
+      long bytesToMoveMB = (long) Math.ceil(proto.getBytesToMove() / (1024.0 * 1024.0));
 
       contentList.add(proto.getNode().getHostName());
       contentList.add(proto.getRunningStatus().name());
@@ -89,7 +90,7 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
           String.valueOf(proto.getDiskBalancerConf().getParallelThread()));
       contentList.add(String.valueOf(proto.getSuccessMoveCount()));
       contentList.add(String.valueOf(proto.getFailureMoveCount()));
-      contentList.add(String.valueOf(proto.getBytesMoved() / (1024 * 1024)));
+      contentList.add(String.valueOf(bytesMovedMB));
       contentList.add(String.valueOf(bytesToMoveMB));
       contentList.add(estimatedTimeLeft >= 0 ? String.valueOf(estimatedTimeLeft) : "N/A");
     }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
@@ -236,7 +236,7 @@ public class TestDiskBalancerSubCommand {
     DiskBalancerStatusSubcommand statusCmd1 = new DiskBalancerStatusSubcommand();
     statusCmd1.execute(scmClient);
 
-    String output = outContent.toString().trim();
+    String output = outContent.toString(DEFAULT_ENCODING).trim();
 
     // Check if expected values appear in output
     assertTrue(output.contains(String.valueOf(bytesMovedMB)));

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -27,15 +28,20 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 /**
@@ -192,6 +198,51 @@ public class TestDiskBalancerSubCommand {
     stopCmd.setAllHosts(false);
   }
 
+  public static Stream<Arguments> values() {
+    return Stream.of(
+        Arguments.arguments(0L, 0L, 0L, 0L, 0L),  // bytesMovedMB = 0, bytesToMoveMB = 0, estimatedTimeLeft = 0
+        Arguments.arguments(512L, 512L, 1L, 1L, 1L), // bytesMoved and bytesToMove < 1MB should be rounded up to 1MB
+        Arguments.arguments(5242880L, 10485760L, 5L, 10L, 1L), // bytesMoved = 5MB, bytesToMove = 10MB, estTimeLeft = 1
+        Arguments.arguments(13774139392L, 3229900800L, 13137L, 3081L, 6L),
+        Arguments.arguments(7482638336L, 939524096L, 7136L, 896L, 6L)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("values")
+  public void testDiskBalancerStatusCalculations(long bytesMoved, long bytesToMove, long bytesMovedMB,
+      long bytesToMoveMB, long estTimeLeft) throws IOException {
+    ScmClient scmClient = mock(ScmClient.class);
+
+    HddsProtos.DatanodeDiskBalancerInfoProto proto =
+        HddsProtos.DatanodeDiskBalancerInfoProto.newBuilder()
+            .setNode(generateDatanodeDetails())
+            .setCurrentVolumeDensitySum(random.nextDouble())
+            .setRunningStatus(HddsProtos.DiskBalancerRunningStatus.
+                valueOf(random.nextInt(2) + 1))
+            .setBytesMoved(bytesMoved)
+            .setBytesToMove(bytesToMove)
+            .setDiskBalancerConf(
+                HddsProtos.DiskBalancerConfigurationProto.newBuilder()
+                    .setDiskBandwidthInMB(10)
+                    .setThreshold(10.0)
+                    .setParallelThread(5)
+                    .build())
+            .build();
+
+    List<HddsProtos.DatanodeDiskBalancerInfoProto> resultList = Collections.singletonList(proto);
+    Mockito.when(scmClient.getDiskBalancerStatus(Mockito.any(), Mockito.any())).thenReturn(resultList);
+
+    DiskBalancerStatusSubcommand statusCmd1 = new DiskBalancerStatusSubcommand();
+    statusCmd1.execute(scmClient);
+
+    String output = outContent.toString().trim();
+
+    // Check if expected values appear in output
+    assertTrue(output.contains(String.valueOf(bytesMovedMB)));
+    assertTrue(output.contains(String.valueOf(bytesToMoveMB)));
+    assertTrue(output.contains(estTimeLeft >= 0 ? String.valueOf(estTimeLeft) : "N/A"));
+  }
 
   private List<DatanodeAdminError> generateError(int count) {
     List<DatanodeAdminError> result = new ArrayList<>();

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -204,7 +203,7 @@ public class TestDiskBalancerSubCommand {
         Arguments.arguments(512L, 512L, 1L, 1L, 1L), // bytesMoved and bytesToMove < 1MB should be rounded up to 1MB
         Arguments.arguments(5242880L, 10485760L, 5L, 10L, 1L), // bytesMoved = 5MB, bytesToMove = 10MB, estTimeLeft = 1
         Arguments.arguments(13774139392L, 3229900800L, 13137L, 3081L, 6L),
-        Arguments.arguments(7482638336L, 939524096L, 7136L, 896L, 6L)
+        Arguments.arguments(7482638336L, 939524096L, 7136L, 896L, 2L)
     );
   }
 
@@ -237,11 +236,14 @@ public class TestDiskBalancerSubCommand {
     statusCmd1.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING).trim();
+    String[] lines = output.split("\\n");
 
-    // Check if expected values appear in output
-    assertTrue(output.contains(String.valueOf(bytesMovedMB)));
-    assertTrue(output.contains(String.valueOf(bytesToMoveMB)));
-    assertTrue(output.contains(estTimeLeft >= 0 ? String.valueOf(estTimeLeft) : "N/A"));
+    // Skip the header and find the data row
+    String[] columns = lines[2].split("\\s+");
+
+    assertEquals(String.valueOf(bytesMovedMB), columns[7]);
+    assertEquals(String.valueOf(bytesToMoveMB), columns[8]);
+    assertEquals(estTimeLeft >= 0 ? String.valueOf(estTimeLeft) : "N/A", columns[9]);
   }
 
   private List<DatanodeAdminError> generateError(int count) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
As VolumeDensity is already covered by report sub command, we will show bytesMoved (bytesBalanced) in status command.

Besides, the meaning of VolumeDensity is clear to end user, but the real value indicating is not that straight forward. Use the estimated pending move size([HDDS-12437](https://issues.apache.org/jira/browse/HDDS-12437)) will help user to clearly understand how much data size need to move. And this bytesMoved is also a straight forward value, indicating the work disk balancer has done.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12546

## How was this patch tested?

Added unit test to test bytesToMoveMB, bytesMovedMB and calculateEstimatedTimeLeft to show reasonable values when  bytesToMove and bytesMoved are less than 1MB.

As well as tested manually by running docker cluster locally.

```
bash-5.1$ ozone admin datanode diskbalancer status
Status result:
Datanode                            Status          Threshold(%)    BandwidthInMB   Threads      SuccessMove  FailureMove  BytesMoved(MB)  EstBytesToMove(MB) EstTimeLeft(min)
ozone-datanode-4.ozone_default      RUNNING         0.0002          10              5            5            3            7136            896             2              
ozone-datanode-3.ozone_default      RUNNING         0.0002          10              5            7            4            13131           3080            6              

Note: Estimated time left is calculated based on the estimated bytes to move and the configured disk bandwidth.

```