### PR TITLE
HDDS-4517. Remove leftover references to RaftServerImpl

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -221,12 +221,6 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <!-- Needed for mocking RaftServerImpl -->
-      <groupId>com.codahale.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-test-utils</artifactId>
       <type>test-jar</type>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -82,9 +82,6 @@ public class SCMStateMachine extends BaseStateMachine {
   private final boolean isInitialized;
   private ExecutorService installSnapshotExecutor;
 
-  // The atomic variable RaftServerImpl#inProgressInstallSnapshotRequest
-  // ensures serializable between notifyInstallSnapshotFromLeader()
-  // and reinitialize().
   private DBCheckpoint installingDBCheckpoint = null;
   private List<ManagedSecretKey> installingSecretKeys = null;
 

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -54,7 +54,7 @@ public class RatisInsight extends BaseInsightPoint implements InsightPoint {
           dn -> {
             result
                 .add(new LoggerSource(dn,
-                    "org.apache.ratis.server.impl",
+                    "org.apache.ratis.server",
                     defaultLevel(verbose)));
             return null;
           });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove leftover references to `RaftServerImpl` and `org.apache.ratis.server.impl`.

https://issues.apache.org/jira/browse/HDDS-4517

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14236556569