### PR TITLE
HDDS-12678. [DiskBalancer] Use ( capacity - free ) / capacity to calculate disk utilization

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -475,7 +475,7 @@ public class MutableVolumeSet implements VolumeSet {
     for (StorageVolume volume: volumeMap.values()) {
       SpaceUsageSource usage = volume.getCurrentUsage();
       totalCapacity += usage.getCapacity();
-      totalUsed += usage.getUsedSpace();
+      totalUsed += (usage.getCapacity() - usage.getAvailable());
     }
     Preconditions.checkArgument(totalCapacity != 0);
     return (double) totalUsed / totalCapacity;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -523,7 +523,7 @@ public class DiskBalancerService extends BackgroundService {
     long totalCapacity = 0;
 
     for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(inputVolumeSet.getVolumesList())) {
-      totalUsedSpace += volume.getCurrentUsage().getUsedSpace();
+      totalUsedSpace += (volume.getCurrentUsage().getCapacity() - volume.getCurrentUsage().getAvailable());
       totalCapacity += volume.getCurrentUsage().getCapacity();
     }
 
@@ -538,7 +538,7 @@ public class DiskBalancerService extends BackgroundService {
 
     // Calculate excess data in overused volumes
     for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(inputVolumeSet.getVolumesList())) {
-      long usedSpace = volume.getCurrentUsage().getUsedSpace();
+      long usedSpace = volume.getCurrentUsage().getCapacity() - volume.getCurrentUsage().getAvailable();
       long capacity = volume.getCurrentUsage().getCapacity();
       double volumeUtilization = (double) usedSpace / capacity;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
@@ -45,9 +45,9 @@ public class DefaultVolumeChoosingPolicy implements VolumeChoosingPolicy {
         .stream()
         .filter(volume ->
             Math.abs(
-                (double) (((volume.getCurrentUsage().getCapacity() - volume.getCurrentUsage().getAvailable())
-                    + deltaMap.getOrDefault(volume, 0L))
-                    / volume.getCurrentUsage().getCapacity()) - idealUsage) >= threshold)
+                ((double)((volume.getCurrentUsage().getCapacity() - volume.getCurrentUsage().getAvailable())
+                    + deltaMap.getOrDefault(volume, 0L)))
+                    / volume.getCurrentUsage().getCapacity() - idealUsage) >= threshold)
         .sorted((v1, v2) ->
             Double.compare(
                 (double) ((v2.getCurrentUsage().getCapacity() - v2.getCurrentUsage().getAvailable())

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
@@ -45,13 +45,16 @@ public class DefaultVolumeChoosingPolicy implements VolumeChoosingPolicy {
         .stream()
         .filter(volume ->
             Math.abs(
-                (double) (volume.getCurrentUsage().getUsedSpace() + deltaMap.getOrDefault(volume, 0L))
-                    / volume.getCurrentUsage().getCapacity() - idealUsage) >= threshold)
+                (double) (((volume.getCurrentUsage().getCapacity() - volume.getCurrentUsage().getAvailable())
+                    + deltaMap.getOrDefault(volume, 0L))
+                    / volume.getCurrentUsage().getCapacity()) - idealUsage) >= threshold)
         .sorted((v1, v2) ->
             Double.compare(
-                (double) (v2.getCurrentUsage().getUsedSpace() + deltaMap.getOrDefault(v2, 0L)) /
+                (double) ((v2.getCurrentUsage().getCapacity() - v2.getCurrentUsage().getAvailable())
+                    + deltaMap.getOrDefault(v2, 0L)) /
                     v2.getCurrentUsage().getCapacity(),
-                (double) (v1.getCurrentUsage().getUsedSpace() + deltaMap.getOrDefault(v1, 0L)) /
+                (double) ((v1.getCurrentUsage().getCapacity() - v1.getCurrentUsage().getAvailable())
+                    + deltaMap.getOrDefault(v1, 0L)) /
                     v1.getCurrentUsage().getCapacity()))
         .collect(Collectors.toList());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -287,7 +287,7 @@ public class DiskBalancerManager {
     double totalCapacity = 0d, totalUsed = 0d;
     for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
       totalCapacity += reportProto.getCapacity();
-      totalUsed += reportProto.getScmUsed();
+      totalUsed += (reportProto.getCapacity() - reportProto.getRemaining());
     }
 
     Preconditions.checkArgument(totalCapacity != 0);
@@ -295,7 +295,7 @@ public class DiskBalancerManager {
 
     double volumeDensitySum = datanodeInfo.getStorageReports().stream()
         .map(report ->
-            Math.abs((double)report.getScmUsed() / report.getCapacity()
+            Math.abs((double) ((report.getCapacity() - report.getRemaining()) / report.getCapacity())
                 - idealUsage))
         .mapToDouble(Double::valueOf).sum();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -295,7 +295,7 @@ public class DiskBalancerManager {
 
     double volumeDensitySum = datanodeInfo.getStorageReports().stream()
         .map(report ->
-            Math.abs((double) ((report.getCapacity() - report.getRemaining()) / report.getCapacity())
+            Math.abs(((double) (report.getCapacity() - report.getRemaining())) / report.getCapacity()
                 - idealUsage))
         .mapToDouble(Double::valueOf).sum();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, (scmUsed / capacity) is used to calculate the disk utilization. When reserved space for non-ozone usage is defined, scmUsed cannot reflect the data used by non-ozone usage, while free space can.

So change to use formula ( capacity - free ) / capacity. This is also consist with the formula used by Container balancer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12678
## How was this patch tested?

Existing test cases.
