### PR TITLE
HDDS-12808. Implement OM entities of lifecycle configurations

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCAction.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+
+/**
+ * Abstract base class that encapsulates lifecycle rule actions.
+ * This class serves as a foundation for various action types in lifecycle
+ * configuration, such as Expiration and (in the future) Transition.
+ */
+public abstract class OmLCAction {
+
+  /**
+   * Validates the action configuration.
+   * Each concrete action implementation must define its own validation logic.
+   *
+   * @throws OMException if the validation fails
+   */
+  public abstract void valid() throws OMException;
+
+  /**
+   * Returns the action type.
+   *
+   * @return the type of this action
+   */
+  public abstract ActionType getActionType();
+
+  /**
+   * Enum defining supported action types.
+   */
+  public enum ActionType {
+    EXPIRATION,
+    // Future action types can be added here (e.g., TRANSITION)
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCAction.java
@@ -20,11 +20,11 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
 /**
- * Abstract base class that encapsulates lifecycle rule actions.
+ * Interface that encapsulates lifecycle rule actions.
  * This class serves as a foundation for various action types in lifecycle
  * configuration, such as Expiration and (in the future) Transition.
  */
-public abstract class OmLCAction {
+public interface OmLCAction {
 
   /**
    * Validates the action configuration.
@@ -32,19 +32,19 @@ public abstract class OmLCAction {
    *
    * @throws OMException if the validation fails
    */
-  public abstract void valid() throws OMException;
+  void valid() throws OMException;
 
   /**
    * Returns the action type.
    *
    * @return the type of this action
    */
-  public abstract ActionType getActionType();
+  ActionType getActionType();
 
   /**
    * Enum defining supported action types.
    */
-  public enum ActionType {
+  enum ActionType {
     EXPIRATION,
     // Future action types can be added here (e.g., TRANSITION)
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
@@ -21,6 +21,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import net.jcip.annotations.Immutable;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
 /**
@@ -28,30 +29,26 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
  * This class extends OmLCAction and represents the expiration
  * action type in lifecycle configuration.
  */
-public class OmLCExpiration implements OmLCAction {
+@Immutable
+public final class OmLCExpiration implements OmLCAction {
+  private final int days;
+  private final String date;
 
-  private int days;
-  private String date;
+  private OmLCExpiration() {
+    throw new UnsupportedOperationException("Default constructor is not supported. Use Builder.");
+  }
 
-  OmLCExpiration(int days, String date) {
-    this.days = days;
-    this.date = date;
+  private OmLCExpiration(Builder builder) {
+    this.days = builder.days;
+    this.date = builder.date;
   }
 
   public int getDays() {
     return days;
   }
 
-  public void setDays(int days) {
-    this.days = days;
-  }
-
   public String getDate() {
     return date;
-  }
-
-  public void setDate(String date) {
-    this.date = date;
   }
 
   @Override
@@ -134,7 +131,7 @@ public class OmLCExpiration implements OmLCAction {
     }
 
     public OmLCExpiration build() {
-      return new OmLCExpiration(days, date);
+      return new OmLCExpiration(this);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+
+/**
+ * A class that encapsulates lifecycle rule expiration action.
+ * This class extends OmLCAction and represents the expiration
+ * action type in lifecycle configuration.
+ */
+public class OmLCExpiration extends OmLCAction {
+
+  private int days;
+  private String date;
+
+  OmLCExpiration(int days, String date) {
+    this.days = days;
+    this.date = date;
+  }
+
+  public int getDays() {
+    return days;
+  }
+
+  public void setDays(int days) {
+    this.days = days;
+  }
+
+  public String getDate() {
+    return date;
+  }
+
+  public void setDate(String date) {
+    this.date = date;
+  }
+
+  @Override
+  public ActionType getActionType() {
+    return ActionType.EXPIRATION;
+  }
+
+  /**
+   * Validates the expiration configuration.
+   * - Days must be a positive number greater than zero
+   * - Either days or date should be specified, but not both or neither
+   * - The date value must conform to the ISO 8601 format
+   * - The date value must be in the future
+   * - The date value must be at midnight UTC (00:00:00Z)
+   *
+   * @throws OMException if the validation fails
+   */
+  @Override
+  public void valid() throws OMException {
+    if (days <= 0 && days != 0) {
+      throw new OMException("'Days' for Expiration action must be a positive integer.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    boolean hasDays = days > 0;
+    boolean hasDate = date != null && !date.isEmpty();
+
+    if (hasDays == hasDate) {
+      throw new OMException("Invalid lifecycle configuration: Either 'days' or 'date' " +
+          "should be specified, but not both or neither.", OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    // The date value must conform to the ISO 8601 format, be in the future, and be at midnight UTC
+    if (hasDate) {
+      try {
+        ZonedDateTime parsedDate = ZonedDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME);
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+        if (parsedDate.isBefore(now)) {
+          throw new OMException("Invalid lifecycle configuration: 'Date' must be in the future",
+              OMException.ResultCodes.INVALID_REQUEST);
+        }
+
+        // Verify that the time is midnight UTC (00:00:00Z)
+        if (parsedDate.getHour() != 0 || parsedDate.getMinute() != 0 || parsedDate.getSecond() != 0
+            || parsedDate.getNano() != 0 || !parsedDate.getZone().equals(ZoneOffset.UTC)) {
+          throw new OMException("Invalid lifecycle configuration: 'Date' must be at midnight GMT",
+              OMException.ResultCodes.INVALID_REQUEST);
+        }
+      } catch (DateTimeParseException ex) {
+        throw new OMException("Invalid lifecycle configuration: 'Date' must be in ISO 8601 format",
+            OMException.ResultCodes.INVALID_REQUEST);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "OmLCExpiration{" +
+        "days=" + days +
+        ", date='" + date + '\'' +
+        '}';
+  }
+
+  /**
+   * Builder of OmLCExpiration.
+   */
+  public static class Builder {
+    private int days;
+    private String date = "";
+
+    public Builder setDays(int lcDays) {
+      this.days = lcDays;
+      return this;
+    }
+
+    public Builder setDate(String lcDate) {
+      this.date = lcDate;
+      return this;
+    }
+
+    public OmLCExpiration build() {
+      return new OmLCExpiration(days, date);
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
@@ -130,8 +130,10 @@ public final class OmLCExpiration implements OmLCAction {
       return this;
     }
 
-    public OmLCExpiration build() {
-      return new OmLCExpiration(this);
+    public OmLCExpiration build() throws OMException {
+      OmLCExpiration omLCExpiration = new OmLCExpiration(this);
+      omLCExpiration.valid();
+      return omLCExpiration;
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
  * This class extends OmLCAction and represents the expiration
  * action type in lifecycle configuration.
  */
-public class OmLCExpiration extends OmLCAction {
+public class OmLCExpiration implements OmLCAction {
 
   private int days;
   private String date;
@@ -71,7 +71,7 @@ public class OmLCExpiration extends OmLCAction {
    */
   @Override
   public void valid() throws OMException {
-    if (days <= 0 && days != 0) {
+    if (days < 0) {
       throw new OMException("'Days' for Expiration action must be a positive integer.",
           OMException.ResultCodes.INVALID_REQUEST);
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
@@ -118,8 +118,10 @@ public final class OmLCFilter {
       return this;
     }
 
-    public OmLCFilter build() {
-      return new OmLCFilter(this);
+    public OmLCFilter build() throws OMException {
+      OmLCFilter omLCFilter = new OmLCFilter(this);
+      omLCFilter.valid();
+      return omLCFilter;
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+
+/**
+ * A class that encapsulates lifecycle rule filter.
+ * At the moment only prefix is supported in filter.
+ */
+public final class OmLCFilter {
+
+  private final String prefix;
+  private final Pair<String, String> tag;
+  private final OmLifecycleRuleAndOperator andOperator;
+
+  public OmLifecycleRuleAndOperator getAndOperator() {
+    return andOperator;
+  }
+
+  private OmLCFilter(String prefix, Pair<String, String> tag,
+      OmLifecycleRuleAndOperator andOperator) {
+    this.prefix = prefix;
+    this.andOperator = andOperator;
+    this.tag = tag;
+  }
+
+  /**
+   * Validates the OmLCFilter.
+   * Ensures that only one of prefix, tag, or andOperator is set.
+   * If the validation fails, an OMException is thrown.
+   *
+   * @throws OMException if the filter is invalid.
+   */
+  public void valid() throws OMException {
+    boolean hasPrefix = prefix != null;
+    boolean hasTag = tag != null;
+    boolean hasAndOperator = andOperator != null;
+
+    if ((hasPrefix && (hasTag || hasAndOperator)) || (hasTag && hasAndOperator)) {
+      throw new OMException("Invalid lifecycle filter configuration: Only one of 'Prefix'," +
+          " 'Tag', or 'AndOperator' should be specified.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (andOperator != null) {
+      andOperator.valid();
+    }
+  }
+
+  @Nullable
+  public String getPrefix() {
+    return prefix;
+  }
+
+  @Nullable
+  public Pair<String, String> getTag() {
+    return tag;
+  }
+
+  @Override
+  public String toString() {
+    return "OmLCFilter{" +
+        "prefix='" + prefix + '\'' +
+        ", tag=" + tag +
+        ", andOperator=" + andOperator +
+        '}';
+  }
+
+  /**
+   * Builder of OmLCFilter.
+   */
+  public static class Builder {
+    private String prefix = null;
+    private Pair<String, String> tag = null;
+    private OmLifecycleRuleAndOperator andOperator = null;
+
+    public Builder setAndOperator(OmLifecycleRuleAndOperator andOp) {
+      this.andOperator = andOp;
+      return this;
+    }
+
+    public Builder setPrefix(String lcPrefix) {
+      this.prefix = lcPrefix;
+      return this;
+    }
+
+    public Builder setTag(String key, String value) {
+      this.tag = Pair.of(key, value);
+      return this;
+    }
+
+    public OmLCFilter build() {
+      return new OmLCFilter(prefix, tag, andOperator);
+    }
+  }
+
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import jakarta.annotation.Nullable;
+import net.jcip.annotations.Immutable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
@@ -26,21 +27,23 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
  * A class that encapsulates lifecycle rule filter.
  * At the moment only prefix is supported in filter.
  */
+@Immutable
 public final class OmLCFilter {
 
   private final String prefix;
-  private final Pair<String, String> tag;
+  private final String tagKey;
+  private final String tagValue;
   private final OmLifecycleRuleAndOperator andOperator;
 
-  public OmLifecycleRuleAndOperator getAndOperator() {
-    return andOperator;
+  private OmLCFilter() {
+    throw new UnsupportedOperationException("Default constructor is not supported. Use Builder.");
   }
 
-  private OmLCFilter(String prefix, Pair<String, String> tag,
-      OmLifecycleRuleAndOperator andOperator) {
-    this.prefix = prefix;
-    this.andOperator = andOperator;
-    this.tag = tag;
+  private OmLCFilter(Builder builder) {
+    this.prefix = builder.prefix;
+    this.andOperator = builder.andOperator;
+    this.tagKey = builder.tagKey;
+    this.tagValue = builder.tagValue;
   }
 
   /**
@@ -52,7 +55,7 @@ public final class OmLCFilter {
    */
   public void valid() throws OMException {
     boolean hasPrefix = prefix != null;
-    boolean hasTag = tag != null;
+    boolean hasTag = tagKey != null && tagValue != null;
     boolean hasAndOperator = andOperator != null;
 
     if ((hasPrefix && (hasTag || hasAndOperator)) || (hasTag && hasAndOperator)) {
@@ -66,6 +69,10 @@ public final class OmLCFilter {
     }
   }
 
+  public OmLifecycleRuleAndOperator getAndOperator() {
+    return andOperator;
+  }
+
   @Nullable
   public String getPrefix() {
     return prefix;
@@ -73,14 +80,15 @@ public final class OmLCFilter {
 
   @Nullable
   public Pair<String, String> getTag() {
-    return tag;
+    return Pair.of(tagKey, tagValue);
   }
 
   @Override
   public String toString() {
     return "OmLCFilter{" +
         "prefix='" + prefix + '\'' +
-        ", tag=" + tag +
+        ", tagKey='" + tagKey + '\'' +
+        ", tagValue='" + tagValue + '\'' +
         ", andOperator=" + andOperator +
         '}';
   }
@@ -90,13 +98,9 @@ public final class OmLCFilter {
    */
   public static class Builder {
     private String prefix = null;
-    private Pair<String, String> tag = null;
+    private String tagKey = null;
+    private String tagValue = null;
     private OmLifecycleRuleAndOperator andOperator = null;
-
-    public Builder setAndOperator(OmLifecycleRuleAndOperator andOp) {
-      this.andOperator = andOp;
-      return this;
-    }
 
     public Builder setPrefix(String lcPrefix) {
       this.prefix = lcPrefix;
@@ -104,12 +108,18 @@ public final class OmLCFilter {
     }
 
     public Builder setTag(String key, String value) {
-      this.tag = Pair.of(key, value);
+      this.tagKey = key;
+      this.tagValue = value;
+      return this;
+    }
+
+    public Builder setAndOperator(OmLifecycleRuleAndOperator andOp) {
+      this.andOperator = andOp;
       return this;
     }
 
     public OmLCFilter build() {
-      return new OmLCFilter(prefix, tag, andOperator);
+      return new OmLCFilter(this);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
@@ -49,6 +49,8 @@ public final class OmLCFilter {
   /**
    * Validates the OmLCFilter.
    * Ensures that only one of prefix, tag, or andOperator is set.
+   * You can specify an empty filter, in which case the rule applies to all objects in the bucket.
+   * Ref: <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-filters.html#filter-examples">...</a>
    * If the validation fails, an OMException is thrown.
    *
    * @throws OMException if the filter is invalid.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCFilter.java
@@ -50,6 +50,7 @@ public final class OmLCFilter {
    * Validates the OmLCFilter.
    * Ensures that only one of prefix, tag, or andOperator is set.
    * You can specify an empty filter, in which case the rule applies to all objects in the bucket.
+   * Prefix can be "", in which case the rule applies to all objects in the bucket.
    * Ref: <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-filters.html#filter-examples">...</a>
    * If the validation fails, an OMException is thrown.
    *

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+
+/**
+ * A class that encapsulates lifecycle rule.
+ */
+public class OmLCRule {
+
+  public static final int LC_ID_LENGTH = 48;
+  // Ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html#intro-lifecycle-rule-id
+  public static final int LC_ID_MAX_LENGTH = 255;
+
+  private String id;
+  private String prefix;
+  private boolean enabled;
+  private boolean isPrefixEnable;
+  private boolean isTagEnable;
+  // List of actions for this rule
+  private List<OmLCAction> actions;
+  private OmLCFilter filter;
+
+  OmLCRule(String id, String prefix, boolean enabled,
+      List<OmLCAction> actions, OmLCFilter filter) {
+    this.id = id;
+    this.prefix = prefix;
+    this.enabled = enabled;
+    this.actions = actions;
+    this.filter = filter;
+
+    if (StringUtils.isEmpty(this.id)) {
+      this.id = RandomStringUtils.randomAlphanumeric(LC_ID_LENGTH);
+    }
+
+    OmLifecycleRuleAndOperator andOperator = filter != null ? filter.getAndOperator() : null;
+
+    if (prefix != null ||
+        (filter != null && filter.getPrefix() != null) ||
+        (andOperator != null && andOperator.getPrefix() != null)) {
+      isPrefixEnable = true;
+    }
+
+    if ((filter != null && filter.getTag() != null) ||
+        (andOperator != null && !andOperator.getTags().isEmpty())) {
+      isTagEnable = true;
+    }
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public void setPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public List<OmLCAction> getActions() {
+    return actions;
+  }
+
+  public void setActions(List<OmLCAction> actions) {
+    this.actions = actions;
+  }
+
+  /**
+   * Get the expiration action if present.
+   * This method is for backward compatibility.
+   *
+   * @return the expiration action if present, null otherwise
+   */
+  public OmLCExpiration getExpiration() {
+    if (actions == null || actions.isEmpty()) {
+      return null;
+    }
+
+    for (OmLCAction action : actions) {
+      if (action instanceof OmLCExpiration) {
+        return (OmLCExpiration) action;
+      }
+    }
+    return null;
+  }
+
+  public OmLCFilter getFilter() {
+    return filter;
+  }
+
+  public boolean isPrefixEnable() {
+    return isPrefixEnable;
+  }
+
+  public boolean isTagEnable() {
+    return isTagEnable;
+  }
+
+  public void setFilter(OmLCFilter filter) {
+    this.filter = filter;
+  }
+
+  /**
+   * Validates the lifecycle rule.
+   * - ID length should not exceed the allowed limit
+   * - At least one action must be specified
+   * - Filter and Prefix cannot be used together
+   * - Actions must be valid
+   * - Filter must be valid
+   * - There must be at most one Expiration action per rule
+   *
+   * @throws OMException if the validation fails
+   */
+  public void valid() throws OMException {
+    if (id.length() > LC_ID_MAX_LENGTH) {
+      throw new OMException("ID length should not exceed allowed limit of " + LC_ID_MAX_LENGTH,
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (actions == null || actions.isEmpty()) {
+      throw new OMException("At least one action needs to be specified in a rule.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    // Check that there is at most one Expiration action
+    for (OmLCAction action : actions) {
+      if (action.getActionType() == OmLCAction.ActionType.EXPIRATION) {
+        if (actions.size() > 1) {
+          throw new OMException("A rule can have at most one Expiration action.",
+              OMException.ResultCodes.INVALID_REQUEST);
+        }
+      }
+      action.valid();
+    }
+
+    if (prefix != null && filter != null) {
+      throw new OMException("Filter and Prefix cannot be used together.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (filter != null) {
+      filter.valid();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "OmLCRule{" +
+        "id='" + id + '\'' +
+        ", prefix='" + prefix + '\'' +
+        ", enabled=" + enabled +
+        ", isPrefixEnable=" + isPrefixEnable +
+        ", isTagEnable=" + isTagEnable +
+        ", actions=" + actions +
+        ", filter=" + filter +
+        '}';
+  }
+
+  /**
+   * Builder of OmLCRule.
+   */
+  public static class Builder {
+    private String id = "";
+    private String prefix;
+    private boolean enabled;
+    private List<OmLCAction> actions = new ArrayList<>();
+    private OmLCFilter filter;
+
+    public Builder setId(String lcId) {
+      this.id = lcId;
+      return this;
+    }
+
+    public Builder setPrefix(String lcPrefix) {
+      this.prefix = lcPrefix;
+      return this;
+    }
+
+    public Builder setEnabled(boolean lcEnabled) {
+      this.enabled = lcEnabled;
+      return this;
+    }
+
+    public Builder setAction(OmLCAction lcAction) {
+      if (lcAction != null) {
+        this.actions = new ArrayList<>();
+        this.actions.add(lcAction);
+      }
+      return this;
+    }
+
+    public Builder setFilter(OmLCFilter lcFilter) {
+      this.filter = lcFilter;
+      return this;
+    }
+
+    public OmLCFilter getFilter() {
+      return filter;
+    }
+
+    public OmLCRule build() {
+      return new OmLCRule(id, prefix, enabled, actions, filter);
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -94,10 +94,6 @@ public final class OmLCRule {
    * @return the expiration action if present, null otherwise
    */
   public OmLCExpiration getExpiration() {
-    if (actions == null || actions.isEmpty()) {
-      return null;
-    }
-
     for (OmLCAction action : actions) {
       if (action instanceof OmLCExpiration) {
         return (OmLCExpiration) action;
@@ -226,8 +222,10 @@ public final class OmLCRule {
       return filter;
     }
 
-    public OmLCRule build() {
-      return new OmLCRule(this);
+    public OmLCRule build() throws OMException {
+      OmLCRule omLCRule = new OmLCRule(this);
+      omLCRule.valid();
+      return omLCRule;
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -119,6 +119,7 @@ public final class OmLCRule {
    * - ID length should not exceed the allowed limit
    * - At least one action must be specified
    * - Filter and Prefix cannot be used together
+   * - Prefix can be "", in which case the rule applies to all objects in the bucket.
    * - Actions must be valid
    * - Filter must be valid
    * - There must be at most one Expiration action per rule

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -157,14 +157,16 @@ public class OmLCRule {
     }
 
     // Check that there is at most one Expiration action
+    int expirationActionCount = 0;
     for (OmLCAction action : actions) {
       if (action.getActionType() == OmLCAction.ActionType.EXPIRATION) {
-        if (actions.size() > 1) {
-          throw new OMException("A rule can have at most one Expiration action.",
-              OMException.ResultCodes.INVALID_REQUEST);
-        }
+        expirationActionCount++;
       }
       action.valid();
+    }
+    if (expirationActionCount > 1) {
+      throw new OMException("A rule can have at most one Expiration action.",
+          OMException.ResultCodes.INVALID_REQUEST);
     }
 
     if (prefix != null && filter != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -49,6 +49,7 @@ public class OmLCRule {
     this.actions = actions;
     this.filter = filter;
 
+    // If no ID is specified in the lifecycle configure, a random ID will be generated
     if (StringUtils.isEmpty(this.id)) {
       this.id = RandomStringUtils.randomAlphanumeric(LC_ID_LENGTH);
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -101,7 +101,6 @@ public class OmLCRule {
 
   /**
    * Get the expiration action if present.
-   * This method is for backward compatibility.
    *
    * @return the expiration action if present, null otherwise
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -162,11 +162,11 @@ public class OmLCRule {
       if (action.getActionType() == OmLCAction.ActionType.EXPIRATION) {
         expirationActionCount++;
       }
+      if (expirationActionCount > 1) {
+        throw new OMException("A rule can have at most one Expiration action.",
+            OMException.ResultCodes.INVALID_REQUEST);
+      }
       action.valid();
-    }
-    if (expirationActionCount > 1) {
-      throw new OMException("A rule can have at most one Expiration action.",
-          OMException.ResultCodes.INVALID_REQUEST);
     }
 
     if (prefix != null && filter != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
@@ -161,7 +161,7 @@ public class OmLifecycleConfiguration extends WithObjectID
         ", bucket='" + bucket + '\'' +
         ", owner='" + owner + '\'' +
         ", creationTime=" + creationTime +
-        ", rulesCount=" + rules +
+        ", rulesCount=" + rules.size() +
         ", objectID=" + getObjectID() +
         ", updateID=" + getUpdateID() +
         '}';

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
@@ -229,8 +229,10 @@ public final class OmLifecycleConfiguration extends WithObjectID
       return this;
     }
 
-    public OmLifecycleConfiguration build() {
-      return new OmLifecycleConfiguration(this);
+    public OmLifecycleConfiguration build() throws OMException {
+      OmLifecycleConfiguration omLifecycleConfiguration = new OmLifecycleConfiguration(this);
+      omLifecycleConfiguration.valid();
+      return omLifecycleConfiguration;
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import net.jcip.annotations.Immutable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.Auditable;
@@ -30,23 +32,28 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 /**
  * A class that encapsulates lifecycle configuration.
  */
-public class OmLifecycleConfiguration extends WithObjectID
+@Immutable
+public final class OmLifecycleConfiguration extends WithObjectID
     implements Auditable {
 
   // Ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html#intro-lifecycle-rule-id
   public static final int LC_MAX_RULES = 1000;
-  private String volume;
-  private String bucket;
-  private String owner;
-  private long creationTime;
-  private List<OmLCRule> rules;
+  private final String volume;
+  private final String bucket;
+  private final String owner;
+  private final long creationTime;
+  private final List<OmLCRule> rules;
+
+  private OmLifecycleConfiguration() {
+    throw new UnsupportedOperationException("Default constructor is not supported. Use Builder.");
+  }
 
   OmLifecycleConfiguration(OmLifecycleConfiguration.Builder builder) {
     super(builder);
     this.volume = builder.volume;
     this.bucket = builder.bucket;
     this.owner = builder.owner;
-    this.rules = builder.rules;
+    this.rules = Collections.unmodifiableList(builder.rules);
     this.creationTime = builder.creationTime;
   }
 
@@ -54,40 +61,20 @@ public class OmLifecycleConfiguration extends WithObjectID
     return rules;
   }
 
-  public void setRules(List<OmLCRule> rules) {
-    this.rules = rules;
-  }
-
   public String getBucket() {
     return bucket;
-  }
-
-  public void setBucket(String bucket) {
-    this.bucket = bucket;
   }
 
   public String getOwner() {
     return owner;
   }
 
-  public void setOwner(String owner) {
-    this.owner = owner;
-  }
-
   public String getVolume() {
     return volume;
   }
 
-  public void setVolume(String volume) {
-    this.volume = volume;
-  }
-
   public long getCreationTime() {
     return creationTime;
-  }
-
-  public void setCreationTime(long creationTime) {
-    this.creationTime = creationTime;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.audit.Auditable;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+
+/**
+ * A class that encapsulates lifecycle configuration.
+ */
+public class OmLifecycleConfiguration extends WithObjectID
+    implements Auditable {
+
+  // Ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html#intro-lifecycle-rule-id
+  public static final int LC_MAX_RULES = 1000;
+  private String volume;
+  private String bucket;
+  private String owner;
+  private long creationTime;
+  private List<OmLCRule> rules;
+
+  OmLifecycleConfiguration(OmLifecycleConfiguration.Builder builder) {
+    super(builder);
+    this.volume = builder.volume;
+    this.bucket = builder.bucket;
+    this.owner = builder.owner;
+    this.rules = builder.rules;
+    this.creationTime = builder.creationTime;
+  }
+
+  public List<OmLCRule> getRules() {
+    return rules;
+  }
+
+  public void setRules(List<OmLCRule> rules) {
+    this.rules = rules;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public void setBucket(String bucket) {
+    this.bucket = bucket;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public String getVolume() {
+    return volume;
+  }
+
+  public void setVolume(String volume) {
+    this.volume = volume;
+  }
+
+  public long getCreationTime() {
+    return creationTime;
+  }
+
+  public void setCreationTime(long creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  /**
+   * Validates the lifecycle configuration.
+   * - Volume, Bucket and Owner cannot be blank
+   * - At least one rule needs to be specified
+   * - Number of rules should not exceed the allowed limit
+   * - Rules must have unique IDs
+   * - Each rule is validated individually
+   *
+   * @throws OMException if the validation fails
+   */
+  public void valid() throws OMException {
+    if (StringUtils.isBlank(volume)) {
+      throw new OMException("Invalid lifecycle configuration: Volume cannot be blank.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (StringUtils.isBlank(bucket)) {
+      throw new OMException("Invalid lifecycle configuration: Bucket cannot be blank.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (StringUtils.isBlank(owner)) {
+      throw new OMException("Invalid lifecycle configuration: Owner cannot be blank.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (rules.isEmpty()) {
+      throw new OMException("At least one rules needs to be specified in a lifecycle configuration.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (rules.size() > LC_MAX_RULES) {
+      throw new OMException("The number of lifecycle rules must not exceed the allowed limit of "
+          + LC_MAX_RULES + " rules", OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (!hasNoDuplicateID()) {
+      throw new OMException("Invalid lifecycle configuration: Duplicate rule IDs found.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    for (OmLCRule rule : rules) {
+      rule.valid();
+    }
+  }
+
+  private boolean hasNoDuplicateID() {
+    return rules.size() == rules.stream()
+        .map(OmLCRule::getId)
+        .collect(Collectors.toSet())
+        .size();
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .setVolume(volume)
+        .setBucket(this.bucket)
+        .setOwner(this.owner)
+        .setCreationTime(this.creationTime)
+        .setRules(this.rules)
+        .setUpdateID(super.getUpdateID())
+        .setObjectID(super.getObjectID());
+  }
+
+  @Override
+  public String toString() {
+    return "OmLifecycleConfiguration{" +
+        "volume='" + volume + '\'' +
+        ", bucket='" + bucket + '\'' +
+        ", owner='" + owner + '\'' +
+        ", creationTime=" + creationTime +
+        ", rulesCount=" + rules +
+        ", objectID=" + getObjectID() +
+        ", updateID=" + getUpdateID() +
+        '}';
+  }
+  /**
+   * Returns formatted key to be used as prevKey when listing lifecycle
+   * configurations.
+   *
+   * @return volume/bucket
+   */
+  public String getFormattedKey() {
+    return volume + "/" + bucket;
+  }
+
+  @Override
+  public Map<String, String> toAuditMap() {
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    auditMap.put(OzoneConsts.VOLUME, this.volume);
+    auditMap.put(OzoneConsts.BUCKET, this.bucket);
+    auditMap.put(OzoneConsts.OWNER, this.owner);
+    auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
+
+    return auditMap;
+  }
+
+  /**
+   * Builder of OmLifecycleConfiguration.
+   */
+  public static class Builder extends WithObjectID.Builder {
+    private String volume = "";
+    private String bucket = "";
+    private String owner = "";
+    private long creationTime;
+    private List<OmLCRule> rules = new ArrayList<>();
+
+    public Builder() {
+    }
+
+    public Builder setVolume(String volumeName) {
+      this.volume = volumeName;
+      return this;
+    }
+
+    public Builder setBucket(String bucketName) {
+      this.bucket = bucketName;
+      return this;
+    }
+
+    public Builder setOwner(String ownerName) {
+      this.owner = ownerName;
+      return this;
+    }
+
+    public Builder setCreationTime(long ctime) {
+      this.creationTime = ctime;
+      return this;
+    }
+
+    public Builder addRule(OmLCRule rule) {
+      this.rules.add(rule);
+      return this;
+    }
+
+    public Builder setRules(List<OmLCRule> lcRules) {
+      this.rules = lcRules;
+      return this;
+    }
+
+    @Override
+    public Builder setObjectID(long oID) {
+      super.setObjectID(oID);
+      return this;
+    }
+
+    @Override
+    public Builder setUpdateID(long uID) {
+      super.setUpdateID(uID);
+      return this;
+    }
+
+    public OmLifecycleConfiguration build() {
+      return new OmLifecycleConfiguration(this);
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
@@ -40,7 +40,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
   public static final int LC_MAX_RULES = 1000;
   private final String volume;
   private final String bucket;
-  private final String owner;
   private final long creationTime;
   private final List<OmLCRule> rules;
 
@@ -52,7 +51,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
     super(builder);
     this.volume = builder.volume;
     this.bucket = builder.bucket;
-    this.owner = builder.owner;
     this.rules = Collections.unmodifiableList(builder.rules);
     this.creationTime = builder.creationTime;
   }
@@ -65,10 +63,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
     return bucket;
   }
 
-  public String getOwner() {
-    return owner;
-  }
-
   public String getVolume() {
     return volume;
   }
@@ -79,7 +73,7 @@ public final class OmLifecycleConfiguration extends WithObjectID
 
   /**
    * Validates the lifecycle configuration.
-   * - Volume, Bucket and Owner cannot be blank
+   * - Volume and Bucket cannot be blank
    * - At least one rule needs to be specified
    * - Number of rules should not exceed the allowed limit
    * - Rules must have unique IDs
@@ -95,11 +89,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
 
     if (StringUtils.isBlank(bucket)) {
       throw new OMException("Invalid lifecycle configuration: Bucket cannot be blank.",
-          OMException.ResultCodes.INVALID_REQUEST);
-    }
-
-    if (StringUtils.isBlank(owner)) {
-      throw new OMException("Invalid lifecycle configuration: Owner cannot be blank.",
           OMException.ResultCodes.INVALID_REQUEST);
     }
 
@@ -134,7 +123,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
     return new Builder()
         .setVolume(volume)
         .setBucket(this.bucket)
-        .setOwner(this.owner)
         .setCreationTime(this.creationTime)
         .setRules(this.rules)
         .setUpdateID(super.getUpdateID())
@@ -146,7 +134,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
     return "OmLifecycleConfiguration{" +
         "volume='" + volume + '\'' +
         ", bucket='" + bucket + '\'' +
-        ", owner='" + owner + '\'' +
         ", creationTime=" + creationTime +
         ", rulesCount=" + rules.size() +
         ", objectID=" + getObjectID() +
@@ -168,7 +155,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
     Map<String, String> auditMap = new LinkedHashMap<>();
     auditMap.put(OzoneConsts.VOLUME, this.volume);
     auditMap.put(OzoneConsts.BUCKET, this.bucket);
-    auditMap.put(OzoneConsts.OWNER, this.owner);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
 
     return auditMap;
@@ -180,7 +166,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
   public static class Builder extends WithObjectID.Builder {
     private String volume = "";
     private String bucket = "";
-    private String owner = "";
     private long creationTime;
     private List<OmLCRule> rules = new ArrayList<>();
 
@@ -194,11 +179,6 @@ public final class OmLifecycleConfiguration extends WithObjectID
 
     public Builder setBucket(String bucketName) {
       this.bucket = bucketName;
-      return this;
-    }
-
-    public Builder setOwner(String ownerName) {
-      this.owner = ownerName;
       return this;
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
@@ -58,6 +58,7 @@ public final class OmLifecycleRuleAndOperator {
    * Ensures the following:
    * - Either tags or prefix must be specified.
    * - If there are tags and no prefix, the tags should be more than one.
+   * - Prefix can be "".
    * - Prefix alone is not allowed.
    *
    * @throws OMException if the validation fails.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
@@ -56,23 +56,22 @@ public final class OmLifecycleRuleAndOperator {
    * @throws OMException if the validation fails.
    */
   public void valid() throws OMException {
-    if ((tags == null || tags.isEmpty()) && (prefix == null || prefix.isEmpty())) {
+    boolean hasTags = tags != null && !tags.isEmpty();
+    boolean hasPrefix = prefix != null;
+
+    if (!hasTags && !hasPrefix) {
       throw new OMException("Invalid lifecycle rule andOperator configuration: " +
           "Either 'Tags' or 'Prefix' must be specified.",
           OMException.ResultCodes.INVALID_REQUEST);
     }
 
-    if (tags != null && !tags.isEmpty()) {
-      if (prefix == null || prefix.isEmpty()) {
-        if (tags.size() == 1) {
-          throw new OMException("Invalid lifecycle rule andOperator configuration: " +
-              "If 'Tags' are specified without 'Prefix', there should be more than one tag.",
-              OMException.ResultCodes.INVALID_REQUEST);
-        }
-      }
+    if (hasTags && !hasPrefix && tags.size() == 1) {
+      throw new OMException("Invalid lifecycle rule andOperator configuration: " +
+          "If 'Tags' are specified without 'Prefix', there should be more than one tag.",
+          OMException.ResultCodes.INVALID_REQUEST);
     }
 
-    if (prefix != null && !prefix.isEmpty() && (tags == null || tags.isEmpty())) {
+    if (hasPrefix && !hasTags) {
       throw new OMException("Invalid lifecycle rule andOperator configuration: " +
           "'Prefix' alone is not allowed.",
           OMException.ResultCodes.INVALID_REQUEST);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
@@ -19,21 +19,28 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import net.jcip.annotations.Immutable;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
 /**
  * A class that encapsulates lifecycleRule andOperator.
  */
+@Immutable
 public final class OmLifecycleRuleAndOperator {
 
   private final Map<String, String> tags;
   private final String prefix;
 
-  private OmLifecycleRuleAndOperator(Map<String, String> tags, String prefix) {
-    this.tags = tags;
-    this.prefix = prefix;
+  private OmLifecycleRuleAndOperator() {
+    throw new UnsupportedOperationException("Default constructor is not supported. Use Builder.");
+  }
+
+  private OmLifecycleRuleAndOperator(Builder builder) {
+    this.tags = Collections.unmodifiableMap(new HashMap<>(builder.tags));
+    this.prefix = builder.prefix;
   }
 
   @Nonnull
@@ -104,7 +111,7 @@ public final class OmLifecycleRuleAndOperator {
     }
 
     public OmLifecycleRuleAndOperator build() {
-      return new OmLifecycleRuleAndOperator(this.tags, this.prefix);
+      return new OmLifecycleRuleAndOperator(this);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
@@ -110,8 +110,10 @@ public final class OmLifecycleRuleAndOperator {
       return this;
     }
 
-    public OmLifecycleRuleAndOperator build() {
-      return new OmLifecycleRuleAndOperator(this);
+    public OmLifecycleRuleAndOperator build() throws OMException {
+      OmLifecycleRuleAndOperator omLifecycleRuleAndOperator = new OmLifecycleRuleAndOperator(this);
+      omLifecycleRuleAndOperator.valid();
+      return omLifecycleRuleAndOperator;
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleRuleAndOperator.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+
+/**
+ * A class that encapsulates lifecycleRule andOperator.
+ */
+public final class OmLifecycleRuleAndOperator {
+
+  private final Map<String, String> tags;
+  private final String prefix;
+
+  private OmLifecycleRuleAndOperator(Map<String, String> tags, String prefix) {
+    this.tags = tags;
+    this.prefix = prefix;
+  }
+
+  @Nonnull
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
+  @Nullable
+  public String getPrefix() {
+    return prefix;
+  }
+
+  /**
+   * Validates the OmLifecycleRuleAndOperator.
+   * Ensures the following:
+   * - Either tags or prefix must be specified.
+   * - If there are tags and no prefix, the tags should be more than one.
+   * - Prefix alone is not allowed.
+   *
+   * @throws OMException if the validation fails.
+   */
+  public void valid() throws OMException {
+    if ((tags == null || tags.isEmpty()) && (prefix == null || prefix.isEmpty())) {
+      throw new OMException("Invalid lifecycle rule andOperator configuration: " +
+          "Either 'Tags' or 'Prefix' must be specified.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (tags != null && !tags.isEmpty()) {
+      if (prefix == null || prefix.isEmpty()) {
+        if (tags.size() == 1) {
+          throw new OMException("Invalid lifecycle rule andOperator configuration: " +
+              "If 'Tags' are specified without 'Prefix', there should be more than one tag.",
+              OMException.ResultCodes.INVALID_REQUEST);
+        }
+      }
+    }
+
+    if (prefix != null && !prefix.isEmpty() && (tags == null || tags.isEmpty())) {
+      throw new OMException("Invalid lifecycle rule andOperator configuration: " +
+          "'Prefix' alone is not allowed.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+  }
+
+
+  /**
+   * The builder for the OmLifecycleRuleAndOperator class.
+   */
+  public static class Builder {
+    private Map<String, String> tags = new HashMap<>();
+    private String prefix;
+
+    public Builder setPrefix(String lcPrefix) {
+      this.prefix = lcPrefix;
+      return this;
+    }
+
+    public Builder addTag(String key, String value) {
+      this.tags.put(key, value);
+      return this;
+    }
+
+    public Builder setTags(Map<String, String> lcTags) {
+      if (lcTags != null) {
+        this.tags = new HashMap<>(lcTags);
+      }
+      return this;
+    }
+
+    public OmLifecycleRuleAndOperator build() {
+      return new OmLifecycleRuleAndOperator(this.tags, this.prefix);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "OmLifecycleRuleAndOperator{" +
+        "prefix='" + prefix + '\'' +
+        ", tags=" + tags +
+        '}';
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
@@ -48,6 +48,16 @@ public final class OMLCUtils {
         "Expected: " + expectedMessageContent + "\n Actual: " + e.getMessage());
   }
 
+  public static String getFutureDateString(long daysInFuture, int hoursInFuture, int minuteInFuture) {
+    return ZonedDateTime.now(ZoneOffset.UTC)
+        .plusDays(daysInFuture)
+        .plusHours(hoursInFuture)
+        .plusMinutes(minuteInFuture)
+        .withSecond(0)
+        .withNano(0)
+        .format(DateTimeFormatter.ISO_DATE_TIME);
+  }
+
   public static String getFutureDateString(long daysInFuture) {
     return ZonedDateTime.now(ZoneOffset.UTC)
         .plusDays(daysInFuture)

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
@@ -78,11 +78,10 @@ public final class OMLCUtils {
   }
 
   public static OmLifecycleConfiguration.Builder getOmLifecycleConfiguration(
-      String volume, String bucket, String owner, List<OmLCRule> rules) {
+      String volume, String bucket, List<OmLCRule> rules) {
     return new OmLifecycleConfiguration.Builder()
         .setVolume(volume)
         .setBucket(bucket)
-        .setOwner(owner)
         .setRules(rules);
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
@@ -36,9 +36,18 @@ import org.junit.jupiter.api.function.Executable;
  */
 public final class OMLCUtils {
 
-  public static final OmLCFilter VALID_OM_LC_FILTER = getOmLCFilter("prefix", null, null);
-  public static final OmLifecycleRuleAndOperator VALID_OM_LC_AND_OPERATOR =
-      getOmLCAndOperator("prefix", Collections.singletonMap("tag1", "value1"));
+  public static final OmLCFilter VALID_OM_LC_FILTER;
+  public static final OmLifecycleRuleAndOperator VALID_OM_LC_AND_OPERATOR;
+
+  static {
+    try {
+      VALID_OM_LC_FILTER = getOmLCFilterBuilder("prefix", null, null).build();
+      VALID_OM_LC_AND_OPERATOR =
+          getOmLCAndOperatorBuilder("prefix", Collections.singletonMap("tag1", "value1")).build();
+    } catch (OMException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   public static void assertOMException(Executable action, OMException.ResultCodes expectedResultCode,
       String expectedMessageContent) {
@@ -68,17 +77,17 @@ public final class OMLCUtils {
         .format(DateTimeFormatter.ISO_DATE_TIME);
   }
 
-  public static OmLifecycleConfiguration getOmLifecycleConfiguration(
+  public static OmLifecycleConfiguration.Builder getOmLifecycleConfiguration(
       String volume, String bucket, String owner, List<OmLCRule> rules) {
     return new OmLifecycleConfiguration.Builder()
         .setVolume(volume)
         .setBucket(bucket)
         .setOwner(owner)
-        .setRules(rules)
-        .build();
+        .setRules(rules);
   }
 
-  public static OmLCRule getOmLCRule(String id, String prefix, boolean enabled, int expirationDays, OmLCFilter filter) {
+  public static OmLCRule.Builder getOmLCRuleBuilder(String id, String prefix, boolean enabled,
+                                                    int expirationDays, OmLCFilter filter) throws OMException {
     OmLCRule.Builder rBuilder = new OmLCRule.Builder()
         .setEnabled(enabled)
         .setId(id)
@@ -90,25 +99,25 @@ public final class OMLCUtils {
           .setDays(expirationDays).build());
     }
 
-    return rBuilder.build();
+    return rBuilder;
   }
 
-  public static OmLCFilter getOmLCFilter(String filterPrefix, Pair<String, String> filterTag,
-      OmLifecycleRuleAndOperator andOperator) {
+  public static OmLCFilter.Builder getOmLCFilterBuilder(String filterPrefix, Pair<String, String> filterTag,
+                                                OmLifecycleRuleAndOperator andOperator) {
     OmLCFilter.Builder lcfBuilder = new OmLCFilter.Builder()
         .setPrefix(filterPrefix)
         .setAndOperator(andOperator);
     if (filterTag != null) {
       lcfBuilder.setTag(filterTag.getKey(), filterTag.getValue());
     }
-    return lcfBuilder.build();
+    return lcfBuilder;
   }
 
-  public static OmLifecycleRuleAndOperator getOmLCAndOperator(String prefix, Map<String, String> tags) {
+  public static OmLifecycleRuleAndOperator.Builder getOmLCAndOperatorBuilder(
+      String prefix, Map<String, String> tags) {
     return new OmLifecycleRuleAndOperator.Builder()
         .setPrefix(prefix)
-        .setTags(tags)
-        .build();
+        .setTags(tags);
   }
 
   private OMLCUtils() {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/OMLCUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * Util Class for OM lifecycle.
+ */
+public final class OMLCUtils {
+
+  public static final OmLCFilter VALID_OM_LC_FILTER = getOmLCFilter("prefix", null, null);
+  public static final OmLifecycleRuleAndOperator VALID_OM_LC_AND_OPERATOR =
+      getOmLCAndOperator("prefix", Collections.singletonMap("tag1", "value1"));
+
+  public static void assertOMException(Executable action, OMException.ResultCodes expectedResultCode,
+      String expectedMessageContent) {
+    OMException e = assertThrows(OMException.class, action);
+    assertEquals(expectedResultCode, e.getResult());
+    assertTrue(e.getMessage().contains(expectedMessageContent),
+        "Expected: " + expectedMessageContent + "\n Actual: " + e.getMessage());
+  }
+
+  public static String getFutureDateString(long daysInFuture) {
+    return ZonedDateTime.now(ZoneOffset.UTC)
+        .plusDays(daysInFuture)
+        .withHour(0)
+        .withMinute(0)
+        .withSecond(0)
+        .withNano(0)
+        .format(DateTimeFormatter.ISO_DATE_TIME);
+  }
+
+  public static OmLifecycleConfiguration getOmLifecycleConfiguration(
+      String volume, String bucket, String owner, List<OmLCRule> rules) {
+    return new OmLifecycleConfiguration.Builder()
+        .setVolume(volume)
+        .setBucket(bucket)
+        .setOwner(owner)
+        .setRules(rules)
+        .build();
+  }
+
+  public static OmLCRule getOmLCRule(String id, String prefix, boolean enabled, int expirationDays, OmLCFilter filter) {
+    OmLCRule.Builder rBuilder = new OmLCRule.Builder()
+        .setEnabled(enabled)
+        .setId(id)
+        .setPrefix(prefix)
+        .setFilter(filter);
+
+    if (expirationDays > 0) {
+      rBuilder.setAction(new OmLCExpiration.Builder()
+          .setDays(expirationDays).build());
+    }
+
+    return rBuilder.build();
+  }
+
+  public static OmLCFilter getOmLCFilter(String filterPrefix, Pair<String, String> filterTag,
+      OmLifecycleRuleAndOperator andOperator) {
+    OmLCFilter.Builder lcfBuilder = new OmLCFilter.Builder()
+        .setPrefix(filterPrefix)
+        .setAndOperator(andOperator);
+    if (filterTag != null) {
+      lcfBuilder.setTag(filterTag.getKey(), filterTag.getValue());
+    }
+    return lcfBuilder.build();
+  }
+
+  public static OmLifecycleRuleAndOperator getOmLCAndOperator(String prefix, Map<String, String> tags) {
+    return new OmLifecycleRuleAndOperator.Builder()
+        .setPrefix(prefix)
+        .setTags(tags)
+        .build();
+  }
+
+  private OMLCUtils() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
@@ -31,135 +31,113 @@ class TestOmLCExpiration {
 
   @Test
   public void testCreateValidOmLCExpiration() {
-    OmLCExpiration exp1 = new OmLCExpiration.Builder()
-        .setDays(30)
-        .build();
-    assertDoesNotThrow(exp1::valid);
+    OmLCExpiration.Builder exp1 = new OmLCExpiration.Builder()
+        .setDays(30);
+    assertDoesNotThrow(exp1::build);
 
-    OmLCExpiration exp2 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:00Z")
-        .build();
-    assertDoesNotThrow(exp2::valid);
+    OmLCExpiration.Builder exp2 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00Z");
+    assertDoesNotThrow(exp2::build);
 
-    OmLCExpiration exp3 = new OmLCExpiration.Builder()
-        .setDays(1)
-        .build();
-    assertDoesNotThrow(exp3::valid);
+    OmLCExpiration.Builder exp3 = new OmLCExpiration.Builder()
+        .setDays(1);
+    assertDoesNotThrow(exp3::build);
 
-    OmLCExpiration exp4 = new OmLCExpiration.Builder()
-        .setDate("2099-12-31T00:00:00Z")
-        .build();
-    assertDoesNotThrow(exp4::valid);
+    OmLCExpiration.Builder exp4 = new OmLCExpiration.Builder()
+        .setDate("2099-12-31T00:00:00Z");
+    assertDoesNotThrow(exp4::build);
 
-    OmLCExpiration exp5 = new OmLCExpiration.Builder()
-        .setDate("2099-02-15T00:00:00.000Z")
-        .build();
-    assertDoesNotThrow(exp5::valid);
+    OmLCExpiration.Builder exp5 = new OmLCExpiration.Builder()
+        .setDate("2099-02-15T00:00:00.000Z");
+    assertDoesNotThrow(exp5::build);
   }
 
   @Test
   public void testCreateInValidOmLCExpiration() {
-    OmLCExpiration exp1 = new OmLCExpiration.Builder()
+    OmLCExpiration.Builder exp1 = new OmLCExpiration.Builder()
         .setDays(30)
-        .setDate(getFutureDateString(100))
-        .build();
-    assertOMException(exp1::valid, INVALID_REQUEST,
+        .setDate(getFutureDateString(100));
+    assertOMException(exp1::build, INVALID_REQUEST,
         "Either 'days' or 'date' should be specified, but not both or neither.");
 
-    OmLCExpiration exp2 = new OmLCExpiration.Builder()
-        .setDays(-1)
-        .build();
-    assertOMException(exp2::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp2 = new OmLCExpiration.Builder()
+        .setDays(-1);
+    assertOMException(exp2::build, INVALID_REQUEST,
         "'Days' for Expiration action must be a positive integer");
 
-    OmLCExpiration exp3 = new OmLCExpiration.Builder()
-        .setDate(null)
-        .build();
-    assertOMException(exp3::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp3 = new OmLCExpiration.Builder()
+        .setDate(null);
+    assertOMException(exp3::build, INVALID_REQUEST,
         "Either 'days' or 'date' should be specified, but not both or neither.");
 
-    OmLCExpiration exp4 = new OmLCExpiration.Builder()
-        .setDate("")
-        .build();
-    assertOMException(exp4::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp4 = new OmLCExpiration.Builder()
+        .setDate("");
+    assertOMException(exp4::build, INVALID_REQUEST,
         "Either 'days' or 'date' should be specified, but not both or neither.");
 
-    OmLCExpiration exp5 = new OmLCExpiration.Builder()
-        .build();
-    assertOMException(exp5::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp5 = new OmLCExpiration.Builder();
+    assertOMException(exp5::build, INVALID_REQUEST,
         "Either 'days' or 'date' should be specified, but not both or neither.");
 
-    OmLCExpiration exp6 = new OmLCExpiration.Builder()
-        .setDate("10-10-2099")
-        .build();
-    assertOMException(exp6::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp6 = new OmLCExpiration.Builder()
+        .setDate("10-10-2099");
+    assertOMException(exp6::build, INVALID_REQUEST,
         "'Date' must be in ISO 8601 format");
 
-    OmLCExpiration exp7 = new OmLCExpiration.Builder()
-        .setDate("2099-12-31T00:00:00")
-        .build();
-    assertOMException(exp7::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp7 = new OmLCExpiration.Builder()
+        .setDate("2099-12-31T00:00:00");
+    assertOMException(exp7::build, INVALID_REQUEST,
         "'Date' must be in ISO 8601 format");
 
     // Testing for date in the past
-    OmLCExpiration exp8 = new OmLCExpiration.Builder()
-        .setDate(getFutureDateString(-1))
-        .build();
-    assertOMException(exp8::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp8 = new OmLCExpiration.Builder()
+        .setDate(getFutureDateString(-1));
+    assertOMException(exp8::build, INVALID_REQUEST,
         "'Date' must be in the future");
 
-    OmLCExpiration exp9 = new OmLCExpiration.Builder()
-        .setDays(0)
-        .build();
-    assertOMException(exp9::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp9 = new OmLCExpiration.Builder()
+        .setDays(0);
+    assertOMException(exp9::build, INVALID_REQUEST,
         "Either 'days' or 'date' should be specified, but not both or neither.");
 
     // 1 minute ago
-    OmLCExpiration exp10 = new OmLCExpiration.Builder()
-        .setDate(getFutureDateString(0, 0, -1))
-        .build();
-    assertOMException(exp10::valid, INVALID_REQUEST,
+    OmLCExpiration.Builder exp10 = new OmLCExpiration.Builder()
+        .setDate(getFutureDateString(0, 0, -1));
+    assertOMException(exp10::build, INVALID_REQUEST,
         "'Date' must be in the future");
   }
 
   @Test
   public void testDateMustBeAtMidnightUTC() {
     // Acceptable date - midnight UTC
-    OmLCExpiration validExp = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:00Z")
-        .build();
-    assertDoesNotThrow(validExp::valid);
+    OmLCExpiration.Builder validExp = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00Z");
+    assertDoesNotThrow(validExp::build);
 
     // Non-midnight UTC dates should be rejected
-    OmLCExpiration exp1 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T10:00:00Z")
-        .build();
-    assertOMException(exp1::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    OmLCExpiration.Builder exp1 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T10:00:00Z");
+    assertOMException(exp1::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
 
-    OmLCExpiration exp2 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:30:00Z")
-        .build();
-    assertOMException(exp2::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    OmLCExpiration.Builder exp2 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:30:00Z");
+    assertOMException(exp2::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
 
-    OmLCExpiration exp3 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:30Z")
-        .build();
-    assertOMException(exp3::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    OmLCExpiration.Builder exp3 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:30Z");
+    assertOMException(exp3::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
 
-    OmLCExpiration exp4 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:00.123Z")
-        .build();
-    assertOMException(exp4::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    OmLCExpiration.Builder exp4 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00.123Z");
+    assertOMException(exp4::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
 
     // Non-UTC timezone should be rejected
-    OmLCExpiration exp5 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:00+01:00")
-        .build();
-    assertOMException(exp5::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    OmLCExpiration.Builder exp5 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00+01:00");
+    assertOMException(exp5::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
 
-    OmLCExpiration exp8 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:00")
-        .build();
-    assertOMException(exp8::valid, INVALID_REQUEST, "ISO 8601 format");
+    OmLCExpiration.Builder exp8 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00");
+    assertOMException(exp8::build, INVALID_REQUEST, "ISO 8601 format");
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
@@ -90,23 +90,36 @@ class TestOmLCExpiration {
         "Either 'days' or 'date' should be specified, but not both or neither.");
 
     OmLCExpiration exp6 = new OmLCExpiration.Builder()
-        .setDate("10-10-2025")
+        .setDate("10-10-2099")
         .build();
     assertOMException(exp6::valid, INVALID_REQUEST,
         "'Date' must be in ISO 8601 format");
 
-    // Testing for date in the past
     OmLCExpiration exp7 = new OmLCExpiration.Builder()
-        .setDate(getFutureDateString(-1))
+        .setDate("2099-12-31T00:00:00")
         .build();
     assertOMException(exp7::valid, INVALID_REQUEST,
-        "'Date' must be in the future");
+        "'Date' must be in ISO 8601 format");
 
+    // Testing for date in the past
     OmLCExpiration exp8 = new OmLCExpiration.Builder()
-        .setDays(0)
+        .setDate(getFutureDateString(-1))
         .build();
     assertOMException(exp8::valid, INVALID_REQUEST,
+        "'Date' must be in the future");
+
+    OmLCExpiration exp9 = new OmLCExpiration.Builder()
+        .setDays(0)
+        .build();
+    assertOMException(exp9::valid, INVALID_REQUEST,
         "Either 'days' or 'date' should be specified, but not both or neither.");
+
+    // 1 minute ago
+    OmLCExpiration exp10 = new OmLCExpiration.Builder()
+        .setDate(getFutureDateString(0, 0, -1))
+        .build();
+    assertOMException(exp10::valid, INVALID_REQUEST,
+        "'Date' must be in the future");
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
@@ -50,6 +50,34 @@ class TestOmLCExpiration {
     OmLCExpiration.Builder exp5 = new OmLCExpiration.Builder()
         .setDate("2099-02-15T00:00:00.000Z");
     assertDoesNotThrow(exp5::build);
+
+    OmLCExpiration.Builder exp6 = new OmLCExpiration.Builder()
+        .setDate("2042-04-02T00:00:00Z");
+    assertDoesNotThrow(exp6::build);
+
+    OmLCExpiration.Builder exp7 = new OmLCExpiration.Builder()
+        .setDate("2042-04-02T00:00:00+00:00");
+    assertDoesNotThrow(exp7::build);
+
+    OmLCExpiration.Builder exp8 = new OmLCExpiration.Builder()
+        .setDate("2099-12-31T00:00:00+00:00");
+    assertDoesNotThrow(exp8::build);
+
+    OmLCExpiration.Builder exp9 = new OmLCExpiration.Builder()
+        .setDate("2099-12-31T23:00:00-01:00");
+    assertDoesNotThrow(exp9::build);
+
+    OmLCExpiration.Builder exp10 = new OmLCExpiration.Builder()
+        .setDate("2100-01-01T01:00:00+01:00");
+    assertDoesNotThrow(exp10::build);
+
+    OmLCExpiration.Builder exp11 = new OmLCExpiration.Builder()
+        .setDate("2099-12-31T12:00:00-12:00");
+    assertDoesNotThrow(exp11::build);
+
+    OmLCExpiration.Builder exp12 = new OmLCExpiration.Builder()
+        .setDate("2100-01-01T12:00:00+12:00");
+    assertDoesNotThrow(exp12::build);
   }
 
   @Test
@@ -117,27 +145,23 @@ class TestOmLCExpiration {
     // Non-midnight UTC dates should be rejected
     OmLCExpiration.Builder exp1 = new OmLCExpiration.Builder()
         .setDate("2099-10-10T10:00:00Z");
-    assertOMException(exp1::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    assertOMException(exp1::build, INVALID_REQUEST, "'Date' must represent midnight UTC");
 
     OmLCExpiration.Builder exp2 = new OmLCExpiration.Builder()
         .setDate("2099-10-10T00:30:00Z");
-    assertOMException(exp2::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    assertOMException(exp2::build, INVALID_REQUEST, "'Date' must represent midnight UTC");
 
     OmLCExpiration.Builder exp3 = new OmLCExpiration.Builder()
         .setDate("2099-10-10T00:00:30Z");
-    assertOMException(exp3::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    assertOMException(exp3::build, INVALID_REQUEST, "'Date' must represent midnight UTC");
 
     OmLCExpiration.Builder exp4 = new OmLCExpiration.Builder()
         .setDate("2099-10-10T00:00:00.123Z");
-    assertOMException(exp4::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
+    assertOMException(exp4::build, INVALID_REQUEST, "'Date' must represent midnight UTC");
 
     // Non-UTC timezone should be rejected
     OmLCExpiration.Builder exp5 = new OmLCExpiration.Builder()
         .setDate("2099-10-10T00:00:00+01:00");
-    assertOMException(exp5::build, INVALID_REQUEST, "'Date' must be at midnight GMT");
-
-    OmLCExpiration.Builder exp8 = new OmLCExpiration.Builder()
-        .setDate("2099-10-10T00:00:00");
-    assertOMException(exp8::build, INVALID_REQUEST, "ISO 8601 format");
+    assertOMException(exp5::build, INVALID_REQUEST, "'Date' must represent midnight UTC");
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getFutureDateString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test OmLCExpiration.
+ */
+class TestOmLCExpiration {
+
+  @Test
+  public void testCreateValidOmLCExpiration() {
+    OmLCExpiration exp1 = new OmLCExpiration.Builder()
+        .setDays(30)
+        .build();
+    assertDoesNotThrow(exp1::valid);
+
+    OmLCExpiration exp2 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00Z")
+        .build();
+    assertDoesNotThrow(exp2::valid);
+
+    OmLCExpiration exp3 = new OmLCExpiration.Builder()
+        .setDays(1)
+        .build();
+    assertDoesNotThrow(exp3::valid);
+
+    OmLCExpiration exp4 = new OmLCExpiration.Builder()
+        .setDate("2099-12-31T00:00:00Z")
+        .build();
+    assertDoesNotThrow(exp4::valid);
+
+    OmLCExpiration exp5 = new OmLCExpiration.Builder()
+        .setDate("2099-02-15T00:00:00.000Z")
+        .build();
+    assertDoesNotThrow(exp5::valid);
+  }
+
+  @Test
+  public void testCreateInValidOmLCExpiration() {
+    OmLCExpiration exp1 = new OmLCExpiration.Builder()
+        .setDays(30)
+        .setDate(getFutureDateString(100))
+        .build();
+    assertOMException(exp1::valid, INVALID_REQUEST,
+        "Either 'days' or 'date' should be specified, but not both or neither.");
+
+    OmLCExpiration exp2 = new OmLCExpiration.Builder()
+        .setDays(-1)
+        .build();
+    assertOMException(exp2::valid, INVALID_REQUEST,
+        "'Days' for Expiration action must be a positive integer");
+
+    OmLCExpiration exp3 = new OmLCExpiration.Builder()
+        .setDate(null)
+        .build();
+    assertOMException(exp3::valid, INVALID_REQUEST,
+        "Either 'days' or 'date' should be specified, but not both or neither.");
+
+    OmLCExpiration exp4 = new OmLCExpiration.Builder()
+        .setDate("")
+        .build();
+    assertOMException(exp4::valid, INVALID_REQUEST,
+        "Either 'days' or 'date' should be specified, but not both or neither.");
+
+    OmLCExpiration exp5 = new OmLCExpiration.Builder()
+        .build();
+    assertOMException(exp5::valid, INVALID_REQUEST,
+        "Either 'days' or 'date' should be specified, but not both or neither.");
+
+    OmLCExpiration exp6 = new OmLCExpiration.Builder()
+        .setDate("10-10-2025")
+        .build();
+    assertOMException(exp6::valid, INVALID_REQUEST,
+        "'Date' must be in ISO 8601 format");
+
+    // Testing for date in the past
+    OmLCExpiration exp7 = new OmLCExpiration.Builder()
+        .setDate(getFutureDateString(-1))
+        .build();
+    assertOMException(exp7::valid, INVALID_REQUEST,
+        "'Date' must be in the future");
+
+    OmLCExpiration exp8 = new OmLCExpiration.Builder()
+        .setDays(0)
+        .build();
+    assertOMException(exp8::valid, INVALID_REQUEST,
+        "Either 'days' or 'date' should be specified, but not both or neither.");
+  }
+
+  @Test
+  public void testDateMustBeAtMidnightUTC() {
+    // Acceptable date - midnight UTC
+    OmLCExpiration validExp = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00Z")
+        .build();
+    assertDoesNotThrow(validExp::valid);
+
+    // Non-midnight UTC dates should be rejected
+    OmLCExpiration exp1 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T10:00:00Z")
+        .build();
+    assertOMException(exp1::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+
+    OmLCExpiration exp2 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:30:00Z")
+        .build();
+    assertOMException(exp2::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+
+    OmLCExpiration exp3 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:30Z")
+        .build();
+    assertOMException(exp3::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+
+    OmLCExpiration exp4 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00.123Z")
+        .build();
+    assertOMException(exp4::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+
+    // Non-UTC timezone should be rejected
+    OmLCExpiration exp5 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00+01:00")
+        .build();
+    assertOMException(exp5::valid, INVALID_REQUEST, "'Date' must be at midnight GMT");
+
+    OmLCExpiration exp8 = new OmLCExpiration.Builder()
+        .setDate("2099-10-10T00:00:00")
+        .build();
+    assertOMException(exp8::valid, INVALID_REQUEST, "ISO 8601 format");
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
@@ -98,7 +98,7 @@ class TestOmLCExpiration {
     OmLCExpiration.Builder exp9 = new OmLCExpiration.Builder()
         .setDays(0);
     assertOMException(exp9::build, INVALID_REQUEST,
-        "Either 'days' or 'date' should be specified, but not both or neither.");
+        "'Days' for Expiration action must be a positive integer");
 
     // 1 minute ago
     OmLCExpiration.Builder exp10 = new OmLCExpiration.Builder()

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCFilter.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCFilter.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.VALID_OM_LC_AND_OPERATOR;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.VALID_OM_LC_FILTER;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCFilter;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCRule;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test OmLCExpiration.
+ */
+class TestOmLCFilter {
+
+  @Test
+  public void testInValidOmLCRulePrefixFilterCoExist() {
+    OmLCRule rule1 = getOmLCRule("id", "prefix", true, 1, VALID_OM_LC_FILTER);
+    assertOMException(rule1::valid, INVALID_REQUEST, "Filter and Prefix cannot be used together");
+
+    OmLCRule rule2 = getOmLCRule("id", "", true, 1, VALID_OM_LC_FILTER);
+    assertOMException(rule2::valid, INVALID_REQUEST, "Filter and Prefix cannot be used together");
+  }
+
+  @Test
+  public void testValidFilter() {
+    OmLCFilter lcFilter1 = getOmLCFilter("prefix", null, null);
+    assertDoesNotThrow(lcFilter1::valid);
+
+    OmLCFilter lcFilter2 = getOmLCFilter(null, Pair.of("key", "value"), null);
+    assertDoesNotThrow(lcFilter2::valid);
+
+    OmLCFilter lcFilter3 = getOmLCFilter(null, null, VALID_OM_LC_AND_OPERATOR);
+    assertDoesNotThrow(lcFilter3::valid);
+
+    OmLCFilter lcFilter4 = getOmLCFilter(null, null, null);
+    assertDoesNotThrow(lcFilter4::valid);
+
+    OmLCFilter lcFilter5 = getOmLCFilter("", null, null);
+    assertDoesNotThrow(lcFilter5::valid);
+  }
+
+  @Test
+  public void testInValidFilter() {
+    OmLCFilter lcFilter1 = getOmLCFilter("prefix", Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
+    assertOMException(lcFilter1::valid, INVALID_REQUEST,
+        "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
+
+    OmLCFilter lcFilter2 = getOmLCFilter("prefix", Pair.of("key", "value"), null);
+    assertOMException(lcFilter2::valid, INVALID_REQUEST,
+        "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
+
+    OmLCFilter lcFilter3 = getOmLCFilter("prefix", null, VALID_OM_LC_AND_OPERATOR);
+    assertOMException(lcFilter3::valid, INVALID_REQUEST,
+        "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
+
+    OmLCFilter lcFilter4 = getOmLCFilter(null, Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
+    assertOMException(lcFilter4::valid, INVALID_REQUEST,
+        "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
+
+  }
+
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCFilter.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCFilter.java
@@ -21,11 +21,12 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.VALID_OM_LC_AND_OPERATOR;
 import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.VALID_OM_LC_FILTER;
 import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
-import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCFilter;
-import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCRule;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCFilterBuilder;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCRuleBuilder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,48 +35,48 @@ import org.junit.jupiter.api.Test;
 class TestOmLCFilter {
 
   @Test
-  public void testInValidOmLCRulePrefixFilterCoExist() {
-    OmLCRule rule1 = getOmLCRule("id", "prefix", true, 1, VALID_OM_LC_FILTER);
-    assertOMException(rule1::valid, INVALID_REQUEST, "Filter and Prefix cannot be used together");
+  public void testInValidOmLCRulePrefixFilterCoExist() throws OMException {
+    OmLCRule.Builder rule1 = getOmLCRuleBuilder("id", "prefix", true, 1, VALID_OM_LC_FILTER);
+    assertOMException(rule1::build, INVALID_REQUEST, "Filter and Prefix cannot be used together");
 
-    OmLCRule rule2 = getOmLCRule("id", "", true, 1, VALID_OM_LC_FILTER);
-    assertOMException(rule2::valid, INVALID_REQUEST, "Filter and Prefix cannot be used together");
+    OmLCRule.Builder rule2 = getOmLCRuleBuilder("id", "", true, 1, VALID_OM_LC_FILTER);
+    assertOMException(rule2::build, INVALID_REQUEST, "Filter and Prefix cannot be used together");
   }
 
   @Test
-  public void testValidFilter() {
-    OmLCFilter lcFilter1 = getOmLCFilter("prefix", null, null);
+  public void testValidFilter() throws OMException {
+    OmLCFilter lcFilter1 = getOmLCFilterBuilder("prefix", null, null).build();
     assertDoesNotThrow(lcFilter1::valid);
 
-    OmLCFilter lcFilter2 = getOmLCFilter(null, Pair.of("key", "value"), null);
+    OmLCFilter lcFilter2 = getOmLCFilterBuilder(null, Pair.of("key", "value"), null).build();
     assertDoesNotThrow(lcFilter2::valid);
 
-    OmLCFilter lcFilter3 = getOmLCFilter(null, null, VALID_OM_LC_AND_OPERATOR);
+    OmLCFilter lcFilter3 = getOmLCFilterBuilder(null, null, VALID_OM_LC_AND_OPERATOR).build();
     assertDoesNotThrow(lcFilter3::valid);
 
-    OmLCFilter lcFilter4 = getOmLCFilter(null, null, null);
+    OmLCFilter lcFilter4 = getOmLCFilterBuilder(null, null, null).build();
     assertDoesNotThrow(lcFilter4::valid);
 
-    OmLCFilter lcFilter5 = getOmLCFilter("", null, null);
+    OmLCFilter lcFilter5 = getOmLCFilterBuilder("", null, null).build();
     assertDoesNotThrow(lcFilter5::valid);
   }
 
   @Test
   public void testInValidFilter() {
-    OmLCFilter lcFilter1 = getOmLCFilter("prefix", Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
-    assertOMException(lcFilter1::valid, INVALID_REQUEST,
+    OmLCFilter.Builder lcFilter1 = getOmLCFilterBuilder("prefix", Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
+    assertOMException(lcFilter1::build, INVALID_REQUEST,
         "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
 
-    OmLCFilter lcFilter2 = getOmLCFilter("prefix", Pair.of("key", "value"), null);
-    assertOMException(lcFilter2::valid, INVALID_REQUEST,
+    OmLCFilter.Builder lcFilter2 = getOmLCFilterBuilder("prefix", Pair.of("key", "value"), null);
+    assertOMException(lcFilter2::build, INVALID_REQUEST,
         "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
 
-    OmLCFilter lcFilter3 = getOmLCFilter("prefix", null, VALID_OM_LC_AND_OPERATOR);
-    assertOMException(lcFilter3::valid, INVALID_REQUEST,
+    OmLCFilter.Builder lcFilter3 = getOmLCFilterBuilder("prefix", null, VALID_OM_LC_AND_OPERATOR);
+    assertOMException(lcFilter3::build, INVALID_REQUEST,
         "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
 
-    OmLCFilter lcFilter4 = getOmLCFilter(null, Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
-    assertOMException(lcFilter4::valid, INVALID_REQUEST,
+    OmLCFilter.Builder lcFilter4 = getOmLCFilterBuilder(null, Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
+    assertOMException(lcFilter4::build, INVALID_REQUEST,
         "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
 
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
@@ -164,7 +164,6 @@ class TestOmLCRule {
     OmLifecycleConfiguration.Builder config = new OmLifecycleConfiguration.Builder()
         .setVolume("volume")
         .setBucket("bucket")
-        .setOwner("owner")
         .setRules(rules);
 
     assertOMException(config::build, INVALID_REQUEST, "Duplicate rule IDs found");

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
@@ -55,14 +55,21 @@ class TestOmLCRule {
         .build();
     assertDoesNotThrow(r1::valid);
 
-    // Empty id should generate a 48 (default) bit one.
     OmLCRule r2 = new OmLCRule.Builder()
+        .setEnabled(true)
+        .setPrefix("")
+        .setAction(exp)
+        .build();
+    assertDoesNotThrow(r2::valid);
+
+    // Empty id should generate a 48 (default) bit one.
+    OmLCRule r3 = new OmLCRule.Builder()
         .setEnabled(true)
         .setAction(exp)
         .build();
 
-    assertDoesNotThrow(r2::valid);
-    assertEquals(OmLCRule.LC_ID_LENGTH, r2.getId().length(),
+    assertDoesNotThrow(r3::valid);
+    assertEquals(OmLCRule.LC_ID_LENGTH, r3.getId().length(),
         "Expected a " + OmLCRule.LC_ID_LENGTH + " length generated ID");
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
@@ -137,9 +137,7 @@ class TestOmLCRule {
     OmLCRule.Builder builder = new OmLCRule.Builder();
     builder.setId("test-rule");
 
-    // Using reflection to bypass the builder's single-action limitation
-    OmLCRule rule = builder.build();
-    rule.setActions(actions);
+    OmLCRule rule = builder.setActions(actions).build();
 
     assertOMException(rule::valid, INVALID_REQUEST, "A rule can have at most one Expiration action");
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCRule.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getFutureDateString;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCAndOperator;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCFilter;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test OmLCRule.
+ */
+class TestOmLCRule {
+
+  @Test
+  public void testCreateValidOmLCRule() {
+    OmLCExpiration exp = new OmLCExpiration.Builder()
+        .setDays(30)
+        .build();
+
+    OmLCRule r1 = new OmLCRule.Builder()
+        .setId("remove Spark logs after 30 days")
+        .setEnabled(true)
+        .setPrefix("/spark/logs")
+        .setAction(exp)
+        .build();
+    assertDoesNotThrow(r1::valid);
+
+    // Empty id should generate a 48 (default) bit one.
+    OmLCRule r2 = new OmLCRule.Builder()
+        .setEnabled(true)
+        .setAction(exp)
+        .build();
+
+    assertDoesNotThrow(r2::valid);
+    assertEquals(OmLCRule.LC_ID_LENGTH, r2.getId().length(),
+        "Expected a " + OmLCRule.LC_ID_LENGTH + " length generated ID");
+  }
+
+  @Test
+  public void testCreateInValidOmLCRule() {
+    OmLCExpiration exp = new OmLCExpiration.Builder()
+        .setDays(30)
+        .build();
+
+    char[] id = new char[OmLCRule.LC_ID_MAX_LENGTH + 1];
+    Arrays.fill(id, 'a');
+
+    OmLCRule r1 = new OmLCRule.Builder()
+        .setId(new String(id))
+        .setAction(exp)
+        .build();
+    assertOMException(r1::valid, INVALID_REQUEST, "ID length should not exceed allowed limit of 255");
+
+    OmLCRule r2 = new OmLCRule.Builder()
+        .setId("remove Spark logs after 30 days")
+        .setEnabled(true)
+        .setPrefix("/spark/logs")
+        .setAction(null)
+        .build();
+    assertOMException(r2::valid, INVALID_REQUEST,
+        "At least one action needs to be specified in a rule");
+
+    OmLCRule r3 = new OmLCRule.Builder()
+        .setId("remove Spark logs after 30 days")
+        .setEnabled(true)
+        .setPrefix("/spark/logs")
+        .setAction(new OmLCExpiration.Builder()
+            .setDays(30)
+            .setDate(getFutureDateString(100))
+            .build())
+        .build();
+    assertOMException(r3::valid, INVALID_REQUEST,
+        "Either 'days' or 'date' should be specified, but not both or neither.");
+
+    OmLCFilter invalidFilter = getOmLCFilter("prefix", Pair.of("key", "value"), null);
+    OmLCRule r5 = new OmLCRule.Builder()
+        .setId("invalid-filter-rule")
+        .setEnabled(true)
+        .setFilter(invalidFilter)
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build();
+    assertOMException(r5::valid, INVALID_REQUEST,
+        "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
+  }
+
+  @Test
+  public void testMultipleActionsInRule() {
+    OmLCExpiration expiration1 = new OmLCExpiration.Builder()
+        .setDays(30)
+        .build();
+
+    OmLCExpiration expiration2 = new OmLCExpiration.Builder()
+        .setDays(60)
+        .build();
+
+    List<OmLCAction> actions = new ArrayList<>();
+    actions.add(expiration1);
+    actions.add(expiration2);
+
+    OmLCRule.Builder builder = new OmLCRule.Builder();
+    builder.setId("test-rule");
+
+    // Using reflection to bypass the builder's single-action limitation
+    OmLCRule rule = builder.build();
+    rule.setActions(actions);
+
+    assertOMException(rule::valid, INVALID_REQUEST, "A rule can have at most one Expiration action");
+  }
+
+  @Test
+  public void testRuleWithAndOperatorFilter() {
+    Map<String, String> tags = ImmutableMap.of("app", "hadoop", "env", "test");
+    OmLifecycleRuleAndOperator andOperator = getOmLCAndOperator("/logs/", tags);
+    OmLCFilter filter = getOmLCFilter(null, null, andOperator);
+
+    OmLCRule rule = new OmLCRule.Builder()
+        .setId("and-operator-rule")
+        .setEnabled(true)
+        .setFilter(filter)
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build();
+
+    assertDoesNotThrow(rule::valid);
+    assertTrue(rule.isPrefixEnable());
+    assertTrue(rule.isTagEnable());
+  }
+
+  @Test
+  public void testRuleWithTagFilter() {
+    OmLCFilter filter = getOmLCFilter(null, Pair.of("app", "hadoop"), null);
+
+    OmLCRule rule = new OmLCRule.Builder()
+        .setId("tag-filter-rule")
+        .setEnabled(true)
+        .setFilter(filter)
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build();
+
+    assertDoesNotThrow(rule::valid);
+    assertFalse(rule.isPrefixEnable());
+    assertTrue(rule.isTagEnable());
+  }
+
+  @Test
+  public void testDuplicateRuleIDs() {
+    List<OmLCRule> rules = new ArrayList<>();
+
+    rules.add(new OmLCRule.Builder()
+        .setId("duplicate-id")
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build());
+
+    rules.add(new OmLCRule.Builder()
+        .setId("duplicate-id") // Same ID
+        .setAction(new OmLCExpiration.Builder().setDays(60).build())
+        .build());
+
+    OmLifecycleConfiguration config = new OmLifecycleConfiguration.Builder()
+        .setVolume("volume")
+        .setBucket("bucket")
+        .setOwner("owner")
+        .setRules(rules)
+        .build();
+
+    assertOMException(config::valid, INVALID_REQUEST, "Duplicate rule IDs found");
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifeCycleConfiguration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifeCycleConfiguration.java
@@ -45,7 +45,6 @@ public class TestOmLifeCycleConfiguration {
     OmLifecycleConfiguration lcc = new OmLifecycleConfiguration.Builder()
         .setVolume("s3v")
         .setBucket("spark")
-        .setOwner("ozone")
         .setRules(Collections.singletonList(new OmLCRule.Builder()
             .setId("spark logs")
             .setAction(new OmLCExpiration.Builder()
@@ -66,17 +65,14 @@ public class TestOmLifeCycleConfiguration {
 
     List<OmLCRule> rules = Collections.singletonList(rule);
 
-    OmLifecycleConfiguration.Builder lcc0 = getOmLifecycleConfiguration(null, "bucket", "owner", rules);
+    OmLifecycleConfiguration.Builder lcc0 = getOmLifecycleConfiguration(null, "bucket", rules);
     assertOMException(lcc0::build, INVALID_REQUEST, "Volume cannot be blank");
 
-    OmLifecycleConfiguration.Builder lcc1 = getOmLifecycleConfiguration("volume", null, "owner", rules);
+    OmLifecycleConfiguration.Builder lcc1 = getOmLifecycleConfiguration("volume", null, rules);
     assertOMException(lcc1::build, INVALID_REQUEST, "Bucket cannot be blank");
 
-    OmLifecycleConfiguration.Builder lcc2 = getOmLifecycleConfiguration("volume", "bucket", null, rules);
-    assertOMException(lcc2::build, INVALID_REQUEST, "Owner cannot be blank");
-
     OmLifecycleConfiguration.Builder lcc3 = getOmLifecycleConfiguration(
-        "volume", "bucket", "owner", Collections.emptyList());
+        "volume", "bucket", Collections.emptyList());
     assertOMException(lcc3::build, INVALID_REQUEST,
         "At least one rules needs to be specified in a lifecycle configuration");
 
@@ -89,7 +85,7 @@ public class TestOmLifeCycleConfiguration {
           .build();
       rules4.add(r);
     }
-    OmLifecycleConfiguration.Builder lcc4 = getOmLifecycleConfiguration("volume", "bucket", "owner", rules4);
+    OmLifecycleConfiguration.Builder lcc4 = getOmLifecycleConfiguration("volume", "bucket", rules4);
     assertOMException(lcc4::build, INVALID_REQUEST,
         "The number of lifecycle rules must not exceed the allowed limit of");
   }
@@ -98,7 +94,6 @@ public class TestOmLifeCycleConfiguration {
   public void testToBuilder() throws OMException {
     String volume = "test-volume";
     String bucket = "test-bucket";
-    String owner = "test-owner";
     long creationTime = System.currentTimeMillis();
     long objectID = 123456L;
     long updateID = 78910L;
@@ -116,7 +111,6 @@ public class TestOmLifeCycleConfiguration {
     OmLifecycleConfiguration originalConfig = new OmLifecycleConfiguration.Builder()
         .setVolume(volume)
         .setBucket(bucket)
-        .setOwner(owner)
         .setCreationTime(creationTime)
         .addRule(rule1)
         .addRule(rule2)
@@ -129,7 +123,6 @@ public class TestOmLifeCycleConfiguration {
 
     assertEquals(volume, rebuiltConfig.getVolume());
     assertEquals(bucket, rebuiltConfig.getBucket());
-    assertEquals(owner, rebuiltConfig.getOwner());
     assertEquals(creationTime, rebuiltConfig.getCreationTime());
     assertEquals(2, rebuiltConfig.getRules().size());
     assertEquals(rule1.getId(), rebuiltConfig.getRules().get(0).getId());
@@ -175,7 +168,6 @@ public class TestOmLifeCycleConfiguration {
     OmLifecycleConfiguration config = new OmLifecycleConfiguration.Builder()
         .setVolume("test-volume")
         .setBucket("test-bucket")
-        .setOwner("test-owner")
         .setRules(rules)
         .build();
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifeCycleConfiguration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifeCycleConfiguration.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.VALID_OM_LC_AND_OPERATOR;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getFutureDateString;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCAndOperator;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCFilter;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCRule;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLifecycleConfiguration;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test lifecycle configuration related entities.
+ */
+public class TestOmLifeCycleConfiguration {
+
+  @Test
+  public void testCreateValidLCConfiguration() {
+    OmLifecycleConfiguration lcc = new OmLifecycleConfiguration.Builder()
+        .setVolume("s3v")
+        .setBucket("spark")
+        .setOwner("ozone")
+        .setRules(Collections.singletonList(new OmLCRule.Builder()
+            .setId("spark logs")
+            .setAction(new OmLCExpiration.Builder()
+                .setDays(30)
+                .build())
+            .build()))
+        .build();
+
+    assertDoesNotThrow(lcc::valid);
+  }
+
+  @Test
+  public void testCreateInValidLCConfiguration() {
+    OmLCRule rule = new OmLCRule.Builder()
+        .setId("spark logs")
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build();
+
+    List<OmLCRule> rules = Collections.singletonList(rule);
+
+    OmLifecycleConfiguration lcc0 = getOmLifecycleConfiguration(null, "bucket", "owner", rules);
+    assertOMException(lcc0::valid, INVALID_REQUEST, "Volume cannot be blank");
+
+    OmLifecycleConfiguration lcc1 = getOmLifecycleConfiguration("volume", null, "owner", rules);
+    assertOMException(lcc1::valid, INVALID_REQUEST, "Bucket cannot be blank");
+
+    OmLifecycleConfiguration lcc2 = getOmLifecycleConfiguration("volume", "bucket", null, rules);
+    assertOMException(lcc2::valid, INVALID_REQUEST, "Owner cannot be blank");
+
+    OmLifecycleConfiguration lcc3 = getOmLifecycleConfiguration(
+        "volume", "bucket", "owner", Collections.emptyList());
+    assertOMException(lcc3::valid, INVALID_REQUEST,
+        "At least one rules needs to be specified in a lifecycle configuration");
+
+    List<OmLCRule> rules4 = new ArrayList<>(
+        OmLifecycleConfiguration.LC_MAX_RULES + 1);
+    for (int i = 0; i < OmLifecycleConfiguration.LC_MAX_RULES + 1; i++) {
+      OmLCRule r = new OmLCRule.Builder()
+          .setId(Integer.toString(i))
+          .setAction(new OmLCExpiration.Builder().setDays(30).build())
+          .build();
+      rules4.add(r);
+    }
+    OmLifecycleConfiguration lcc4 = getOmLifecycleConfiguration("volume", "bucket", "owner", rules4);
+    assertOMException(lcc4::valid, INVALID_REQUEST,
+        "The number of lifecycle rules must not exceed the allowed limit of");
+
+    List<OmLCRule> rules5 = rules4.subList(0, rules4.size() - 2);
+    // last rule is invalid.
+    rules5.add(new OmLCRule.Builder().build());
+  }
+
+
+  @Test
+  public void testInValidFilterInLCConfiguration() {
+    OmLCFilter invalidLCFilter = getOmLCFilter("prefix", Pair.of("key", "value"), VALID_OM_LC_AND_OPERATOR);
+    OmLCRule rule1 = getOmLCRule("id", null, true, 1, invalidLCFilter);
+    OmLifecycleConfiguration lcc0 =
+        getOmLifecycleConfiguration("volume", "bucket", "owner", Collections.singletonList(rule1));
+    assertOMException(lcc0::valid, INVALID_REQUEST,
+        "Only one of 'Prefix', 'Tag', or 'AndOperator' should be specified");
+  }
+
+  @Test
+  public void testInValidAndOperatorInLCConfiguration() {
+    OmLifecycleRuleAndOperator invalidAndOperator = getOmLCAndOperator("prefix", null);
+    OmLCFilter invalidLCFilter = getOmLCFilter(null, null, invalidAndOperator);
+    OmLCRule rule1 = getOmLCRule("id", null, true, 1, invalidLCFilter);
+    OmLifecycleConfiguration lcc0 =
+        getOmLifecycleConfiguration("volume", "bucket", "owner", Collections.singletonList(rule1));
+    assertOMException(lcc0::valid, INVALID_REQUEST,
+        "'Prefix' alone is not allowed");
+  }
+
+  @Test
+  public void testToBuilder() {
+    String volume = "test-volume";
+    String bucket = "test-bucket";
+    String owner = "test-owner";
+    long creationTime = System.currentTimeMillis();
+    long objectID = 123456L;
+    long updateID = 78910L;
+
+    OmLCRule rule1 = new OmLCRule.Builder()
+        .setId("test-rule1")
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build();
+
+    OmLCRule rule2 = new OmLCRule.Builder()
+        .setId("test-rule2")
+        .setAction(new OmLCExpiration.Builder().setDays(60).build())
+        .build();
+
+    OmLifecycleConfiguration originalConfig = new OmLifecycleConfiguration.Builder()
+        .setVolume(volume)
+        .setBucket(bucket)
+        .setOwner(owner)
+        .setCreationTime(creationTime)
+        .addRule(rule1)
+        .addRule(rule2)
+        .setObjectID(objectID)
+        .setUpdateID(updateID)
+        .build();
+
+    OmLifecycleConfiguration.Builder builder = originalConfig.toBuilder();
+    OmLifecycleConfiguration rebuiltConfig = builder.build();
+
+    assertEquals(volume, rebuiltConfig.getVolume());
+    assertEquals(bucket, rebuiltConfig.getBucket());
+    assertEquals(owner, rebuiltConfig.getOwner());
+    assertEquals(creationTime, rebuiltConfig.getCreationTime());
+    assertEquals(2, rebuiltConfig.getRules().size());
+    assertEquals(rule1.getId(), rebuiltConfig.getRules().get(0).getId());
+    assertEquals(rule2.getId(), rebuiltConfig.getRules().get(1).getId());
+    assertEquals(objectID, rebuiltConfig.getObjectID());
+    assertEquals(updateID, rebuiltConfig.getUpdateID());
+  }
+
+  @Test
+  public void testComplexLifecycleConfiguration() {
+    List<OmLCRule> rules = new ArrayList<>();
+
+    // Rule 1: Simple expiration by days with prefix
+    rules.add(new OmLCRule.Builder()
+        .setId("rule1")
+        .setEnabled(true)
+        .setPrefix("/logs/")
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build());
+
+    // Rule 2: Expiration by date with tag filter
+    rules.add(new OmLCRule.Builder()
+        .setId("rule2")
+        .setEnabled(true)
+        .setFilter(getOmLCFilter(null, Pair.of("temporary", "true"), null))
+        .setAction(new OmLCExpiration.Builder()
+            .setDate(getFutureDateString(100))
+            .build())
+        .build());
+
+    // Rule 3: Expiration with complex AND filter
+    rules.add(new OmLCRule.Builder()
+        .setId("rule3")
+        .setEnabled(true)
+        .setFilter(getOmLCFilter(null, null,
+            getOmLCAndOperator("/backups/",
+                ImmutableMap.of("tier", "archive", "retention", "short"))))
+        .setAction(new OmLCExpiration.Builder().setDays(365).build())
+        .build());
+
+    OmLifecycleConfiguration config = new OmLifecycleConfiguration.Builder()
+        .setVolume("test-volume")
+        .setBucket("test-bucket")
+        .setOwner("test-owner")
+        .setRules(rules)
+        .build();
+
+    assertDoesNotThrow(config::valid);
+    assertEquals(3, config.getRules().size());
+  }
+
+  @Test
+  public void testDisabledRule() {
+    OmLCRule rule = new OmLCRule.Builder()
+        .setId("disabled-rule")
+        .setEnabled(false) // Explicitly disabled
+        .setPrefix("/temp/")
+        .setAction(new OmLCExpiration.Builder().setDays(7).build())
+        .build();
+
+    assertFalse(rule.isEnabled());
+    assertDoesNotThrow(rule::valid);
+  }
+
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifecycleRuleAndOperator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCAndOperator;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test OmLifecycleRuleAndOperator.
+ */
+class TestOmLifecycleRuleAndOperator {
+
+  @Test
+  public void testValidAndOperator() {
+    OmLifecycleRuleAndOperator andOperator1 = getOmLCAndOperator("prefix", Collections.singletonMap("tag1", "value1"));
+    assertDoesNotThrow(andOperator1::valid);
+
+    OmLifecycleRuleAndOperator andOperator2 =
+        getOmLCAndOperator("prefix", ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    assertDoesNotThrow(andOperator2::valid);
+
+    OmLifecycleRuleAndOperator andOperator3 = getOmLCAndOperator(
+        null, ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    assertDoesNotThrow(andOperator3::valid);
+  }
+
+  @Test
+  public void testInValidAndOperator() {
+    OmLifecycleRuleAndOperator andOperator1 = getOmLCAndOperator("prefix", null);
+    assertOMException(andOperator1::valid, INVALID_REQUEST, "'Prefix' alone is not allowed");
+
+    OmLifecycleRuleAndOperator andOperator2 = getOmLCAndOperator(null, Collections.singletonMap("tag1", "value1"));
+    assertOMException(andOperator2::valid, INVALID_REQUEST,
+        "If 'Tags' are specified without 'Prefix', there should be more than one tag");
+
+    OmLifecycleRuleAndOperator andOperator3 = getOmLCAndOperator(null, null);
+    assertOMException(andOperator3::valid, INVALID_REQUEST, "Either 'Tags' or 'Prefix' must be specified.");
+  }
+
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifecycleRuleAndOperator.java
@@ -36,13 +36,18 @@ class TestOmLifecycleRuleAndOperator {
     OmLifecycleRuleAndOperator andOperator1 = getOmLCAndOperator("prefix", Collections.singletonMap("tag1", "value1"));
     assertDoesNotThrow(andOperator1::valid);
 
-    OmLifecycleRuleAndOperator andOperator2 =
-        getOmLCAndOperator("prefix", ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    OmLifecycleRuleAndOperator andOperator2 = getOmLCAndOperator("", Collections.singletonMap("tag1", "value1"));
     assertDoesNotThrow(andOperator2::valid);
 
-    OmLifecycleRuleAndOperator andOperator3 = getOmLCAndOperator(
-        null, ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    OmLifecycleRuleAndOperator andOperator3 =
+        getOmLCAndOperator("prefix", ImmutableMap.of("tag1", "value1", "tag2", "value2"));
     assertDoesNotThrow(andOperator3::valid);
+
+    OmLifecycleRuleAndOperator andOperator4 = getOmLCAndOperator(
+        null, ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    assertDoesNotThrow(andOperator4::valid);
+
+
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifecycleRuleAndOperator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLifecycleRuleAndOperator.java
@@ -19,11 +19,12 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.assertOMException;
-import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCAndOperator;
+import static org.apache.hadoop.ozone.om.helpers.OMLCUtils.getOmLCAndOperatorBuilder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,19 +33,21 @@ import org.junit.jupiter.api.Test;
 class TestOmLifecycleRuleAndOperator {
 
   @Test
-  public void testValidAndOperator() {
-    OmLifecycleRuleAndOperator andOperator1 = getOmLCAndOperator("prefix", Collections.singletonMap("tag1", "value1"));
+  public void testValidAndOperator() throws OMException {
+    OmLifecycleRuleAndOperator andOperator1 =
+        getOmLCAndOperatorBuilder("prefix", Collections.singletonMap("tag1", "value1")).build();
     assertDoesNotThrow(andOperator1::valid);
 
-    OmLifecycleRuleAndOperator andOperator2 = getOmLCAndOperator("", Collections.singletonMap("tag1", "value1"));
+    OmLifecycleRuleAndOperator andOperator2 =
+        getOmLCAndOperatorBuilder("", Collections.singletonMap("tag1", "value1")).build();
     assertDoesNotThrow(andOperator2::valid);
 
-    OmLifecycleRuleAndOperator andOperator3 =
-        getOmLCAndOperator("prefix", ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    OmLifecycleRuleAndOperator andOperator3 = getOmLCAndOperatorBuilder(
+        "prefix", ImmutableMap.of("tag1", "value1", "tag2", "value2")).build();
     assertDoesNotThrow(andOperator3::valid);
 
-    OmLifecycleRuleAndOperator andOperator4 = getOmLCAndOperator(
-        null, ImmutableMap.of("tag1", "value1", "tag2", "value2"));
+    OmLifecycleRuleAndOperator andOperator4 = getOmLCAndOperatorBuilder(
+        null, ImmutableMap.of("tag1", "value1", "tag2", "value2")).build();
     assertDoesNotThrow(andOperator4::valid);
 
 
@@ -52,15 +55,16 @@ class TestOmLifecycleRuleAndOperator {
 
   @Test
   public void testInValidAndOperator() {
-    OmLifecycleRuleAndOperator andOperator1 = getOmLCAndOperator("prefix", null);
-    assertOMException(andOperator1::valid, INVALID_REQUEST, "'Prefix' alone is not allowed");
+    OmLifecycleRuleAndOperator.Builder andOperator1 = getOmLCAndOperatorBuilder("prefix", null);
+    assertOMException(andOperator1::build, INVALID_REQUEST, "'Prefix' alone is not allowed");
 
-    OmLifecycleRuleAndOperator andOperator2 = getOmLCAndOperator(null, Collections.singletonMap("tag1", "value1"));
-    assertOMException(andOperator2::valid, INVALID_REQUEST,
+    OmLifecycleRuleAndOperator.Builder andOperator2 =
+        getOmLCAndOperatorBuilder(null, Collections.singletonMap("tag1", "value1"));
+    assertOMException(andOperator2::build, INVALID_REQUEST,
         "If 'Tags' are specified without 'Prefix', there should be more than one tag");
 
-    OmLifecycleRuleAndOperator andOperator3 = getOmLCAndOperator(null, null);
-    assertOMException(andOperator3::valid, INVALID_REQUEST, "Either 'Tags' or 'Prefix' must be specified.");
+    OmLifecycleRuleAndOperator.Builder andOperator3 = getOmLCAndOperatorBuilder(null, null);
+    assertOMException(andOperator3::build, INVALID_REQUEST, "Either 'Tags' or 'Prefix' must be specified.");
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

AWS doc about the Lifecycle configuration : https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html

Introducing the basic java objects of Lifecycle, and verification logic
- OmLifecycleConfiguration: Corresponding to the object of S3 Lifecycle, an S3 Lifecycle can contain multiple Rules.
- OmLCRule: Corresponding to the specific Rule in Lifecycle configuration, Rule is responsible for defining the action and filtering conditions. Objects that meet the filtering conditions will perform the corresponding action.
- OmLifecycleRuleAndOperator: Corresponding to the And element in Rule, the And element can contain multiple different elements, such as a prefix + a tag or multiple tags
- OmLCAction:  Define what a Rule does to the object, including: Transition (not include current) and Expiration .
  - OmLCExpiration: Define the specific time when the object expires
- OmLCFilter: Corresponding to the Filter in Rule, it is responsible for placing a single filter condition.



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12808

## How was this patch tested?
unit test.
https://github.com/xichen01/ozone/actions/runs/14430304643

