### PR TITLE
HDDS-12581. Multi-threaded Log File Parsing with Batch Updates to DB

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
@@ -117,15 +117,7 @@ public class ContainerDatanodeDatabase {
     }
   }
 
-  public void insertContainerDatanodeData(String key, List<DatanodeContainerInfo> transitionList) throws SQLException {
-    String[] parts = key.split(CONTAINER_KEY_DELIMITER);
-    if (parts.length != 2) {
-      System.err.println("Invalid key format: " + key);
-      return;
-    }
-
-    long containerId = Long.parseLong(parts[0]);
-    long datanodeId = Long.parseLong(parts[1]);
+  public void insertContainerDatanodeData(List<DatanodeContainerInfo> transitionList) throws SQLException {
 
     String insertSQL = queries.get("INSERT_DATANODE_CONTAINER_LOG");
 
@@ -135,8 +127,8 @@ public class ContainerDatanodeDatabase {
       int count = 0;
 
       for (DatanodeContainerInfo info : transitionList) {
-        preparedStatement.setLong(1, datanodeId);
-        preparedStatement.setLong(2, containerId);
+        preparedStatement.setLong(1, info.getDatanodeId());
+        preparedStatement.setLong(2, info.getContainerId());
         preparedStatement.setString(3, info.getTimestamp());
         preparedStatement.setString(4, info.getState());
         preparedStatement.setLong(5, info.getBcsid());
@@ -157,7 +149,7 @@ public class ContainerDatanodeDatabase {
         preparedStatement.executeBatch();
       }
     } catch (SQLException e) {
-      LOG.error("Failed to insert container log for container {} on datanode {}", containerId, datanodeId, e);
+      LOG.error("Failed to insert container log", e);
       throw e;
     } catch (Exception e) {
       LOG.error(e.getMessage());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
@@ -170,9 +170,9 @@ public class ContainerDatanodeDatabase {
          PreparedStatement selectStmt = connection.prepareStatement(selectSQL);
          ResultSet resultSet = selectStmt.executeQuery();
          PreparedStatement insertStmt = connection.prepareStatement(insertSQL)) {
-
+      
       int count = 0;
-
+      
       while (resultSet.next()) {
         long datanodeId = resultSet.getLong("datanode_id");
         long containerId = resultSet.getLong("container_id");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
@@ -133,7 +133,7 @@ public class ContainerDatanodeDatabase {
       int count = 0;
 
       for (DatanodeContainerInfo info : transitionList) {
-        preparedStatement.setLong(1, info.getDatanodeId());
+        preparedStatement.setString(1, info.getDatanodeId());
         preparedStatement.setLong(2, info.getContainerId());
         preparedStatement.setString(3, info.getTimestamp());
         preparedStatement.setString(4, info.getState());
@@ -186,12 +186,12 @@ public class ContainerDatanodeDatabase {
       int count = 0;
       
       while (resultSet.next()) {
-        long datanodeId = resultSet.getLong("datanode_id");
+        String datanodeId = resultSet.getString("datanode_id");
         long containerId = resultSet.getLong("container_id");
         String containerState = resultSet.getString("container_state");
         long bcsid = resultSet.getLong("bcsid");
         try {
-          insertStmt.setLong(1, datanodeId);
+          insertStmt.setString(1, datanodeId);
           insertStmt.setLong(2, containerId);
           insertStmt.setString(3, containerState);
           insertStmt.setLong(4, bcsid);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
@@ -35,7 +35,8 @@ import org.sqlite.SQLiteConfig;
 
 
 /**
- * Datanode container Database.
+ * Handles creation and interaction with the database.
+ * Provides methods for table creation, log data insertion, and index setup.
  */
 
 public class ContainerDatanodeDatabase {
@@ -116,6 +117,12 @@ public class ContainerDatanodeDatabase {
     }
   }
 
+  /**
+   * Inserts a list of container log entries into the DatanodeContainerLogTable.
+   *
+   * @param transitionList List of container log entries to insert into the table.
+   */
+  
   public synchronized void insertContainerDatanodeData(List<DatanodeContainerInfo> transitionList) throws SQLException {
 
     String insertSQL = queries.get("INSERT_DATANODE_CONTAINER_LOG");
@@ -160,6 +167,11 @@ public class ContainerDatanodeDatabase {
     String createIndexSQL = queries.get("CREATE_DATANODE_CONTAINER_INDEX");
     stmt.execute(createIndexSQL);
   }
+
+  /**
+   * Extracts the latest container log data from the DatanodeContainerLogTable
+   * and inserts it into ContainerLogTable.
+   */
 
   public void insertLatestContainerLogData() throws SQLException {
     createContainerLogTable();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
@@ -127,14 +127,20 @@ public class ContainerDatanodeDatabase {
 
     String insertSQL = queries.get("INSERT_DATANODE_CONTAINER_LOG");
 
+    long containerId = 0;
+    String datanodeId = null;
+    
     try (Connection connection = getConnection();
          PreparedStatement preparedStatement = connection.prepareStatement(insertSQL)) {
 
       int count = 0;
 
       for (DatanodeContainerInfo info : transitionList) {
-        preparedStatement.setString(1, info.getDatanodeId());
-        preparedStatement.setLong(2, info.getContainerId());
+        datanodeId = info.getDatanodeId();
+        containerId = info.getContainerId();
+
+        preparedStatement.setString(1, datanodeId);
+        preparedStatement.setLong(2, containerId);
         preparedStatement.setString(3, info.getTimestamp());
         preparedStatement.setString(4, info.getState());
         preparedStatement.setLong(5, info.getBcsid());
@@ -155,7 +161,7 @@ public class ContainerDatanodeDatabase {
         preparedStatement.executeBatch();
       }
     } catch (SQLException e) {
-      LOG.error("Failed to insert container log", e);
+      LOG.error("Failed to insert container log for container {} on datanode {}", containerId, datanodeId, e);
       throw e;
     } catch (Exception e) {
       LOG.error(e.getMessage());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerDatanodeDatabase.java
@@ -41,7 +41,6 @@ import org.sqlite.SQLiteConfig;
 public class ContainerDatanodeDatabase {
 
   private static Map<String, String> queries;
-  public static final String CONTAINER_KEY_DELIMITER = "#";
 
   static {
     loadProperties();
@@ -117,7 +116,7 @@ public class ContainerDatanodeDatabase {
     }
   }
 
-  public void insertContainerDatanodeData(List<DatanodeContainerInfo> transitionList) throws SQLException {
+  public synchronized void insertContainerDatanodeData(List<DatanodeContainerInfo> transitionList) throws SQLException {
 
     String insertSQL = queries.get("INSERT_DATANODE_CONTAINER_LOG");
 
@@ -171,9 +170,9 @@ public class ContainerDatanodeDatabase {
          PreparedStatement selectStmt = connection.prepareStatement(selectSQL);
          ResultSet resultSet = selectStmt.executeQuery();
          PreparedStatement insertStmt = connection.prepareStatement(insertSQL)) {
-      
+
       int count = 0;
-      
+
       while (resultSet.next()) {
         long datanodeId = resultSet.getLong("datanode_id");
         long containerId = resultSet.getLong("container_id");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
@@ -50,7 +50,7 @@ public class ContainerLogFileParser {
   private static final String KEY_BCSID = "BCSID";
   private static final String KEY_STATE = "State";
   private static final String KEY_INDEX = "Index";
-  AtomicBoolean hasErrorOccurred = new AtomicBoolean(false);
+  private final AtomicBoolean hasErrorOccurred = new AtomicBoolean(false);
   
   /**
    * Scans the specified log directory, processes each file in a separate thread.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
@@ -33,7 +33,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Container log file Parsing logic.
+ * Parses container log files and stores container details into a database.
+ * Uses multithreading to process multiple log files concurrently.
  */
 
 public class ContainerLogFileParser {
@@ -49,6 +50,15 @@ public class ContainerLogFileParser {
   private static final String KEY_BCSID = "BCSID";
   private static final String KEY_STATE = "State";
   private static final String KEY_INDEX = "Index";
+
+  /**
+   * Scans the specified log directory, processes each file in a separate thread.
+   * Expects each log filename to follow the format: dn-container-datanodeId.log
+   *
+   * @param logDirectoryPath Path to the directory containing container log files.
+   * @param dbstore Database object used to persist parsed container data.
+   * @param threadCount Number of threads to use for parallel processing.
+   */
 
   public void processLogEntries(String logDirectoryPath, ContainerDatanodeDatabase dbstore, int threadCount)
       throws SQLException {
@@ -108,6 +118,15 @@ public class ContainerLogFileParser {
     }
   }
 
+  /**
+   * Processes a single container log file and extracts container details.
+   * Parses, batches, and writes valid container log entries into the database.
+   *
+   * @param logFilePath Path to the log file.
+   * @param dbstore Database object used to persist parsed container data.
+   * @param datanodeId Datanode ID derived from the log filename.
+   */
+  
   private void processFile(String logFilePath, ContainerDatanodeDatabase dbstore, long datanodeId) throws SQLException {
     List<DatanodeContainerInfo> batchList = new ArrayList<>(5100);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
@@ -64,7 +64,7 @@ public class ContainerLogFileParser {
       executorService = Executors.newFixedThreadPool(threadCount);
 
       CountDownLatch latch = new CountDownLatch(files.size());
-      //int count = 1;
+
       for (Path file : files) {
         Path fileNamePath = file.getFileName();
         String fileName = (fileNamePath != null) ? fileNamePath.toString() : "";
@@ -83,7 +83,6 @@ public class ContainerLogFileParser {
 
         try {
           datanodeId = Long.parseLong(datanodeIdStr);
-          System.out.println("Parsed datanodeId: " + datanodeId);
 
         } catch (NumberFormatException e) {
           System.out.println("Invalid datanode ID in filename: " + fileName);
@@ -91,8 +90,7 @@ public class ContainerLogFileParser {
         }
 
         long finalDatanodeId = datanodeId;
-        //count++;
-        //int finalCount = count;
+
         executorService.submit(() -> {
 
           String threadName = Thread.currentThread().getName();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
@@ -80,7 +80,7 @@ public class ContainerLogFileParser {
         
         String datanodeId = fileName.substring(pos + 5);
         
-        if (datanodeId.trim().isEmpty()) {
+        if (datanodeId.isEmpty()) {
           System.out.println("Filename format is incorrect, datanodeId is missing or empty: " + fileName);
           continue;
         }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/ContainerLogFileParser.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.containerlog.parser;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Container log file Parsing logic.
+ */
+
+public class ContainerLogFileParser {
+
+  private  ExecutorService executorService;
+  private final Map<String, List<DatanodeContainerInfo>> batchMap = new HashMap<>(500);
+  private final Map<String, ReentrantLock> locks = new HashMap<>(500);
+  private final ReentrantLock globalLock = new ReentrantLock();
+  private static final int MAX_KEYS_IN_MAP = 400;
+  private final AtomicBoolean isGlobalLockHeld = new AtomicBoolean(false);
+  private final Object globalLockNotifier = new Object();
+
+  private static final String FILENAME_PARTS_REGEX = "-";
+  private static final String DATANODE_ID_REGEX = "\\.";
+  private static final String LOG_LINE_SPLIT_REGEX = " \\| ";
+  private static final String KEY_VALUE_SPLIT_REGEX = "=";
+
+  public void processLogEntries(String logDirectoryPath, ContainerDatanodeDatabase dbstore, int threadCount)
+      throws SQLException {
+    try (Stream<Path> paths = Files.walk(Paths.get(logDirectoryPath))) {
+
+      List<Path> files = paths.filter(Files::isRegularFile).collect(Collectors.toList());
+
+      executorService = Executors.newFixedThreadPool(threadCount);
+
+      CountDownLatch latch = new CountDownLatch(files.size());
+      //int count = 1;
+      for (Path file : files) {
+        String fileName = file.getFileName().toString();
+        String[] parts = fileName.split(FILENAME_PARTS_REGEX);
+
+        if (parts.length < 3) {
+          System.out.println("Filename format is incorrect (not enough parts): " + fileName);
+          continue;
+        }
+
+        long datanodeId = 0;
+        String datanodeIdStr = parts[2];
+        if (datanodeIdStr.contains(".log")) {
+          datanodeIdStr = datanodeIdStr.split(DATANODE_ID_REGEX)[0];
+        }
+
+        try {
+          datanodeId = Long.parseLong(datanodeIdStr);
+          System.out.println("Parsed datanodeId: " + datanodeId);
+
+        } catch (NumberFormatException e) {
+          System.out.println("Invalid datanode ID in filename: " + fileName);
+          continue;
+        }
+
+        long finalDatanodeId = datanodeId;
+        //count++;
+        //int finalCount = count;
+        executorService.submit(() -> {
+
+          String threadName = Thread.currentThread().getName();
+          try {
+            System.out.println(threadName + " is starting to process file: " + file.toString());
+            processFile(file.toString(), dbstore, finalDatanodeId);
+          } catch (Exception e) {
+            System.out.println("Thread " + threadName + " is stopping to process the file: " + file.toString() +
+                " due to SQLException: " + e.getMessage());
+            executorService.shutdown();
+          } finally {
+            try {
+              latch.countDown();
+              System.out.println(threadName + " finished processing file: " + file.toString() +
+                  ", Latch count after countdown: " + latch.getCount());
+            } catch (Exception e) {
+              e.printStackTrace();
+            }
+          }
+        });
+      }
+      latch.await();
+
+
+      if (!batchMap.isEmpty()) {
+        processAndClearAllBatches(dbstore);
+      }
+
+      executorService.shutdown();
+
+    } catch (IOException | InterruptedException e) {
+      e.printStackTrace();
+    } catch (SQLException e) {
+      System.out.println("Thread " + Thread.currentThread().getName() +
+          " is stopping due to SQLException: " + e.getMessage());
+      executorService.shutdown();
+      throw e;
+    }
+  }
+
+
+  private synchronized void  processAndClearAllBatches(ContainerDatanodeDatabase dbstore) throws SQLException {
+    globalLock.lock();
+    try {
+      isGlobalLockHeld.set(true);
+      for (Map.Entry<String, List<DatanodeContainerInfo>> entry : batchMap.entrySet()) {
+        String key = entry.getKey();
+        List<DatanodeContainerInfo> transitionList = entry.getValue();
+
+        dbstore.insertContainerDatanodeData(key, transitionList);
+        transitionList.clear();
+      }
+      batchMap.clear();
+      locks.clear();
+
+    }  finally {
+      globalLock.unlock();
+      isGlobalLockHeld.set(false);
+      synchronized (globalLockNotifier) {
+        notifyAll();
+      }
+    }
+  }
+
+  public void processFile(String logFilePath, ContainerDatanodeDatabase dbstore, long datanodeId) throws SQLException {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(logFilePath),
+        StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String[] parts = line.split(LOG_LINE_SPLIT_REGEX);
+        String timestamp = parts[0];
+        String logLevel = parts[1];
+        String id = null, bcsid = null, state = null, index = null;
+
+        for (String part : parts) {
+          part = part.trim();
+
+          if (part.contains(KEY_VALUE_SPLIT_REGEX)) {
+            String[] keyValue = part.split(KEY_VALUE_SPLIT_REGEX);
+            if (keyValue.length == 2) {
+              String key = keyValue[0].trim();
+              String value = keyValue[1].trim();
+
+              switch (key) {
+              case "ID":
+                id = value;
+                break;
+              case "BCSID":
+                bcsid = value;
+                break;
+              case "State":
+                state = value.replace("|", "").trim();
+                break;
+              case "Index":
+                index = value;
+                break;
+              default:
+                System.out.println("Unexpected key: " + key);
+                break;
+              }
+            }
+          }
+
+        }
+
+        if (index == null || !index.equals("0")) {
+          continue;
+        }
+
+        String errorMessage = "No error";
+        if (line.contains("ERROR") || line.contains("WARN")) {
+          errorMessage = null;
+          for (int i = parts.length - 1; i >= 0; i--) {
+            String part = parts[i].trim();
+
+            if (part.isEmpty()) {
+              continue;
+            }
+
+            if (part.startsWith("State=") || part.startsWith("ID=") || part.startsWith("BCSID=") ||
+                part.startsWith("Index=")  || part.equals("ERROR") || part.equals("INFO")
+                || part.equals("WARN") || part.equals(timestamp)) {
+              continue;
+            }
+            if (part.endsWith("|")) {
+              part = part.replace("|", "").trim();
+            }
+            errorMessage = part;
+
+            break;
+          }
+        }
+
+        if (id != null && bcsid != null && state != null) {
+          try {
+            long containerId = Long.parseLong(id);
+            long bcsidValue = Long.parseLong(bcsid);
+
+            String key = containerId + "#" + datanodeId;
+
+            try {
+              synchronized (globalLockNotifier) {
+                while (isGlobalLockHeld.get()) {
+                  try {
+                    globalLockNotifier.wait();
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                  }
+                }
+
+                if (!isGlobalLockHeld.get()) {
+                  ReentrantLock lock = locks.computeIfAbsent(key, k -> new ReentrantLock());
+                  lock.lock();
+
+                  try {
+                    List<DatanodeContainerInfo> currentBatch = batchMap.computeIfAbsent(key, k -> new ArrayList<>());
+
+                    currentBatch.add(new DatanodeContainerInfo(timestamp, state, bcsidValue, errorMessage,
+                        logLevel, Integer.parseInt(index)));
+
+                    if (batchMap.size() >= MAX_KEYS_IN_MAP) {
+                      processAndClearAllBatches(dbstore);
+                    }
+                  } finally {
+                    lock.unlock();
+                  }
+                }
+              }
+            } catch (SQLException e) {
+              throw new SQLException(e.getMessage());
+            } catch (Exception e) {
+              System.out.println("Error processing the batch for key: " + key);
+              e.printStackTrace();
+            }
+          } catch (NumberFormatException e) {
+            System.out.println("Error parsing ID or BCSID as Long: " + line);
+          }
+        } else {
+          System.out.println("Log line does not have all required fields: " + line);
+        }
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DBConsts.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DBConsts.java
@@ -31,7 +31,7 @@ public final class DBConsts {
   public static final String DATABASE_NAME = "container_datanode.db";
   public static final String PROPS_FILE = "container-log-db-queries.properties";
   public static final int CACHE_SIZE = 1000000;
-  public static final int BATCH_SIZE = 1000;
+  public static final int BATCH_SIZE = 2500;
   public static final String DATANODE_CONTAINER_LOG_TABLE_NAME = "DatanodeContainerLogTable";
   public static final String CONTAINER_LOG_TABLE_NAME = "ContainerLogTable";
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DatanodeContainerInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DatanodeContainerInfo.java
@@ -23,6 +23,8 @@ package org.apache.hadoop.ozone.containerlog.parser;
 
 public class DatanodeContainerInfo {
 
+  private long containerId;
+  private long datanodeId;
   private String timestamp;
   private String state;
   private long bcsid;
@@ -32,14 +34,31 @@ public class DatanodeContainerInfo {
 
   public DatanodeContainerInfo() {
   }
-  public DatanodeContainerInfo(String timestamp, String state, long bcsid, String errorMessage,
-                               String logLevel, int indexValue) {
+  public DatanodeContainerInfo(long containerId, long datanodeId, String timestamp, String state, long bcsid, String errorMessage, String logLevel, int indexValue) {
+    this.containerId=containerId;
+    this.datanodeId=datanodeId;
     this.timestamp = timestamp;
     this.state = state;
     this.bcsid = bcsid;
     this.errorMessage = errorMessage;
     this.logLevel = logLevel;
     this.indexValue = indexValue;
+  }
+
+  public long getContainerId() {
+    return containerId;
+  }
+
+  public void setContainerId(long containerId) {
+    this.containerId = containerId;
+  }
+
+  public long getDatanodeId() {
+    return datanodeId;
+  }
+
+  public void setDatanodeId(long datanodeId) {
+    this.datanodeId = datanodeId;
   }
 
   public String getTimestamp() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DatanodeContainerInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DatanodeContainerInfo.java
@@ -24,7 +24,7 @@ package org.apache.hadoop.ozone.containerlog.parser;
 public final class DatanodeContainerInfo {
 
   private final long containerId;
-  private final long datanodeId;
+  private final String datanodeId;
   private final String timestamp;
   private final String state;
   private final long bcsid;
@@ -44,12 +44,12 @@ public final class DatanodeContainerInfo {
   }
 
   /**
-   * Builder for DatanodeContainerInfo..
+   * Builder for DatanodeContainerInfo.
    */
 
   public static class Builder {
     private long containerId;
-    private long datanodeId;
+    private String datanodeId;
     private String timestamp;
     private String state;
     private long bcsid;
@@ -62,7 +62,7 @@ public final class DatanodeContainerInfo {
       return this;
     }
 
-    public Builder setDatanodeId(long datanodeId) {
+    public Builder setDatanodeId(String datanodeId) {
       this.datanodeId = datanodeId;
       return this;
     }
@@ -106,7 +106,7 @@ public final class DatanodeContainerInfo {
     return containerId;
   }
 
-  public long getDatanodeId() {
+  public String getDatanodeId() {
     return datanodeId;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DatanodeContainerInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/containerlog/parser/DatanodeContainerInfo.java
@@ -21,92 +21,117 @@ package org.apache.hadoop.ozone.containerlog.parser;
  *Holds information about a container.
  */
 
-public class DatanodeContainerInfo {
+public final class DatanodeContainerInfo {
 
-  private long containerId;
-  private long datanodeId;
-  private String timestamp;
-  private String state;
-  private long bcsid;
-  private String errorMessage;
-  private String logLevel;
-  private int indexValue;
+  private final long containerId;
+  private final long datanodeId;
+  private final String timestamp;
+  private final String state;
+  private final long bcsid;
+  private final String errorMessage;
+  private final String logLevel;
+  private final int indexValue;
 
-  public DatanodeContainerInfo() {
+  private DatanodeContainerInfo(Builder builder) {
+    this.containerId = builder.containerId;
+    this.datanodeId = builder.datanodeId;
+    this.timestamp = builder.timestamp;
+    this.state = builder.state;
+    this.bcsid = builder.bcsid;
+    this.errorMessage = builder.errorMessage;
+    this.logLevel = builder.logLevel;
+    this.indexValue = builder.indexValue;
   }
-  public DatanodeContainerInfo(long containerId, long datanodeId, String timestamp, String state, long bcsid, String errorMessage, String logLevel, int indexValue) {
-    this.containerId=containerId;
-    this.datanodeId=datanodeId;
-    this.timestamp = timestamp;
-    this.state = state;
-    this.bcsid = bcsid;
-    this.errorMessage = errorMessage;
-    this.logLevel = logLevel;
-    this.indexValue = indexValue;
+
+  /**
+   * Builder for DatanodeContainerInfo..
+   */
+
+  public static class Builder {
+    private long containerId;
+    private long datanodeId;
+    private String timestamp;
+    private String state;
+    private long bcsid;
+    private String errorMessage;
+    private String logLevel;
+    private int indexValue;
+
+    public Builder setContainerId(long containerId) {
+      this.containerId = containerId;
+      return this;
+    }
+
+    public Builder setDatanodeId(long datanodeId) {
+      this.datanodeId = datanodeId;
+      return this;
+    }
+
+    public Builder setTimestamp(String timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public Builder setState(String state) {
+      this.state = state;
+      return this;
+    }
+
+    public Builder setBcsid(long bcsid) {
+      this.bcsid = bcsid;
+      return this;
+    }
+
+    public Builder setErrorMessage(String errorMessage) {
+      this.errorMessage = errorMessage;
+      return this;
+    }
+
+    public Builder setLogLevel(String logLevel) {
+      this.logLevel = logLevel;
+      return this;
+    }
+
+    public Builder setIndexValue(int indexValue) {
+      this.indexValue = indexValue;
+      return this;
+    }
+
+    public DatanodeContainerInfo build() {
+      return new DatanodeContainerInfo(this);
+    }
   }
 
   public long getContainerId() {
     return containerId;
   }
 
-  public void setContainerId(long containerId) {
-    this.containerId = containerId;
-  }
-
   public long getDatanodeId() {
     return datanodeId;
-  }
-
-  public void setDatanodeId(long datanodeId) {
-    this.datanodeId = datanodeId;
   }
 
   public String getTimestamp() {
     return timestamp;
   }
 
-  public void setTimestamp(String timestamp) {
-    this.timestamp = timestamp;
-  }
-
   public String getState() {
     return state;
-  }
-
-  public void setState(String state) {
-    this.state = state;
   }
 
   public long getBcsid() {
     return bcsid;
   }
 
-  public void setBcsid(long bcsid) {
-    this.bcsid = bcsid;
-  }
-
   public String getErrorMessage() {
     return errorMessage;
-  }
-
-  public void setErrorMessage(String errorMessage) {
-    this.errorMessage = errorMessage;
   }
 
   public String getLogLevel() {
     return logLevel;
   }
 
-  public void setLogLevel(String logLevel) {
-    this.logLevel = logLevel;
-  }
-
   public int getIndexValue() {
     return indexValue;
   }
-
-  public void setIndexValue(int indexValue) {
-    this.indexValue = indexValue;
-  }
-
 }
+

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogController.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogController.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.container;
+
+import org.apache.hadoop.hdds.cli.DebugSubcommand;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * A controller for managing container log operations like parsing and listing containers.
+ */
+
+@CommandLine.Command(
+    name = "container",
+    subcommands = {
+        ContainerLogParser.class
+    },
+    description = "Parse, Store, Retrieve"
+)
+@MetaInfServices(DebugSubcommand.class)
+public class ContainerLogController implements DebugSubcommand  {
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogParser.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.container;
+
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.hadoop.ozone.containerlog.parser.ContainerDatanodeDatabase;
+import org.apache.hadoop.ozone.containerlog.parser.ContainerLogFileParser;
+import picocli.CommandLine;
+
+/**
+ * Parses container logs, processes them, and updates the database accordingly.
+ */
+
+@CommandLine.Command(
+    name = "container_log_parse",
+    description = "parse the container logs"
+)
+public class ContainerLogParser implements Callable<Void> {
+  @CommandLine.Option(names = {"--parse"},
+      description = "path to the dir which contains log files")
+  private String path;
+
+  @CommandLine.Option(names = {"--thread-count"},
+      description = "Thread count for concurrent processing.",
+      defaultValue = "10")
+  private int threadCount;
+
+  @CommandLine.ParentCommand
+  private ContainerLogController parent;
+
+  @Override
+  public Void call() throws Exception {
+    if (path != null) {
+
+      ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase();
+      ContainerLogFileParser parser = new ContainerLogFileParser();
+      AtomicBoolean isProcessingSuccessful = new AtomicBoolean(true);
+
+      try {
+        // Try creating the table, if this fails, mark the process as unsuccessful
+        try {
+          cdd.createDatanodeContainerLogTable();
+        } catch (SQLException e) {
+          isProcessingSuccessful.set(false);
+          System.err.println("Error occurred while creating the Datanode Container Log Table: " + e.getMessage());
+        }
+
+        // If the table creation was successful, proceed with processing the log entries
+        if (isProcessingSuccessful.get()) {
+          try {
+            parser.processLogEntries(path, cdd, threadCount);
+          } catch (Exception e) {
+            isProcessingSuccessful.set(false);
+            System.err.println("Error occurred during processing logs: " + e.getMessage());
+          }
+
+          // Insert the latest log data, if processing was successful
+          if (isProcessingSuccessful.get()) {
+            try {
+              cdd.insertLatestContainerLogData();
+            } catch (SQLException e) {
+              isProcessingSuccessful.set(false);
+              System.err.println("Error occurred while inserting container log data: " + e.getMessage());
+            }
+          }
+
+          if (isProcessingSuccessful.get()) {
+            System.out.println("Successfully parsed the log files and updated the respective tables");
+          } else {
+            System.err.println("Log processing failed.");
+          }
+        }
+      } catch (Exception e) {
+        isProcessingSuccessful.set(false);
+        System.err.println("An unexpected error occurred: " + e.getMessage());
+      }
+
+    } else {
+      System.out.println("path to logs folder not provided");
+    }
+
+    return null;
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogParser.java
@@ -17,6 +17,9 @@
 
 package org.apache.hadoop.ozone.debug.container;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.ozone.containerlog.parser.ContainerDatanodeDatabase;
@@ -32,6 +35,8 @@ import picocli.CommandLine;
     description = "parse the container logs"
 )
 public class ContainerLogParser implements Callable<Void> {
+  private static final int DEFAULT_THREAD_COUNT = 10;
+  
   @CommandLine.Option(names = {"--parse"},
       description = "path to the dir which contains log files")
   private String path;
@@ -46,7 +51,18 @@ public class ContainerLogParser implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
+    if (threadCount <= 0) {
+      System.out.println("Invalid threadCount value provided (" + threadCount + "). Using default value: "
+          + DEFAULT_THREAD_COUNT);
+      threadCount = DEFAULT_THREAD_COUNT;
+    }
+    
     if (path != null) {
+      Path logPath = Paths.get(path);
+      if (!Files.exists(logPath) || !Files.isDirectory(logPath)) {
+        System.err.println("Invalid path provided: " + path);
+        return null;
+      }
 
       ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase();
       ContainerLogFileParser parser = new ContainerLogFileParser();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerLogParser.java
@@ -61,7 +61,8 @@ public class ContainerLogParser implements Callable<Void> {
         System.out.println("Successfully parsed the log files and updated the respective tables");
 
       } catch (SQLException e) {
-        System.err.println("Error occurred while processing logs or inserting data into the database: " + e.getMessage());
+        System.err.println("Error occurred while processing logs or inserting data into the database: "
+            + e.getMessage());
       } catch (Exception e) {
         System.err.println("An unexpected error occurred: " + e.getMessage());
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides functionality for managing container log operations, including parsing, processing, and storing log data.
+ */
+
+package org.apache.hadoop.ozone.debug.container;

--- a/hadoop-ozone/tools/src/main/resources/container-log-db-queries.properties
+++ b/hadoop-ozone/tools/src/main/resources/container-log-db-queries.properties
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-CREATE_DATANODE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS DatanodeContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, timestamp TEXT NOT NULL, container_state TEXT NOT NULL, bcsid INTEGER NOT NULL, error_message TEXT NOT NUL, log_level TEXT NOT NULL, index_value INTEGER NOT NULL);
+CREATE_DATANODE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS DatanodeContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, timestamp TEXT NOT NULL, container_state TEXT NOT NULL, bcsid INTEGER NOT NULL, error_message TEXT NOT NULL, log_level TEXT NOT NULL, index_value INTEGER NOT NULL);
 CREATE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS ContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, latest_state TEXT NOT NULL, latest_bcsid INTEGER NOT NULL, PRIMARY KEY (datanode_id, container_id));
 CREATE_DATANODE_CONTAINER_INDEX=CREATE INDEX IF NOT EXISTS idx_datanode_container ON DatanodeContainerLogTable (datanode_id, container_id, timestamp);
 INSERT_DATANODE_CONTAINER_LOG=INSERT INTO DatanodeContainerLogTable (datanode_id, container_id, timestamp, container_state, bcsid, error_message, log_level, index_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?);

--- a/hadoop-ozone/tools/src/main/resources/container-log-db-queries.properties
+++ b/hadoop-ozone/tools/src/main/resources/container-log-db-queries.properties
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-CREATE_DATANODE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS DatanodeContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, timestamp TEXT NOT NULL, container_state TEXT, bcsid INTEGER, error_message TEXT, log_level TEXT NOT NULL, index_value INTEGER);
-CREATE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS ContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, latest_state TEXT, latest_bcsid INTEGER, PRIMARY KEY (datanode_id, container_id));
+CREATE_DATANODE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS DatanodeContainerLogTable (datanode_id TEXT NOT NULL, container_id INTEGER NOT NULL, timestamp TEXT NOT NULL, container_state TEXT, bcsid INTEGER, error_message TEXT, log_level TEXT NOT NULL, index_value INTEGER);
+CREATE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS ContainerLogTable (datanode_id TEXT NOT NULL, container_id INTEGER NOT NULL, latest_state TEXT, latest_bcsid INTEGER, PRIMARY KEY (datanode_id, container_id));
 CREATE_DATANODE_CONTAINER_INDEX=CREATE INDEX IF NOT EXISTS idx_datanode_container ON DatanodeContainerLogTable (datanode_id, container_id, timestamp);
 INSERT_DATANODE_CONTAINER_LOG=INSERT INTO DatanodeContainerLogTable (datanode_id, container_id, timestamp, container_state, bcsid, error_message, log_level, index_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 INSERT_CONTAINER_LOG=INSERT OR REPLACE INTO ContainerLogTable (datanode_id, container_id, latest_state, latest_bcsid) VALUES (?, ?, ?, ?);

--- a/hadoop-ozone/tools/src/main/resources/container-log-db-queries.properties
+++ b/hadoop-ozone/tools/src/main/resources/container-log-db-queries.properties
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-CREATE_DATANODE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS DatanodeContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, timestamp TEXT NOT NULL, container_state TEXT NOT NULL, bcsid INTEGER NOT NULL, error_message TEXT NOT NULL, log_level TEXT NOT NULL, index_value INTEGER NOT NULL);
-CREATE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS ContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, latest_state TEXT NOT NULL, latest_bcsid INTEGER NOT NULL, PRIMARY KEY (datanode_id, container_id));
+CREATE_DATANODE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS DatanodeContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, timestamp TEXT NOT NULL, container_state TEXT, bcsid INTEGER, error_message TEXT, log_level TEXT NOT NULL, index_value INTEGER);
+CREATE_CONTAINER_LOG_TABLE=CREATE TABLE IF NOT EXISTS ContainerLogTable (datanode_id INTEGER NOT NULL, container_id INTEGER NOT NULL, latest_state TEXT, latest_bcsid INTEGER, PRIMARY KEY (datanode_id, container_id));
 CREATE_DATANODE_CONTAINER_INDEX=CREATE INDEX IF NOT EXISTS idx_datanode_container ON DatanodeContainerLogTable (datanode_id, container_id, timestamp);
 INSERT_DATANODE_CONTAINER_LOG=INSERT INTO DatanodeContainerLogTable (datanode_id, container_id, timestamp, container_state, bcsid, error_message, log_level, index_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 INSERT_CONTAINER_LOG=INSERT OR REPLACE INTO ContainerLogTable (datanode_id, container_id, latest_state, latest_bcsid) VALUES (?, ?, ?, ?);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This update introduces multithreaded processing to efficiently parse and store container log files into the database. Each log file is processed in a separate thread, allowing multiple files to be handled concurrently. The logs are parsed, and the data, including container IDs, datanode IDs, and other related information, is collected into batches. Once a batch reaches a predefined size, it is inserted into the database. Synchronization is used to ensure thread safety when inserting data into the database, preventing potential race conditions.

Also created a ozone debug CLI command for the same.
`./ozone debug container container_log_parse --parse=<path to logs folder>  --thread-count=<num of threads>`

Below is a sample output of the command 

> pool-1-thread-1 is starting to process file: <path to folder>/sampleFolder/dn-container-5.log
> pool-1-thread-3 is starting to process file: <path to folder>/sampleFolder/dn-container-1.log
> pool-1-thread-2 is starting to process file: <path to folder>/sampleFolder/dn-container-3.log
> pool-1-thread-2 finished processing file: <path to folder>/sampleFolder/dn-container-3.log, Latch count after countdown: 4
> pool-1-thread-2 is starting to process file: <path to folder>/sampleFolder/dn-container-2.log
> pool-1-thread-1 finished processing file: <path to folder>/sampleFolder/dn-container-5.log, Latch count after countdown: 3
> pool-1-thread-1 is starting to process file: <path to folder>/sampleFolder/dn-container-4.log
> pool-1-thread-3 finished processing file:<path to folder>/sampleFolder/dn-container-1.log, Latch count after countdown: 2
> pool-1-thread-2 finished processing file: <path to folder>/sampleFolder/dn-container-2.log, Latch count after countdown: 1
> pool-1-thread-1 finished processing file: <path to folder>/sampleFolder/dn-container-4.log, Latch count after countdown: 0
> Successfully parsed the log files and updated the respective tables

DatanodeContainerLogTable : (sample)
```
datanode_id  | container_id | latest_state  | latest_bcsid
--------------------------------------------------------
XXXXXX       | 44998        | CLOSED        | 744081  
XXXXXX       | 7327339      | CLOSED        | 682
XXXXXX       | 7360687      | CLOSED        | 672
XXXXXX       | 4548399      | QUASI_CLOSED  | 0
XXXXXX       | 4548495      | CLOSED        | 713593
XXXXXX       | 4646571      | CLOSED        | 25902
 
``` 
ContainerLogTable : (sample)
```
| datanode_id | container_id | timestamp               | container_state |   bcsid | error_message                  | log_level | index_value |
|-------------|--------------|-------------------------|-----------------|---------|--------------------------------|-----------|-------------|
| XXXXXX      | 44998        | 2024-10-08 14:32:37,024 | OPEN            |       0 | No error                       | INFO      |           0 |
| XXXXXX      | 44998        | 2024-11-08 11:39:47,473 | CLOSING         |  744081 | No error                       | INFO      |           0 |
| XXXXXX      | 44998        | 2024-11-08 11:39:47,474 | QUASI_CLOSED    |  744081 | Ratis pipeline does not exist | WARN      |           0 |
| XXXXXX      | 44998        | 2024-11-08 11:44:48,523 | CLOSED          |  744081 | No error                       | INFO      |           0 |
| XXXXXX      | 7327339      | 2025-01-22 13:09:57,731 | CLOSED          |     682 | No error                       | INFO      |           0 |
| XXXXXX      | 7360687      | 2025-01-22 13:11:02,460 | CLOSED          |     672 | No error                       | INFO      |           0 |
| XXXXXX      | 4548399      | 2025-01-22 13:11:29,874 | QUASI_CLOSED    |       0 | No error                       | INFO      |           0 |
| XXXXXX      | 4548495      | 2025-01-22 13:11:41,326 | CLOSED          |  713593 | No error                       | INFO      |           0 |
| XXXXXX      | 4646571      | 2025-01-22 13:17:11,313 | CLOSED          |   25902 | No error                       | INFO      |           0 |

```



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12581

## How was this patch tested?
Below is the workflow link that passed successfully:
https://github.com/sreejasahithi/ozone/actions/runs/14351650273
