### PR TITLE
HDDS-12694. Disable TestMiniChaosOzoneCluster after fixing init and shutdown

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -132,12 +132,12 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
   public void shutdown() {
     try {
       failureManager.stop();
-      //this should be called after stopChaos to be sure that the
-      //datanode collection is not modified during the shutdown
-      super.shutdown();
     } catch (Exception e) {
-      LOG.error("failed to shutdown MiniOzoneChaosCluster", e);
+      LOG.error("failed to stop FailureManager", e);
     }
+    //this should be called after failureManager.stop to be sure that the
+    //datanode collection is not modified during the shutdown
+    super.shutdown();
   }
 
   /**

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestAllMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestAllMiniChaosOzoneCluster.java
@@ -21,33 +21,34 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.loadgenerators.LoadGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import picocli.CommandLine;
 
 /**
- * Command line utility to parse and dump a datanode ratis segment file.
+ * Test all kinds of chaos.
  */
 @CommandLine.Command(
     name = "all",
     description = "run chaos cluster across all daemons",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestAllMiniChaosOzoneCluster extends TestMiniChaosOzoneCluster
     implements Callable<Void> {
 
-  @CommandLine.ParentCommand
-  private OzoneChaosCluster chaosCluster;
+  @BeforeAll
+  void setup() {
+    setNumManagers(3, 3, true);
+
+    LoadGenerator.getClassList().forEach(this::addLoadClasses);
+    Failures.getClassList().forEach(this::addFailureClasses);
+  }
 
   @Override
   public Void call() throws Exception {
-    setNumManagers(3, 3, true);
-
-    LoadGenerator.getClassList().forEach(
-        TestMiniChaosOzoneCluster::addLoadClasses);
-    Failures.getClassList().forEach(
-        TestMiniChaosOzoneCluster::addFailureClasses);
-
+    setup();
     startChaosCluster();
-
     return null;
   }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestDatanodeMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestDatanodeMiniChaosOzoneCluster.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.loadgenerators.AgedLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.RandomLoadGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import picocli.CommandLine;
 
 /**
@@ -32,19 +34,23 @@ import picocli.CommandLine;
     description = "run chaos cluster across Ozone Datanodes",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestDatanodeMiniChaosOzoneCluster extends
     TestMiniChaosOzoneCluster implements Callable<Void> {
 
-  @Override
-  public Void call() throws Exception {
+  @BeforeAll
+  void setup() {
     addLoadClasses(RandomLoadGenerator.class);
     addLoadClasses(AgedLoadGenerator.class);
 
     addFailureClasses(Failures.DatanodeStartStopFailure.class);
     addFailureClasses(Failures.DatanodeRestartFailure.class);
+  }
 
+  @Override
+  public Void call() throws Exception {
+    setup();
     startChaosCluster();
-
     return null;
   }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -62,60 +62,60 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
   @Option(names = {"-d", "--num-datanodes", "--numDatanodes"},
       description = "num of datanodes. Full name --numDatanodes will be" +
           " removed in later versions.")
-  private static int numDatanodes = 20;
+  private int numDatanodes = 20;
 
   @Option(names = {"-o", "--num-ozone-manager", "--numOzoneManager"},
       description = "num of ozoneManagers. Full name --numOzoneManager will" +
           " be removed in later versions.")
-  private static int numOzoneManagers = 1;
+  private int numOzoneManagers = 1;
 
   @Option(names = {"-s", "--num-storage-container-manager",
       "--numStorageContainerManagers"},
       description = "num of storageContainerManagers." +
           "Full name --numStorageContainerManagers will" +
           " be removed in later versions.")
-  private static int numStorageContainerManagerss = 1;
+  private int numStorageContainerManagerss = 1;
 
   @Option(names = {"-t", "--num-threads", "--numThreads"},
       description = "num of IO threads. Full name --numThreads will be" +
           " removed in later versions.")
-  private static int numThreads = 5;
+  private int numThreads = 5;
 
   @Option(names = {"-b", "--num-buffers", "--numBuffers"},
       description = "num of IO buffers. Full name --numBuffers will be" +
           " removed in later versions.")
-  private static int numBuffers = 16;
+  private int numBuffers = 16;
 
   @Option(names = {"-m", "--num-minutes", "--numMinutes"},
       description = "total run time. Full name --numMinutes will be " +
           "removed in later versions.")
-  private static int numMinutes = 1440; // 1 day by default
+  private int numMinutes = 1440; // 1 day by default
 
   @Option(names = {"-v", "--num-data-volume", "--numDataVolume"},
       description = "number of datanode volumes to create. Full name " +
           "--numDataVolume will be removed in later versions.")
-  private static int numDataVolumes = 3;
+  private int numDataVolumes = 3;
 
   @Option(names = {"-i", "--failure-interval", "--failureInterval"},
       description = "time between failure events in seconds. Full name " +
           "--failureInterval will be removed in later versions.")
-  private static int failureInterval = 300; // 5 minute period between failures.
+  private int failureInterval = 300; // 5 minute period between failures.
 
   @CommandLine.Mixin
-  private static FreonReplicationOptions freonReplication =
+  private FreonReplicationOptions freonReplication =
           new FreonReplicationOptions();
 
   @Option(names = {"-l", "--layout"},
       description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}")
-  private static AllowedBucketLayouts allowedBucketLayout =
+  private AllowedBucketLayouts allowedBucketLayout =
       AllowedBucketLayouts.FILE_SYSTEM_OPTIMIZED;
 
   private MiniOzoneChaosCluster cluster;
   private OzoneClient client;
   private MiniOzoneLoadGenerator loadGenerator;
 
-  private String omServiceId = null;
-  private String scmServiceId = null;
+  private String omServiceId;
+  private String scmServiceId;
 
   private static final String OM_SERVICE_ID = "ozoneChaosTest";
   private static final String SCM_SERVICE_ID = "scmChaosTest";

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.freon.FreonReplicationOptions;
 import org.apache.hadoop.ozone.loadgenerators.LoadGenerator;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ import picocli.CommandLine.Option;
 @Command(description = "Starts IO with MiniOzoneChaosCluster",
     name = "chaos", mixinStandardHelpOptions = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Unhealthy("HDDS-3131")
 public class TestMiniChaosOzoneCluster extends GenericCli {
 
   private final List<Class<? extends Failures>> failureClasses

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -33,9 +33,10 @@ import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.freon.FreonReplicationOptions;
 import org.apache.hadoop.ozone.loadgenerators.LoadGenerator;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -45,12 +46,13 @@ import picocli.CommandLine.Option;
  */
 @Command(description = "Starts IO with MiniOzoneChaosCluster",
     name = "chaos", mixinStandardHelpOptions = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestMiniChaosOzoneCluster extends GenericCli {
 
-  private static List<Class<? extends Failures>> failureClasses
+  private final List<Class<? extends Failures>> failureClasses
       = new ArrayList<>();
 
-  private static List<Class<? extends LoadGenerator>> loadClasses
+  private final List<Class<? extends LoadGenerator>> loadClasses
       = new ArrayList<>();
 
   enum AllowedBucketLayouts { FILE_SYSTEM_OPTIMIZED, OBJECT_STORE }
@@ -106,18 +108,18 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
   private static AllowedBucketLayouts allowedBucketLayout =
       AllowedBucketLayouts.FILE_SYSTEM_OPTIMIZED;
 
-  private static MiniOzoneChaosCluster cluster;
-  private static OzoneClient client;
-  private static MiniOzoneLoadGenerator loadGenerator;
+  private MiniOzoneChaosCluster cluster;
+  private OzoneClient client;
+  private MiniOzoneLoadGenerator loadGenerator;
 
-  private static String omServiceId = null;
-  private static String scmServiceId = null;
+  private String omServiceId = null;
+  private String scmServiceId = null;
 
   private static final String OM_SERVICE_ID = "ozoneChaosTest";
   private static final String SCM_SERVICE_ID = "scmChaosTest";
 
-  @BeforeAll
-  public static void init() throws Exception {
+  @BeforeEach
+  void init() throws Exception {
     OzoneConfiguration configuration = new OzoneConfiguration();
 
     MiniOzoneChaosCluster.Builder chaosBuilder =
@@ -164,19 +166,19 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     loadGenerator = loadBuilder.build();
   }
 
-  static void addFailureClasses(Class<? extends Failures> clz) {
+  void addFailureClasses(Class<? extends Failures> clz) {
     failureClasses.add(clz);
   }
 
-  static void addLoadClasses(Class<? extends LoadGenerator> clz) {
+  void addLoadClasses(Class<? extends LoadGenerator> clz) {
     loadClasses.add(clz);
   }
 
-  static void setNumDatanodes(int nDns) {
+  void setNumDatanodes(int nDns) {
     numDatanodes = nDns;
   }
 
-  static void setNumManagers(int nOms, int numScms, boolean enableHA) {
+  void setNumManagers(int nOms, int numScms, boolean enableHA) {
 
     if (nOms > 1 || enableHA) {
       omServiceId = OM_SERVICE_ID;
@@ -189,11 +191,8 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     numStorageContainerManagerss = numScms;
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
-  @AfterAll
-  public static void shutdown() {
+  @AfterEach
+  void shutdown() {
     if (loadGenerator != null) {
       loadGenerator.shutdownLoadGenerator();
     }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestOzoneManagerMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestOzoneManagerMiniChaosOzoneCluster.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.loadgenerators.AgedDirLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.NestedDirLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.RandomDirLoadGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import picocli.CommandLine;
 
 /**
@@ -33,11 +35,12 @@ import picocli.CommandLine;
     description = "run chaos cluster across Ozone Managers",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestOzoneManagerMiniChaosOzoneCluster extends
     TestMiniChaosOzoneCluster implements Callable<Void> {
 
-  @Override
-  public Void call() throws Exception {
+  @BeforeAll
+  void setup() {
     setNumManagers(3, 1, true);
     setNumDatanodes(3);
 
@@ -47,7 +50,11 @@ public class TestOzoneManagerMiniChaosOzoneCluster extends
 
     addFailureClasses(Failures.OzoneManagerRestartFailure.class);
     addFailureClasses(Failures.OzoneManagerStartStopFailure.class);
+  }
 
+  @Override
+  public Void call() throws Exception {
+    setup();
     startChaosCluster();
     return null;
   }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerMiniChaosOzoneCluster.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.loadgenerators.AgedDirLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.NestedDirLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.RandomDirLoadGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import picocli.CommandLine;
 
 /**
@@ -33,11 +35,12 @@ import picocli.CommandLine;
     description = "run chaos cluster across Storage Container Managers",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestStorageContainerManagerMiniChaosOzoneCluster extends
     TestMiniChaosOzoneCluster implements Callable<Void> {
 
-  @Override
-  public Void call() throws Exception {
+  @BeforeAll
+  void setup() {
     setNumManagers(3, 3, true);
     setNumDatanodes(3);
 
@@ -47,7 +50,11 @@ public class TestStorageContainerManagerMiniChaosOzoneCluster extends
 
     addFailureClasses(Failures.StorageContainerManagerRestartFailure.class);
     addFailureClasses(Failures.StorageContainerManagerStartStopFailure.class);
+  }
 
+  @Override
+  public Void call() throws Exception {
+    setup();
     startChaosCluster();
     return null;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Error in `FailureManager.stop()` causes cluster shutdown to be skipped in `MiniOzoneChaosCluster`:

    ```
    [main] ERROR ozone.MiniOzoneChaosCluster (MiniOzoneChaosCluster.java:shutdown(139)) - failed to shutdown MiniOzoneChaosCluster
    java.util.concurrent.CancellationException
      at java.util.concurrent.FutureTask.report(FutureTask.java:121)
      at java.util.concurrent.FutureTask.get(FutureTask.java:192)
      at org.apache.hadoop.ozone.failure.FailureManager.stop(FailureManager.java:84)
      at org.apache.hadoop.ozone.MiniOzoneChaosCluster.shutdown(MiniOzoneChaosCluster.java:134)
      at org.apache.hadoop.ozone.TestMiniChaosOzoneCluster.shutdown(TestMiniChaosOzoneCluster.java:204)
    ```

    This leaves test data around for each test run:

    ```
    $ du -sh hadoop-ozone/fault-injection-test/mini-chaos-tests/target/test-dir/*
    931M     hadoop-ozone/fault-injection-test/mini-chaos-tests/target/test-dir/MiniOzoneClusterImpl-389ad749-d0b0-4c5e-ade5-edf595aecb24
    931M    hadoop-ozone/fault-injection-test/mini-chaos-tests/target/test-dir/MiniOzoneClusterImpl-494a0152-b65d-49a3-a1f9-b09c635f8e6e
    931M    hadoop-ozone/fault-injection-test/mini-chaos-tests/target/test-dir/MiniOzoneClusterImpl-4e4b8259-df88-494e-a20b-9cf96e496401
    931M    hadoop-ozone/fault-injection-test/mini-chaos-tests/target/test-dir/MiniOzoneClusterImpl-95882346-4d20-4731-b36c-0bef4d02bd86
    931M    hadoop-ozone/fault-injection-test/mini-chaos-tests/target/test-dir/MiniOzoneClusterImpl-f94c4864-22b3-4c8f-9ca0-fb7bbc794f28
    ```

    Fix it by moving cluster shutdown out of the try-catch block.

2. Tests do not execute anything useful, because subclasses do not properly initialize `Failures` and `LoadGenerators`:

    ```
    [main] INFO  ozone.MiniOzoneLoadGenerator (MiniOzoneLoadGenerator.java:startIO(85)) - Starting MiniOzoneLoadGenerator for time 120:SECONDS
    [main] ERROR loadgenerators.LoadExecutors (LoadExecutors.java:waitForCompletion(97)) - startIO failed with exception
    java.util.concurrent.ExecutionException: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
      at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
      at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
      at org.apache.hadoop.ozone.loadgenerators.LoadExecutors.waitForCompletion(LoadExecutors.java:95)
      at org.apache.hadoop.ozone.MiniOzoneLoadGenerator.startIO(MiniOzoneLoadGenerator.java:89)
      at org.apache.hadoop.ozone.TestMiniChaosOzoneCluster.testReadWriteWithChaosCluster(TestMiniChaosOzoneCluster.java:221)
    ...
    Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
      at java.util.ArrayList.rangeCheck(ArrayList.java:659)
      at java.util.ArrayList.get(ArrayList.java:435)
      at org.apache.hadoop.ozone.loadgenerators.LoadExecutors.load(LoadExecutors.java:60)
      at org.apache.hadoop.ozone.loadgenerators.LoadExecutors.lambda$startLoad$0(LoadExecutors.java:87)
    ```

    Fix it by initializing `Failures` and `LoadGenerators` in `@BeforeAll`, and moving cluster startup to `@BeforeEach`.

3. After fixing the above, tests run for a long time or time out.  Enabling them in HDDS-3131 was premature.  Disable the tests again by marking them as `@Unhealthy`.

https://issues.apache.org/jira/browse/HDDS-12694

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14069026745