### PR TITLE
HDDS-12524. Reuse TestDataUtil.createKey in more tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.PrivilegedExceptionAction;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -215,7 +214,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
   private Path bucketPath;
   private String rootPath;
   private final BucketLayout bucketLayout;
-  private SecureRandom random;
 
   private static final String USER1 = "regularuser1";
   private static final UserGroupInformation UGI_USER1 = UserGroupInformation
@@ -274,7 +272,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
     userOfs = UGI_USER1.doAs(
         (PrivilegedExceptionAction<RootedOzoneFileSystem>)()
             -> (RootedOzoneFileSystem) FileSystem.get(conf));
-    random = new SecureRandom();
   }
 
   protected OMMetrics getOMMetrics() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1548,8 +1548,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
       random.nextBytes(bytes);
       TestDataUtil.createKey(objectStore.getVolume(srcVolume).
           getBucket(srcBucket), key, bytes);
-      assertEquals(key, objectStore.getVolume(volumeName).
-          getBucket(bucketName).getKey(key).getName());
+      assertEquals(key, objectStore.getVolume(srcVolume).
+          getBucket(srcBucket).getKey(key).getName());
 
       // test symlink -rm destVol/destBucket -> srcVol/srcBucket
       // should delete only link, srcBucket and key unaltered

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -62,6 +62,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -112,6 +113,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -340,8 +342,12 @@ abstract class AbstractRootedOzoneFileSystemTest {
     String key = "object-dir/object-name1";
 
     // write some test data into bucket
-    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName), key,
-        new ECReplicationConfig("RS-3-2-1024k"), RandomUtils.nextBytes(1));
+    try (OzoneOutputStream outputStream = objectStore.getVolume(volumeName).
+        getBucket(bucketName).createKey(key, 1,
+            new ECReplicationConfig("RS-3-2-1024k"),
+            new HashMap<>())) {
+      outputStream.write(RandomUtils.nextBytes(1));
+    }
 
     List<String> dirs = Arrays.asList(volumeName, bucketName, "object-dir",
             "object-name1");
@@ -1489,8 +1495,11 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
       // add key in source bucket
       final String key = "object-dir/object-name1";
-      TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-          key, RandomUtils.nextBytes(1));
+      try (OzoneOutputStream outputStream = objectStore.getVolume(srcVolume)
+          .getBucket(srcBucket)
+          .createKey(key, 1)) {
+        outputStream.write(RandomUtils.nextBytes(1));
+      }
       assertEquals(objectStore.getVolume(srcVolume)
           .getBucket(srcBucket).getKey(key).getName(), key);
 
@@ -1537,8 +1546,11 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
       // add key to srcBucket
       final String key = "object-dir/object-name1";
-      TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-          key, RandomUtils.nextBytes(1));
+      try (OzoneOutputStream outputStream = objectStore.getVolume(srcVolume)
+          .getBucket(srcBucket)
+          .createKey(key, 1)) {
+        outputStream.write(RandomUtils.nextBytes(1));
+      }
       assertEquals(objectStore.getVolume(srcVolume)
           .getBucket(srcBucket).getKey(key).getName(), key);
 
@@ -2219,8 +2231,12 @@ abstract class AbstractRootedOzoneFileSystemTest {
     Path bucketPathTest = new Path(volPathTest, bucketName);
 
     // write some test data into bucket
-    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-        key, new ECReplicationConfig("RS-3-2-1024k"), RandomUtils.nextBytes(1));
+    try (OzoneOutputStream outputStream = objectStore.getVolume(volumeName).
+        getBucket(bucketName).createKey(key, 1,
+            new ECReplicationConfig("RS-3-2-1024k"),
+            new HashMap<>())) {
+      outputStream.write(RandomUtils.nextBytes(1));
+    }
     // make sure the disk usage matches the expected value
     Path filePath = new Path(bucketPathTest, key);
     ContentSummary contentSummary = ofs.getContentSummary(filePath);
@@ -2242,9 +2258,13 @@ abstract class AbstractRootedOzoneFileSystemTest {
     Path filePathTest = new Path(bucketPathTest, key);
 
     // write some test data into bucket
-    byte[] bytes = new byte[1];
-    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-        key, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), bytes);
+    try (OzoneOutputStream outputStream = objectStore.getVolume(volumeName).
+        getBucket(bucketName).createKey(key, 1,
+            RatisReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.THREE),
+            new HashMap<>())) {
+      outputStream.write(RandomUtils.nextBytes(1));
+    }
     // make sure the disk usage matches the expected value
     ContentSummary contentSummary = ofs.getContentSummary(filePathTest);
     long length = contentSummary.getLength();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1495,6 +1495,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
       // add key in source bucket
       final String key = "object-dir/object-name1";
       byte[] bytes = new byte[1];
+      random.nextBytes(bytes);
       TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
           key, bytes);
       assertEquals(objectStore.getVolume(srcVolume)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.PrivilegedExceptionAction;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -221,7 +220,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
       .createUserForTesting(USER1,  new String[] {"usergroup"});
   // Non-privileged OFS instance
   private RootedOzoneFileSystem userOfs;
-  private SecureRandom random;
 
   @BeforeAll
   void initClusterAndEnv() throws IOException, InterruptedException, TimeoutException {
@@ -274,7 +272,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
     userOfs = UGI_USER1.doAs(
         (PrivilegedExceptionAction<RootedOzoneFileSystem>)()
             -> (RootedOzoneFileSystem) FileSystem.get(conf));
-    random = new SecureRandom();
   }
 
   protected OMMetrics getOMMetrics() {
@@ -343,10 +340,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     String key = "object-dir/object-name1";
 
     // write some test data into bucket
-    byte[] bytes = new byte[1];
-    random.nextBytes(bytes);
     TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName), key,
-        new ECReplicationConfig("RS-3-2-1024k"), bytes);
+        new ECReplicationConfig("RS-3-2-1024k"), RandomUtils.nextBytes(1));
 
     List<String> dirs = Arrays.asList(volumeName, bucketName, "object-dir",
             "object-name1");
@@ -1494,10 +1489,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
       // add key in source bucket
       final String key = "object-dir/object-name1";
-      byte[] bytes = new byte[1];
-      random.nextBytes(bytes);
       TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-          key, bytes);
+          key, RandomUtils.nextBytes(1));
       assertEquals(objectStore.getVolume(srcVolume)
           .getBucket(srcBucket).getKey(key).getName(), key);
 
@@ -1544,10 +1537,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
       // add key to srcBucket
       final String key = "object-dir/object-name1";
-      byte[] bytes = new byte[1];
-      random.nextBytes(bytes);
       TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-          key, bytes);
+          key, RandomUtils.nextBytes(1));
       assertEquals(objectStore.getVolume(srcVolume)
           .getBucket(srcBucket).getKey(key).getName(), key);
 
@@ -2228,10 +2219,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     Path bucketPathTest = new Path(volPathTest, bucketName);
 
     // write some test data into bucket
-    byte[] bytes = new byte[1];
-    random.nextBytes(bytes);
     TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
-        key, new ECReplicationConfig("RS-3-2-1024k"), bytes);
+        key, new ECReplicationConfig("RS-3-2-1024k"), RandomUtils.nextBytes(1));
     // make sure the disk usage matches the expected value
     Path filePath = new Path(bucketPathTest, key);
     ContentSummary contentSummary = ofs.getContentSummary(filePath);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -216,7 +216,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
   private String rootPath;
   private final BucketLayout bucketLayout;
   private SecureRandom random;
-  private OzoneBucket bucket;
 
   private static final String USER1 = "regularuser1";
   private static final UserGroupInformation UGI_USER1 = UserGroupInformation
@@ -276,7 +275,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
         (PrivilegedExceptionAction<RootedOzoneFileSystem>)()
             -> (RootedOzoneFileSystem) FileSystem.get(conf));
     random = new SecureRandom();
-    bucket = objectStore.getVolume(volumeName).getBucket(bucketName);
   }
 
   protected OMMetrics getOMMetrics() {
@@ -347,7 +345,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     // write some test data into bucket
     byte[] bytes = new byte[1];
     random.nextBytes(bytes);
-    TestDataUtil.createKey(bucket, key,
+    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName), key,
         new ECReplicationConfig("RS-3-2-1024k"), bytes);
 
     List<String> dirs = Arrays.asList(volumeName, bucketName, "object-dir",
@@ -1498,9 +1496,10 @@ abstract class AbstractRootedOzoneFileSystemTest {
       final String key = "object-dir/object-name1";
       byte[] bytes = new byte[1];
       random.nextBytes(bytes);
-      TestDataUtil.createKey(bucket, key, bytes);
-      assertEquals(objectStore.getVolume(srcVolume)
-          .getBucket(srcBucket).getKey(key).getName(), key);
+      TestDataUtil.createKey(objectStore.getVolume(volumeName).
+          getBucket(bucketName), key, bytes);
+      assertEquals(key, objectStore.getVolume(srcVolume)
+          .getBucket(srcBucket).getKey(key).getName());
 
       // test ls -R /destVol/destBucket, srcBucket with key (non-empty)
       try (GenericTestUtils.SystemOutCapturer capture =
@@ -1547,8 +1546,10 @@ abstract class AbstractRootedOzoneFileSystemTest {
       final String key = "object-dir/object-name1";
       byte[] bytes = new byte[1];
       random.nextBytes(bytes);
-      TestDataUtil.createKey(bucket, key, bytes);
-      assertEquals(key, bucket.getKey(key).getName());
+      TestDataUtil.createKey(objectStore.getVolume(volumeName).
+          getBucket(bucketName), key, bytes);
+      assertEquals(key, objectStore.getVolume(volumeName).
+          getBucket(bucketName).getKey(key).getName());
 
       // test symlink -rm destVol/destBucket -> srcVol/srcBucket
       // should delete only link, srcBucket and key unaltered
@@ -2229,7 +2230,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     // write some test data into bucket
     byte[] bytes = new byte[1];
     random.nextBytes(bytes);
-    TestDataUtil.createKey(bucket, key,
+    TestDataUtil.createKey(objectStore.getVolume(volumeName).
+            getBucket(bucketName), key,
         new ECReplicationConfig("RS-3-2-1024k"), bytes);
     // make sure the disk usage matches the expected value
     Path filePath = new Path(bucketPathTest, key);
@@ -2254,7 +2256,9 @@ abstract class AbstractRootedOzoneFileSystemTest {
     // write some test data into bucket
     byte[] bytes = new byte[1];
     random.nextBytes(bytes);
-    TestDataUtil.createKey(bucket, key, RatisReplicationConfig.getInstance(
+    TestDataUtil.createKey(objectStore.
+        getVolume(volumeName).getBucket(bucketName), key,
+        RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE),bytes);
     // make sure the disk usage matches the expected value
     ContentSummary contentSummary = ofs.getContentSummary(filePathTest);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -343,10 +343,9 @@ abstract class AbstractRootedOzoneFileSystemTest {
     String key = "object-dir/object-name1";
 
     // write some test data into bucket
-    byte[] bytes = new byte[1];
-    random.nextBytes(bytes);
-    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName), key,
-        new ECReplicationConfig("RS-3-2-1024k"), bytes);
+    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
+        key, new ECReplicationConfig("RS-3-2-1024k"),
+        RandomUtils.secure().randomBytes(1));
 
     List<String> dirs = Arrays.asList(volumeName, bucketName, "object-dir",
             "object-name1");
@@ -1494,10 +1493,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
       // add key in source bucket
       final String key = "object-dir/object-name1";
-      byte[] bytes = new byte[1];
-      random.nextBytes(bytes);
-      TestDataUtil.createKey(objectStore.getVolume(srcVolume).
-          getBucket(srcBucket), key, bytes);
+      TestDataUtil.createKey(objectStore.getVolume(srcVolume).getBucket(srcBucket),
+          key, RandomUtils.secure().randomBytes(1));
       assertEquals(key, objectStore.getVolume(srcVolume)
           .getBucket(srcBucket).getKey(key).getName());
 
@@ -1544,10 +1541,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
       // add key to srcBucket
       final String key = "object-dir/object-name1";
-      byte[] bytes = new byte[1];
-      random.nextBytes(bytes);
-      TestDataUtil.createKey(objectStore.getVolume(srcVolume).
-          getBucket(srcBucket), key, bytes);
+      TestDataUtil.createKey(objectStore.getVolume(srcVolume).getBucket(srcBucket),
+          key, RandomUtils.secure().randomBytes(1));
       assertEquals(key, objectStore.getVolume(srcVolume).
           getBucket(srcBucket).getKey(key).getName());
 
@@ -2228,11 +2223,9 @@ abstract class AbstractRootedOzoneFileSystemTest {
     Path bucketPathTest = new Path(volPathTest, bucketName);
 
     // write some test data into bucket
-    byte[] bytes = new byte[1];
-    random.nextBytes(bytes);
     TestDataUtil.createKey(objectStore.getVolume(volumeName).
-            getBucket(bucketName), key,
-        new ECReplicationConfig("RS-3-2-1024k"), bytes);
+            getBucket(bucketName), key, new ECReplicationConfig("RS-3-2-1024k"),
+        RandomUtils.secure().randomBytes(1));
     // make sure the disk usage matches the expected value
     Path filePath = new Path(bucketPathTest, key);
     ContentSummary contentSummary = ofs.getContentSummary(filePath);
@@ -2254,12 +2247,10 @@ abstract class AbstractRootedOzoneFileSystemTest {
     Path filePathTest = new Path(bucketPathTest, key);
 
     // write some test data into bucket
-    byte[] bytes = new byte[1];
-    random.nextBytes(bytes);
     TestDataUtil.createKey(objectStore.
         getVolume(volumeName).getBucket(bucketName), key,
-        RatisReplicationConfig.getInstance(
-        HddsProtos.ReplicationFactor.THREE), bytes);
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
+        RandomUtils.secure().randomBytes(1));
     // make sure the disk usage matches the expected value
     ContentSummary contentSummary = ofs.getContentSummary(filePathTest);
     long length = contentSummary.getLength();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -2259,7 +2259,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     TestDataUtil.createKey(objectStore.
         getVolume(volumeName).getBucket(bucketName), key,
         RatisReplicationConfig.getInstance(
-        HddsProtos.ReplicationFactor.THREE),bytes);
+        HddsProtos.ReplicationFactor.THREE), bytes);
     // make sure the disk usage matches the expected value
     ContentSummary contentSummary = ofs.getContentSummary(filePathTest);
     long length = contentSummary.getLength();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1496,8 +1496,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
       final String key = "object-dir/object-name1";
       byte[] bytes = new byte[1];
       random.nextBytes(bytes);
-      TestDataUtil.createKey(objectStore.getVolume(volumeName).
-          getBucket(bucketName), key, bytes);
+      TestDataUtil.createKey(objectStore.getVolume(srcVolume).
+          getBucket(srcBucket), key, bytes);
       assertEquals(key, objectStore.getVolume(srcVolume)
           .getBucket(srcBucket).getKey(key).getName());
 
@@ -1546,8 +1546,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
       final String key = "object-dir/object-name1";
       byte[] bytes = new byte[1];
       random.nextBytes(bytes);
-      TestDataUtil.createKey(objectStore.getVolume(volumeName).
-          getBucket(bucketName), key, bytes);
+      TestDataUtil.createKey(objectStore.getVolume(srcVolume).
+          getBucket(srcBucket), key, bytes);
       assertEquals(key, objectStore.getVolume(volumeName).
           getBucket(bucketName).getKey(key).getName());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHAWithAllRunning.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.ha.SCMHAMetrics;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -129,9 +130,7 @@ public abstract class TestStorageContainerManagerHAWithAllRunning implements HAT
 
       byte[] bytes = value.getBytes(UTF_8);
       RatisReplicationConfig replication = RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE);
-      try (OutputStream out = bucket.createKey(keyName, bytes.length, replication, new HashMap<>())) {
-        out.write(bytes);
-      }
+      TestDataUtil.createKey(bucket, keyName, replication, bytes);
 
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHAWithAllRunning.java
@@ -25,9 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.OutputStream;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -42,7 +41,6 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -104,13 +105,9 @@ public class TestBCSID {
 
   @Test
   public void testBCSID() throws Exception {
-    OzoneOutputStream key =
-        objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey("ratis", 1024,
-                ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    key.write("ratis".getBytes(UTF_8));
-    key.close();
+    TestDataUtil.createKey(objectStore.getVolume(volumeName).getBucket(bucketName),
+        "ratis", ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+            ReplicationFactor.ONE), "ratis".getBytes(UTF_8));
 
     // get the name of a valid container.
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName).

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -39,6 +38,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -111,22 +110,16 @@ public class TestHybridPipelineOnDatanode {
     String keyName1 = UUID.randomUUID().toString();
 
     // Write data into a key
-    OzoneOutputStream out = bucket
-        .createKey(keyName1, data.length,
-            ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                ReplicationFactor.ONE), new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName1,
+        ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+            ReplicationFactor.ONE), value.getBytes(UTF_8));
 
     String keyName2 = UUID.randomUUID().toString();
 
     // Write data into a key
-    out = bucket
-        .createKey(keyName2, data.length,
-            ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                ReplicationFactor.THREE), new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName2,
+        ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+            ReplicationFactor.THREE), value.getBytes(UTF_8));
 
     // We need to find the location of the chunk file corresponding to the
     // data we just wrote.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -86,6 +86,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.ClientConfigForTesting;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -298,22 +299,19 @@ class TestOzoneAtRestEncryption {
     Instant testStartTime = getTestStartTime();
     String keyName = UUID.randomUUID().toString();
     String value = "sample value";
-    try (OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(StandardCharsets.UTF_8).length,
+
+    TestDataUtil.createKey(bucket, keyName,
         ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-        new HashMap<>())) {
-      out.write(value.getBytes(StandardCharsets.UTF_8));
-    }
+        value.getBytes(StandardCharsets.UTF_8));
+
     verifyKeyData(bucket, keyName, value, testStartTime);
     OzoneKeyDetails key1 = bucket.getKey(keyName);
 
     // Overwrite the key
-    try (OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(StandardCharsets.UTF_8).length,
+    TestDataUtil.createKey(bucket, keyName,
         ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-        new HashMap<>())) {
-      out.write(value.getBytes(StandardCharsets.UTF_8));
-    }
+        value.getBytes(StandardCharsets.UTF_8));
+
     OzoneKeyDetails key2 = bucket.getKey(keyName);
     assertNotEquals(key1.getFileEncryptionInfo().toString(), key2.getFileEncryptionInfo().toString());
   }
@@ -429,12 +427,9 @@ class TestOzoneAtRestEncryption {
     String keyName = UUID.randomUUID().toString();
     Map<String, String> keyMetadata = new HashMap<>();
     keyMetadata.put(OzoneConsts.GDPR_FLAG, "true");
-    try (OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(StandardCharsets.UTF_8).length,
+    TestDataUtil.createKey(bucket, keyName,
         ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-        keyMetadata)) {
-      out.write(value.getBytes(StandardCharsets.UTF_8));
-    }
+        value.getBytes(StandardCharsets.UTF_8));
 
     OzoneKeyDetails key = bucket.getKey(keyName);
     assertEquals(keyName, key.getName());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -427,9 +427,12 @@ class TestOzoneAtRestEncryption {
     String keyName = UUID.randomUUID().toString();
     Map<String, String> keyMetadata = new HashMap<>();
     keyMetadata.put(OzoneConsts.GDPR_FLAG, "true");
-    TestDataUtil.createKey(bucket, keyName,
+    try (OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes(StandardCharsets.UTF_8).length,
         ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-        value.getBytes(StandardCharsets.UTF_8));
+        keyMetadata)) {
+      out.write(value.getBytes(StandardCharsets.UTF_8));
+    }
 
     OzoneKeyDetails key = bucket.getKey(keyName);
     assertEquals(keyName, key.getName());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -25,8 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
@@ -34,6 +32,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -105,10 +104,7 @@ public abstract class TestOzoneRpcClientWithKeyLatestVersion implements NonHATes
 
   private static void writeKey(OzoneBucket bucket, String key, byte[] content,
       ReplicationConfig replication) throws IOException {
-    try (OutputStream out = bucket.createKey(key, content.length, replication,
-        new HashMap<>())) {
-      out.write(content);
-    }
+    TestDataUtil.createKey(bucket, key, replication, content);
   }
 
   public static void assertKeyContent(OzoneBucket bucket, String key,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -25,8 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomUtils;
@@ -39,6 +37,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -81,10 +80,8 @@ class TestReadRetries {
 
         String keyName = "a/b/c/" + UUID.randomUUID();
         byte[] content = RandomUtils.nextBytes(128);
-        try (OutputStream out = bucket.createKey(keyName, content.length,
-            RatisReplicationConfig.getInstance(THREE), new HashMap<>())) {
-          out.write(content);
-        }
+        TestDataUtil.createKey(bucket, keyName,
+            RatisReplicationConfig.getInstance(THREE), content);
 
         // First, confirm the key info from the client matches the info in OM.
         OmKeyArgs keyArgs = new OmKeyArgs.Builder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKey;
@@ -159,10 +160,7 @@ class TestSecureOzoneRpcClient extends OzoneRpcClientTests {
       String keyName = UUID.randomUUID().toString();
 
       long committedBytes = ozoneManager.getMetrics().getDataCommittedBytes();
-      try (OzoneOutputStream out = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, replication, new HashMap<>())) {
-        out.write(value.getBytes(UTF_8));
-      }
+      TestDataUtil.createKey(bucket, keyName, replication, value.getBytes(UTF_8));
 
       assertEquals(committedBytes + value.getBytes(UTF_8).length,
           ozoneManager.getMetrics().getDataCommittedBytes());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType.KeyValueContainer;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_EC_IMPL_KEY;
@@ -40,11 +39,9 @@ import static org.mockito.Mockito.any;
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +66,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.Repli
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -193,10 +191,8 @@ class TestContainerReplication {
 
     OzoneBucket bucket = volume.getBucket(BUCKET);
 
-    try (OutputStream out = bucket.createKey(KEY, 0,
-        RatisReplicationConfig.getInstance(THREE), emptyMap())) {
-      out.write("Hello".getBytes(UTF_8));
-    }
+    TestDataUtil.createKey(bucket, KEY,
+        RatisReplicationConfig.getInstance(THREE), "Hello".getBytes(UTF_8));
   }
 
   private byte[] createTestData(OzoneClient client, int size) throws IOException {
@@ -205,13 +201,12 @@ class TestContainerReplication {
     OzoneVolume volume = objectStore.getVolume(VOLUME);
     volume.createBucket(BUCKET);
     OzoneBucket bucket = volume.getBucket(BUCKET);
-    try (OutputStream out = bucket.createKey(KEY, 0, new ECReplicationConfig("RS-3-2-1k"),
-        new HashMap<>())) {
-      byte[] b = new byte[size];
-      b = RandomUtils.secure().randomBytes(b.length);
-      out.write(b);
-      return b;
-    }
+
+    byte[] b = new byte[size];
+    b = RandomUtils.secure().randomBytes(b.length);
+    TestDataUtil.createKey(bucket, KEY,
+        new ECReplicationConfig("RS-3-2-1k"), b);
+    return b;
   }
 
   private static List<OmKeyLocationInfo> lookupKey(MiniOzoneCluster cluster)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -192,7 +192,8 @@ class TestContainerReplication {
     OzoneBucket bucket = volume.getBucket(BUCKET);
 
     TestDataUtil.createKey(bucket, KEY,
-        RatisReplicationConfig.getInstance(THREE), "Hello".getBytes(UTF_8));
+        RatisReplicationConfig.getInstance(THREE),
+        "Hello".getBytes(UTF_8));
   }
 
   private byte[] createTestData(OzoneClient client, int size) throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -43,6 +41,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -151,10 +150,8 @@ public class TestContainerReportHandling {
 
     OzoneBucket bucket = volume.getBucket(BUCKET);
 
-    try (OutputStream out = bucket.createKey(KEY, 0,
-        RatisReplicationConfig.getInstance(THREE), emptyMap())) {
-      out.write("Hello".getBytes(UTF_8));
-    }
+    TestDataUtil.createKey(bucket, KEY,
+        RatisReplicationConfig.getInstance(THREE), "Hello".getBytes(UTF_8));
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -46,6 +44,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -156,10 +155,8 @@ public class TestContainerReportHandlingWithHA {
 
     OzoneBucket bucket = volume.getBucket(BUCKET);
 
-    try (OutputStream out = bucket.createKey(KEY, 0,
-        RatisReplicationConfig.getInstance(THREE), emptyMap())) {
-      out.write("Hello".getBytes(UTF_8));
-    }
+    TestDataUtil.createKey(bucket, KEY,
+        RatisReplicationConfig.getInstance(THREE), "Hello".getBytes(UTF_8));
   }
 
   private static void waitForContainerStateInAllSCMs(MiniOzoneHAClusterImpl cluster, ContainerID containerID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.dn.volume;
 
-import static java.util.Collections.emptyMap;
 import static org.apache.commons.io.IOUtils.readFully;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
@@ -31,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -282,10 +280,7 @@ class TestDatanodeHddsVolumeFailureDetection {
     byte[] bytes = RandomUtils.nextBytes(KEY_SIZE);
     RatisReplicationConfig replication =
         RatisReplicationConfig.getInstance(ReplicationFactor.ONE);
-    try (OutputStream out = bucket.createKey(key, bytes.length, replication,
-        emptyMap())) {
-      out.write(bytes);
-    }
+    TestDataUtil.createKey(bucket, key, replication, bytes);
     OzoneKeyDetails keyDetails = bucket.getKey(key);
     assertEquals(key, keyDetails.getName());
     return keyDetails.getOzoneKeyLocations().get(0).getContainerID();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
@@ -18,13 +18,11 @@
 package org.apache.hadoop.ozone.om;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -79,9 +80,7 @@ public final class TestBucket {
 
   public void writeKey(String key, ReplicationConfig repConfig,
       byte[] inputData) throws IOException {
-    try (OutputStream out = bucket.createKey(key, 0, repConfig, emptyMap())) {
-      out.write(inputData);
-    }
+    TestDataUtil.createKey(bucket, key, repConfig, inputData);
   }
 
   public byte[] writeRandomBytes(String keyName, int dataLength)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.recon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
@@ -38,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -419,10 +417,7 @@ class TestReconAndAdminContainerCLI {
       ReplicationConfig replicationConfig)
       throws IOException {
     byte[] textBytes = "Testing".getBytes(UTF_8);
-    try (OutputStream out = ozoneBucket.createKey(keyName,
-        textBytes.length, replicationConfig, emptyMap())) {
-      out.write(textBytes);
-    }
+    TestDataUtil.createKey(ozoneBucket, keyName, replicationConfig, textBytes);
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
                             .setVolumeName(ozoneBucket.getVolumeName())


### PR DESCRIPTION
## What changes were proposed in this pull request?
In many tests, we just want to create a key in the bucket, we can reuse `TestDataUtil.createKey()` in these tests. BTW, to avoid huge patch, the replacement of `OzoneRpcClientTests` would be done in another PR.

## What is the link to the Apache JIRA
[HDDS-12524](https://issues.apache.org/jira/browse/HDDS-12524)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14418469711