### PR TITLE
HDDS-11107. Remove unnecessary run_test_scripts call in upgrade tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -25,9 +25,6 @@ source "$TEST_DIR/testlib.sh"
 export TEST_DIR
 export COMPOSE_DIR="$TEST_DIR"
 
-RESULT=0
-run_test_scripts ${tests} || RESULT=$?
-
 RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # Upgrade tests to be run. In CI we want to run just one set, but for a release
@@ -44,4 +41,4 @@ run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 
 generate_report "upgrade" "$ALL_RESULT_DIR"
 
-exit "$RESULT"
+exit "$?"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -41,4 +41,4 @@ run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 
 generate_report "upgrade" "$ALL_RESULT_DIR"
 
-exit "$?"
+exit "$RESULT"


### PR DESCRIPTION
## What changes were proposed in this pull request?

As discussed in HDDS-11107, this PR removes the unnecessary run_test_scripts invocation and simplifies the test.sh script.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11107

## How was this patch tested?

Tested by running the GitHub Actions workflow on a forked repository.

