### PR TITLE
HDDS-12740. Use DatanodeID in HddsTestUtils

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -161,8 +161,8 @@ public final class HddsTestUtils {
    */
   public static NodeReportProto getRandomNodeReport(int numberOfStorageReport,
       int numberOfMetadataStorageReport) {
-    DatanodeID nodeId = MockDatanodeDetails.randomDatanodeDetails().getID();
-    return getRandomNodeReport(nodeId, File.separator + nodeId,
+    DatanodeID nodeId = DatanodeID.randomID();
+    return getRandomNodeReport(nodeId, File.separator + nodeId.getID(),
         numberOfStorageReport, numberOfMetadataStorageReport);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -160,7 +161,7 @@ public final class HddsTestUtils {
    */
   public static NodeReportProto getRandomNodeReport(int numberOfStorageReport,
       int numberOfMetadataStorageReport) {
-    UUID nodeId = UUID.randomUUID();
+    DatanodeID nodeId = MockDatanodeDetails.randomDatanodeDetails().getID();
     return getRandomNodeReport(nodeId, File.separator + nodeId,
         numberOfStorageReport, numberOfMetadataStorageReport);
   }
@@ -176,7 +177,7 @@ public final class HddsTestUtils {
    *
    * @return NodeReportProto
    */
-  public static NodeReportProto getRandomNodeReport(UUID nodeId,
+  public static NodeReportProto getRandomNodeReport(DatanodeID nodeId,
       String basePath, int numberOfStorageReport,
       int numberOfMetadataStorageReport) {
     List<StorageReportProto> storageReports = new ArrayList<>();
@@ -218,7 +219,7 @@ public final class HddsTestUtils {
    *
    * @return StorageReportProto
    */
-  public static StorageReportProto getRandomStorageReport(UUID nodeId,
+  public static StorageReportProto getRandomStorageReport(DatanodeID nodeId,
       String path) {
     return createStorageReport(nodeId, path,
         random.nextInt(1000),
@@ -243,7 +244,7 @@ public final class HddsTestUtils {
         StorageTypeProto.DISK);
   }
 
-  public static StorageReportProto createStorageReport(UUID nodeId, String path,
+  public static StorageReportProto createStorageReport(DatanodeID nodeId, String path,
       long capacity) {
     return createStorageReport(nodeId, path,
         capacity,
@@ -252,7 +253,7 @@ public final class HddsTestUtils {
         StorageTypeProto.DISK);
   }
 
-  public static StorageReportProto createStorageReport(UUID nodeId, String path,
+  public static StorageReportProto createStorageReport(DatanodeID nodeId, String path,
        long capacity, long used, long remaining, StorageTypeProto type) {
     return createStorageReport(nodeId, path, capacity, used, remaining,
             type, false);
@@ -269,7 +270,7 @@ public final class HddsTestUtils {
      *
      * @return StorageReportProto
      */
-  public static StorageReportProto createStorageReport(UUID nodeId, String path,
+  public static StorageReportProto createStorageReport(DatanodeID nodeId, String path,
       long capacity, long used, long remaining, StorageTypeProto type,
                                                        boolean failed) {
     Preconditions.checkNotNull(nodeId);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm;
 
-import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto.DISK;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -483,14 +482,14 @@ public class TestSCMCommonPlacementPolicy {
 
     // capacity = 200000, used = 90000, remaining = 101000, committed = 500
     StorageContainerDatanodeProtocolProtos.StorageReportProto storageReport1 =
-        HddsTestUtils.createStorageReport(randomDatanodeDetails().getID(), "/data/hdds",
+        HddsTestUtils.createStorageReport(DatanodeID.randomID(), "/data/hdds",
                 200000, 90000, 101000, DISK).toBuilder()
             .setCommitted(500)
             .setFreeSpaceToSpare(10000)
             .build();
     // capacity = 200000, used = 90000, remaining = 101000, committed = 1000
     StorageContainerDatanodeProtocolProtos.StorageReportProto storageReport2 =
-        HddsTestUtils.createStorageReport(randomDatanodeDetails().getID(), "/data/hdds",
+        HddsTestUtils.createStorageReport(DatanodeID.randomID(), "/data/hdds",
                 200000, 90000, 101000, DISK).toBuilder()
             .setCommitted(1000)
             .setFreeSpaceToSpare(100000)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm;
 
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto.DISK;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -482,14 +483,14 @@ public class TestSCMCommonPlacementPolicy {
 
     // capacity = 200000, used = 90000, remaining = 101000, committed = 500
     StorageContainerDatanodeProtocolProtos.StorageReportProto storageReport1 =
-        HddsTestUtils.createStorageReport(UUID.randomUUID(), "/data/hdds",
+        HddsTestUtils.createStorageReport(randomDatanodeDetails().getID(), "/data/hdds",
                 200000, 90000, 101000, DISK).toBuilder()
             .setCommitted(500)
             .setFreeSpaceToSpare(10000)
             .build();
     // capacity = 200000, used = 90000, remaining = 101000, committed = 1000
     StorageContainerDatanodeProtocolProtos.StorageReportProto storageReport2 =
-        HddsTestUtils.createStorageReport(UUID.randomUUID(), "/data/hdds",
+        HddsTestUtils.createStorageReport(randomDatanodeDetails().getID(), "/data/hdds",
                 200000, 90000, 101000, DISK).toBuilder()
             .setCommitted(1000)
             .setFreeSpaceToSpare(100000)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -271,7 +271,7 @@ public class MockNodeManager implements NodeManager {
         long used = nodeMetricMap.get(dd).getScmUsed().get();
         long remaining = nodeMetricMap.get(dd).getRemaining().get();
         StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-            di.getUuid(), "/data1-" + di.getUuidString(),
+            di.getID(), "/data1-" + di.getUuidString(),
             capacity, used, remaining, null);
         MetadataStorageReportProto metaStorage1 =
             HddsTestUtils.createMetadataStorageReport(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -105,7 +105,7 @@ public class TestContainerPlacementFactory {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
           STORAGE_CAPACITY, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(
@@ -122,19 +122,19 @@ public class TestContainerPlacementFactory {
     }
 
     StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-        dnInfos.get(2).getUuid(),
+        dnInfos.get(2).getID(),
         "/data1-" + dnInfos.get(2).getUuidString(),
         STORAGE_CAPACITY, 90L, 10L, null);
     dnInfos.get(2).updateStorageReports(
         new ArrayList<>(Arrays.asList(storage2)));
     StorageReportProto storage3 = HddsTestUtils.createStorageReport(
-        dnInfos.get(3).getUuid(),
+        dnInfos.get(3).getID(),
         "/data1-" + dnInfos.get(3).getUuidString(),
         STORAGE_CAPACITY, 80L, 20L, null);
     dnInfos.get(3).updateStorageReports(
         new ArrayList<>(Arrays.asList(storage3)));
     StorageReportProto storage4 = HddsTestUtils.createStorageReport(
-        dnInfos.get(4).getUuid(),
+        dnInfos.get(4).getID(),
         "/data1-" + dnInfos.get(4).getUuidString(),
         STORAGE_CAPACITY, 70L, 30L, null);
     dnInfos.get(4).updateStorageReports(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -67,7 +67,7 @@ public class TestSCMContainerPlacementCapacity {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
           100L, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(
@@ -82,19 +82,19 @@ public class TestSCMContainerPlacementCapacity {
     }
 
     StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-        datanodes.get(2).getUuid(),
+        datanodes.get(2).getID(),
         "/data1-" + datanodes.get(2).getUuidString(),
         100L, 90L, 10L, null);
     datanodes.get(2).updateStorageReports(
         new ArrayList<>(Arrays.asList(storage2)));
     StorageReportProto storage3 = HddsTestUtils.createStorageReport(
-        datanodes.get(3).getUuid(),
+        datanodes.get(3).getID(),
         "/data1-" + datanodes.get(3).getUuidString(),
         100L, 80L, 20L, null);
     datanodes.get(3).updateStorageReports(
         new ArrayList<>(Arrays.asList(storage3)));
     StorageReportProto storage4 = HddsTestUtils.createStorageReport(
-        datanodes.get(4).getUuid(),
+        datanodes.get(4).getID(),
         "/data1-" + datanodes.get(4).getUuidString(),
         100L, 70L, 30L, null);
     datanodes.get(4).updateStorageReports(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -117,7 +117,7 @@ public class TestSCMContainerPlacementRackAware {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
           STORAGE_CAPACITY, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(
@@ -132,39 +132,39 @@ public class TestSCMContainerPlacementRackAware {
 
     if (datanodeCount > 4) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-          dnInfos.get(2).getUuid(),
+          dnInfos.get(2).getID(),
           "/data1-" + datanodes.get(2).getUuidString(),
           STORAGE_CAPACITY, 90L, 10L, null);
       dnInfos.get(2).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage2)));
       StorageReportProto storage3 = HddsTestUtils.createStorageReport(
-          dnInfos.get(3).getUuid(),
+          dnInfos.get(3).getID(),
           "/data1-" + dnInfos.get(3).getUuidString(),
           STORAGE_CAPACITY, 80L, 20L, null);
       dnInfos.get(3).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage3)));
       StorageReportProto storage4 = HddsTestUtils.createStorageReport(
-          dnInfos.get(4).getUuid(),
+          dnInfos.get(4).getID(),
           "/data1-" + dnInfos.get(4).getUuidString(),
           STORAGE_CAPACITY, 70L, 30L, null);
       dnInfos.get(4).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage4)));
     } else if (datanodeCount > 3) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-          dnInfos.get(2).getUuid(),
+          dnInfos.get(2).getID(),
           "/data1-" + dnInfos.get(2).getUuidString(),
           STORAGE_CAPACITY, 90L, 10L, null);
       dnInfos.get(2).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage2)));
       StorageReportProto storage3 = HddsTestUtils.createStorageReport(
-          dnInfos.get(3).getUuid(),
+          dnInfos.get(3).getID(),
           "/data1-" + dnInfos.get(3).getUuidString(),
           STORAGE_CAPACITY, 80L, 20L, null);
       dnInfos.get(3).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage3)));
     } else if (datanodeCount > 2) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-          dnInfos.get(2).getUuid(),
+          dnInfos.get(2).getID(),
           "/data1-" + dnInfos.get(2).getUuidString(),
           STORAGE_CAPACITY, 84L, 16L, null);
       dnInfos.get(2).updateStorageReports(
@@ -460,7 +460,7 @@ public class TestSCMContainerPlacementRackAware {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          dnInfo.getUuid(), "/data1-" + dnInfo.getUuidString(),
+          dnInfo.getID(), "/data1-" + dnInfo.getUuidString(),
           STORAGE_CAPACITY, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -97,7 +97,7 @@ public class TestSCMContainerPlacementRackScatter {
 
   private void updateStorageInDatanode(int dnIndex, long used, long remaining) {
     StorageReportProto storage = HddsTestUtils.createStorageReport(
-            dnInfos.get(dnIndex).getUuid(),
+            dnInfos.get(dnIndex).getID(),
             "/data1-" + dnInfos.get(dnIndex).getUuidString(),
             STORAGE_CAPACITY, used, remaining, null);
     dnInfos.get(dnIndex).updateStorageReports(
@@ -183,7 +183,7 @@ public class TestSCMContainerPlacementRackScatter {
         UpgradeUtils.defaultLayoutVersionProto());
 
     StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-        datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+        datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
         STORAGE_CAPACITY, 0, 100L, null);
     MetadataStorageReportProto metaStorage1 =
         HddsTestUtils.createMetadataStorageReport(
@@ -199,39 +199,39 @@ public class TestSCMContainerPlacementRackScatter {
   private void createMocksAndUpdateStorageReports(int datanodeCount) {
     if (datanodeCount > 4) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-          dnInfos.get(2).getUuid(),
+          dnInfos.get(2).getID(),
           "/data1-" + datanodes.get(2).getUuidString(),
           STORAGE_CAPACITY, 90L, 10L, null);
       dnInfos.get(2).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage2)));
       StorageReportProto storage3 = HddsTestUtils.createStorageReport(
-          dnInfos.get(3).getUuid(),
+          dnInfos.get(3).getID(),
           "/data1-" + dnInfos.get(3).getUuidString(),
           STORAGE_CAPACITY, 80L, 20L, null);
       dnInfos.get(3).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage3)));
       StorageReportProto storage4 = HddsTestUtils.createStorageReport(
-          dnInfos.get(4).getUuid(),
+          dnInfos.get(4).getID(),
           "/data1-" + dnInfos.get(4).getUuidString(),
           STORAGE_CAPACITY, 70L, 30L, null);
       dnInfos.get(4).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage4)));
     } else if (datanodeCount > 3) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-          dnInfos.get(2).getUuid(),
+          dnInfos.get(2).getID(),
           "/data1-" + dnInfos.get(2).getUuidString(),
           STORAGE_CAPACITY, 90L, 10L, null);
       dnInfos.get(2).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage2)));
       StorageReportProto storage3 = HddsTestUtils.createStorageReport(
-          dnInfos.get(3).getUuid(),
+          dnInfos.get(3).getID(),
           "/data1-" + dnInfos.get(3).getUuidString(),
           STORAGE_CAPACITY, 80L, 20L, null);
       dnInfos.get(3).updateStorageReports(
           new ArrayList<>(Arrays.asList(storage3)));
     } else if (datanodeCount > 2) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-          dnInfos.get(2).getUuid(),
+          dnInfos.get(2).getID(),
           "/data1-" + dnInfos.get(2).getUuidString(),
           STORAGE_CAPACITY, 84L, 16L, null);
       dnInfos.get(2).updateStorageReports(
@@ -493,7 +493,7 @@ public class TestSCMContainerPlacementRackScatter {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          dnInfo.getUuid(), "/data1-" + dnInfo.getUuidString(),
+          dnInfo.getID(), "/data1-" + dnInfo.getUuidString(),
           STORAGE_CAPACITY, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -64,7 +64,7 @@ public class TestSCMContainerPlacementRandom {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
           100L, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(
@@ -79,7 +79,7 @@ public class TestSCMContainerPlacementRandom {
     }
 
     StorageReportProto storage2 = HddsTestUtils.createStorageReport(
-        datanodes.get(2).getUuid(),
+        datanodes.get(2).getID(),
         "/data1-" + datanodes.get(2).getUuidString(),
         100L, 90L, 10L, null);
     datanodes.get(2).updateStorageReports(
@@ -170,7 +170,7 @@ public class TestSCMContainerPlacementRandom {
           UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
           100L, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
           HddsTestUtils.createMetadataStorageReport(
@@ -185,7 +185,7 @@ public class TestSCMContainerPlacementRandom {
     }
 
     StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-        datanodes.get(1).getUuid(),
+        datanodes.get(1).getID(),
         "/data1-" + datanodes.get(1).getUuidString(),
         100L, 90L, 10L, null);
     datanodes.get(1).updateStorageReports(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -33,13 +33,13 @@ import java.time.Clock;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
@@ -191,7 +191,7 @@ public class TestContainerPlacement {
     XceiverClientManager xceiverClientManager = null;
     try {
       for (DatanodeDetails datanodeDetails : datanodes) {
-        UUID dnId = datanodeDetails.getUuid();
+        DatanodeID dnId = datanodeDetails.getID();
         DatanodeInfo datanodeInfo = scmNodeManager.getNodeStateManager()
             .getNode(datanodeDetails.getID());
         StorageContainerDatanodeProtocolProtos.StorageReportProto report =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -145,7 +145,7 @@ public class TestDeadNodeHandler {
         .concat("/metadata-" + datanode1.getUuidString());
 
     StorageReportProto storageOne = HddsTestUtils.createStorageReport(
-        datanode1.getUuid(), storagePath, 100 * OzoneConsts.TB,
+        datanode1.getID(), storagePath, 100 * OzoneConsts.TB,
         10 * OzoneConsts.TB, 90 * OzoneConsts.TB, null);
     MetadataStorageReportProto metaStorageOne =
         HddsTestUtils.createMetadataStorageReport(metaStoragePath,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
@@ -85,7 +85,7 @@ public class TestNodeReportHandler implements EventPublisher {
   public void testNodeReport() throws IOException {
     DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
     StorageReportProto storageOne = HddsTestUtils
-        .createStorageReport(dn.getUuid(), storagePath.getPath(), 100, 10, 90, null);
+        .createStorageReport(dn.getID(), storagePath.getPath(), 100, 10, 90, null);
     MetadataStorageReportProto metaStorageOne = HddsTestUtils
         .createMetadataStorageReport(metaStoragePath.getPath(), 100, 10, 90, null);
 
@@ -101,7 +101,7 @@ public class TestNodeReportHandler implements EventPublisher {
     assertEquals(10, (long) nodeMetric.get().getScmUsed().get());
 
     StorageReportProto storageTwo = HddsTestUtils
-        .createStorageReport(dn.getUuid(), storagePath.getPath(), 100, 10, 90, null);
+        .createStorageReport(dn.getID(), storagePath.getPath(), 100, 10, 90, null);
     nodeReportHandler.onMessage(
         getNodeReport(dn, Arrays.asList(storageOne, storageTwo),
             Arrays.asList(metaStorageOne)), this);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
@@ -322,7 +323,7 @@ public class TestSCMNodeManager {
     DatanodeDetails details = MockDatanodeDetails.randomDatanodeDetails();
 
     StorageReportProto storageReport =
-        HddsTestUtils.createStorageReport(details.getUuid(),
+        HddsTestUtils.createStorageReport(details.getID(),
             details.getNetworkFullPath(), Long.MAX_VALUE);
     MetadataStorageReportProto metadataStorageReport =
         HddsTestUtils.createMetadataStorageReport(details.getNetworkFullPath(),
@@ -1487,7 +1488,7 @@ public class TestSCMNodeManager {
       for (int x = 0; x < nodeCount; x++) {
         DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
         dnList.add(dn);
-        UUID dnId = dn.getUuid();
+        DatanodeID dnId = dn.getID();
         long free = capacity - used;
         String storagePath = testDir.getAbsolutePath() + "/" + dnId;
         StorageReportProto report = HddsTestUtils
@@ -1509,7 +1510,7 @@ public class TestSCMNodeManager {
   }
 
   private List<StorageReportProto> generateStorageReportProto(
-      int volumeCount, UUID dnId, long capacity, long used, long remaining) {
+      int volumeCount, DatanodeID dnId, long capacity, long used, long remaining) {
     List<StorageReportProto> reports = new ArrayList<>(volumeCount);
     boolean failed = true;
     for (int x = 0; x < volumeCount; x++) {
@@ -1539,7 +1540,7 @@ public class TestSCMNodeManager {
       long used, long remaining, int volumeCount, String totalCapacity,
           String scmUsedPerc, String nonScmUsedPerc) {
     DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
-    UUID dnId = dn.getUuid();
+    DatanodeID dnId = dn.getID();
     List<StorageReportProto> reports = volumeCount > 0 ?
         generateStorageReportProto(volumeCount, dnId, perCapacity,
             used, remaining) : null;
@@ -1573,7 +1574,7 @@ public class TestSCMNodeManager {
       EventQueue eventQueue = (EventQueue) scm.getEventQueue();
       DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
       dnList.add(dn);
-      UUID dnId = dn.getUuid();
+      DatanodeID dnId = dn.getID();
       long free = capacity - used;
       List<StorageReportProto> reports = new ArrayList<>(volumeCount);
       boolean failed = true;
@@ -1626,7 +1627,7 @@ public class TestSCMNodeManager {
       EventPublisher publisher = mock(EventPublisher.class);
       final long capacity = 2000;
       final long usedPerHeartbeat = 100;
-      UUID dnId = datanodeDetails.getUuid();
+      DatanodeID dnId = datanodeDetails.getID();
       for (int x = 0; x < heartbeatCount; x++) {
         long scmUsed = x * usedPerHeartbeat;
         long remaining = capacity - scmUsed;
@@ -1745,7 +1746,7 @@ public class TestSCMNodeManager {
         100, TimeUnit.MILLISECONDS);
 
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
-    UUID dnId = datanodeDetails.getUuid();
+    DatanodeID dnId = datanodeDetails.getID();
     String storagePath = testDir.getAbsolutePath() + "/" + dnId;
     StorageReportProto report =
         HddsTestUtils.createStorageReport(dnId, storagePath, 100, 10, 90, null);
@@ -1885,7 +1886,7 @@ public class TestSCMNodeManager {
       final long capacity = 2000;
       final long used = 100;
       final long remaining = 1900;
-      UUID dnId = datanodeDetails.getUuid();
+      DatanodeID dnId = datanodeDetails.getID();
       String storagePath = testDir.getAbsolutePath() + "/" + dnId;
       StorageReportProto report = HddsTestUtils
           .createStorageReport(dnId, storagePath, capacity, used,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeMetrics.java
@@ -121,7 +121,7 @@ public class TestSCMNodeMetrics {
     long nrProcessed = getCounter("NumNodeReportProcessed");
 
     StorageReportProto storageReport =
-        HddsTestUtils.createStorageReport(registeredDatanode.getUuid(), "/tmp",
+        HddsTestUtils.createStorageReport(registeredDatanode.getID(), "/tmp",
             100, 10, 90, null);
     NodeReportProto nodeReport = NodeReportProto.newBuilder()
         .addStorageReport(storageReport).build();
@@ -142,7 +142,7 @@ public class TestSCMNodeMetrics {
         MockDatanodeDetails.randomDatanodeDetails();
 
     StorageReportProto storageReport = HddsTestUtils.createStorageReport(
-        randomDatanode.getUuid(), "/tmp", 100, 10, 90, null);
+        randomDatanode.getID(), "/tmp", 100, 10, 90, null);
 
     NodeReportProto nodeReport = NodeReportProto.newBuilder()
         .addStorageReport(storageReport).build();
@@ -160,7 +160,7 @@ public class TestSCMNodeMetrics {
   public void testNodeCountAndInfoMetricsReported() throws Exception {
 
     StorageReportProto storageReport = HddsTestUtils.createStorageReport(
-        registeredDatanode.getUuid(), "/tmp", 100, 10, 90, null);
+        registeredDatanode.getID(), "/tmp", 100, 10, 90, null);
     NodeReportProto nodeReport = NodeReportProto.newBuilder()
         .addStorageReport(storageReport).build();
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeStorageStatMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeStorageStatMap.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
-import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -135,7 +134,7 @@ public class TestSCMNodeStorageStatMap {
     SCMNodeStorageStatMap map = new SCMNodeStorageStatMap(conf);
     map.insertNewDatanode(key, reportSet);
     assertTrue(map.isKnownDatanode(key));
-    DatanodeID storageId = randomDatanodeDetails().getID();
+    DatanodeID storageId = DatanodeID.randomID();
     String path = tempFile.getPath().concat("/" + storageId);
     StorageLocationReport report = reportSet.iterator().next();
     long reportCapacity = report.getCapacity();
@@ -157,7 +156,7 @@ public class TestSCMNodeStorageStatMap {
     assertEquals(SCMNodeStorageStatMap.ReportStatus.ALL_IS_WELL, result.getStatus());
 
     reportList.add(HddsTestUtils
-        .createStorageReport(randomDatanodeDetails().getID(), path, reportCapacity,
+        .createStorageReport(DatanodeID.randomID(), path, reportCapacity,
             reportCapacity, 0, null));
     result = map.processNodeReport(key, HddsTestUtils.createNodeReport(
         reportList, Collections.emptyList()));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeStorageStatMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeStorageStatMap.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
@@ -133,7 +135,7 @@ public class TestSCMNodeStorageStatMap {
     SCMNodeStorageStatMap map = new SCMNodeStorageStatMap(conf);
     map.insertNewDatanode(key, reportSet);
     assertTrue(map.isKnownDatanode(key));
-    UUID storageId = UUID.randomUUID();
+    DatanodeID storageId = randomDatanodeDetails().getID();
     String path = tempFile.getPath().concat("/" + storageId);
     StorageLocationReport report = reportSet.iterator().next();
     long reportCapacity = report.getCapacity();
@@ -155,7 +157,7 @@ public class TestSCMNodeStorageStatMap {
     assertEquals(SCMNodeStorageStatMap.ReportStatus.ALL_IS_WELL, result.getStatus());
 
     reportList.add(HddsTestUtils
-        .createStorageReport(UUID.randomUUID(), path, reportCapacity,
+        .createStorageReport(randomDatanodeDetails().getID(), path, reportCapacity,
             reportCapacity, 0, null));
     result = map.processNodeReport(key, HddsTestUtils.createNodeReport(
         reportList, Collections.emptyList()));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
@@ -79,9 +79,9 @@ public class TestStatisticsUpdate {
     DatanodeDetails datanode2 = MockDatanodeDetails.randomDatanodeDetails();
 
     StorageReportProto storageOne = HddsTestUtils.createStorageReport(
-        datanode1.getUuid(), datanode1.getUuidString(), 100, 10, 90, null);
+        datanode1.getID(), datanode1.getUuidString(), 100, 10, 90, null);
     StorageReportProto storageTwo = HddsTestUtils.createStorageReport(
-        datanode2.getUuid(), datanode2.getUuidString(), 200, 20, 180, null);
+        datanode2.getID(), datanode2.getUuidString(), 200, 20, 180, null);
 
     nodeManager.register(datanode1,
         HddsTestUtils.createNodeReport(Arrays.asList(storageOne),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
@@ -111,7 +111,7 @@ public class TestPipelinePlacementFactory {
 
       StorageContainerDatanodeProtocolProtos.StorageReportProto storage1 =
           HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          datanodeInfo.getID(), "/data1-" + datanodeInfo.getUuidString(),
           STORAGE_CAPACITY, 0, 100L, null);
       StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto
           metaStorage1 =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -424,7 +424,7 @@ public class TestEndPoint {
   private RegisterEndpointTask getRegisterEndpointTask(boolean clearDatanodeDetails, OzoneConfiguration conf,
                                                        EndpointStateMachine rpcEndPoint) throws Exception {
     OzoneContainer ozoneContainer = mock(OzoneContainer.class);
-    DatanodeID datanodeID = randomDatanodeDetails().getID();
+    DatanodeID datanodeID = DatanodeID.randomID();
     when(ozoneContainer.getNodeReport()).thenReturn(HddsTestUtils
         .createNodeReport(Arrays.asList(getStorageReports(datanodeID)),
             Arrays.asList(getMetadataStorageReports(datanodeID))));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CloseContainerCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus.Status;
@@ -394,9 +395,9 @@ public class TestEndPoint {
           .register(nodeToRegister.getExtendedProtoBufMessage(), HddsTestUtils
                   .createNodeReport(
                       Arrays.asList(getStorageReports(
-                          nodeToRegister.getUuid())),
+                          nodeToRegister.getID())),
                       Arrays.asList(getMetadataStorageReports(
-                          nodeToRegister.getUuid()))),
+                          nodeToRegister.getID()))),
               HddsTestUtils.getRandomContainerReports(10),
               HddsTestUtils.getRandomPipelineReports(),
               defaultLayoutVersionProto());
@@ -408,13 +409,13 @@ public class TestEndPoint {
     }
   }
 
-  private StorageReportProto getStorageReports(UUID id) {
+  private StorageReportProto getStorageReports(DatanodeID id) {
     String storagePath = testDir.getAbsolutePath() + "/data-" + id;
     return HddsTestUtils.createStorageReport(id, storagePath, 100, 10, 90,
         null);
   }
 
-  private MetadataStorageReportProto getMetadataStorageReports(UUID id) {
+  private MetadataStorageReportProto getMetadataStorageReports(DatanodeID id) {
     String storagePath = testDir.getAbsolutePath() + "/metadata-" + id;
     return HddsTestUtils.createMetadataStorageReport(storagePath, 100, 10, 90,
         null);
@@ -423,7 +424,7 @@ public class TestEndPoint {
   private RegisterEndpointTask getRegisterEndpointTask(boolean clearDatanodeDetails, OzoneConfiguration conf,
                                                        EndpointStateMachine rpcEndPoint) throws Exception {
     OzoneContainer ozoneContainer = mock(OzoneContainer.class);
-    UUID datanodeID = UUID.randomUUID();
+    DatanodeID datanodeID = randomDatanodeDetails().getID();
     when(ozoneContainer.getNodeReport()).thenReturn(HddsTestUtils
         .createNodeReport(Arrays.asList(getStorageReports(datanodeID)),
             Arrays.asList(getMetadataStorageReports(datanodeID))));
@@ -519,8 +520,8 @@ public class TestEndPoint {
       SCMHeartbeatRequestProto request = SCMHeartbeatRequestProto.newBuilder()
           .setDatanodeDetails(dataNode.getProtoBufMessage())
           .setNodeReport(HddsTestUtils.createNodeReport(
-              Arrays.asList(getStorageReports(dataNode.getUuid())),
-              Arrays.asList(getMetadataStorageReports(dataNode.getUuid()))))
+              Arrays.asList(getStorageReports(dataNode.getID())),
+              Arrays.asList(getMetadataStorageReports(dataNode.getID()))))
           .build();
 
       SCMHeartbeatResponseProto responseProto = rpcEndPoint.getEndPoint()
@@ -542,8 +543,8 @@ public class TestEndPoint {
       SCMHeartbeatRequestProto request = SCMHeartbeatRequestProto.newBuilder()
           .setDatanodeDetails(dataNode.getProtoBufMessage())
           .setNodeReport(HddsTestUtils.createNodeReport(
-              Arrays.asList(getStorageReports(dataNode.getUuid())),
-              Arrays.asList(getMetadataStorageReports(dataNode.getUuid()))))
+              Arrays.asList(getStorageReports(dataNode.getID())),
+              Arrays.asList(getMetadataStorageReports(dataNode.getID()))))
           .build();
 
       SCMHeartbeatResponseProto responseProto = rpcEndPoint.getEndPoint()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaced UUID with DatanodeID in HddsTestUtils.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12740

## How was this patch tested?

https://github.com/peterxcli/ozone/actions/runs/14440286413