### PR TITLE
HDDS-12745. Container checksum should be reported during container close and DN restart

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
@@ -389,8 +389,8 @@ public class ContainerChecksumTreeManager {
 
     try (FileInputStream inStream = new FileInputStream(checksumFile)) {
       return Optional.of(ContainerProtos.ContainerChecksumInfo.parseFrom(inStream));
-    } catch (Exception e) {
-      LOG.error("Error while reading the checksum file for container {}", data.getContainerID());
+    } catch (IOException ex) {
+      LOG.error("Error while reading the checksum file for container {}", data.getContainerID(), ex);
       return Optional.empty();
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
@@ -373,6 +373,11 @@ public class ContainerChecksumTreeManager {
     }
   }
 
+  /**
+   * Reads the container checksum info file (containerID.tree) from the disk.
+   * Callers are not required to hold a lock while calling this since writes are done to a tmp file and atomically
+   * swapped into place.
+   */
   public static Optional<ContainerProtos.ContainerChecksumInfo> readChecksumInfo(ContainerData data)
       throws IOException {
     long containerID = data.getContainerID();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
@@ -361,6 +361,8 @@ public class ContainerChecksumTreeManager {
       throw new IOException("Error occurred when writing container merkle tree for containerID "
           + data.getContainerID(), ex);
     }
+    // Set in-memory data checksum.
+    data.setDataChecksum(checksumInfo.getContainerMerkleTree().getDataChecksum());
   }
 
   /**
@@ -375,6 +377,21 @@ public class ContainerChecksumTreeManager {
     File checksumFile = getContainerChecksumFile(data);
     try (FileInputStream inStream = new FileInputStream(checksumFile)) {
       return ByteString.readFrom(inStream);
+    }
+  }
+
+  public static Optional<ContainerProtos.ContainerChecksumInfo> readChecksumInfo(KeyValueContainerData data) {
+    File checksumFile = getContainerChecksumFile(data);
+    if (!checksumFile.exists()) {
+      LOG.error("Checksum file not found for container {}", data.getContainerID());
+      return Optional.empty();
+    }
+
+    try (FileInputStream inStream = new FileInputStream(checksumFile)) {
+      return Optional.of(ContainerProtos.ContainerChecksumInfo.parseFrom(inStream));
+    } catch (Exception e) {
+      LOG.error("Error while reading the checksum file for container {}", data.getContainerID());
+      return Optional.empty();
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -281,6 +281,10 @@ public final class KeyValueContainerUtil {
   }
 
   private static void populateContainerDataChecksum(KeyValueContainerData kvContainerData) {
+    if (kvContainerData.isOpen()) {
+      return;
+    }
+
     Optional<ContainerChecksumInfo> optionalContainerChecksumInfo = ContainerChecksumTreeManager
         .readChecksumInfo(kvContainerData);
     if (optionalContainerChecksumInfo.isPresent()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -285,11 +285,15 @@ public final class KeyValueContainerUtil {
       return;
     }
 
-    Optional<ContainerChecksumInfo> optionalContainerChecksumInfo = ContainerChecksumTreeManager
-        .readChecksumInfo(kvContainerData);
-    if (optionalContainerChecksumInfo.isPresent()) {
-      ContainerChecksumInfo containerChecksumInfo = optionalContainerChecksumInfo.get();
-      kvContainerData.setDataChecksum(containerChecksumInfo.getContainerMerkleTree().getDataChecksum());
+    try {
+      Optional<ContainerChecksumInfo> optionalContainerChecksumInfo = ContainerChecksumTreeManager
+          .readChecksumInfo(kvContainerData);
+      if (optionalContainerChecksumInfo.isPresent()) {
+        ContainerChecksumInfo containerChecksumInfo = optionalContainerChecksumInfo.get();
+        kvContainerData.setDataChecksum(containerChecksumInfo.getContainerMerkleTree().getDataChecksum());
+      }
+    } catch (IOException ex) {
+      LOG.warn("Failed to read checksum info for container {}", kvContainerData.getContainerID(), ex);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -26,12 +26,15 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerChecksumInfo;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
@@ -277,6 +280,15 @@ public final class KeyValueContainerUtil {
     }
   }
 
+  private static void populateContainerDataChecksum(KeyValueContainerData kvContainerData) {
+    Optional<ContainerChecksumInfo> optionalContainerChecksumInfo = ContainerChecksumTreeManager
+        .readChecksumInfo(kvContainerData);
+    if (optionalContainerChecksumInfo.isPresent()) {
+      ContainerChecksumInfo containerChecksumInfo = optionalContainerChecksumInfo.get();
+      kvContainerData.setDataChecksum(containerChecksumInfo.getContainerMerkleTree().getDataChecksum());
+    }
+  }
+
   private static void populateContainerMetadata(
       KeyValueContainerData kvContainerData, DatanodeStore store,
       boolean bCheckChunksFilePath)
@@ -356,6 +368,7 @@ public final class KeyValueContainerUtil {
 
     // Load finalizeBlockLocalIds for container in memory.
     populateContainerFinalizeBlock(kvContainerData, store);
+    populateContainerDataChecksum(kvContainerData);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestContainerChecksumTreeManager.java
@@ -201,7 +201,6 @@ class TestContainerChecksumTreeManager {
     assertEquals(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     List<Long> expectedBlocksToDelete = Arrays.asList(1L, 2L, 3L);
     checksumManager.markBlocksAsDeleted(container, new ArrayList<>(expectedBlocksToDelete));
-    assertEquals(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     ContainerMerkleTreeWriter tree = buildTestTree(config);
     checksumManager.writeContainerDataTree(container, tree);
     assertTrue(metrics.getWriteContainerMerkleTreeLatencyNS().lastStat().total() > 0);
@@ -222,7 +221,6 @@ class TestContainerChecksumTreeManager {
     assertEquals(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     ContainerMerkleTreeWriter tree = buildTestTree(config);
     checksumManager.writeContainerDataTree(container, tree);
-    assertEquals(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     List<Long> expectedBlocksToDelete = Arrays.asList(1L, 2L, 3L);
     checksumManager.markBlocksAsDeleted(container, new ArrayList<>(expectedBlocksToDelete));
     assertTrue(metrics.getWriteContainerMerkleTreeLatencyNS().lastStat().total() > 0);
@@ -241,8 +239,6 @@ class TestContainerChecksumTreeManager {
     assertEquals(metrics.getWriteContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     assertEquals(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     ContainerMerkleTreeWriter tree = buildTestTree(config);
-    checksumManager.writeContainerDataTree(container, tree);
-    assertEquals(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total(), 0);
     checksumManager.writeContainerDataTree(container, tree);
     assertTrue(metrics.getWriteContainerMerkleTreeLatencyNS().lastStat().total() > 0);
     assertTrue(metrics.getReadContainerMerkleTreeLatencyNS().lastStat().total() > 0);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -188,6 +188,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
         ",replicaIndex=" + replicaIndex :
         "") +
         ", isEmpty=" + isEmpty +
+        ", dataChecksum=" + dataChecksum +
         '}';
   }
 

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
@@ -153,8 +153,8 @@ Reconcile closed container
     # TODO When the scanner is computing checksums automatically, this test may need to be updated.
     ${container} =      Execute          ozone admin container list --state CLOSED | jq -r 'select(.replicationConfig.replicationFactor == "THREE") | .containerID' | head -1
     ${data_checksum} =  Execute          ozone admin container info "${container}" --json | jq -r '.replicas[].dataChecksum' | head -n1
-    # 0 is the hex value of an empty checksum.
-    Should Be Equal As Strings    0    ${data_checksum}
+    # 0 is the hex value of an empty checksum. After container close the data checksum should not be 0.
+    Should Not Be Equal As Strings    0    ${data_checksum}
     # When reconciliation finishes, replica checksums should be shown.
     Execute    ozone admin container reconcile ${container}
     Wait until keyword succeeds    1min    5sec    Reconciliation complete    ${container}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCloseContainer.java
@@ -158,6 +158,9 @@ public class TestCloseContainer {
     // Ensure 3 replicas are reported successfully as expected.
     GenericTestUtils.waitFor(() ->
             getContainerReplicas(newContainer).size() == 3, 200, 30000);
+    for (ContainerReplica replica : getContainerReplicas(newContainer)) {
+      assertNotEquals(0, replica.getDataChecksum());
+    }
   }
 
   /**
@@ -196,6 +199,10 @@ public class TestCloseContainer {
     for (HddsDatanodeService hddsDatanode: hddsDatanodes) {
       GenericTestUtils.waitFor(() -> checkContainerCloseInDatanode(hddsDatanode, container), 100, 5000);
       assertTrue(containerChecksumFileExists(hddsDatanode, container));
+    }
+
+    for (ContainerReplica replica : getContainerReplicas(container)) {
+      assertNotEquals(0, replica.getDataChecksum());
     }
 
     assertThrows(IOException.class,
@@ -269,6 +276,12 @@ public class TestCloseContainer {
     assertNotEquals(prevExpectedChecksumInfo1.getContainerID(), prevExpectedChecksumInfo2.getContainerID());
     assertNotEquals(prevExpectedChecksumInfo1.getContainerMerkleTree().getDataChecksum(),
         prevExpectedChecksumInfo2.getContainerMerkleTree().getDataChecksum());
+    for (ContainerReplica replica : getContainerReplicas(containerInfo1)) {
+      assertNotEquals(0, replica.getDataChecksum());
+    }
+    for (ContainerReplica replica : getContainerReplicas(containerInfo2)) {
+      assertNotEquals(0, replica.getDataChecksum());
+    }
   }
 
   private boolean checkContainerCloseInDatanode(HddsDatanodeService hddsDatanode,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -114,7 +114,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -150,6 +149,7 @@ public class TestContainerCommandReconciliation {
     conf.setStorageSize(OZONE_SCM_CHUNK_SIZE_KEY, 128 * 1024, StorageUnit.BYTES);
     conf.setStorageSize(OZONE_SCM_BLOCK_SIZE,  512 * 1024, StorageUnit.BYTES);
     // Disable the container scanner so it does not create merkle tree files that interfere with this test.
+    // TODO: Currently container scrub sets the checksum to 0, Revert this after HDDS-10374 is merged.
     conf.getObject(ContainerScannerConfiguration.class).setEnabled(false);
     conf.setBoolean("hdds.container.scrub.enabled", false);
 
@@ -348,7 +348,7 @@ public class TestContainerCommandReconciliation {
         .getContainerReplicas(ContainerID.valueOf(containerID))
         .stream().map(ContainerReplica::getDatanodeDetails)
         .collect(Collectors.toList());
-    Assertions.assertEquals(3, dataNodeDetails.size());
+    assertEquals(3, dataNodeDetails.size());
     HddsDatanodeService hddsDatanodeService = cluster.getHddsDatanode(dataNodeDetails.get(0));
     DatanodeStateMachine datanodeStateMachine = hddsDatanodeService.getDatanodeStateMachine();
     Container<?> container = datanodeStateMachine.getContainer().getContainerSet().getContainer(containerID);
@@ -383,7 +383,7 @@ public class TestContainerCommandReconciliation {
         readChecksumFile(container.getContainerData());
     long dataChecksumAfterBlockDelete = containerChecksumAfterBlockDelete.getContainerMerkleTree().getDataChecksum();
     // Checksum should have changed after block delete.
-    Assertions.assertNotEquals(oldDataChecksum, dataChecksumAfterBlockDelete);
+    assertNotEquals(oldDataChecksum, dataChecksumAfterBlockDelete);
 
     // Since the container is already closed, we have manually updated the container checksum file.
     // This doesn't update the checksum reported to SCM, and we need to trigger an ICR.
@@ -414,7 +414,7 @@ public class TestContainerCommandReconciliation {
         .getContainerReplicas(ContainerID.valueOf(containerID))
         .stream().map(ContainerReplica::getDatanodeDetails)
         .collect(Collectors.toList());
-    Assertions.assertEquals(3, dataNodeDetails.size());
+    assertEquals(3, dataNodeDetails.size());
     HddsDatanodeService hddsDatanodeService = cluster.getHddsDatanode(dataNodeDetails.get(0));
     DatanodeStateMachine datanodeStateMachine = hddsDatanodeService.getDatanodeStateMachine();
     Container<?> container = datanodeStateMachine.getContainer().getContainerSet().getContainer(containerID);
@@ -468,11 +468,11 @@ public class TestContainerCommandReconciliation {
     long dataChecksumAfterAfterChunkCorruption = containerChecksumAfterChunkCorruption
         .getContainerMerkleTree().getDataChecksum();
     // Checksum should have changed after chunk corruption.
-    Assertions.assertNotEquals(oldDataChecksum, dataChecksumAfterAfterChunkCorruption);
+    assertNotEquals(oldDataChecksum, dataChecksumAfterAfterChunkCorruption);
 
     // 3. Set Unhealthy for first chunk of all blocks. This should be done by the scanner, Until then this is a
     // manual step.
-    // // TODO: Use On-demand container scanner to build the new container merkle tree (HDDS-10374)
+    // TODO: Use On-demand container scanner to build the new container merkle tree (HDDS-10374)
     Random random = new Random();
     ContainerProtos.ContainerChecksumInfo.Builder builder = containerChecksumAfterChunkCorruption.toBuilder();
     List<ContainerProtos.BlockMerkleTree> blockMerkleTreeList = builder.getContainerMerkleTree()
@@ -503,7 +503,7 @@ public class TestContainerCommandReconciliation {
     ContainerProtos.ContainerChecksumInfo newContainerChecksumInfo = readChecksumFile(container.getContainerData());
     assertTreesSortedAndMatch(oldContainerChecksumInfo.getContainerMerkleTree(),
         newContainerChecksumInfo.getContainerMerkleTree());
-    Assertions.assertEquals(oldDataChecksum, newContainerChecksumInfo.getContainerMerkleTree().getDataChecksum());
+    assertEquals(oldDataChecksum, newContainerChecksumInfo.getContainerMerkleTree().getDataChecksum());
     TestHelper.validateData(KEY_NAME, data, store, volume, bucket);
   }
 
@@ -521,7 +521,7 @@ public class TestContainerCommandReconciliation {
         .getContainerReplicas(ContainerID.valueOf(containerID))
         .stream().map(ContainerReplica::getDatanodeDetails)
         .collect(Collectors.toList());
-    Assertions.assertEquals(3, dataNodeDetails.size());
+    assertEquals(3, dataNodeDetails.size());
     HddsDatanodeService hddsDatanodeService = cluster.getHddsDatanode(dataNodeDetails.get(0));
     DatanodeStateMachine datanodeStateMachine = hddsDatanodeService.getDatanodeStateMachine();
     Container<?> container = datanodeStateMachine.getContainer().getContainerSet().getContainer(containerID);
@@ -564,7 +564,7 @@ public class TestContainerCommandReconciliation {
         readChecksumFile(container.getContainerData());
     long dataChecksumAfterBlockDelete = containerChecksumAfterBlockDelete.getContainerMerkleTree().getDataChecksum();
     // Checksum should have changed after block delete.
-    Assertions.assertNotEquals(oldDataChecksum, dataChecksumAfterBlockDelete);
+    assertNotEquals(oldDataChecksum, dataChecksumAfterBlockDelete);
 
     // Since the container is already closed, we have manually updated the container checksum file.
     // This doesn't update the checksum reported to SCM, and we need to trigger an ICR.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -530,9 +530,6 @@ public class TestContainerCommandReconciliation {
     KeyValueHandler kvHandler = (KeyValueHandler) datanodeStateMachine.getContainer().getDispatcher()
         .getHandler(ContainerProtos.ContainerType.KeyValueContainer);
 
-    BlockManager blockManager = kvHandler.getBlockManager();
-    List<BlockData> blockDataList = blockManager.listBlock(container, -1, 100);
-    String chunksPath = container.getContainerData().getChunksPath();
     long oldDataChecksum = oldContainerChecksumInfo.getContainerMerkleTree().getDataChecksum();
     // Check non-zero checksum after container close
     StorageContainerLocationProtocolClientSideTranslatorPB scmClient = cluster.getStorageContainerLocationClient();
@@ -544,6 +541,9 @@ public class TestContainerCommandReconciliation {
     }
 
     // 2. Delete some blocks to simulate missing blocks.
+    BlockManager blockManager = kvHandler.getBlockManager();
+    List<BlockData> blockDataList = blockManager.listBlock(container, -1, 100);
+    String chunksPath = container.getContainerData().getChunksPath();
     try (DBHandle db = BlockUtils.getDB(containerData, conf);
          BatchOperation op = db.getStore().getBatchHandler().initBatchOperation()) {
       for (int i = 0; i < blockDataList.size(); i += 2) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -87,6 +87,7 @@ public class TestContainerCommandReconciliation {
     conf.set(OZONE_METADATA_DIRS, testDir.getAbsolutePath());
     // Disable the container scanner so it does not create merkle tree files that interfere with this test.
     conf.getObject(ContainerScannerConfiguration.class).setEnabled(false);
+    conf.setBoolean("hdds.container.scrub.enabled", false);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();
@@ -270,9 +271,8 @@ public class TestContainerCommandReconciliation {
     }
 
     // Check non-zero checksum after datanode restart
-    cluster.shutdownHddsDatanodes();
-    cluster.startHddsDatanodes();
-    cluster.waitForClusterToBeReady();
+    // Restarting all the nodes take more time in mini ozone cluster, so restarting only one node
+    cluster.restartHddsDatanode(0, true);
     containerReplicas = cluster.getStorageContainerManager().getContainerManager()
         .getContainerReplicas(ContainerID.valueOf(containerID));
     for (ContainerReplica containerReplica: containerReplicas) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -255,8 +255,10 @@ public class TestContainerCommandReconciliation {
   public void testDataChecksumReportedAtSCM() throws Exception {
     long containerID = writeDataAndGetContainer(true);
     // Check non-zero checksum after container close
+    // TODO: Introduce corruption in the container and after reconciliation all checksums should match (HDDS-11763)
     Set<ContainerReplica> containerReplicas = cluster.getStorageContainerManager().getContainerManager()
         .getContainerReplicas(ContainerID.valueOf(containerID));
+    assertEquals(3, containerReplicas.size());
     for (ContainerReplica containerReplica: containerReplicas) {
       assertNotEquals(0, containerReplica.getDataChecksum());
     }
@@ -266,6 +268,7 @@ public class TestContainerCommandReconciliation {
     // Check non-zero checksum after container reconciliation
     containerReplicas = cluster.getStorageContainerManager().getContainerManager()
         .getContainerReplicas(ContainerID.valueOf(containerID));
+    assertEquals(3, containerReplicas.size());
     for (ContainerReplica containerReplica: containerReplicas) {
       assertNotEquals(0, containerReplica.getDataChecksum());
     }
@@ -273,8 +276,10 @@ public class TestContainerCommandReconciliation {
     // Check non-zero checksum after datanode restart
     // Restarting all the nodes take more time in mini ozone cluster, so restarting only one node
     cluster.restartHddsDatanode(0, true);
+    cluster.restartStorageContainerManager(true);
     containerReplicas = cluster.getStorageContainerManager().getContainerManager()
         .getContainerReplicas(ContainerID.valueOf(containerID));
+    assertEquals(3, containerReplicas.size());
     for (ContainerReplica containerReplica: containerReplicas) {
       assertNotEquals(0, containerReplica.getDataChecksum());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. The container checksum though generated during container close, is not being reported to the SCM. 
2. During DN restart we are not fetching the container checksum into `KeyValueContainerData` hence the SCM doesn't get the checksum.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12745

## How was this patch tested?

Integration Test
