### PR TITLE
HDDS-12735. Unused rocksDBConfiguration variable in `OmMetadataManagerImpl#start`

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -553,9 +553,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         ExitUtils.terminate(1, errorMsg, LOG);
       }
 
-      RocksDBConfiguration rocksDBConfiguration =
-          configuration.getObject(RocksDBConfiguration.class);
-
       // As When ratis is not enabled, when we perform put/commit to rocksdb we
       // should turn on sync flag. This needs to be done as when we return
       // response to client it is considered as complete, but if we have


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a unused rocksDBConfiguration variable in `OmMetadaManagerImpl#start`

https://github.com/peterxcli/ozone/blob/0834515693f5927856722625994b6bfb5f874a2b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java#L556-L557

## What is the link to the Apache JIRA


https://issues.apache.org/jira/browse/HDDS-12735

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14158729935