### PR TITLE
HDDS-12356 OmOperationLock

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/com/google/common/util/concurrent/StripedLock.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/com/google/common/util/concurrent/StripedLock.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.util.concurrent;
+
+import java.util.Comparator;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/** Locks obtained from {@link Striped}. */
+public class StripedLock<K> {
+  private static final Comparator<StripedLock<?>> COMPARATOR = Comparator.comparingInt(StripedLock::getIndex);
+
+  public static Comparator<StripedLock<?>> getComparator() {
+    return COMPARATOR;
+  }
+
+  private final K stripeKey;
+  private final ReentrantReadWriteLock lock;
+  /** Stripe index. */
+  private final int index;
+
+  StripedLock(K stripeKey, ReentrantReadWriteLock lock, int index) {
+    this.stripeKey = stripeKey;
+    this.lock = lock;
+    this.index = index;
+  }
+
+  public K getStripeKey() {
+    return stripeKey;
+  }
+
+  public ReentrantReadWriteLock getLock() {
+    return lock;
+  }
+
+  /** @return the stripe index. */
+  public int getIndex() {
+    return index;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/com/google/common/util/concurrent/StripedReadWriteLocks.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/com/google/common/util/concurrent/StripedReadWriteLocks.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.util.concurrent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Similar to {@link Striped} except that
+ * the get methods in this class
+ * return {@link StripedLock} which includes the stripe index.
+ */
+public final class StripedReadWriteLocks {
+
+  public static StripedReadWriteLocks newInstance(int stripes, boolean fair) {
+    final Striped<ReentrantReadWriteLock> striped = Striped.custom(
+        stripes, () -> new ReentrantReadWriteLock(fair));
+    return new StripedReadWriteLocks(striped);
+  }
+
+  private final Striped<ReentrantReadWriteLock> striped;
+
+  private StripedReadWriteLocks(Striped<ReentrantReadWriteLock> striped) {
+    this.striped = striped;
+  }
+
+  public <K> StripedLock<K> get(K key) {
+    final int index = striped.indexFor(key);
+    final ReentrantReadWriteLock lock = striped.getAt(index);
+    return new StripedLock<>(key, lock, index);
+  }
+
+  public <K> Iterable<StripedLock<K>> bulkGet(Iterable<K> keys) {
+    final Map<Integer, ReentrantReadWriteLock> sorted = new TreeMap<>();
+    final List<StripedLock<K>> list = new ArrayList<>();
+    for (K k : keys) {
+      final int index = striped.indexFor(k);
+      final ReentrantReadWriteLock lock = sorted.computeIfAbsent(index, striped::getAt);
+      list.add(new StripedLock<>(k, lock, index));
+    }
+    list.sort(StripedLock.getComparator());
+    return Collections.unmodifiableList(list);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/lock/granular/OmComponentLock.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/lock/granular/OmComponentLock.java
@@ -1,0 +1,68 @@
+package org.apache.hadoop.ozone.om.lock.granular;
+
+import org.apache.ratis.util.Preconditions;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/** Locks for components volume, bucket and keys. */
+public class OmComponentLock {
+  private static final Comparator<OmComponentLock> COMPARATOR
+      = Comparator.comparing(OmComponentLock::getComponent)
+      .thenComparingInt(OmComponentLock::getStripeIndex);
+
+  public static Comparator<OmComponentLock> getComparator() {
+    return COMPARATOR;
+  }
+
+  public enum Component {
+    VOLUME, BUCKET, KEY
+  }
+
+  public enum Type {
+    READ, WRITE
+  }
+
+  private final String name;
+  private final Component component;
+  private final Type type;
+  private final int stripeIndex;
+  private final Lock stripeLock;
+  private boolean locked = false;
+
+  OmComponentLock(String name, Component component, Type type, int stripeIndex, ReadWriteLock stripeLock) {
+    Objects.requireNonNull(stripeLock, "stripeLock == null");
+    this.name = Objects.requireNonNull(name, "name == null");
+    this.component = Objects.requireNonNull(component, "component == null");
+    this.type = Objects.requireNonNull(type, "type == null");
+    this.stripeIndex = stripeIndex;
+    this.stripeLock = type == Type.READ ? stripeLock.readLock() : stripeLock.writeLock();
+  }
+
+  Component getComponent() {
+    return component;
+  }
+
+  int getStripeIndex() {
+    return stripeIndex;
+  }
+
+  void acquire() {
+    Preconditions.assertTrue(!locked, () -> this + " is already acquired");
+    stripeLock.lock();
+    locked = true;
+  }
+
+  void release() {
+    Preconditions.assertTrue(locked, () -> this + " is NOT yet acquired");
+    locked = false;
+    stripeLock.unlock();
+  }
+
+
+  @Override
+  public String toString() {
+    return name + ":" + component + "_" + type + ":s" + stripeIndex + "-" + (locked ? "LOCKED" : "unlocked");
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/lock/granular/OmLockManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/lock/granular/OmLockManager.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.lock.granular;
+
+import com.google.common.util.concurrent.StripedLock;
+import com.google.common.util.concurrent.StripedReadWriteLocks;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hadoop.ozone.om.lock.granular.OmComponentLock.Component;
+import org.apache.hadoop.ozone.om.lock.granular.OmComponentLock.Type;
+import org.apache.ratis.util.UncheckedAutoCloseable;
+
+/**
+ * Manage locking of volume, bucket and keys.
+ */
+public class OmLockManager {
+  private final StripedReadWriteLocks volumeLocks =  StripedReadWriteLocks.newInstance(1 << 10, true);
+  private final StripedReadWriteLocks bucketLocks = StripedReadWriteLocks.newInstance(1 << 12, true);
+  private final StripedReadWriteLocks keyLocks = StripedReadWriteLocks.newInstance(1 << 16, true);
+
+  static OmComponentLock newOmComponentLock(Component component, Type type, StripedLock<String> lock) {
+    return new OmComponentLock(lock.getStripeKey(), component, type, lock.getIndex(), lock.getLock());
+  }
+
+  private OmComponentLock newVolumeLock(Type type, String name) {
+    return newOmComponentLock(Component.VOLUME, type, volumeLocks.get(name));
+  }
+
+  private OmComponentLock newBucketLock(Type type, String name) {
+    return newOmComponentLock(Component.BUCKET, type, bucketLocks.get(name));
+  }
+
+  private OmComponentLock newKeyLock(Type type, String name) {
+    return newOmComponentLock(Component.KEY, type, keyLocks.get(name));
+  }
+
+  private List<OmComponentLock> newKeyLocks(Type type, List<String> names) {
+    final List<OmComponentLock> list = new ArrayList<>();
+    for(StripedLock<String> lock : keyLocks.bulkGet(names)) {
+      list.add(newOmComponentLock(Component.KEY, type, lock));
+    }
+    return Collections.unmodifiableList(list);
+  }
+
+  private OmOperationLock newVolumeReadBucketWriteLock(String volume, String bucket) {
+    return OmOperationLock.newInstance(
+        newVolumeLock(Type.READ, volume),
+        newBucketLock(Type.WRITE, bucket));
+  }
+
+  private OmOperationLock newBucketReadKeyWriteLock(String bucket, String key) {
+    return OmOperationLock.newInstance(
+        newBucketLock(Type.READ, bucket),
+        newKeyLock(Type.WRITE, key));
+  }
+
+  private OmOperationLock newBucketReadKeyWriteLock(String bucket, List<String> keys) {
+    return OmOperationLock.newInstance(
+        newBucketLock(Type.READ, bucket),
+        newKeyLocks(Type.WRITE, keys));
+  }
+
+  /**
+   * Acquire the OM operation lock for the given bucket and key.
+   * <p>
+   * try (UncheckedAutoCloseable ignored = lockManager.acquireObsLock("buck1", "key1")) {
+   *   // op code
+   * }
+   */
+  public UncheckedAutoCloseable acquireBucketReadKeyWriteLock(String bucket, String key) {
+    return newBucketReadKeyWriteLock(bucket, key)
+        .acquire();
+  }
+
+  public UncheckedAutoCloseable acquireBucketReadKeyWriteLock(String bucket, List<String> keys) {
+    return newBucketReadKeyWriteLock(bucket, keys)
+        .acquire();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/lock/granular/OmOperationLock.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/lock/granular/OmOperationLock.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.lock.granular;
+
+import org.apache.hadoop.util.Time;
+import org.apache.ratis.util.Preconditions;
+import org.apache.ratis.util.UncheckedAutoCloseable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * For operations such as creating a key, reading a key, etc.
+ * A {@link OmOperationLock} encapsulates one or more {@link OmComponentLock}s.
+ * <p>
+ * final OmOperationLock lock = ...;
+ * try (UncheckedAutoCloseable ignored = acquire()) {
+ *   // execute the operation
+ * }
+ */
+public abstract class OmOperationLock {
+  static class TimeInfo {
+    private Long acquireTimestamp = null;
+    private volatile long waitTimeNanos = 0;
+    private volatile long lockTimeNanos = 0;
+
+    private synchronized void acquire(long startTime) {
+      Preconditions.assertNull(acquireTimestamp, "acquireTimestamp");
+      acquireTimestamp = Time.monotonicNowNanos();
+      waitTimeNanos += acquireTimestamp - startTime;
+    }
+
+    private synchronized void release() {
+      Objects.requireNonNull(acquireTimestamp, "acquireTimestamp == null");
+      lockTimeNanos += Time.monotonicNowNanos() - acquireTimestamp;
+    }
+
+    public long getLockTimeNanos() {
+      return lockTimeNanos;
+    }
+
+    public long getWaitTimeNanos() {
+      return waitTimeNanos;
+    }
+  }
+
+  private TimeInfo timeInfo;
+
+  TimeInfo getTimeInfo() {
+    return timeInfo;
+  }
+
+  /**
+   * Acquire this lock.
+   *
+   * @return an object to auto-release this lock when using try-with-resource.
+   */
+  public synchronized UncheckedAutoCloseable acquire() {
+    final long startTime = Time.monotonicNowNanos();
+    acquireImpl();
+    getTimeInfo().acquire(startTime);
+    return this::release;
+  }
+
+  abstract void acquireImpl();
+
+  /**
+   * Release this lock.
+   * Instead of calling this method directly,
+   * it is better to call {@link #acquire()} with try-with-resource.
+   */
+  public synchronized void release() {
+    getTimeInfo().release();
+    releaseImpl();
+  }
+
+  abstract void releaseImpl();
+
+  static OmOperationLock newInstance(OmComponentLock first, OmComponentLock second) {
+    return new CompCompLocks(first, second);
+  }
+
+  static OmOperationLock newInstance(OmComponentLock first, List<OmComponentLock> second) {
+    return new CompListLock(first, second);
+  }
+
+  private static class CompCompLocks extends OmOperationLock {
+    private final OmComponentLock first;
+    private final OmComponentLock second;
+
+    private CompCompLocks(OmComponentLock first, OmComponentLock second) {
+      this.first = Objects.requireNonNull(first, "first == null");
+      this.second = Objects.requireNonNull(second, "second == null");
+      Preconditions.assertTrue(OmComponentLock.getComparator().compare(first, second) < 0,
+          () -> "Unexpect order: first = " + first + " >= second = " + second);
+    }
+
+    @Override
+    void acquireImpl() {
+      first.acquire();
+      second.acquire();
+    }
+
+    @Override
+    void releaseImpl() {
+      second.release();
+      first.release();
+    }
+  }
+
+  private static class CompListLock extends OmOperationLock {
+    private final OmComponentLock first;
+    private final List<OmComponentLock> second;
+
+    private CompListLock(OmComponentLock first, List<OmComponentLock> second) {
+      this.first = Objects.requireNonNull(first, "first == null");
+      this.second = Objects.requireNonNull(second, "second == null");
+
+      // assert lock ordering
+      OmComponentLock prev = first;
+      for (OmComponentLock current : second) {
+        final OmComponentLock previous = prev; // need final for Supplier
+        Preconditions.assertTrue(OmComponentLock.getComparator().compare(previous, current) < 0,
+            () -> "Unexpect order: previous = " + previous + " >= current = " + current
+                + ", first = " + first + ", second = " + second);
+        prev = current;
+      }
+    }
+
+    @Override
+    void acquireImpl() {
+      first.acquire();
+      for (OmComponentLock lock : second) {
+        lock.acquire();
+      }
+    }
+
+    @Override
+    void releaseImpl() {
+      for (int i = second.size() - 1; i >= 0; i--) {
+        second.get(i).release();
+      }
+      first.release();
+    }
+  }
+}


### PR DESCRIPTION
This is an idea for implementing HDDS-12356

- OmComponentLock: for Volumes, Buckets and Keys
- OmOperationLock: for operations such as creating a key, deleting a key, etc.