### PR TITLE
HDDS-12756. Speed up TestReconfigShell and TestOzoneDebugShell

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -17,12 +17,6 @@
 
 package org.apache.hadoop.ozone.shell;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
@@ -36,27 +30,22 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.debug.OzoneDebug;
 import org.apache.hadoop.ozone.debug.ldb.RDBParser;
@@ -66,9 +55,11 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.ozone.test.NonHATests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
@@ -76,41 +67,21 @@ import picocli.CommandLine;
 /**
  * Test Ozone Debug shell.
  */
-public class TestOzoneDebugShell {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TestOzoneDebugShell implements NonHATests.TestCase {
 
-  private static MiniOzoneCluster cluster = null;
-  private static OzoneClient client;
-  private static OzoneDebug ozoneDebugShell;
+  private OzoneClient client;
+  private OzoneDebug ozoneDebugShell;
 
-  private static OzoneConfiguration conf = null;
-
-  protected static void startCluster() throws Exception {
-    // Init HA cluster
-    final int numDNs = 5;
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(numDNs)
-        .build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
+  @BeforeEach
+  void init() throws Exception {
+    ozoneDebugShell = new OzoneDebug();
+    client = cluster().newClient();
   }
 
-
-  @BeforeAll
-  public static void init() throws Exception {
-    ozoneDebugShell = new OzoneDebug();
-    conf = ozoneDebugShell.getOzoneConf();
-    conf.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL,
-        100, TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, SECONDS);
-    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1, SECONDS);
-    conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 1, SECONDS);
-    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, SECONDS);
-    ReplicationManager.ReplicationManagerConfiguration replicationConf =
-        conf.getObject(
-            ReplicationManager.ReplicationManagerConfiguration.class);
-    replicationConf.setInterval(Duration.ofSeconds(1));
-    conf.setFromObject(replicationConf);
-    startCluster();
+  @AfterEach
+  void shutdown() {
+    IOUtils.closeQuietly(client);
   }
 
   @ParameterizedTest
@@ -171,13 +142,13 @@ public class TestOzoneDebugShell {
     assertThat(cmdOut).contains(keyName);
   }
 
-  private static String getSnapshotDBPath(String checkPointDir) {
-    return OMStorage.getOmDbDir(conf) +
+  private String getSnapshotDBPath(String checkPointDir) {
+    return OMStorage.getOmDbDir(cluster().getConf()) +
         OM_KEY_PREFIX + OM_SNAPSHOT_CHECKPOINT_DIR + OM_KEY_PREFIX +
         OM_DB_NAME + checkPointDir;
   }
 
-  private static void writeKey(String volumeName, String bucketName,
+  private void writeKey(String volumeName, String bucketName,
       String keyName, boolean isEcKey) throws IOException {
     ReplicationConfig repConfig;
     if (isEcKey) {
@@ -186,14 +157,12 @@ public class TestOzoneDebugShell {
       repConfig = ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
           ReplicationFactor.THREE);
     }
-    try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
-      // see HDDS-10091 for making this work with FILE_SYSTEM_OPTIMIZED layout
-      TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,
-          BucketLayout.LEGACY);
-      TestDataUtil.createKey(
-          client.getObjectStore().getVolume(volumeName).getBucket(bucketName),
-          keyName, repConfig, "test".getBytes(StandardCharsets.UTF_8));
-    }
+    // see HDDS-10091 for making this work with FILE_SYSTEM_OPTIMIZED layout
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,
+        BucketLayout.LEGACY);
+    TestDataUtil.createKey(
+        client.getObjectStore().getVolume(volumeName).getBucket(bucketName),
+        keyName, repConfig, "test".getBytes(StandardCharsets.UTF_8));
   }
 
   private int runChunkInfoCommand(String volumeName, String bucketName,
@@ -202,23 +171,18 @@ public class TestOzoneDebugShell {
         Path.SEPARATOR + volumeName + Path.SEPARATOR + bucketName;
     String[] args = new String[] {
         getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY),
+        getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY),
         "replicas", "chunk-info", bucketPath + Path.SEPARATOR + keyName };
 
-    int exitCode = ozoneDebugShell.execute(args);
-    return exitCode;
+    return ozoneDebugShell.execute(args);
   }
 
   private int runChunkInfoAndVerifyPaths(String volumeName, String bucketName,
       String keyName) throws Exception {
-    String bucketPath =
-        Path.SEPARATOR + volumeName + Path.SEPARATOR + bucketName;
-    String[] args = new String[] {
-        getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY),
-        "replicas", "chunk-info", bucketPath + Path.SEPARATOR + keyName };
     int exitCode = 1;
     try (GenericTestUtils.SystemOutCapturer capture = new GenericTestUtils
         .SystemOutCapturer()) {
-      exitCode = ozoneDebugShell.execute(args);
+      exitCode = runChunkInfoCommand(volumeName, bucketName, keyName);
       Set<String> blockFilePaths = new HashSet<>();
       String output = capture.getOutput();
       ObjectMapper objectMapper = new ObjectMapper();
@@ -244,34 +208,23 @@ public class TestOzoneDebugShell {
    * connect to OM by setting the right om address.
    */
   private String getSetConfStringFromConf(String key) {
-    return String.format("--set=%s=%s", key, conf.get(key));
+    return String.format("--set=%s=%s", key, cluster().getConf().get(key));
   }
 
-  private static void closeContainerForKey(String volumeName, String bucketName,
+  private void closeContainerForKey(String volumeName, String bucketName,
       String keyName)
       throws IOException, TimeoutException, InterruptedException {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).build();
 
     OmKeyLocationInfo omKeyLocationInfo =
-        cluster.getOzoneManager().lookupKey(keyArgs).getKeyLocationVersions()
+        cluster().getOzoneManager().lookupKey(keyArgs).getKeyLocationVersions()
             .get(0).getBlocksLatestVersionOnly().get(0);
 
     ContainerInfo container =
-        cluster.getStorageContainerManager().getContainerManager().getContainer(
+        cluster().getStorageContainerManager().getContainerManager().getContainer(
             ContainerID.valueOf(omKeyLocationInfo.getContainerID()));
-    OzoneTestUtils.closeContainer(cluster.getStorageContainerManager(),
+    OzoneTestUtils.closeContainer(cluster().getStorageContainerManager(),
         container);
-  }
-
-  /**
-   * shutdown MiniOzoneCluster.
-   */
-  @AfterAll
-  public static void shutdown() {
-    IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface;
 import org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestOmReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestScmReconfiguration;
+import org.apache.hadoop.ozone.shell.TestOzoneDebugShell;
 import org.apache.hadoop.ozone.shell.TestReconfigShell;
 import org.apache.hadoop.ozone.shell.TestReplicationConfigPreference;
 import org.junit.jupiter.api.Nested;
@@ -365,6 +366,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class OmReconfiguration extends TestOmReconfiguration {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class OzoneDebugShell extends TestOzoneDebugShell {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface;
 import org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestOmReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestScmReconfiguration;
+import org.apache.hadoop.ozone.shell.TestReconfigShell;
 import org.apache.hadoop.ozone.shell.TestReplicationConfigPreference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
@@ -364,6 +365,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class OmReconfiguration extends TestOmReconfiguration {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class ReconfigShell extends TestReconfigShell {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up TestReconfigShell and TestOzoneDebugShell by using shared cluster in `NonHATests`.

Remove a small part of `TestReconfigShell` that runs the command with stopped datanode.  (I think testing with `DECOMMISSIONING` node is enough.)

https://issues.apache.org/jira/browse/HDDS-12756

## How was this patch tested?

Before:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.81 s -- in org.apache.hadoop.ozone.shell.TestOzoneDebugShell
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 47.26 s -- in org.apache.hadoop.ozone.shell.TestReconfigShell
```

After:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.840 s -- in org.apache.ozone.test.NonHATests$OzoneDebugShell
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.076 s -- in org.apache.ozone.test.NonHATests$ReconfigShell
```

https://github.com/adoroszlai/ozone/actions/runs/14226355835