### PR TITLE
HDDS-12773. bad substitution in bats test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -31,8 +31,23 @@ source "${_testlib_dir}/../smoketest/testlib.sh"
 : ${SECURITY_ENABLED:=false}
 : ${SCM:=scm}
 
-# version is used in bucket name, which does not allow uppercase
-export OZONE_CURRENT_VERSION="$(echo "${ozone.version}" | sed -e 's/-SNAPSHOT//' | tr '[:upper:]' '[:lower:]')"
+# Check if running from output of Maven build or from source
+_is_build() {
+  local file=""
+  # Variable is replaced by Maven at build time,
+  # so if it empty, we are running from source, if non-empty, then running in build output (target)
+  [[ -n "${file}" ]]
+}
+
+# Avoid `bad substitution` error
+if _is_build; then
+  # version is used in bucket name, which does not allow uppercase
+  # variable is replaced by Maven at build time
+  OZONE_CURRENT_VERSION="$(echo "${ozone.version}" | sed -e 's/-SNAPSHOT//' | tr '[:upper:]' '[:lower:]')"
+else
+  OZONE_CURRENT_VERSION=src
+fi
+export OZONE_CURRENT_VERSION
 
 # create temp directory for test data; only once, even if testlib.sh is sourced again
 if [[ -z "${TEST_DATA_DIR:-}" ]] && [[ "${KEEP_RUNNING:-false}" == "false" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `bad substitution` in bats test:

```
1..5
Using Docker Compose v2
/home/runner/work/ozone/ozone/hadoop-ozone/dist/src/test/shell/../../main/compose/testlib.sh: line 37: ${ozone.version}: bad substitution
Using Docker Compose v2
/home/runner/work/ozone/ozone/hadoop-ozone/dist/src/test/shell/../../main/compose/testlib.sh: line 37: ${ozone.version}: bad substitution
ok 1 Find test recursive, only on one level
Using Docker Compose v2
/home/runner/work/ozone/ozone/hadoop-ozone/dist/src/test/shell/../../main/compose/testlib.sh: line 37: ${ozone.version}: bad substitution
ok 2 Find tests without explicit filter
Using Docker Compose v2
/home/runner/work/ozone/ozone/hadoop-ozone/dist/src/test/shell/../../main/compose/testlib.sh: line 37: ${ozone.version}: bad substitution
ok 3 Find test by suite
Using Docker Compose v2
/home/runner/work/ozone/ozone/hadoop-ozone/dist/src/test/shell/../../main/compose/testlib.sh: line 37: ${ozone.version}: bad substitution
ok 4 Find failing test suite explicitly
Using Docker Compose v2
/home/runner/work/ozone/ozone/hadoop-ozone/dist/src/test/shell/../../main/compose/testlib.sh: line 37: ${ozone.version}: bad substitution
ok 5 Find test default suite
```

This is just a cosmetic issue, test passes anyway.

https://issues.apache.org/jira/browse/HDDS-12773

## How was this patch tested?

```
$ ./hadoop-ozone/dev-support/checks/bats.sh
...
1..5
Using Docker Compose v2
Using Docker Compose v2
ok 1 Find test recursive, only on one level
Using Docker Compose v2
ok 2 Find tests without explicit filter
Using Docker Compose v2
ok 3 Find test by suite
Using Docker Compose v2
ok 4 Find failing test suite explicitly
Using Docker Compose v2
ok 5 Find test default suite
...
```

https://github.com/adoroszlai/ozone/actions/runs/14474768804