### PR TITLE
HDDS-12690. Remove om.fs.snapshot.max.limit from RDBStore and OmMetadataManagerImpl

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -237,10 +237,6 @@ public final class DBStoreBuilder {
     }
   }
 
-  public DBStoreBuilder setMaxFSSnapshots(int maxFSSnapshots) {
-    this.maxFSSnapshots = maxFSSnapshots;
-    return this;
-  }
   public DBStoreBuilder setName(String name) {
     dbname = name;
     return this;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -98,7 +98,6 @@ public final class DBStoreBuilder {
   private RocksDBConfiguration rocksDBConfiguration;
   // Flag to indicate if the RocksDB should be opened readonly.
   private boolean openReadOnly = false;
-  private int maxFSSnapshots = 0;
   private final DBProfile defaultCfProfile;
   private boolean enableCompactionDag;
   private boolean createCheckpointDirs = true;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -230,9 +230,9 @@ public final class DBStoreBuilder {
       }
 
       return new RDBStore(dbFile, rocksDBOption, statistics, writeOptions, tableConfigs,
-          registry.build(), openReadOnly, maxFSSnapshots, dbJmxBeanNameName,
-          enableCompactionDag, maxDbUpdatesSizeThreshold, createCheckpointDirs,
-          configuration, enableRocksDbMetrics);
+          registry.build(), openReadOnly, dbJmxBeanNameName, enableCompactionDag,
+          maxDbUpdatesSizeThreshold, createCheckpointDirs, configuration,
+          enableRocksDbMetrics);
     } finally {
       tableConfigs.forEach(TableConfig::close);
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -78,7 +78,7 @@ public class RDBStore implements DBStore {
   @SuppressWarnings("parameternumber")
   public RDBStore(File dbFile, ManagedDBOptions dbOptions, ManagedStatistics statistics,
                   ManagedWriteOptions writeOptions, Set<TableConfig> families,
-                  CodecRegistry registry, boolean readOnly, int maxFSSnapshots,
+                  CodecRegistry registry, boolean readOnly,
                   String dbJmxBeanName, boolean enableCompactionDag,
                   long maxDbUpdatesSizeThreshold,
                   boolean createCheckpointDirs,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -61,7 +61,7 @@ public class TestRDBStore {
       long maxDbUpdatesSizeThreshold)
       throws IOException {
     return new RDBStore(dbFile, options, null, new ManagedWriteOptions(), families,
-        CodecRegistry.newBuilder().build(), false, 1000, null, false,
+        CodecRegistry.newBuilder().build(), false, null, false,
         maxDbUpdatesSizeThreshold, true, null, true);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -23,8 +23,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_ROCKSDB_METRICS_ENABLED;
@@ -589,15 +587,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       boolean createCheckpointDirs,
       boolean enableRocksDBMetrics)
       throws IOException {
-    final int maxFSSnapshots = configuration.getInt(
-        OZONE_OM_FS_SNAPSHOT_MAX_LIMIT, OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT);
     RocksDBConfiguration rocksDBConfiguration =
         configuration.getObject(RocksDBConfiguration.class);
     DBStoreBuilder dbStoreBuilder = DBStoreBuilder.newBuilder(configuration,
         rocksDBConfiguration).setName(dbName)
         .setOpenReadOnly(readOnly)
         .setPath(Paths.get(metaDir.getPath()))
-        .setMaxFSSnapshots(maxFSSnapshots)
         .setEnableCompactionDag(enableCompactionDag)
         .setCreateCheckpointDirs(createCheckpointDirs)
         .setMaxNumberOfOpenFiles(maxOpenFiles)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The check for om.fs.snapshot.max.limit will be moved from DB layer to OM metadata layer after https://github.com/apache/ozone/pull/8157.
So we can clean up om.fs.snapshot.max.limit in RDBStore and its builder.

 
Remove the config from [OmMetadataManagerImpl](https://github.com/apache/ozone/blob/86d2027e328cd66c3319b355f3438842440ffa70/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java#L592) and [DBStoreBuilder](https://github.com/apache/ozone/blob/eb96ff489209ad9dab10a3cded277ae5ccd7cb4a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java#L101).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12690

## How was this patch tested?


CI:
~~https://github.com/peterxcli/ozone/actions/runs/14158659139~~
~~https://github.com/peterxcli/ozone/actions/runs/14158762896~~
https://github.com/peterxcli/ozone/actions/runs/14158813613