### PR TITLE
HDDS-12715. create a common miniozone cluster for ozone debug tools tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/DebugShellOzoneClusterExtension.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/DebugShellOzoneClusterExtension.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.debug.OzoneDebug;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+
+public class DebugShellOzoneClusterExtension implements BeforeAllCallback, AfterAllCallback {
+  private static MiniOzoneCluster cluster = null;
+  private static OzoneConfiguration conf = null;
+  private static OzoneClient client;
+  private static ObjectStore store = null;
+  private static OzoneDebug ozoneDebugShell;
+  private static OzoneShell ozoneShell;
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    if (cluster != null) {
+      return;
+    }
+    // Configure properties
+    ozoneShell = new OzoneShell();
+    ozoneDebugShell = new OzoneDebug();
+    conf = ozoneDebugShell.getOzoneConf();
+    conf.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL,
+        100, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, SECONDS);
+    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1, SECONDS);
+    conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 1, SECONDS);
+    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, SECONDS);
+    ReplicationManager.ReplicationManagerConfiguration replicationConf =
+        conf.getObject(ReplicationManager.ReplicationManagerConfiguration.class);
+    replicationConf.setInterval(Duration.ofSeconds(1));
+    conf.setFromObject(replicationConf);
+    startCluster();
+  }
+
+  static void startCluster() throws Exception {
+    final int numDNs = 5;
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(numDNs)
+        .build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+    store = client.getObjectStore();
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    if (context.getParent().isPresent()) {
+      return;
+    }
+    IOUtils.closeQuietly(client, cluster);
+    cluster = null;
+  }
+
+  public MiniOzoneCluster getCluster() {
+    return cluster;
+  }
+
+  public OzoneConfiguration getConfiguration() {
+    return conf;
+  }
+
+  public OzoneClient getClient() {
+    return client;
+  }
+
+  public ObjectStore getStore() {
+    return store;
+  }
+
+  public OzoneDebug getOzoneDebugShell() {
+    return ozoneDebugShell;
+  }
+
+  public static OzoneShell getOzoneShell() {
+    return ozoneShell;
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerifyChecksums.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerifyChecksums.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.debug.OzoneDebug;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test Ozone Debug shell.
+ */
+@ExtendWith(DebugShellOzoneClusterExtension.class)
+public class TestOzoneDebugReplicasVerifyChecksums {
+  @RegisterExtension
+  static DebugShellOzoneClusterExtension clusterExtension = new DebugShellOzoneClusterExtension();
+
+  @TempDir
+  private static File tempDir;
+  private static final StringWriter out = new StringWriter();
+  private static final StringWriter err = new StringWriter();
+
+  private static OzoneShell ozoneShell;
+  private static OzoneDebug ozoneDebugShell;
+  private static OzoneClient client;
+  private static ObjectStore store = null;
+  private static String volume;
+  private static String ozoneAddress;
+
+  @BeforeAll
+  static void setup() {
+    store = clusterExtension.getStore();
+    client = clusterExtension.getClient();
+    ozoneShell = clusterExtension.getOzoneShell();
+    ozoneDebugShell = clusterExtension.getOzoneDebugShell();
+    ozoneDebugShell.getCmd().setOut(new PrintWriter(out));
+    ozoneDebugShell.getCmd().setErr(new PrintWriter(err));
+  }
+
+  @BeforeAll
+  static void setupKeys() throws IOException {
+    volume = generateVolume("vol-a-");
+    ozoneAddress = "/" + volume;
+    generateKeys(volume, "level1/key-a-",10);
+    generateKeys(volume, "key-b-",10);
+  }
+
+  @AfterEach
+  void cleanupKeys() throws IOException {
+//    ozoneShell.execute(new String[] {
+//       "volume",
+//        "delete",
+//        ozoneAddress,
+//        "-r",
+//        "--yes"
+//    });
+//    for (Iterator<? extends OzoneBucket> it = store.getVolume(volume).listBuckets(null); it.hasNext();) {
+//      OzoneBucket bucket = it.next();
+//      store.getVolume(volume).deleteBucket(bucket.getName());
+//    }
+//    store.deleteVolume(volume);
+  }
+
+  private static String generateVolume(String volumePrefix) throws IOException {
+    String volumeA = volumePrefix + RandomStringUtils.randomNumeric(5);
+    store.createVolume(volumeA);
+    return store.getVolume(volumeA).getName();
+  }
+
+  private static void generateKeys(String volume, String keyPrefix, int numberOfKeys) throws IOException {
+    ReplicationConfig repConfig = ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS, ReplicationFactor.THREE);
+    String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);
+    String bucketB = "buc-b-" + RandomStringUtils.randomNumeric(5);
+    OzoneVolume volA = store.getVolume(volume);
+    volA.createBucket(bucketA);
+    volA.createBucket(bucketB);
+    List<OzoneBucket> ozoneBuckets = new ArrayList<>();
+    ozoneBuckets.add(volA.getBucket(bucketA));
+    ozoneBuckets.add(volA.getBucket(bucketB));
+
+    for (int i = 0; i < numberOfKeys; i++) {
+      for (OzoneBucket bucket : ozoneBuckets) {
+        byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+        String key = keyPrefix + i + "-" + RandomStringUtils.randomNumeric(5);
+        TestDataUtil.createKey(bucket, key, repConfig, value);
+      }
+    }
+  }
+
+  public static Stream<Arguments> getTestChecksumsArguments() {
+    return Stream.of(
+        Arguments.of("case 1: test an invalid command", 2, new String[] {
+            "replicas",
+            "verify",
+            "--checksums",
+            ""}
+        ),
+        Arguments.of("case 2: test a valid command", 0, new String[] {
+            "replicas",
+            "verify",
+            "--checksums",
+            "--output-dir=" + tempDir.getAbsolutePath(),
+            ""}
+        )
+    );
+  }
+
+  @MethodSource("getTestChecksumsArguments")
+  @ParameterizedTest(name = "{0}")
+  void testReplicas(String description, int expectedExitCode, String[] parameters) {
+    parameters[parameters.length - 1] = ozoneAddress;
+    int exitCode = ozoneDebugShell.execute(parameters);
+
+    System.out.println(out);
+    System.out.println(err);
+    assertEquals(expectedExitCode, exitCode, err.toString());
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -17,12 +17,7 @@
 
 package org.apache.hadoop.ozone.shell;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
@@ -35,12 +30,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -50,8 +42,6 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -66,9 +56,10 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
@@ -76,41 +67,27 @@ import picocli.CommandLine;
 /**
  * Test Ozone Debug shell.
  */
+@ExtendWith(DebugShellOzoneClusterExtension.class)
 public class TestOzoneDebugShell {
+  @RegisterExtension
+  static DebugShellOzoneClusterExtension clusterExtension = new DebugShellOzoneClusterExtension();
+
+  private final StringWriter out = new StringWriter();
+  private final StringWriter err = new StringWriter();
 
   private static MiniOzoneCluster cluster = null;
   private static OzoneClient client;
   private static OzoneDebug ozoneDebugShell;
-
   private static OzoneConfiguration conf = null;
 
-  protected static void startCluster() throws Exception {
-    // Init HA cluster
-    final int numDNs = 5;
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(numDNs)
-        .build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
-  }
-
-
-  @BeforeAll
-  public static void init() throws Exception {
-    ozoneDebugShell = new OzoneDebug();
-    conf = ozoneDebugShell.getOzoneConf();
-    conf.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL,
-        100, TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, SECONDS);
-    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1, SECONDS);
-    conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 1, SECONDS);
-    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, SECONDS);
-    ReplicationManager.ReplicationManagerConfiguration replicationConf =
-        conf.getObject(
-            ReplicationManager.ReplicationManagerConfiguration.class);
-    replicationConf.setInterval(Duration.ofSeconds(1));
-    conf.setFromObject(replicationConf);
-    startCluster();
+  @BeforeEach
+  public void setup() {
+    conf = clusterExtension.getConfiguration();
+    cluster = clusterExtension.getCluster();
+    client = clusterExtension.getClient();
+    ozoneDebugShell = clusterExtension.getOzoneDebugShell();
+    ozoneDebugShell.getCmd().setOut(new PrintWriter(out));
+    ozoneDebugShell.getCmd().setErr(new PrintWriter(err));
   }
 
   @ParameterizedTest
@@ -192,7 +169,7 @@ public class TestOzoneDebugShell {
           BucketLayout.LEGACY);
       TestDataUtil.createKey(
           client.getObjectStore().getVolume(volumeName).getBucket(bucketName),
-          keyName, repConfig, "test".getBytes(StandardCharsets.UTF_8));
+          keyName, repConfig, "test".getBytes(UTF_8));
     }
   }
 
@@ -262,16 +239,5 @@ public class TestOzoneDebugShell {
             ContainerID.valueOf(omKeyLocationInfo.getContainerID()));
     OzoneTestUtils.closeContainer(cluster.getStorageContainerManager(),
         container);
-  }
-
-  /**
-   * shutdown MiniOzoneCluster.
-   */
-  @AfterAll
-  public static void shutdown() {
-    IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 }


### PR DESCRIPTION
Please describe your PR in detail:
1. Implemented an Extension class which creates the miniozonecluster that can be reused
2. Implemented an integration test for the `ozone debug replicas verify checksums` command

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12715

## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/14188256141