### PR TITLE
HDDS-12748. Remove unused config ozone.manager.db.checkpoint.transfer.bandwidthPerSec

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2725,16 +2725,6 @@
   </property>
 
   <property>
-    <name>ozone.manager.db.checkpoint.transfer.bandwidthPerSec</name>
-    <value>0</value>
-    <tag>OZONE</tag>
-    <description>
-      Maximum bandwidth used for Ozone Manager DB checkpoint download through
-      the servlet.
-    </description>
-  </property>
-
-  <property>
     <name>ozone.freon.http-address</name>
     <value>0.0.0.0:9884</value>
     <tag>OZONE, MANAGEMENT</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -317,9 +317,6 @@ public final class OMConfigKeys {
       "ozone.manager.delegation.token.max-lifetime";
   public static final long    DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT =
       7 * 24 * 60 * 60 * 1000; // 7 days
-  
-  public static final long OZONE_DB_CHECKPOINT_TRANSFER_RATE_DEFAULT =
-      0;  //no throttling
 
   // Comma separated acls (users, groups) allowing clients accessing
   // OM client protocol

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -317,9 +317,7 @@ public final class OMConfigKeys {
       "ozone.manager.delegation.token.max-lifetime";
   public static final long    DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT =
       7 * 24 * 60 * 60 * 1000; // 7 days
-
-  public static final String OZONE_DB_CHECKPOINT_TRANSFER_RATE_KEY =
-      "ozone.manager.db.checkpoint.transfer.bandwidthPerSec";
+  
   public static final long OZONE_DB_CHECKPOINT_TRANSFER_RATE_DEFAULT =
       0;  //no throttling
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove unused config [ozone.manager.db.checkpoint.transfer.bandwidthPerSec]

Please describe your PR in detail:
Remove unused config [ozone.manager.db.checkpoint.transfer.bandwidthPerSec](https://github.com/apache/ozone/blob/7fb92b014428f78e40705a88f9ae6cb7198a5b8b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java#L321) from ozone-default.xml and OmConfigKeys.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12748

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
