### PR TITLE
HDDS-12567. [DiskBalancer] Log success container move action

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.container.common.interfaces.Container.Scan
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -149,6 +150,20 @@ public final class ContainerLogger {
     LOG.info(getMessage(containerData));
   }
 
+  /**
+   * Logged when a container is successfully moved from one data volume to another.
+   *
+   * @param containerId The ID of the moved container.
+   * @param sourceVolume The source volume path.
+   * @param destinationVolume The destination volume path.
+   * @param containerSize The size of data moved from container in bytes.
+   * @param timeTaken The time taken for the move in milliseconds.
+   */
+  public static void logMoveSuccess(long containerId, HddsVolume sourceVolume,
+      HddsVolume destinationVolume, long containerSize, long timeTaken) {
+    LOG.info(getMessage(containerId, sourceVolume, destinationVolume, containerSize, timeTaken));
+  }
+
   private static String getMessage(ContainerData containerData,
                                    String message) {
     return String.join(FIELD_SEPARATOR, getMessage(containerData), message);
@@ -160,5 +175,16 @@ public final class ContainerLogger {
         "Index=" + containerData.getReplicaIndex(),
         "BCSID=" + containerData.getBlockCommitSequenceId(),
         "State=" + containerData.getState());
+  }
+
+  private static String getMessage(long containerId, HddsVolume sourceVolume,
+      HddsVolume destinationVolume, long containerSize, long timeTaken) {
+    return String.join(FIELD_SEPARATOR,
+        "Container Move Successful",
+        "ID=" + containerId,
+        "Source=" + sourceVolume,
+        "Destination=" + destinationVolume,
+        "Size=" + containerSize + " bytes",
+        "TimeTaken=" + timeTaken + " ms");
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -21,7 +21,7 @@ import static org.apache.hadoop.ozone.container.common.interfaces.Container.Scan
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
-import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -159,8 +159,8 @@ public final class ContainerLogger {
    * @param containerSize The size of data moved from container in bytes.
    * @param timeTaken The time taken for the move in milliseconds.
    */
-  public static void logMoveSuccess(long containerId, HddsVolume sourceVolume,
-      HddsVolume destinationVolume, long containerSize, long timeTaken) {
+  public static void logMoveSuccess(long containerId, StorageVolume sourceVolume,
+      StorageVolume destinationVolume, long containerSize, long timeTaken) {
     LOG.info(getMessage(containerId, sourceVolume, destinationVolume, containerSize, timeTaken));
   }
 
@@ -177,13 +177,12 @@ public final class ContainerLogger {
         "State=" + containerData.getState());
   }
 
-  private static String getMessage(long containerId, HddsVolume sourceVolume,
-      HddsVolume destinationVolume, long containerSize, long timeTaken) {
+  private static String getMessage(long containerId, StorageVolume sourceVolume,
+      StorageVolume destinationVolume, long containerSize, long timeTaken) {
     return String.join(FIELD_SEPARATOR,
-        "Container Move Successful",
         "ID=" + containerId,
-        "Source=" + sourceVolume,
-        "Destination=" + destinationVolume,
+        "SrcVolume=" + sourceVolume,
+        "DestVolume=" + destinationVolume,
         "Size=" + containerSize + " bytes",
         "TimeTaken=" + timeTaken + " ms");
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.utils.ContainerLogger;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -485,6 +486,8 @@ public class DiskBalancerService extends BackgroundService {
         long endTime = Time.monotonicNow();
         if (moveSucceeded) {
           metrics.getMoveSuccessTime().add(endTime - startTime);
+          ContainerLogger.logMoveSuccess(containerId, sourceVolume,
+              destVolume, containerSize, endTime - startTime);
         } else {
           metrics.getMoveFailureTime().add(endTime - startTime);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use ContainerLogger to log success container move action.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12567

## How was this patch tested?

Tested manually by running on docker-cluster.
```
2025-03-27 04:33:43,292 | INFO  | ID=1039 | SrcVolume=/data/hdds3/hdds | DestVolume=/data/hdds1/hdds | Size=997195776 bytes | TimeTaken=2332 ms |
2025-03-27 04:33:43,874 | INFO  | ID=1037 | SrcVolume=/data/hdds3/hdds | DestVolume=/data/hdds2/hdds | Size=998244352 bytes | TimeTaken=2916 ms |
2025-03-27 04:34:41,345 | INFO  | ID=1050 | SrcVolume=/data/hdds3/hdds | DestVolume=/data/hdds2/hdds | Size=200278016 bytes | TimeTaken=383 ms |
2025-03-27 04:34:41,350 | INFO  | ID=1049 | SrcVolume=/data/hdds3/hdds | DestVolume=/data/hdds2/hdds | Size=200278016 bytes | TimeTaken=388 ms |
```