### PR TITLE
HDDS-12603. Fix ContainerTable keys re-rendering issue

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/containersTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/containersTable.tsx
@@ -225,7 +225,7 @@ const ContainerTable: React.FC<ContainerTableProps> = ({
         dataSource={dataSource}
         columns={KEY_TABLE_COLUMNS}
         pagination={paginationConfig}
-        rowKey={(record: KeyResponse) => `${record.Volume}/${record.Bucket}/${record.Key}`}
+        rowKey={(record: KeyResponse) => record.CompletePath}
         locale={{ filterTitle: '' }} />
     )
   };


### PR DESCRIPTION
## What changes were proposed in this pull request?
The ContainerTable component renders keys under the provided container ID that might be missing, under-replicated, over-replicated or mis-replicated.
Currently due to non-unique keys between the elements, the Keys might get re-rendered when switching pages.
This PR fixes that issue

Please describe your PR in detail:
- Currently the `key` field required to uniquely identify a react element is `volume/bucket/key`.
- However for nested paths, this React `key` will be common as for paths like `vol1/buck1/dir1/key1` and `vol1/buck1/dir1/dir2/key1` they react key will be equal to `vol1/buck1/key1` on both the elements.
- This causes the Ozone Keys to be re-rendered/repeated multiple times as they are not uniquely identifiable in the UI.
- This PR changes the React key to use complete path instead which will include any nested directories ensuring that keys are always mapped to unique values.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12603

## How was this patch tested?
Patch was tested manually by docker build.
Ran the following commands:
```
fallocate -l 10M testfile1
fallocate -l 10M testfile2
ozone sh volume create volume1
ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED volume1/fso-bucket
ozone fs -mkdir -p ofs://om/volume1/fso-bucket/dir1/dir2/dir3
ozone fs -put -f testfile1 ofs://om/volume1/fso-bucket/dir1/
ozone fs -put -f testfile2 ofs://om/volume1/fso-bucket/dir1/
ozone fs -put -f testfile1 ofs://om/volume1/fso-bucket/dir1/dir2/
ozone fs -put -f testfile2 ofs://om/volume1/fso-bucket/dir1/dir2/
ozone fs -put -f testfile1 ofs://om/volume1/fso-bucket/dir1/dir2/dir3/
ozone fs -put -f testfile2 ofs://om/volume1/fso-bucket/dir1/dir2/dir3/

ozone sh bucket create --layout LEGACY volume1/legacy-bucket
ozone fs -mkdir -p ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/dir4/dir5
ozone fs -put -f testfile1 ofs://om/volume1/legacy-bucket/dir1/
ozone fs -put -f testfile2 ofs://om/volume1/legacy-bucket/dir1/
ozone fs -put -f testfile1 ofs://om/volume1/legacy-bucket/dir1/dir2/
ozone fs -put -f testfile2 ofs://om/volume1/legacy-bucket/dir1/dir2/
ozone fs -put -f testfile1 ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/
ozone fs -put -f testfile2 ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/
ozone fs -put -f testfile1 ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/dir4/
ozone fs -put -f testfile2 ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/dir4/
ozone fs -put -f testfile1 ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/dir4/dir5/
ozone fs -put -f testfile2 ofs://om/volume1/legacy-bucket/dir1/dir2/dir3/dir4/dir5/
```

Then stopped all the datanodes to simulate missing containers.
Below is attached video after the above steps where pagination no longer causes elements to be repeated.

https://github.com/user-attachments/assets/f372b2d9-b78c-46d0-bb04-f49bf3e04655
