### PR TITLE
HDDS-12803. OmKeyInfo#isKeyInfoSame should handle object tags

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -818,6 +818,7 @@ public final class OmKeyInfo extends WithParentObjectId
         replicationConfig.equals(omKeyInfo.replicationConfig) &&
         Objects.equals(getMetadata(), omKeyInfo.getMetadata()) &&
         Objects.equals(acls, omKeyInfo.acls) &&
+        Objects.equals(getTags(), omKeyInfo.getTags()) &&
         getObjectID() == omKeyInfo.getObjectID();
 
     if (isEqual && checkUpdateID) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -123,6 +123,8 @@ public class TestOmKeyInfo {
         .setReplicationConfig(replicationConfig)
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
+        .addTag("tagKey1", "tagValue1")
+        .addTag("tagKey2", "tagValue2")
         .setExpectedDataGeneration(5678L)
         .build();
   }
@@ -149,6 +151,8 @@ public class TestOmKeyInfo {
             RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
+        .addTag("tagKey1", "tagValue1")
+        .addTag("tagKey2", "tagValue2")
         .setOmKeyLocationInfos(
             Collections.singletonList(createOmKeyLocationInfoGroup(isMPU)))
         .build();
@@ -194,6 +198,11 @@ public class TestOmKeyInfo {
     cloneKey = key.copyObject();
 
     assertEquals(key.getAcls(), cloneKey.getAcls());
+
+    // Change object tags and check
+    key.setTags(Collections.singletonMap("tagKey3", "tagValue3"));
+
+    assertNotEquals(key, cloneKey);
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

OmKeyInfo#isKeyInfoSame is used by SnapDiffManager#isKeyModified to generate a MODIFY diff entry. 

We need to take into account for object tags so that the Snapdiff can detect the change in key object tags.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12803

## How was this patch tested?

Unit test and manual snapdiff test for key with different object tags.

Previously it will result in `RENAME` diff entry (i.e. `R ./key1 ./key1`), after this change it becomes `MODIFY` diff entry (i.e. `M ./key1`).

Clean CI: https://github.com/ivandika3/ozone/actions/runs/14383134109