### PR TITLE
HDDS-12660. Allow --verbose option of GenericCli at leaf subcommands

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -48,6 +48,7 @@ public abstract class GenericCli implements GenericParentCommand {
   private UserGroupInformation user;
 
   @Option(names = {"--verbose"},
+      scope = CommandLine.ScopeType.INHERIT,
       description = "More verbose output. Show the stack trace of the errors.")
   private boolean verbose;
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
@@ -49,10 +49,6 @@ import picocli.CommandLine.Command;
     versionProvider = HddsVersionProvider.class)
 public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
 
-  @CommandLine.Option(names = {"-v", "--verbose"},
-          description = "Verbose output. Show current iteration info.")
-  private boolean verbose;
-
   @CommandLine.Option(names = {"-H", "--history"},
       description = "Verbose output with history. Show current iteration info and history of iterations. " +
           "Works only with -v.")
@@ -69,7 +65,7 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
           LocalDateTime.ofInstant(startedAtInstant, ZoneId.systemDefault());
       System.out.println("ContainerBalancer is Running.");
 
-      if (verbose) {
+      if (isVerbose()) {
         System.out.printf("Started at: %s %s%n",
             dateTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE),
             dateTime.toLocalTime().format(DateTimeFormatter.ISO_LOCAL_TIME));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /**
@@ -35,10 +34,6 @@ import picocli.CommandLine.Command;
     versionProvider = HddsVersionProvider.class)
 public class SafeModeCheckSubcommand extends ScmSubcommand {
 
-  @CommandLine.Option(names = {"--verbose"},
-      description = "Show detailed status of rules.")
-  private boolean verbose;
-
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     boolean execReturn = scmClient.inSafeMode();
@@ -49,7 +44,7 @@ public class SafeModeCheckSubcommand extends ScmSubcommand {
     } else {
       System.out.println("SCM is out of safe mode.");
     }
-    if (verbose) {
+    if (isVerbose()) {
       for (Map.Entry<String, Pair<Boolean, String>> entry :
           scmClient.getSafeModeRuleStatuses().entrySet()) {
         Pair<Boolean, String> value = entry.getValue();

--- a/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
@@ -98,13 +98,13 @@ Run Balancer Status
                      Should Contain                  ${result}             ContainerBalancer is Running.
 
 Run Balancer Verbose Status
-    ${result} =      Execute                         ozone admin containerbalancer status -v
+    ${result} =      Execute                         ozone admin containerbalancer status --verbose
                      Verify Balancer Iteration       ${result}             1
                      Should Contain                  ${result}             Iteration result -    collapse_spaces=True
 
 
 Run Balancer Verbose History Status
-    ${result} =    Execute                         ozone admin containerbalancer status -v --history
+    ${result} =    Execute                         ozone admin containerbalancer status --verbose --history
                    Verify Balancer Iteration            ${result}             1
                    Verify Balancer Iteration History    ${result}
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -117,11 +117,6 @@ public class BaseFreonGenerator implements FreonSubcommand {
       defaultValue = "")
   private String prefix = "";
 
-  @Option(names = {"--verbose"},
-          description = "More verbose output. "
-              + "Show all the command line Option info.")
-  private boolean verbose;
-
   @CommandLine.Spec
   private CommandLine.Model.CommandSpec spec;
 
@@ -324,7 +319,7 @@ public class BaseFreonGenerator implements FreonSubcommand {
             LOG.error("HTTP server can't be stopped.", ex);
           }
           printReport();
-          if (verbose) {
+          if (freonCommand.isVerbose()) {
             printOption();
           }
         }, 10);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -93,10 +93,6 @@ public class FSORepairTool extends RepairTool {
       description = "Filter by bucket name")
   private String bucketFilter;
 
-  @CommandLine.Option(names = {"--verbose"},
-      description = "Verbose output. Show all intermediate steps.")
-  private boolean verbose;
-
   @Nonnull
   @Override
   protected Component serviceToBeOffline() {
@@ -112,7 +108,7 @@ public class FSORepairTool extends RepairTool {
       throw new IllegalArgumentException("FSO repair failed: " + ex.getMessage());
     }
 
-    if (verbose) {
+    if (isVerbose()) {
       info("FSO repair finished.");
     }
   }
@@ -407,7 +403,7 @@ public class FSORepairTool extends RepairTool {
         // directory delete. It is also not possible here if the file's parent
         // is gone. The name of the key does not matter so just use IDs.
         deletedTable.putWithBatch(batch, fileKey, updatedRepeatedOmKeyInfo);
-        if (verbose) {
+        if (isVerbose()) {
           info("Added entry " + fileKey + " to open key table: " + updatedRepeatedOmKeyInfo);
         }
         store.commitBatchOperation(batch);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the `--verbose` option of GenericCli is accepted only when placed immediately after `ozone admin`, `ozone debug` or `ozone admin`, unless explicitly defined in the respective subcommand classes.

The goal of this task is to improve usability by allowing `--verbose` to be placed anywhere in the command, including after a subcommand or other options.

## What is the link to the Apache JIRA
[HDDS-12660](https://issues.apache.org/jira/browse/HDDS-12660)

## How was this patch tested?
Before adding ScopeType._INHERIT_ to `--verbose` option.
```
bash-5.1$ ozone admin safemode status
SCM is out of safe mode.

bash-5.1$ ozone admin --verbose safemode status          
SCM is out of safe mode.
validated:true, DataNodeSafeModeRule, registered datanodes (=1) >= required datanodes (=1)
validated:true, HealthyPipelineSafeModeRule, healthy Ratis/THREE pipelines (=0) >= healthyPipelineThresholdCount (=0)
validated:true, ContainerSafeModeRule, 100.00% of [Ratis] Containers(0 / 0) with at least one reported replica (=1.00) >= safeModeCutoff (=0.99);
100.00% of [EC] Containers(0 / 0) with at least N reported replica (=1.00) >= safeModeCutoff (=0.99);
validated:true, AtleastOneDatanodeReportedRule, reported Ratis/THREE pipelines with at least one datanode (=0) >= threshold (=0)

bash-5.1$ ozone admin safemode status --verbose
Unknown option: '--verbose'
Possible solutions: --version

bash-5.1$ ozone admin safemode --verbose status
Unknown option: '--verbose'
Possible solutions: --version
```
After adding ScopeType._INHERIT_ to `--verbose` option.
```
bash-5.1$ ozone admin safemode status
SCM is out of safe mode.

bash-5.1$ ozone admin safemode status --verbose
SCM is out of safe mode.
validated:true, DataNodeSafeModeRule, registered datanodes (=1) >= required datanodes (=1)
validated:true, HealthyPipelineSafeModeRule, healthy Ratis/THREE pipelines (=0) >= healthyPipelineThresholdCount (=0)
validated:true, ContainerSafeModeRule, 100.00% of [Ratis] Containers(0 / 0) with at least one reported replica (=1.00) >= safeModeCutoff (=0.99);
100.00% of [EC] Containers(0 / 0) with at least N reported replica (=1.00) >= safeModeCutoff (=0.99);
validated:true, AtleastOneDatanodeReportedRule, reported Ratis/THREE pipelines with at least one datanode (=0) >= threshold (=0)

bash-5.1$ ozone admin safemode --verbose status          
SCM is out of safe mode.
validated:true, DataNodeSafeModeRule, registered datanodes (=1) >= required datanodes (=1)
validated:true, HealthyPipelineSafeModeRule, healthy Ratis/THREE pipelines (=0) >= healthyPipelineThresholdCount (=0)
validated:true, ContainerSafeModeRule, 100.00% of [Ratis] Containers(0 / 0) with at least one reported replica (=1.00) >= safeModeCutoff (=0.99);
100.00% of [EC] Containers(0 / 0) with at least N reported replica (=1.00) >= safeModeCutoff (=0.99);
validated:true, AtleastOneDatanodeReportedRule, reported Ratis/THREE pipelines with at least one datanode (=0) >= threshold (=0)
```
