### PR TITLE
HDDS-12670. Improve encapsulation of volume spare space check

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
@@ -616,10 +615,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         .orElse(Boolean.FALSE);
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
-      SpaceUsageSource usage = volume.getCurrentUsage();
-      long volumeFreeSpaceToSpare = volume.getFreeSpaceToSpare(usage.getCapacity());
-      return !VolumeUsage.hasVolumeEnoughSpace(usage.getAvailable(), volume.getCommittedBytes(), 0,
-          volumeFreeSpaceToSpare);
+      return !VolumeUsage.hasVolumeEnoughSpace(volume.getReport(), 0);
     }
     return false;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -615,7 +615,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         .orElse(Boolean.FALSE);
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
-      return VolumeUsage.getUsableSpace(volume.getReport()) > 0;
+      return VolumeUsage.getUsableSpace(volume.getReport()) <= 0;
     }
     return false;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -615,7 +615,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         .orElse(Boolean.FALSE);
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
-      return !VolumeUsage.hasVolumeEnoughSpace(volume.getReport(), 0);
+      return VolumeUsage.getUsableSpace(volume.getReport()) > 0;
     }
     return false;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -41,19 +41,16 @@ public final class StorageLocationReport implements
   private final StorageType storageType;
   private final String storageLocation;
 
-  @SuppressWarnings("checkstyle:parameternumber")
-  private StorageLocationReport(String id, boolean failed, long capacity,
-      long scmUsed, long remaining, long committed, long freeSpaceToSpare,
-      StorageType storageType, String storageLocation) {
-    this.id = id;
-    this.failed = failed;
-    this.capacity = capacity;
-    this.scmUsed = scmUsed;
-    this.remaining = remaining;
-    this.committed = committed;
-    this.freeSpaceToSpare = freeSpaceToSpare;
-    this.storageType = storageType;
-    this.storageLocation = storageLocation;
+  private StorageLocationReport(Builder builder) {
+    this.id = builder.id;
+    this.failed = builder.failed;
+    this.capacity = builder.capacity;
+    this.scmUsed = builder.scmUsed;
+    this.remaining = builder.remaining;
+    this.committed = builder.committed;
+    this.freeSpaceToSpare = builder.freeSpaceToSpare;
+    this.storageType = builder.storageType;
+    this.storageLocation = builder.storageLocation;
   }
 
   @Override
@@ -387,8 +384,7 @@ public final class StorageLocationReport implements
      * @return StorageLocationReport
      */
     public StorageLocationReport build() {
-      return new StorageLocationReport(id, failed, capacity, scmUsed,
-          remaining, committed, freeSpaceToSpare, storageType, storageLocation);
+      return new StorageLocationReport(this);
     }
 
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -301,6 +301,10 @@ public final class StorageLocationReport implements
       return this;
     }
 
+    public boolean isFailed() {
+      return failed;
+    }
+
     /**
      * Sets the capacity of volume.
      *
@@ -311,6 +315,11 @@ public final class StorageLocationReport implements
       this.capacity = capacityValue;
       return this;
     }
+
+    public long getCapacity() {
+      return capacity;
+    }
+
     /**
      * Sets the scmUsed Value.
      *

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container.common.impl;
 
 import java.io.IOException;
+import net.jcip.annotations.Immutable;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
@@ -28,8 +29,8 @@ import org.apache.hadoop.ozone.container.common.interfaces.StorageLocationReport
  * Storage location stats of datanodes that provide back store for containers.
  *
  */
-public final class StorageLocationReport implements
-    StorageLocationReportMXBean {
+@Immutable
+public final class StorageLocationReport implements StorageLocationReportMXBean {
 
   private final String id;
   private final boolean failed;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
@@ -40,12 +40,15 @@ public class AvailableSpaceFilter implements Predicate<HddsVolume> {
   @Override
   public boolean test(HddsVolume vol) {
     StorageLocationReport report = vol.getReport();
+    long free = report.getRemaining();
+    long committed = vol.getCommittedBytes();
+    long available = free - committed;
     boolean hasEnoughSpace = VolumeUsage.hasVolumeEnoughSpace(report, requiredSpace);
 
-    mostAvailableSpace = Math.max(report.getRemaining(), mostAvailableSpace);
+    mostAvailableSpace = Math.max(available, mostAvailableSpace);
 
     if (!hasEnoughSpace) {
-      fullVolumes.put(vol, new AvailableSpace(report.getRemaining(), report.getCommitted()));
+      fullVolumes.put(vol, new AvailableSpace(free, committed));
     }
 
     return hasEnoughSpace;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
+import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.utils.RawDB;
@@ -177,6 +178,16 @@ public class HddsVolume extends StorageVolume {
 
   public VolumeInfoMetrics getVolumeInfoStats() {
     return volumeInfoMetrics;
+  }
+
+  @Override
+  protected StorageLocationReport.Builder reportBuilder() {
+    StorageLocationReport.Builder builder = super.reportBuilder();
+    if (!builder.isFailed()) {
+      builder.setCommitted(getCommittedBytes())
+          .setFreeSpaceToSpare(getFreeSpaceToSpare(builder.getCapacity()));
+    }
+    return builder;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -21,20 +21,17 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
-import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
@@ -455,68 +452,15 @@ public class MutableVolumeSet implements VolumeSet {
   }
 
   public StorageLocationReport[] getStorageReport() {
-    boolean failed;
     this.readLock();
     try {
-      StorageLocationReport[] reports = new StorageLocationReport[volumeMap
-          .size() + failedVolumeMap.size()];
+      StorageLocationReport[] reports = new StorageLocationReport[volumeMap.size() + failedVolumeMap.size()];
       int counter = 0;
-      StorageVolume volume;
-      for (Map.Entry<String, StorageVolume> entry : volumeMap.entrySet()) {
-        volume = entry.getValue();
-        Optional<VolumeUsage> volumeUsage = volume.getVolumeUsage();
-        long scmUsed = 0;
-        long remaining = 0;
-        long capacity = 0;
-        long committed = 0;
-        long spare = 0;
-        String rootDir = volume.getVolumeRootDir();
-        failed = true;
-        if (volumeUsage.isPresent()) {
-          try {
-            SpaceUsageSource usage = volumeUsage.get().getCurrentUsage();
-            scmUsed = usage.getUsedSpace();
-            remaining = usage.getAvailable();
-            capacity = usage.getCapacity();
-            HddsVolume hddsVolume = volume instanceof HddsVolume ? (HddsVolume) volume : null;
-            committed = hddsVolume != null ? hddsVolume.getCommittedBytes() : 0;
-            spare = hddsVolume != null ? hddsVolume.getFreeSpaceToSpare(capacity) : 0;
-            failed = false;
-          } catch (UncheckedIOException ex) {
-            LOG.warn("Failed to get scmUsed and remaining for container " +
-                    "storage location {}", rootDir, ex);
-            // reset scmUsed and remaining if df/du failed.
-            scmUsed = 0;
-            remaining = 0;
-            capacity = 0;
-          }
-        }
-
-        StorageLocationReport.Builder builder =
-            StorageLocationReport.newBuilder();
-        builder.setStorageLocation(rootDir)
-            .setId(volume.getStorageID())
-            .setFailed(failed)
-            .setCapacity(capacity)
-            .setRemaining(remaining)
-            .setScmUsed(scmUsed)
-            .setCommitted(committed)
-            .setFreeSpaceToSpare(spare)
-            .setStorageType(volume.getStorageType());
-        StorageLocationReport r = builder.build();
-        reports[counter++] = r;
+      for (StorageVolume volume : volumeMap.values()) {
+        reports[counter++] = volume.getReport();
       }
-      for (Map.Entry<String, StorageVolume> entry
-          : failedVolumeMap.entrySet()) {
-        volume = entry.getValue();
-        StorageLocationReport.Builder builder = StorageLocationReport
-            .newBuilder();
-        builder.setStorageLocation(volume.getStorageDir()
-            .getAbsolutePath()).setId(volume.getStorageID()).setFailed(true)
-            .setCapacity(0).setRemaining(0).setScmUsed(0).setStorageType(
-            volume.getStorageType());
-        StorageLocationReport r = builder.build();
-        reports[counter++] = r;
+      for (StorageVolume volume : failedVolumeMap.values()) {
+        reports[counter++] = volume.getReport();
       }
       return reports;
     } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdfs.server.datanode.checker.Checkable;
 import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
+import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.DiskCheckUtil;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
@@ -452,6 +453,27 @@ public abstract class StorageVolume
   public SpaceUsageSource getCurrentUsage() {
     return volumeUsage.map(VolumeUsage::getCurrentUsage)
         .orElse(SpaceUsageSource.UNKNOWN);
+  }
+
+  protected StorageLocationReport.Builder reportBuilder() {
+    StorageLocationReport.Builder builder = StorageLocationReport.newBuilder()
+        .setFailed(isFailed())
+        .setId(getStorageID())
+        .setStorageLocation(volumeRoot)
+        .setStorageType(storageType);
+
+    if (!builder.isFailed()) {
+      SpaceUsageSource usage = getCurrentUsage();
+      builder.setCapacity(usage.getCapacity())
+          .setRemaining(usage.getAvailable())
+          .setScmUsed(usage.getUsedSpace());
+    }
+
+    return builder;
+  }
+
+  public StorageLocationReport getReport() {
+    return reportBuilder().build();
   }
 
   public File getStorageDir() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hdds.conf.StorageSize;
 import org.apache.hadoop.hdds.fs.CachingSpaceUsageSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckParams;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,6 +184,16 @@ public class VolumeUsage {
                                              long requiredSpace,
                                              long volumeFreeSpaceToSpare) {
     return (volumeAvailableSpace - volumeCommittedBytesCount - volumeFreeSpaceToSpare) > requiredSpace;
+  }
+
+  public static boolean hasVolumeEnoughSpace(StorageReportProto report, long requiredSpace) {
+    return hasVolumeEnoughSpace(report.getRemaining(), report.getCommitted(), requiredSpace,
+        report.getFreeSpaceToSpare());
+  }
+
+  public static boolean hasVolumeEnoughSpace(StorageLocationReport report, long requiredSpace) {
+    return hasVolumeEnoughSpace(report.getRemaining(), report.getCommitted(), requiredSpace,
+        report.getFreeSpaceToSpare());
   }
 
   private static long getReserved(ConfigurationSource conf, String rootDir,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -180,18 +180,18 @@ public class VolumeUsage {
   }
 
   private static boolean hasVolumeEnoughSpace(
-      long available, long committed, long required, long minFreeSpace) {
+      long required, long available, long committed, long minFreeSpace) {
     return (available - committed - minFreeSpace) > required;
   }
 
   public static boolean hasVolumeEnoughSpace(StorageReportProto report, long requiredSpace) {
-    return hasVolumeEnoughSpace(report.getRemaining(), report.getCommitted(), requiredSpace,
-        report.getFreeSpaceToSpare());
+    return hasVolumeEnoughSpace(requiredSpace,
+        report.getRemaining(), report.getCommitted(), report.getFreeSpaceToSpare());
   }
 
   public static boolean hasVolumeEnoughSpace(StorageLocationReport report, long requiredSpace) {
-    return hasVolumeEnoughSpace(report.getRemaining(), report.getCommitted(), requiredSpace,
-        report.getFreeSpaceToSpare());
+    return hasVolumeEnoughSpace(requiredSpace,
+        report.getRemaining(), report.getCommitted(), report.getFreeSpaceToSpare());
   }
 
   private static long getReserved(ConfigurationSource conf, String rootDir,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -179,11 +179,9 @@ public class VolumeUsage {
     return reservedInBytes;
   }
 
-  public static boolean hasVolumeEnoughSpace(long volumeAvailableSpace,
-                                             long volumeCommittedBytesCount,
-                                             long requiredSpace,
-                                             long volumeFreeSpaceToSpare) {
-    return (volumeAvailableSpace - volumeCommittedBytesCount - volumeFreeSpaceToSpare) > requiredSpace;
+  private static boolean hasVolumeEnoughSpace(
+      long available, long committed, long required, long minFreeSpace) {
+    return (available - committed - minFreeSpace) > required;
   }
 
   public static boolean hasVolumeEnoughSpace(StorageReportProto report, long requiredSpace) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -179,19 +179,17 @@ public class VolumeUsage {
     return reservedInBytes;
   }
 
-  private static boolean hasVolumeEnoughSpace(
-      long required, long available, long committed, long minFreeSpace) {
-    return (available - committed - minFreeSpace) > required;
+  private static long getUsableSpace(
+      long available, long committed, long minFreeSpace) {
+    return available - committed - minFreeSpace;
   }
 
-  public static boolean hasVolumeEnoughSpace(StorageReportProto report, long requiredSpace) {
-    return hasVolumeEnoughSpace(requiredSpace,
-        report.getRemaining(), report.getCommitted(), report.getFreeSpaceToSpare());
+  public static long getUsableSpace(StorageReportProto report) {
+    return getUsableSpace(report.getRemaining(), report.getCommitted(), report.getFreeSpaceToSpare());
   }
 
-  public static boolean hasVolumeEnoughSpace(StorageLocationReport report, long requiredSpace) {
-    return hasVolumeEnoughSpace(requiredSpace,
-        report.getRemaining(), report.getCommitted(), report.getFreeSpaceToSpare());
+  public static long getUsableSpace(StorageLocationReport report) {
+    return getUsableSpace(report.getRemaining(), report.getCommitted(), report.getFreeSpaceToSpare());
   }
 
   private static long getReserved(ConfigurationSource conf, String rootDir,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -309,7 +309,7 @@ public abstract class SCMCommonPlacementPolicy implements
 
     if (dataSizeRequired > 0) {
       for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
-        if (VolumeUsage.hasVolumeEnoughSpace(reportProto, dataSizeRequired)) {
+        if (VolumeUsage.getUsableSpace(reportProto) > dataSizeRequired) {
           enoughForData = true;
           break;
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -309,9 +309,7 @@ public abstract class SCMCommonPlacementPolicy implements
 
     if (dataSizeRequired > 0) {
       for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
-        if (VolumeUsage.hasVolumeEnoughSpace(reportProto.getRemaining(),
-              reportProto.getCommitted(), dataSizeRequired,
-              reportProto.getFreeSpaceToSpare())) {
+        if (VolumeUsage.hasVolumeEnoughSpace(reportProto, dataSizeRequired)) {
           enoughForData = true;
           break;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Let volumes create their own `StorageLocationReport`, with `HddsVolume` adding extra items specific to it.
- Let `hasVolumeEnoughSpace` decide based on a `StorageLocationReport`.
- Fix `parameternumber` warning in `StorageLocationReport`.

https://issues.apache.org/jira/browse/HDDS-12670

## How was this patch tested?

~https://github.com/adoroszlai/ozone/actions/runs/14082163097~
https://github.com/adoroszlai/ozone/actions/runs/14083416514