### PR TITLE
HDDS-12770. Use ContainerID instead of Long in CONTAINER_IDS_TABLE.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -178,8 +178,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   @Override
   public void buildMissingContainerSetAndValidate(
       Map<Long, Long> container2BCSIDMap) {
-    containerSet
-        .buildMissingContainerSetAndValidate(container2BCSIDMap);
+    containerSet.buildMissingContainerSetAndValidate(container2BCSIDMap, n -> n);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/WitnessedContainerDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/WitnessedContainerDBDefinition.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.ozone.container.metadata;
 
 import java.util.Map;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
-import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.OzoneConsts;
 
@@ -32,10 +32,10 @@ public final class WitnessedContainerDBDefinition extends DBDefinition.WithMap {
 
   private static final String CONTAINER_IDS_TABLE_NAME = "containerIds";
 
-  public static final DBColumnFamilyDefinition<Long, String>
+  public static final DBColumnFamilyDefinition<ContainerID, String>
       CONTAINER_IDS_TABLE = new DBColumnFamilyDefinition<>(
       CONTAINER_IDS_TABLE_NAME,
-      LongCodec.get(),
+      ContainerID.getCodec(),
       StringCodec.get());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>
@@ -62,7 +62,7 @@ public final class WitnessedContainerDBDefinition extends DBDefinition.WithMap {
     return ScmConfigKeys.OZONE_SCM_DATANODE_ID_DIR;
   }
 
-  public DBColumnFamilyDefinition<Long, String> getContainerIdsTable() {
+  DBColumnFamilyDefinition<ContainerID, String> getContainerIdsTable() {
     return CONTAINER_IDS_TABLE;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/WitnessedContainerMetadataStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/WitnessedContainerMetadataStore.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.container.metadata;
 
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.utils.db.Table;
 
 /**
@@ -28,5 +29,5 @@ public interface WitnessedContainerMetadataStore extends DBStoreManager {
    *
    * @return Table
    */
-  Table<Long, String> getContainerIdsTable();
+  Table<ContainerID, String> getContainerIdsTable();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/WitnessedContainerMetadataStoreImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/WitnessedContainerMetadataStoreImpl.java
@@ -22,6 +22,7 @@ import java.io.UncheckedIOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -33,7 +34,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 public final class WitnessedContainerMetadataStoreImpl extends AbstractRDBStore<WitnessedContainerDBDefinition>
     implements WitnessedContainerMetadataStore {
 
-  private Table<Long, String> containerIdsTable;
+  private Table<ContainerID, String> containerIdsTable;
   private static final ConcurrentMap<String, WitnessedContainerMetadataStore> INSTANCES =
       new ConcurrentHashMap<>();
 
@@ -63,13 +64,13 @@ public final class WitnessedContainerMetadataStoreImpl extends AbstractRDBStore<
   @Override
   protected DBStore initDBStore(DBStoreBuilder dbStoreBuilder, ManagedDBOptions options, ConfigurationSource config)
       throws IOException {
-    DBStore dbStore = dbStoreBuilder.build();
+    final DBStore dbStore = dbStoreBuilder.build();
     this.containerIdsTable = this.getDbDef().getContainerIdsTable().getTable(dbStore);
     return dbStore;
   }
 
   @Override
-  public Table<Long, String> getContainerIdsTable() {
+  public Table<ContainerID, String> getContainerIdsTable() {
     return containerIdsTable;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyVerifierClient;
@@ -339,13 +340,13 @@ public class OzoneContainer {
       for (Thread volumeThread : volumeThreads) {
         volumeThread.join();
       }
-      try (TableIterator<Long, ? extends Table.KeyValue<Long, String>> itr =
+      try (TableIterator<ContainerID, ? extends Table.KeyValue<ContainerID, String>> itr =
                containerSet.getContainerIdsTable().iterator()) {
-        Map<Long, Long> containerIds = new HashMap<>();
+        final Map<ContainerID, Long> containerIds = new HashMap<>();
         while (itr.hasNext()) {
           containerIds.put(itr.next().getKey(), 0L);
         }
-        containerSet.buildMissingContainerSetAndValidate(containerIds);
+        containerSet.buildMissingContainerSetAndValidate(containerIds, ContainerID::getId);
       }
     } catch (InterruptedException ex) {
       LOG.error("Volume Threads Interrupted exception", ex);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -56,6 +56,22 @@ import org.rocksdb.StatsLevel;
  * RDBStore Tests.
  */
 public class TestRDBStore {
+  static ManagedDBOptions newManagedDBOptions() {
+    final ManagedDBOptions options = new ManagedDBOptions();
+    options.setCreateIfMissing(true);
+    options.setCreateMissingColumnFamilies(true);
+
+    Statistics statistics = new Statistics();
+    statistics.setStatsLevel(StatsLevel.ALL);
+    options.setStatistics(statistics);
+    return options;
+  }
+
+  static RDBStore newRDBStore(File dbFile, ManagedDBOptions options, Set<TableConfig> families)
+      throws IOException {
+    return newRDBStore(dbFile, options, families, MAX_DB_UPDATES_SIZE_THRESHOLD);
+  }
+
   public static RDBStore newRDBStore(File dbFile, ManagedDBOptions options,
       Set<TableConfig> families,
       long maxDbUpdatesSizeThreshold)
@@ -72,20 +88,14 @@ public class TestRDBStore {
           "Fourth", "Fifth",
           "Sixth");
   private RDBStore rdbStore = null;
-  private ManagedDBOptions options = null;
+  private ManagedDBOptions options;
   private Set<TableConfig> configSet;
 
   @BeforeEach
   public void setUp(@TempDir File tempDir) throws Exception {
     CodecBuffer.enableLeakDetection();
 
-    options = new ManagedDBOptions();
-    options.setCreateIfMissing(true);
-    options.setCreateMissingColumnFamilies(true);
-
-    Statistics statistics = new Statistics();
-    statistics.setStatsLevel(StatsLevel.ALL);
-    options.setStatistics(statistics);
+    options = newManagedDBOptions();
     configSet = new HashSet<>();
     for (String name : families) {
       TableConfig newConfig = new TableConfig(name,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedTable.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedTable.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.LongFunction;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
+import org.apache.ratis.util.UncheckedAutoCloseable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.RocksDB;
+
+/**
+ * Tests for RocksDBTable Store.
+ */
+public class TestTypedTable {
+  private final List<String> families = Arrays.asList(StringUtils.bytes2String(RocksDB.DEFAULT_COLUMN_FAMILY),
+      "First", "Second");
+
+  private RDBStore rdb;
+  private final List<UncheckedAutoCloseable> closeables = new ArrayList<>();
+
+  static TableConfig newTableConfig(String name, List<UncheckedAutoCloseable> closeables) {
+    final ManagedColumnFamilyOptions option = new ManagedColumnFamilyOptions();
+    closeables.add(option::close);
+    return new TableConfig(name, option);
+  }
+
+  @BeforeEach
+  public void setUp(@TempDir File tempDir) throws Exception {
+    CodecBuffer.enableLeakDetection();
+
+    final Set<TableConfig> configSet = families.stream()
+        .map(name -> newTableConfig(name, closeables))
+        .collect(Collectors.toSet());
+    final ManagedDBOptions options = TestRDBStore.newManagedDBOptions();
+    closeables.add(options::close);
+    rdb = TestRDBStore.newRDBStore(tempDir, options, configSet);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    rdb.close();
+    closeables.forEach(UncheckedAutoCloseable::close);
+    closeables.clear();
+    CodecBuffer.assertNoLeaks();
+  }
+
+  <K, V> TypedTable<K, V> newTypedTable(int index, Codec<K> keyCodec, Codec<V> valueCodec) throws IOException {
+    final RDBTable rawTable = rdb.getTable(families.get(index));
+    return new TypedTable<>(rawTable, keyCodec, valueCodec, TableCache.CacheType.PARTIAL_CACHE);
+  }
+
+  static <V> V put(Map<Long, V> map, long key, LongFunction<V> constructor) {
+    return map.put(key, constructor.apply(key));
+  }
+
+  static <V> Map<Long, V> newMap(LongFunction<V> constructor) {
+    final Map<Long, V> map = new HashMap<>();
+    for (long n = 1; n > 0; n <<= 1) {
+      put(map, n, constructor);
+      put(map, n - 1, constructor);
+      put(map, n + 1, constructor);
+    }
+    put(map, Long.MAX_VALUE, constructor);
+    for (int i = 0; i < 1000; i++) {
+      final long key = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE) + 1;
+      put(map, key, constructor);
+    }
+    return map;
+  }
+
+  @Test
+  public void testContainerIDvsLong() throws Exception {
+    final Map<Long, ContainerID> keys = newMap(ContainerID::valueOf);
+
+    // Table 1: ContainerID -> String
+    // Table 2: Long -> String
+    try (TypedTable<ContainerID, String> idTable = newTypedTable(
+        1, ContainerID.getCodec(), StringCodec.get());
+         TypedTable<Long, String> longTable = newTypedTable(
+             2, LongCodec.get(), StringCodec.get())) {
+
+      for (Map.Entry<Long, ContainerID> e : keys.entrySet()) {
+        final long n = e.getKey();
+        final ContainerID id = e.getValue();
+        final String value = id.toString();
+        // put the same value to both tables
+        idTable.put(id, value);
+        longTable.put(n, value);
+      }
+    }
+
+    // Reopen tables with different key types
+
+    // Table 1: Long -> String
+    // Table 2: ContainerID -> String
+    try (TypedTable<ContainerID, String> idTable = newTypedTable(
+        2, ContainerID.getCodec(), StringCodec.get());
+         TypedTable<Long, String> longTable = newTypedTable(
+             1, LongCodec.get(), StringCodec.get())) {
+
+      for (Map.Entry<Long, ContainerID> e : keys.entrySet()) {
+        final long n = e.getKey();
+        final ContainerID id = e.getValue();
+        final String expected = id.toString();
+        // Read the value using a different key type
+        final String idValue = idTable.get(id);
+        assertEquals(expected, idValue);
+        final String longValue = longTable.get(n);
+        assertEquals(expected, longValue);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The key type of CONTAINER_IDS_TABLE is Long. It is better to use ContainerID.

Note that the binary encodings are the same for Long and ContainerID. It is compatible to replace Long with ContainerID in db.

## What is the link to the Apache JIRA

HDDS-12770

## How was this patch tested?

Added new tests