### PR TITLE
HDDS-12764. NodeDecommissionManager#monitorInterval should get with ms unit from config

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.xml.bind.JAXBContext;
@@ -53,6 +54,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.slf4j.Logger;
 
 /**
  * Configuration for ozone.
@@ -474,6 +476,36 @@ public class OzoneConfiguration extends Configuration
       // that version, so we are safe to catch the exception and return a new Properties object.
       return new Properties();
     }
+  }
+
+  /**
+   * Get a duration value from the configuration, and default to the given value if it's invalid.
+   * @param logger the logger to use
+   * @param key the key to get the value from
+   * @param defaultValue the default value to use if the key is not set
+   * @param unit the unit of the duration
+   * @return the duration value
+   */
+  public long getOrFixDuration(Logger logger, String key, String defaultValue, TimeUnit unit) {
+    maybeFixInvalidDuration(logger, key, defaultValue, unit);
+    return getTimeDuration(key, defaultValue, unit);
+  }
+
+  private boolean maybeFixInvalidDuration(Logger logger, String key, String defaultValue, TimeUnit unit) {
+    boolean fixed = maybeFixInvalidDuration(key, defaultValue, unit);
+    if (fixed) {
+      logger.warn("{} must be greater than zero, defaulting to {}", key, defaultValue);
+    }
+    return fixed;
+  }
+
+  private boolean maybeFixInvalidDuration(String key, String defaultValue, TimeUnit unit) {
+    long duration = getTimeDuration(key, defaultValue, unit);
+    if (duration <= 0) {
+      set(key, defaultValue);
+      return true;
+    }
+    return false;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -276,21 +276,12 @@ public class NodeDecommissionManager {
         HddsConfigKeys.HDDS_DATANODE_USE_DN_HOSTNAME,
         HddsConfigKeys.HDDS_DATANODE_USE_DN_HOSTNAME_DEFAULT);
 
-    long monitorInterval = config.getTimeDuration(
+    long monitorIntervalMs = config.getOrFixDuration(
+        LOG,
         ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL,
         ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL_DEFAULT,
-        TimeUnit.SECONDS);
-    if (monitorInterval <= 0) {
-      LOG.warn("{} must be greater than zero, defaulting to {}",
-          ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL,
-          ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL_DEFAULT);
-      config.set(ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL,
-          ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL_DEFAULT);
-      monitorInterval = config.getTimeDuration(
-          ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL,
-          ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL_DEFAULT,
-          TimeUnit.SECONDS);
-    }
+        TimeUnit.MILLISECONDS);
+
     setMaintenanceConfigs(config.getInt("hdds.scm.replication.maintenance.replica.minimum", 2),
         config.getInt("hdds.scm.replication.maintenance.remaining.redundancy", 1));
 
@@ -298,8 +289,8 @@ public class NodeDecommissionManager {
         rm);
     this.metrics = NodeDecommissionMetrics.create();
     monitor.setMetrics(this.metrics);
-    executor.scheduleAtFixedRate(monitor, monitorInterval, monitorInterval,
-        TimeUnit.SECONDS);
+    executor.scheduleAtFixedRate(monitor, monitorIntervalMs, monitorIntervalMs,
+        TimeUnit.MILLISECONDS);
   }
 
   public Map<String, List<ContainerID>> getContainersPendingReplication(DatanodeDetails dn)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The monitorInterval of `NodeDecommissionManager` needs to get duration with millisecond, otherwise if millisecond value is set(eg. 100ms), it would be consider as 0 and be set to default value.

https://github.com/apache/ozone/blob/1ebf2652b19759e8ed473003f029714fb6204ded/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java#L279-L293
https://github.com/apache/ozone/blob/1ebf2652b19759e8ed473003f029714fb6204ded/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java#L301-L302

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12764

## How was this patch tested?

Existing tests.
CI:
https://github.com/peterxcli/ozone/actions/runs/14350143861