### PR TITLE
HDDS-12809. Avoid reverse DNS lookup in check ACL

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/RequestContext.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/RequestContext.java
@@ -166,7 +166,7 @@ public class RequestContext {
       ACLType aclType, String ownerName) {
     return getBuilder(ugi,
         ProtobufRpcEngine.Server.getRemoteIp(),
-        ProtobufRpcEngine.Server.getRemoteIp().getHostName(),
+        ProtobufRpcEngine.Server.getRemoteIp().getHostAddress(),
         aclType, ownerName);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -537,7 +537,8 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
         user != null ? user : getRemoteUser(),
         remoteIp != null ? remoteIp :
             ozoneManager.getOmRpcServerAddr().getAddress(),
-        remoteIp != null ? remoteIp.getHostName() :
+        // We set Address directly to avoid reverse DNS lookup
+        remoteIp != null ? remoteIp.getHostAddress() :
             ozoneManager.getOmRpcServerAddr().getHostName());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2597,7 +2597,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return checkAcls(resType, store, acl, vol, bucket, key,
           UserGroupInformation.createRemoteUser(userName),
           ProtobufRpcEngine.Server.getRemoteIp(),
-          ProtobufRpcEngine.Server.getRemoteIp().getHostName(),
+          // We set Address directly to avoid reverse DNS lookup
+          ProtobufRpcEngine.Server.getRemoteIp().getHostAddress(),
           false, getVolumeOwner(vol, acl, resType));
     } catch (OMException ex) {
       // Should not trigger exception here at all


### PR DESCRIPTION
## What changes were proposed in this pull request?

We noticed a 14ms delay in OM's check ACL operation.

The cause is the reverse DNS lookup for the client's hostName, it's operated by local server's DNS lookup method, when the hostname is not found, there will be a 14ms delay, and during the negative cache, the delay is gone, but after the negative cache expires, the 14ms delay appears again.

IMO, the server side can not always have the client's hostname, and it's ok to return the IP directly in checkACL, and since we do have the "InetAddress", we can invoke getHostName() when needed, and we don't need to invoke getHostName() on every client call.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12809

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Existing tests.
