### PR TITLE
HDDS-12696. Replace link to Hadoop with Ozone in httpfs site.xml

### DIFF
--- a/hadoop-ozone/httpfsgateway/src/site/site.xml
+++ b/hadoop-ozone/httpfsgateway/src/site/site.xml
@@ -22,7 +22,7 @@
 
     <body>
       <links>
-        <item name="Apache Hadoop" href="http://hadoop.apache.org/"/>
+        <item name="Apache Ozone" href="https://ozone.apache.org/"/>
       </links>
     </body>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone httpfs `site.xml` refers to Apache Hadoop. We should rename it to Apache Ozone.

## What is the link to the Apache JIRA
[HDDS-12696](https://issues.apache.org/jira/browse/HDDS-12696)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14106171268
