### PR TITLE
HDDS-12173. Follow RocksDB basic tuning guide

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -24,8 +24,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedBloomFilter;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedLRUCache;
-import org.rocksdb.CompactionPriority;
-import org.rocksdb.CompactionStyle;
+import org.rocksdb.*;
 
 /**
  * User visible configs based RocksDB tuning page. Documentation for Options.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedBloomFilter;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedLRUCache;
+import org.rocksdb.CompactionPriority;
 import org.rocksdb.CompactionStyle;
 
 /**
@@ -65,10 +66,12 @@ public enum DBProfile {
       final long bytesPerSync = toLong(StorageUnit.MB.toBytes(1.00));
       final boolean createIfMissing = true;
       final boolean createMissingColumnFamilies = true;
+      final int maxBackgroundJobs = 2;
       ManagedDBOptions dbOptions = new ManagedDBOptions();
       dbOptions
           .setIncreaseParallelism(Runtime.getRuntime().availableProcessors())
           .setMaxBackgroundCompactions(maxBackgroundCompactions)
+          .setMaxBackgroundJobs(maxBackgroundJobs)
           .setMaxBackgroundFlushes(maxBackgroundFlushes)
           .setBytesPerSync(bytesPerSync)
           .setCreateIfMissing(createIfMissing)
@@ -88,6 +91,7 @@ public enum DBProfile {
       config.setBlockCache(new ManagedLRUCache(blockCacheSize))
             .setBlockSize(blockSize)
             .setPinL0FilterAndIndexBlocksInCache(true)
+            .setCacheIndexAndFilterBlocks(true)
             .setFilterPolicy(new ManagedBloomFilter());
       return config;
     }
@@ -111,6 +115,7 @@ public enum DBProfile {
     public ManagedColumnFamilyOptions getColumnFamilyOptions() {
       ManagedColumnFamilyOptions cfOptions = SSD.getColumnFamilyOptions();
       cfOptions.setCompactionStyle(CompactionStyle.LEVEL);
+      cfOptions.setCompactionPriority(CompactionPriority.MinOverlappingRatio);
       return cfOptions;
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -24,7 +24,8 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedBloomFilter;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedLRUCache;
-import org.rocksdb.*;
+import org.rocksdb.CompactionPriority;
+import org.rocksdb.CompactionStyle;
 
 /**
  * User visible configs based RocksDB tuning page. Documentation for Options.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -65,7 +65,7 @@ public enum DBProfile {
       final long bytesPerSync = toLong(StorageUnit.MB.toBytes(1.00));
       final boolean createIfMissing = true;
       final boolean createMissingColumnFamilies = true;
-      final int maxBackgroundJobs = 2;
+      final int maxBackgroundJobs = 6;
       ManagedDBOptions dbOptions = new ManagedDBOptions();
       dbOptions
           .setIncreaseParallelism(Runtime.getRuntime().availableProcessors())

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedBlockBasedTableConfig.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedBlockBasedTableConfig.java
@@ -48,6 +48,7 @@ public class ManagedBlockBasedTableConfig extends BlockBasedTableConfig {
 
     blockCacheHolder = blockCache;
     super.setBlockCache(blockCache);
+    super.setCacheIndexAndFilterBlocks(true);
     return this;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1546,6 +1546,7 @@
                       <!-- Allow non-RocksObject classes. -->
                       <allowedImport>org.rocksdb.ColumnFamilyDescriptor</allowedImport>
                       <allowedImport>org.rocksdb.CompactionStyle</allowedImport>
+                      <allowedImport>org.rocksdb.CompactionPriority</allowedImport>
                       <allowedImport>org.rocksdb.KeyMayExist</allowedImport>
                       <allowedImport>org.rocksdb.HistogramData</allowedImport>
                       <allowedImport>org.rocksdb.HistogramType</allowedImport>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added rocksdb options for tuning.

Please describe your PR in detail:
Added these 3 rocksdb options to DBProfile:
```
opts.max_background_jobs = 6;
options.compaction_pri = kMinOverlappingRatio;
table_options.cache_index_and_filter_blocks = true;
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12173

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
