### PR TITLE
HDDS-11703. xcompat audit logs are overwritten

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/xcompat/test-old.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test-old.sh
@@ -26,5 +26,6 @@ source "${COMPOSE_DIR}/lib.sh"
 # old cluster with clients: same version and current version
 for cluster_version in ${old_versions}; do
   export OZONE_VERSION=${cluster_version}
+  export RESULT_DIR="${COMPOSE_DIR}/result/xcompat/old/${cluster_version}-${current_version}"
   COMPOSE_FILE=old-cluster.yaml:clients.yaml test_cross_compatibility ${cluster_version} ${current_version}
 done


### PR DESCRIPTION
## What changes were proposed in this pull request?

Audit logs are saved when shutting down Docker Compose cluster during tests. xcompat starts/stops a cluster for each version being tested. Audit logs from each run overwrite those from previous run.

We should assign a unique prefix or suffix to each run's audit logs to prevent overwrites.

---

For compact old:
create a subdir for each `${cluster_version}-${current_version}`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11703

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14436894307

compact old:
```
'result/xcompat/old/xcompat/old/1.1.0-2.1.0/dn-audit-dn.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.1.0-2.1.0/dn-audit-dn.log'
'result/xcompat/old/xcompat/old/1.1.0-2.1.0/kms-audit.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.1.0-2.1.0/kms-audit.log'
'result/xcompat/old/xcompat/old/1.1.0-2.1.0/om-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.1.0-2.1.0/om-audit-om.log'
'result/xcompat/old/xcompat/old/1.1.0-2.1.0/om-sys-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.1.0-2.1.0/om-sys-audit-om.log'
'result/xcompat/old/xcompat/old/1.1.0-2.1.0/scm-audit-scm.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.1.0-2.1.0/scm-audit-scm.log'

...

'result/xcompat/old/xcompat/old/1.2.1-2.1.0/dn-audit-dn.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.2.1-2.1.0/dn-audit-dn.log'
'result/xcompat/old/xcompat/old/1.2.1-2.1.0/kms-audit.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.2.1-2.1.0/kms-audit.log'
'result/xcompat/old/xcompat/old/1.2.1-2.1.0/om-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.2.1-2.1.0/om-audit-om.log'
'result/xcompat/old/xcompat/old/1.2.1-2.1.0/om-sys-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.2.1-2.1.0/om-sys-audit-om.log'
'result/xcompat/old/xcompat/old/1.2.1-2.1.0/scm-audit-scm.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.2.1-2.1.0/scm-audit-scm.log'

...

'result/xcompat/old/xcompat/old/1.3.0-2.1.0/dn-audit-dn.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.3.0-2.1.0/dn-audit-dn.log'
'result/xcompat/old/xcompat/old/1.3.0-2.1.0/kms-audit.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.3.0-2.1.0/kms-audit.log'
'result/xcompat/old/xcompat/old/1.3.0-2.1.0/om-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.3.0-2.1.0/om-audit-om.log'
'result/xcompat/old/xcompat/old/1.3.0-2.1.0/om-sys-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.3.0-2.1.0/om-sys-audit-om.log'
'result/xcompat/old/xcompat/old/1.3.0-2.1.0/s3g-audit-s3g.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.3.0-2.1.0/s3g-audit-s3g.log'
'result/xcompat/old/xcompat/old/1.3.0-2.1.0/scm-audit-scm.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.3.0-2.1.0/scm-audit-scm.log'

...

'result/xcompat/old/xcompat/old/1.4.0-2.1.0/dn-audit-dn.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.0-2.1.0/dn-audit-dn.log'
'result/xcompat/old/xcompat/old/1.4.0-2.1.0/kms-audit.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.0-2.1.0/kms-audit.log'
'result/xcompat/old/xcompat/old/1.4.0-2.1.0/om-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.0-2.1.0/om-audit-om.log'
'result/xcompat/old/xcompat/old/1.4.0-2.1.0/om-sys-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.0-2.1.0/om-sys-audit-om.log'
'result/xcompat/old/xcompat/old/1.4.0-2.1.0/s3g-audit-s3g.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.0-2.1.0/s3g-audit-s3g.log'
'result/xcompat/old/xcompat/old/1.4.0-2.1.0/scm-audit-scm.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.0-2.1.0/scm-audit-scm.log'

...

'result/xcompat/old/xcompat/old/1.4.1-2.1.0/dn-audit-dn.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.1-2.1.0/dn-audit-dn.log'
'result/xcompat/old/xcompat/old/1.4.1-2.1.0/kms-audit.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.1-2.1.0/kms-audit.log'
'result/xcompat/old/xcompat/old/1.4.1-2.1.0/om-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.1-2.1.0/om-audit-om.log'
'result/xcompat/old/xcompat/old/1.4.1-2.1.0/om-sys-audit-om.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.1-2.1.0/om-sys-audit-om.log'
'result/xcompat/old/xcompat/old/1.4.1-2.1.0/s3g-audit-s3g.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.1-2.1.0/s3g-audit-s3g.log'
'result/xcompat/old/xcompat/old/1.4.1-2.1.0/scm-audit-scm.log' -> '/home/runner/work/ozone/ozone/target/acceptance/xcompat/old/xcompat/old/1.4.1-2.1.0/scm-audit-scm.log'
```