### PR TITLE
HDDS-12775. flaky-test-check builds the workflow branch

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -147,6 +147,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
       - name: Cache for maven dependencies
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

`flaky-test-check` has input for the Git ref to test, but its `build` job checks out the branch given in "Use workflow from".  This can cause test failure, e.g. if Ozone version is different on the two branches.

```
Reset branch 'master'
branch 'master' set up to track 'origin/master'.
```

https://github.com/adoroszlai/ozone/actions/runs/14294769454/job/40060575305#step:2:73

https://issues.apache.org/jira/browse/HDDS-12775

## How was this patch tested?

```
Switched to a new branch 'flaky-test-check-debug'
branch 'flaky-test-check-debug' set up to track 'origin/flaky-test-check-debug'.
```

https://github.com/adoroszlai/ozone/actions/runs/14294864376/job/40060779727#step:2:77