### PR TITLE
HDDS-12816. Ozone debug replicas chunk-info has incorrect or None in FileLocations

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -327,9 +327,12 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       ContainerCommandRequestProto request, DatanodeDetails dn) {
     boolean isEcRequest = pipeline.getReplicationConfig()
         .getReplicationType() == HddsProtos.ReplicationType.EC;
+    if (request.hasReadContainer() && isEcRequest) {
+      request = request.toBuilder().setDatanodeUuid(dn.getUuidString()).build();
+    }
     if (request.hasGetBlock() && isEcRequest) {
       ContainerProtos.GetBlockRequestProto gbr = request.getGetBlock();
-      request = request.toBuilder().setGetBlock(gbr.toBuilder().setBlockID(
+      request = request.toBuilder().setDatanodeUuid(dn.getUuidString()).setGetBlock(gbr.toBuilder().setBlockID(
           gbr.getBlockID().toBuilder().setReplicaIndex(
               pipeline.getReplicaIndex(dn)).build()).build()).build();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The debug chunkinfo was missing file location for other data indexes or parity blocks.
This issue occurred due to recent changes introduced in [HDDS-11667](https://issues.apache.org/jira/browse/HDDS-11667), which added validation of the DatanodeID on all incoming requests to a datanode.

In the chunkinfo tool, we send both GetBlock and ReadContainer requests to all relevant datanodes. However, the requests were being constructed using a fixed datanode UUID, regardless of which datanode the request was actually being sent to. As a result, the UUID in the request didn’t match the UUID of the target datanode, causing these requests to fail validation and leading to missing file location information in the output.

This patch ensures that the datanodeUuid field is correctly set in the request, matching the datanode the request is intended for.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12816

## How was this patch tested?

Tested Manually.
Output:
```
bash-4.2$ ozone sh volume create /vol
bash-4.2$ ozone sh bucket create vol/buckec -r RS-3-2-1024k -t EC
bash-4.2$ ozone sh key put vol/buckec/3MB HISTORY.md 
bash-4.2$ ozone debug replicas chunk-info vol/buckec/3MB

{
  "KeyLocations" : [ [ {
    "Locations" : {
      "files" : [ "/data/hdds/hdds/CID-6f49a927-1793-4d0f-b7e2-9305c3d88ae5/current/containerDir0/3/chunks/115816896921600003.block" ],
      "pipelineID" : "126e763f-0b91-493b-87d6-7ad95c588022",
      "chunkType" : "PARITY"
    },
    "Datanode-HostName" : "ozone-ha-datanode-6.ozone-ha_default",
    "Datanode-IP" : "172.25.0.6",
    "Container-ID" : 3,
    "Block-ID" : 115816896921600003
  }, {
    "Locations" : {
      "files" : [ "/data/hdds/hdds/CID-6f49a927-1793-4d0f-b7e2-9305c3d88ae5/current/containerDir0/3/chunks/115816896921600003.block" ],
      "pipelineID" : "126e763f-0b91-493b-87d6-7ad95c588022",
      "chunkType" : "PARITY"
    },
    "Datanode-HostName" : "ozone-ha-datanode-1.ozone-ha_default",
    "Datanode-IP" : "172.25.0.14",
    "Container-ID" : 3,
    "Block-ID" : 115816896921600003
  }, {
    "Locations" : {
      "files" : [ "/data/hdds/hdds/CID-6f49a927-1793-4d0f-b7e2-9305c3d88ae5/current/containerDir0/3/chunks/115816896921600003.block" ],
      "pipelineID" : "126e763f-0b91-493b-87d6-7ad95c588022",
      "chunkType" : "DATA"
    },
    "Datanode-HostName" : "ozone-ha-datanode-4.ozone-ha_default",
    "Datanode-IP" : "172.25.0.15",
    "Container-ID" : 3,
    "Block-ID" : 115816896921600003
  }, {
    "Locations" : {
      "files" : [ "/data/hdds/hdds/CID-6f49a927-1793-4d0f-b7e2-9305c3d88ae5/current/containerDir0/3/chunks/115816896921600003.block" ],
      "pipelineID" : "126e763f-0b91-493b-87d6-7ad95c588022",
      "chunkType" : "DATA"
    },
    "Datanode-HostName" : "ozone-ha-datanode-5.ozone-ha_default",
    "Datanode-IP" : "172.25.0.16",
    "Container-ID" : 3,
    "Block-ID" : 115816896921600003
  }, {
    "Locations" : {
      "files" : [ "/data/hdds/hdds/CID-6f49a927-1793-4d0f-b7e2-9305c3d88ae5/current/containerDir0/3/chunks/115816896921600003.block" ],
      "pipelineID" : "126e763f-0b91-493b-87d6-7ad95c588022",
      "chunkType" : "DATA"
    },
    "Datanode-HostName" : "ozone-ha-datanode-2.ozone-ha_default",
    "Datanode-IP" : "172.25.0.12",
    "Container-ID" : 3,
    "Block-ID" : 115816896921600003
  } ] ]
}

```