### PR TITLE
HDDS-12755. Redundant declaration in TestHadoopNestedDirGenerator#spanCheck()

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
@@ -145,10 +145,7 @@ public abstract class TestHadoopNestedDirGenerator implements NonHATests.TestCas
 
   private int spanCheck(FileSystem fs, int span, Path p) throws IOException {
     int sp = 0;
-    int depth = 0;
-    if (span >= 0) {
-      depth = 0;
-    } else {
+    if (span <= 0) {
       LOG.info("Span value can never be negative");
     }
     FileStatus[] fileStatuses = fs.listStatus(p);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
@@ -90,12 +90,10 @@ public abstract class TestHadoopNestedDirGenerator implements NonHATests.TestCas
       // verify root path details
       FileStatus[] fileStatuses = fileSystem.listStatus(rootDir);
       Path p = null;
-      for (FileStatus fileStatus : fileStatuses) {
-        // verify the num of peer directories and span directories
-        p = depthBFS(fileSystem, fileStatuses, span, actualDepth);
-        int actualSpan = spanCheck(fileSystem, span, p);
-        assertEquals(span, actualSpan, "Mismatch span in a path");
-      }
+      // verify the num of peer directories and span directories
+      p = depthBFS(fileSystem, fileStatuses, span, actualDepth);
+      int actualSpan = spanCheck(fileSystem, p);
+      assertEquals(span, actualSpan, "Mismatch span in a path");
     }
   }
 
@@ -143,11 +141,8 @@ public abstract class TestHadoopNestedDirGenerator implements NonHATests.TestCas
      * and count the span directories.
      */
 
-  private int spanCheck(FileSystem fs, int span, Path p) throws IOException {
+  private int spanCheck(FileSystem fs, Path p) throws IOException {
     int sp = 0;
-    if (span <= 0) {
-      LOG.info("Span value can never be negative");
-    }
     FileStatus[] fileStatuses = fs.listStatus(p);
     for (FileStatus fileStatus : fileStatuses) {
       if (fileStatus.isDirectory()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Some of the declaration of in `TestHadoopNestedDirGenerator`#`spanCheck()` is redundant and can be removed, refactored as well.

## What is the link to the Apache JIRA
[HDDS-12755](https://issues.apache.org/jira/browse/HDDS-12755)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14219163027
