### PR TITLE
HDDS-12327. HDDS-12668. Fix HSync upgrade test failure in non-HA upgrade test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-config
@@ -38,7 +38,9 @@ OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
+OZONE-SITE.XML_ozone.client.hbase.enhancements.allowed=true
 OZONE-SITE.XML_ozone.fs.hsync.enabled=true
+OZONE-SITE.XML_ozone.hbase.enhancements.allowed=true
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12668 fixed upgrade test failure related to hsync feature, which was reproduced only in `ozone-2.0` branch.

HDDS-12327 restored non-HA upgrade test, but without the hsync fix.

So we need to apply HDDS-12668 to the `non-ha` cluster.  This fixes test failure in `ozone-2.0` branch: https://github.com/apache/ozone/actions/runs/14090453425/job/39466405013

https://issues.apache.org/jira/browse/HDDS-12327

## How was this patch tested?

Applied to `ozone-2.0` branch, and ran upgrade test locally.

```
Using docker cluster defined in /home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-2.0.0/compose/upgrade/compose/non-ha/docker-compose.yaml
Executing test /home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-2.0.0/compose/upgrade/upgrades/non-rolling-upgrade/./driver.sh
...
------------------------------------------------------------------------------
Generate key for o3fs by HSYNC prior to finalization                  | PASS |
------------------------------------------------------------------------------
Generate key for o3fs by HFLUSH prior to finalization                 | PASS |
------------------------------------------------------------------------------
Generate key for ofs by HSYNC prior to finalization                   | PASS |
------------------------------------------------------------------------------
Generate key for ofs by HFLUSH prior to finalization                  | PASS |
```

https://github.com/adoroszlai/ozone/actions/runs/14092354936/job/39472684061#step:13:213