### PR TITLE
HDDS-12687. Avoid ambiguity in URI descriptions

### DIFF
--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class BucketUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_BUCKET_URI_DESCRIPTION =
-      "URI of the volume/bucket.\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the bucket (format: volume/bucket).\n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_BUCKET_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/common/VolumeBucketUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/common/VolumeBucketUri.java
@@ -29,7 +29,7 @@ public class VolumeBucketUri
     implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_VOLUME_BUCKET_URI_DESCRIPTION =
-      "URI of the volume or bucket.\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the volume (format: volume) or bucket (format: volume/bucket).\n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_VOLUME_BUCKET_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class KeyUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_KEY_URI_DESCRIPTION =
-      "URI of the volume/bucket/key.\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the key (format: volume/bucket/key).\n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_KEY_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class PrefixUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_PREFIX_URI_DESCRIPTION =
-      "URI of the volume/bucket/prefix.\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the prefix (format: volume/bucket/prefix).\n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_PREFIX_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotUri.java
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 public class SnapshotUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_SNAPSHOT_URI_DESCRIPTION =
-      "URI of the volume/bucket/snapshot.\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the snapshot (format: volume/bucket/snapshot).\n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_SNAPSHOT_URI_DESCRIPTION,


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `OZONE_KEY_URI_DESCRIPTION` says "URI of the volume/bucket/key" which may suggest that it refers to three separate entities rather than a single key path.
To make this clearer, we are refining the URI descriptions.

## What is the link to the Apache JIRA
[HDDS-12687](https://issues.apache.org/jira/browse/HDDS-12687)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/14057798994