### PR TITLE
HDDS-12484. Allow ini files to configure ColumnFamilyOptions for rocksDB

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -125,6 +125,9 @@ public final class HddsConfigKeys {
   // metadata locations must be configured explicitly.
   public static final String OZONE_METADATA_DIRS = "ozone.metadata.dirs";
 
+  public static final String ROCKS_DB_CONFIG_PATH = "rocks.db.config.path";
+  public static final String ROCKS_DB_CONFIG_PATH_DEFAULT = "";
+
   public static final String HDDS_PROMETHEUS_ENABLED =
       "hdds.prometheus.endpoint.enabled";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2681,6 +2681,14 @@
     </description>
   </property>
   <property>
+    <name>rocks.db.config.path</name>
+    <value/>
+    <tag>OZONE, OM</tag>
+    <description>
+      Path to an ini configuration file for RocksDB.
+    </description>
+  </property>
+  <property>
     <name>hdds.priv.key.file.name</name>
     <value>private.pem</value>
     <tag>X509, SECURITY</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hdds.utils.db.DBStoreBuilder.HDDS_DEFAULT_DB_PRO
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.nio.file.Paths;
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
@@ -60,7 +62,8 @@ public abstract class AbstractRDBStore<DEF extends DBDefinition> implements DBSt
   public void start(ConfigurationSource config)
       throws IOException {
     if (this.store == null) {
-      ManagedDBOptions options = dbProfile.getDBOptions();
+      String dbPath = config.get(HddsConfigKeys.ROCKS_DB_CONFIG_PATH, HddsConfigKeys.ROCKS_DB_CONFIG_PATH_DEFAULT);
+      ManagedDBOptions options = dbProfile.getDBOptions(Paths.get(dbPath));
       options.setCreateIfMissing(true);
       options.setCreateMissingColumnFamilies(true);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
+import static org.apache.hadoop.hdds.utils.db.DBStoreBuilder.DEFAULT_COLUMN_FAMILY_NAME;
 import static org.apache.hadoop.hdds.utils.db.DBStoreBuilder.HDDS_DEFAULT_DB_PROFILE;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -52,7 +54,9 @@ public abstract class AbstractRDBStore<DEF extends DBDefinition> implements DBSt
     // The same config instance is used on each datanode, so we can share the
     // corresponding column family options, providing a single shared cache
     // for all containers on a datanode.
-    cfOptions = dbProfile.getColumnFamilyOptions(config);
+    Path pathToDb = Paths.get(
+        config.get(HddsConfigKeys.ROCKS_DB_CONFIG_PATH, HddsConfigKeys.ROCKS_DB_CONFIG_PATH_DEFAULT));
+    cfOptions = dbProfile.getColumnFamilyOptions(config, pathToDb, DEFAULT_COLUMN_FAMILY_NAME);
     this.dbDef = dbDef;
     this.openReadOnly = openReadOnly;
     start(config);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -704,10 +704,11 @@ public class TestKeyValueContainer {
     for (Supplier<DatanodeDBProfile> dbProfileSupplier : new Supplier[] {
         DatanodeDBProfile.Disk::new, DatanodeDBProfile.SSD::new }) {
       // ColumnFamilyOptions should be same across configurations
+      OzoneConfiguration config = new OzoneConfiguration();
       ColumnFamilyOptions columnFamilyOptions1 = dbProfileSupplier.get()
-          .getColumnFamilyOptions(new OzoneConfiguration());
+          .getColumnFamilyOptions(config);
       ColumnFamilyOptions columnFamilyOptions2 = dbProfileSupplier.get()
-          .getColumnFamilyOptions(new OzoneConfiguration());
+          .getColumnFamilyOptions(config);
       assertEquals(columnFamilyOptions1, columnFamilyOptions2);
 
       // ColumnFamilyOptions should be same when queried multiple times
@@ -768,12 +769,12 @@ public class TestKeyValueContainer {
     // DBOtions should be different, except SCHEMA-V3
     if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       assertEquals(
-          outProfile1.getDBOptions().compactionReadaheadSize(),
-          outProfile2.getDBOptions().compactionReadaheadSize());
+          outProfile1.getDBOptions(null).compactionReadaheadSize(),
+          outProfile2.getDBOptions(null).compactionReadaheadSize());
     } else {
       assertNotEquals(
-          outProfile1.getDBOptions().compactionReadaheadSize(),
-          outProfile2.getDBOptions().compactionReadaheadSize());
+          outProfile1.getDBOptions(null).compactionReadaheadSize(),
+          outProfile2.getDBOptions(null).compactionReadaheadSize());
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedBloomFilter;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedLRUCache;
-import org.eclipse.jetty.util.StringUtil;
-import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.CompactionStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,6 +94,8 @@ public enum DBProfile {
 
       if (option != null) {
         LOG.info("Using RocksDB CFOptions from {}.ini file", dbPath);
+        // TODO HDDS-12695: RocksDB 7.x doesn't read TableConfigs from files, remove this setting once upgraded
+        option.setTableFormatConfig(createDefaultBlockBasedTableConfig());
         return option;
       }
 
@@ -110,6 +110,9 @@ public enum DBProfile {
 
     @Override
     public ManagedBlockBasedTableConfig getBlockBasedTableConfig(Path dbPath, String cfName) {
+      // TODO HDDS-12695: RocksDB 7.x doesn't read TableConfigs from files,
+      //  so this can be commented out once upgrade happens.
+      /*
       ManagedBlockBasedTableConfig option = new ManagedBlockBasedTableConfig();
       if (dbPath != null && dbPath.toFile().exists() && StringUtil.isNotBlank(cfName)) {
         try {
@@ -123,7 +126,7 @@ public enum DBProfile {
           option.close();
           LOG.error("Unable to read RocksDB BlockBasedTableConfig from {}, exception {}", dbPath, ex);
         }
-      }
+      }*/
       return createDefaultBlockBasedTableConfig();
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -115,7 +115,7 @@ public final class RocksDatabase implements Closeable {
         .stream()
         .map(TableConfig::toName)
         .filter(familyName -> !existingFamilyNames.contains(familyName))
-        .map(TableConfig::newTableConfig)
+        .map(familyName -> TableConfig.newTableConfig(file.toPath(), familyName))
         .collect(Collectors.toList());
     if (LOG.isDebugEnabled()) {
       LOG.debug("Found column families in DB {}: {}", file, columnFamilies);
@@ -139,8 +139,8 @@ public final class RocksDatabase implements Closeable {
   }
 
   static RocksDatabase open(File dbFile, ManagedDBOptions dbOptions,
-        ManagedWriteOptions writeOptions, Set<TableConfig> families,
-        boolean readOnly) throws IOException {
+                            ManagedWriteOptions writeOptions, Set<TableConfig> families,
+                            boolean readOnly) throws IOException {
     List<ColumnFamilyDescriptor> descriptors = null;
     ManagedRocksDB db = null;
     final Map<String, ColumnFamily> columnFamilies = new HashMap<>();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TableConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TableConfig.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
+import java.nio.file.Path;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.hdds.StringUtils;
@@ -27,9 +28,8 @@ import org.rocksdb.ColumnFamilyDescriptor;
  * Class that maintains Table Configuration.
  */
 public class TableConfig implements AutoCloseable {
-  static TableConfig newTableConfig(String name) {
-    return new TableConfig(name,
-        DBStoreBuilder.HDDS_DEFAULT_DB_PROFILE.getColumnFamilyOptions());
+  static TableConfig newTableConfig(Path dbPath, String cfName) {
+    return new TableConfig(cfName, DBStoreBuilder.HDDS_DEFAULT_DB_PROFILE.getColumnFamilyOptions(dbPath, cfName));
   }
 
   private final String name;
@@ -41,11 +41,11 @@ public class TableConfig implements AutoCloseable {
 
   /**
    * Constructs a Table Config.
-   * @param name - Name of the Table.
+   *
+   * @param name                - Name of the Table.
    * @param columnFamilyOptions - Column Family options.
    */
-  public TableConfig(String name,
-                     ManagedColumnFamilyOptions columnFamilyOptions) {
+  public TableConfig(String name, ManagedColumnFamilyOptions columnFamilyOptions) {
     this.name = name;
     this.columnFamilyOptions = columnFamilyOptions;
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBConfigFromFile.java
@@ -32,12 +32,14 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 
@@ -77,8 +79,7 @@ public class TestDBConfigFromFile {
               new ColumnFamilyOptions()));
     }
 
-    final DBOptions options = DBConfigFromFile.readFromFile(DB_FILE,
-        columnFamilyDescriptors);
+    final DBOptions options = DBConfigFromFile.readDBOptionsFromFile(Paths.get(DB_FILE));
 
     // Some Random Values Defined in the test.db.ini, we verify that we are
     // able to get values that are defined in the test.db.ini.
@@ -103,10 +104,23 @@ public class TestDBConfigFromFile {
               new ColumnFamilyOptions()));
     }
 
-    final DBOptions options = DBConfigFromFile.readFromFile("badfile.db.ini",
-        columnFamilyDescriptors);
+    final DBOptions options = DBConfigFromFile.readDBOptionsFromFile(Paths.get("badfile.db.ini")
+    );
 
     // This has to return a Null, since we have config defined for badfile.db
     assertNull(options);
+  }
+
+  @Test
+  public void readColumnFamilyOptionsFromFile() throws IOException {
+    ManagedColumnFamilyOptions managedColumnFamily = DBConfigFromFile.readCFOptionsFromFile(
+        Paths.get(DB_FILE), "default");
+    assertNotNull(managedColumnFamily);
+    assertEquals(134217728, managedColumnFamily.writeBufferSize());
+    assertEquals(6, managedColumnFamily.numLevels());
+    assertEquals(268435456, managedColumnFamily.blobFileSize());
+    assertEquals("SkipListFactory", managedColumnFamily.memTableFactoryName());
+    assertEquals(CompactionStyle.LEVEL, managedColumnFamily.compactionStyle());
+    assertEquals(16777216, managedColumnFamily.arenaBlockSize());
   }
 }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedBlockBasedTableConfig.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedBlockBasedTableConfig.java
@@ -31,7 +31,7 @@ public class ManagedBlockBasedTableConfig extends BlockBasedTableConfig {
   public synchronized ManagedBlockBasedTableConfig closeAndSetBlockCache(
       Cache blockCache) {
     Cache previous = blockCacheHolder;
-    if (previous.isOwningHandle()) {
+    if (previous != null && previous.isOwningHandle()) {
       previous.close();
     }
     return setBlockCache(blockCache);
@@ -68,5 +68,38 @@ public class ManagedBlockBasedTableConfig extends BlockBasedTableConfig {
         blockCacheHolder.close();
       }
     }
+  }
+
+  public synchronized ManagedBlockBasedTableConfig setAllProperties(
+      BlockBasedTableConfig config) {
+    this.setBlockSize(config.blockSize());
+    this.setBlockSizeDeviation(config.blockSizeDeviation());
+    this.setBlockRestartInterval(config.blockRestartInterval());
+    this.setChecksumType(config.checksumType());
+    this.setFilterPolicy(config.filterPolicy());
+    this.setIndexType(config.indexType());
+    this.setNoBlockCache(config.noBlockCache());
+    this.setBlockCacheSize(config.blockCacheSize());
+    this.setCacheNumShardBits(config.cacheNumShardBits());
+    this.setEnableIndexCompression(config.enableIndexCompression());
+    this.setWholeKeyFiltering(config.wholeKeyFiltering());
+    this.setFormatVersion(config.formatVersion());
+    this.setBlockAlign(config.blockAlign());
+    this.setCacheIndexAndFilterBlocks(config.cacheIndexAndFilterBlocks());
+    this.setCacheIndexAndFilterBlocksWithHighPriority(config.cacheIndexAndFilterBlocksWithHighPriority());
+    this.setDataBlockHashTableUtilRatio(config.dataBlockHashTableUtilRatio());
+    this.setDataBlockIndexType(config.dataBlockIndexType());
+    this.setHashIndexAllowCollision(config.hashIndexAllowCollision());
+    this.setIndexBlockRestartInterval(config.indexBlockRestartInterval());
+    this.setIndexShortening(config.indexShortening());
+    this.setMetadataBlockSize(config.metadataBlockSize());
+    this.setOptimizeFiltersForMemory(config.optimizeFiltersForMemory());
+    this.setPartitionFilters(config.partitionFilters());
+    this.setPinL0FilterAndIndexBlocksInCache(config.pinL0FilterAndIndexBlocksInCache());
+    this.setPinTopLevelIndexAndFilter(config.pinTopLevelIndexAndFilter());
+    this.setReadAmpBytesPerBit(config.readAmpBytesPerBit());
+    this.setUseDeltaEncoding(config.useDeltaEncoding());
+    this.setVerifyCompression(config.verifyCompression());
+    return this;
   }
 }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedColumnFamilyOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedColumnFamilyOptions.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.utils.db.managed;
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.track;
 
 import org.apache.ratis.util.UncheckedAutoCloseable;
+import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.TableFormatConfig;
 
@@ -49,7 +50,9 @@ public class ManagedColumnFamilyOptions extends ColumnFamilyOptions {
       if (!((ManagedBlockBasedTableConfig) previous).isClosed()) {
         throw new IllegalStateException("Overriding an unclosed value.");
       }
-    } else if (previous != null) {
+    } else if (!(previous instanceof BlockBasedTableConfig) && previous != null) {
+      //Note that the type of tableFormatConfig read directly from
+      //the ini file is org.rocksdb.BlockBasedTableConfig
       throw new UnsupportedOperationException("Overwrite is not supported for "
           + previous.getClass());
     }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedConfigOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedConfigOptions.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db.managed;
+
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.track;
+
+import org.apache.ratis.util.UncheckedAutoCloseable;
+import org.rocksdb.ConfigOptions;
+
+/**
+ * Managed ConfigOptions.
+ */
+public class ManagedConfigOptions extends ConfigOptions {
+  private final UncheckedAutoCloseable leakTracker = track(this);
+
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      leakTracker.close();
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1558,6 +1558,7 @@
                       <allowedImport>org.rocksdb.TransactionLogIterator.BatchResult</allowedImport>
                       <allowedImport>org.rocksdb.TickerType</allowedImport>
                       <allowedImport>org.rocksdb.LiveFileMetaData</allowedImport>
+                      <allowedImport>org.rocksdb.BlockBasedTableConfig</allowedImport>
                       <!-- Allow RocksObjects whose native pointer is managed by RocksDB. -->
                       <allowedImport>org.rocksdb.ColumnFamilyHandle</allowedImport>
                       <allowedImport>org.rocksdb.Env</allowedImport>


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/HDDS-12484
Ozone only had a way to change DBOptions from a ini configuration file before, now it's possible to also specify ColumnFamilyOptions.


This PR gives the option to fully customize all RocksDB options. It also enables the user to specify a path from which the configuration file will be read and used.

There are a few known issues regarding this: 7.x versions of RocksDB have a bug where TableFormatConfigs are not read from a file. This is fixed in later versions, but upgrading Ozone to a newer version requires a bigger effort, see here: https://issues.apache.org/jira/browse/HDDS-12392 . For handling this the Ozone default configs are set, and I've created the following Jira to change these places once 9.x versions of RocksDB are used: https://issues.apache.org/jira/browse/HDDS-12695

Due to RocksDB calls invoking native libraries the resource management has to be carefully observed and some unusual behaviour is created in java. Mainly freeing up resources in a catch block.


Snapshots shouldn't be affected as they should remain unchanged even if the user changes cf settings.

## How was this patch tested?

Manually firing up a cluster through docker and checking if the cfoptions really did change, and added unit tests.