### PR TITLE
HDDS-11943. Fail storage volume after numerous reported IO errors.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -103,6 +103,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   private final Map<ContainerType, Handler> handlers;
   private final ConfigurationSource conf;
   private final ContainerSet containerSet;
+  private final VolumeSet volumeSet;
   private final StateContext context;
   private final float containerCloseThreshold;
   private final ProtocolMessageMetrics<ProtocolMessageEnum> protocolMetrics;
@@ -127,6 +128,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     this.context = context;
     this.handlers = handlers;
     this.metrics = metrics;
+    this.volumeSet = volumes;
     this.containerCloseThreshold = conf.getFloat(
         HddsConfigKeys.HDDS_CONTAINER_CLOSE_THRESHOLD,
         HddsConfigKeys.HDDS_CONTAINER_CLOSE_THRESHOLD_DEFAULT);
@@ -424,7 +426,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         // Create a specific exception that signals for on demand scanning
         // and move this general scan to where it is more appropriate.
         // Add integration tests to test the full functionality.
-        OnDemandContainerDataScanner.scanContainer(container);
+        OnDemandContainerDataScanner.scanContainer(container, volumeSet);
         audit(action, eventType, msg, dispatcherContext, AuditEventStatus.FAILURE,
             new Exception(responseProto.getMessage()));
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -136,6 +136,7 @@ public abstract class StorageVolume
   private AtomicInteger currentIOFailureCount;
   private Queue<Boolean> ioTestSlidingWindow;
   private int healthCheckFileSize;
+  private AtomicInteger cumulativeIOFailureCount;
 
   protected StorageVolume(Builder<?> b) throws IOException {
     if (!b.failedVolume) {
@@ -158,6 +159,7 @@ public abstract class StorageVolume
       this.ioFailureTolerance = dnConf.getVolumeIOFailureTolerance();
       this.ioTestSlidingWindow = new LinkedList<>();
       this.currentIOFailureCount = new AtomicInteger(0);
+      this.cumulativeIOFailureCount = new AtomicInteger(0);
       this.healthCheckFileSize = dnConf.getVolumeHealthCheckFileSize();
     } else {
       storageDir = new File(b.volumeRootStr);
@@ -482,6 +484,10 @@ public abstract class StorageVolume
   public void decrementUsedSpace(long reclaimedSpace) {
     volumeInfo.ifPresent(volInfo -> volInfo
             .decrementUsedSpace(reclaimedSpace));
+  }
+
+  public int incrementAndGetCumulativeIOFailureCount() {
+    return cumulativeIOFailureCount.incrementAndGet();
   }
 
   public VolumeSet getVolumeSet() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScannerConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScannerConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.ozoneimpl;
 
 import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
@@ -67,6 +68,7 @@ public class ContainerScannerConfiguration {
   public static final long BANDWIDTH_PER_VOLUME_DEFAULT = OzoneConsts.MB * 5L;
   public static final long ON_DEMAND_BANDWIDTH_PER_VOLUME_DEFAULT =
       OzoneConsts.MB * 5L;
+  public static final int ON_DEMAND_IO_ERROR_TOLERANCE_DEFAULT = 1000;
 
   @Config(key = "enabled",
       type = ConfigType.BOOLEAN,
@@ -136,6 +138,13 @@ public class ContainerScannerConfiguration {
           + " postfix (ns,ms,s,m,h,d)."
   )
   private long containerScanMinGap = CONTAINER_SCAN_MIN_GAP_DEFAULT;
+
+  @Config(key = "on.demand.io.failure.tolerance.count",
+      type = ConfigType.INT,
+      defaultValue = "1000",
+      tags = {ConfigTag.STORAGE},
+      description = "Config parameter to set io failure tolerance count for volume")
+  private int onDemandIOErrorToleranceCount = ON_DEMAND_IO_ERROR_TOLERANCE_DEFAULT;
 
   @PostConstruct
   public void validate() {
@@ -216,5 +225,14 @@ public class ContainerScannerConfiguration {
 
   public long getContainerScanMinGap() {
     return containerScanMinGap;
+  }
+
+  public int getOnDemandIOErrorToleranceCount() {
+    return onDemandIOErrorToleranceCount;
+  }
+
+  @VisibleForTesting
+  public void setOnDemandIOErrorToleranceCount(int onDemandIOErrorToleranceCount) {
+    this.onDemandIOErrorToleranceCount = onDemandIOErrorToleranceCount;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
@@ -163,6 +163,7 @@ public abstract class TestContainerScannersAbstract {
 
     KeyValueContainerData data = mock(KeyValueContainerData.class);
     when(data.getContainerID()).thenReturn(CONTAINER_SEQ_ID.incrementAndGet());
+    when(data.getVolume()).thenReturn(vol);
     when(unhealthy.getContainerData()).thenReturn(data);
     when(unhealthy.getContainerState()).thenReturn(CLOSED);
     // The above mocks should be enough for the scanners to call this method


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently volume scanner only keeps track of new sector for read/write and based on that it marks volume fail.
But the old sector can go wrong as well, in that case in on-demand container scan we are keeping a counter of number of IO errors have that been reported for a volume. If that number crosses a configurable count(added 1000 as default, we can change once we decide the value), we are marking it as volume fail.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11943

## How was this patch tested?

Unit test
https://github.com/ashishkumar50/ozone/actions/runs/14076691821/workflow