### PR TITLE
HDDS-12736. Bump hadoop-thirdparty to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <gson.version>2.10.1</gson.version>
     <guava.version>32.1.3-jre</guava.version>
     <guice.version>6.0.0</guice.version>
-    <hadoop-thirdparty.version>1.3.0</hadoop-thirdparty.version>
+    <hadoop-thirdparty.version>1.4.0</hadoop-thirdparty.version>
     <hadoop.version>3.4.1</hadoop.version>
     <hadoop2.version>2.10.2</hadoop2.version>
     <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump hadoop-thirdparty from 1.3.0 to 1.4.0.

https://issues.apache.org/jira/browse/HDDS-12736

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14157653572