### PR TITLE
HDDS-12779. Parallelize table iteration across different ranges

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/BooleanCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/BooleanCodec.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Codec to serialize/deserialize {@link Boolean}.
@@ -27,6 +29,7 @@ public final class BooleanCodec implements Codec<Boolean> {
   private static final byte TRUE = 1;
   private static final byte FALSE = 0;
   private static final BooleanCodec INSTANCE = new BooleanCodec();
+  private static final Comparator<Boolean> COMPARATOR = (o1, o2) -> Objects.compare(o1, o2, Boolean::compare);
 
   public static BooleanCodec get() {
     return INSTANCE;
@@ -74,5 +77,10 @@ public final class BooleanCodec implements Codec<Boolean> {
   @Override
   public Boolean copyObject(Boolean object) {
     return object;
+  }
+
+  @Override
+  public Comparator<Boolean> comparator() {
+    return COMPARATOR;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Codec interface to serialize/deserialize objects to/from bytes.
@@ -29,6 +31,7 @@ import java.io.IOException;
  */
 public interface Codec<T> {
   byte[] EMPTY_BYTE_ARRAY = {};
+  ByteArrayComparator COMPARATOR = new ByteArrayComparator();
 
   /** @return the class of the {@link T}. */
   Class<T> getTypeClass();
@@ -112,4 +115,36 @@ public interface Codec<T> {
    *         the returned object can possibly be the same as the given object.
    */
   T copyObject(T object);
+
+  /**
+   * @return Comparator for the given type of object.
+   */
+  default Comparator<T> comparator() {
+    return (o1, o2) -> {
+      try {
+        byte[] a1 = o1 == null ? null : toPersistedFormat(o1);
+        byte[] a2 = o2 == null ? null : toPersistedFormat(o2);
+        return Objects.compare(a1, a2, COMPARATOR);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  /**
+   * Comparator to compare 2 byte arrays based on their relative lexicographical ordering.
+   */
+  class ByteArrayComparator implements Comparator<byte[]> {
+    @Override
+    public int compare(byte[] o1, byte[] o2) {
+      int len = Math.min(o1.length, o2.length);
+      for (int i = 0; i < len; i++) {
+        int cmp = Byte.toUnsignedInt(o1[i]) - Byte.toUnsignedInt(o2[i]);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+      return Integer.compare(o1.length, o2.length);
+    }
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -134,7 +135,7 @@ public interface Codec<T> {
   /**
    * Comparator to compare 2 byte arrays based on their relative lexicographical ordering.
    */
-  class ByteArrayComparator implements Comparator<byte[]> {
+  class ByteArrayComparator implements Comparator<byte[]>, Serializable {
     @Override
     public int compare(byte[] o1, byte[] o2) {
       int len = Math.min(o1.length, o2.length);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
@@ -19,6 +19,9 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Comparator;
+import java.util.Objects;
 import org.apache.ratis.util.function.CheckedFunction;
 
 /**
@@ -127,5 +130,19 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
     } catch (IOException e) {
       throw new IllegalStateException("Failed to copyObject", e);
     }
+  }
+
+  @Override
+  public Comparator<T> comparator() {
+    return (o1, o2) -> {
+      try {
+        DELEGATE d1 = o1 == null ? null : backward.apply(o1);
+        DELEGATE d2 = o2 == null ? null : backward.apply(o2);
+        return Objects.compare(d1, d2, delegate.comparator());
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+
+    };
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Codec to serialize/deserialize {@link Integer}.
@@ -26,6 +28,7 @@ import java.nio.ByteBuffer;
 public final class IntegerCodec implements Codec<Integer> {
 
   private static final IntegerCodec INSTANCE = new IntegerCodec();
+  private static final Comparator<Integer> COMPARATOR = (o1, o2) -> Objects.compare(o1, o2, Integer::compare);
 
   public static IntegerCodec get() {
     return INSTANCE;
@@ -69,5 +72,10 @@ public final class IntegerCodec implements Codec<Integer> {
   @Override
   public Integer copyObject(Integer object) {
     return object;
+  }
+
+  @Override
+  public Comparator<Integer> comparator() {
+    return COMPARATOR;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -19,12 +19,15 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Codec to serialize/deserialize {@link Long}.
  */
 public final class LongCodec implements Codec<Long> {
   private static final LongCodec CODEC = new LongCodec();
+  private static final Comparator<Long> COMPARATOR = (o1, o2) -> Objects.compare(o1, o2, Long::compare);
 
   public static LongCodec get() {
     return CODEC;
@@ -73,5 +76,10 @@ public final class LongCodec implements Codec<Long> {
   @Override
   public Long copyObject(Long object) {
     return object;
+  }
+
+  @Override
+  public Comparator<Long> comparator() {
+    return COMPARATOR;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Codec to serialize/deserialize {@link Short}.
@@ -26,6 +28,7 @@ import java.nio.ByteBuffer;
 public final class ShortCodec implements Codec<Short> {
 
   private static final ShortCodec INSTANCE = new ShortCodec();
+  private static final Comparator<Short> COMPARATOR = (o1, o2) -> Objects.compare(o1, o2, Short::compare);
 
   public static ShortCodec get() {
     return INSTANCE;
@@ -70,5 +73,10 @@ public final class ShortCodec implements Codec<Short> {
   @Override
   public Short copyObject(Short object) {
     return object;
+  }
+
+  @Override
+  public Comparator<Short> comparator() {
+    return COMPARATOR;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -26,6 +26,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.Function;
 import org.apache.hadoop.hdds.StringUtils;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 abstract class StringCodecBase implements Codec<String> {
   static final Logger LOG = LoggerFactory.getLogger(StringCodecBase.class);
+  private static final Comparator<String> COMPARATOR = (o1, o2) -> Objects.compare(o1, o2, String::compareTo);
 
   private final Charset charset;
   private final boolean fixedLength;
@@ -196,5 +198,10 @@ abstract class StringCodecBase implements Codec<String> {
   @Override
   public String copyObject(String object) {
     return object;
+  }
+
+  @Override
+  public Comparator<String> comparator() {
+    return COMPARATOR;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -197,6 +197,10 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_EC_GRPC_WRITE_TIMEOUT =
       "ozone.client.ec.grpc.write.timeout";
   public static final String OZONE_CLIENT_EC_GRPC_WRITE_TIMEOUT_DEFAULT = "30s";
+  public static final String OZONE_PARALLEL_DB_ITERATORS_CORE_POOL_SIZE = "ozone.db.parallel.iterators.core.pool.size";
+  public static final int OZONE_PARALLEL_DB_ITERATORS_CORE_POOL_SIZE_DEFAULT = 0;
+  public static final String OZONE_PARALLEL_DB_ITERATORS_MAX_POOL_SIZE = "ozone.db.parallel.iterators.max.pool.size";
+  public static final int OZONE_PARALLEL_DB_ITERATORS_MAX_POOL_SIZE_DEFAULT = 10;
 
 
   /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3963,6 +3963,14 @@
       OM grpc server netty boss event group size.
     </description>
   </property>
+  <property>
+    <name>ozone.om.snapshot.db.parallel.iterator.pool.size</name>
+    <value>1</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Max iterator pool size for parallely iterating through DB.
+    </description>
+  </property>
 
   <property>
     <name>ozone.om.grpc.workergroup.size</name>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.ozone.container.metadata;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.ratis.util.function.CheckedFunction;
+import org.slf4j.Logger;
 
 /**
  * Wrapper class to represent a table in a datanode RocksDB instance.
@@ -87,6 +90,14 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
     throw new UnsupportedOperationException("Iterating tables directly is not" +
         " supported for datanode containers due to differing schema " +
         "version.");
+  }
+
+  @Override
+  public void parallelTableOperation(
+      KEY startKey, KEY endKey, CheckedFunction<KeyValue<KEY, VALUE>, Void, IOException> operation,
+      Logger logger, int logPercentageThreshold)
+      throws IOException, ExecutionException, InterruptedException {
+    table.parallelTableOperation(startKey, endKey, operation, logger, logPercentageThreshold);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/BaseRDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/BaseRDBTable.java
@@ -15,29 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.container.common.impl;
+package org.apache.hadoop.hdds.utils.db;
 
-import java.time.Clock;
-import org.apache.hadoop.hdds.utils.db.InMemoryTestTable;
-import org.apache.hadoop.hdds.utils.db.LongCodec;
+import java.io.IOException;
+import java.util.List;
+import org.rocksdb.LiveFileMetaData;
 
 /**
- * Helper utility to test container impl.
+ * Base table interface for Rocksdb.
  */
-public final class ContainerImplTestUtils {
-
-  private ContainerImplTestUtils() {
-  }
-
-  public static ContainerSet newContainerSet() {
-    return newContainerSet(1000);
-  }
-
-  public static ContainerSet newContainerSet(long recoveringTimeout) {
-    return ContainerSet.newRwContainerSet(new InMemoryTestTable<>(LongCodec.get()), recoveringTimeout);
-  }
-
-  public static ContainerSet newContainerSet(long recoveringTimeout, Clock clock) {
-    return new ContainerSet(new InMemoryTestTable<>(LongCodec.get()), recoveringTimeout, clock);
-  }
+public interface BaseRDBTable<KEY, VALUE> extends Table<KEY, VALUE> {
+  List<LiveFileMetaData> getTableSstFiles() throws IOException;
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -211,6 +211,11 @@ public interface DBStore extends Closeable, BatchOperationHandler {
       throws IOException;
 
   /**
+   * Gets the executor pool parallel table iterator.
+   */
+  ThrottledThreadpoolExecutor getParallelTableIteratorPool();
+
+  /**
    * Return if the underlying DB is closed. This call is thread safe.
    * @return true if the DB is closed.
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ParallelTableOperator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ParallelTableOperator.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.ratis.util.function.CheckedFunction;
+import org.slf4j.Logger;
+
+/**
+ * Class to iterate through a table in parallel by breaking table into multiple iterators for RDB store.
+ */
+public abstract class ParallelTableOperator<TABLE extends Table<K, V>, K, V> {
+  private final TABLE table;
+  private final Codec<K> keyCodec;
+  private final Comparator<K> comparator;
+  private final ThrottledThreadpoolExecutor executor;
+
+  public ParallelTableOperator(ThrottledThreadpoolExecutor throttledThreadpoolExecutor,
+                               TABLE table, Codec<K> keyCodec) {
+    this.executor = throttledThreadpoolExecutor;
+    this.table = table;
+    this.keyCodec = keyCodec;
+    this.comparator = keyCodec.comparator();
+  }
+
+  /**
+   * Provide all the bounds that fall in range [startKey, endKey] in a sorted list to facilitate efficiently
+   * splitting table iteration of keys into multiple parallel iterators of the table.
+   */
+  protected abstract List<K> getBounds(K startKey, K endKey) throws IOException;
+
+  @SuppressWarnings("parameternumber")
+  private <THROWABLE extends Throwable> CompletableFuture<Void> submit(
+      CheckedFunction<Table.KeyValue<K, V>, Void, THROWABLE> keyOperation, K beg, K end,
+      AtomicLong keyCounter, AtomicLong prevLogCounter, long logCountThreshold, Logger log,
+      AtomicBoolean cancelled) throws InterruptedException {
+    return executor.submit(() -> {
+      try (TableIterator<K, ? extends Table.KeyValue<K, V>> iter  = table.iterator()) {
+        if (beg != null) {
+          iter.seek(beg);
+        } else {
+          iter.seekToFirst();
+        }
+        while (iter.hasNext() && !cancelled.get()) {
+          Table.KeyValue<K, V> kv = iter.next();
+          if (end == null || Objects.compare(kv.getKey(), end, comparator) < 0) {
+            keyOperation.apply(kv);
+            keyCounter.incrementAndGet();
+            if (keyCounter.get() - prevLogCounter.get() > logCountThreshold) {
+              log.info("Iterated through table : {} {} keys while performing task.", table.getName(),
+                  keyCounter.get());
+              prevLogCounter.set(keyCounter.get());
+            }
+          } else {
+            break;
+          }
+        }
+      }
+    });
+  }
+
+  public <THROWABLE extends Throwable> void performTaskOnTableVals(K startKey, K endKey,
+                                     CheckedFunction<Table.KeyValue<K, V>, Void, THROWABLE> keyOperation,
+                                     Logger log, int logPercentageThreshold)
+      throws ExecutionException, InterruptedException, IOException, THROWABLE {
+    List<K> bounds;
+    long logCountThreshold = Math.max((table.getEstimatedKeyCount() * logPercentageThreshold) / 100, 1L);
+    try {
+      bounds = getBounds(startKey, endKey);
+    } catch (IOException e) {
+      log.warn("Error while getting bounds Table: {} startKey: {}, endKey: {}", table.getName(), startKey, endKey, e);
+      bounds = Arrays.asList(startKey, endKey);
+    }
+    AtomicLong keyCounter = new AtomicLong();
+    AtomicLong prevLogCounter = new AtomicLong();
+    CompletableFuture<Void> iterFutures = CompletableFuture.completedFuture(null);
+    AtomicBoolean cancelled = new AtomicBoolean(false);
+    for (int idx = 1; idx < bounds.size(); idx++) {
+      K beg = bounds.get(idx - 1);
+      K end = bounds.get(idx);
+      if (cancelled.get()) {
+        break;
+      }
+      CompletableFuture<Void> future = submit(keyOperation, beg, end, keyCounter, prevLogCounter,
+          logCountThreshold, log, cancelled);
+      future.exceptionally((e -> {
+        cancelled.set(true);
+        return null;
+      }));
+      iterFutures = iterFutures.thenCombine(future, (v1, v2) -> null);
+    }
+    iterFutures.get();
+  }
+
+  protected TABLE getTable() {
+    return table;
+  }
+
+  public Codec<K> getKeyCodec() {
+    return keyCodec;
+  }
+
+  public Comparator<K> getComparator() {
+    return comparator;
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBParallelTableOperator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBParallelTableOperator.java
@@ -36,6 +36,7 @@ public class RDBParallelTableOperator<K, V> extends ParallelTableOperator<BaseRD
     super(throttledThreadpoolExecutor, table, keyCodec);
   }
 
+  @Override
   protected List<K> getBounds(K startKey, K endKey) throws IOException {
     Set<K> keys = new HashSet<>();
     for (LiveFileMetaData sstFile : this.getTable().getTableSstFiles()) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBParallelTableOperator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBParallelTableOperator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.rocksdb.LiveFileMetaData;
+
+/**
+ * Class to iterate through a table in parallel by breaking table into multiple iterators for RDB store.
+ */
+public class RDBParallelTableOperator<K, V> extends ParallelTableOperator<BaseRDBTable<K, V>, K, V> {
+
+  public RDBParallelTableOperator(ThrottledThreadpoolExecutor throttledThreadpoolExecutor,
+                                  BaseRDBTable<K, V> table, Codec<K> keyCodec) {
+    super(throttledThreadpoolExecutor, table, keyCodec);
+  }
+
+  protected List<K> getBounds(K startKey, K endKey) throws IOException {
+    Set<K> keys = new HashSet<>();
+    for (LiveFileMetaData sstFile : this.getTable().getTableSstFiles()) {
+      keys.add(this.getKeyCodec().fromPersistedFormat(sstFile.smallestKey()));
+      keys.add(this.getKeyCodec().fromPersistedFormat(sstFile.largestKey()));
+    }
+    List<K> boundKeys = new ArrayList<>();
+    boundKeys.add(startKey);
+    boundKeys.addAll(keys.stream().sorted().filter(Objects::nonNull)
+            .filter(key -> startKey == null || getComparator().compare(key, startKey) > 0)
+            .filter(key -> endKey == null || getComparator().compare(endKey, key) > 0)
+            .collect(Collectors.toList()));
+    boundKeys.add(endKey);
+    return boundKeys;
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OM;
+import static org.apache.hadoop.hdds.conf.ConfigTag.RECON;
 import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
 
 import org.apache.hadoop.hdds.conf.Config;
@@ -84,6 +85,13 @@ public class RocksDBConfiguration {
           + "Default 0 means no limit.")
   private long walSizeLimit = 0;
 
+  @Config(key = "rocksdb.parallel.iterator.max.pool.size",
+      type = ConfigType.INT,
+      defaultValue = "10",
+      tags = {OM, SCM, DATANODE, RECON},
+      description = "Max pool size for parallely iterating a rocksdb table in ozone")
+  private int parallelIteratorMaxPoolSize = 10;
+
   public void setRocksdbLoggingEnabled(boolean enabled) {
     this.rocksdbLogEnabled = enabled;
   }
@@ -138,5 +146,9 @@ public class RocksDBConfiguration {
 
   public int getKeepLogFileNum() {
     return rocksdbKeepLogFileNum;
+  }
+
+  public int getParallelIteratorMaxPoolSize() {
+    return parallelIteratorMaxPoolSize;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ThrottledThreadpoolExecutor.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ThrottledThreadpoolExecutor.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.ratis.util.function.CheckedRunnable;
+
+/**
+ * ThreadPoolExecutor which throttles on the request before submitting a runnable to a ThreadPoolExecutor.
+ */
+public class ThrottledThreadpoolExecutor implements Closeable {
+  private final ThreadPoolExecutor pool;
+  private final AtomicInteger availableTaskSlots;
+  private final Object lock;
+
+  public ThrottledThreadpoolExecutor(int maxNumberOfThreads) {
+    pool = new ThreadPoolExecutor(maxNumberOfThreads, maxNumberOfThreads, 5, TimeUnit.MINUTES,
+        new LinkedBlockingQueue<>());
+    pool.allowCoreThreadTimeOut(true);
+    int maxNumberOfTasks = 2 * maxNumberOfThreads;
+    availableTaskSlots = new AtomicInteger(maxNumberOfTasks);
+    lock = new Object();
+  }
+
+  public CompletableFuture<Void> submit(CheckedRunnable<?> task) throws InterruptedException {
+    waitForQueue();
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    pool.submit(() -> {
+      try {
+        task.run();
+        future.complete(null);
+      } catch (Throwable e) {
+        future.completeExceptionally(e);
+      } finally {
+        availableTaskSlots.incrementAndGet();
+        synchronized (lock) {
+          lock.notify();
+        }
+      }
+    });
+    return future;
+  }
+
+  public void waitForQueue() throws InterruptedException {
+    synchronized (lock) {
+      while (availableTaskSlots.get() <= 0) {
+        lock.wait(10000);
+      }
+      availableTaskSlots.decrementAndGet();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.pool.shutdown();
+  }
+
+  public long getTaskCount() {
+    return pool.getTaskCount();
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
@@ -23,12 +23,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.ratis.util.function.CheckedFunction;
+import org.slf4j.Logger;
 
 /**
  * InMemory Table implementation for tests.
  */
 public final class InMemoryTestTable<KEY, VALUE> implements Table<KEY, VALUE> {
-  private final Map<KEY, VALUE> map = new ConcurrentHashMap<>();
+  private final Map<KEY, VALUE> map;
+  private final Codec<KEY> keyCodec;
+
+  public InMemoryTestTable(Codec<KEY> keyCodec) {
+    this.keyCodec = keyCodec;
+    this.map = new ConcurrentHashMap<>();
+  }
 
   @Override
   public void close() {
@@ -80,12 +88,19 @@ public final class InMemoryTestTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator() {
-    throw new UnsupportedOperationException();
+  public TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator() throws IOException {
+    return new InMemoryTestTableIterator<>(this.map, null, this.keyCodec);
   }
 
   @Override
-  public TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator(KEY prefix) {
+  public TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator(KEY prefix) throws IOException {
+    return new InMemoryTestTableIterator<>(this.map, prefix, this.keyCodec);
+  }
+
+  @Override
+  public void parallelTableOperation(
+      KEY startKey, KEY endKey, CheckedFunction<KeyValue<KEY, VALUE>, Void, IOException> operation,
+      Logger logger, int logPercentageThreshold) {
     throw new UnsupportedOperationException();
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTableIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTableIterator.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Generic Table Iterator implementation that can be used for unit tests to reduce redundant mocking in tests.
+ */
+public class InMemoryTestTableIterator<K, V> implements Table.KeyValueIterator<K, V> {
+
+  private Iterator<Table.KeyValue<K, V>> itr;
+  private final Comparator<byte[]> comparator;
+  private final Comparator<K> keyComparator;
+  private final Codec<K> keyCodec;
+  private final NavigableMap<K, V> values;
+
+  public InMemoryTestTableIterator(Map<K, V> values, K prefix, Codec<K> keyCodec) throws IOException {
+    byte[] startKey = prefix == null ? null : keyCodec.toPersistedFormat(prefix);
+    byte[] endKey = prefix == null ? null : keyCodec.toPersistedFormat(prefix);
+    if (endKey != null) {
+      endKey[endKey.length - 1] += 1;
+    }
+    comparator = new Codec.ByteArrayComparator();
+    this.keyComparator = keyCodec.comparator();
+    this.keyCodec = keyCodec;
+    this.values = values.entrySet().stream()
+        .filter(e -> startKey == null || compare(startKey, e.getKey()) >= 0)
+        .filter(e -> endKey == null || compare(endKey, e.getKey()) < 0)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v2, TreeMap::new));
+    this.seekToFirst();
+  }
+
+  private int compare(byte[] b1, K key) {
+    try {
+      return this.comparator.compare(b1, keyCodec.toPersistedFormat(key));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void seekToFirst() {
+    this.itr = this.values.entrySet().stream()
+        .map(e -> Table.newKeyValue(e.getKey(), e.getValue())).iterator();
+  }
+
+  @Override
+  public void seekToLast() {
+    try {
+      this.seek(this.values.lastKey());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Table.KeyValue<K, V> seek(K s) throws IOException {
+    this.itr = this.values.entrySet().stream()
+        .filter(e -> keyComparator.compare(e.getKey(), s) >= 0)
+        .map(e -> Table.newKeyValue(e.getKey(), e.getValue())).iterator();
+    Map.Entry<K, V> firstEntry = values.ceilingEntry(s);
+    return firstEntry == null ? null : Table.newKeyValue(firstEntry.getKey(), firstEntry.getValue());
+  }
+
+  @Override
+  public void removeFromDB() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  @Override
+  public boolean hasNext() {
+    return this.itr.hasNext();
+  }
+
+  @Override
+  public Table.KeyValue<K, V> next() {
+    return itr.next();
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestParallelTableOperator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestParallelTableOperator.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -55,7 +54,7 @@ public class TestParallelTableOperator {
 
   private static ThrottledThreadpoolExecutor executor;
   private static final Logger LOG = LoggerFactory.getLogger(TestParallelTableOperator.class);
-  Map<Integer, Integer> visited;
+  private Map<Integer, Integer> visited;
 
   @BeforeAll
   public static void init() {
@@ -94,7 +93,7 @@ public class TestParallelTableOperator {
     );
   }
 
-
+  @SuppressWarnings("checkstyle:ParameterNumber")
   private void testParallelTableOperator(Table<Integer, Integer> intTable,
       ParallelTableOperator<Table<Integer, Integer>, Integer, Integer> parallelTableOperator,
       int maxKeyIdx, int keyJumps, Integer start, Integer end, List<Integer> bounds,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestParallelTableOperator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestParallelTableOperator.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.ratis.util.function.CheckedFunction;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test class for ParallelTableOperator.
+ */
+public class TestParallelTableOperator {
+
+  private static ThrottledThreadpoolExecutor executor;
+  private static final Logger LOG = LoggerFactory.getLogger(TestParallelTableOperator.class);
+  Map<Integer, Integer> visited;
+
+  @BeforeAll
+  public static void init() {
+    executor = new ThrottledThreadpoolExecutor(10);
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    IOUtils.closeQuietly(executor);
+  }
+
+  @BeforeEach
+  public void setup() {
+    visited = new ConcurrentHashMap<>();
+  }
+
+  private static Stream<Arguments> getParallelTableOperatorArguments() {
+    return Stream.of(
+        Arguments.of(1, null, null, 1),
+        Arguments.of(1, 100, 200, 1),
+        Arguments.of(5, null, null, 8),
+        Arguments.of(5, 100, 200, 8),
+        Arguments.of(8, null, null, 5),
+        Arguments.of(8, 100, 200, 5)
+    );
+  }
+
+  private static Stream<Arguments> getParallelTableOperatorArgumentsBoundsException() {
+    return Stream.of(
+        Arguments.of(1, null, null),
+        Arguments.of(1, 100, 200),
+        Arguments.of(5, null, null),
+        Arguments.of(5, 100, 200),
+        Arguments.of(8, null, null),
+        Arguments.of(8, 100, 200)
+    );
+  }
+
+
+  private void testParallelTableOperator(Table<Integer, Integer> intTable,
+      ParallelTableOperator<Table<Integer, Integer>, Integer, Integer> parallelTableOperator,
+      int maxKeyIdx, int keyJumps, Integer start, Integer end, List<Integer> bounds,
+      CheckedFunction<Table.KeyValue<Integer, Integer>, Void, IOException> opr, Supplier<Exception> expectedException)
+      throws IOException, ExecutionException, InterruptedException {
+    List<Integer> seekedKeys = Collections.synchronizedList(new ArrayList<>());
+    when(intTable.iterator()).thenAnswer(i -> {
+      Table.KeyValueIterator<Integer, Integer> itr = (Table.KeyValueIterator<Integer, Integer>) spy(i.callRealMethod());
+      doAnswer(j -> {
+        seekedKeys.add(null);
+        return j.callRealMethod();
+      }).when(itr).seekToFirst();
+      doAnswer(j -> {
+        seekedKeys.add(j.getArgument(0));
+        return j.callRealMethod();
+      }).when(itr).seek(any(Integer.class));
+      return itr;
+    });
+    Map<Integer, Integer> expectedKeys = new HashMap<>();
+    for (int i = 0; i < maxKeyIdx; i += keyJumps) {
+      intTable.put(i, i);
+      if ((start == null || start <= i) && (end == null || end > i)) {
+        expectedKeys.put(i, 1);
+      }
+    }
+
+    List<Integer> expectedSeekedKeys = bounds.subList(0, bounds.size() - 1);
+    if (expectedException != null) {
+      Exception e = assertThrows(ExecutionException.class,
+          () -> parallelTableOperator.performTaskOnTableVals(start, end, opr, LOG, 1));
+      Exception expectedEx = expectedException.get();
+      assertEquals(expectedEx.getClass(), e.getCause().getClass());
+      assertEquals(expectedEx.getMessage(), e.getCause().getMessage());
+    } else {
+      parallelTableOperator.performTaskOnTableVals(start, end, opr, LOG, 1);
+      assertEquals(expectedKeys, visited);
+      seekedKeys.sort((a, b) -> {
+        if (Objects.equals(a, b)) {
+          return 0;
+        }
+        if (a == null) {
+          return -1;
+        }
+        if (b == null) {
+          return 1;
+        }
+        return Integer.compare(a, b);
+      });
+      assertEquals(expectedSeekedKeys, seekedKeys);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("getParallelTableOperatorArguments")
+  public void testParallelTableOperator(int keyJumps, Integer start, Integer end, int boundJumps)
+      throws IOException, ExecutionException, InterruptedException {
+    int maxKeyIdx = 1001;
+    List<Integer> bounds = new ArrayList<>();
+    bounds.add(start);
+    for (int i = (start == null ? 0 : start) + boundJumps;
+         i < (end == null ? (maxKeyIdx - 1) : end); i += boundJumps) {
+      bounds.add(i);
+    }
+    bounds.add(end);
+    Table<Integer, Integer> intTable = spy(new InMemoryTestTable<>(IntegerCodec.get()));
+    CheckedFunction<Table.KeyValue<Integer, Integer>, Void, IOException> opr = kv -> {
+      visited.compute(kv.getKey(), (k, v) -> v == null ? 1 : v + 1);
+      return null;
+    };
+
+    ParallelTableOperator<Table<Integer, Integer>, Integer, Integer> parallelTableOperator =
+        new ParallelTableOperator<Table<Integer, Integer>, Integer, Integer>(executor, intTable, IntegerCodec.get()) {
+          @Override
+          protected List<Integer> getBounds(Integer startKey, Integer endKey) {
+            return bounds;
+          }
+        };
+    testParallelTableOperator(intTable, parallelTableOperator, maxKeyIdx, keyJumps, start, end, bounds, opr, null);
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("getParallelTableOperatorArgumentsBoundsException")
+  public void testParallelTableOperatorWithBoundsException(int keyJumps, Integer start, Integer end)
+      throws IOException, ExecutionException, InterruptedException {
+    int maxKeyIdx = 1001;
+    List<Integer> bounds = new ArrayList<>();
+    bounds.add(start);
+    bounds.add(end);
+    Table<Integer, Integer> intTable = spy(new InMemoryTestTable<>(IntegerCodec.get()));
+
+    CheckedFunction<Table.KeyValue<Integer, Integer>, Void, IOException> opr = kv -> {
+      visited.compute(kv.getKey(), (k, v) -> v == null ? 1 : v + 1);
+      return null;
+    };
+
+    ParallelTableOperator<Table<Integer, Integer>, Integer, Integer> parallelTableOperator =
+        new ParallelTableOperator<Table<Integer, Integer>, Integer, Integer>(executor, intTable, IntegerCodec.get()) {
+          @Override
+          protected List<Integer> getBounds(Integer startKey, Integer endKey) throws IOException {
+            throw new IOException("Exception while getting bounds");
+          }
+        };
+    testParallelTableOperator(intTable, parallelTableOperator, maxKeyIdx, keyJumps, start, end, bounds, opr, null);
+  }
+
+  @ParameterizedTest
+  @MethodSource("getParallelTableOperatorArguments")
+  public void testParallelTableOperatorWithException(int keyJumps, Integer start, Integer end, int boundJumps)
+      throws IOException, ExecutionException, InterruptedException {
+    int maxKeyIdx = 1001;
+    List<Integer> bounds = new ArrayList<>();
+    bounds.add(start);
+    for (int i = (start == null ? 0 : start) + boundJumps;
+         i < (end == null ? (maxKeyIdx - 1) : end); i += boundJumps) {
+      bounds.add(i);
+    }
+    bounds.add(end);
+    AtomicInteger minException = new AtomicInteger(Integer.MAX_VALUE);
+    Table<Integer, Integer> intTable = spy(new InMemoryTestTable<>(IntegerCodec.get()));
+    CheckedFunction<Table.KeyValue<Integer, Integer>, Void, IOException> opr = kv -> {
+      Integer key = kv.getKey();
+      visited.compute(kv.getKey(), (k, v) -> v == null ? 1 : v + 1);
+      if (key != 0 && key % (3 * keyJumps) == 0) {
+        minException.updateAndGet((prev) -> Math.min(prev, key));
+        throw new IOException("Exception while getting bounds for key " + key);
+      }
+      return null;
+    };
+
+    ParallelTableOperator<Table<Integer, Integer>, Integer, Integer> parallelTableOperator =
+        new ParallelTableOperator<Table<Integer, Integer>, Integer, Integer>(executor, intTable, IntegerCodec.get()) {
+          @Override
+          protected List<Integer> getBounds(Integer startKey, Integer endKey) {
+            return bounds;
+          }
+        };
+    testParallelTableOperator(intTable, parallelTableOperator, maxKeyIdx, keyJumps, start, end, bounds, opr,
+        () -> new IOException("Exception while getting bounds for key " + minException.get()));
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -62,7 +62,7 @@ public class TestRDBStore {
       throws IOException {
     return new RDBStore(dbFile, options, null, new ManagedWriteOptions(), families,
         CodecRegistry.newBuilder().build(), false, null, false,
-        maxDbUpdatesSizeThreshold, true, null, true);
+        maxDbUpdatesSizeThreshold, true, null, true, 5);
   }
 
   public static final int MAX_DB_UPDATES_SIZE_THRESHOLD = 80;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -406,9 +406,8 @@ public class TestRDBTableStore {
     final StringCodec codec = StringCodec.get();
     final String tableName = families.get(0);
     try (RDBTable testTable = rdbStore.getTable(tableName)) {
-      final TypedTable<String, String> typedTable = new TypedTable<>(
-          testTable, CodecRegistry.newBuilder().build(),
-          String.class, String.class);
+      final TypedTable<String, String> typedTable = new TypedTable<>(testTable, CodecRegistry.newBuilder().build(),
+          String.class, String.class, null);
 
       for (int i = 0; i < 20; i++) {
         final int valueSize = TypedTable.BUFFER_SIZE_DEFAULT * i / 4;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -123,10 +123,8 @@ public class TestTypedRDBTableStore {
 
   private Table<String, String> createTypedTable(String name)
       throws IOException {
-    return new TypedTable<String, String>(
-        rdbStore.getTable(name),
-        codecRegistry,
-        String.class, String.class);
+    return new TypedTable<String, String>(rdbStore.getTable(name),
+        codecRegistry, String.class, String.class, rdbStore.getParallelTableIteratorPool());
   }
 
   @Test
@@ -253,7 +251,7 @@ public class TestTypedRDBTableStore {
     when(rdbTable.iterator((CodecBuffer) null))
         .thenThrow(new IOException());
     try (Table<String, String> testTable = new TypedTable<>(rdbTable,
-        codecRegistry, String.class, String.class)) {
+        codecRegistry, String.class, String.class, rdbStore.getParallelTableIteratorPool())) {
       assertThrows(IOException.class, testTable::iterator);
     }
   }
@@ -412,7 +410,7 @@ public class TestTypedRDBTableStore {
     try (Table<byte[], byte[]> testTable = new TypedTable<>(
             rdbStore.getTable("Ten"),
             codecRegistry,
-            byte[].class, byte[].class)) {
+            byte[].class, byte[].class, null)) {
       byte[] key = new byte[] {1, 2, 3};
       byte[] value = new byte[] {4, 5, 6};
       testTable.put(key, value);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/ThrottledThreadpoolExecutorTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/ThrottledThreadpoolExecutorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for ThrottledThreadpoolExecutor.
+ */
+public class ThrottledThreadpoolExecutorTest {
+
+  private ThrottledThreadpoolExecutor executor;
+
+  @BeforeEach
+  public void setup() {
+    // coreThreads = 2, maxThreads = 4 => maxTasks = 8
+    executor = new ThrottledThreadpoolExecutor(4);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    executor.close();
+  }
+
+  @Test
+  public void testThrottlingDoesNotExceedMaxTasks() throws Exception {
+    int maxThreads = 4;
+    int maxTasks = 2 * maxThreads; // 8
+    AtomicInteger concurrentTasks = new AtomicInteger(0);
+    AtomicInteger maxObservedConcurrentTasks = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(maxThreads);
+    CountDownLatch releaseLatch = new CountDownLatch(1); // To block all tasks
+
+    for (int i = 0; i < maxTasks; i++) {
+      executor.submit(() -> {
+        int current = concurrentTasks.incrementAndGet();
+        System.out.println(current);
+        maxObservedConcurrentTasks.updateAndGet(prev -> Math.max(prev, current));
+        latch.countDown();
+        releaseLatch.await(); // block the task
+        concurrentTasks.decrementAndGet();
+      });
+    }
+
+    // Wait for all tasks to start (meaning all 8 task slots used)
+    assertTrue(latch.await(10, TimeUnit.SECONDS), "Tasks did not start in time");
+    assertEquals(maxTasks, executor.getTaskCount());
+
+    // Now try to submit one more task — it should block until a slot frees up
+    CompletableFuture<Void> extraTask = CompletableFuture.runAsync(() -> {
+      try {
+        executor.submit(() -> {
+        });
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    // Wait for 1 second and ensure extraTask hasn't completed yet
+    Thread.sleep(1000);
+    assertFalse(extraTask.isDone(), "Extra task should be throttled and blocked");
+    assertEquals(maxTasks, executor.getTaskCount());
+
+    // Finish all initially submitted threads.
+    releaseLatch.countDown();
+
+    // Now the extra task should complete within a few seconds
+    assertDoesNotThrow(() -> extraTask.get(5, TimeUnit.SECONDS));
+
+    // Make sure we never had more than maxTasks in flight
+    assertEquals(4, maxObservedConcurrentTasks.get(), "Throttling failed");
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.scm.metadata;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Comparator;
+import java.util.Objects;
 import org.apache.hadoop.hdds.utils.db.Codec;
 
 /**
@@ -27,6 +29,7 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 public final class BigIntegerCodec implements Codec<BigInteger> {
 
   private static final Codec<BigInteger> INSTANCE = new BigIntegerCodec();
+  private static final Comparator<BigInteger> COMPARATOR = (o1, o2) -> Objects.compare(o1, o2, BigInteger::compareTo);
 
   public static Codec<BigInteger> get() {
     return INSTANCE;
@@ -54,5 +57,10 @@ public final class BigIntegerCodec implements Codec<BigInteger> {
   @Override
   public BigInteger copyObject(BigInteger object) {
     return object;
+  }
+
+  @Override
+  public Comparator<BigInteger> comparator() {
+    return COMPARATOR;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -171,6 +171,9 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT = "5m";
   public static final String OZONE_OM_SNAPSHOT_ROCKSDB_METRICS_ENABLED =
       "ozone.om.snapshot.rocksdb.metrics.enabled";
+  public static final String OZONE_OM_SNAPSHOT_DB_PARALLEL_ITERATOR_MAX_POOL_SIZE =
+      "ozone.om.snapshot.db.parallel.iterator.pool.size";
+  public static final int OZONE_OM_SNAPSHOT_DB_PARALLEL_ITERATOR_MAX_POOL_SIZE_DEFAULT = 1;
   public static final boolean
       OZONE_OM_SNAPSHOT_ROCKSDB_METRICS_ENABLED_DEFAULT = false;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently most of the operations performed on the tables are agnostic to order of iteration of keys and can be executed in parallel to speed up most of such operations. The proposal here is to introduce a central functionaliy to achieve this.

The whole idea for parallelizing in this approach is to peek into the sst files metadata of rocksdb to get the keyRanges(smallestKey and largestKey) from LiveFileMetadata corresponding to the rocksdb column family and get an approximate set of range of keys in the table. Thus indirectly the table would be iterated based on the number of sst files as there are on the DB.
For instance consider the case:
1.sst has key range [k1 - k10]
2.sst has key range [k5 - k15]
3.sst has key range [k15 - k30].
Thus with the approach we would be splitting the table into 4 iterators iterating the key range:
[k1 - k5), [k5, k10), [k10, k15), [k15, k30] 
Each of these iterators can be split into multiple threads and can be iterated within a threadpool task.
Similar to a pub-sub model an operation can be performed on the key which would be defined by the caller of this function.
The only con I see with this approach is that since all of these table iterators have been initialized independently then consistency would be an issue. E.g. If we are iterating through the file table where a key has been renamed from k to k' while we are iterating through the db. Depending on the iterator initialization order we could either see both k and k' while iterating or see none or see one. From what I understand we might not have use cases where we would be iterating through table ranges where there would be active mutation happening in the ranges(OM background Garbage collection, Recon bootstrap, SCM initialization etc.). Since I only see use cases where consistency is not really a key from my understanding we can live with this.

The patch also includes to have a centralized threadpool which would be responsible for throttling the number of rocksdb table iterators initialized governed by the configuration "hadoop.hdds.db.rocksdb.parallel.iterator.max.pool.size". This has been put in place as a guardrail so that this iteration doesn't impact main system performance while such background iterations are running.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12779

## How was this patch tested?
Adding unit tests.