### PR TITLE
HDDS-12709. Intermittent failure in Balancer acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-compose.yaml
@@ -188,36 +188,36 @@ volumes:
    tmpfs1:
       driver: local
       driver_opts:
-         o: "size=1g,uid=1000"
+         o: "size=2g,uid=1000"
          device: tmpfs
          type: tmpfs
    tmpfs2:
       driver: local
       driver_opts:
-         o: "size=1g,uid=2000"
+         o: "size=2g,uid=2000"
          device: tmpfs
          type: tmpfs
    tmpfs3:
       driver: local
       driver_opts:
-         o: "size=1g,uid=3000"
+         o: "size=2g,uid=3000"
          device: tmpfs
          type: tmpfs
    tmpfs4:
       driver: local
       driver_opts:
-         o: "size=1g,uid=4000"
+         o: "size=2g,uid=4000"
          device: tmpfs
          type: tmpfs
    tmpfs5:
       driver: local
       driver_opts:
-         o: "size=1g,uid=5000"
+         o: "size=2g,uid=5000"
          device: tmpfs
          type: tmpfs
    tmpfs6:
       driver: local
       driver_opts:
-         o: "size=1g,uid=6000"
+         o: "size=2g,uid=6000"
          device: tmpfs
          type: tmpfs


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in balancer robot test by providing more space for datanodes.

Concurrent import of several containers fails, because we reserve 200MB per container (2x default size of 100MB), and datanode only has 1GB:

```
2025-03-28 10:20:58,460 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-1] INFO replication.SendContainerRequestHandler: Accepting container 5
2025-03-28 10:20:58,807 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-2] INFO replication.SendContainerRequestHandler: Container 5 is downloaded with size 20997632, starting to import.
2025-03-28 10:20:59,104 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-2] INFO replication.SendContainerRequestHandler: Container 5 is replicated successfully
2025-03-28 10:21:12,207 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-4] INFO replication.SendContainerRequestHandler: Accepting container 2
2025-03-28 10:21:12,369 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-8] INFO replication.SendContainerRequestHandler: Accepting container 3
2025-03-28 10:21:12,410 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-1] INFO replication.SendContainerRequestHandler: Accepting container 4
2025-03-28 10:21:12,690 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-4] INFO replication.SendContainerRequestHandler: Container 2 is downloaded with size 29426176, starting to import.
2025-03-28 10:21:12,756 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-7] INFO volume.CapacityVolumeChoosingPolicy: No volumes have enough space for a new container.  Most available space: 154062848 bytes; required space: 209715200, volumes: [{ dir=/data/hdds/hdds type=DISK id=DS-e9e757ec-e4a9-42dc-833e-6cf2f2dfb4cb capacity=1073634449 used=20979712 available=888066048 minFree=104857600 committed=629145600 }]
2025-03-28 10:21:12,759 [459ba096-e723-49c4-8f09-d0b16f4c2651-ReplicationContainerReader-7] WARN replication.SendContainerRequestHandler: Error receiving container 1 at 0
org.apache.hadoop.util.DiskChecker$DiskOutOfSpaceException: No volumes have enough space for a new container.  Most available space: 154062848 bytes
	at org.apache.hadoop.ozone.container.common.volume.VolumeChoosingUtil.throwDiskOutOfSpace(VolumeChoosingUtil.java:38)
	at org.apache.hadoop.ozone.container.common.volume.CapacityVolumeChoosingPolicy.chooseVolume(CapacityVolumeChoosingPolicy.java:66)
	at org.apache.hadoop.ozone.container.replication.ContainerImporter.chooseNextVolume(ContainerImporter.java:153)
	at org.apache.hadoop.ozone.container.replication.SendContainerRequestHandler.onNext(SendContainerRequestHandler.java:89)
```

https://issues.apache.org/jira/browse/HDDS-12709

## How was this patch tested?

Repeated runs (but also passed on `master`...):
https://github.com/adoroszlai/ozone/actions/runs/14116094845

CI:
https://github.com/adoroszlai/ozone/actions/runs/14116362818