### PR TITLE
HDDS-12758. Reading and writing double dash prefixes will result in an error.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -170,6 +170,7 @@ public final class OzoneConsts {
    */
 
   public static final String OM_KEY_PREFIX = "/";
+  public static final String DOUBLE_SLASH_OM_KEY_PREFIX  = "//";
   public static final String OM_USER_PREFIX = "$";
   public static final String OM_S3_PREFIX = "S3:";
   public static final String OM_S3_CALLER_CONTEXT_PREFIX = "S3Auth:S3G|";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -761,7 +761,7 @@ public final class OmUtils {
     if (!StringUtils.isBlank(keyName)) {
       String normalizedKeyName;
       if (keyName.startsWith(OM_KEY_PREFIX)) {
-        normalizedKeyName = new Path(normalizeDoubleSlashPath(keyName)).toUri().getPath();
+        normalizedKeyName = new Path(normalizeLeadingSlashes(keyName)).toUri().getPath();
       } else {
         normalizedKeyName = new Path(OM_KEY_PREFIX + keyName)
             .toUri().getPath();
@@ -780,18 +780,15 @@ public final class OmUtils {
   }
 
   /**
-   * Normalizes paths that start with double slashes to avoid URI authority parsing issues.
-   * This prevents Path parsing issues where paths starting with "//" have the content
-   * after "//" interpreted as the URI authority rather than as part of the path.
-   * For example: Path("//dir1").toUri().getAuthority() returns "dir1" and getPath() returns ""
+   * Normalizes paths by replacing multiple leading slashes with a single slash.
    */
-  private static String normalizeDoubleSlashPath(String keyName) {
+  private static String normalizeLeadingSlashes(String keyName) {
     if (keyName.startsWith(DOUBLE_SLASH_OM_KEY_PREFIX)) {
-      int doubleSlashLen = DOUBLE_SLASH_OM_KEY_PREFIX.length();
-      if (keyName.length() > doubleSlashLen && keyName.charAt(doubleSlashLen) != OM_KEY_PREFIX.charAt(0)) {
-        keyName = OM_KEY_PREFIX + keyName.substring(2);
+      int index = 0;
+      while (index < keyName.length() && keyName.charAt(index) == OM_KEY_PREFIX.charAt(0)) {
+        index++;
       }
-      return new Path(keyName).toUri().getPath();
+      return OM_KEY_PREFIX + keyName.substring(index);
     }
     return keyName;
   }

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -101,6 +101,9 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.s3.S3ClientFactory;
 import org.apache.hadoop.ozone.s3.S3GatewayService;
 import org.apache.ozone.test.OzoneTestBase;
@@ -363,6 +366,34 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
 
     PutObjectResult putObjectResult = s3Client.putObject(bucketName, keyName, is, new ObjectMetadata());
     assertEquals("37b51d194a7513e45b56f6524f2d51f2", putObjectResult.getETag());
+  }
+
+  @Test
+  public void testPutDoubleSlashPrefixObject() {
+    final String bucketName = getBucketName();
+    final String keyName = "//dir1";
+    final String content = "bar";
+    OzoneConfiguration conf = cluster.getConf();
+    // Create a FSO bucket for test
+    try (OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(conf)) {
+      ObjectStore store = ozoneClient.getObjectStore();
+      OzoneVolume volume = store.getS3Volume();
+      OmBucketInfo.Builder bucketInfo = new OmBucketInfo.Builder()
+          .setVolumeName(volume.getName())
+          .setBucketName(bucketName)
+          .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      OzoneManagerProtocol ozoneManagerProtocol = store.getClientProxy().getOzoneManagerClient();
+      ozoneManagerProtocol.createBucket(bucketInfo.build());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    PutObjectResult putObjectResult = s3Client.putObject(bucketName, keyName, is, new ObjectMetadata());
+    assertEquals("37b51d194a7513e45b56f6524f2d51f2", putObjectResult.getETag());
+
+    S3Object object = s3Client.getObject(bucketName, keyName);
+    assertEquals(content.length(), object.getObjectMetadata().getContentLength());
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -369,7 +369,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
   }
 
   @Test
-  public void testPutDoubleSlashPrefixObject() {
+  public void testPutDoubleSlashPrefixObject() throws IOException {
     final String bucketName = getBucketName();
     final String keyName = "//dir1";
     final String content = "bar";
@@ -384,8 +384,6 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
           .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED);
       OzoneManagerProtocol ozoneManagerProtocol = store.getClientProxy().getOzoneManagerClient();
       ozoneManagerProtocol.createBucket(bucketInfo.build());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
 
     InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -58,6 +58,9 @@ public class TestNormalizePaths {
         validateAndNormalizeKey(true, "a/b/c/d/"));
     assertEquals("a/b/c/...../d",
         validateAndNormalizeKey(true, "////a/b/////c/...../d/"));
+    assertEquals("a/b/c", validateAndNormalizeKey(true, "/a/b/c"));
+    assertEquals("a/b/c", validateAndNormalizeKey(true, "//a/b/c"));
+    assertEquals("a/b/c", validateAndNormalizeKey(true, "///a/b/c"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed the bug when reading and writing keys starting with ‘//’ for FSO bucket and LEGACY  + ozone.om.enable.filesystem.paths=true bucket.

For detail; see https://issues.apache.org/jira/browse/HDDS-12758

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12758

## How was this patch tested?
CI:
https://github.com/xichen01/ozone/actions/runs/14242969366
