### PR TITLE
HDDS-12684. Update NOTICE and LICENSE file

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Ozone
-Copyright 2024 The Apache Software Foundation
+Copyright 2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -324,6 +324,7 @@ Apache License 2.0
    io.grpc:grpc-protobuf
    io.grpc:grpc-protobuf-lite
    io.grpc:grpc-stub
+   io.grpc:grpc-util
    io.jaegertracing:jaeger-client
    io.jaegertracing:jaeger-core
    io.jaegertracing:jaeger-thrift
@@ -355,6 +356,7 @@ Apache License 2.0
    io.prometheus:simpleclient_common
    io.prometheus:simpleclient_dropwizard
    joda-time:joda-time
+   jakarta.inject:jakarta.inject
    jakarta.inject:jakarta.inject-api
    jakarta.validation:jakarta.validation-api
    javax.enterprise:cdi-api
@@ -374,7 +376,7 @@ Apache License 2.0
    org.apache.hadoop:hadoop-hdfs
    org.apache.hadoop:hadoop-hdfs-client
    org.apache.hadoop:hadoop-shaded-guava
-   org.apache.hadoop:hadoop-shaded-protobuf
+   org.apache.hadoop:hadoop-shaded-protobuf_3_25
    org.apache.httpcomponents:httpasyncclient
    org.apache.httpcomponents:httpcore
    org.apache.httpcomponents:httpcore-nio

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Ozone
-Copyright 2022 The Apache Software Foundation
+Copyright 2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -508,3 +508,10 @@ The Apache Software Foundation (http://www.apache.org/).
 ====================
 ratis-thirdparty-misc is a shaded dependency which includes additional 3rd party dependencies in shaded form.
 For the detailed list of the dependencies and the associated NOTICE file see licenses/NOTICE-ratis-thirdparty-misc.txt.
+
+====================
+Apache Hadoop Third-party Libs
+Copyright 2020 and onwards The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/hadoop-ozone/dist/src/main/license/bin/licenses/LICENSE-org.jline.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/licenses/LICENSE-org.jline.txt
@@ -1,0 +1,35 @@
+Copyright (c) 2002-2023, the original author or authors.
+All rights reserved.
+
+https://opensource.org/licenses/BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with
+the distribution.
+
+Neither the name of JLine nor the names of its contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/hadoop-ozone/dist/src/main/license/bin/licenses/NOTICE-hadoop.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/licenses/NOTICE-hadoop.txt
@@ -1,0 +1,34 @@
+Apache Hadoop
+Copyright 2006 and onwards The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+Export Control Notice
+---------------------
+
+This distribution includes cryptographic software.  The country in
+which you currently reside may have restrictions on the import,
+possession, use, and/or re-export to another country, of
+encryption software.  BEFORE using any encryption software, please
+check your country's laws, regulations and policies concerning the
+import, possession, or use, and re-export of encryption software, to
+see if this is permitted.  See <http://www.wassenaar.org/> for more
+information.
+
+The U.S. Government Department of Commerce, Bureau of Industry and
+Security (BIS), has classified this software as Export Commodity
+Control Number (ECCN) 5D002.C.1, which includes information security
+software using or performing cryptographic functions with asymmetric
+algorithms.  The form and manner of this Apache Software Foundation
+distribution makes it eligible for export under the License Exception
+ENC Technology Software Unrestricted (TSU) exception (see the BIS
+Export Administration Regulations, Section 740.13) for both object
+code and source code.
+
+The following provides more details on the included cryptographic software:
+
+This software uses the SSL libraries from the Jetty project written
+by mortbay.org.
+Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
+cryptography APIs written by the Legion of the Bouncy Castle Inc.


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12684. Update NOTICE and LICENSE file

Please describe your PR in detail:
Following the ASF guideline: https://infra.apache.org/licensing-howto.html

* Update copyright year.
* Added Hadoop and Hadoop thirdparty NOTICE.
* Update LICENSE for:
[HDDS-11826](https://issues.apache.org/jira/browse/HDDS-11826) (jline3)
[HDDS-11052](https://issues.apache.org/jira/browse/HDDS-11052) (jersey-servlet)
[HDDS-10368](https://issues.apache.org/jira/browse/HDDS-10368) (jakarta.inject)
[HDDS-9192](https://issues.apache.org/jira/browse/HDDS-9192) (io.grpc:grpc-util)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12684

## How was this patch tested?

Cross checked every commit to jar-report.txt after the last license update (1/25/2024) and updated accordingly.