### PR TITLE
HDDS-12705. Replace Whitebox with HddsWhiteboxTestUtils

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -77,6 +77,7 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.MultipartInputStream;
@@ -109,7 +110,6 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.test.Whitebox;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ozone.test.tag.Unhealthy;
@@ -237,7 +237,7 @@ class TestOzoneAtRestEncryption {
 
   private KMSClientProvider getKMSClientProvider() {
     LoadBalancingKMSClientProvider lbkmscp =
-        (LoadBalancingKMSClientProvider) Whitebox.getInternalState(
+        (LoadBalancingKMSClientProvider) HddsWhiteboxTestUtils.getInternalState(
             cluster.getOzoneManager().getKmsProvider(), "extension");
     assert lbkmscp.getProviders().length == 1;
     return lbkmscp.getProviders()[0];

--- a/pom.xml
+++ b/pom.xml
@@ -1623,6 +1623,7 @@
                       <bannedImport>org.apache.hadoop.test.GenericTestUtils</bannedImport>
                       <bannedImport>org.apache.hadoop.test.LambdaTestUtils</bannedImport>
                       <bannedImport>org.apache.hadoop.test.MetricsAssert</bannedImport>
+                      <bannedImport>org.apache.hadoop.test.Whitebox</bannedImport>
                       <bannedImport>org.apache.hadoop.classification.InterfaceAudience</bannedImport>
                       <bannedImport>org.apache.hadoop.classification.InterfaceStability</bannedImport>
                     </bannedImports>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-719 replaced classes from Hadoop, including `Whitebox`.  HDDS-12486 re-introduced usage of `Whitebox` in `TestOzoneAtRestEncryption`.

1. Replace `Whitebox` with `HddsWhiteboxTestUtils`
2. Ban `Whitebox`

https://issues.apache.org/jira/browse/HDDS-12705

## How was this patch tested?

CI (pending):
https://github.com/adoroszlai/ozone/actions/runs/14093616797