### PR TITLE
HDDS-12654. [DiskBalancer]Add a hdds.datanode.disk.balancer.stop.after.disk.even property

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -505,6 +505,7 @@ public interface ScmClient extends Closeable {
       Optional<Double> threshold,
       Optional<Long> bandwidthInMB,
       Optional<Integer> parallelThread,
+      Optional<Boolean> stopAfterDiskEven,
       Optional<List<String>> hosts) throws IOException;
 
   /**
@@ -521,5 +522,6 @@ public interface ScmClient extends Closeable {
       Optional<Double> threshold,
       Optional<Long> bandwidth,
       Optional<Integer> parallelThread,
+      Optional<Boolean> stopAfterDiskEven,
       Optional<List<String>> hosts) throws IOException;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -508,6 +508,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
       Optional<Double> threshold,
       Optional<Long> bandwidthInMB,
       Optional<Integer> parallelThread,
+      Optional<Boolean> stopAfterDiskEven,
       Optional<List<String>> hosts) throws IOException;
 
   /**
@@ -523,5 +524,6 @@ public interface StorageContainerLocationProtocol extends Closeable {
       Optional<Double> threshold,
       Optional<Long> bandwidthInMB,
       Optional<Integer> parallelThread,
+      Optional<Boolean> stopAfterDiskEven,
       Optional<List<String>> hosts) throws IOException;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/DiskBalancerConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/DiskBalancerConfiguration.java
@@ -147,15 +147,31 @@ public final class DiskBalancerConfiguration {
     return containerChoosingPolicyClass;
   }
 
+  @Config(key = "stop.after.disk.even",
+      type = ConfigType.BOOLEAN,
+      defaultValue = "true",
+      tags = {ConfigTag.DISKBALANCER},
+      description = "If true, the DiskBalancer will automatically stop once disks are balanced.")
+  private boolean stopAfterDiskEven = true;
+
+  public boolean getStopAfterDiskEven() {
+    return stopAfterDiskEven;
+  }
+
+  public void setStopAfterDiskEven(boolean stopAfterDiskEven) {
+    this.stopAfterDiskEven = stopAfterDiskEven;
+  }
+
   public DiskBalancerConfiguration() {
   }
 
   public DiskBalancerConfiguration(Optional<Double> threshold,
       Optional<Long> bandwidthInMB,
-      Optional<Integer> parallelThread) {
+      Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven) {
     threshold.ifPresent(aDouble -> this.threshold = aDouble);
     bandwidthInMB.ifPresent(aLong -> this.diskBandwidthInMB = aLong);
     parallelThread.ifPresent(integer -> this.parallelThread = integer);
+    stopAfterDiskEven.ifPresent(bool -> this.stopAfterDiskEven = bool);
   }
 
   /**
@@ -235,10 +251,11 @@ public final class DiskBalancerConfiguration {
             "%-50s %s%n" +
             "%-50s %s%n" +
             "%-50s %s%n" +
+            "%-50s %s%n" +
             "%-50s %s%n",
             "Key", "Value",
         "Threshold", threshold, "Max disk bandwidth", diskBandwidthInMB,
-        "Parallel Thread", parallelThread);
+        "Parallel Thread", parallelThread, "Stop After Disk Even", stopAfterDiskEven);
   }
 
   public HddsProtos.DiskBalancerConfigurationProto.Builder toProtobufBuilder() {
@@ -247,7 +264,8 @@ public final class DiskBalancerConfiguration {
 
     builder.setThreshold(threshold)
         .setDiskBandwidthInMB(diskBandwidthInMB)
-        .setParallelThread(parallelThread);
+        .setParallelThread(parallelThread)
+        .setStopAfterDiskEven(stopAfterDiskEven);
     return builder;
   }
 
@@ -264,6 +282,9 @@ public final class DiskBalancerConfiguration {
     }
     if (proto.hasParallelThread()) {
       config.setParallelThread(proto.getParallelThread());
+    }
+    if (proto.hasStopAfterDiskEven()) {
+      config.setStopAfterDiskEven(proto.getStopAfterDiskEven());
     }
     return config;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -31,6 +31,7 @@ public class DiskBalancerInfo {
   private double threshold;
   private long bandwidthInMB;
   private int parallelThread;
+  private boolean stopAfterDiskEven;
   private DiskBalancerVersion version;
   private long successCount;
   private long failureCount;
@@ -38,28 +39,30 @@ public class DiskBalancerInfo {
   private long balancedBytes;
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
-      long bandwidthInMB, int parallelThread) {
-    this(shouldRun, threshold, bandwidthInMB, parallelThread,
+      long bandwidthInMB, int parallelThread, boolean stopAfterDiskEven) {
+    this(shouldRun, threshold, bandwidthInMB, parallelThread, stopAfterDiskEven,
         DiskBalancerVersion.DEFAULT_VERSION);
   }
 
   public DiskBalancerInfo(boolean shouldRun, double threshold,
-      long bandwidthInMB, int parallelThread, DiskBalancerVersion version) {
+      long bandwidthInMB, int parallelThread, boolean stopAfterDiskEven, DiskBalancerVersion version) {
     this.shouldRun = shouldRun;
     this.threshold = threshold;
     this.bandwidthInMB = bandwidthInMB;
     this.parallelThread = parallelThread;
+    this.stopAfterDiskEven = stopAfterDiskEven;
     this.version = version;
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public DiskBalancerInfo(boolean shouldRun, double threshold,
-      long bandwidthInMB, int parallelThread, DiskBalancerVersion version,
+      long bandwidthInMB, int parallelThread, boolean stopAfterDiskEven, DiskBalancerVersion version,
       long successCount, long failureCount, long bytesToMove, long balancedBytes) {
     this.shouldRun = shouldRun;
     this.threshold = threshold;
     this.bandwidthInMB = bandwidthInMB;
     this.parallelThread = parallelThread;
+    this.stopAfterDiskEven = stopAfterDiskEven;
     this.version = version;
     this.successCount = successCount;
     this.failureCount = failureCount;
@@ -73,6 +76,7 @@ public class DiskBalancerInfo {
     this.threshold = diskBalancerConf.getThreshold();
     this.bandwidthInMB = diskBalancerConf.getDiskBandwidthInMB();
     this.parallelThread = diskBalancerConf.getParallelThread();
+    this.stopAfterDiskEven = diskBalancerConf.getStopAfterDiskEven();
     this.version = DiskBalancerVersion.DEFAULT_VERSION;
   }
 
@@ -86,11 +90,14 @@ public class DiskBalancerInfo {
     if (parallelThread != diskBalancerConf.getParallelThread()) {
       setParallelThread(diskBalancerConf.getParallelThread());
     }
+    if (stopAfterDiskEven != diskBalancerConf.getStopAfterDiskEven()) {
+      setStopAfterDiskEven(diskBalancerConf.getStopAfterDiskEven());
+    }
   }
 
   public StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto toDiskBalancerReportProto() {
     DiskBalancerConfiguration conf = new DiskBalancerConfiguration(Optional.of(threshold),
-        Optional.of(bandwidthInMB), Optional.of(parallelThread));
+        Optional.of(bandwidthInMB), Optional.of(parallelThread), Optional.of(stopAfterDiskEven));
     HddsProtos.DiskBalancerConfigurationProto confProto = conf.toProtobufBuilder().build();
 
     StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto.Builder builder =
@@ -134,6 +141,14 @@ public class DiskBalancerInfo {
 
   public void setParallelThread(int parallelThread) {
     this.parallelThread = parallelThread;
+  }
+
+  public boolean isStopAfterDiskEven() {
+    return stopAfterDiskEven;
+  }
+
+  public void setStopAfterDiskEven(boolean stopAfterDiskEven) {
+    this.stopAfterDiskEven = stopAfterDiskEven;
   }
 
   public DiskBalancerVersion getVersion() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -172,12 +172,13 @@ public class DiskBalancerInfo {
         Double.compare(that.threshold, threshold) == 0 &&
         bandwidthInMB == that.bandwidthInMB &&
         parallelThread == that.parallelThread &&
+        stopAfterDiskEven == that.stopAfterDiskEven &&
         version == that.version;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(shouldRun, threshold, bandwidthInMB, parallelThread,
+    return Objects.hash(shouldRun, threshold, bandwidthInMB, parallelThread, stopAfterDiskEven,
         version);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -82,6 +82,7 @@ public class DiskBalancerService extends BackgroundService {
   private double threshold;
   private long bandwidthInMB;
   private int parallelThread;
+  private boolean stopAfterDiskEven;
 
   private DiskBalancerVersion version;
 
@@ -201,6 +202,7 @@ public class DiskBalancerService extends BackgroundService {
     setThreshold(diskBalancerInfo.getThreshold());
     setBandwidthInMB(diskBalancerInfo.getBandwidthInMB());
     setParallelThread(diskBalancerInfo.getParallelThread());
+    setStopAfterDiskEven(diskBalancerInfo.isStopAfterDiskEven());
     setVersion(diskBalancerInfo.getVersion());
 
     // Default executorService is ScheduledThreadPoolExecutor, so we can
@@ -292,6 +294,10 @@ public class DiskBalancerService extends BackgroundService {
     this.parallelThread = parallelThread;
   }
 
+  public void setStopAfterDiskEven(boolean stopAfterDiskEven) {
+    this.stopAfterDiskEven = stopAfterDiskEven;
+  }
+
   public void setVersion(DiskBalancerVersion version) {
     this.version = version;
   }
@@ -306,6 +312,7 @@ public class DiskBalancerService extends BackgroundService {
                 .setThreshold(threshold)
                 .setDiskBandwidthInMB(bandwidthInMB)
                 .setParallelThread(parallelThread)
+                .setStopAfterDiskEven(stopAfterDiskEven)
                 .build())
         .build();
   }
@@ -352,6 +359,10 @@ public class DiskBalancerService extends BackgroundService {
     }
 
     if (queue.isEmpty()) {
+      bytesToMove = 0;
+      if (stopAfterDiskEven) {
+        setShouldRun(false);
+      }
       metrics.incrIdleLoopNoAvailableVolumePairCount();
     } else {
       bytesToMove = calculateBytesToMove(volumeSet);
@@ -463,7 +474,8 @@ public class DiskBalancerService extends BackgroundService {
         moveSucceeded = false;
         if (diskBalancerTmpDir != null) {
           try {
-            Files.deleteIfExists(diskBalancerTmpDir);
+            File dir = new File(String.valueOf(diskBalancerTmpDir));
+            org.apache.commons.io.FileUtils.deleteDirectory(dir);
           } catch (IOException ex) {
             LOG.warn("Failed to delete tmp directory {}", diskBalancerTmpDir,
                 ex);
@@ -471,10 +483,11 @@ public class DiskBalancerService extends BackgroundService {
         }
         if (diskBalancerDestDir != null) {
           try {
-            Files.deleteIfExists(diskBalancerDestDir);
+            File dir = new File(String.valueOf(diskBalancerDestDir));
+            org.apache.commons.io.FileUtils.deleteDirectory(dir);
           } catch (IOException ex) {
             LOG.warn("Failed to delete dest directory {}: {}.",
-                diskBalancerDestDir, ex.getMessage());
+                diskBalancerDestDir, ex.getMessage(), ex);
           }
         }
         // Only need to check for destVolume, sourceVolume's usedSpace is
@@ -513,7 +526,7 @@ public class DiskBalancerService extends BackgroundService {
 
   public DiskBalancerInfo getDiskBalancerInfo() {
     return new DiskBalancerInfo(shouldRun, threshold, bandwidthInMB,
-        parallelThread, version, metrics.getSuccessCount(),
+        parallelThread, stopAfterDiskEven, version, metrics.getSuccessCount(),
         metrics.getFailureCount(), bytesToMove, metrics.getSuccessBytes());
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerYaml.java
@@ -79,6 +79,7 @@ public final class DiskBalancerYaml {
           diskBalancerInfoYaml.getThreshold(),
           diskBalancerInfoYaml.getBandwidthInMB(),
           diskBalancerInfoYaml.getParallelThread(),
+          diskBalancerInfoYaml.isStopAfterDiskEven(),
           DiskBalancerVersion.getDiskBalancerVersion(
               diskBalancerInfoYaml.version));
     }
@@ -94,6 +95,7 @@ public final class DiskBalancerYaml {
     private double threshold;
     private long bandwidthInMB;
     private int parallelThread;
+    private boolean stopAfterDiskEven;
 
     private int version;
 
@@ -102,11 +104,12 @@ public final class DiskBalancerYaml {
     }
 
     private DiskBalancerInfoYaml(boolean shouldRun, double threshold,
-        long bandwidthInMB, int parallelThread, int version) {
+        long bandwidthInMB, int parallelThread, boolean stopAfterDiskEven, int version) {
       this.shouldRun = shouldRun;
       this.threshold = threshold;
       this.bandwidthInMB = bandwidthInMB;
       this.parallelThread = parallelThread;
+      this.stopAfterDiskEven = stopAfterDiskEven;
       this.version = version;
     }
 
@@ -142,6 +145,14 @@ public final class DiskBalancerYaml {
       return this.parallelThread;
     }
 
+    public boolean isStopAfterDiskEven() {
+      return stopAfterDiskEven;
+    }
+
+    public void setStopAfterDiskEven(boolean stopAfterDiskEven) {
+      this.stopAfterDiskEven = stopAfterDiskEven;
+    }
+
     public void setVersion(int version) {
       this.version = version;
     }
@@ -159,6 +170,7 @@ public final class DiskBalancerYaml {
         diskBalancerInfo.getThreshold(),
         diskBalancerInfo.getBandwidthInMB(),
         diskBalancerInfo.getParallelThread(),
+        diskBalancerInfo.isStopAfterDiskEven(),
         diskBalancerInfo.getVersion().getVersion());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -79,7 +79,7 @@ public class TestHeartbeatEndpointTask {
   public void setup() {
     datanodeStateMachine = mock(DatanodeStateMachine.class);
     container = mock(OzoneContainer.class);
-    when(container.getDiskBalancerInfo()).thenReturn(new DiskBalancerInfo(true, 10, 20, 30));
+    when(container.getDiskBalancerInfo()).thenReturn(new DiskBalancerInfo(true, 10, 20, 30, true));
     when(datanodeStateMachine.getContainer()).thenReturn(container);
     PipelineReportsProto pipelineReportsProto = mock(PipelineReportsProto.class);
     when(pipelineReportsProto.getPipelineReportList()).thenReturn(Collections.emptyList());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -120,6 +120,7 @@ public class TestDiskBalancerService {
     svc.setThreshold(10.0d);
     svc.setBandwidthInMB(1L);
     svc.setParallelThread(5);
+    svc.setStopAfterDiskEven(true);
     svc.setVersion(DiskBalancerVersion.DEFAULT_VERSION);
 
     svc.start();
@@ -128,14 +129,16 @@ public class TestDiskBalancerService {
     assertEquals(10, svc.getDiskBalancerInfo().getThreshold(), 0.0);
     assertEquals(1, svc.getDiskBalancerInfo().getBandwidthInMB());
     assertEquals(5, svc.getDiskBalancerInfo().getParallelThread());
+    assertTrue(svc.getDiskBalancerInfo().isStopAfterDiskEven());
 
-    DiskBalancerInfo newInfo = new DiskBalancerInfo(false, 20.0d, 5L, 10);
+    DiskBalancerInfo newInfo = new DiskBalancerInfo(false, 20.0d, 5L, 10, false);
     svc.refresh(newInfo);
 
     assertFalse(svc.getDiskBalancerInfo().isShouldRun());
     assertEquals(20, svc.getDiskBalancerInfo().getThreshold(), 0.0);
     assertEquals(5, svc.getDiskBalancerInfo().getBandwidthInMB());
     assertEquals(10, svc.getDiskBalancerInfo().getParallelThread());
+    assertFalse(svc.getDiskBalancerInfo().isStopAfterDiskEven());
 
     svc.shutdown();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerYaml.java
@@ -39,13 +39,14 @@ public class TestDiskBalancerYaml {
     double threshold = 10;
     long bandwidthInMB = 100;
     int parallelThread = 5;
+    boolean stopAfterDiskEven = true;
     DiskBalancerVersion version = DiskBalancerVersion.DEFAULT_VERSION;
 
     File file = new File(tmpDir.toString(),
         OZONE_SCM_DATANODE_DISK_BALANCER_INFO_FILE_DEFAULT);
 
     DiskBalancerInfo info = new DiskBalancerInfo(shouldRun, threshold,
-        bandwidthInMB, parallelThread, version);
+        bandwidthInMB, parallelThread, stopAfterDiskEven, version);
 
     DiskBalancerYaml.createDiskBalancerInfoFile(info, file);
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -1247,12 +1247,14 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   @Override
   public List<DatanodeAdminError> startDiskBalancer(Optional<Double> threshold,
       Optional<Long> bandwidthInMB, Optional<Integer> parallelThread,
-      Optional<List<String>> hosts) throws IOException {
+      Optional<Boolean> stopAfterDiskEven, Optional<List<String>> hosts)
+      throws IOException {
     HddsProtos.DiskBalancerConfigurationProto.Builder confBuilder =
         HddsProtos.DiskBalancerConfigurationProto.newBuilder();
     threshold.ifPresent(confBuilder::setThreshold);
     bandwidthInMB.ifPresent(confBuilder::setDiskBandwidthInMB);
     parallelThread.ifPresent(confBuilder::setParallelThread);
+    stopAfterDiskEven.ifPresent(confBuilder::setStopAfterDiskEven);
 
     DatanodeDiskBalancerOpRequestProto.Builder requestBuilder =
         DatanodeDiskBalancerOpRequestProto.newBuilder()
@@ -1297,13 +1299,14 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   @Override
   public List<DatanodeAdminError> updateDiskBalancerConfiguration(
       Optional<Double> threshold, Optional<Long> bandwidthInMB,
-      Optional<Integer> parallelThread, Optional<List<String>> hosts)
+      Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven, Optional<List<String>> hosts)
       throws IOException {
     HddsProtos.DiskBalancerConfigurationProto.Builder confBuilder =
         HddsProtos.DiskBalancerConfigurationProto.newBuilder();
     threshold.ifPresent(confBuilder::setThreshold);
     bandwidthInMB.ifPresent(confBuilder::setDiskBandwidthInMB);
     parallelThread.ifPresent(confBuilder::setParallelThread);
+    stopAfterDiskEven.ifPresent(confBuilder::setStopAfterDiskEven);
 
     DatanodeDiskBalancerOpRequestProto.Builder requestBuilder =
         DatanodeDiskBalancerOpRequestProto.newBuilder()

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -542,6 +542,7 @@ message DiskBalancerConfigurationProto {
     optional double threshold = 1;
     optional uint64 diskBandwidthInMB = 2;
     optional int32 parallelThread = 3;
+    optional bool stopAfterDiskEven = 4;
 }
 
 enum DiskBalancerRunningStatus {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -143,8 +143,8 @@ public class DiskBalancerManager {
    */
   public List<DatanodeAdminError> startDiskBalancer(
       Optional<Double> threshold, Optional<Long> bandwidthInMB,
-      Optional<Integer> parallelThread, Optional<List<String>> hosts)
-      throws IOException {
+      Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven,
+      Optional<List<String>> hosts) throws IOException {
     List<DatanodeDetails> dns;
     if (hosts.isPresent()) {
       dns = NodeUtils.mapHostnamesToDatanodes(nodeManager, hosts.get(),
@@ -164,7 +164,7 @@ public class DiskBalancerManager {
         // If command doesn't have configuration change, then we reuse the
         // latest configuration reported from Datnaodes
         DiskBalancerConfiguration updateConf = attachDiskBalancerConf(dn,
-            threshold, bandwidthInMB, parallelThread);
+            threshold, bandwidthInMB, parallelThread, stopAfterDiskEven);
         DiskBalancerCommand command = new DiskBalancerCommand(
             HddsProtos.DiskBalancerOpType.START, updateConf);
         sendCommand(dn, command);
@@ -217,7 +217,7 @@ public class DiskBalancerManager {
    */
   public List<DatanodeAdminError> updateDiskBalancerConfiguration(
       Optional<Double> threshold, Optional<Long> bandwidthInMB,
-      Optional<Integer> parallelThread, Optional<List<String>> hosts)
+      Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven, Optional<List<String>> hosts)
       throws IOException {
     List<DatanodeDetails> dns;
     if (hosts.isPresent()) {
@@ -233,7 +233,7 @@ public class DiskBalancerManager {
         // If command doesn't have configuration change, then we reuse the
         // latest configuration reported from Datnaodes
         DiskBalancerConfiguration updateConf = attachDiskBalancerConf(dn,
-            threshold, bandwidthInMB, parallelThread);
+            threshold, bandwidthInMB, parallelThread, stopAfterDiskEven);
         DiskBalancerCommand command = new DiskBalancerCommand(
             HddsProtos.DiskBalancerOpType.UPDATE, updateConf);
         sendCommand(dn, command);
@@ -339,13 +339,14 @@ public class DiskBalancerManager {
 
   private DiskBalancerConfiguration attachDiskBalancerConf(
       DatanodeDetails dn, Optional<Double> threshold,
-      Optional<Long> bandwidthInMB, Optional<Integer> parallelThread) {
+      Optional<Long> bandwidthInMB, Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven) {
     DiskBalancerConfiguration baseConf = statusMap.containsKey(dn) ?
         statusMap.get(dn).getDiskBalancerConfiguration() :
         new DiskBalancerConfiguration();
     threshold.ifPresent(baseConf::setThreshold);
     bandwidthInMB.ifPresent(baseConf::setDiskBandwidthInMB);
     parallelThread.ifPresent(baseConf::setParallelThread);
+    stopAfterDiskEven.ifPresent(baseConf::setStopAfterDiskEven);
     return baseConf;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -1404,6 +1404,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
           conf.hasThreshold() ? Optional.of(conf.getThreshold()) : Optional.empty(),
           conf.hasDiskBandwidthInMB() ? Optional.of(conf.getDiskBandwidthInMB()) : Optional.empty(),
           conf.hasParallelThread() ? Optional.of(conf.getParallelThread()) : Optional.empty(),
+          conf.hasStopAfterDiskEven() ? Optional.of(conf.getStopAfterDiskEven()) : Optional.empty(),
           request.getHostsList().isEmpty() ? Optional.empty() : Optional.of(request.getHostsList()));
       break;
     case UPDATE:
@@ -1412,6 +1413,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
           conf.hasThreshold() ? Optional.of(conf.getThreshold()) : Optional.empty(),
           conf.hasDiskBandwidthInMB() ? Optional.of(conf.getDiskBandwidthInMB()) : Optional.empty(),
           conf.hasParallelThread() ? Optional.of(conf.getParallelThread()) : Optional.empty(),
+          conf.hasStopAfterDiskEven() ? Optional.of(conf.getStopAfterDiskEven()) : Optional.empty(),
           request.getHostsList().isEmpty() ? Optional.empty() : Optional.of(request.getHostsList()));
       break;
     case STOP:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1358,7 +1358,8 @@ public class SCMClientProtocolServer implements
   @Override
   public List<DatanodeAdminError> startDiskBalancer(Optional<Double> threshold,
       Optional<Long> bandwidthInMB, Optional<Integer> parallelThread,
-      Optional<List<String>> hosts) throws IOException {
+      Optional<Boolean> stopAfterDiskEven, Optional<List<String>> hosts)
+      throws IOException {
     try {
       getScm().checkAdminAccess(getRemoteUser(), false);
     } catch (IOException e) {
@@ -1367,7 +1368,7 @@ public class SCMClientProtocolServer implements
     }
 
     return scm.getDiskBalancerManager()
-        .startDiskBalancer(threshold, bandwidthInMB, parallelThread, hosts);
+        .startDiskBalancer(threshold, bandwidthInMB, parallelThread, stopAfterDiskEven, hosts);
   }
 
   @Override
@@ -1386,7 +1387,7 @@ public class SCMClientProtocolServer implements
   @Override
   public List<DatanodeAdminError> updateDiskBalancerConfiguration(
       Optional<Double> threshold, Optional<Long> bandwidthInMB,
-      Optional<Integer> parallelThread, Optional<List<String>> hosts)
+      Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven, Optional<List<String>> hosts)
       throws IOException {
     try {
       getScm().checkAdminAccess(getRemoteUser(), false);
@@ -1396,7 +1397,7 @@ public class SCMClientProtocolServer implements
     }
 
     return scm.getDiskBalancerManager().updateDiskBalancerConfiguration(
-        threshold, bandwidthInMB, parallelThread, hosts);
+        threshold, bandwidthInMB, parallelThread, stopAfterDiskEven, hosts);
   }
 
   /**

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -612,10 +612,10 @@ public class ContainerOperationClient implements ScmClient {
 
   @Override
   public List<DatanodeAdminError> startDiskBalancer(Optional<Double> threshold,
-      Optional<Long> bandwidthInMB, Optional<Integer> parallelThread,
+      Optional<Long> bandwidthInMB, Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven,
       Optional<List<String>> hosts) throws IOException {
     return storageContainerLocationClient.startDiskBalancer(threshold,
-        bandwidthInMB, parallelThread, hosts);
+        bandwidthInMB, parallelThread, stopAfterDiskEven, hosts);
   }
 
   @Override
@@ -636,9 +636,9 @@ public class ContainerOperationClient implements ScmClient {
   @Override
   public List<DatanodeAdminError> updateDiskBalancerConfiguration(
       Optional<Double> threshold, Optional<Long> bandwidth,
-      Optional<Integer> parallelThread, Optional<List<String>> hosts)
+      Optional<Integer> parallelThread, Optional<Boolean> stopAfterDiskEven, Optional<List<String>> hosts)
       throws IOException {
     return storageContainerLocationClient.updateDiskBalancerConfiguration(
-        threshold, bandwidth, parallelThread, hosts);
+        threshold, bandwidth, parallelThread, stopAfterDiskEven, hosts);
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommands.java
@@ -34,6 +34,7 @@ import picocli.CommandLine.Command;
  *      [ -t/--threshold {@literal <threshold>}]
  *      [ -b/--bandwidthInMB {@literal <bandwidthInMB>}]
  *      [ -p/--parallelThread {@literal <parallelThread>}]
+ *      [ -s/--stop-after-disk-even {@literal <stopAfterDiskEven>}]
  *      [ -a/--all {@literal <alldatanodes>}]
  *      [ -d/--datanodes {@literal <datanodes>}]
  *      [ {@literal <hosts>}]
@@ -43,13 +44,16 @@ import picocli.CommandLine.Command;
  *        datanodes
  *      ozone admin datanode diskbalancer start -a
  *        start balancer with default values in the configuration on all
- *        datanodes in the cluster
+ *        datanodes in the cluster and stops automatically after balancing
  *      ozone admin datanode diskbalancer start -t 5 -d {@literal <hosts>}
  *        start balancer with a threshold of 5%
  *      ozone admin datanode diskbalancer start -b 20 -d {@literal <hosts>}
  *        start balancer with maximum 20MB/s diskbandwidth
  *      ozone admin datanode diskbalancer start -p 5 -d {@literal <hosts>}
  *        start balancer with 5 parallel thread on each datanode
+ *      ozone admin datanode diskbalancer start -s=false -a}
+ *        start balancer and will keep running until stopped by the
+ *        stop command
  * To stop:
  *      ozone admin datanode diskbalancer stop -a
  *        stop diskblancer on all datanodes

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
@@ -53,6 +53,10 @@ public class DiskBalancerStartSubcommand extends ScmSubcommand {
       description = "Max parallelThread for DiskBalancer.")
   private Optional<Integer> parallelThread;
 
+  @Option(names = {"-s", "--stop-after-disk-even"},
+      description = "Stop DiskBalancer automatically after disk utilization is even.")
+  private Optional<Boolean> stopAfterDiskEven;
+
   @CommandLine.Mixin
   private DiskBalancerCommonOptions commonOptions =
       new DiskBalancerCommonOptions();
@@ -63,7 +67,7 @@ public class DiskBalancerStartSubcommand extends ScmSubcommand {
       return;
     }
     List<DatanodeAdminError> errors =
-        scmClient.startDiskBalancer(threshold, bandwidthInMB, parallelThread,
+        scmClient.startDiskBalancer(threshold, bandwidthInMB, parallelThread, stopAfterDiskEven,
             commonOptions.getSpecifiedDatanodes());
 
     System.out.println("Start DiskBalancer on datanode(s):\n" +

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
@@ -53,6 +53,10 @@ public class DiskBalancerUpdateSubcommand extends ScmSubcommand {
       description = "Max parallelThread for DiskBalancer.")
   private Optional<Integer> parallelThread;
 
+  @Option(names = {"-s", "--stop-after-disk-even"},
+      description = "Stop DiskBalancer automatically after disk utilization is even.")
+  private Optional<Boolean> stopAfterDiskEven;
+
   @CommandLine.Mixin
   private DiskBalancerCommonOptions commonOptions =
       new DiskBalancerCommonOptions();
@@ -64,7 +68,7 @@ public class DiskBalancerUpdateSubcommand extends ScmSubcommand {
     }
     List<DatanodeAdminError> errors =
         scmClient.updateDiskBalancerConfiguration(threshold, bandwidthInMB,
-            parallelThread, commonOptions.getSpecifiedDatanodes());
+            parallelThread, stopAfterDiskEven, commonOptions.getSpecifiedDatanodes());
 
     System.out.println("Update DiskBalancer Configuration on datanode(s):\n" +
         commonOptions.getHostString());

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommand.java
@@ -116,7 +116,7 @@ public class TestDiskBalancerSubCommand {
 
     // Return error
     Mockito.when(scmClient.startDiskBalancer(Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any()))
+            Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(generateError(10));
 
     try {
@@ -127,7 +127,7 @@ public class TestDiskBalancerSubCommand {
 
     // Do not return error
     Mockito.when(scmClient.startDiskBalancer(Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any()))
+            Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(generateError(0));
 
     try {
@@ -146,7 +146,7 @@ public class TestDiskBalancerSubCommand {
 
     // Return error
     Mockito.when(scmClient.updateDiskBalancerConfiguration(Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()))
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(generateError(10));
 
     try {
@@ -157,7 +157,7 @@ public class TestDiskBalancerSubCommand {
 
     // Do not return error
     Mockito.when(scmClient.updateDiskBalancerConfiguration(Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()))
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(generateError(0));
 
     try {

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/testdiskbalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/testdiskbalancer.robot
@@ -39,3 +39,13 @@ Check success with non-admin user for status and report diskbalancer
                         Should Contain                  ${result}                Status result:
     ${result} =         Execute                         ozone admin datanode diskbalancer report
                         Should Contain                  ${result}                Report result:
+
+Check if balancer stops automatically
+    Run Keyword         Kinit test user                 testuser                testuser.keytab
+    Execute             ozone admin datanode diskbalancer start -a
+    Sleep               12s
+    ${result} =         Execute                         ozone admin datanode diskbalancer status
+                        Should Contain                  ${result}               RUNNING
+    Sleep               1min
+    ${result} =         Execute                         ozone admin datanode diskbalancer status
+                        Should Contain                  ${result}               STOPPED

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/testdiskbalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/testdiskbalancer.robot
@@ -18,6 +18,12 @@ Documentation       Test ozone admin datanode diskbalancer command
 Library             OperatingSystem
 Resource            ../commonlib.robot
 
+*** Keywords ***
+Check Balancer Status
+    [Arguments]         ${expected_status}
+    ${result} =         Execute             ozone admin datanode diskbalancer status
+    Should Contain      ${result}           ${expected_status}
+
 ** Test Cases ***
 Check failure with non-admin user to start, stop and update diskbalancer
     Requires admin privilege     ozone admin datanode diskbalancer start -a
@@ -43,9 +49,9 @@ Check success with non-admin user for status and report diskbalancer
 Check if balancer stops automatically
     Run Keyword         Kinit test user                 testuser                testuser.keytab
     Execute             ozone admin datanode diskbalancer start -a
-    Sleep               12s
-    ${result} =         Execute                         ozone admin datanode diskbalancer status
-                        Should Contain                  ${result}               RUNNING
-    Sleep               1min
-    ${result} =         Execute                         ozone admin datanode diskbalancer status
-                        Should Contain                  ${result}               STOPPED
+
+    # Wait until the balancer status contains "RUNNING", retry every 5s for up to 1 min
+    Wait Until Keyword Succeeds   1 min   5 sec   Check Balancer Status   RUNNING
+
+    # Wait until the balancer status contains "STOPPED", retry every 5s for up to 2 min
+    Wait Until Keyword Succeeds   2 min   5 sec   Check Balancer Status   STOPPED


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Add a "hdds.datanode.disk.balancer.stop.after.disk.even" new property with default value true.

This hdds.datanode.disk.balancer.stop.after.disk.even means once the disks become even, disk balancer on datanode will stop by itself, also update the on disk diskBalancer.info state.

2. Add a "--stop-after-disk-even" option to disk balancer start and update sub command.
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12654

## How was this patch tested?

Added acceptance test and also checked by manual testing on docker cluster.
