### PR TITLE
HDDS-12724. hdds-rocks-native build fails if JAVA_HOME not set

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -302,6 +302,25 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <compilerArgs>
+                    <arg>-h</arg>
+                    <arg>${project.build.directory}/native/javah</arg>
+                  </compilerArgs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <configuration>
               <includes>
@@ -320,94 +339,6 @@
               <groups>native</groups>
               <argLine>${maven-surefire-plugin.argLine} @{argLine} -Djava.library.path=${project.build.directory}/native/rocksdb</argLine>
             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>java-8</id>
-      <activation>
-        <jdk>1.8</jdk>
-        <property>
-          <name>rocks_tools_native</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>javah</goal>
-                </goals>
-                <phase>compile</phase>
-                <configuration>
-                  <javahPath>${env.JAVA_HOME}/bin/javah</javahPath>
-                  <javahClassNames>
-                    <javahClassName>org.apache.hadoop.hdds.utils.db.managed.ManagedRawSSTFileReader</javahClassName>
-                    <javahClassName>org.apache.hadoop.hdds.utils.db.managed.ManagedRawSSTFileIterator</javahClassName>
-                  </javahClassNames>
-                  <javahOutputDirectory>${project.build.directory}/native/javah</javahOutputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>java-11</id>
-      <activation>
-        <jdk>[11,]</jdk>
-        <property>
-          <name>rocks_tools_native</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-dependencies</id>
-                <goals>
-                  <goal>copy-dependencies</goal>
-                </goals>
-                <phase>process-sources</phase>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/dependency</outputDirectory>
-                  <includeScope>runtime</includeScope>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>javach</id>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <phase>compile</phase>
-                <configuration>
-                  <executable>${env.JAVA_HOME}/bin/javac</executable>
-                  <arguments>
-                    <argument>-cp</argument>
-                    <argument>${project.build.outputDirectory}:${project.build.directory}/dependency/*</argument>
-                    <argument>-h</argument>
-                    <argument>${project.build.directory}/native/javah</argument>
-                    <argument>${project.basedir}/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRawSSTFileReader.java</argument>
-                    <argument>${project.basedir}/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRawSSTFileIterator.java</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,6 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <metainf-services.version>1.11</metainf-services.version>
     <mockito.version>4.11.0</mockito.version>
-    <native-maven-plugin.version>1.0-M1</native-maven-plugin.version>
     <native.lib.tmp.dir />
     <!-- Use netty version known to work with grpc-netty. See table: -->
     <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
@@ -1458,11 +1457,6 @@
             <xmlOutput>true</xmlOutput>
             <includeTests>true</includeTests>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>native-maven-plugin</artifactId>
-          <version>${native-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build error that happens in `hdds-rocks-native` if `JAVA_HOME` is not set.

```
Failed to execute goal org.codehaus.mojo:native-maven-plugin:1.0-M1:javah (default) on project hdds-rocks-native: Error running javah command
...
Caused by: IOException: Cannot run program "${env.JAVA_HOME}/bin/javah" (in directory "hadoop-hdds/rocks-native"): error=2, No such file or directory
```

Also, fix the root cause of HDDS-10118 and HDDS-11054:

```
Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.0.2:copy-dependencies (copy-jars) on project hdds-rocks-native: Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187.
```

(HDDS-10118 was repurposed for another bug, HDDS-11054 only provided a workaround for the original bug.)

Both of these issues are fixed by using `maven-compiler-plugin` instead of `maven-dependency-plugin:copy-dependencies` and `exec-maven-plugin` (for Java 11+) or `native-maven-plugin` (for Java 8).

https://issues.apache.org/jira/browse/HDDS-12724

## How was this patch tested?

```
$ unset JAVA_HOME
```

Tested with Java 8:

```
$ export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:$PATH

$ mvn -V -am -pl :hdds-rocks-native -Drocks_tools_native -Dtest='TestManagedRawSSTFileIterator,TestNativeLibraryLoader' clean test
...
Java version: 1.8.0_442, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
...
[INFO]      [exec] [100%] Built target ozone_rocksdb_tools
...
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.694 s -- in org.apache.hadoop.hdds.utils.TestNativeLibraryLoader
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.644 s -- in org.apache.hadoop.hdds.utils.db.managed.TestManagedRawSSTFileIterator
...
[INFO] BUILD SUCCESS
```

Java 11:

```
$ export PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH

$ mvn -V -am -pl :hdds-rocks-native -Drocks_tools_native -Dtest='TestManagedRawSSTFileIterator,TestNativeLibraryLoader' clean test
...
Java version: 11.0.26, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
...
[INFO]      [exec] [100%] Built target ozone_rocksdb_tools
...
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.711 s -- in org.apache.hadoop.hdds.utils.TestNativeLibraryLoader
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.556 s -- in org.apache.hadoop.hdds.utils.db.managed.TestManagedRawSSTFileIterator
...
[INFO] BUILD SUCCESS
```

Java 17:

```
$ export PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH

$ mvn -V -am -pl :hdds-rocks-native -Drocks_tools_native -Dtest='TestManagedRawSSTFileIterator,TestNativeLibraryLoader' clean test
...
Java version: 17.0.14, vendor: Ubuntu, runtime: /usr/lib/jvm/java-17-openjdk-amd64
...
[INFO]      [exec] [100%] Built target ozone_rocksdb_tools
...
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.664 s -- in org.apache.hadoop.hdds.utils.TestNativeLibraryLoader
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.518 s -- in org.apache.hadoop.hdds.utils.db.managed.TestManagedRawSSTFileIterator
...
[INFO] BUILD SUCCESS
```

Java 21:

```
$ export PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH

$ mvn -V -am -pl :hdds-rocks-native -Drocks_tools_native -Dtest='TestManagedRawSSTFileIterator,TestNativeLibraryLoader' clean test
...
Java version: 21.0.6, vendor: Ubuntu, runtime: /usr/lib/jvm/java-21-openjdk-amd64
...
[INFO]      [exec] [100%] Built target ozone_rocksdb_tools
...
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.644 s -- in org.apache.hadoop.hdds.utils.TestNativeLibraryLoader
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.444 s -- in org.apache.hadoop.hdds.utils.db.managed.TestManagedRawSSTFileIterator
...
[INFO] BUILD SUCCESS
```

_native_ check:
https://github.com/adoroszlai/ozone/actions/runs/14132096809/job/39595380304