### PR TITLE
HDDS-12711. Change log level to debug to print excluded SST Files during bootstrap

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -195,7 +195,9 @@ public class DBCheckpointServlet extends HttpServlet
               .filter(s -> s.endsWith(ROCKSDB_SST_SUFFIX))
               .distinct()
               .collect(Collectors.toList()));
-      LOG.info("Received excluding SST {}", receivedSstList);
+      if (sstParam.length % 10 == 0) {
+        LOG.debug("Received excluding SST {}", receivedSstList);
+      }
     }
 
     Path tmpdir = null;
@@ -229,9 +231,10 @@ public class DBCheckpointServlet extends HttpServlet
       long duration = Duration.between(start, end).toMillis();
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: {} milliseconds", duration);
-
-      LOG.info("Excluded SST {} from the latest checkpoint.",
-          excludedSstList);
+      if (excludedSstList.size() % 10 == 0) {
+        LOG.debug("Excluded SST {} from the latest checkpoint.",
+            excludedSstList);
+      }
       if (!excludedSstList.isEmpty()) {
         dbMetrics.incNumIncrementalCheckpoint();
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -130,8 +130,7 @@ public class DBCheckpointServlet extends HttpServlet
     }
   }
 
-  private static void logSstFileList(List<String>sstList, int sampleSize) {
-    String msg = "Received list of {} SST files to be excluded{}: {}";
+  private static void logSstFileList(List<String>sstList, String msg, int sampleSize) {
     int count = sstList.size();
     if (LOG.isDebugEnabled()) {
       LOG.debug(msg, count, "", sstList);
@@ -151,6 +150,7 @@ public class DBCheckpointServlet extends HttpServlet
    */
   private void generateSnapshotCheckpoint(HttpServletRequest request,
       HttpServletResponse response, boolean isFormData) {
+    String msg = "Received list of {} SST files to be excluded{}: {}";
     if (dbStore == null) {
       LOG.error(
           "Unable to process metadata snapshot request. DB Store is null");
@@ -208,7 +208,7 @@ public class DBCheckpointServlet extends HttpServlet
               .filter(s -> s.endsWith(ROCKSDB_SST_SUFFIX))
               .distinct()
               .collect(Collectors.toList()));
-      logSstFileList(receivedSstList, 5);
+      logSstFileList(receivedSstList, msg, 5);
     }
 
     Path tmpdir = null;
@@ -242,7 +242,7 @@ public class DBCheckpointServlet extends HttpServlet
       long duration = Duration.between(start, end).toMillis();
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: {} milliseconds", duration);
-      logSstFileList(excludedSstList, 5);
+      logSstFileList(excludedSstList, msg, 5);
       if (!excludedSstList.isEmpty()) {
         dbMetrics.incNumIncrementalCheckpoint();
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -195,9 +195,10 @@ public class DBCheckpointServlet extends HttpServlet
               .filter(s -> s.endsWith(ROCKSDB_SST_SUFFIX))
               .distinct()
               .collect(Collectors.toList()));
+      LOG.info("Received excluding SST {}. The total excluded sst files count is {}",
+          receivedSstList.subList(0, Math.min(5, receivedSstList.size())), receivedSstList.size());
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Received excluding SST {}. The total excluded sst files count is {}",
-            receivedSstList.subList(0, Math.min(5, receivedSstList.size())), receivedSstList.size());
+        LOG.debug("Received excluding SST {}", receivedSstList);
       }
     }
 
@@ -232,9 +233,10 @@ public class DBCheckpointServlet extends HttpServlet
       long duration = Duration.between(start, end).toMillis();
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: {} milliseconds", duration);
+      LOG.info("Excluded SST {} from the latest checkpoint. The total excluded sst files count is {}",
+          excludedSstList.subList(0, Math.min(5, excludedSstList.size())), excludedSstList.size());
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Excluded SST {} from the latest checkpoint. The total excluded sst files count is {}",
-            excludedSstList.subList(0, Math.min(5, excludedSstList.size())), excludedSstList.size());
+        LOG.debug("Excluded SST {} from the latest checkpoint.", excludedSstList);
       }
       if (!excludedSstList.isEmpty()) {
         dbMetrics.incNumIncrementalCheckpoint();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -130,6 +130,10 @@ public class DBCheckpointServlet extends HttpServlet
     }
   }
 
+  private static List<String> extractSubList(List<String>input, int index) {
+    return input.subList(0, Math.min(index, input.size()));
+  }
+
   /**
    * Generates Snapshot checkpoint as tar ball.
    * @param request the HTTP servlet request
@@ -195,11 +199,8 @@ public class DBCheckpointServlet extends HttpServlet
               .filter(s -> s.endsWith(ROCKSDB_SST_SUFFIX))
               .distinct()
               .collect(Collectors.toList()));
-      LOG.info("Received excluding SST {}. The total excluded sst files count is {}",
-          receivedSstList.subList(0, Math.min(5, receivedSstList.size())), receivedSstList.size());
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Received excluding SST {}", receivedSstList);
-      }
+      LOG.info("Received list of {} SST files to be excluded, sample: {}",
+          receivedSstList.size(), extractSubList(receivedSstList, 5));
     }
 
     Path tmpdir = null;
@@ -234,10 +235,7 @@ public class DBCheckpointServlet extends HttpServlet
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: {} milliseconds", duration);
       LOG.info("Excluded SST {} from the latest checkpoint. The total excluded sst files count is {}",
-          excludedSstList.subList(0, Math.min(5, excludedSstList.size())), excludedSstList.size());
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Excluded SST {} from the latest checkpoint.", excludedSstList);
-      }
+          extractSubList(excludedSstList, 5), excludedSstList.size());
       if (!excludedSstList.isEmpty()) {
         dbMetrics.incNumIncrementalCheckpoint();
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -150,7 +150,6 @@ public class DBCheckpointServlet extends HttpServlet
    */
   private void generateSnapshotCheckpoint(HttpServletRequest request,
       HttpServletResponse response, boolean isFormData) {
-    String msg = "Received list of {} SST files to be excluded{}: {}";
     if (dbStore == null) {
       LOG.error(
           "Unable to process metadata snapshot request. DB Store is null");
@@ -208,7 +207,8 @@ public class DBCheckpointServlet extends HttpServlet
               .filter(s -> s.endsWith(ROCKSDB_SST_SUFFIX))
               .distinct()
               .collect(Collectors.toList()));
-      logSstFileList(receivedSstList, msg, 5);
+      logSstFileList(receivedSstList,
+          "Received list of {} SST files to be excluded{}: {}", 5);
     }
 
     Path tmpdir = null;
@@ -242,7 +242,8 @@ public class DBCheckpointServlet extends HttpServlet
       long duration = Duration.between(start, end).toMillis();
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: {} milliseconds", duration);
-      logSstFileList(excludedSstList, msg, 5);
+      logSstFileList(excludedSstList,
+          "Excluded {} SST files from the latest checkpoint{}: {}", 5);
       if (!excludedSstList.isEmpty()) {
         dbMetrics.incNumIncrementalCheckpoint();
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -196,8 +196,8 @@ public class DBCheckpointServlet extends HttpServlet
               .distinct()
               .collect(Collectors.toList()));
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Received excluding SST {}. The total excluded sst files count is {}"
-            , receivedSstList.subList(0, Math.min(5, receivedSstList.size())), receivedSstList.size());
+        LOG.debug("Received excluding SST {}. The total excluded sst files count is {}",
+            receivedSstList.subList(0, Math.min(5, receivedSstList.size())), receivedSstList.size());
       }
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -195,8 +195,9 @@ public class DBCheckpointServlet extends HttpServlet
               .filter(s -> s.endsWith(ROCKSDB_SST_SUFFIX))
               .distinct()
               .collect(Collectors.toList()));
-      if (sstParam.length % 10 == 0) {
-        LOG.debug("Received excluding SST {}", receivedSstList);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Received excluding SST {}. The total excluded sst files count is {}"
+            , receivedSstList.subList(0, Math.min(5, receivedSstList.size())), receivedSstList.size());
       }
     }
 
@@ -231,9 +232,9 @@ public class DBCheckpointServlet extends HttpServlet
       long duration = Duration.between(start, end).toMillis();
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: {} milliseconds", duration);
-      if (excludedSstList.size() % 10 == 0) {
-        LOG.debug("Excluded SST {} from the latest checkpoint.",
-            excludedSstList);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Excluded SST {} from the latest checkpoint. The total excluded sst files count is {}",
+            excludedSstList.subList(0, Math.min(5, excludedSstList.size())), excludedSstList.size());
       }
       if (!excludedSstList.isEmpty()) {
         dbMetrics.incNumIncrementalCheckpoint();


### PR DESCRIPTION
## What changes were proposed in this pull request?
 In `DBCheckpointServlet`:
```java
LOG.info("Received excluding SST {}", receivedSstList);
LOG.info("Excluded SST {} from the latest checkpoint.", excludedSstList); 
```

In a cluster with large workloads and multiple snapshots, number of SST's per DB can be in the order of tens of thousands. This will just flood the logs during incremental bootstrap process.

Change the log level to debug and only print say 5 or 10 and print the total number of sst files to exclude under `LOG.info`
## What is the link to the Apache JIRA
[HDDS-12711](https://issues.apache.org/jira/browse/HDDS-12711)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14141287743
