### PR TITLE
HDDS-12700. Add compose-cluster directory to upgrade test result path to prevent overwrite

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -106,7 +106,7 @@ run_test() {
 
   local test_dir="$_upgrade_dir/upgrades/$upgrade_type"
   local callback_dir="$test_dir"/callbacks
-  local execution_dir="$test_dir"/execution/"${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}"
+  local execution_dir="$test_dir"/execution/"$compose_cluster"/"${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}"
   local compose_dir="$_upgrade_dir"/compose/"$compose_cluster"
   # Export variables needed by test, since it is run in a subshell.
   export OZONE_UPGRADE_CALLBACK="$callback_dir"/"$OZONE_UPGRADE_TO"/callback.sh


### PR DESCRIPTION
## What changes were proposed in this pull request?

As mentioned in [HDDS-12700](https://issues.apache.org/jira/browse/HDDS-12700), this PR adds compose-cluster directory to upgrade test result path to prevent overwrite.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12700

## How was this patch tested?

This patch was tested by running the upgrade acceptance tests locally, which confirmed that cluster-specific result directories are created as expected, thereby preventing result overwrites. In addition, the changes were validated via the GitHub Actions workflow on a forked repository.

<img width="447" alt="HDDS-12700 test result" src="https://github.com/user-attachments/assets/ddc4605c-6540-43de-b086-c8ee4e4967d4" />