### PR TITLE
HDDS-12827. Move out NodeStateMap.Entry and ContainerMap.Entry.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerEntry.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerEntry.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.states;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+
+/**
+ * The entry ({@link ContainerInfo} and {@link ContainerReplica}s)
+ * for a container in {@link ContainerStateMap}.
+ */
+public class ContainerEntry {
+  private final ContainerInfo info;
+  private final Map<DatanodeID, ContainerReplica> replicas = new HashMap<>();
+
+  ContainerEntry(ContainerInfo info) {
+    this.info = info;
+  }
+
+  public ContainerInfo getInfo() {
+    return info;
+  }
+
+  public Set<ContainerReplica> getReplicas() {
+    return new HashSet<>(replicas.values());
+  }
+
+  public ContainerReplica put(ContainerReplica r) {
+    return replicas.put(r.getDatanodeDetails().getID(), r);
+  }
+
+  public ContainerReplica removeReplica(DatanodeID datanodeID) {
+    return replicas.remove(datanodeID);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -17,10 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.container.states;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
@@ -78,43 +75,18 @@ public class ContainerStateMap {
 
   /**
    * Two levels map.
-   * Outer container map: {@link ContainerID} -> {@link Entry} (info and replicas)
+   * Outer container map: {@link ContainerID} -> {@link ContainerEntry} (info and replicas)
    * Inner replica map: {@link DatanodeID} -> {@link ContainerReplica}
    */
   private static class ContainerMap {
-    private static class Entry {
-      private final ContainerInfo info;
-      private final Map<DatanodeID, ContainerReplica> replicas = new HashMap<>();
-
-      Entry(ContainerInfo info) {
-        this.info = info;
-      }
-
-      ContainerInfo getInfo() {
-        return info;
-      }
-
-      Set<ContainerReplica> getReplicas() {
-        return new HashSet<>(replicas.values());
-      }
-
-      ContainerReplica put(ContainerReplica r) {
-        return replicas.put(r.getDatanodeDetails().getID(), r);
-      }
-
-      ContainerReplica removeReplica(DatanodeID datanodeID) {
-        return replicas.remove(datanodeID);
-      }
-    }
-
-    private final NavigableMap<ContainerID, Entry> map = new TreeMap<>();
+    private final NavigableMap<ContainerID, ContainerEntry> map = new TreeMap<>();
 
     boolean contains(ContainerID id) {
       return map.containsKey(id);
     }
 
     ContainerInfo getInfo(ContainerID id) {
-      final Entry entry = map.get(id);
+      final ContainerEntry entry = map.get(id);
       return entry == null ? null : entry.getInfo();
     }
 
@@ -122,14 +94,14 @@ public class ContainerStateMap {
       Objects.requireNonNull(start, "start == null");
       Preconditions.assertTrue(count >= 0, "count < 0");
       return map.tailMap(start).values().stream()
-          .map(Entry::getInfo)
+          .map(ContainerEntry::getInfo)
           .limit(count)
           .collect(Collectors.toList());
     }
 
     Set<ContainerReplica> getReplicas(ContainerID id) {
       Objects.requireNonNull(id, "id == null");
-      final Entry entry = map.get(id);
+      final ContainerEntry entry = map.get(id);
       return entry == null ? null : entry.getReplicas();
     }
 
@@ -144,27 +116,27 @@ public class ContainerStateMap {
       if (map.containsKey(id)) {
         return false; // already exist
       }
-      final Entry previous = map.put(id, new Entry(info));
+      final ContainerEntry previous = map.put(id, new ContainerEntry(info));
       Preconditions.assertNull(previous, "previous");
       return true;
     }
 
     ContainerReplica put(ContainerReplica replica) {
       Objects.requireNonNull(replica, "replica == null");
-      final Entry entry = map.get(replica.getContainerID());
+      final ContainerEntry entry = map.get(replica.getContainerID());
       return entry == null ? null : entry.put(replica);
     }
 
     ContainerInfo remove(ContainerID id) {
       Objects.requireNonNull(id, "id == null");
-      final Entry removed = map.remove(id);
+      final ContainerEntry removed = map.remove(id);
       return removed == null ? null : removed.getInfo();
     }
 
     ContainerReplica removeReplica(ContainerID containerID, DatanodeID datanodeID) {
       Objects.requireNonNull(containerID, "containerID == null");
       Objects.requireNonNull(datanodeID, "datanodeID == null");
-      final Entry entry = map.get(containerID);
+      final ContainerEntry entry = map.get(containerID);
       return entry == null ? null : entry.removeReplica(datanodeID);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/DatanodeEntry.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/DatanodeEntry.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.node.states;
+
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+
+/**
+ * The entry ({@link DatanodeInfo} and {@link ContainerID}s)
+ * for a datanode in {@link NodeStateMap}.
+ */
+public class DatanodeEntry {
+  private final DatanodeInfo info;
+  private final Set<ContainerID> containers = new TreeSet<>();
+
+  DatanodeEntry(DatanodeInfo info) {
+    this.info = info;
+  }
+
+  public DatanodeInfo getInfo() {
+    return info;
+  }
+
+  public int getContainerCount() {
+    return containers.size();
+  }
+
+  public Set<ContainerID> copyContainers() {
+    return new TreeSet<>(containers);
+  }
+
+  public void add(ContainerID containerId) {
+    containers.add(containerId);
+  }
+
+  public void remove(ContainerID containerID) {
+    containers.remove(containerID);
+  }
+
+  public void setContainersForTesting(Set<ContainerID> newContainers) {
+    containers.clear();
+    containers.addAll(newContainers);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This code refactoring is for [HDDS-12826](https://issues.apache.org/jira/browse/HDDS-12826).  When processing an IncrementalContainerReport, it should obtain NodeStateMap.Entry and ContainerMap.Entry in order to avoid multiple lookups.

## What is the link to the Apache JIRA

HDDS-12827

## How was this patch tested?

By existing tests.