### PR TITLE
HDDS-12698. Unused FailureService in MiniOzoneChaosCluster

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -66,39 +66,6 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
   private final Set<StorageContainerManager> failedScmSet;
   private final Set<DatanodeDetails> failedDnSet;
 
-  // The service on which chaos will be unleashed.
-  enum FailureService {
-    DATANODE,
-    OZONE_MANAGER,
-    STORAGE_CONTAINER_MANAGER;
-
-    @Override
-    public String toString() {
-      switch (this) {
-      case DATANODE:
-        return "Datanode";
-      case OZONE_MANAGER:
-        return "OzoneManager";
-      case STORAGE_CONTAINER_MANAGER:
-        return "StorageContainerManager";
-      default:
-        return "";
-      }
-    }
-
-    public static FailureService of(String serviceName) {
-      if (serviceName.equalsIgnoreCase("Datanode")) {
-        return DATANODE;
-      } else if (serviceName.equalsIgnoreCase("OzoneManager")) {
-        return OZONE_MANAGER;
-      } else if (serviceName.equalsIgnoreCase("StorageContainerManager")) {
-        return STORAGE_CONTAINER_MANAGER;
-      }
-      throw new IllegalArgumentException("Unrecognized value for " +
-          "FailureService enum: " + serviceName);
-    }
-  }
-
   @SuppressWarnings("parameternumber")
   public MiniOzoneChaosCluster(OzoneConfiguration conf,
       OMHAService omService, SCMHAService scmService,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`FailureService` is no longer used in MiniOzoneChaosCluster. Remove `FailureService` to clean up MiniOzoneChaosCluster.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12698

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14158844349