### PR TITLE
HDDS-12841. Remove unnecessary getBucketInfo() call under OFS#readFile API

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -379,8 +379,8 @@ public class BasicRootedOzoneClientAdapterImpl
         config);
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
-      return bucket.readFile(key).getInputStream();
+      ClientProtocol clientProtocol = ozoneClient.getProxy();
+      return clientProtocol.readFile(ofsPath.getVolumeName(), ofsPath.getBucketName(), key).getInputStream();
     } catch (OMException ex) {
       if (ex.getResult() == OMException.ResultCodes.FILE_NOT_FOUND
           || ex.getResult() == OMException.ResultCodes.KEY_NOT_FOUND


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of today, the readFile API for the OFS client makes two round trips to the Ozone Manager impacting performance:

- First, it calls getBucketInfo() to fetch information about the bucket.
- Then, it calls getKeyInfo() to fetch information about the actual file being read.

However, the first call to obtain getBucketInfo() is not required and can safely be removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12841

## How was this patch tested?

Green Git CI: https://github.com/tanvipenumudy/ozone/actions/runs/14463440199/ (existing test-suite should pass)