### PR TITLE
HDDS-12845. Reuse TestDataUtil.createKey in OzoneRpcClientTests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -1922,9 +1922,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
                         int valueLength, Map<String, String> customMetadata,
                         Map<String, String> tags)
       throws IOException {
-    TestDataUtil.createKey(bucket, keyName,
-        ReplicationConfig.
-            fromTypeAndFactor(RATIS, replication), value.getBytes(UTF_8));
+    OzoneOutputStream out = bucket.createKey(keyName, valueLength,
+        ReplicationConfig.fromTypeAndFactor(RATIS, replication), customMetadata, tags);
+    out.write(value.getBytes(UTF_8));
+    out.close();
   }
 
   private void writeFile(OzoneBucket bucket, String keyName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -1184,10 +1184,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     ReplicationConfig replicationConfig =
             new ECReplicationConfig(replicationValue);
     if (isValidReplicationConfig) {
-      OzoneOutputStream out = bucket.createKey(keyName,
-              value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
-      out.write(value.getBytes(UTF_8));
-      out.close();
+      TestDataUtil.createKey(bucket, keyName,
+          replicationConfig, value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -1217,11 +1215,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
 
-      OzoneOutputStream out = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, RATIS,
-          ONE, new HashMap<>());
-      out.write(value.getBytes(UTF_8));
-      out.close();
+      TestDataUtil.createKey(bucket, keyName,
+          ReplicationConfig.
+              fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -1926,10 +1922,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
                         int valueLength, Map<String, String> customMetadata,
                         Map<String, String> tags)
       throws IOException {
-    OzoneOutputStream out = bucket.createKey(keyName, valueLength,
-        ReplicationConfig.fromTypeAndFactor(RATIS, replication), customMetadata, tags);
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.
+            fromTypeAndFactor(RATIS, replication), value.getBytes(UTF_8));
   }
 
   private void writeFile(OzoneBucket bucket, String keyName,
@@ -1995,10 +1990,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyName = UUID.randomUUID().toString();
 
     // create the initial key with size 0, write will allocate the first block.
-    OzoneOutputStream out = bucket.createKey(keyName, 0,
-        RATIS, ONE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        value.getBytes(UTF_8));
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
         .setKeyName(keyName);
@@ -2030,11 +2024,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
 
-      OzoneOutputStream out = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, ReplicationType.RATIS,
-          ONE, new HashMap<>());
-      out.write(value.getBytes(UTF_8));
-      out.close();
+      TestDataUtil.createKey(bucket, keyName, ReplicationConfig.
+          fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2065,11 +2056,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
 
-      OzoneOutputStream out = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, ReplicationType.RATIS,
-          THREE, new HashMap<>());
-      out.write(value.getBytes(UTF_8));
-      out.close();
+      TestDataUtil.createKey(bucket, keyName, value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2107,11 +2094,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           String keyName = UUID.randomUUID().toString();
           String data = Arrays.toString(generateData(5 * 1024 * 1024,
               (byte) RandomUtils.nextLong()));
-          OzoneOutputStream out = bucket.createKey(keyName,
-              data.getBytes(UTF_8).length, ReplicationType.RATIS,
-              THREE, new HashMap<>());
-          out.write(data.getBytes(UTF_8));
-          out.close();
+          TestDataUtil.createKey(bucket, keyName, data.getBytes(UTF_8));
           OzoneKey key = bucket.getKey(keyName);
           assertEquals(keyName, key.getName());
           try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2185,11 +2168,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneBucket bucket = volume.getBucket(bucketName);
 
     // Write data into a key
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        ONE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
 
     // We need to find the location of the chunk file corresponding to the
     // data we just wrote.
@@ -2247,11 +2227,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyValue = RandomStringUtils.random(128);
     //String keyValue = "this is a test value.glx";
     // create the initial key with size 0, write will allocate the first block.
-    OzoneOutputStream out = bucket.createKey(keyName,
-        keyValue.getBytes(UTF_8).length, RATIS,
-        ONE, new HashMap<>());
-    out.write(keyValue.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.
+            fromTypeAndFactor(RATIS, ONE), keyValue.getBytes(UTF_8));
 
     // First, confirm the key info from the client matches the info in OM.
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
@@ -2342,11 +2320,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyName = UUID.randomUUID().toString();
 
     // Write data into a key
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        ONE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        value.getBytes(UTF_8));
 
     // We need to find the location of the chunk file corresponding to the
     // data we just wrote.
@@ -2393,20 +2369,14 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyName1 = UUID.randomUUID().toString();
 
     // Write first key
-    OzoneOutputStream out = bucket.createKey(keyName1,
-        value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        THREE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName1, ReplicationConfig.
+        fromTypeAndFactor(RATIS, THREE), value.getBytes(UTF_8));
 
     // Write second key
     String keyName2 = UUID.randomUUID().toString();
     value = "unhealthy container replica";
-    out = bucket.createKey(keyName2,
-        value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        THREE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName2, ReplicationConfig.
+        fromTypeAndFactor(RATIS, THREE), value.getBytes(UTF_8));
 
     // Find container ID
     OzoneKey key = bucket.getKey(keyName2);
@@ -2491,11 +2461,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyName = UUID.randomUUID().toString();
 
     // Write data into a key
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        THREE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, THREE), value.getBytes(UTF_8));
 
     // We need to find the location of the chunk file corresponding to the
     // data we just wrote.
@@ -2560,11 +2527,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, RATIS,
-        ONE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName, ReplicationConfig.
+        fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
     OzoneKey key = bucket.getKey(keyName);
     assertEquals(keyName, key.getName());
     bucket.deleteKey(keyName);
@@ -2853,30 +2817,20 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyBaseA = "key-a-";
     for (int i = 0; i < 10; i++) {
       byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-      OzoneOutputStream one = volAbucketA.createKey(
+      TestDataUtil.createKey(volAbucketA,
           keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      one.write(value);
-      one.close();
-      OzoneOutputStream two = volAbucketB.createKey(
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
+      TestDataUtil.createKey(volAbucketB,
           keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      two.write(value);
-      two.close();
-      OzoneOutputStream three = volBbucketA.createKey(
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
+      TestDataUtil.createKey(volBbucketA,
           keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      three.write(value);
-      three.close();
-      OzoneOutputStream four = volBbucketB.createKey(
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value);
+      TestDataUtil.createKey(volBbucketB,
           keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      four.write(value);
-      four.close();
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value);
     }
     /*
     Create 10 keys in  vol-a-<random>/buc-a-<random>,
@@ -2886,30 +2840,22 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyBaseB = "key-b-";
     for (int i = 0; i < 10; i++) {
       byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-      OzoneOutputStream one = volAbucketA.createKey(
+      TestDataUtil.createKey(volAbucketA,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      one.write(value);
-      one.close();
-      OzoneOutputStream two = volAbucketB.createKey(
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value);
+      TestDataUtil.createKey(volAbucketB,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      two.write(value);
-      two.close();
-      OzoneOutputStream three = volBbucketA.createKey(
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value);
+      TestDataUtil.createKey(volBbucketA,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      three.write(value);
-      three.close();
-      OzoneOutputStream four = volBbucketB.createKey(
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value);
+      TestDataUtil.createKey(volBbucketB,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      four.write(value);
-      four.close();
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value);
     }
     Iterator<? extends OzoneKey> volABucketAIter =
         volAbucketA.listKeys("key-");
@@ -3349,10 +3295,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneBucket bucket = volume.getBucket(bucketName);
     byte[] data = new byte[10];
     Arrays.fill(data, (byte) 1);
-    try (OzoneOutputStream out = bucket.createKey(keyName, 10,
-        ReplicationConfig.fromTypeAndFactor(RATIS, ONE), new HashMap<>())) {
-      out.write(data);
-    }
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        data);
     client = null;
     System.gc();
     GenericTestUtils.waitFor(() -> ozoneClientFactoryLogCapturer.getOutput()
@@ -4244,10 +4189,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   }
 
   private void writeKey(String key1, OzoneBucket bucket) throws IOException {
-    OzoneOutputStream out = bucket.createKey(key1, 1024, RATIS,
-        ONE, new HashMap<>());
-    out.write(RandomStringUtils.random(1024).getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, key1,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        RandomStringUtils.random(1024).getBytes(UTF_8));
   }
 
   private byte[] generateData(int size, byte val) {
@@ -4621,10 +4565,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
     String keyName = UUID.randomUUID().toString();
 
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        replicationConfig, value.getBytes(UTF_8));
 
     OzoneKey key = bucket.headObject(keyName);
     assertEquals(volumeName, key.getVolumeName());
@@ -4666,16 +4608,12 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         .setBucketLayout(BucketLayout.OBJECT_STORE).build());
     OzoneBucket bucket = volume.getBucket(bucketName);
 
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        replicationConfig, value.getBytes(UTF_8));
 
     // Override key
-    out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        replicationConfig, value.getBytes(UTF_8));
   }
 
   private void checkExceptedResultForVersioningTest(String volumeName,
@@ -4896,11 +4834,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyName = UUID.randomUUID().toString();
 
     // Write data into a key
-    try (OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, ReplicationConfig.fromTypeAndFactor(
-            ReplicationType.RATIS, THREE), new HashMap<>())) {
-      out.write(value.getBytes(UTF_8));
-    }
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
+        value.getBytes(UTF_8));
 
     // Since the rpc client is outside of cluster, then getFirstNode should be
     // equal to getClosestNode.
@@ -5181,10 +5117,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
     String keyName = UUID.randomUUID().toString();
 
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, anyReplication(), new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+    TestDataUtil.createKey(bucket, keyName,
+        anyReplication(), value.getBytes(UTF_8));
 
     OzoneKey key = bucket.getKey(keyName);
     assertTrue(key.getTags().isEmpty());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -1216,8 +1216,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       String keyName = UUID.randomUUID().toString();
 
       TestDataUtil.createKey(bucket, keyName,
-          ReplicationConfig.
-              fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2025,8 +2025,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
 
-      TestDataUtil.createKey(bucket, keyName, ReplicationConfig.
-          fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
+      TestDataUtil.createKey(bucket, keyName,
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+          value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2057,7 +2058,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
 
-      TestDataUtil.createKey(bucket, keyName, value.getBytes(UTF_8));
+      TestDataUtil.createKey(bucket, keyName,
+          ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
+          value.getBytes(UTF_8));
       OzoneKey key = bucket.getKey(keyName);
       assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2095,7 +2098,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           String keyName = UUID.randomUUID().toString();
           String data = Arrays.toString(generateData(5 * 1024 * 1024,
               (byte) RandomUtils.nextLong()));
-          TestDataUtil.createKey(bucket, keyName, data.getBytes(UTF_8));
+          TestDataUtil.createKey(bucket, keyName,
+              ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
+              data.getBytes(UTF_8));
           OzoneKey key = bucket.getKey(keyName);
           assertEquals(keyName, key.getName());
           try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -2170,7 +2175,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
     // Write data into a key
     TestDataUtil.createKey(bucket, keyName,
-        ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        value.getBytes(UTF_8));
 
     // We need to find the location of the chunk file corresponding to the
     // data we just wrote.
@@ -2229,8 +2235,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     //String keyValue = "this is a test value.glx";
     // create the initial key with size 0, write will allocate the first block.
     TestDataUtil.createKey(bucket, keyName,
-        ReplicationConfig.
-            fromTypeAndFactor(RATIS, ONE), keyValue.getBytes(UTF_8));
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        keyValue.getBytes(UTF_8));
 
     // First, confirm the key info from the client matches the info in OM.
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
@@ -2370,14 +2376,16 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String keyName1 = UUID.randomUUID().toString();
 
     // Write first key
-    TestDataUtil.createKey(bucket, keyName1, ReplicationConfig.
-        fromTypeAndFactor(RATIS, THREE), value.getBytes(UTF_8));
+    TestDataUtil.createKey(bucket, keyName1,
+        ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
+        value.getBytes(UTF_8));
 
     // Write second key
     String keyName2 = UUID.randomUUID().toString();
     value = "unhealthy container replica";
-    TestDataUtil.createKey(bucket, keyName2, ReplicationConfig.
-        fromTypeAndFactor(RATIS, THREE), value.getBytes(UTF_8));
+    TestDataUtil.createKey(bucket, keyName2,
+        ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
+        value.getBytes(UTF_8));
 
     // Find container ID
     OzoneKey key = bucket.getKey(keyName2);
@@ -2463,7 +2471,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
     // Write data into a key
     TestDataUtil.createKey(bucket, keyName,
-        ReplicationConfig.fromTypeAndFactor(RATIS, THREE), value.getBytes(UTF_8));
+        ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
+        value.getBytes(UTF_8));
 
     // We need to find the location of the chunk file corresponding to the
     // data we just wrote.
@@ -2528,8 +2537,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    TestDataUtil.createKey(bucket, keyName, ReplicationConfig.
-        fromTypeAndFactor(RATIS, ONE), value.getBytes(UTF_8));
+    TestDataUtil.createKey(bucket, keyName,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        value.getBytes(UTF_8));
     OzoneKey key = bucket.getKey(keyName);
     assertEquals(keyName, key.getName());
     bucket.deleteKey(keyName);
@@ -2826,12 +2836,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketA,
           keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-          value);
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketB,
           keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-          value);
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
     }
     /*
     Create 10 keys in  vol-a-<random>/buc-a-<random>,
@@ -2843,20 +2851,16 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
       TestDataUtil.createKey(volAbucketA,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-          value);
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volAbucketB,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-          value);
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketA,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-          value);
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketB,
           keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-          value);
+          ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
     }
     Iterator<? extends OzoneKey> volABucketAIter =
         volAbucketA.listKeys("key-");


### PR DESCRIPTION
## What changes were proposed in this pull request?
Some of the `createkey()` in `OzoneRpcClientTests` can be replaced with `TestDataUtil.createKey()`. Please take a look, thanks!

## What is the link to the Apache JIRA
[HDDS-12845](https://issues.apache.org/jira/browse/HDDS-12845)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14428478602
