### PR TITLE
HDDS-12757. Duplicated declaration of dnsInterface in HddsUtils

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -372,7 +372,6 @@ public final class HddsUtils {
       if (dnsInterface == null) {
         // Try the legacy configuration keys.
         dnsInterface = conf.get(HDDS_DATANODE_DNS_INTERFACE_KEY);
-        dnsInterface = conf.get(HDDS_DATANODE_DNS_INTERFACE_KEY);
         nameServer = conf.get(HDDS_DATANODE_DNS_NAMESERVER_KEY);
       } else {
         // If HADOOP_SECURITY_DNS_* is set then also attempt hosts file


### PR DESCRIPTION
## What changes were proposed in this pull request?
There're two identical line of below declaration, I think that one of them can  be removed.
```java
dnsInterface = conf.get(HDDS_DATANODE_DNS_INTERFACE_KEY); 
```

## What is the link to the Apache JIRA
[HDDS-12757](https://issues.apache.org/jira/browse/HDDS-12757)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14224664936
