### PR TITLE
HDDS-11074. Persist group information to DB

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -262,6 +262,7 @@ public final class OzoneConsts {
   public static final String UPDATE_ID = "updateID";
   public static final String CLIENT_ID = "clientID";
   public static final String OWNER = "owner";
+  public static final String GROUP = "group";
   public static final String ADMIN = "admin";
   public static final String USERNAME = "username";
   public static final String PREV_KEY = "prevKey";

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -1456,6 +1456,7 @@ public class OzoneBucket extends WithMetadata {
         metadata,
         keyInfo.isFile(),
         keyInfo.getOwnerName(),
+        keyInfo.getGroupName(),
         Collections.emptyMap());
   }
 
@@ -1928,7 +1929,8 @@ public class OzoneBucket extends WithMetadata {
             keyInfo.getDataSize(), keyInfo.getCreationTime(),
             keyInfo.getModificationTime(),
             keyInfo.getReplicationConfig(),
-            keyInfo.isFile(), keyInfo.getOwnerName());
+            keyInfo.isFile(), keyInfo.getOwnerName(),
+            keyInfo.getGroupName());
         keysResultList.add(ozoneKey);
       }
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -47,6 +47,10 @@ public class OzoneKey {
    */
   private final String owner;
   /**
+   * Name of the Key group.
+   */
+  private final String group;
+  /**
    * Size of the data.
    */
   private final long dataSize;
@@ -74,7 +78,7 @@ public class OzoneKey {
   public OzoneKey(String volumeName, String bucketName,
       String keyName, long size, long creationTime,
       long modificationTime, ReplicationConfig replicationConfig,
-      boolean isFile, String owner) {
+      boolean isFile, String owner, String group) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.name = keyName;
@@ -84,6 +88,7 @@ public class OzoneKey {
     this.replicationConfig = replicationConfig;
     this.isFile = isFile;
     this.owner = owner;
+    this.group = group;
   }
 
   @SuppressWarnings("parameternumber")
@@ -91,9 +96,9 @@ public class OzoneKey {
                   String keyName, long size, long creationTime,
                   long modificationTime, ReplicationConfig replicationConfig,
                   Map<String, String> metadata, boolean isFile, String owner,
-                  Map<String, String> tags) {
+                  String group, Map<String, String> tags) {
     this(volumeName, bucketName, keyName, size, creationTime,
-        modificationTime, replicationConfig, isFile, owner);
+        modificationTime, replicationConfig, isFile, owner, group);
     this.metadata.putAll(metadata);
     this.tags.putAll(tags);
   }
@@ -128,10 +133,19 @@ public class OzoneKey {
   /**
    * Returns the Owner Name.
    *
-   * @return keyName
+   * @return ownerName
    */
   public String getOwner() {
     return owner;
+  }
+
+  /**
+   * Returns the Group Name.
+   *
+   * @return groupName
+   */
+  public String getGroup() {
+    return group;
   }
 
   /**
@@ -222,7 +236,7 @@ public class OzoneKey {
         keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
         keyInfo.getModificationTime(), keyInfo.getReplicationConfig(),
         keyInfo.getMetadata(), keyInfo.isFile(), keyInfo.getOwnerName(),
-        keyInfo.getTags());
+        keyInfo.getGroupName(), keyInfo.getTags());
   }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
@@ -57,9 +57,9 @@ public class OzoneKeyDetails extends OzoneKey {
       Map<String, String> metadata,
       FileEncryptionInfo feInfo,
       CheckedSupplier<OzoneInputStream, IOException> contentSupplier,
-      boolean isFile, String owner, Map<String, String> tags, Long generation) {
+      boolean isFile, String owner, String group, Map<String, String> tags, Long generation) {
     super(volumeName, bucketName, keyName, size, creationTime,
-        modificationTime, replicationConfig, metadata, isFile, owner, tags);
+        modificationTime, replicationConfig, metadata, isFile, owner, group, tags);
     this.ozoneKeyLocations = ozoneKeyLocations;
     this.feInfo = feInfo;
     this.contentSupplier = contentSupplier;
@@ -77,10 +77,10 @@ public class OzoneKeyDetails extends OzoneKey {
                          Map<String, String> metadata,
                          FileEncryptionInfo feInfo,
                          CheckedSupplier<OzoneInputStream, IOException> contentSupplier,
-                         boolean isFile, String owner, Map<String, String> tags) {
+                         boolean isFile, String owner, String group, Map<String, String> tags) {
     this(volumeName, bucketName, keyName, size, creationTime,
         modificationTime, ozoneKeyLocations, replicationConfig, metadata, feInfo, contentSupplier,
-        isFile, owner, tags, null);
+        isFile, owner, group, tags, null);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1374,6 +1374,7 @@ public class RpcClient implements ClientProtocol {
     }
 
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
 
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
@@ -1384,7 +1385,8 @@ public class RpcClient implements ClientProtocol {
         .addAllMetadataGdpr(metadata)
         .addAllTags(tags)
         .setLatestVersionLocation(getLatestVersionLocation)
-        .setOwnerName(ownerName);
+        .setOwnerName(ownerName)
+        .setGroupName(groupName);
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());
     // For bucket with layout OBJECT_STORE, when create an empty file (size=0),
@@ -1481,6 +1483,7 @@ public class RpcClient implements ClientProtocol {
     }
 
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
 
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
@@ -1491,7 +1494,8 @@ public class RpcClient implements ClientProtocol {
         .addAllMetadataGdpr(metadata)
         .addAllTags(tags)
         .setSortDatanodesInPipeline(true)
-        .setOwnerName(ownerName);
+        .setOwnerName(ownerName)
+        .setGroupName(groupName);
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());
     return createDataStreamOutput(openKey);
@@ -1623,6 +1627,7 @@ public class RpcClient implements ClientProtocol {
             .setParentObjectID(keyInfo.getParentObjectID())
             .setFileChecksum(keyInfo.getFileChecksum())
             .setOwnerName(keyInfo.getOwnerName())
+            .setGroupName(keyInfo.getGroupName())
             .build();
         dnKeyInfo.setMetadata(keyInfo.getMetadata());
         dnKeyInfo.setKeyLocationVersions(keyLocationInfoGroups);
@@ -1725,7 +1730,8 @@ public class RpcClient implements ClientProtocol {
               key.getModificationTime(),
               key.getReplicationConfig(),
               key.isFile(),
-              key.getOwnerName()))
+              key.getOwnerName(),
+              key.getGroupName()))
           .collect(Collectors.toList());
     } else {
       List<OmKeyInfo> keys = ozoneManagerClient.listKeys(
@@ -1738,7 +1744,8 @@ public class RpcClient implements ClientProtocol {
               key.getModificationTime(),
               key.getReplicationConfig(),
               key.isFile(),
-              key.getOwnerName()))
+              key.getOwnerName(),
+              key.getGroupName()))
           .collect(Collectors.toList());
     }
   }
@@ -1771,7 +1778,7 @@ public class RpcClient implements ClientProtocol {
         keyInfo.getReplicationConfig(), keyInfo.getMetadata(),
         keyInfo.getFileEncryptionInfo(),
         () -> getInputStreamWithRetryFunction(keyInfo), keyInfo.isFile(),
-        keyInfo.getOwnerName(), keyInfo.getTags(),
+        keyInfo.getOwnerName(), keyInfo.getGroupName(), keyInfo.getTags(),
         keyInfo.getGeneration()
     );
   }
@@ -1934,6 +1941,7 @@ public class RpcClient implements ClientProtocol {
     verifyBucketName(bucketName);
     HddsClientUtils.checkNotNull(keyName);
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
     if (omVersion
         .compareTo(OzoneManagerVersion.ERASURE_CODED_STORAGE_SUPPORT) < 0) {
       if (replicationConfig != null && replicationConfig.getReplicationType()
@@ -1957,6 +1965,7 @@ public class RpcClient implements ClientProtocol {
         .setReplicationConfig(replicationConfig)
         .addAllMetadataGdpr(metadata)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .addAllTags(tags)
         .build();
     OmMultipartInfo multipartInfo = ozoneManagerClient
@@ -1982,6 +1991,7 @@ public class RpcClient implements ClientProtocol {
     Preconditions.checkArgument(size >= 0, "size should be greater than or " +
         "equal to zero");
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -1992,6 +2002,7 @@ public class RpcClient implements ClientProtocol {
         .setMultipartUploadPartNumber(partNumber)
         .setSortDatanodesInPipeline(sortDatanodesInPipeline)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .build();
     return ozoneManagerClient.openKey(keyArgs);
   }
@@ -2056,6 +2067,7 @@ public class RpcClient implements ClientProtocol {
     verifyBucketName(bucketName);
     HddsClientUtils.checkNotNull(keyName, uploadID);
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
@@ -2063,6 +2075,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setMultipartUploadID(uploadID)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .build();
 
     OmMultipartUploadCompleteList
@@ -2172,10 +2185,12 @@ public class RpcClient implements ClientProtocol {
   public void createDirectory(String volumeName, String bucketName,
       String keyName) throws IOException {
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .build();
     ozoneManagerClient.createDirectory(keyArgs);
   }
@@ -2249,6 +2264,7 @@ public class RpcClient implements ClientProtocol {
       }
     }
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -2257,6 +2273,7 @@ public class RpcClient implements ClientProtocol {
         .setReplicationConfig(replicationConfig)
         .setLatestVersionLocation(getLatestVersionLocation)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .build();
     OpenKeySession keySession =
         ozoneManagerClient.createFile(keyArgs, overWrite, recursive);
@@ -2280,6 +2297,7 @@ public class RpcClient implements ClientProtocol {
       ReplicationConfig replicationConfig, boolean overWrite, boolean recursive)
       throws IOException {
     String ownerName = getRealUserInfo().getShortUserName();
+    String groupName = getRealUserInfo().getPrimaryGroupName();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -2289,6 +2307,7 @@ public class RpcClient implements ClientProtocol {
         .setLatestVersionLocation(getLatestVersionLocation)
         .setSortDatanodesInPipeline(true)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .build();
     OpenKeySession keySession =
         ozoneManagerClient.createFile(keyArgs, overWrite, recursive);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -42,6 +42,7 @@ public final class BasicOmKeyInfo {
   private final boolean isFile;
   private final String eTag;
   private String ownerName;
+  private String groupName;
 
   private BasicOmKeyInfo(Builder b) {
     this.volumeName = b.volumeName;
@@ -54,6 +55,7 @@ public final class BasicOmKeyInfo {
     this.isFile = b.isFile;
     this.eTag = StringUtils.isNotEmpty(b.eTag) ? b.eTag : null;
     this.ownerName = b.ownerName;
+    this.groupName = b.groupName;
   }
 
   private BasicOmKeyInfo(OmKeyInfo b) {
@@ -67,6 +69,7 @@ public final class BasicOmKeyInfo {
     this.isFile = b.isFile();
     this.eTag = b.getMetadata().get(ETAG);
     this.ownerName = b.getOwnerName();
+    this.groupName = b.getGroupName();
   }
 
   public String getVolumeName() {
@@ -109,6 +112,10 @@ public final class BasicOmKeyInfo {
     return ownerName;
   }
 
+  public String getGroupName() {
+    return groupName;
+  }
+
   public long getReplicatedSize() {
     return QuotaUtil.getReplicatedSize(getDataSize(), replicationConfig);
   }
@@ -127,6 +134,7 @@ public final class BasicOmKeyInfo {
     private boolean isFile;
     private String eTag;
     private String ownerName;
+    private String groupName;
 
     public Builder setVolumeName(String volumeName) {
       this.volumeName = volumeName;
@@ -178,6 +186,11 @@ public final class BasicOmKeyInfo {
       return this;
     }
 
+    public Builder setGroupName(String groupName) {
+      this.groupName = groupName;
+      return this;
+    }
+
     public BasicOmKeyInfo build() {
       return new BasicOmKeyInfo(this);
     }
@@ -192,6 +205,9 @@ public final class BasicOmKeyInfo {
         .setType(replicationConfig.getReplicationType());
     if (ownerName != null) {
       builder.setOwnerName(ownerName);
+    }
+    if (groupName != null) {
+      builder.setGroupName(groupName);
     }
     if (replicationConfig instanceof ECReplicationConfig) {
       builder.setEcReplicationConfig(
@@ -228,7 +244,8 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getEcReplicationConfig()))
         .setETag(basicKeyInfo.getETag())
         .setIsFile(!keyName.endsWith("/"))
-        .setOwnerName(basicKeyInfo.getOwnerName());
+        .setOwnerName(basicKeyInfo.getOwnerName())
+        .setGroupName(basicKeyInfo.getGroupName());
 
     return builder.build();
   }
@@ -254,7 +271,8 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getEcReplicationConfig()))
         .setETag(basicKeyInfo.getETag())
         .setIsFile(!keyName.endsWith("/"))
-        .setOwnerName(basicKeyInfo.getOwnerName());
+        .setOwnerName(basicKeyInfo.getOwnerName())
+        .setGroupName(basicKeyInfo.getGroupName());
 
     return builder.build();
   }
@@ -277,7 +295,8 @@ public final class BasicOmKeyInfo {
         replicationConfig.equals(basicOmKeyInfo.replicationConfig) &&
         Objects.equals(eTag, basicOmKeyInfo.eTag) &&
         isFile == basicOmKeyInfo.isFile &&
-        ownerName.equals(basicOmKeyInfo.ownerName);
+        ownerName.equals(basicOmKeyInfo.ownerName) &&
+        groupName.equals(basicOmKeyInfo.groupName);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -48,6 +48,7 @@ public class OmDirectoryInfo extends WithParentObjectId
 
   private final String name; // directory name
   private String owner;
+  private String group;
 
   private final long creationTime;
   private final long modificationTime;
@@ -58,6 +59,7 @@ public class OmDirectoryInfo extends WithParentObjectId
     super(builder);
     this.name = builder.name;
     this.owner = builder.owner;
+    this.group = builder.group;
     this.acls = builder.acls;
     this.creationTime = builder.creationTime;
     this.modificationTime = builder.modificationTime;
@@ -78,6 +80,7 @@ public class OmDirectoryInfo extends WithParentObjectId
   public static class Builder extends WithParentObjectId.Builder {
     private String name;
     private String owner;
+    private String group;
 
     private long creationTime;
     private long modificationTime;
@@ -114,6 +117,11 @@ public class OmDirectoryInfo extends WithParentObjectId
 
     public Builder setOwner(String ownerName) {
       this.owner = ownerName;
+      return this;
+    }
+
+    public Builder setGroup(String groupName) {
+      this.group = groupName;
       return this;
     }
 
@@ -175,6 +183,10 @@ public class OmDirectoryInfo extends WithParentObjectId
     return owner;
   }
 
+  public String getGroup() {
+    return group;
+  }
+
   public long getCreationTime() {
     return creationTime;
   }
@@ -201,6 +213,9 @@ public class OmDirectoryInfo extends WithParentObjectId
                     .setParentID(getParentObjectID());
     if (owner != null) {
       pib.setOwnerName(owner);
+    }
+    if (group != null) {
+      pib.setGroupName(group);
     }
     if (acls != null) {
       pib.addAllAcls(OzoneAclUtil.toProtobuf(acls));
@@ -235,6 +250,9 @@ public class OmDirectoryInfo extends WithParentObjectId
     if (dirInfo.hasOwnerName()) {
       opib.setOwner(dirInfo.getOwnerName());
     }
+    if (dirInfo.hasGroupName()) {
+      opib.setGroup(dirInfo.getGroupName());
+    }
     return opib.build();
   }
 
@@ -251,6 +269,7 @@ public class OmDirectoryInfo extends WithParentObjectId
             modificationTime == omDirInfo.modificationTime &&
             name.equals(omDirInfo.name) &&
             Objects.equals(owner, omDirInfo.owner) &&
+            Objects.equals(group, omDirInfo.group) &&
             Objects.equals(getMetadata(), omDirInfo.getMetadata()) &&
             Objects.equals(acls, omDirInfo.acls) &&
             getObjectID() == omDirInfo.getObjectID() &&
@@ -271,6 +290,7 @@ public class OmDirectoryInfo extends WithParentObjectId
     OmDirectoryInfo.Builder builder = new Builder()
             .setName(name)
             .setOwner(owner)
+            .setGroup(group)
             .setCreationTime(creationTime)
             .setModificationTime(modificationTime)
             .setAcls(acls)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -40,6 +40,7 @@ public final class OmKeyArgs implements Auditable {
   private final String bucketName;
   private final String keyName;
   private final String ownerName;
+  private final String groupName;
   private long dataSize;
   private final ReplicationConfig replicationConfig;
   private List<OmKeyLocationInfo> locationInfoList;
@@ -80,6 +81,7 @@ public final class OmKeyArgs implements Auditable {
     this.headOp = b.headOp;
     this.forceUpdateContainerCacheFromSCM = b.forceUpdateContainerCacheFromSCM;
     this.ownerName = b.ownerName;
+    this.groupName = b.groupName;
     this.tags = b.tags;
     this.expectedDataGeneration = b.expectedDataGeneration;
   }
@@ -118,6 +120,10 @@ public final class OmKeyArgs implements Auditable {
 
   public String getOwner() {
     return ownerName;
+  }
+
+  public String getGroup() {
+    return groupName;
   }
 
   public long getDataSize() {
@@ -175,6 +181,7 @@ public final class OmKeyArgs implements Auditable {
     auditMap.put(OzoneConsts.BUCKET, this.bucketName);
     auditMap.put(OzoneConsts.KEY, this.keyName);
     auditMap.put(OzoneConsts.OWNER, this.ownerName);
+    auditMap.put(OzoneConsts.GROUP, this.groupName);
     auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(this.dataSize));
     auditMap.put(OzoneConsts.REPLICATION_CONFIG,
         (this.replicationConfig != null) ?
@@ -196,6 +203,7 @@ public final class OmKeyArgs implements Auditable {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .setDataSize(dataSize)
         .setReplicationConfig(replicationConfig)
         .setLocationInfoList(locationInfoList)
@@ -247,6 +255,7 @@ public final class OmKeyArgs implements Auditable {
     private String bucketName;
     private String keyName;
     private String ownerName;
+    private String groupName;
     private long dataSize;
     private ReplicationConfig replicationConfig;
     private List<OmKeyLocationInfo> locationInfoList;
@@ -280,6 +289,11 @@ public final class OmKeyArgs implements Auditable {
 
     public Builder setOwnerName(String owner) {
       this.ownerName = owner;
+      return this;
+    }
+
+    public Builder setGroupName(String group) {
+      this.groupName = group;
       return this;
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -95,6 +95,7 @@ public final class OmKeyInfo extends WithParentObjectId
    */
   private String fileName;
   private String ownerName;
+  private String groupName;
 
   /**
    * ACL Information.
@@ -130,6 +131,7 @@ public final class OmKeyInfo extends WithParentObjectId
     this.fileName = b.fileName;
     this.isFile = b.isFile;
     this.ownerName = b.ownerName;
+    this.groupName = b.groupName;
     this.tags = b.tags;
     this.expectedDataGeneration = b.expectedDataGeneration;
   }
@@ -184,6 +186,10 @@ public final class OmKeyInfo extends WithParentObjectId
 
   public String getOwnerName() {
     return ownerName;
+  }
+
+  public String getGroupName() {
+    return groupName;
   }
 
   /**
@@ -461,6 +467,7 @@ public final class OmKeyInfo extends WithParentObjectId
     private String bucketName;
     private String keyName;
     private String ownerName;
+    private String groupName;
     private long dataSize;
     private final List<OmKeyLocationInfoGroup> omKeyLocationInfoGroups =
         new ArrayList<>();
@@ -501,6 +508,11 @@ public final class OmKeyInfo extends WithParentObjectId
 
     public Builder setOwnerName(String owner) {
       this.ownerName = owner;
+      return this;
+    }
+
+    public Builder setGroupName(String owner) {
+      this.groupName = owner;
       return this;
     }
 
@@ -730,6 +742,9 @@ public final class OmKeyInfo extends WithParentObjectId
     if (ownerName != null) {
       kb.setOwnerName(ownerName);
     }
+    if (groupName != null) {
+      kb.setGroupName(groupName);
+    }
     return kb.build();
   }
 
@@ -784,6 +799,9 @@ public final class OmKeyInfo extends WithParentObjectId
     if (keyInfo.hasOwnerName()) {
       builder.setOwnerName(keyInfo.getOwnerName());
     }
+    if (keyInfo.hasGroupName()) {
+      builder.setGroupName(keyInfo.getGroupName());
+    }
     // not persisted to DB. FileName will be filtered out from keyName
     builder.setFileName(OzoneFSUtils.getFileName(keyInfo.getKeyName()));
     return builder.build();
@@ -796,6 +814,7 @@ public final class OmKeyInfo extends WithParentObjectId
         ", bucket='" + bucketName + '\'' +
         ", key='" + keyName + '\'' +
         ", owner='" + ownerName + '\'' +
+        ", group='" + groupName + '\'' +
         ", dataSize='" + dataSize + '\'' +
         ", creationTime='" + creationTime + '\'' +
         ", objectID='" + getObjectID() + '\'' +
@@ -810,7 +829,8 @@ public final class OmKeyInfo extends WithParentObjectId
                                boolean checkKeyLocationVersions,
                                boolean checkModificationTime,
                                boolean checkUpdateID,
-                               boolean checkOwnerName) {
+                               boolean checkOwnerName,
+                               boolean checkGroupName) {
     boolean isEqual = dataSize == omKeyInfo.dataSize &&
         creationTime == omKeyInfo.creationTime &&
         volumeName.equals(omKeyInfo.volumeName) &&
@@ -843,6 +863,11 @@ public final class OmKeyInfo extends WithParentObjectId
           .equals(ownerName, omKeyInfo.ownerName);
     }
 
+    if (isEqual && checkGroupName) {
+      isEqual = Objects
+          .equals(groupName, omKeyInfo.groupName);
+    }
+
     return isEqual;
   }
 
@@ -854,7 +879,7 @@ public final class OmKeyInfo extends WithParentObjectId
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    return isKeyInfoSame((OmKeyInfo) o, true, true, true, true, true);
+    return isKeyInfoSame((OmKeyInfo) o, true, true, true, true, true, true);
   }
 
   @Override
@@ -872,6 +897,7 @@ public final class OmKeyInfo extends WithParentObjectId
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
         .setDataSize(dataSize)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -698,6 +698,10 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       keyArgs.setOwnerName(args.getOwner());
     }
 
+    if (args.getGroup() != null) {
+      keyArgs.setGroupName(args.getGroup());
+    }
+
     if (args.getAcls() != null) {
       keyArgs.addAllAcls(args.getAcls().stream().distinct().map(a ->
           OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
@@ -1650,6 +1654,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setKeyName(omKeyArgs.getKeyName())
         .addAllMetadata(KeyValueUtil.toProtobuf(omKeyArgs.getMetadata()))
         .setOwnerName(omKeyArgs.getOwner())
+        .setGroupName(omKeyArgs.getGroup())
         .addAllTags(KeyValueUtil.toProtobuf(omKeyArgs.getTags()));
 
     if (omKeyArgs.getAcls() != null) {
@@ -1728,6 +1733,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(omKeyArgs.getBucketName())
         .setKeyName(omKeyArgs.getKeyName())
         .setOwnerName(omKeyArgs.getOwner())
+        .setGroupName(omKeyArgs.getGroup())
         .setMultipartUploadID(omKeyArgs.getMultipartUploadID());
     if (omKeyArgs.getAcls() != null) {
       keyArgs.addAllAcls(omKeyArgs.getAcls().stream().map(a ->
@@ -2142,7 +2148,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setVolumeName(args.getVolumeName())
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
-        .setOwnerName(args.getOwner());
+        .setOwnerName(args.getOwner())
+        .setGroupName(args.getGroup());
     if (args.getAcls() != null) {
       keyArgsBuilder.addAllAcls(args.getAcls().stream().map(a ->
           OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
@@ -2310,7 +2317,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setDataSize(args.getDataSize())
-        .setOwnerName(args.getOwner());
+        .setOwnerName(args.getOwner())
+        .setGroupName(args.getGroup());
     if (args.getAcls() != null) {
       keyArgsBuilder.addAllAcls(args.getAcls().stream().map(a ->
           OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-owner-s3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-owner-s3.robot
@@ -61,3 +61,5 @@ Verify Owner of Uploaded S3 Object By testuser
                     Execute and checkrc    aws s3api --endpoint-url ${ENDPOINT_URL} put-object --bucket bucket-test-owner1 --key mykey --body /tmp/testfile  0
     ${result} =     Execute    ozone sh key info /s3v/bucket-test-owner1/mykey | jq -r '.owner'
                     Should Be Equal    ${result}    testuser
+    ${result} =     Execute    ozone sh key info /s3v/bucket-test-owner1/mykey | jq -r '.group'
+                    Should Be Equal    ${result}    testuser

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -62,8 +62,10 @@ Create Bucket 1 Success via S3 API
     ${output} =         Execute          aws s3api --endpoint-url ${S3G_ENDPOINT_URL} list-buckets
                         Should contain   ${output}         bucket-test1
 
-Verify Bucket 1 Owner
+Verify Bucket 1 Owner and Group
     ${result} =         Execute          ozone sh bucket info /tenantone/bucket-test1 | jq -r '.owner'
+                        Should Be Equal  ${result}       testuser
+    ${result} =         Execute          ozone sh bucket info /tenantone/bucket-test1 | jq -r '.group'
                         Should Be Equal  ${result}       testuser
 
 Put a key in the tenant bucket

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -379,7 +379,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     store.deleteVolume(volumeName);
   }
 
-  @Test void testKeyOwner() throws IOException {
+  @Test void testKeyOwnerAndGroup() throws IOException {
     // Save the old user, and switch to the old user after test
     UserGroupInformation oldUser = UserGroupInformation.getCurrentUser();
     try {
@@ -418,8 +418,12 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       assertNotNull(bucket.getKey(key2));
       assertEquals(user1.getShortUserName(),
           bucket.getKey(key1).getOwner());
+      assertEquals(user1.getPrimaryGroupName(),
+          bucket.getKey(key1).getGroup());
       assertEquals(user2.getShortUserName(),
           bucket.getKey(key2).getOwner());
+      assertEquals(user2.getPrimaryGroupName(),
+          bucket.getKey(key2).getGroup());
     } finally {
       UserGroupInformation.setLoginUser(oldUser);
       setOzClient(OzoneClientFactory.getRpcClient(cluster.getConf()));
@@ -3239,7 +3243,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     // User without permission should fail to upload the object
     String userName = "test-user";
     UserGroupInformation remoteUser =
-        UserGroupInformation.createRemoteUser(userName);
+        UserGroupInformation.createUserForTesting(userName, new String[] {userName});
     try (OzoneClient client =
         remoteUser.doAs((PrivilegedExceptionAction<OzoneClient>)
             () -> OzoneClientFactory.getRpcClient(cluster.getConf()))) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -86,6 +86,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
         .setAcls(new ArrayList<>())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setOwnerName("user" + RandomStringUtils.randomNumeric(5))
+        .setGroupName("group" + RandomStringUtils.randomNumeric(5))
         .build();
 
     // 1st update, version 0

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -897,6 +897,7 @@ public class TestOmMetrics {
         .setAcls(Lists.emptyList())
         .setReplicationConfig(repConfig)
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+        .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
         .build();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -637,6 +637,7 @@ public abstract class TestOmSnapshotFileSystem {
         .setAcls(Collections.emptyList())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+        .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
         .setLocationInfoList(new ArrayList<>()).build();
 
     OpenKeySession session = writeClient.openKey(keyArgs);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1081,6 +1081,7 @@ message KeyArgs {
     // This allows a key to be created an committed atomically if the original has not
     // been modified.
     optional uint64 expectedDataGeneration = 23;
+    optional string groupName = 24;
 }
 
 message KeyLocation {
@@ -1172,6 +1173,7 @@ message KeyInfo {
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
     optional uint64 expectedDataGeneration = 22;
+    optional string groupName = 23;
 }
 
 message BasicKeyInfo {
@@ -1184,6 +1186,7 @@ message BasicKeyInfo {
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
     optional string eTag = 8;
     optional string ownerName = 9;
+    optional string groupName = 10;
 }
 
 message DirectoryInfo {
@@ -1196,6 +1199,7 @@ message DirectoryInfo {
     required uint64 updateID = 7;
     required uint64 parentID = 8;
     optional string ownerName = 9;
+    optional string groupName = 10;
 }
 
 message RepeatedKeyInfo {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1493,6 +1493,7 @@ public class KeyManagerImpl implements KeyManager {
         .setFileEncryptionInfo(encInfo)
         .setAcls(keyInfo.getAcls())
         .setOwnerName(keyInfo.getOwnerName())
+        .setGroupName(keyInfo.getGroupName())
         .build();
   }
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -750,6 +750,7 @@ public final class OMFileRequest {
         .setOmKeyLocationInfos(Collections.singletonList(
             new OmKeyLocationInfoGroup(0, new ArrayList<>())))
         .setOwnerName(dirInfo.getOwner())
+        .setGroupName(dirInfo.getGroup())
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1117,6 +1117,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
                     keyArgs.getTagsList()))
             .setUpdateID(transactionLogIndex)
             .setOwnerName(keyArgs.getOwnerName())
+            .setGroupName(keyArgs.getGroupName())
             .setFile(true);
     if (omPathInfo instanceof OMFileRequest.OMPathInfoWithFSO) {
       // FileTable metadata format

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -214,6 +214,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
               OMPBHelper.convert(keyArgs.getFileEncryptionInfo()) : null)
           .addAllMetadata(KeyValueUtil.getFromProtobuf(keyArgs.getMetadataList()))
           .setOwnerName(keyArgs.getOwnerName())
+          .setGroupName(keyArgs.getGroupName())
           .addAllTags(KeyValueUtil.getFromProtobuf(keyArgs.getTagsList()))
           .build();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -175,6 +175,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
           .setBucketName(bucketName)
           .setKeyName(keyArgs.getKeyName())
           .setOwnerName(keyArgs.getOwnerName())
+          .setGroupName(keyArgs.getGroupName())
           .setCreationTime(keyArgs.getModificationTime())
           .setModificationTime(keyArgs.getModificationTime())
           .setReplicationConfig(replicationConfig)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -490,6 +490,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           .addMetadata(OzoneConsts.ETAG,
               multipartUploadedKeyHash(partKeyInfoMap))
           .setOwnerName(keyArgs.getOwnerName())
+          .setGroupName(keyArgs.getGroupName())
           .addAllTags(dbOpenKeyInfo.getTags());
       // Check if db entry has ObjectID. This check is required because
       // it is possible that between multipart key uploads and complete,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1442,7 +1442,7 @@ public class SnapshotDiffManager implements AutoCloseable {
    */
   private boolean isKeyModified(OmKeyInfo fromKey, OmKeyInfo toKey) {
     return !fromKey.isKeyInfoSame(toKey,
-        false, false, false, false, true)
+        false, false, false, false, true, true)
         || !SnapshotDeletingService.isBlockLocationInfoSame(
         fromKey, toKey);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -338,6 +338,7 @@ class TestBucketManagerImpl extends OzoneTestBase {
             .setKeyName("key-one")
             .setOwnerName(
                 UserGroupInformation.getCurrentUser().getShortUserName())
+            .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
             .setAcls(Collections.emptyList())
             .setLocationInfoList(new ArrayList<>())
             .setReplicationConfig(
@@ -353,6 +354,7 @@ class TestBucketManagerImpl extends OzoneTestBase {
             .setKeyName("key-two")
             .setOwnerName(
                 UserGroupInformation.getCurrentUser().getShortUserName())
+            .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
             .setAcls(Collections.emptyList())
             .setLocationInfoList(new ArrayList<>())
             .setReplicationConfig(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -184,6 +184,7 @@ class TestKeyManagerUnit extends OzoneTestBase {
               .setReplicationConfig(
                   RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
               .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+              .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
               .build();
 
       OpenKeySession openKey = writeClient.openKey(partKeyArgs);
@@ -454,6 +455,7 @@ class TestKeyManagerUnit extends OzoneTestBase {
             RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setAcls(new ArrayList<>())
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+        .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
         .build();
     OmMultipartInfo omMultipartInfo = omtest.initiateMultipartUpload(key1);
     return omMultipartInfo;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -827,6 +827,7 @@ class TestKeyDeletingService extends OzoneTestBase {
             .setDataSize(1000L)
             .setLocationInfoList(new ArrayList<>())
             .setOwnerName("user" + RandomStringUtils.randomNumeric(5))
+            .setGroupName("group" + RandomStringUtils.randomNumeric(5))
             .build();
     //Open and Commit the Key in the Key Manager.
     OpenKeySession session = writeClient.openKey(keyArg);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestMultipartUploadCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestMultipartUploadCleanupService.java
@@ -211,6 +211,7 @@ class TestMultipartUploadCleanupService {
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setLocationInfoList(new ArrayList<>())
             .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+            .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
             .build();
 
     OmMultipartInfo omMultipartInfo = writeClient.
@@ -230,6 +231,7 @@ class TestMultipartUploadCleanupService {
               .setReplicationConfig(
                   StandaloneReplicationConfig.getInstance(ONE))
               .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+              .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
               .build();
 
       OpenKeySession openKey = writeClient.openKey(partKeyArgs);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -516,6 +516,7 @@ class TestOpenKeyCleanupService {
             .setLocationInfoList(new ArrayList<>())
             .setOwnerName(UserGroupInformation.getCurrentUser()
                 .getShortUserName())
+            .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
             .build();
 
     // Open and write the key without commit it.
@@ -573,6 +574,7 @@ class TestOpenKeyCleanupService {
                 HddsProtos.ReplicationFactor.ONE))
             .setLocationInfoList(new ArrayList<>())
             .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+            .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
             .build();
 
     OmMultipartInfo omMultipartInfo = writeClient.
@@ -592,6 +594,7 @@ class TestOpenKeyCleanupService {
               .setReplicationConfig(RatisReplicationConfig.getInstance(
                   HddsProtos.ReplicationFactor.ONE))
               .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+              .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
               .build();
 
       OpenKeySession openKey = writeClient.openKey(partKeyArgs);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -839,7 +839,7 @@ public class TestSnapshotDiffManager {
         when(keyInfo.getKeyName()).thenReturn(i.getArgument(0));
         when(keyInfo.isKeyInfoSame(any(OmKeyInfo.class),
             eq(false), eq(false),
-            eq(false), eq(false), eq(true)))
+            eq(false), eq(false), eq(true), eq(true)))
             .thenAnswer(k -> {
               int keyVal = Integer.parseInt(((String)i.getArgument(0))
                   .substring(3));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSstFilteringService.java
@@ -376,6 +376,7 @@ public class TestSstFilteringService {
             .setLocationInfoList(new ArrayList<>())
             .setOwnerName(
                 UserGroupInformation.getCurrentUser().getShortUserName())
+            .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
             .build();
     //Open and Commit the Key in the Key Manager.
     OpenKeySession session = managerProtocol.openKey(keyArg);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -171,6 +171,7 @@ public class TestOzoneNativeAuthorizer {
         .setDataSize(0)
         .setAcls(OzoneAclUtil.getAclList(testUgi, ALL, ALL))
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+        .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
         .build();
 
     if (keyName.split(OZONE_URI_DELIMITER).length > 1) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -339,6 +339,7 @@ public class TestParentAcl {
         // here we give test ugi full access
         .setAcls(OzoneAclUtil.getAclList(testUgi, ALL, ALL))
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
+        .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
         .build();
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -137,6 +137,7 @@ public class TestVolumeOwner {
                       HddsProtos.ReplicationFactor.ONE))
               .setOwnerName(
                   UserGroupInformation.getCurrentUser().getShortUserName())
+              .setGroupName(UserGroupInformation.getCurrentUser().getPrimaryGroupName())
               .setDataSize(0);
           if (k == 0) {
             keyArgsBuilder.setAcls(OzoneAclUtil.getAclList(testUgi, ALL, ALL));

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -549,7 +549,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         keyInfo.getModificationTime(),
         status.isDirectory() ? (short) 00777 : (short) 00666,
         StringUtils.defaultIfEmpty(keyInfo.getOwnerName(), owner),
-        owner,
+        StringUtils.defaultIfEmpty(keyInfo.getGroupName(), owner),
         null,
         getBlockLocations(status),
         OzoneClientUtils.isKeyEncrypted(keyInfo),

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1044,7 +1044,7 @@ public class BasicRootedOzoneClientAdapterImpl
         keyInfo.getModificationTime(),
         status.isDirectory() ? (short) 00777 : (short) 00666,
         StringUtils.defaultIfEmpty(keyInfo.getOwnerName(), owner),
-        owner,
+        StringUtils.defaultIfEmpty(keyInfo.getGroupName(), owner),
         null,
         getBlockLocations(status),
         OzoneClientUtils.isKeyEncrypted(keyInfo),

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -148,6 +148,7 @@ public final class OzoneBucketStub extends OzoneBucket {
                 new ArrayList<>(), finalReplicationCon, metadata, null,
                 () -> readKey(key), true,
                 UserGroupInformation.getCurrentUser().getShortUserName(),
+                UserGroupInformation.getCurrentUser().getPrimaryGroupName(),
                 tags
             ));
             super.close();
@@ -180,7 +181,7 @@ public final class OzoneBucketStub extends OzoneBucket {
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 new ArrayList<>(), finalReplicationCon, metadata, null,
-                () -> readKey(keyName), true, null, null
+                () -> readKey(keyName), true, null, null, null
             ));
             super.close();
           }
@@ -222,6 +223,7 @@ public final class OzoneBucketStub extends OzoneBucket {
                 new ArrayList<>(), rConfig, objectMetadata, null,
                 null, false,
                 UserGroupInformation.getCurrentUser().getShortUserName(),
+                UserGroupInformation.getCurrentUser().getPrimaryGroupName(),
                 tags
             ));
           }
@@ -316,6 +318,7 @@ public final class OzoneBucketStub extends OzoneBucket {
           ozoneKeyDetails.getMetadata(),
           ozoneKeyDetails.isFile(),
           ozoneKeyDetails.getOwner(),
+          ozoneKeyDetails.getGroup(),
           ozoneKeyDetails.getTags());
     } else {
       throw new OMException(ResultCodes.KEY_NOT_FOUND);
@@ -372,7 +375,8 @@ public final class OzoneBucketStub extends OzoneBucket {
               key.getDataSize(),
               key.getCreationTime().getEpochSecond() * 1000,
               key.getModificationTime().getEpochSecond() * 1000,
-              key.getReplicationConfig(), key.isFile(), key.getOwner());
+              key.getReplicationConfig(), key.isFile(), key.getOwner(),
+              key.getGroup());
         }).collect(Collectors.toList());
 
     if (prevKey != null) {
@@ -498,6 +502,7 @@ public final class OzoneBucketStub extends OzoneBucket {
           keyToMultipartUpload.get(key).getMetadata(), null,
           () -> readKey(key), true,
           UserGroupInformation.getCurrentUser().getShortUserName(),
+          UserGroupInformation.getCurrentUser().getPrimaryGroupName(),
           keyToMultipartUpload.get(key).getTags()
       ));
     }
@@ -679,6 +684,7 @@ public final class OzoneBucketStub extends OzoneBucket {
         new ArrayList<>(), replicationConfig, new HashMap<>(), null,
         () -> readKey(keyName), false,
         UserGroupInformation.getCurrentUser().getShortUserName(),
+        UserGroupInformation.getCurrentUser().getPrimaryGroupName(),
         Collections.emptyMap()));
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -104,6 +104,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
   private void createKey(long counter) throws Exception {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     String ownerName = ugi.getShortUserName();
+    String groupName = ugi.getPrimaryGroupName();
     OmKeyArgs keyArgs = new Builder()
         .setBucketName(bucketName)
         .setVolumeName(volumeName)
@@ -112,6 +113,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
         .setLocationInfoList(new ArrayList<>())
         .setAcls(OzoneAclUtil.getAclList(ugi, ALL, ALL))
         .setOwnerName(ownerName)
+        .setGroupName(groupName)
         .build();
 
     timer.time(() -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- This PR adds support to persist and retrieve group information from the DB, similar to how owner information is handled.
- The group will be set as the primary group of the user creating the object.
- For ozone fs and ozone sh key, it will use the logged-in user’s primary group information.
- For AWS S3, the group will be derived from the user mapped to the AWS Access Key ID.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11074

## How was this patch tested?

Added UTs and robot tests
