### PR TITLE
HDDS-12686. Suppress OzoneAddress print output in --verbose mode

### DIFF
--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -68,9 +68,6 @@ public abstract class Handler extends AbstractSubcommand implements Callable<Voi
 
     OzoneAddress address = getAddress();
     try (OzoneClient client = createClient(address)) {
-      if (isVerbose()) {
-        address.print(out());
-      }
       execute(client, address);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When the `--verbose` flag is passed, the command prints the OzoneAddress, which includes the volume, bucket, and key name. However, this disrupts the JSON output format and makes it difficult to parse.
Since, the print output is not essential we can remove it.

## What is the link to the Apache JIRA
[HDDS-12686](https://issues.apache.org/jira/browse/HDDS-12686)

## How was this patch tested?
Before
```
bash-5.1$ ozone debug --verbose replicas chunk-info /vol1/buck1/key
Volume Name : vol1
Bucket Name : buck1
Key Name : key
{
  "KeyLocations" : [ [ {
    "Locations" : {
      "containerPath" : "/data/hdds/hdds/CID-f9c2918d-2647-4673-ae26-4712146b9ceb/current/containerDir0/1",
      "chunkInfos" : [ {
        "chunkName" : "/data/hdds/hdds/CID-f9c2918d-2647-4673-ae26-4712146b9ceb/current/containerDir0/1/chunks/115816896921600001.block",
        "chunkOffset" : 0
      } ],
.....
```
After
```
bash-5.1$ ozone debug --verbose replicas chunk-info /vol1/buck1/key
{
  "KeyLocations" : [ [ {
    "Locations" : {
      "containerPath" : "/data/hdds/hdds/CID-aa417689-18c5-49dc-924b-8ac6b4bc37f8/current/containerDir0/1",
      "chunkInfos" : [ {
        "chunkName" : "/data/hdds/hdds/CID-aa417689-18c5-49dc-924b-8ac6b4bc37f8/current/containerDir0/1/chunks/115816896921600001.block",
        "chunkOffset" : 0
      } ],
.....
```