### PR TITLE
HDDS-12587. Detect test class module in flaky-test-check

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: ${{ github.event.inputs.java-version }}
       - name: Find tests
         run: |
           # find tests to be run in splits by running them with very short timeout

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -61,6 +61,9 @@ env:
   RATIS_REPO: ${{ github.event.inputs.ratis-repo }}
   RATIS_VERSION: ${{ github.event.inputs.ratis-ref }}
   JAVA_VERSION: ${{ github.event.inputs.java-version }}
+  # Surefire 3.0.0-M4 is used because newer versions do not reliably kill the fork on timeout
+  # SUREFIRE-1722, SUREFIRE-1815
+  SUREFIRE_VERSION: 3.0.0-M4
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}-java{5}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations, inputs.java-version) || '' }}
 jobs:
   prepare-job:
@@ -87,11 +90,54 @@ jobs:
     with:
       repo: ${{ github.event.inputs.ratis-repo || format('{0}/ratis', github.repository_owner) }}
       ref: ${{ github.event.inputs.ratis-ref }}
+  find-tests:
+    if: ${{ always() }}
+    needs:
+      - prepare-job
+    runs-on: ubuntu-24.04
+    outputs:
+      modules: ${{ steps.modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: Cache for maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-repo-
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: Find tests
+        run: |
+          # find tests to be run in splits by running them with very short timeout
+          hadoop-ozone/dev-support/checks/junit.sh -DexcludedGroups="native|slow|unhealthy" -DskipShade \
+              -Dtest="$TEST_CLASS,Abstract*Test*\$*" \
+              -Dsurefire.fork.timeout=1 -Dmaven-surefire-plugin.version=${{ env.SUREFIRE_VERSION }} \
+              || true # ignore errors
+        env:
+          ITERATIONS: 1
+      - name: Find modules
+        id: modules
+        run: |
+          grep -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' target/unit/output.log | grep -B1 'Running org.apache'
+          modules=$(grep -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' target/unit/output.log | grep -B1 'Running org.apache' \
+              | grep surefire | cut -f2 -d'@' | awk '{ print $1 }' | sed 's/^/:/' | xargs | sed -e 's/ /,/g')
+          echo "modules=$modules" >> $GITHUB_OUTPUT
+        if: ${{ !cancelled() }}
   build:
     if: ${{ always() }}
     needs:
       - prepare-job
       - ratis
+      - find-tests
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -129,6 +175,10 @@ jobs:
             args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
           fi
 
+          if [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
+            args="$args -am -pl ${{ needs.find-tests.outputs.modules }}"
+          fi
+
           hadoop-ozone/dev-support/checks/build.sh $args
       - name: Store Maven repo for tests
         uses: actions/upload-artifact@v4
@@ -143,6 +193,7 @@ jobs:
       - prepare-job
       - ratis
       - build
+      - find-tests
     name: Run-Split
     runs-on: ubuntu-24.04
     strategy:
@@ -195,6 +246,10 @@ jobs:
             args="$args -Dio.grpc.version=${{ needs.ratis.outputs.grpc-version }}"
             args="$args -Dnetty.version=${{ needs.ratis.outputs.netty-version }}"
             args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
+          fi
+
+          if [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
+            args="$args -pl ${{ needs.find-tests.outputs.modules }}"
           fi
 
           if [ "$TEST_METHOD" = "ALL" ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add time-limited run of tests in `flaky-test-check` to find which modules they are in.
- Build only those modules and their dependencies (`-am -pl`).
- Limit real test run to those modules (`-pl`).

https://issues.apache.org/jira/browse/HDDS-12587

## How was this patch tested?

Triggered 2x2 [run](https://github.com/adoroszlai/ozone/actions/runs/14076965592) of `TestConfigurationSource,TestHddsClientUtils`.

[`find-tests`](https://github.com/adoroszlai/ozone/actions/runs/14076965592/job/39421709849#step:6:20) found these in `hdds-config` and `hdds-client`, respectively:

```
[INFO] --- surefire:3.0.0-M4:test (default-test) @ hdds-config ---
[INFO] Running org.apache.hadoop.hdds.conf.TestConfigurationSource
--
[INFO] --- surefire:3.0.0-M4:test (default-test) @ hdds-client ---
[INFO] Running org.apache.hadoop.hdds.scm.client.TestHddsClientUtils
```

[`build`](https://github.com/adoroszlai/ozone/actions/runs/14076965592/job/39421800521#step:6:1053) has built dependencies, too:

```
[INFO] Reactor Summary for Apache Ozone Main 2.1.0-SNAPSHOT:
[INFO] 
[INFO] Apache Ozone Main .................................. SUCCESS [  1.779 s]
[INFO] Apache Ozone Dev Support ........................... SUCCESS [  1.554 s]
[INFO] Apache Ozone HDDS .................................. SUCCESS [  0.405 s]
[INFO] Apache Ozone Annotation Processing ................. SUCCESS [  1.013 s]
[INFO] Apache Ozone HDDS Config ........................... SUCCESS [  1.715 s]
[INFO] Apache Ozone HDDS Hadoop Client dependencies ....... SUCCESS [  1.726 s]
[INFO] Apache Ozone HDDS Client Interface ................. SUCCESS [ 10.770 s]
[INFO] Apache Ozone HDDS Admin Interface .................. SUCCESS [  2.708 s]
[INFO] Apache Ozone HDDS Test Utils ....................... SUCCESS [  1.141 s]
[INFO] Apache Ozone HDDS Common ........................... SUCCESS [  5.271 s]
[INFO] Apache Ozone HDDS Erasurecode ...................... SUCCESS [  0.931 s]
[INFO] Apache Ozone HDDS Client ........................... SUCCESS [  1.828 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  32.380 s
```

[`run-test`](https://github.com/adoroszlai/ozone/actions/runs/14076965592/job/39421835533#step:7:248) limited to two modules:

```
[INFO] Reactor Summary for Apache Ozone HDDS Config 2.1.0-SNAPSHOT:
[INFO] 
[INFO] Apache Ozone HDDS Config ........................... SUCCESS [  7.266 s]
[INFO] Apache Ozone HDDS Client ........................... SUCCESS [  8.229 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16.931 s
```