### PR TITLE
HDDS-12751. native build fails with CMake 4

### DIFF
--- a/hadoop-hdds/rocks-native/src/CMakeLists.txt
+++ b/hadoop-hdds/rocks-native/src/CMakeLists.txt
@@ -20,7 +20,7 @@
 # CMake configuration.
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.31)
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub recently [upgraded](https://github.com/actions/runner-images/blob/ubuntu24/20250330.1/images/ubuntu/Ubuntu2404-Readme.md) to CMake 4, so native build fails with:

```
[INFO]      [exec] -- Configuring incomplete, errors occurred!
[INFO]      [exec] CMake Error at CMakeLists.txt:23 (cmake_minimum_required):
[INFO]      [exec]   Compatibility with CMake < 3.5 has been removed from CMake.
[INFO]      [exec] 
[INFO]      [exec]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[INFO]      [exec]   to tell CMake that the project requires at least <min> but has been updated
[INFO]      [exec]   to work with policies introduced by <max> or earlier.
[INFO]      [exec] 
[INFO]      [exec]   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This change adds `...<max>` as suggested by the error message.

https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

https://issues.apache.org/jira/browse/HDDS-12751

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14214764762/job/39828822507