### PR TITLE
HDDS-12703. Close pipeline command should display error when closure fails

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -808,6 +808,7 @@ public class SCMClientProtocolServer implements
     } catch (Exception ex) {
       AUDIT.logWriteFailure(buildAuditMessageForFailure(
           SCMAction.CLOSE_PIPELINE, auditMap, ex));
+      throw ex;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
when closing a pipeline, if the user is not super-user, the command just runs without an exception. it writes the exception to audit but not to the client console.

Please describe your PR in detail:
Added a line to throw the exception in closePipeline method

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12703

## How was this patch tested?
I tested by running in my local intellij ozone setup.
```
svenkataramanasam@22187 ozone_cdp % sudo -u hive sh ozoneadmin.sh pipeline close 42a68542-30e9-4eda-9ba3-7b587182fd52 
Access denied for user hive. SCM superuser privilege is required.
```
