### PR TITLE
HDDS-12823. SnapshotDiffReportOzone#fromProtobuf empty token handling

### DIFF
--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -156,7 +156,7 @@ public class SnapshotDiffHandler extends Handler {
         .forEach(diffReportEntry -> resArray.add(getJsonObject(diffReportEntry)));
     diffReportNode.set("diffList", resArray);
 
-    if (StringUtils.isNotEmpty(diffReportOzone.getToken())) {
+    if (diffReportOzone.getToken() != null) {
       diffReportNode.put("nextToken", diffReportOzone.getToken());
     }
     return diffReportNode;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -156,7 +156,7 @@ public class SnapshotDiffHandler extends Handler {
         .forEach(diffReportEntry -> resArray.add(getJsonObject(diffReportEntry)));
     diffReportNode.set("diffList", resArray);
 
-    if (diffReportOzone.getToken() != null) {
+    if (StringUtils.isNotEmpty(diffReportOzone.getToken())) {
       diffReportNode.put("nextToken", diffReportOzone.getToken());
     }
     return diffReportNode;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -149,7 +149,7 @@ public class SnapshotDiffReportOzone
         report.getDiffListList().stream()
             .map(SnapshotDiffReportOzone::fromProtobufDiffReportEntry)
             .collect(Collectors.toList()),
-        report.getToken());
+        report.hasToken() ? report.getToken() : null);
   }
 
   public static DiffType fromProtobufDiffType(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -2092,7 +2092,6 @@ public abstract class TestOmSnapshot {
         bucketName, snapshot1, snapshot2, null, pageSize);
 
     List<DiffReportEntry> diffReportEntries = diffReport.getDiffList();
-    String nextToken = diffReport.getToken();
 
     // Restart the OM and no need to wait because snapDiff job finished before
     // the restart.
@@ -2101,11 +2100,10 @@ public abstract class TestOmSnapshot {
     await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS,
         () -> cluster.getOzoneManager().isRunning());
 
-    while (nextToken == null || !nextToken.isEmpty()) {
+    while (diffReport.getToken() != null) {
       diffReport = fetchReportPage(volumeName, bucketName, snapshot1,
-          snapshot2, nextToken, pageSize);
+          snapshot2, diffReport.getToken(), pageSize);
       diffReportEntries.addAll(diffReport.getDiffList());
-      nextToken = diffReport.getToken();
     }
     assertEquals(100, diffReportEntries.size());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.leftPad;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
@@ -2100,7 +2101,7 @@ public abstract class TestOmSnapshot {
     await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS,
         () -> cluster.getOzoneManager().isRunning());
 
-    while (diffReport.getToken() != null) {
+    while (isNotEmpty(diffReport.getToken())) {
       diffReport = fetchReportPage(volumeName, bucketName, snapshot1,
           snapshot2, diffReport.getToken(), pageSize);
       diffReportEntries.addAll(diffReport.getDiffList());

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -703,7 +703,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       SnapshotDiffReportOzone report =
           getSnapshotDiffReportOnceComplete(fromSnapshot, toSnapshot, "");
       aggregated = report;
-      while (!report.getToken().isEmpty()) {
+      while (report.getToken() != null) {
         LOG.info(
             "Total Snapshot Diff length between snapshot {} and {} exceeds"
                 + " max page size, Performing another " +

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -703,7 +703,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       SnapshotDiffReportOzone report =
           getSnapshotDiffReportOnceComplete(fromSnapshot, toSnapshot, "");
       aggregated = report;
-      while (report.getToken() != null) {
+      while (StringUtils.isNotEmpty(report.getToken())) {
         LOG.info(
             "Total Snapshot Diff length between snapshot {} and {} exceeds"
                 + " max page size, Performing another " +

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1367,7 +1367,7 @@ public class BasicRootedOzoneClientAdapterImpl
           getSnapshotDiffReportOnceComplete(fromSnapshot, toSnapshot, volume,
               bucket, "");
       aggregated = report;
-      while (!report.getToken().isEmpty()) {
+      while (report.getToken() != null) {
         LOG.info(
             "Total Snapshot Diff length between snapshot {} and {} exceeds"
                 + " max page size, Performing another" +

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1367,7 +1367,7 @@ public class BasicRootedOzoneClientAdapterImpl
           getSnapshotDiffReportOnceComplete(fromSnapshot, toSnapshot, volume,
               bucket, "");
       aggregated = report;
-      while (report.getToken() != null) {
+      while (StringUtils.isNotEmpty(report.getToken())) {
         LOG.info(
             "Total Snapshot Diff length between snapshot {} and {} exceeds"
                 + " max page size, Performing another" +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in SnapshotDiffReportOzone#fromProtobuf, SnapshotDiffReportProto#getToken when initializing SnapshotDiffReportOzone is called regardless whether the token is specified (SnapshotDiffReportProto#hasToken). This causes token to be an empty string due to the protobuf default value.

If a client wants to list all the snapdiff entries and only check whether the token is not null as the termination condition, it will cause the snapdiff list to get stuck infinite loop. It's better to set the SnapshotDiffReportOzone token to null in SnapshotDiffReportOzone#fromProtobuf.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12823

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14439636390