### PR TITLE
HDDS-12801. SCM should remove pipeline before DN.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -446,7 +446,7 @@ public class PipelineManagerImpl implements PipelineManager {
    */
   protected void removePipeline(Pipeline pipeline)
       throws IOException {
-    pipelineFactory.close(pipeline.getType(), pipeline);
+    // Removing the pipeline from SCM.
     HddsProtos.PipelineID pipelineID = pipeline.getId().getProtobuf();
     acquireWriteLock();
     try {
@@ -457,6 +457,8 @@ public class PipelineManagerImpl implements PipelineManager {
     } finally {
       releaseWriteLock();
     }
+    // Firing pipeline close command to datanode.
+    pipelineFactory.close(pipeline.getType(), pipeline);
     LOG.info("Pipeline {} removed.", pipeline);
     metrics.incNumPipelineDestroyed();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, SCM first fires the pipeline close command to DN and then, without waiting for ACK, removes the pipeline from its state map. 
Sometimes, we observed that the pipeline got removed from the DN but didn't get removed from SCM, so it caused the SCM to get stuck in safemode as SCM is expecting the pipelines from DN. So, first, we should remove the pipeline from the SCM pipeline statemap and then fire the close pipeline command to DN.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12801

## How was this patch tested?

Tested Manually.
