### PR TITLE
HDDS-12498. Allow limiting flaky-test-check to specific submodule

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -28,6 +28,10 @@ on:
         description: Test Name
         default:  ALL
         required: false
+      submodule:
+        description: Submodule
+        default: 'AUTO'
+        required: true
       iterations:
         description: Number of Iterations per split
         default: 10
@@ -91,7 +95,7 @@ jobs:
       repo: ${{ github.event.inputs.ratis-repo || format('{0}/ratis', github.repository_owner) }}
       ref: ${{ github.event.inputs.ratis-ref }}
   find-tests:
-    if: ${{ always() }}
+    if: ${{ always() && github.event.inputs.submodule == 'AUTO' }}
     needs:
       - prepare-job
     runs-on: ubuntu-24.04
@@ -175,7 +179,9 @@ jobs:
             args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
           fi
 
-          if [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
+          if [[ "${{ github.event.inputs.submodule }}" != "AUTO" ]]; then
+            args="$args -am -pl :${{ github.event.inputs.submodule }}"
+          elif [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
             args="$args -am -pl ${{ needs.find-tests.outputs.modules }}"
           fi
 
@@ -248,7 +254,9 @@ jobs:
             args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
           fi
 
-          if [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
+          if [[ "${{ github.event.inputs.submodule }}" != "AUTO" ]]; then
+            args="$args -pl :${{ github.event.inputs.submodule }}"
+          elif [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
             args="$args -pl ${{ needs.find-tests.outputs.modules }}"
           fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new input "submodule" in flaky-test-check. I think adding it after test-name would make it easy to spot when entering inputs. Default value could be either empty (to preserve existing behavior) or ozone-integration-test (to cover the most frequent use case).
If input is provided, limit Maven execution to that specific module by appending to $args:
build should also make dependencies, so add: -am -pl
test execution should skip re-building dependencies, so only add: -pl
The module name can be specified as following (note : as prefix):

`-pl :${{ github.event.inputs.submodule }}`


submodule:
- submodule == 'AUTO" (default) -> detect with find-test job
- submodule != 'AUTO" -> set `args="$args -pl ${submodule}"`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12498

## How was this patch tested?

Normal CI: https://github.com/peterxcli/ozone/actions/runs/14158501809

### Triggered 2x2 of TestConfigurationSource.

#### Run with `AUTO` submodule 

https://github.com/peterxcli/ozone/actions/runs/14158504985

- Works as usual.

#### Run with designated submodule


https://github.com/peterxcli/ozone/actions/runs/14158510758

- It did skip the find-test step.
  - ![image](https://github.com/user-attachments/assets/d0b13eb1-328e-4f43-9c8e-173165d3d9bb)

- Get a shorter execution time. 🤩
  - `4m 20s` -> `1m 41s`