### PR TITLE
HDDS-12677. Support Prefix-Based Searching for Container Key Mapping API.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -205,7 +205,7 @@ public class TestReconContainerEndpoint {
             cluster.getReconServer().getReconNamespaceSummaryManager(),
             cluster.getReconServer().getReconContainerMetadataManager(),
             omMetadataManagerInstance);
-    return containerEndpoint.getKeysForContainer(containerId, 10, "");
+    return containerEndpoint.getKeysForContainer(containerId, 10, "", "");
   }
 
   private void writeTestData(String volumeName, String bucketName,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -414,16 +414,15 @@ public class ReconUtils {
    * @throws IOException If database access fails.
    * @throws IllegalArgumentException If the provided path is invalid or cannot be converted.
    */
-  public static String convertToObjectPathForOpenKeySearch(String prevKeyPrefix,
-                                                           ReconOMMetadataManager omMetadataManager,
-                                                           ReconNamespaceSummaryManager reconNamespaceSummaryManager,
-                                                           OzoneStorageContainerManager reconSCM)
+  public static String convertToObjectPathForSearch(String prevKeyPrefix,
+                                                    ReconOMMetadataManager omMetadataManager,
+                                                    ReconNamespaceSummaryManager reconNamespaceSummaryManager,
+                                                    OzoneStorageContainerManager reconSCM,
+                                                    Table<String, OmKeyInfo> table)
       throws IOException {
     try {
       String[] names = EntityHandler.parseRequestPath(EntityHandler.normalizePath(
           prevKeyPrefix, BucketLayout.FILE_SYSTEM_OPTIMIZED));
-      Table<String, OmKeyInfo> openFileTable = omMetadataManager.getOpenKeyTable(
-          BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
       // Root-Level: Return the original path
       if (names.length == 0 || names[0].isEmpty()) {
@@ -466,7 +465,7 @@ public class ReconUtils {
         long dirID = handler.getDirObjectId(names, names.length);
         String keyKey = constructObjectPathWithPrefix(volumeId, bucketId, dirID) +
             OM_KEY_PREFIX + lastEntiry;
-        OmKeyInfo keyInfo = openFileTable.getSkipCache(keyKey);
+        OmKeyInfo keyInfo = table.getSkipCache(keyKey);
         if (keyInfo != null && keyInfo.getFileName().equals(lastEntiry)) {
           return constructObjectPathWithPrefix(volumeId, bucketId,
               keyInfo.getParentObjectID()) + OM_KEY_PREFIX + lastEntiry;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -403,7 +403,7 @@ public class ReconUtils {
    * <pre>
    * {@code
    * Examples:
-   * - Input: "volume/bucket/key" -> Output: "/volumeID/bucketID/parentDirID/key"
+   * - Input: "volume/bucket/key" -> Output: "/volumeID/bucketID/bucketID/key"
    * - Input: "volume/bucket/dir1" -> Output: "/volumeID/bucketID/dir1ID/"
    * - Input: "volume/bucket/dir1/key1" -> Output: "/volumeID/bucketID/dir1ID/key1"
    * - Input: "volume/bucket/dir1/dir2" -> Output: "/volumeID/bucketID/dir2ID/"

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -239,8 +239,8 @@ public class ContainerEndpoint {
         boolean isFSO = isFSOBucket(startPrefix);
         if (isFSO) {
           Table<String, OmKeyInfo> fileTable = omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED);
-          startPrefix = ReconUtils.convertToObjectPathForSearch(startPrefix, omMetadataManager,
-              reconNamespaceSummaryManager, reconSCM, fileTable);
+          startPrefix = ReconUtils.convertToObjectPathForSearch(
+              startPrefix, omMetadataManager, reconNamespaceSummaryManager, reconSCM, fileTable);
         }
 
         // If a startPrefix is provided, fetch only the specific matching record(s).

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -259,12 +259,11 @@ public class OMDBInsightEndpoint {
                                                     int limit, String prevKey)
       throws IOException, IllegalArgumentException {
     Map<String, OmKeyInfo> matchedKeys = new LinkedHashMap<>();
+    Table<String, OmKeyInfo> openFileTable = omMetadataManager.getOpenKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED);
     // Convert the search prefix to an object path for FSO buckets
-    String startPrefixObjectPath = ReconUtils.convertToObjectPathForOpenKeySearch(
-            startPrefix, omMetadataManager, reconNamespaceSummaryManager, reconSCM);
+    String startPrefixObjectPath = ReconUtils.convertToObjectPathForSearch(
+        startPrefix, omMetadataManager, reconNamespaceSummaryManager, reconSCM, openFileTable);
     String[] names = parseRequestPath(startPrefixObjectPath);
-    Table<String, OmKeyInfo> openFileTable =
-        omMetadataManager.getOpenKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     // If names.length <= 2, then the search prefix is at the volume or bucket level hence
     // no need to find parent or extract id's or find subpaths as the openFileTable is

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.recon.spi;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
@@ -262,4 +263,18 @@ public interface ReconContainerMetadataManager {
    */
   Map<KeyPrefixContainer, Integer> getContainerForKeyPrefixes(
       String prevKeyPrefix, long keyVersion) throws IOException;
+
+  /**
+   * Get container key records from the containerKeyTable that exactly match the given
+   * startPrefix for the provided containerId.
+   *
+   * @param containerId the container ID.
+   * @param startPrefix the key prefix to search for.
+   * @param isFSO boolean flag to check if its FSO bucket.
+   * @return A List of ContainerKeyPrefix records if found; an empty list otherwise.
+   * @throws IOException if a DB operation fails.
+   */
+  List<ContainerKeyPrefix> getKeyRecordsForPrefix(long containerId, String startPrefix, int limit, boolean isFSO)
+      throws IOException;
+
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -436,7 +436,7 @@ public class TestContainerEndpoint {
 
   @Test
   public void testGetKeysForContainer() throws IOException {
-    Response response = containerEndpoint.getKeysForContainer(1L, -1, "");
+    Response response = containerEndpoint.getKeysForContainer(1L, -1, "", "");
 
     KeysResponse data = (KeysResponse) response.getEntity();
     Collection<KeyMetadata> keyMetadataList = data.getKeys();
@@ -463,14 +463,14 @@ public class TestContainerEndpoint {
     assertEquals(103, blockIds.get(0L).iterator().next().getLocalID());
     assertEquals(104, blockIds.get(1L).iterator().next().getLocalID());
 
-    response = containerEndpoint.getKeysForContainer(3L, -1, "");
+    response = containerEndpoint.getKeysForContainer(3L, -1, "", "");
     data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertThat(keyMetadataList).isEmpty();
     assertEquals(0, data.getTotalCount());
 
     // test if limit works as expected
-    response = containerEndpoint.getKeysForContainer(1L, 1, "");
+    response = containerEndpoint.getKeysForContainer(1L, 1, "", "");
     data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertEquals(1, keyMetadataList.size());
@@ -485,7 +485,7 @@ public class TestContainerEndpoint {
     nSSummaryTaskWithFso.reprocessWithFSO(reconOMMetadataManager);
     // Reprocess the container key mapper to ensure the latest mapping is used
     reprocessContainerKeyMapper();
-    response = containerEndpoint.getKeysForContainer(20L, -1, "");
+    response = containerEndpoint.getKeysForContainer(20L, -1, "", "");
 
     // Ensure that the expected number of keys is returned
     data = (KeysResponse) response.getEntity();
@@ -516,7 +516,7 @@ public class TestContainerEndpoint {
   public void testGetKeysForContainerWithPrevKey() throws IOException {
     // test if prev-key param works as expected
     Response response = containerEndpoint.getKeysForContainer(
-        1L, -1, "/sampleVol/bucketOne/key_one");
+        1L, -1, "/sampleVol/bucketOne/key_one", "");
 
     KeysResponse data =
         (KeysResponse) response.getEntity();
@@ -536,7 +536,7 @@ public class TestContainerEndpoint {
 
     // test for an empty prev-key parameter
     response = containerEndpoint.getKeysForContainer(
-        1L, -1, StringUtils.EMPTY);
+        1L, -1, StringUtils.EMPTY, "");
     data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
 
@@ -548,7 +548,7 @@ public class TestContainerEndpoint {
 
     // test for negative cases
     response = containerEndpoint.getKeysForContainer(
-        1L, -1, "/sampleVol/bucketOne/invalid_key");
+        1L, -1, "/sampleVol/bucketOne/invalid_key", "");
     data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertEquals(3, data.getTotalCount());
@@ -556,7 +556,7 @@ public class TestContainerEndpoint {
 
     // test for a container ID that does not exist
     response = containerEndpoint.getKeysForContainer(
-        5L, -1, "");
+        5L, -1, "", "");
     data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertEquals(0, keyMetadataList.size());
@@ -571,7 +571,7 @@ public class TestContainerEndpoint {
         new NSSummaryTaskWithFSO(reconNamespaceSummaryManager,
             reconOMMetadataManager, 10);
     nSSummaryTaskWithFso.reprocessWithFSO(reconOMMetadataManager);
-    response = containerEndpoint.getKeysForContainer(20L, -1, "/0/1/2/file7");
+    response = containerEndpoint.getKeysForContainer(20L, -1, "/0/1/2/file7", "");
 
     // Ensure that the expected number of keys is returned
     data = (KeysResponse) response.getEntity();
@@ -1796,7 +1796,7 @@ public class TestContainerEndpoint {
     reprocessContainerKeyMapper();
 
     // Assume that FSO keys are mapped to container ID 20L (as in previous tests for FSO).
-    Response response = containerEndpoint.getKeysForContainer(20L, -1, "");
+    Response response = containerEndpoint.getKeysForContainer(20L, -1, "", "");
     KeysResponse keysResponse = (KeysResponse) response.getEntity();
     Collection<KeyMetadata> keyMetadataList = keysResponse.getKeys();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR enhances the Container Key Mapping API in Recon to support prefix-based key filtering within a specific container.
Users can now pass a startPrefix query parameter to retrieve only the keys in a container that match the provided prefix.

1. For OBS buckets, since keys are stored in a human-readable format, RocksDB’s seek operation is used for efficient prefix lookup.
2. For FSO buckets, keys are stored as object ID–based paths. This PR reuses the logic developed for global prefix-based search (for open and deleted keys) to convert the human-readable path into the internal object path format before querying.
3. A limit is also enforced on the number of results returned for better pagination and performance.

This functionality allows users to perform key lookups within containers using familiar prefixes.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12677
## How was this patch tested?

