### PR TITLE
HDDS-12771. xcompat fails if run in itself due to undefined OZONE_CURRENT_VERSION

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/compatibility/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/test.sh
@@ -17,6 +17,8 @@
 
 #suite:misc
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/test-ec.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/test-ec.sh
@@ -17,6 +17,8 @@
 
 #suite:balancer
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE0}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 export OM_SERVICE_ID="om"

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/test-ratis.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/test-ratis.sh
@@ -17,6 +17,8 @@
 
 #suite:balancer
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 export OM_SERVICE_ID="om"

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -u -o pipefail
+
 COMPOSE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test-hadoop.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test-hadoop.sh
@@ -17,6 +17,8 @@
 
 #suite:MR
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -17,6 +17,8 @@
 
 #suite:HA-unsecure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test-ec.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-ec.sh
@@ -17,6 +17,8 @@
 
 #suite:EC
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test-failures1.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-failures1.sh
@@ -17,6 +17,8 @@
 
 #suite:failing
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test-failures2.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-failures2.sh
@@ -17,6 +17,8 @@
 
 #suite:failing
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test-hadoop.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-hadoop.sh
@@ -17,6 +17,8 @@
 
 #suite:MR
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test-legacy-bucket.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-legacy-bucket.sh
@@ -17,6 +17,8 @@
 
 #suite:unsecure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test-s3a.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-s3a.sh
@@ -17,6 +17,8 @@
 
 #suite:s3a
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -17,6 +17,8 @@
 
 #suite:unsecure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/test.sh
@@ -17,6 +17,8 @@
 
 #suite:misc
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-leadership.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-leadership.sh
@@ -17,6 +17,8 @@
 
 #suite:leadership
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-om-bootstrap.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-om-bootstrap.sh
@@ -47,6 +47,8 @@
 #   * the keys are read from the snapshot and not the active file system
 #   * the contents of each key should be the same as the key name
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-s3a.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-s3a.sh
@@ -17,6 +17,8 @@
 
 #suite:s3a
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-s3g-virtual-host.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-s3g-virtual-host.sh
@@ -17,6 +17,8 @@
 
 #suite:misc
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-scm-decommission.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-scm-decommission.sh
@@ -17,6 +17,8 @@
 
 #suite:leadership
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -17,6 +17,8 @@
 
 #suite:HA-secure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
@@ -17,6 +17,8 @@
 
 #suite:MR
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-certificate-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-certificate-rotation.sh
@@ -17,6 +17,8 @@
 
 #suite:cert-rotation
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-ec.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-ec.sh
@@ -17,6 +17,8 @@
 
 #suite:EC
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-fcq.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-fcq.sh
@@ -17,6 +17,8 @@
 
 #suite:secure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-haproxy-s3g.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-haproxy-s3g.sh
@@ -17,6 +17,8 @@
 
 #suite:secure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
@@ -17,6 +17,8 @@
 
 #suite:cert-rotation
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-vault.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-vault.sh
@@ -17,6 +17,8 @@
 
 #suite:misc
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -17,6 +17,8 @@
 
 #suite:secure
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/restart/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/restart/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -50,7 +50,7 @@ fi
 
 if [[ "${OZONE_ACCEPTANCE_TEST_TYPE}" == "robot" ]]; then
   # does not apply to JUnit tests run via Maven
-  generate_report "acceptance" "${ALL_RESULT_DIR}" "${XUNIT_RESULT_DIR}"
+  generate_report "acceptance" "${ALL_RESULT_DIR}" "${XUNIT_RESULT_DIR:-}"
 fi
 
 exit $RESULT

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -u -o pipefail
 
 #
 # Test executor to test all the compose/*/test.sh test scripts.

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -19,19 +19,16 @@ set -e -u -o pipefail
 
 _testlib_this="${BASH_SOURCE[0]}"
 _testlib_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+: "${COMPOSE_DIR:=$_testlib_dir}"
 COMPOSE_ENV_NAME=$(basename "$COMPOSE_DIR")
 RESULT_DIR=${RESULT_DIR:-"$COMPOSE_DIR/result"}
-RESULT_DIR_INSIDE="/tmp/smoketest/$(basename "$COMPOSE_ENV_NAME")/result"
-
-OM_HA_PARAM=""
-if [[ -n "${OM_SERVICE_ID}" ]] && [[ "${OM_SERVICE_ID}" != "om" ]]; then
-  OM_HA_PARAM="--om-service-id=${OM_SERVICE_ID}"
-fi
 
 source ${_testlib_dir}/compose_v2_compatibility.sh
 source "${_testlib_dir}/../smoketest/testlib.sh"
 
 : ${OZONE_COMPOSE_RUNNING:=false}
+: ${SECURITY_ENABLED:=false}
 : ${SCM:=scm}
 
 # version is used in bucket name, which does not allow uppercase
@@ -72,7 +69,7 @@ all_tests_in_immediate_child_dirs() {
 ## @description Find all test*.sh scripts in immediate child dirs,
 ## @description applying OZONE_ACCEPTANCE_SUITE or OZONE_TEST_SELECTOR filter.
 find_tests(){
-  if [[ -n "${OZONE_ACCEPTANCE_SUITE}" ]]; then
+  if [[ -n "${OZONE_ACCEPTANCE_SUITE:-}" ]]; then
     tests=$(all_tests_in_immediate_child_dirs | xargs grep -l "^#suite:${OZONE_ACCEPTANCE_SUITE}$" || echo "")
 
      # 'misc' is default suite, add untagged tests, too
@@ -87,7 +84,7 @@ find_tests(){
       echo "No tests found for suite ${OZONE_ACCEPTANCE_SUITE}"
       exit 1
     fi
-  elif [[ -n "${OZONE_TEST_SELECTOR}" ]]; then
+  elif [[ -n "${OZONE_TEST_SELECTOR:-}" ]]; then
     tests=$(all_tests_in_immediate_child_dirs | grep "${OZONE_TEST_SELECTOR}" || echo "")
 
     if [[ -z "${tests}" ]]; then
@@ -216,22 +213,29 @@ execute_robot_test(){
     fi
   done
 
-  SMOKETEST_DIR_INSIDE="${OZONE_DIR:-/opt/hadoop}/smoketest"
+  : ${OZONE_DIR:=/opt/hadoop}
+  SMOKETEST_DIR_INSIDE="$OZONE_DIR/smoketest"
 
+  RESULT_DIR_INSIDE="/tmp/smoketest/$COMPOSE_ENV_NAME/result"
   OUTPUT_PATH="$RESULT_DIR_INSIDE/${OUTPUT_FILE}"
+
+  OM_HA_PARAM=""
+  if [[ -n "${OM_SERVICE_ID:-}" ]] && [[ "${OM_SERVICE_ID}" != "om" ]]; then
+    OM_HA_PARAM="--om-service-id=${OM_SERVICE_ID}"
+  fi
 
   set +e
 
   # shellcheck disable=SC2068
   docker-compose exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE" \
     && docker-compose exec -T "$CONTAINER" robot \
-      -v ENCRYPTION_KEY:"${OZONE_BUCKET_KEY_NAME}" \
+      -v ENCRYPTION_KEY:"${OZONE_BUCKET_KEY_NAME:-}" \
       -v OM_HA_PARAM:"${OM_HA_PARAM}" \
       -v OM_SERVICE_ID:"${OM_SERVICE_ID:-om}" \
       -v OZONE_DIR:"${OZONE_DIR}" \
       -v SECURITY_ENABLED:"${SECURITY_ENABLED}" \
       -v SCM:"${SCM}" \
-      ${ARGUMENTS[@]} --log NONE --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" \
+      ${ARGUMENTS[@]} --log NONE --report NONE --output "$OUTPUT_PATH" \
       "$SMOKETEST_DIR_INSIDE/$TEST"
   local -i rc=$?
 
@@ -320,7 +324,7 @@ create_containers() {
 }
 
 get_output_name() {
-  if [[ -n "${OUTPUT_NAME}" ]]; then
+  if [[ -n "${OUTPUT_NAME:-}" ]]; then
     echo "${OUTPUT_NAME}-"
   fi
 }

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e -o pipefail
+
+set -e -u -o pipefail
 
 _testlib_this="${BASH_SOURCE[0]}"
 _testlib_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -17,6 +17,7 @@
 
 #suite:upgrade
 
+set -u -o pipefail
 
 TEST_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 source "$TEST_DIR/testlib.sh"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -19,12 +19,12 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
 
+# shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
+source "${COMPOSE_DIR}/../testlib.sh"
+
 current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
 old_versions="1.1.0 1.2.1 1.3.0 1.4.0 1.4.1" # container is needed for each version in clients.yaml
-
-# shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
-source "${COMPOSE_DIR}/../testlib.sh"
 
 export SECURITY_ENABLED=true
 : ${OZONE_BUCKET_KEY_NAME:=key1}

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test-new.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test-new.sh
@@ -17,6 +17,8 @@
 
 #suite:compat-new
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test-old.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test-old.sh
@@ -17,6 +17,8 @@
 
 #suite:compat-old
 
+set -u -o pipefail
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/test/shell/compose_testlib.bats
+++ b/hadoop-ozone/dist/src/test/shell/compose_testlib.bats
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 load ../../main/compose/testlib.sh
 @test "Find test recursive, only on one level" {
   cd $BATS_TEST_DIRNAME

--- a/hadoop-ozone/dist/src/test/shell/compose_testlib.bats
+++ b/hadoop-ozone/dist/src/test/shell/compose_testlib.bats
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 load ../../main/compose/testlib.sh
 @test "Find test recursive, only on one level" {
   cd $BATS_TEST_DIRNAME


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12666 introduced a bug in `xcompat` test by using `OZONE_CURRENT_VERSION` before it is set.

Steps:

```
cd hadoop-ozone/dist/target/ozone-2.1.0-SNAPSHOT/compose/xcompat
./test-new.sh
```

Output:

```
Create Encrypted Bucket                                               | FAIL |
255 != 0
```

Test log:

```
Running command 'ozone sh bucket create -k key1 /vol1/encrypted-'
${rc} = 255
${output} = INVALID_BUCKET_NAME bucket name cannot end with a period or dash
```

Fix:

- treat unset variables as error (`set -u`) for all acceptance tests
- fix usage of unset variables

https://issues.apache.org/jira/browse/HDDS-12771

## How was this patch tested?

Same steps as described above.

```
Create Encrypted Bucket                                               | PASS |
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/14291344037