### PR TITLE
HDDS-12746. Reduce visibility of Logger members

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -659,11 +659,6 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     return config;
   }
 
-  @VisibleForTesting
-  public static Logger getLogger() {
-    return LOG;
-  }
-
   public void setTimeout(long timeout) {
     this.timeout = timeout;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -70,7 +70,7 @@ import org.slf4j.LoggerFactory;
  * The underlying RPC mechanism can be chosen via the constructor.
  */
 public final class XceiverClientRatis extends XceiverClientSpi {
-  public static final Logger LOG = LoggerFactory.getLogger(XceiverClientRatis.class);
+  private static final Logger LOG = LoggerFactory.getLogger(XceiverClientRatis.class);
 
   private final Pipeline pipeline;
   private final RpcType rpcType;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
  * through to the container.
  */
 public class BlockDataStreamOutput implements ByteBufferStreamOutput {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BlockDataStreamOutput.class);
 
   public static final int PUT_BLOCK_REQUEST_LENGTH_MAX = 1 << 20;  // 1MB

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BlockInputStream extends BlockExtendedInputStream {
 
-  public static final Logger LOG = LoggerFactory.getLogger(BlockInputStream.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockInputStream.class);
 
   private static final List<Validator> VALIDATORS =
       ContainerProtocolCalls.toValidatorList((request, response) -> validate(response));

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
  * through to the container.
  */
 public class BlockOutputStream extends OutputStream {
-  public static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(BlockOutputStream.class);
   public static final String EXCEPTION_MSG =
       "Unexpected Storage Container Exception: ";

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * wait until a allocated buffer is released.
  */
 public class BufferPool {
-  public static final Logger LOG = LoggerFactory.getLogger(BufferPool.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BufferPool.class);
 
   private static final BufferPool EMPTY = new BufferPool(0, 0);
   private final int bufferSize;

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.StatusException;
 import org.junit.jupiter.api.BeforeEach;
@@ -266,9 +267,8 @@ public class TestBlockInputStream {
 
   @Test
   public void testRefreshPipelineFunction() throws Exception {
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(BlockInputStream.LOG);
-    GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(BlockInputStream.class);
+    GenericTestUtils.setLogLevel(BlockInputStream.class, Level.DEBUG);
     BlockID blockID = new BlockID(new ContainerBlockID(1, 1));
     AtomicBoolean isRefreshed = new AtomicBoolean();
     createChunkList(5);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
@@ -43,7 +43,7 @@ class TestBufferPool {
 
   @BeforeAll
   static void init() {
-    GenericTestUtils.setLogLevel(BufferPool.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BufferPool.class, Level.DEBUG);
   }
 
   @Test
@@ -67,7 +67,7 @@ class TestBufferPool {
     // As the pool is full, allocation will need to wait until a buffer is released.
     assertFull(pool);
 
-    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.class);
     AtomicReference<ChunkBuffer> allocated = new AtomicReference<>();
     AtomicBoolean allocatorStarted = new AtomicBoolean();
     Thread allocator = new Thread(() -> {
@@ -101,7 +101,7 @@ class TestBufferPool {
     // As the pool is full, new allocation will be blocked interruptably if no allocated buffer is released.
     assertFull(pool);
 
-    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.class);
     AtomicBoolean allocatorStarted = new AtomicBoolean();
     AtomicBoolean interrupted = new AtomicBoolean(false);
     Thread allocator = new Thread(() -> {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
@@ -55,7 +55,7 @@ public class InnerNodeImpl extends NodeImpl implements InnerNode {
   // number of descendant leaves under this node
   private int numOfLeaves;
   // LOGGER
-  public static final Logger LOG = LoggerFactory.getLogger(InnerNodeImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(InnerNodeImpl.class);
 
   /**
    * Construct an InnerNode from its name, network location, parent, level and

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * manages traffic in/out of data centers or racks.
  */
 public class NetworkTopologyImpl implements NetworkTopology {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(NetworkTopologyImpl.class);
 
   /** The Inner node crate factory. */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/ssl/ReloadingX509KeyManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/ssl/ReloadingX509KeyManager.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public class ReloadingX509KeyManager extends X509ExtendedKeyManager implements CertificateNotification {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ReloadingX509KeyManager.class);
 
   private final String type;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/ssl/ReloadingX509TrustManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/ssl/ReloadingX509TrustManager.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public final class ReloadingX509TrustManager implements X509TrustManager, CertificateNotification {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ReloadingX509TrustManager.class);
 
   static final String RELOAD_ERROR_MESSAGE =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -47,7 +47,7 @@ public final class JsonUtils {
   private static final ObjectMapper MAPPER;
   private static final ObjectWriter WRITER;
   private static final ObjectMapper INDENT_OUTPUT_MAPPER; // New mapper instance
-  public static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class);
 
   static {
     MAPPER = new ObjectMapper()

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/StringCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/StringCodec.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StringCodec implements Codec<StringBuilder> {
 
-  public static final Logger LOG  = LoggerFactory.getLogger(StringCodec.class);
+  private static final Logger LOG  = LoggerFactory.getLogger(StringCodec.class);
   public static final StringFormat FORMAT = new StringFormat();
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -37,8 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class BackgroundService {
 
-  @VisibleForTesting
-  public static final Logger LOG =
+  protected static final Logger LOG =
       LoggerFactory.getLogger(BackgroundService.class);
 
   // Executor to launch child tasks

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * for supporting RocksDB direct {@link ByteBuffer} APIs.
  */
 public class CodecBuffer implements UncheckedAutoCloseable {
-  public static final Logger LOG = LoggerFactory.getLogger(CodecBuffer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CodecBuffer.class);
 
   /** To create {@link CodecBuffer} instances. */
   private static class Factory {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * This class is not thread safe.
  */
 public class Checksum {
-  public static final Logger LOG = LoggerFactory.getLogger(Checksum.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Checksum.class);
 
   private static Function<ByteBuffer, ByteString> newMessageDigestFunction(
       String algorithm) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * For CRC32/CRC32C, each checksum takes 4 bytes. Thus each block chunk has 4 MB / 16 KB * 4 B = 1 KB of checksum data.
  */
 public class ChecksumCache {
-  public static final Logger LOG = LoggerFactory.getLogger(ChecksumCache.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ChecksumCache.class);
 
   private final int bytesPerChecksum;
   private final List<ByteString> checksums;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * Utilities for buffers.
  */
 public final class BufferUtils {
-  public static final Logger LOG = LoggerFactory.getLogger(BufferUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BufferUtils.class);
 
   private static final ByteBuffer[] EMPTY_BYTE_BUFFER_ARRAY = {};
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
@@ -26,14 +26,11 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test class for {@link ChecksumCache}.
  */
 class TestChecksumCache {
-  public static final Logger LOG = LoggerFactory.getLogger(TestChecksumCache.class);
 
   @ParameterizedTest
   @EnumSource(ChecksumType.class)

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class TimeDurationUtil {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(TimeDurationUtil.class);
 
   private TimeDurationUtil() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -163,10 +163,6 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
     }
   }
 
-  public static Logger getLogger() {
-    return LOG;
-  }
-
   @Override
   public Void call() throws Exception {
     OzoneConfiguration configuration = getOzoneConf();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -89,8 +89,7 @@ import org.slf4j.LoggerFactory;
  * State Machine Class.
  */
 public class DatanodeStateMachine implements Closeable {
-  @VisibleForTesting
-  static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DatanodeStateMachine.class);
   private final ExecutorService executorService;
   private final ExecutorService pipelineCommandExecutorService;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -78,7 +78,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DeleteBlocksCommandHandler implements CommandHandler {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DeleteBlocksCommandHandler.class);
 
   private final ContainerSet containerSet;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -68,8 +68,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HeartbeatEndpointTask
     implements Callable<EndpointStateMachine.EndPointStates> {
-  public static final Logger LOG =
-      LoggerFactory.getLogger(HeartbeatEndpointTask.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HeartbeatEndpointTask.class);
   private final EndpointStateMachine rpcEndpoint;
   private DatanodeDetailsProto datanodeDetailsProto;
   private StateContext context;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -39,8 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class VersionEndpointTask implements
     Callable<EndpointStateMachine.EndPointStates> {
-  public static final Logger LOG = LoggerFactory.getLogger(VersionEndpointTask
-      .class);
+  private static final Logger LOG = LoggerFactory.getLogger(VersionEndpointTask.class);
   private final EndpointStateMachine rpcEndPoint;
   private final ConfigurationSource configuration;
   private final OzoneContainer ozoneContainer;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
 
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       CapacityVolumeChoosingPolicy.class);
 
   // Stores the index of the next volume to be returned.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/RoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/RoundRobinVolumeChoosingPolicy.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RoundRobinVolumeChoosingPolicy implements VolumeChoosingPolicy {
 
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       RoundRobinVolumeChoosingPolicy.class);
 
   // Stores the index of the next volume to be returned.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeChecker.java
@@ -60,7 +60,7 @@ public class StorageVolumeChecker {
 
   public static final int MAX_VOLUME_FAILURE_TOLERATED_LIMIT = -1;
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(StorageVolumeChecker.class);
 
   private AsyncChecker<Boolean, VolumeCheckResult> delegateChecker;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/ThrottledAsyncChecker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/ThrottledAsyncChecker.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class ThrottledAsyncChecker<K, V> implements AsyncChecker<K, V> {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ThrottledAsyncChecker.class);
 
   private final Timer timer;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
  * log4j.appender.inspectorAppender.layout=org.apache.log4j.PatternLayout
  */
 public class KeyValueContainerMetadataInspector implements ContainerInspector {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(KeyValueContainerMetadataInspector.class);
   public static final Logger REPORT_LOG = LoggerFactory.getLogger(
       "ContainerMetadataInspectorReport");

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -136,7 +136,7 @@ import org.slf4j.LoggerFactory;
  */
 public class KeyValueHandler extends Handler {
 
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       KeyValueHandler.class);
 
   private final BlockManager blockManager;
@@ -1577,10 +1577,6 @@ public class KeyValueHandler extends Handler {
       }
     }
     return null;
-  }
-
-  public static Logger getLogger() {
-    return LOG;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BlockManagerImpl implements BlockManager {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BlockManagerImpl.class);
 
   private ConfigurationSource config;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/KeyValueStreamDataChannel.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/KeyValueStreamDataChannel.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * This class is used to get the DataChannel for streaming.
  */
 public class KeyValueStreamDataChannel extends StreamDataChannelBase {
-  public static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(KeyValueStreamDataChannel.class);
 
   interface WriteMethod {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -57,7 +57,7 @@ public class AbstractDatanodeStore extends AbstractRDBStore<AbstractDatanodeDBDe
 
   private Table<String, Long> finalizeBlocksTableWithIterator;
 
-  public static final Logger LOG =
+  protected static final Logger LOG =
       LoggerFactory.getLogger(AbstractDatanodeStore.class);
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/AbstractBackgroundContainerScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/AbstractBackgroundContainerScanner.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * Base class for scheduled scanners on a Datanode.
  */
 public abstract class AbstractBackgroundContainerScanner implements Runnable {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(AbstractBackgroundContainerScanner.class);
 
   private final long dataScanInterval;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BackgroundContainerDataScanner extends
     AbstractBackgroundContainerScanner {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BackgroundContainerDataScanner.class);
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BackgroundContainerMetadataScanner extends
     AbstractBackgroundContainerScanner {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BackgroundContainerMetadataScanner.class);
 
   private final ContainerMetadataScannerMetrics metrics;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * Class for performing on demand scans of containers.
  */
 public final class OnDemandContainerDataScanner {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OnDemandContainerDataScanner.class);
 
   private static volatile OnDemandContainerDataScanner instance;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DownloadAndImportReplicator implements ContainerReplicator {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DownloadAndImportReplicator.class);
 
   private final ConfigurationSource conf;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleContainerDownloader implements ContainerDownloader {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SimpleContainerDownloader.class);
 
   private final SecurityConfig securityConfig;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeSchemaV2FinalizeAction.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeSchemaV2FinalizeAction.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public class DatanodeSchemaV2FinalizeAction
     implements HDDSUpgradeAction<DatanodeStateMachine> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DatanodeSchemaV2FinalizeAction.class);
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeSchemaV3FinalizeAction.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeSchemaV3FinalizeAction.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class DatanodeSchemaV3FinalizeAction
     implements HDDSUpgradeAction<DatanodeStateMachine> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DatanodeSchemaV3FinalizeAction.class);
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.util.ServicePlugin;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -80,7 +81,7 @@ public class TestHddsSecureDatanodeInit {
   private static String[] args = new String[]{};
   private static PrivateKey privateKey;
   private static PublicKey publicKey;
-  private static GenericTestUtils.LogCapturer dnLogs;
+  private static LogCapturer dnLogs;
   private static SecurityConfig securityConfig;
   private static KeyStorage keyStorage;
   private static CertificateCodec certCodec;
@@ -125,8 +126,7 @@ public class TestHddsSecureDatanodeInit {
       service.initializeCertificateClient(service.getCertificateClient());
       return null;
     });
-    dnLogs = GenericTestUtils.LogCapturer.captureLogs(
-        ((DNCertificateClient)service.getCertificateClient()).getLogger());
+    dnLogs = LogCapturer.captureLogs(DNCertificateClient.class);
     certCodec = new CertificateCodec(securityConfig, DN_COMPONENT);
     keyStorage = new KeyStorage(securityConfig, DN_COMPONENT);
     dnLogs.clearOutput();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -26,7 +26,6 @@ import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.WRITE_
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerImplTestUtils.newContainerSet;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_BLOCK;
-import static org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask.LOG;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -109,6 +108,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -116,6 +116,8 @@ import org.slf4j.LoggerFactory;
  */
 @Timeout(30)
 public class TestBlockDeletingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestBlockDeletingService.class);
 
   @TempDir
   private File testRoot;
@@ -815,7 +817,7 @@ public class TestBlockDeletingService {
         10, conf);
     svc.start();
 
-    LogCapturer log = LogCapturer.captureLogs(BackgroundService.LOG);
+    LogCapturer log = LogCapturer.captureLogs(BackgroundService.class);
     GenericTestUtils.waitFor(() -> {
       if (log.getOutput().contains("Background task execution took")) {
         log.stopCapturing();
@@ -842,7 +844,7 @@ public class TestBlockDeletingService {
         (KeyValueContainer) containerSet.iterator().next();
     KeyValueContainerData data = container.getContainerData();
     try (DBHandle meta = BlockUtils.getDB(data, conf)) {
-      LogCapturer newLog = LogCapturer.captureLogs(BackgroundService.LOG);
+      LogCapturer newLog = LogCapturer.captureLogs(BackgroundService.class);
       GenericTestUtils.waitFor(() -> {
         try {
           return getUnderDeletionBlocksCount(meta, data) == 0;
@@ -951,9 +953,7 @@ public class TestBlockDeletingService {
   public void testContainerMaxLockHoldingTime(
       ContainerTestVersionInfo versionInfo) throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
-    GenericTestUtils.LogCapturer log =
-        GenericTestUtils.LogCapturer.captureLogs(
-            LoggerFactory.getLogger(BlockDeletingTask.class));
+    LogCapturer log = LogCapturer.captureLogs(BlockDeletingTask.class);
     DatanodeConfiguration dnConf = conf.getObject(DatanodeConfiguration.class);
 
     // Ensure that the lock holding timeout occurs every time a deletion

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -92,7 +92,7 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.security.token.Token;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -391,8 +391,7 @@ public class TestHddsDispatcher {
       assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
-      GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-          .captureLogs(HddsDispatcher.LOG);
+      LogCapturer logCapturer = LogCapturer.captureLogs(HddsDispatcher.class);
       // send write chunk request without sending create container
       response = hddsDispatcher.dispatch(writeChunkRequest, COMMIT_STAGE);
       // container should not be found
@@ -429,8 +428,7 @@ public class TestHddsDispatcher {
       doReturn(builder.build()).when(mockDispatcher)
           .createContainer(writeChunkRequest);
 
-      GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-          .captureLogs(HddsDispatcher.LOG);
+      LogCapturer logCapturer = LogCapturer.captureLogs(HddsDispatcher.class);
       // send write chunk request without sending create container
       mockDispatcher.dispatch(writeChunkRequest, null);
       // verify the error log

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(150)
 public class TestPeriodicVolumeChecker {
 
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestPeriodicVolumeChecker.class);
 
   @TempDir

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
  */
 @Timeout(300)
 public class TestStorageVolumeChecker {
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestStorageVolumeChecker.class);
 
   private static final int NUM_VOLUMES = 2;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests {@link MutableVolumeSet} operations.
@@ -164,8 +163,7 @@ public class TestVolumeSet {
 
     // Attempting to remove a volume which does not exist in VolumeSet should
     // log a warning.
-    LogCapturer logs = LogCapturer.captureLogs(
-        LoggerFactory.getLogger(MutableVolumeSet.class));
+    LogCapturer logs = LogCapturer.captureLogs(MutableVolumeSet.class);
     volumeSet.removeVolume(HddsVolumeUtil.getHddsRoot(volume1));
     assertEquals(1, volumeSet.getVolumesList().size());
     String expectedLogMessage = "Volume : " +

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -78,7 +78,7 @@ public class TestVolumeSetDiskChecks {
   @TempDir
   private Path tempDir;
 
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestVolumeSetDiskChecks.class);
   @TempDir
   private File dir;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 @Timeout(600)
 public class TestKeyValueContainerMarkUnhealthy {
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestKeyValueContainerMarkUnhealthy.class);
 
   @TempDir

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -70,7 +70,7 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -440,8 +440,7 @@ public class TestKeyValueHandler {
 
       // Case 3:  Delete Container on a failed volume
       hddsVolume.failVolume();
-      GenericTestUtils.LogCapturer kvHandlerLogs =
-          GenericTestUtils.LogCapturer.captureLogs(KeyValueHandler.getLogger());
+      LogCapturer kvHandlerLogs = LogCapturer.captureLogs(KeyValueHandler.class);
       // add the container back to containerSet as removed in previous delete
       containerSet.addContainer(container);
       kvHandler.deleteContainer(container, true);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -60,16 +60,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test that KeyValueHandler fails certain operations when the
  * container is unhealthy.
  */
 public class TestKeyValueHandlerWithUnhealthyContainer {
-  public static final Logger LOG = LoggerFactory.getLogger(
-      TestKeyValueHandlerWithUnhealthyContainer.class);
 
   @TempDir
   private File tempDir;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestKeyValueStreamDataChannel.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestKeyValueStreamDataChannel.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 
 /** For testing {@link KeyValueStreamDataChannel}. */
 public class TestKeyValueStreamDataChannel {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyValueStreamDataChannel.class);
 
   private static final ContainerCommandRequestProto PUT_BLOCK_PROTO

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -68,11 +68,10 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.util.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test ContainerReader class which loads containers from disks.
@@ -350,8 +349,7 @@ public class TestContainerReader {
       FileUtils.deleteFully(dbPath.toPath());
     }
 
-    GenericTestUtils.LogCapturer dnLogs = GenericTestUtils.LogCapturer.captureLogs(
-        LoggerFactory.getLogger(ContainerReader.class));
+    LogCapturer dnLogs = LogCapturer.captureLogs(ContainerReader.class);
     dnLogs.clearOutput();
     ContainerReader containerReader = new ContainerReader(volumeSet1,
         hddsVolume1, containerSet1, conf, true);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -104,6 +104,7 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -337,8 +338,7 @@ public class TestReplicationSupervisor {
 
     replicatorRef.set(replicator);
 
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(DownloadAndImportReplicator.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(DownloadAndImportReplicator.class);
 
     supervisor.addTask(createTask(1L));
     assertEquals(1, supervisor.getReplicationFailureCount());
@@ -406,8 +406,7 @@ public class TestReplicationSupervisor {
         new DownloadAndImportReplicator(conf, set, importer, moc);
     replicatorRef.set(replicator);
 
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(DownloadAndImportReplicator.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(DownloadAndImportReplicator.class);
 
     // Acquire semaphore so that container import will pause after reserving space.
     semaphore.acquire();

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawDecoder.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @SuppressWarnings("checkstyle:VisibilityModifier")
 abstract class AbstractNativeRawDecoder extends RawErasureDecoder {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(AbstractNativeRawDecoder.class);
 
   // Protect ISA-L coder data structure in native layer from being accessed and

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawEncoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawEncoder.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @SuppressWarnings("checkstyle:VisibilityModifier")
 abstract class AbstractNativeRawEncoder extends RawErasureEncoder {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(AbstractNativeRawEncoder.class);
 
   // Protect ISA-L coder data structure in native layer from being accessed and

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/util/CodecUtil.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/util/CodecUtil.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 public final class CodecUtil {
 
-  public static final Logger LOG = LoggerFactory.getLogger(CodecUtil.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CodecUtil.class);
 
   private CodecUtil() {
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolClientSideTranslatorPB.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Stable
 public class ReconfigureProtocolClientSideTranslatorPB implements
     ProtocolMetaInterface, ReconfigureProtocol, ProtocolTranslator {
-  public static final Logger LOG = LoggerFactory
+  private static final Logger LOG = LoggerFactory
       .getLogger(ReconfigureProtocolClientSideTranslatorPB.class);
 
   private static final RpcController NULL_CONTROLLER = null;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * Utility class used by SCM HA.
  */
 public final class SCMHAUtils {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMHAUtils.class);
 
   private static final ImmutableList<Class<? extends Exception>>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SCMBlockLocationFailoverProxyProvider extends
     SCMFailoverProxyProviderBase<ScmBlockLocationProtocolPB> {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMBlockLocationFailoverProxyProvider.class);
 
   public SCMBlockLocationFailoverProxyProvider(ConfigurationSource conf) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SCMContainerLocationFailoverProxyProvider extends
     SCMFailoverProxyProviderBase<StorageContainerLocationProtocolPB> {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMContainerLocationFailoverProxyProvider.class);
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SCMSecurityProtocolFailoverProxyProvider extends SCMFailoverProxyProviderBase<SCMSecurityProtocolPB> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMSecurityProtocolFailoverProxyProvider.class);
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SecretKeyProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SecretKeyProtocolFailoverProxyProvider.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class SecretKeyProtocolFailoverProxyProvider
     <T extends SCMSecretKeyProtocolService.BlockingInterface> extends SCMFailoverProxyProviderBase<T> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SecretKeyProtocolFailoverProxyProvider.class);
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SingleSecretKeyProtocolProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SingleSecretKeyProtocolProxyProvider.java
@@ -31,7 +31,7 @@ public class SingleSecretKeyProtocolProxyProvider
     <T extends SCMSecretKeyProtocolService.BlockingInterface>
     extends SecretKeyProtocolFailoverProxyProvider<T> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SingleSecretKeyProtocolProxyProvider.class);
 
   private final String scmNodeId;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpRequestLog.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpRequestLog.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class HttpRequestLog {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(HttpRequestLog.class);
   private static final HashMap<String, String> SERVER_TO_COMPONENT;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -131,7 +131,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public final class HttpServer2 implements FilterContainer {
-  public static final Logger LOG = LoggerFactory.getLogger(HttpServer2.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HttpServer2.class);
 
   public static final String HTTP_SCHEME = "http";
   public static final String HTTPS_SCHEME = "https";

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
  * utility class used by SCM and OM for HA.
  */
 public final class HAUtils {
-  public static final Logger LOG = LoggerFactory.getLogger(HAUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HAUtils.class);
 
   private HAUtils() {
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -486,8 +486,4 @@ public class RDBStore implements DBStore {
   public RDBMetrics getMetrics() {
     return rdbMetrics;
   }
-
-  public static Logger getLogger() {
-    return LOG;
-  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/FullTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/FullTableCache.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @Evolving
 public class FullTableCache<KEY, VALUE> implements TableCache<KEY, VALUE> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(FullTableCache.class);
 
   private final Map<CacheKey<KEY>, CacheValue<VALUE>> cache;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 @Evolving
 public class PartialTableCache<KEY, VALUE> implements TableCache<KEY, VALUE> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(PartialTableCache.class);
 
   private final Map<CacheKey<KEY>, CacheValue<VALUE>> cache;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 public class StorageInfo {
 
-  public static final Logger LOG = LoggerFactory.getLogger(StorageInfo.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StorageInfo.class);
 
   private Properties properties = new Properties();
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestSpaceUsageFactory.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestSpaceUsageFactory.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for {@link SpaceUsageCheckFactory}.
@@ -59,8 +58,7 @@ public class TestSpaceUsageFactory {
 
   @BeforeEach
   public void setUp() {
-    capturer = LogCapturer.captureLogs(
-        LoggerFactory.getLogger(SpaceUsageCheckFactory.class));
+    capturer = LogCapturer.captureLogs(SpaceUsageCheckFactory.class);
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
  */
 public class TestReloadingX509KeyManager {
   private final LogCapturer reloaderLog =
-      LogCapturer.captureLogs(ReloadingX509KeyManager.LOG);
+      LogCapturer.captureLogs(ReloadingX509KeyManager.class);
   private static OzoneConfiguration conf;
   private static CertificateClientTestImpl caClient;
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
  */
 public class TestReloadingX509TrustManager {
   private final LogCapturer reloaderLog =
-      LogCapturer.captureLogs(ReloadingX509TrustManager.LOG);
+      LogCapturer.captureLogs(ReloadingX509TrustManager.class);
   private static CertificateClientTestImpl caClient;
 
   @BeforeAll

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -66,7 +66,7 @@ import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -370,8 +370,7 @@ public class TestDefaultCertificateClient {
 
   @Test
   public void testInitCertAndKeypairValidationFailures() throws Exception {
-    GenericTestUtils.LogCapturer dnClientLog = GenericTestUtils.LogCapturer
-        .captureLogs(dnCertClient.getLogger());
+    LogCapturer dnClientLog = LogCapturer.captureLogs(DNCertificateClient.class);
     KeyPair keyPair = keyGenerator.generateKey();
     KeyPair keyPair1 = keyGenerator.generateKey();
     dnClientLog.clearOutput();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -53,7 +54,7 @@ import org.mockito.MockitoAnnotations;
 public class TestRootCaRotationPoller {
 
   private SecurityConfig secConf;
-  private GenericTestUtils.LogCapturer logCapturer;
+  private LogCapturer logCapturer;
 
   @Mock
   private SCMSecurityProtocolClientSideTranslatorPB scmSecurityClient;
@@ -64,8 +65,7 @@ public class TestRootCaRotationPoller {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL, "PT1s");
     secConf = new SecurityConfig(conf);
-    logCapturer = GenericTestUtils.LogCapturer.captureLogs(
-        org.slf4j.LoggerFactory.getLogger(RootCaRotationPoller.class));
+    logCapturer = LogCapturer.captureLogs(RootCaRotationPoller.class);
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -43,7 +43,7 @@ public class TestTableCache {
 
   @BeforeAll
   public static void setLogLevel() {
-    GenericTestUtils.setLogLevel(FullTableCache.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(FullTableCache.class, Level.DEBUG);
   }
 
   private void createTableCache(TableCache.CacheType cacheType) {

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -37,7 +37,7 @@ public final class ManagedRocksObjectUtils {
   private ManagedRocksObjectUtils() {
   }
 
-  public static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(ManagedRocksObjectUtils.class);
 
   private static final Duration POLL_INTERVAL_DURATION = Duration.ofMillis(100);

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1392,11 +1392,6 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   }
 
   @VisibleForTesting
-  public static Logger getLog() {
-    return LOG;
-  }
-
-  @VisibleForTesting
   public ConcurrentHashMap<String, CompactionNode> getCompactionNodeMap() {
     return compactionNodeMap;
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -155,9 +155,9 @@ public class TestRocksDBCheckpointDiffer {
   @BeforeEach
   public void init() throws RocksDBException {
     // Checkpoint differ log level. Set to DEBUG for verbose output
-    GenericTestUtils.setLogLevel(RocksDBCheckpointDiffer.getLog(), Level.INFO);
+    GenericTestUtils.setLogLevel(RocksDBCheckpointDiffer.class, Level.INFO);
     // Test class log level. Set to DEBUG for verbose output
-    GenericTestUtils.setLogLevel(TestRocksDBCheckpointDiffer.LOG, Level.INFO);
+    GenericTestUtils.setLogLevel(TestRocksDBCheckpointDiffer.class, Level.INFO);
 
     activeDbDir = new File(ACTIVE_DB_DIR_NAME);
     createDir(activeDbDir, ACTIVE_DB_DIR_NAME);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -280,11 +280,4 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
   public SCMBlockDeletingService getSCMBlockDeletingService() {
     return this.blockDeletingService;
   }
-
-  /**
-   * Get class logger.
-   * */
-  public static Logger getLogger() {
-    return LOG;
-  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
 public class DeletedBlockLogImpl
     implements DeletedBlockLog, EventHandler<DeleteBlockStatus> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DeletedBlockLogImpl.class);
 
   private final int maxRetry;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class DeletedBlockLogStateManagerImpl
     implements DeletedBlockLogStateManager {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DeletedBlockLogStateManagerImpl.class);
 
   private Table<Long, DeletedBlocksTransaction> deletedTable;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
 public class SCMBlockDeletingService extends BackgroundService
     implements SCMService {
 
-  public static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(SCMBlockDeletingService.class);
 
   private static final int BLOCK_DELETING_SERVICE_CORE_POOL_SIZE = 1;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * DeletedBlockTransaction sent to the DN.
  */
 public class SCMDeletedBlockTransactionStatusManager {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMDeletedBlockTransactionStatusManager.class);
   // Maps txId to set of DNs which are successful in committing the transaction
   private final Map<Long, Set<UUID>> transactionToDNsCommitMap;
@@ -98,7 +98,7 @@ public class SCMDeletedBlockTransactionStatusManager {
    * on DeleteBlocksCommand.
    */
   protected static class SCMDeleteBlocksCommandStatusManager {
-    public static final Logger LOG =
+    private static final Logger LOG =
         LoggerFactory.getLogger(SCMDeleteBlocksCommandStatusManager.class);
     private final Map<UUID, Map<Long, CmdStatusData>> scmCmdStatusRecord;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CloseContainerEventHandler implements EventHandler<ContainerID> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(CloseContainerEventHandler.class);
 
   private final PipelineManager pipelineManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -41,7 +41,7 @@ public class ContainerBalancer extends StatefulService {
 
   private static final AtomicInteger ID = new AtomicInteger();
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ContainerBalancer.class);
 
   private StorageContainerManager scm;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ContainerBalancerTask implements Runnable {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ContainerBalancerTask.class);
   public static final long ABSENCE_OF_DURATION = -1L;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByNetworkTopology.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByNetworkTopology.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FindTargetGreedyByNetworkTopology
     extends AbstractFindTargetGreedy {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(FindTargetGreedyByNetworkTopology.class);
 
   private NetworkTopology networkTopology;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByUsageInfo.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * target with the lowest space usage.
  */
 public class FindTargetGreedyByUsageInfo extends AbstractFindTargetGreedy {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(FindTargetGreedyByUsageInfo.class);
 
   public FindTargetGreedyByUsageInfo(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -102,7 +102,7 @@ public final class MoveManager implements
     FAIL_UNEXPECTED_ERROR
   }
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(MoveManager.class);
 
   // TODO - Should pending ops notify under lock to allow MM to schedule a

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 public final class SCMContainerPlacementCapacity
     extends SCMCommonPlacementPolicy {
   @VisibleForTesting
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMContainerPlacementCapacity.class);
 
   private final SCMContainerPlacementMetrics metrics;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 public final class SCMContainerPlacementRackAware
     extends SCMCommonPlacementPolicy {
   @VisibleForTesting
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMContainerPlacementRackAware.class);
   private final NetworkTopology networkTopology;
   private boolean fallback;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 public final class SCMContainerPlacementRackScatter
     extends SCMCommonPlacementPolicy {
   @VisibleForTesting
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMContainerPlacementRackScatter.class);
   private final NetworkTopology networkTopology;
   private static final int RACK_LEVEL = 1;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
     implements PlacementPolicy {
   @VisibleForTesting
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMContainerPlacementRandom.class);
 
   private final SCMContainerPlacementMetrics metrics;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * commands.
  */
 public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ECOverReplicationHandler.class);
 
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ECUnderReplicationHandler.class);
   private final PlacementPolicy containerPlacement;
   private final long currentContainerSize;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 public abstract class MisReplicationHandler implements
         UnhealthyReplicationHandler {
 
-  public static final Logger LOG =
+  protected static final Logger LOG =
           LoggerFactory.getLogger(MisReplicationHandler.class);
   private final PlacementPolicy containerPlacement;
   private final long currentContainerSize;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * Class to correct under replicated QuasiClosed Stuck Ratis containers.
  */
 public class QuasiClosedStuckUnderReplicationHandler implements UnhealthyReplicationHandler {
-  public static final Logger LOG = LoggerFactory.getLogger(QuasiClosedStuckUnderReplicationHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(QuasiClosedStuckUnderReplicationHandler.class);
 
   private final PlacementPolicy placementPolicy;
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RatisOverReplicationHandler
     extends AbstractOverReplicationHandler {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RatisOverReplicationHandler.class);
 
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RatisUnderReplicationHandler
     implements UnhealthyReplicationHandler {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RatisUnderReplicationHandler.class);
   private final PlacementPolicy placementPolicy;
   private final long currentContainerSize;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -103,7 +103,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReplicationManager implements SCMService, ContainerReplicaPendingOpsSubscriber {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ReplicationManager.class);
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ClosedWithUnhealthyReplicasHandler extends AbstractCheck {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ClosedWithUnhealthyReplicasHandler.class);
   private final ReplicationManager replicationManager;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/DeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/DeletingContainerHandler.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 public class DeletingContainerHandler extends AbstractCheck {
   private final ReplicationManager replicationManager;
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DeletingContainerHandler.class);
 
   public DeletingContainerHandler(ReplicationManager replicationManager) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * and all its replicas are empty.
  */
 public class EmptyContainerHandler extends AbstractCheck {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(EmptyContainerHandler.class);
 
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MismatchedReplicasHandler extends AbstractCheck {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(MismatchedReplicasHandler.class);
 
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedContainerHandler.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * under and over replication etc.
  */
 public class QuasiClosedContainerHandler extends AbstractCheck {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(QuasiClosedContainerHandler.class);
 
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedStuckReplicationCheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedStuckReplicationCheck.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * if there is more than 1 origin. If there is only 1 origin, then we need to maintain 3 copies.
  */
 public class QuasiClosedStuckReplicationCheck  extends AbstractCheck {
-  public static final Logger LOG = LoggerFactory.getLogger(QuasiClosedStuckReplicationCheck.class);
+  private static final Logger LOG = LoggerFactory.getLogger(QuasiClosedStuckReplicationCheck.class);
 
   public static boolean shouldHandleAsQuasiClosedStuck(ContainerInfo containerInfo, Set<ContainerReplica> replicas) {
     if (containerInfo.getState() != QUASI_CLOSED) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  */
 public class RatisReplicationCheckHandler extends AbstractCheck {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RatisReplicationCheckHandler.class);
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  */
 public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       RatisUnhealthyReplicationCheckHandler.class);
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/VulnerableUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/VulnerableUnhealthyReplicasHandler.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * copy of such replicas.
  */
 public class VulnerableUnhealthyReplicasHandler extends AbstractCheck {
-  public static final Logger LOG = LoggerFactory.getLogger(VulnerableUnhealthyReplicasHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(VulnerableUnhealthyReplicasHandler.class);
   private final ReplicationManager replicationManager;
 
   public VulnerableUnhealthyReplicasHandler(ReplicationManager replicationManager) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.container.states;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -192,11 +191,6 @@ public class ContainerStateMap {
    * Create a ContainerStateMap.
    */
   public ContainerStateMap() {
-  }
-
-  @VisibleForTesting
-  public static Logger getLogger() {
-    return LOG;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -63,7 +63,7 @@ public final class  HASecurityUtils {
   private HASecurityUtils() {
   }
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(HASecurityUtils.class);
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SCMHADBTransactionBufferImpl implements SCMHADBTransactionBuffer {
 
-  public static final Logger LOG = LoggerFactory.getLogger(SCMHADBTransactionBufferImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SCMHADBTransactionBufferImpl.class);
   private final StorageContainerManager scm;
   private SCMMetadataStore metadataStore;
   private BatchOperation currentBatchOperation;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -470,8 +470,4 @@ public class SCMHAManagerImpl implements SCMHAManager {
     grpcServer.stop();
   }
 
-  @VisibleForTesting
-  public static Logger getLogger() {
-    return LOG;
-  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  * SCM HA node details.
  */
 public class SCMHANodeDetails {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMHANodeDetails.class);
 
   private final SCMNodeDetails localNodeDetails;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHATransactionBufferMonitorTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHATransactionBufferMonitorTask.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * buffer.
  */
 public class SCMHATransactionBufferMonitorTask implements Runnable {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMHATransactionBufferMonitorTask.class);
   private final SCMRatisServer server;
   private final SCMHADBTransactionBuffer transactionBuffer;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMNodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMNodeDetails.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.hdds.scm.ha;
 import java.net.InetSocketAddress;
 import org.apache.hadoop.hdds.NodeDetails;
 import org.apache.hadoop.net.NetUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Construct SCM node details.
@@ -34,9 +32,6 @@ public final class SCMNodeDetails extends NodeDetails {
   private final InetSocketAddress datanodeProtocolServerAddress;
   private final String datanodeAddressKey;
   private final int grpcPort;
-
-  public static final Logger LOG =
-      LoggerFactory.getLogger(SCMNodeDetails.class);
 
   private SCMNodeDetails(Builder b) {
     super(b.scmServiceId, b.scmNodeId, b.rpcAddress, b.ratisPort, b.httpAddr, b.httpsAddr);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManagerImpl.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public final class StatefulServiceStateManagerImpl
     implements StatefulServiceStateManager {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(StatefulServiceStateManagerImpl.class);
 
   // this table maps the service name to the configuration (ByteString)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -114,7 +114,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SCMNodeManager implements NodeManager {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMNodeManager.class);
 
   private final NodeStateManager nodeStateManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class PipelineActionHandler
     implements EventHandler<PipelineActionsFromDatanode> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(PipelineActionHandler.class);
 
   private final PipelineManager pipelineManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RoundRobinPipelineChoosePolicy implements PipelineChoosePolicy {
 
-  public static final Logger LOG = LoggerFactory.getLogger(RoundRobinPipelineChoosePolicy.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RoundRobinPipelineChoosePolicy.class);
 
   // Stores the index of the next pipeline to be returned.
   private int nextPipelineIndex = 0;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 public class ContainerSafeModeRule extends
     SafeModeExitRule<NodeRegistrationContainerReport> {
 
-  public static final Logger LOG = LoggerFactory.getLogger(ContainerSafeModeRule.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerSafeModeRule.class);
   
   private static final String NAME = "ContainerSafeModeRule";
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(HealthyPipelineSafeModeRule.class);
 
   private static final String NAME = "HealthyPipelineSafeModeRule";

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationHandlerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationHandlerImpl.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RootCARotationHandlerImpl implements RootCARotationHandler {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RootCARotationHandlerImpl.class);
 
   private final StorageContainerManager scm;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -75,7 +75,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RootCARotationManager extends StatefulService {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RootCARotationManager.class);
 
   private static final String SERVICE_NAME =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/SecretKeyManagerService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/SecretKeyManagerService.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * A background service running in SCM to maintain the SecretKeys lifecycle.
  */
 public class SecretKeyManagerService implements SCMService, Runnable {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SecretKeyManagerService.class);
 
   private static final String SERVICE_NAME =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class SCMDatanodeHeartbeatDispatcher {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMDatanodeHeartbeatDispatcher.class);
 
   private final NodeManager nodeManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManagerImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.server.upgrade;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -40,8 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FinalizationStateManagerImpl implements FinalizationStateManager {
 
-  @VisibleForTesting
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(FinalizationStateManagerImpl.class);
 
   private Table<String, String> finalizationStore;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmOnFinalizeActionForDatanodeSchemaV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmOnFinalizeActionForDatanodeSchemaV2.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
     ON_FINALIZE)
 public class ScmOnFinalizeActionForDatanodeSchemaV2 implements
     HDDSUpgradeAction<SCMUpgradeFinalizationContext> {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ScmOnFinalizeActionForDatanodeSchemaV2.class);
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/ozone/protocol/commands/RetriableDatanodeEventWatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/ozone/protocol/commands/RetriableDatanodeEventWatcher.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class RetriableDatanodeEventWatcher<T extends CommandStatusEvent>
     extends EventWatcher<CommandForDatanode, T> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(RetriableDatanodeEventWatcher.class);
 
   public RetriableDatanodeEventWatcher(Event<CommandForDatanode> startEvent,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestHddsServerUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestHddsServerUtils.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 @Timeout(300)
 public class TestHddsServerUtils {
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestHddsServerUtils.class);
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/command/TestCommandStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/command/TestCommandStatusReportHandler.java
@@ -55,8 +55,7 @@ public class TestCommandStatusReportHandler implements EventPublisher {
 
   @Test
   public void testCommandStatusReport() {
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(LOG);
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(LOG);
 
     CommandStatusReportFromDatanode report = this.getStatusReport(Collections
         .emptyList());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -81,7 +81,7 @@ public class TestContainerManagerImpl {
   @BeforeAll
   static void init() {
     // Print container state transition logs
-    GenericTestUtils.setLogLevel(ContainerStateMap.getLogger(), Level.TRACE);
+    GenericTestUtils.setLogLevel(ContainerStateMap.class, Level.TRACE);
   }
 
   @BeforeEach

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -90,7 +91,7 @@ public class TestContainerBalancer {
     // time to verify, and interrupt when stop.
     balancerConfiguration.setTriggerDuEnable(true);
     conf.setFromObject(balancerConfiguration);
-    GenericTestUtils.setLogLevel(ContainerBalancer.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ContainerBalancer.class, Level.DEBUG);
 
     when(scm.getScmNodeManager()).thenReturn(mock(NodeManager.class));
     when(scm.getScmContext()).thenReturn(SCMContext.emptyContext());
@@ -236,8 +237,7 @@ public class TestContainerBalancer {
     containerBalancer.notifyStatusChanged();
     assertFalse(containerBalancer.isBalancerRunning());
 
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(ContainerBalancerTask.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(ContainerBalancerTask.class);
     String expectedLog = "ContainerBalancer will sleep for " + delayDuration +
         " seconds before starting balancing.";
     /*

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -74,7 +74,7 @@ public class TestContainerBalancerDatanodeNodeLimit {
 
   @BeforeAll
   public static void setup() {
-    GenericTestUtils.setLogLevel(ContainerBalancerTask.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ContainerBalancerTask.class, Level.DEBUG);
   }
 
   private static Stream<Arguments> createMockedSCMs() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -144,7 +144,7 @@ public class TestContainerBalancerTask {
     balancerConfiguration.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     balancerConfiguration.setMaxSizeEnteringTarget(50 * STORAGE_UNIT);
     conf.setFromObject(balancerConfiguration);
-    GenericTestUtils.setLogLevel(ContainerBalancerTask.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ContainerBalancerTask.class, Level.DEBUG);
 
     int[] sizeArray = testInfo.getTestMethod()
             .filter(method -> method.getName().equals("balancerShouldMoveOnlyPositiveSizeContainers"))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -101,7 +101,7 @@ public class TestRatisOverReplicationHandler {
     ReplicationTestUtil.mockRMSendThrottledDeleteCommand(replicationManager,
         commandsSent);
 
-    GenericTestUtils.setLogLevel(RatisOverReplicationHandler.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(RatisOverReplicationHandler.class, Level.DEBUG);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestNodeStateManager {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(TestNodeStateManager.class);
 
   private NodeStateManager nsm;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -882,8 +883,7 @@ public class TestSCMNodeManager {
     // than SCM should not be found in the cluster.
     DatanodeDetails node1 =
         HddsTestUtils.createRandomDatanodeAndRegister(nodeManager);
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(SCMNodeManager.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(SCMNodeManager.class);
     int scmMlv =
         nodeManager.getLayoutVersionManager().getMetadataLayoutVersion();
     int scmSlv =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -101,6 +101,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.util.function.CheckedRunnable;
@@ -110,7 +111,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for PipelineManagerImpl.
@@ -671,8 +671,7 @@ public class TestPipelineManagerImpl {
 
   @Test
   public void testAddContainerWithClosedPipelineScmStart() throws Exception {
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.
-            captureLogs(LoggerFactory.getLogger(PipelineStateMap.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(PipelineStateMap.class);
     SCMHADBTransactionBuffer buffer = new SCMHADBTransactionBufferStub(dbStore);
     PipelineManagerImpl pipelineManager =
             createPipelineManager(true, buffer);
@@ -717,8 +716,7 @@ public class TestPipelineManagerImpl {
 
   @Test
   public void testPipelineCloseFlow() throws IOException, TimeoutException {
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-            .captureLogs(LoggerFactory.getLogger(PipelineManagerImpl.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(PipelineManagerImpl.class);
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
             RatisReplicationConfig

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -48,9 +48,9 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManagerImpl;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class tests HealthyPipelineSafeMode rule.
@@ -283,10 +283,7 @@ public class TestHealthyPipelineSafeModeRule {
       // No pipeline event have sent to SCMSafemodeManager
       assertFalse(healthyPipelineSafeModeRule.validate());
 
-
-      GenericTestUtils.LogCapturer logCapturer =
-          GenericTestUtils.LogCapturer.captureLogs(LoggerFactory.getLogger(
-              SCMSafeModeManager.class));
+      LogCapturer logCapturer = LogCapturer.captureLogs(SCMSafeModeManager.class);
 
       // fire event with pipeline create status with ratis type and factor 1
       // pipeline, validate() should return false

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -55,10 +55,10 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class tests OneReplicaPipelineSafeModeRule.
@@ -135,9 +135,7 @@ public class TestOneReplicaPipelineSafeModeRule {
     int pipelineCountOne = 0;
     setup(nodes, pipelineFactorThreeCount, pipelineCountOne);
 
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(
-            LoggerFactory.getLogger(SCMSafeModeManager.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(SCMSafeModeManager.class);
 
     List<Pipeline> pipelines = pipelineManager.getPipelines();
     firePipelineEvent(pipelines.subList(0, pipelineFactorThreeCount - 1));
@@ -170,9 +168,7 @@ public class TestOneReplicaPipelineSafeModeRule {
 
     setup(nodes, pipelineCountThree, pipelineCountOne);
 
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(
-            LoggerFactory.getLogger(SCMSafeModeManager.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(SCMSafeModeManager.class);
 
     List<Pipeline> pipelines =
         pipelineManager.getPipelines(RatisReplicationConfig.getInstance(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -195,9 +196,8 @@ public class TestRootCARotationManager {
 
     rootCARotationManager = new RootCARotationManager(scm);
     rootCARotationManager.setRootCARotationHandler(handler);
-    GenericTestUtils.LogCapturer logs =
-        GenericTestUtils.LogCapturer.captureLogs(RootCARotationManager.LOG);
-    GenericTestUtils.setLogLevel(RootCARotationManager.LOG, INFO);
+    LogCapturer logs = LogCapturer.captureLogs(RootCARotationManager.class);
+    GenericTestUtils.setLogLevel(RootCARotationManager.class, INFO);
     rootCARotationManager.start();
     rootCARotationManager.notifyStatusChanged();
 
@@ -228,9 +228,8 @@ public class TestRootCARotationManager {
 
     rootCARotationManager = new RootCARotationManager(scm);
     rootCARotationManager.setRootCARotationHandler(handler);
-    GenericTestUtils.LogCapturer logs =
-        GenericTestUtils.LogCapturer.captureLogs(RootCARotationManager.LOG);
-    GenericTestUtils.setLogLevel(RootCARotationManager.LOG, INFO);
+    LogCapturer logs = LogCapturer.captureLogs(RootCARotationManager.class);
+    GenericTestUtils.setLogLevel(RootCARotationManager.class, INFO);
     rootCARotationManager.start();
     rootCARotationManager.notifyStatusChanged();
 
@@ -262,9 +261,8 @@ public class TestRootCARotationManager {
     certCodec.writeCertificate(cert);
     rootCARotationManager = new RootCARotationManager(scm);
     rootCARotationManager.setRootCARotationHandler(handler);
-    GenericTestUtils.LogCapturer logs =
-        GenericTestUtils.LogCapturer.captureLogs(RootCARotationManager.LOG);
-    GenericTestUtils.setLogLevel(RootCARotationManager.LOG, INFO);
+    LogCapturer logs = LogCapturer.captureLogs(RootCARotationManager.class);
+    GenericTestUtils.setLogLevel(RootCARotationManager.class, INFO);
     rootCARotationManager.start();
     rootCARotationManager.notifyStatusChanged();
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -81,7 +81,7 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.apache.hadoop.ozone.protocol.commands.CommandStatus;
 import org.apache.hadoop.util.Time;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -228,8 +228,7 @@ public class TestEndPoint {
     ozoneConf.setFromObject(new ReplicationConfig().setPort(0));
     try (EndpointStateMachine rpcEndPoint = createEndpoint(ozoneConf,
         serverAddress, 1000)) {
-      GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-          .captureLogs(VersionEndpointTask.LOG);
+      LogCapturer logCapturer = LogCapturer.captureLogs(VersionEndpointTask.class);
       OzoneContainer ozoneContainer = new OzoneContainer(dnDetails, ozoneConf,
           ContainerTestUtils.getMockContext(dnDetails, ozoneConf));
       rpcEndPoint.setState(EndpointStateMachine.EndPointStates.GETVERSION);

--- a/hadoop-hdds/test-utils/src/test/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/test/java/org/apache/ozone/test/GenericTestUtils.java
@@ -180,6 +180,10 @@ public abstract class GenericTestUtils {
     setLogLevel(toLog4j(logger), Level.toLevel(level.toString()));
   }
 
+  public static void setLogLevel(Class<?> clazz, org.slf4j.event.Level level) {
+    setLogLevel(LoggerFactory.getLogger(clazz), level);
+  }
+
   public static void withLogDisabled(Class<?> clazz, Runnable task) {
     org.slf4j.Logger logger = LoggerFactory.getLogger(clazz);
     final Logger log4j = toLog4j(logger);
@@ -248,6 +252,10 @@ public abstract class GenericTestUtils {
 
     public static LogCapturer captureLogs(Logger logger, Layout layout) {
       return new Log4j1Capturer(logger, layout);
+    }
+
+    public static LogCapturer captureLogs(Class<?> clazz) {
+      return captureLogs(LoggerFactory.getLogger(clazz));
     }
 
     public static LogCapturer captureLogs(org.slf4j.Logger logger) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/UpgradeManager.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/UpgradeManager.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UpgradeManager {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(UpgradeManager.class);
 
   private final Map<String, DatanodeStoreSchemaThreeImpl>

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/UpgradeTask.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/UpgradeTask.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UpgradeTask {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(UpgradeTask.class);
 
   private final ConfigurationSource config;

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/TestUpgradeManager.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/TestUpgradeManager.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMMIT_STAGE;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.WRITE_STAGE;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerImplTestUtils.newContainerSet;
-import static org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask.LOG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyList;
@@ -72,6 +71,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests for UpgradeManager class.
@@ -79,6 +80,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestUpgradeManager {
   private static final String SCM_ID = UUID.randomUUID().toString();
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
+  private static final Logger LOG = LoggerFactory.getLogger(TestUpgradeManager.class);
 
   @TempDir
   private File testRoot;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -66,11 +66,6 @@ public final class OzoneClientFactory {
             HddsUtils.formatStackTrace(stackTrace, 4), LOG));
   }
 
-  public static Logger getLogger() {
-    return LOG;
-  }
-
-
   /**
    * Constructs and return an OzoneClient with default configuration.
    *

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BlockDataStreamOutputEntryPool implements KeyMetadataAware {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BlockDataStreamOutputEntryPool.class);
 
   private final List<BlockDataStreamOutputEntry> streamEntries;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * but there can be other implementations that are using a different way.
  */
 public class BlockOutputStreamEntry extends OutputStream {
-  public static final Logger LOG = LoggerFactory.getLogger(BlockOutputStreamEntry.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockOutputStreamEntry.class);
   private final OzoneClientConfig config;
   private BlockOutputStream outputStream;
   private BlockID blockID;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BlockOutputStreamEntryPool implements KeyMetadataAware {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BlockOutputStreamEntryPool.class);
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -80,7 +80,7 @@ public final class ECKeyOutputStream extends KeyOutputStream
     FAILED
   }
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(KeyOutputStream.class);
 
   private volatile boolean closed;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -67,7 +67,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     FLUSH, HSYNC, CLOSE, FULL
   }
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(KeyDataStreamOutput.class);
 
   private boolean closed;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -84,7 +84,7 @@ public class KeyOutputStream extends OutputStream
     FLUSH, HSYNC, CLOSE, FULL
   }
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(KeyOutputStream.class);
 
   private boolean closed;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class KeyOutputStreamSemaphore {
 
-  public static final Logger LOG = LoggerFactory.getLogger(KeyOutputStreamSemaphore.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KeyOutputStreamSemaphore.class);
   private final Semaphore requestSemaphore;
 
   KeyOutputStreamSemaphore(int maxConcurrentWritePerKey) {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * State represents persisted data of one specific datanode.
  */
 public class MockDatanodeStorage {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(MockDatanodeStorage.class);
   public static final String FULL_CHUNK = "full";
   public static final ContainerProtos.KeyValue FULL_CHUNK_KV =

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyOutputStream.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyOutputStream.java
@@ -46,7 +46,7 @@ public class TestKeyOutputStream {
 
   @BeforeAll
   static void init() {
-    GenericTestUtils.setLogLevel(KeyOutputStreamSemaphore.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(KeyOutputStreamSemaphore.class, Level.DEBUG);
   }
 
   @Test

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
  * communication.
  */
 public final class OmUtils {
-  public static final Logger LOG = LoggerFactory.getLogger(OmUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OmUtils.class);
   private static final SecureRandom SRAND = new SecureRandom();
   private static byte[] randomBytes = new byte[32];
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GrpcOMFailoverProxyProvider<T> extends
     OMFailoverProxyProviderBase<T> {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(GrpcOMFailoverProxyProvider.class);
 
   public GrpcOMFailoverProxyProvider(ConfigurationSource configuration,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class HadoopRpcOMFailoverProxyProvider<T> extends
       OMFailoverProxyProviderBase<T> {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(HadoopRpcOMFailoverProxyProvider.class);
 
   private final Text delegationTokenService;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
 public abstract class OMFailoverProxyProviderBase<T> implements
     FailoverProxyProvider<T>, Closeable {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMFailoverProxyProviderBase.class);
 
   private final ConfigurationSource conf;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  * Grpc transport for grpc between s3g and om.
  */
 public class GrpcOmTransport implements OmTransport {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(GrpcOmTransport.class);
 
   private static final String CLIENT_NAME = "GrpcOmTransport";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTestWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTestWithFSO.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -518,8 +519,7 @@ abstract class AbstractOzoneFileSystemTestWithFSO extends AbstractOzoneFileSyste
 
   @Test
   public void testFSDeleteLogWarnNoExist() throws Exception {
-    GenericTestUtils.LogCapturer logCapture = GenericTestUtils.LogCapturer
-        .captureLogs(BasicOzoneClientAdapterImpl.LOG);
+    LogCapturer logCapture = LogCapturer.captureLogs(BasicOzoneClientAdapterImpl.class);
     getFs().delete(new Path("/d1/d3/noexist/"), true);
     assertThat(logCapture.getOutput()).contains(
         "delete key failed Unable to get file status");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSyncUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSyncUpgrade.java
@@ -141,13 +141,13 @@ public class TestHSyncUpgrade {
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);
 
     // Enable DEBUG level logging for relevant classes
-    GenericTestUtils.setLogLevel(BlockManagerImpl.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(AbstractDatanodeStore.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(BlockOutputStream.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(KeyValueHandler.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockManagerImpl.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(AbstractDatanodeStore.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockOutputStream.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockInputStream.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(KeyValueHandler.class, Level.DEBUG);
 
-    GenericTestUtils.setLogLevel(BufferPool.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BufferPool.class, Level.DEBUG);
 
     OpenKeyCleanupService openKeyCleanupService =
         (OpenKeyCleanupService) cluster.getOzoneManager().getKeyManager()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.utils.FaultInjectorImpl;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.OzoneTestBase;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
@@ -106,7 +107,7 @@ public class TestLeaseRecovery extends OzoneTestBase {
   private final OzoneConfiguration conf = new OzoneConfiguration();
   private String dir;
   private Path file;
-  private GenericTestUtils.LogCapturer xceiverClientLogs;
+  private LogCapturer xceiverClientLogs;
   private RootedOzoneFileSystem fs;
 
   /**
@@ -166,14 +167,14 @@ public class TestLeaseRecovery extends OzoneTestBase {
     // create a volume and a bucket to be used by OzoneFileSystem
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);
 
-    GenericTestUtils.setLogLevel(XceiverClientGrpc.getLogger(), Level.DEBUG);
+    GenericTestUtils.setLogLevel(XceiverClientGrpc.class, Level.DEBUG);
 
     // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s/", OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
     dir = OZONE_ROOT + bucket.getVolumeName() + OZONE_URI_DELIMITER + bucket.getName();
 
-    xceiverClientLogs = GenericTestUtils.LogCapturer.captureLogs(XceiverClientGrpc.getLogger());
+    xceiverClientLogs = LogCapturer.captureLogs(XceiverClientGrpc.class);
   }
 
   @BeforeEach
@@ -295,8 +296,8 @@ public class TestLeaseRecovery extends OzoneTestBase {
           "Requested operation not allowed as ContainerState is CLOSED",
           ContainerProtos.Result.CLOSED_CONTAINER_IO);
       injector.setException(sce);
-      GenericTestUtils.LogCapturer logs =
-          GenericTestUtils.LogCapturer.captureLogs(BasicRootedOzoneClientAdapterImpl.LOG);
+      LogCapturer logs =
+          LogCapturer.captureLogs(BasicRootedOzoneClientAdapterImpl.class);
 
       fs.recoverLease(file);
       assertTrue(logs.getOutput().contains("Failed to execute finalizeBlock command"));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
@@ -63,7 +63,7 @@ public abstract class TestOzoneFsHAURLs implements HATests.TestCase {
   /**
     * Set a timeout for each test.
     */
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestOzoneFsHAURLs.class);
 
   private OzoneConfiguration conf;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCommitInRatis.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.proto.RaftProtos;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -135,8 +135,7 @@ public class TestCommitInRatis {
     ratisClientConfig.setWatchType(watchType.toString());
     conf.setFromObject(ratisClientConfig);
     startCluster(conf);
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(XceiverClientRatis.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(XceiverClientRatis.class);
     XceiverClientManager clientManager = new XceiverClientManager(conf);
 
     ContainerWithPipeline container1 = storageContainerLocationClient

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestFailoverWithSCMHA.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,9 +114,8 @@ public class TestFailoverWithSCMHA {
         new ScmBlockLocationProtocolClientSideTranslatorPB(
             failoverProxyProvider);
     GenericTestUtils
-        .setLogLevel(SCMBlockLocationFailoverProxyProvider.LOG, Level.DEBUG);
-    GenericTestUtils.LogCapturer logCapture = GenericTestUtils.LogCapturer
-        .captureLogs(SCMBlockLocationFailoverProxyProvider.LOG);
+        .setLogLevel(SCMBlockLocationFailoverProxyProvider.class, Level.DEBUG);
+    LogCapturer logCapture = LogCapturer.captureLogs(SCMBlockLocationFailoverProxyProvider.class);
     ScmBlockLocationProtocol scmBlockLocationProtocol = TracingUtil
         .createProxy(scmBlockLocationClient, ScmBlockLocationProtocol.class,
             conf);
@@ -125,10 +125,9 @@ public class TestFailoverWithSCMHA {
     scm = getLeader(cluster);
     SCMContainerLocationFailoverProxyProvider proxyProvider =
         new SCMContainerLocationFailoverProxyProvider(conf, null);
-    GenericTestUtils.setLogLevel(SCMContainerLocationFailoverProxyProvider.LOG,
+    GenericTestUtils.setLogLevel(SCMContainerLocationFailoverProxyProvider.class,
         Level.DEBUG);
-    logCapture = GenericTestUtils.LogCapturer
-        .captureLogs(SCMContainerLocationFailoverProxyProvider.LOG);
+    logCapture = LogCapturer.captureLogs(SCMContainerLocationFailoverProxyProvider.class);
     proxyProvider.changeCurrentProxy(scm.getSCMNodeId());
     StorageContainerLocationProtocol scmContainerClient =
         TracingUtil.createProxy(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
@@ -100,8 +100,7 @@ public class TestRatisPipelineLeader {
     final Logger log = LoggerFactory.getLogger(
         "org.apache.ratis.grpc.server.GrpcClientProtocolService");
     GenericTestUtils.setLogLevel(log, Level.DEBUG);
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(log);
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(log);
     try (XceiverClientRatis xceiverClientRatis =
         XceiverClientRatis.newXceiverClientRatis(ratisPipeline, conf)) {
       xceiverClientRatis.connect();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshotWithHA.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.LifeCycle;
@@ -180,9 +181,8 @@ public class TestSCMInstallSnapshotWithHA {
     followerSM.notifyTermIndexUpdated(lastTermIndex.getTerm(),
         lastTermIndex.getIndex() + 100);
 
-    GenericTestUtils.setLogLevel(SCMHAManagerImpl.getLogger(), Level.INFO);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(SCMHAManagerImpl.getLogger());
+    GenericTestUtils.setLogLevel(SCMHAManagerImpl.class, Level.INFO);
+    LogCapturer logCapture = LogCapturer.captureLogs(SCMHAManagerImpl.class);
 
     // Install the old checkpoint on the follower . This should fail as the
     // follower is already ahead of that transactionLogIndex and the
@@ -254,9 +254,8 @@ public class TestSCMInstallSnapshotWithHA {
 
     SCMHAManagerImpl scmhaManager =
         (SCMHAManagerImpl) (followerSCM.getScmHAManager());
-    GenericTestUtils.setLogLevel(SCMHAManagerImpl.getLogger(), Level.ERROR);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(SCMHAManagerImpl.getLogger());
+    GenericTestUtils.setLogLevel(SCMHAManagerImpl.class, Level.ERROR);
+    LogCapturer logCapture = LogCapturer.captureLogs(SCMHAManagerImpl.class);
     scmhaManager.setExitManagerForTesting(new DummyExitManager());
 
     followerSM.pause();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMMXBean.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(300)
 public abstract class TestSCMMXBean implements NonHATests.TestCase {
 
-  public static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
   private StorageContainerManager scm;
   private MBeanServer mbs;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMNodeManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMNodeManagerMXBean.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(300)
 public abstract class TestSCMNodeManagerMXBean implements NonHATests.TestCase {
 
-  public static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
   private StorageContainerManager scm;
   private MBeanServer mbs;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -141,6 +141,7 @@ import org.apache.hadoop.util.ExitUtil;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -358,14 +359,10 @@ public class TestStorageContainerManager {
       assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
           endpoint.getState());
     }
-    GenericTestUtils.LogCapturer scmDnHBDispatcherLog =
-        GenericTestUtils.LogCapturer.captureLogs(
-            SCMDatanodeHeartbeatDispatcher.LOG);
+    LogCapturer scmDnHBDispatcherLog = LogCapturer.captureLogs(SCMDatanodeHeartbeatDispatcher.class);
     LogManager.getLogger(HeartbeatEndpointTask.class).setLevel(Level.DEBUG);
-    GenericTestUtils.LogCapturer heartbeatEndpointTaskLog =
-        GenericTestUtils.LogCapturer.captureLogs(HeartbeatEndpointTask.LOG);
-    GenericTestUtils.LogCapturer versionEndPointTaskLog =
-        GenericTestUtils.LogCapturer.captureLogs(VersionEndpointTask.LOG);
+    LogCapturer heartbeatEndpointTaskLog = LogCapturer.captureLogs(HeartbeatEndpointTask.class);
+    LogCapturer versionEndPointTaskLog = LogCapturer.captureLogs(VersionEndpointTask.class);
     // Initially empty
     assertThat(scmDnHBDispatcherLog.getOutput()).isEmpty();
     assertThat(versionEndPointTaskLog.getOutput()).isEmpty();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -62,7 +62,7 @@ import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
@@ -251,8 +251,7 @@ public class TestWatchForCommit {
   @ParameterizedTest
   @EnumSource(value = RaftProtos.ReplicationLevel.class, names = {"MAJORITY_COMMITTED", "ALL_COMMITTED"})
   public void testWatchForCommitForRetryfailure(RaftProtos.ReplicationLevel watchType) throws Exception {
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(XceiverClientRatis.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(XceiverClientRatis.class);
     RatisClientConfig ratisClientConfig = conf.getObject(RatisClientConfig.class);
     ratisClientConfig.setWatchType(watchType.toString());
     conf.setFromObject(ratisClientConfig);
@@ -303,8 +302,7 @@ public class TestWatchForCommit {
   @ParameterizedTest
   @EnumSource(value = RaftProtos.ReplicationLevel.class, names = {"MAJORITY_COMMITTED", "ALL_COMMITTED"})
   public void test2WayCommitForTimeoutException(RaftProtos.ReplicationLevel watchType) throws Exception {
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(XceiverClientRatis.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(XceiverClientRatis.class);
     RatisClientConfig ratisClientConfig = conf.getObject(RatisClientConfig.class);
     ratisClientConfig.setWatchType(watchType.toString());
     conf.setFromObject(ratisClientConfig);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.ozone.upgrade.InjectedUpgradeFinalizationExecutor.Upgra
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizationExecutor;
 import org.apache.hadoop.ozone.upgrade.UpgradeTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -252,8 +253,7 @@ public class TestScmHAFinalization {
 
     init(conf, new DefaultUpgradeFinalizationExecutor<>(), numInactiveSCMs);
 
-    GenericTestUtils.LogCapturer logCapture = GenericTestUtils.LogCapturer
-        .captureLogs(FinalizationStateManagerImpl.LOG);
+    LogCapturer logCapture = LogCapturer.captureLogs(FinalizationStateManagerImpl.class);
 
     StorageContainerManager inactiveScm = cluster.getInactiveSCM().next();
     LOG.info("Inactive SCM node ID: {}", inactiveScm.getSCMNodeId());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -275,9 +275,8 @@ public final class TestDelegationToken {
 
     // Capture logs for assertions
     LogCapturer logs = LogCapturer.captureLogs(Server.AUDITLOG);
-    LogCapturer omLogs = LogCapturer.captureLogs(OzoneManager.getLogger());
-    GenericTestUtils
-        .setLogLevel(LoggerFactory.getLogger(Server.class.getName()), INFO);
+    LogCapturer omLogs = LogCapturer.captureLogs(OzoneManager.class);
+    GenericTestUtils.setLogLevel(Server.class, INFO);
     SecurityUtil.setTokenServiceUseIp(useIp);
 
     // Setup secure OM for start

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetClusterTreeInformation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetClusterTreeInformation.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(300)
 public abstract class TestGetClusterTreeInformation implements HATests.TestCase {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(TestGetClusterTreeInformation.class);
   private OzoneConfiguration conf;
   private StorageContainerManager scm;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestMultipartObjectGet {
 
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       TestMultipartObjectGet.class);
   private static OzoneConfiguration conf;
   private static String omServiceId;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -545,8 +545,8 @@ final class TestSecureOzoneCluster {
     initSCM();
     // Create a secure SCM instance as om client will connect to it
     scm = HddsTestUtils.getScmSimple(conf);
-    LogCapturer logs = LogCapturer.captureLogs(OzoneManager.getLogger());
-    GenericTestUtils.setLogLevel(OzoneManager.getLogger(), INFO);
+    LogCapturer logs = LogCapturer.captureLogs(OzoneManager.class);
+    GenericTestUtils.setLogLevel(OzoneManager.class, INFO);
 
     try {
       scm.start();
@@ -566,8 +566,8 @@ final class TestSecureOzoneCluster {
   @Test
   void testAccessControlExceptionOnClient() throws Exception {
     initSCM();
-    LogCapturer logs = LogCapturer.captureLogs(OzoneManager.getLogger());
-    GenericTestUtils.setLogLevel(OzoneManager.getLogger(), INFO);
+    LogCapturer logs = LogCapturer.captureLogs(OzoneManager.class);
+    GenericTestUtils.setLogLevel(OzoneManager.class, INFO);
     try {
       // Create a secure SCM instance as om client will connect to it
       scm = HddsTestUtils.getScmSimple(conf);
@@ -605,7 +605,7 @@ final class TestSecureOzoneCluster {
             ClientId.randomId().toString());
     String exMessage = "org.apache.hadoop.security.AccessControlException: " +
         "Client cannot authenticate via:[TOKEN, KERBEROS]";
-    logs = LogCapturer.captureLogs(Client.LOG);
+    logs = LogCapturer.captureLogs(Client.class);
     IOException ioException = assertThrows(IOException.class,
         () -> unsecureClient.listAllVolumes(null, null, 0));
     assertThat(ioException).hasMessageContaining(exMessage);
@@ -626,9 +626,8 @@ final class TestSecureOzoneCluster {
    */
   @Test
   void testDelegationTokenRenewal() throws Exception {
-    GenericTestUtils
-        .setLogLevel(LoggerFactory.getLogger(Server.class.getName()), INFO);
-    LogCapturer omLogs = LogCapturer.captureLogs(OzoneManager.getLogger());
+    GenericTestUtils.setLogLevel(Server.class, INFO);
+    LogCapturer omLogs = LogCapturer.captureLogs(OzoneManager.class);
 
     // Setup SCM
     initSCM();
@@ -822,8 +821,7 @@ final class TestSecureOzoneCluster {
    */
   @Test
   void testSecureOmReInit() throws Exception {
-    LogCapturer omLogs =
-        LogCapturer.captureLogs(OMCertificateClient.LOG);
+    LogCapturer omLogs = LogCapturer.captureLogs(OMCertificateClient.class);
     omLogs.clearOutput();
 
     initSCM();
@@ -879,7 +877,7 @@ final class TestSecureOzoneCluster {
   @Test
   void testSecureOmInitSuccess() throws Exception {
     LogCapturer omLogs =
-        LogCapturer.captureLogs(OMCertificateClient.LOG);
+        LogCapturer.captureLogs(OMCertificateClient.class);
     omLogs.clearOutput();
     initSCM();
     try {
@@ -1004,7 +1002,7 @@ final class TestSecureOzoneCluster {
    */
   @Test
   void testCertificateRotationRecoverableFailure() throws Exception {
-    LogCapturer omLogs = LogCapturer.captureLogs(OMCertificateClient.LOG);
+    LogCapturer omLogs = LogCapturer.captureLogs(OMCertificateClient.class);
     OMStorage omStorage = new OMStorage(conf);
     omStorage.setClusterId(clusterId);
     omStorage.setOmId(omId);
@@ -1094,8 +1092,8 @@ final class TestSecureOzoneCluster {
   void testCertificateRotationUnRecoverableFailure() throws Exception {
     ExitUtils.disableSystemExit();
     ExitUtil.disableSystemExit();
-    LogCapturer certClientLogs = LogCapturer.captureLogs(OMCertificateClient.LOG);
-    LogCapturer exitUtilLog = LogCapturer.captureLogs(LoggerFactory.getLogger(ExitUtil.class));
+    LogCapturer certClientLogs = LogCapturer.captureLogs(OMCertificateClient.class);
+    LogCapturer exitUtilLog = LogCapturer.captureLogs(ExitUtil.class);
 
 
     OMStorage omStorage = new OMStorage(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -27,7 +27,6 @@ import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.utils.ClusterContainersUtil.corruptData;
 import static org.apache.hadoop.hdds.utils.ClusterContainersUtil.getContainerByID;
-import static org.apache.hadoop.ozone.OmUtils.LOG;
 import static org.apache.hadoop.ozone.OmUtils.MAX_TRXN_ID;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
@@ -192,6 +191,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.OzoneTestBase;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ozone.test.tag.Unhealthy;
@@ -205,6 +205,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is an abstract class to test all the public facing APIs of Ozone
@@ -212,6 +214,8 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @TestMethodOrder(MethodOrderer.MethodName.class)
 abstract class OzoneRpcClientTests extends OzoneTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OzoneRpcClientTests.class);
 
   private static MiniOzoneCluster cluster = null;
   private static OzoneClient ozClient = null;
@@ -2460,7 +2464,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     }, 1000, 10000);
 
     // Try reading keyName2
-    GenericTestUtils.setLogLevel(XceiverClientGrpc.getLogger(), DEBUG);
+    GenericTestUtils.setLogLevel(XceiverClientGrpc.class, DEBUG);
     try (OzoneInputStream is = bucket.readKey(keyName2)) {
       byte[] content = new byte[100];
       is.read(content);
@@ -3335,9 +3339,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();
-    GenericTestUtils.LogCapturer ozoneClientFactoryLogCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(
-            OzoneClientFactory.getLogger());
+    LogCapturer ozoneClientFactoryLogCapturer =
+        LogCapturer.captureLogs(
+            OzoneClientFactory.class);
 
     client.getObjectStore().createVolume(volumeName);
     OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
@@ -5060,8 +5064,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     volume.createBucket(bucketName);
     String keyName = UUID.randomUUID().toString();
 
-    GenericTestUtils.LogCapturer omSMLog = GenericTestUtils.LogCapturer
-        .captureLogs(OzoneManagerStateMachine.LOG);
+    LogCapturer omSMLog = LogCapturer.captureLogs(OzoneManagerStateMachine.class);
     OzoneManagerStateMachine omSM = getCluster().getOzoneManager()
         .getOmRatisServer().getOmStateMachine();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -118,9 +118,9 @@ class TestContainerReplication {
 
   @BeforeAll
   static void setUp() {
-    setLogLevel(SCMContainerPlacementCapacity.LOG, Level.DEBUG);
-    setLogLevel(SCMContainerPlacementRackAware.LOG, Level.DEBUG);
-    setLogLevel(SCMContainerPlacementRandom.LOG, Level.DEBUG);
+    setLogLevel(SCMContainerPlacementCapacity.class, Level.DEBUG);
+    setLogLevel(SCMContainerPlacementRackAware.class, Level.DEBUG);
+    setLogLevel(SCMContainerPlacementRandom.class, Level.DEBUG);
   }
 
   @ParameterizedTest

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -110,7 +110,7 @@ import org.slf4j.event.Level;
  */
 public class TestBlockDeletion {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(TestBlockDeletion.class);
 
   private OzoneConfiguration conf = null;
@@ -127,9 +127,9 @@ public class TestBlockDeletion {
   @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
-    GenericTestUtils.setLogLevel(DeletedBlockLogImpl.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(SCMBlockDeletingService.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(ReplicationManager.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(DeletedBlockLogImpl.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(SCMBlockDeletingService.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ReplicationManager.class, Level.DEBUG);
 
     conf.set("ozone.replication.allowed-configs",
         "^(RATIS/THREE)|(EC/2-1-256k)$");
@@ -209,8 +209,7 @@ public class TestBlockDeletion {
   public void testBlockDeletion(ReplicationConfig repConfig) throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(DeleteBlocksCommandHandler.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(DeleteBlocksCommandHandler.class);
 
     String value = RandomStringUtils.random(1024 * 1024);
     store.createVolume(volumeName);
@@ -403,7 +402,7 @@ public class TestBlockDeletion {
       });
     });
 
-    LogCapturer logCapturer = LogCapturer.captureLogs(ReplicationManager.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(ReplicationManager.class);
     logCapturer.clearOutput();
     cluster.shutdownHddsDatanode(0);
     replicationManager.processAll();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -73,11 +73,11 @@ import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests DeleteContainerCommand Handler.
@@ -235,9 +235,7 @@ public class TestDeleteContainerHandler {
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
 
     // Check the log for the error message when deleting non-empty containers
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(
-            LoggerFactory.getLogger(KeyValueHandler.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(KeyValueHandler.class);
     GenericTestUtils.waitFor(() ->
             logCapturer.getOutput().
                 contains("Files still part of the container on delete"),
@@ -432,9 +430,7 @@ public class TestDeleteContainerHandler {
 
 
     // Check the log for the error message when deleting non-empty containers
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(
-            LoggerFactory.getLogger(KeyValueHandler.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(KeyValueHandler.class);
     GenericTestUtils.waitFor(() ->
             logCapturer.getOutput().
                 contains("the container is not empty with blockCount"),
@@ -641,9 +637,7 @@ public class TestDeleteContainerHandler {
     // Deleting a non-empty container should fail on DN when the force flag
     // is false.
     // Check the log for the error message when deleting non-empty containers
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(
-            LoggerFactory.getLogger(DeleteContainerCommandHandler.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(DeleteContainerCommandHandler.class);
     GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains("Non" +
             "-force deletion of non-empty container is not allowed"), 500,
         5 * 1000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -46,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -90,8 +89,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
@@ -143,8 +140,7 @@ public class TestOzoneContainerWithTLS {
     dn = aDatanode();
     pipeline = createPipeline(singletonList(dn));
 
-    Logger logger = LoggerFactory.getLogger(ClientTrustManager.class);
-    setLogLevel(logger, Level.DEBUG);
+    setLogLevel(ClientTrustManager.class, Level.DEBUG);
   }
 
   @Test
@@ -224,7 +220,7 @@ public class TestOzoneContainerWithTLS {
 
   @Test
   public void testLongLivingClientWithCertRenews() throws Exception {
-    LogCapturer logs = captureLogs(getLogger(ClientTrustManager.class));
+    LogCapturer logs = captureLogs(ClientTrustManager.class);
     OzoneContainer container = createAndStartOzoneContainerInstance();
 
     ScmClientConfig scmClientConf = conf.getObject(ScmClientConfig.class);
@@ -326,7 +322,7 @@ public class TestOzoneContainerWithTLS {
 
   private void assertDownloadContainerFails(long containerId,
       List<DatanodeDetails> sourceDatanodes) {
-    LogCapturer logCapture = captureLogs(SimpleContainerDownloader.LOG);
+    LogCapturer logCapture = captureLogs(SimpleContainerDownloader.class);
     SimpleContainerDownloader downloader =
         new SimpleContainerDownloader(conf, caClient);
     Path file = downloader.getContainerDataFromReplicas(containerId,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class tests datanode can tolerate configured num of failed volumes.
@@ -132,10 +131,8 @@ public class TestDatanodeHddsVolumeFailureToleration {
     // datanode will not actually exit. Use log messages to determine that
     // the ExitUtil was invoked which would terminate the process in a normal
     // deployment.
-    LogCapturer dsmCapturer = LogCapturer.captureLogs(
-        LoggerFactory.getLogger(DatanodeStateMachine.class));
-    LogCapturer exitCapturer = LogCapturer.captureLogs(
-            LoggerFactory.getLogger(ExitUtil.class.getName()));
+    LogCapturer dsmCapturer = LogCapturer.captureLogs(DatanodeStateMachine.class);
+    LogCapturer exitCapturer = LogCapturer.captureLogs(ExitUtil.class);
     cluster.restartHddsDatanode(0, false);
     // Give the datanode time to restart. This may be slow in a mini ozone
     // cluster.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.grpc.server.GrpcLogAppender;
 import org.apache.ratis.protocol.RaftPeer;
@@ -229,10 +230,8 @@ public class TestAddRemoveOzoneManager {
     OzoneManager existingOM = cluster.getOzoneManager(0);
     String existingOMNodeId = existingOM.getOMNodeId();
 
-    GenericTestUtils.LogCapturer omLog =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
-    GenericTestUtils.LogCapturer miniOzoneClusterLog =
-        GenericTestUtils.LogCapturer.captureLogs(MiniOzoneHAClusterImpl.LOG);
+    LogCapturer omLog = LogCapturer.captureLogs(OzoneManager.class);
+    LogCapturer miniOzoneClusterLog = LogCapturer.captureLogs(MiniOzoneHAClusterImpl.class);
 
     /***************************************************************************
      * 1. Bootstrap without updating config on any existing OM -> fail
@@ -301,10 +300,8 @@ public class TestAddRemoveOzoneManager {
     config.setInt(
         OMConfigKeys.OZONE_OM_ADMIN_PROTOCOL_WAIT_BETWEEN_RETRIES_KEY, 100);
 
-    GenericTestUtils.LogCapturer omLog =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
-    GenericTestUtils.LogCapturer miniOzoneClusterLog =
-        GenericTestUtils.LogCapturer.captureLogs(MiniOzoneHAClusterImpl.LOG);
+    LogCapturer omLog = LogCapturer.captureLogs(OzoneManager.class);
+    LogCapturer miniOzoneClusterLog = LogCapturer.captureLogs(MiniOzoneHAClusterImpl.class);
 
     /***************************************************************************
      * 1. Force bootstrap (with 1 node down and updated configs on rest) -> pass

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -85,6 +85,7 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.hadoop.utils.FaultInjectorImpl;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
@@ -241,8 +242,7 @@ public class TestOMRatisSnapshots {
 
     // Start the inactive OM. Checkpoint installation will happen spontaneously.
     cluster.startInactiveOM(followerNodeId);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
+    LogCapturer logCapture = LogCapturer.captureLogs(OzoneManager.class);
 
     // The recently started OM should be lagging behind the leader OM.
     // Wait & for follower to update transactions to leader snapshot index.
@@ -767,8 +767,7 @@ public class TestOMRatisSnapshots {
 
     // Start the inactive OM. Checkpoint installation will happen spontaneously.
     cluster.startInactiveOM(followerNodeId);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
+    LogCapturer logCapture = LogCapturer.captureLogs(OzoneManager.class);
 
     // Continuously create new keys
     ExecutorService executor = Executors.newFixedThreadPool(1);
@@ -867,8 +866,7 @@ public class TestOMRatisSnapshots {
 
     // Start the inactive OM. Checkpoint installation will happen spontaneously.
     cluster.startInactiveOM(followerNodeId);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
+    LogCapturer logCapture = LogCapturer.captureLogs(OzoneManager.class);
 
     // Continuously read keys
     ExecutorService executor = Executors.newFixedThreadPool(1);
@@ -939,9 +937,8 @@ public class TestOMRatisSnapshots {
       followerNodeId = leaderOM.getPeerNodes().get(1).getNodeId();
     }
     cluster.startInactiveOM(followerNodeId);
-    GenericTestUtils.setLogLevel(OzoneManager.LOG, Level.INFO);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
+    GenericTestUtils.setLogLevel(OzoneManager.class, Level.INFO);
+    LogCapturer logCapture = LogCapturer.captureLogs(OzoneManager.class);
 
     OzoneManager followerOM = cluster.getOzoneManager(followerNodeId);
     OzoneManagerRatisServer followerRatisServer = followerOM.getOmRatisServer();
@@ -1023,9 +1020,8 @@ public class TestOMRatisSnapshots {
       }
     }
 
-    GenericTestUtils.setLogLevel(OzoneManager.LOG, Level.INFO);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
+    GenericTestUtils.setLogLevel(OzoneManager.class, Level.INFO);
+    LogCapturer logCapture = LogCapturer.captureLogs(OzoneManager.class);
     followerOM.setExitManagerForTesting(new DummyExitManager());
     // Install corrupted checkpoint
     followerOM.installCheckpoint(leaderOMNodeId, leaderCheckpointLocation,
@@ -1101,7 +1097,7 @@ public class TestOMRatisSnapshots {
     }
   }
 
-  private void assertLogCapture(GenericTestUtils.LogCapturer logCapture,
+  private void assertLogCapture(LogCapturer logCapture,
                               String msg)
       throws InterruptedException, TimeoutException {
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IOzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,7 +64,7 @@ public class TestOmAcls {
   private static boolean prefixAclAllow = true;
   private static MiniOzoneCluster cluster = null;
   private static OzoneClient client;
-  private static GenericTestUtils.LogCapturer logCapturer;
+  private static LogCapturer logCapturer;
 
   static {
     AuditLogTestUtils.enableAuditLog();
@@ -86,8 +86,7 @@ public class TestOmAcls {
         .build();
     cluster.waitForClusterToBeReady();
     client = cluster.newClient();
-    logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.getLogger());
+    logCapturer = LogCapturer.captureLogs(OzoneManager.class);
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -77,6 +77,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -471,8 +472,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     String volumeName = randomUUID().toString();
 
 
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(OMVolumeCreateRequest.getLogger());
+    LogCapturer logCapturer = LogCapturer.captureLogs(OMVolumeCreateRequest.class);
 
     OzoneManagerProtocolProtos.UserInfo userInfo =
         OzoneManagerProtocolProtos.UserInfo.newBuilder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -246,8 +247,7 @@ public class TestScmSafeMode {
     });
     cluster.stop();
 
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(SCMSafeModeManager.getLogger());
+    LogCapturer logCapturer = LogCapturer.captureLogs(SCMSafeModeManager.getLogger());
     logCapturer.clearOutput();
 
     cluster = builder.build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
@@ -156,10 +156,8 @@ public class TestRangerBGSyncService {
     conf = new OzoneConfiguration();
     simulateOzoneSiteXmlConfig();
 
-    GenericTestUtils.setLogLevel(OMRangerBGSyncService.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(
-        LoggerFactory.getLogger(RangerClientMultiTenantAccessController.class),
-        Level.INFO);
+    GenericTestUtils.setLogLevel(OMRangerBGSyncService.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(RangerClientMultiTenantAccessController.class, Level.INFO);
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -134,7 +134,7 @@ class TestReconAndAdminContainerCLI {
                   .includeRecon(true)
                   .build();
     cluster.waitForClusterToBeReady();
-    GenericTestUtils.setLogLevel(ReconNodeManager.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ReconNodeManager.class, Level.DEBUG);
 
     scmClient = new ContainerOperationClient(CONF);
     StorageContainerManager scm = cluster.getStorageContainerManager();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +70,7 @@ public class TestReconAsPassiveScm {
     cluster =  MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3)
         .includeRecon(true).build();
     cluster.waitForClusterToBeReady();
-    GenericTestUtils.setLogLevel(ReconNodeManager.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ReconNodeManager.class, Level.DEBUG);
   }
 
   @AfterEach
@@ -132,9 +133,8 @@ public class TestReconAsPassiveScm {
     assertEquals(scmContainerManager.getContainers(),
         reconContainerManager.getContainers());
 
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(ReconNodeManager.LOG);
-    GenericTestUtils.setLogLevel(ReconNodeManager.LOG, Level.DEBUG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(ReconNodeManager.class);
+    GenericTestUtils.setLogLevel(ReconNodeManager.class, Level.DEBUG);
     reconScm.getEventQueue().fireEvent(CLOSE_CONTAINER,
         containerInfo.containerID());
     GenericTestUtils.waitFor(() -> logCapturer.getOutput()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
@@ -35,12 +35,12 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test Recon SCM Snapshot Download implementation.
@@ -71,9 +71,7 @@ public class TestReconScmSnapshot {
   }
 
   public static void testSnapshot(MiniOzoneCluster cluster) throws Exception {
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(LoggerFactory.getLogger(
-        ReconStorageContainerManagerFacade.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(ReconStorageContainerManagerFacade.class);
 
     List<ContainerInfo> reconContainers = cluster.getReconServer()
         .getReconStorageContainerManager().getContainerManager()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -79,7 +79,7 @@ public class TestReconTasks {
         .includeRecon(true).build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(ONE, 30000);
-    GenericTestUtils.setLogLevel(SCMDatanodeHeartbeatDispatcher.LOG,
+    GenericTestUtils.setLogLevel(SCMDatanodeHeartbeatDispatcher.class,
         Level.DEBUG);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -65,6 +65,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -268,15 +269,11 @@ public class TestReconWithOzoneManager {
   // And Recon should fall back on full snapshot and recover itself.
   @Test
   public void testOmDBSyncWithSeqNumberMismatch() throws Exception {
-    GenericTestUtils.LogCapturer
-        logs = GenericTestUtils.LogCapturer.captureLogs(RDBStore.getLogger());
-    GenericTestUtils.setLogLevel(RDBStore.getLogger(), INFO);
+    LogCapturer logs = LogCapturer.captureLogs(RDBStore.class);
+    GenericTestUtils.setLogLevel(RDBStore.class, INFO);
 
-    GenericTestUtils.LogCapturer
-        omServiceProviderImplLogs = GenericTestUtils.LogCapturer.captureLogs(
-        OzoneManagerServiceProviderImpl.getLogger());
-    GenericTestUtils.setLogLevel(OzoneManagerServiceProviderImpl.getLogger(),
-        INFO);
+    LogCapturer omServiceProviderImplLogs = LogCapturer.captureLogs(OzoneManagerServiceProviderImpl.class);
+    GenericTestUtils.setLogLevel(OzoneManagerServiceProviderImpl.class, INFO);
 
     // add a vol, bucket and key
     addKeys(10, 15);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -70,7 +70,7 @@ import picocli.CommandLine;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestFSORepairTool {
 
-  public static final Logger LOG = LoggerFactory.getLogger(TestFSORepairTool.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestFSORepairTool.class);
   private static final int ORDER_DRY_RUN = 1;
   //private static final int ORDER_REPAIR_SOME = 2; // TODO add test case
   private static final int ORDER_REPAIR_ALL = 3;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -172,14 +172,14 @@ public class TestOzoneTenantShell {
     ozoneSh.getCmd().setOut(new PrintWriter(out));
     ozoneSh.getCmd().setErr(new PrintWriter(err));
     // Suppress OMNotLeaderException in the log
-    GenericTestUtils.setLogLevel(RetryInvocationHandler.LOG, Level.WARN);
+    GenericTestUtils.setLogLevel(RetryInvocationHandler.class, Level.WARN);
     // Enable debug logging for interested classes
-    GenericTestUtils.setLogLevel(OMTenantCreateRequest.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMTenantCreateRequest.class, Level.DEBUG);
     GenericTestUtils.setLogLevel(
-        OMTenantAssignUserAccessIdRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(AuthorizerLockImpl.LOG, Level.DEBUG);
+        OMTenantAssignUserAccessIdRequest.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(AuthorizerLockImpl.class, Level.DEBUG);
 
-    GenericTestUtils.setLogLevel(OMRangerBGSyncService.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMRangerBGSyncService.class, Level.DEBUG);
   }
 
   /**

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(MiniOzoneHAClusterImpl.class);
 
   private final OMHAService omhaService;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -108,7 +108,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class OmSnapshotManager implements AutoCloseable {
   public static final String OM_HARDLINK_FILE = "hardLinkFile";
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OmSnapshotManager.class);
 
   // Threshold for the table iterator loop in nanoseconds.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -61,7 +61,7 @@ public class OMHANodeDetails {
       OMConfigKeys.OZONE_OM_ADDRESS_KEY,
   };
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMHANodeDetails.class);
   private final OMNodeDetails localNodeDetails;
   private final List<OMNodeDetails> peerNodeDetails;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/AuthorizerLockImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/AuthorizerLockImpl.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AuthorizerLockImpl implements AuthorizerLock {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(AuthorizerLockImpl.class);
 
   private final StampedLock authorizerStampedLock = new StampedLock();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OzoneManagerStateMachine extends BaseStateMachine {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerStateMachine.class);
   private final SimpleStateMachineStorage storage =
       new SimpleStateMachineStorage();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -77,7 +77,7 @@ import org.slf4j.LoggerFactory;
 public class OMKeyCommitRequest extends OMKeyRequest {
 
   @VisibleForTesting
-  public static final Logger LOG = LoggerFactory.getLogger(OMKeyCommitRequest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OMKeyCommitRequest.class);
 
   public OMKeyCommitRequest(OMRequest omRequest, BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
 public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
   @VisibleForTesting
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyCommitRequestWithFSO.class);
 
   public OMKeyCommitRequestWithFSO(OMRequest omRequest,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -31,7 +31,6 @@ import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.getDefaultAclList;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.util.Time.monotonicNow;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -113,8 +112,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
   // bits are set aside for this in ObjectID.
   private static final long MAX_NUM_OF_RECURSIVE_DIRS = 255;
 
-  @VisibleForTesting
-  public static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
 
   private BucketLayout bucketLayout = BucketLayout.DEFAULT;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
 
-  public static final Logger LOG = LoggerFactory.getLogger(OmKeysDeleteRequestWithFSO.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OmKeysDeleteRequestWithFSO.class);
 
   public OmKeysDeleteRequestWithFSO(
       OzoneManagerProtocolProtos.OMRequest omRequest,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMSetRangerServiceVersionRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMSetRangerServiceVersionRequest.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetRangerServiceVersionRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetRangerServiceVersionResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles OMSetRangerServiceVersionRequest.
@@ -42,8 +40,6 @@ import org.slf4j.LoggerFactory;
  * OzoneServiceVersion (retrieved from Ranger) to OM DB during the sync.
  */
 public class OMSetRangerServiceVersionRequest extends OMClientRequest {
-  public static final Logger LOG =
-      LoggerFactory.getLogger(OMSetRangerServiceVersionRequest.class);
 
   public OMSetRangerServiceVersionRequest(OMRequest omRequest) {
     super(omRequest);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  *   - Update tenantAccessIdTable
  */
 public class OMTenantAssignAdminRequest extends OMClientRequest {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMTenantAssignAdminRequest.class);
 
   public OMTenantAssignAdminRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -94,7 +94,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMTenantAssignUserAccessIdRequest.class);
 
   public OMTenantAssignUserAccessIdRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -95,7 +95,7 @@ import org.slf4j.LoggerFactory;
  *       OMMultiTenantManager#createTenant
  */
 public class OMTenantCreateRequest extends OMVolumeRequest {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMTenantCreateRequest.class);
 
   public OMTenantCreateRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * Handles OMTenantDelete request.
  */
 public class OMTenantDeleteRequest extends OMVolumeRequest {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMTenantDeleteRequest.class);
 
   public OMTenantDeleteRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  *     - Update tenantAccessIdTable
  */
 public class OMTenantRevokeAdminRequest extends OMClientRequest {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMTenantRevokeAdminRequest.class);
 
   public OMTenantRevokeAdminRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
  *     - Update DB tables
  */
 public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
-  public static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       OMTenantRevokeUserAccessIdRequest.class);
 
   public OMTenantRevokeUserAccessIdRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OmKeyHSyncUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OmKeyHSyncUtil.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class OmKeyHSyncUtil {
 
-  public static final Logger LOG = LoggerFactory.getLogger(OmKeyHSyncUtil.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OmKeyHSyncUtil.class);
 
   private OmKeyHSyncUtil() {
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.getDefaultAclList;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.USER_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
@@ -209,11 +208,6 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
       omMetrics.incNumVolumeCreateFails();
     }
     return omClientResponse;
-  }
-
-  @VisibleForTesting
-  public static Logger getLogger() {
-    return LOG;
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @CleanupTableInfo(cleanupTables = {KEY_TABLE})
 public class OMDirectoryCreateResponse extends OmKeyResponse {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateResponse.class);
 
   private OmKeyInfo dirKeyInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @CleanupTableInfo(cleanupTables = {DIRECTORY_TABLE})
 public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateResponseWithFSO.class);
 
   private OmDirectoryInfo dirInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, KEY_TABLE, BUCKET_TABLE})
 public class OMKeyCreateResponse extends OmKeyResponse {
 
-  public static final Logger LOG =
+  protected static final Logger LOG =
       LoggerFactory.getLogger(OMKeyCreateResponse.class);
   private OmKeyInfo omKeyInfo;
   private long openKeySessionID;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -70,7 +70,7 @@ import org.slf4j.LoggerFactory;
  * components of an orphan directory is visited.
  */
 public class DirectoryDeletingService extends AbstractKeyDeletingService {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DirectoryDeletingService.class);
 
   // Using multi thread for DirDeletion. Multiple threads would read

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OMRangerBGSyncService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OMRangerBGSyncService.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OMRangerBGSyncService extends BackgroundService {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMRangerBGSyncService.class);
   private static final ClientId CLIENT_ID = ClientId.randomId();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OMCertificateClient extends DefaultCertificateClient {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OMCertificateClient.class);
 
   public static final String COMPONENT_NAME = "om";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
 public class OzoneDelegationTokenSecretManager
     extends OzoneSecretManager<OzoneTokenIdentifier> {
 
-  public static final Logger LOG = LoggerFactory
+  private static final Logger LOG = LoggerFactory
       .getLogger(OzoneDelegationTokenSecretManager.class);
   private final Map<OzoneTokenIdentifier, TokenInfo> currentTokens;
   private final OzoneSecretStore store;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestAuthorizerLockImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestAuthorizerLockImpl.java
@@ -40,7 +40,7 @@ public class TestAuthorizerLockImpl {
   @BeforeAll
   public static void init() {
     // Enable debug logging for the test
-    GenericTestUtils.setLogLevel(AuthorizerLockImpl.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(AuthorizerLockImpl.class, Level.DEBUG);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -143,9 +144,8 @@ class TestOmSnapshotManager {
   public void testCloseOnEviction() throws IOException,
       InterruptedException, TimeoutException {
 
-    GenericTestUtils.setLogLevel(RDBStore.getLogger(), Level.DEBUG);
-    GenericTestUtils.LogCapturer logCapture =
-        GenericTestUtils.LogCapturer.captureLogs(RDBStore.getLogger());
+    GenericTestUtils.setLogLevel(RDBStore.class, Level.DEBUG);
+    LogCapturer logCapture = LogCapturer.captureLogs(RDBStore.class);
     // set up db tables
     Table<String, OmVolumeArgs> volumeTable = mock(Table.class);
     Table<String, OmBucketInfo> bucketTable = mock(Table.class);
@@ -654,8 +654,7 @@ class TestOmSnapshotManager {
   @Test
   public void testCreateSnapshotIdempotent() throws Exception {
     // set up db tables
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(OmSnapshotManager.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(OmSnapshotManager.class);
     Table<String, OmVolumeArgs> volumeTable = mock(Table.class);
     Table<String, OmBucketInfo> bucketTable = mock(Table.class);
     Table<String, SnapshotInfo> snapshotInfoTable = mock(Table.class);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
@@ -56,9 +57,8 @@ public class TestOMFailovers {
 
     testException = new AccessControlException();
 
-    GenericTestUtils.setLogLevel(OMFailoverProxyProviderBase.LOG, Level.DEBUG);
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(OMFailoverProxyProviderBase.LOG);
+    GenericTestUtils.setLogLevel(OMFailoverProxyProviderBase.class, Level.DEBUG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(OMFailoverProxyProviderBase.class);
 
     MockFailoverProxyProvider failoverProxyProvider =
         new MockFailoverProxyProvider(conf);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.security.OMCertificateClient;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.statemachine.SnapshotInfo;
@@ -59,7 +59,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test OM Ratis server.
@@ -179,8 +178,7 @@ public class TestOzoneManagerRatisServer {
    */
   @Test
   public void testIsReadOnlyCapturesAllCmdTypeEnums() throws Exception {
-    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
-        .captureLogs(LoggerFactory.getLogger(OmUtils.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(OmUtils.class);
     OzoneManagerProtocolProtos.Type[] cmdTypes =
         OzoneManagerProtocolProtos.Type.values();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -41,9 +41,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyRequest;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests OMBucketSetPropertyRequest class which handles OMSetBucketProperty
@@ -185,10 +184,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     OMBucketSetPropertyRequest omBucketSetPropertyRequest =
         new OMBucketSetPropertyRequest(omRequest);
 
-    GenericTestUtils.LogCapturer logs =
-            GenericTestUtils.LogCapturer.captureLogs(
-                    LoggerFactory.getLogger(OMBucketSetPropertyRequest.class)
-            );
+    LogCapturer logs = LogCapturer.captureLogs(OMBucketSetPropertyRequest.class);
 
     OMClientResponse omClientResponse = omBucketSetPropertyRequest
         .validateAndUpdateCache(ozoneManager, 1);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -254,9 +254,9 @@ public class TestOMKeyRequest {
         .thenReturn(omSnapshotManager);
 
     // Enable DEBUG level logging for relevant classes
-    GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMKeyRequest.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMKeyCommitRequest.class, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.class, Level.DEBUG);
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
@@ -31,9 +31,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests set volume property request.
@@ -183,10 +182,7 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     OMVolumeSetQuotaRequest omVolumeSetQuotaRequest =
         new OMVolumeSetQuotaRequest(originalRequest);
 
-    GenericTestUtils.LogCapturer logs =
-            GenericTestUtils.LogCapturer.captureLogs(
-                    LoggerFactory.getLogger(OMVolumeSetQuotaRequest.class)
-            );
+    LogCapturer logs = LogCapturer.captureLogs(OMVolumeSetQuotaRequest.class);
 
     OMClientResponse omClientResponse = omVolumeSetQuotaRequest
         .validateAndUpdateCache(ozoneManager, 1);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotCache.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotCache.java
@@ -72,7 +72,7 @@ class TestSnapshotCache {
     );
 
     // Set SnapshotCache log level. Set to DEBUG for verbose output
-    GenericTestUtils.setLogLevel(SnapshotCache.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(SnapshotCache.class, Level.DEBUG);
   }
 
   @BeforeEach

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -379,9 +380,8 @@ public class TestOzoneDelegationTokenSecretManager {
 
   @Test
   public void testVerifyAsymmetricSignatureSuccess() throws Exception {
-    GenericTestUtils.setLogLevel(OzoneDelegationTokenSecretManager.LOG, Level.DEBUG);
-    GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneDelegationTokenSecretManager.LOG);
+    GenericTestUtils.setLogLevel(OzoneDelegationTokenSecretManager.class, Level.DEBUG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(OzoneDelegationTokenSecretManager.class);
     secretManager = createSecretManager(conf, TOKEN_MAX_LIFETIME,
         expiryTime, TOKEN_REMOVER_SCAN_INTERVAL);
     secretManager.start(certificateClient);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -119,7 +119,7 @@ import org.slf4j.LoggerFactory;
 public class BasicRootedOzoneClientAdapterImpl
     implements OzoneClientAdapter {
 
-  static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(BasicRootedOzoneClientAdapterImpl.class);
 
   private OzoneClient ozoneClient;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -732,16 +732,6 @@ public class ContainerHealthTask extends ReconScmTask {
   }
 
   /**
-   * Expose the logger for testing purposes.
-   *
-   * @return the logger instance
-   */
-  @VisibleForTesting
-  public Logger getLogger() {
-    return LOG;
-  }
-
-  /**
    * Expose the unhealthyContainerStateStatsMap for testing purposes.
    */
   @VisibleForTesting

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReconNodeManager extends SCMNodeManager {
 
-  public static final Logger LOG = LoggerFactory
+  private static final Logger LOG = LoggerFactory
       .getLogger(ReconNodeManager.class);
 
   private Table<UUID, DatanodeDetails> nodeDB;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -772,9 +772,5 @@ public class OzoneManagerServiceProviderImpl
   public OzoneManagerSyncMetrics getMetrics() {
     return metrics;
   }
-
-  public static Logger getLogger() {
-    return LOG;
-  }
 }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconTaskStatusTableUpgradeAction.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconTaskStatusTableUpgradeAction.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
     type = ReconUpgradeAction.UpgradeActionType.FINALIZE)
 public class ReconTaskStatusTableUpgradeAction implements ReconUpgradeAction {
 
-  public static final Logger LOG = LoggerFactory.getLogger(ReconTaskStatusTableUpgradeAction.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ReconTaskStatusTableUpgradeAction.class);
 
   /**
    * Utility function to add provided column to RECON_TASK_STATUS table as INTEGER type.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/DBScanner.java
@@ -88,7 +88,7 @@ import picocli.CommandLine;
 )
 public class DBScanner extends AbstractSubcommand implements Callable<Void> {
 
-  public static final Logger LOG = LoggerFactory.getLogger(DBScanner.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DBScanner.class);
   private static final String SCHEMA_V3 = "V3";
 
   @CommandLine.ParentCommand

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ldb/ValueSchema.java
@@ -54,7 +54,7 @@ public class ValueSchema extends AbstractSubcommand implements Callable<Void> {
   @CommandLine.ParentCommand
   private RDBParser parent;
 
-  public static final Logger LOG = LoggerFactory.getLogger(ValueSchema.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ValueSchema.class);
 
   @CommandLine.Option(names = {"--column_family", "--column-family", "--cf"},
       required = true,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -41,7 +41,7 @@ import picocli.CommandLine.Option;
     mixinStandardHelpOptions = true)
 public class Freon extends GenericCli implements ExtensibleParentCommand {
 
-  public static final Logger LOG = LoggerFactory.getLogger(Freon.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Freon.class);
 
   @Option(names = "--server",
       description = "Enable internal http server to provide metric "

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
@@ -113,7 +113,7 @@ import picocli.CommandLine;
 @SuppressWarnings("java:S2245") // no need for secure random
 public final class SCMThroughputBenchmark implements Callable<Void>, FreonSubcommand {
 
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(SCMThroughputBenchmark.class);
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -77,7 +77,7 @@ import picocli.CommandLine;
         "OM should be stopped while this tool is run."
 )
 public class FSORepairTool extends RepairTool {
-  public static final Logger LOG = LoggerFactory.getLogger(FSORepairTool.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FSORepairTool.class);
   private static final String REACHABLE_TABLE = "reachable";
 
   @CommandLine.Option(names = {"--db"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not rely on public `Logger` members in tests.  Instead, look up the logger by class when setting log level or capturing logs in tests.

Remove some unused loggers.

https://issues.apache.org/jira/browse/HDDS-12746

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14181801897