### PR TITLE
HDDS-12720. Use DatanodeID in SimpleMockNodeManager

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -58,20 +59,20 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
  */
 public class SimpleMockNodeManager implements NodeManager {
 
-  private Map<UUID, DatanodeInfo> nodeMap = new ConcurrentHashMap<>();
-  private Map<UUID, Set<PipelineID>> pipelineMap = new ConcurrentHashMap<>();
-  private Map<UUID, Set<ContainerID>> containerMap = new ConcurrentHashMap<>();
+  private Map<DatanodeID, DatanodeInfo> nodeMap = new ConcurrentHashMap<>();
+  private Map<DatanodeID, Set<PipelineID>> pipelineMap = new ConcurrentHashMap<>();
+  private Map<DatanodeID, Set<ContainerID>> containerMap = new ConcurrentHashMap<>();
 
   public void register(DatanodeDetails dd, NodeStatus status) {
     dd.setPersistedOpState(status.getOperationalState());
     dd.setPersistedOpStateExpiryEpochSec(status.getOpStateExpiryEpochSeconds());
-    nodeMap.put(dd.getUuid(), new DatanodeInfo(dd, status, null));
+    nodeMap.put(dd.getID(), new DatanodeInfo(dd, status, null));
   }
 
   public void setNodeStatus(DatanodeDetails dd, NodeStatus status) {
     dd.setPersistedOpState(status.getOperationalState());
     dd.setPersistedOpStateExpiryEpochSec(status.getOpStateExpiryEpochSeconds());
-    DatanodeInfo dni = nodeMap.get(dd.getUuid());
+    DatanodeInfo dni = nodeMap.get(dd.getID());
     dni.setNodeStatus(status);
   }
 
@@ -91,7 +92,7 @@ public class SimpleMockNodeManager implements NodeManager {
     for (int i = 0; i < count; i++) {
       pipelines.add(PipelineID.randomId());
     }
-    pipelineMap.put(dd.getUuid(), pipelines);
+    pipelineMap.put(dd.getID(), pipelines);
   }
 
   /**
@@ -105,7 +106,7 @@ public class SimpleMockNodeManager implements NodeManager {
   @Override
   public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    DatanodeInfo dni = nodeMap.get(datanodeDetails.getUuid());
+    DatanodeInfo dni = nodeMap.get(datanodeDetails.getID());
     if (dni != null) {
       return dni.getNodeStatus();
     } else {
@@ -125,7 +126,7 @@ public class SimpleMockNodeManager implements NodeManager {
                                       NodeOperationalState newState,
                                       long opStateExpiryEpocSec)
       throws NodeNotFoundException {
-    DatanodeInfo dni = nodeMap.get(dn.getUuid());
+    DatanodeInfo dni = nodeMap.get(dn.getID());
     if (dni == null) {
       throw new NodeNotFoundException(dn.getID());
     }
@@ -145,7 +146,7 @@ public class SimpleMockNodeManager implements NodeManager {
    */
   @Override
   public Set<PipelineID> getPipelines(DatanodeDetails datanodeDetails) {
-    Set<PipelineID> p = pipelineMap.get(datanodeDetails.getUuid());
+    Set<PipelineID> p = pipelineMap.get(datanodeDetails.getID());
     if (p == null || p.isEmpty()) {
       return null;
     } else {
@@ -159,7 +160,7 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   public void setContainers(DatanodeDetails dn, Set<ContainerID> containerIds) {
-    containerMap.put(dn.getUuid(), containerIds);
+    containerMap.put(dn.getID(), containerIds);
   }
 
   /**
@@ -177,7 +178,7 @@ public class SimpleMockNodeManager implements NodeManager {
     // The concrete implementation of this method in SCMNodeManager will return
     // an empty set if there are no containers, and will never return null.
     return containerMap
-        .computeIfAbsent(dn.getUuid(), key -> new HashSet<>());
+        .computeIfAbsent(dn.getID(), key -> new HashSet<>());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SimpleMockNodeManager` should use DatanodeID instead of UUID.

This changes only invlove test code.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12720

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14158924941