### PR TITLE
HDDS-12846. Log DatanodeDetails instead of DatanodeDetails.getUuidString

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -140,10 +140,10 @@ public class ClosePipelineCommandHandler implements CommandHandler {
           // well. It is a no-op for XceiverServerSpi implementations (e.g. XceiverServerGrpc)
           server.removeGroup(pipelineIdProto);
           LOG.info("Close Pipeline {} command on datanode {}.", pipelineID,
-              dn.getUuidString());
+              dn);
         } else {
           LOG.debug("Ignoring close pipeline command for pipeline {} on datanode {} " +
-              "as it does not exist", pipelineID, dn.getUuidString());
+              "as it does not exist", pipelineID, dn);
         }
       } catch (IOException e) {
         Throwable gme = HddsClientUtils.containsException(e, GroupMismatchException.class);
@@ -151,7 +151,7 @@ public class ClosePipelineCommandHandler implements CommandHandler {
           // ignore silently since this means that the group has been closed by earlier close pipeline
           // command in another datanode
           LOG.debug("The group for pipeline {} on datanode {} has been removed by earlier close " +
-              "pipeline command handled in another datanode", pipelineID, dn.getUuidString());
+              "pipeline command handled in another datanode", pipelineID, dn);
         } else {
           LOG.error("Can't close pipeline {}", pipelineID, e);
         }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -139,8 +139,7 @@ public class ClosePipelineCommandHandler implements CommandHandler {
           // Remove the Ratis group from the current datanode pipeline, might throw GroupMismatchException as
           // well. It is a no-op for XceiverServerSpi implementations (e.g. XceiverServerGrpc)
           server.removeGroup(pipelineIdProto);
-          LOG.info("Close Pipeline {} command on datanode {}.", pipelineID,
-              dn);
+          LOG.info("Close Pipeline {} command on datanode {}.", pipelineID, dn);
         } else {
           LOG.debug("Ignoring close pipeline command for pipeline {} on datanode {} " +
               "as it does not exist", pipelineID, dn);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -127,7 +127,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
       }
     }
     logger.debug("Container Balancer could not find a target for " +
-        "source datanode {}", source.getUuidString());
+        "source datanode {}", source);
     return null;
   }
 
@@ -164,8 +164,8 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
     boolean isPolicySatisfied = placementStatus.isPolicySatisfied();
     if (!isPolicySatisfied) {
       logger.debug("Moving container {} from source {} to target {} will not " +
-              "satisfy placement policy.", containerID, source.getUuidString(),
-          target.getUuidString());
+              "satisfy placement policy.", containerID, source,
+          target);
     }
     return isPolicySatisfied;
   }
@@ -191,7 +191,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
       if (sizeEnteringAfterMove > config.getMaxSizeEnteringTarget()) {
         logger.debug("{} bytes cannot enter datanode {} because 'size" +
                 ".entering.target.max' limit is {} and {} bytes have already " +
-                "entered.", size, target.getUuidString(),
+                "entered.", size, target,
             config.getMaxSizeEnteringTarget(),
             sizeEnteringNode.get(target));
         return false;
@@ -200,14 +200,14 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
           .calculateUtilization(sizeEnteringAfterMove), upperLimit) > 0) {
         logger.debug("{} bytes cannot enter datanode {} because its " +
                 "utilization will exceed the upper limit of {}.", size,
-            target.getUuidString(), upperLimit);
+            target, upperLimit);
         return false;
       }
       return true;
     }
 
     logger.warn("No record of how much size has entered datanode {}",
-        target.getUuidString());
+        target);
     return false;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -164,8 +164,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
     boolean isPolicySatisfied = placementStatus.isPolicySatisfied();
     if (!isPolicySatisfied) {
       logger.debug("Moving container {} from source {} to target {} will not " +
-              "satisfy placement policy.", containerID, source,
-          target);
+              "satisfy placement policy.", containerID, source, target);
     }
     return isPolicySatisfied;
   }
@@ -206,8 +205,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
       return true;
     }
 
-    logger.warn("No record of how much size has entered datanode {}",
-        target);
+    logger.warn("No record of how much size has entered datanode {}", target);
     return false;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -945,7 +945,7 @@ public class ContainerBalancerTask implements Runnable {
         if (ex != null) {
           LOG.info("Container move for container {} from source {} to " +
                   "target {} failed with exceptions.",
-              containerID.toString(), source,
+              containerID, source,
               moveSelection.getTargetNode(), ex);
           metrics.incrementNumContainerMovesFailedInLatestIteration(1);
         } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -506,7 +506,7 @@ public class ContainerBalancerTask implements Runnable {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Utilization for node {} with capacity {}B, used {}B, and " +
                 "remaining {}B is {}",
-            datanodeUsageInfo.getDatanodeDetails().getUuidString(),
+            datanodeUsageInfo.getDatanodeDetails(),
             datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
             datanodeUsageInfo.getScmNodeStat().getScmUsed().get(),
             datanodeUsageInfo.getScmNodeStat().getRemaining().get(),
@@ -683,8 +683,8 @@ public class ContainerBalancerTask implements Runnable {
             "{}B from source datanode {} to target datanode {}",
         containerID.toString(),
         containerInfo.getUsedBytes(),
-        source.getUuidString(),
-        moveSelection.getTargetNode().getUuidString());
+        source,
+        moveSelection.getTargetNode());
 
     if (moveContainer(source, moveSelection)) {
       // consider move successful for now, and update selection criteria
@@ -792,9 +792,8 @@ public class ContainerBalancerTask implements Runnable {
       if (!entry.getValue().isDone()) {
         LOG.warn("Container move timed out for container {} from source {}" +
                 " to target {}.", entry.getKey().getContainerID(),
-            containerToSourceMap.get(entry.getKey().getContainerID())
-                                .getUuidString(),
-            entry.getKey().getTargetNode().getUuidString());
+            containerToSourceMap.get(entry.getKey().getContainerID()),
+            entry.getKey().getTargetNode());
 
         entry.getValue().cancel(true);
         numCancelled += 1;
@@ -817,14 +816,14 @@ public class ContainerBalancerTask implements Runnable {
     if (sourceContainerIDSet.isEmpty()) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("ContainerBalancer could not find any candidate containers " +
-            "for datanode {}", source.getUuidString());
+            "for datanode {}", source);
       }
       return null;
     }
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("ContainerBalancer is finding suitable target for source " +
-          "datanode {}", source.getUuidString());
+          "datanode {}", source);
     }
 
     ContainerMoveSelection moveSelection = null;
@@ -846,12 +845,11 @@ public class ContainerBalancerTask implements Runnable {
 
     if (moveSelection == null) {
       LOG.info("ContainerBalancer could not find a suitable target for " +
-          "source node {}.", source.getUuidString());
+          "source node {}.", source);
       return null;
     }
     LOG.info("ContainerBalancer matched source datanode {} with target " +
-            "datanode {} for container move.", source.getUuidString(),
-        moveSelection.getTargetNode().getUuidString());
+            "datanode {} for container move.", source, moveSelection.getTargetNode());
 
     return moveSelection;
   }
@@ -947,24 +945,22 @@ public class ContainerBalancerTask implements Runnable {
         if (ex != null) {
           LOG.info("Container move for container {} from source {} to " +
                   "target {} failed with exceptions.",
-              containerID.toString(),
-              source.getUuidString(),
-              moveSelection.getTargetNode().getUuidString(), ex);
+              containerID.toString(), source,
+              moveSelection.getTargetNode(), ex);
           metrics.incrementNumContainerMovesFailedInLatestIteration(1);
         } else {
           if (result == MoveManager.MoveResult.COMPLETED) {
             sizeActuallyMovedInLatestIteration +=
                 containerInfo.getUsedBytes();
             LOG.debug("Container move completed for container {} from " +
-                    "source {} to target {}", containerID,
-                source.getUuidString(),
-                moveSelection.getTargetNode().getUuidString());
+                    "source {} to target {}", containerID, source,
+                moveSelection.getTargetNode());
           } else {
             LOG.warn(
                 "Container move for container {} from source {} to target" +
                     " {} failed: {}",
-                moveSelection.getContainerID(), source.getUuidString(),
-                moveSelection.getTargetNode().getUuidString(), result);
+                moveSelection.getContainerID(), source,
+                moveSelection.getTargetNode(), result);
           }
         }
       });

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
@@ -178,8 +178,7 @@ public class FindSourceGreedy implements FindSourceStrategy {
       if (Double.compare(nodeManager.getUsageInfo(source)
           .calculateUtilization(-sizeLeavingAfterMove), lowerLimit) < 0) {
         LOG.debug("{} bytes cannot leave datanode {} because its utilization " +
-                "will drop below the lower limit of {}.", size,
-            source, lowerLimit);
+                "will drop below the lower limit of {}.", size, source, lowerLimit);
         return false;
       }
       return true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
@@ -165,13 +165,13 @@ public class FindSourceGreedy implements FindSourceStrategy {
       //3 after subtracting sizeLeavingAfterMove, the usage is bigger
       // than or equal to lowerLimit
       if (size <= 0) {
-        LOG.debug("{} bytes container cannot leave datanode {}", size, source.getUuidString());
+        LOG.debug("{} bytes container cannot leave datanode {}", size, source);
         return false;
       }
       if (sizeLeavingAfterMove > config.getMaxSizeLeavingSource()) {
         LOG.debug("{} bytes cannot leave datanode {} because 'size.leaving" +
                 ".source.max' limit is {} and {} bytes have already left.",
-            size, source.getUuidString(), config.getMaxSizeLeavingSource(),
+            size, source, config.getMaxSizeLeavingSource(),
             sizeLeavingNode.get(source));
         return false;
       }
@@ -179,7 +179,7 @@ public class FindSourceGreedy implements FindSourceStrategy {
           .calculateUtilization(-sizeLeavingAfterMove), lowerLimit) < 0) {
         LOG.debug("{} bytes cannot leave datanode {} because its utilization " +
                 "will drop below the lower limit of {}.", size,
-            source.getUuidString(), lowerLimit);
+            source, lowerLimit);
         return false;
       }
       return true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -300,7 +300,7 @@ public final class MoveManager implements
       }
       startMove(containerInfo, src, tgt, ret);
       LOG.debug("Processed a move request for container {}, from {} to {}",
-          cid, src.getUuidString(), tgt.getUuidString());
+          cid, src, tgt);
       return ret;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/DeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/DeletingContainerHandler.java
@@ -98,7 +98,7 @@ public class DeletingContainerHandler extends AbstractCheck {
           } catch (NotLeaderException e) {
             LOG.warn("Failed to delete empty replica with index {} for " +
                     "container {} on datanode {}", rp.getReplicaIndex(),
-                cID, rp.getDatanodeDetails().getUuidString(), e);
+                cID, rp.getDatanodeDetails(), e);
           }
         });
     return true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -134,7 +134,7 @@ public class EmptyContainerHandler extends AbstractCheck {
                 " {} on datanode {}",
             rp.getReplicaIndex(),
             containerInfo.containerID(),
-            rp.getDatanodeDetails().getUuidString(), e);
+            rp.getDatanodeDetails(), e);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/HealthyReadOnlyNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/HealthyReadOnlyNodeHandler.java
@@ -88,7 +88,7 @@ public class HealthyReadOnlyNodeHandler
                 "containers.",
             pipelineID, pipeline.getPipelineState(),
             HddsProtos.NodeState.HEALTHY_READONLY,
-            datanodeDetails.getUuidString());
+            datanodeDetails);
         pipelineManager.closePipeline(pipelineID);
       } catch (IOException ex) {
         LOG.error("Failed to close pipeline {} which uses HEALTHY READONLY " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -439,10 +439,7 @@ public class SCMNodeManager implements NodeManager {
         final DatanodeInfo oldNode = nodeStateManager.getNode(datanodeDetails);
         if (updateDnsToDnIdMap(oldNode.getHostName(), oldNode.getIpAddress(),
             hostName, ipAddress, dnId)) {
-          LOG.info("Updating datanode {} from {} to {}",
-                  datanodeDetails,
-                  oldNode,
-                  datanodeDetails);
+          LOG.info("Updating datanode from {} to {}", oldNode, datanodeDetails);
           clusterMap.update(oldNode, datanodeDetails);
           nodeStateManager.updateNode(datanodeDetails, layoutInfo);
           DatanodeDetails dn = nodeStateManager.getNode(datanodeDetails);
@@ -1069,8 +1066,7 @@ public class SCMNodeManager implements NodeManager {
       return new SCMNodeStat(capacity, used, remaining, committed,
           freeSpaceToSpare);
     } catch (NodeNotFoundException e) {
-      LOG.warn("Cannot generate NodeStat, datanode {} not found.",
-          datanodeDetails);
+      LOG.warn("Cannot generate NodeStat, datanode {} not found.", datanodeDetails);
       return null;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -440,7 +440,7 @@ public class SCMNodeManager implements NodeManager {
         if (updateDnsToDnIdMap(oldNode.getHostName(), oldNode.getIpAddress(),
             hostName, ipAddress, dnId)) {
           LOG.info("Updating datanode {} from {} to {}",
-                  datanodeDetails.getUuidString(),
+                  datanodeDetails,
                   oldNode,
                   datanodeDetails);
           clusterMap.update(oldNode, datanodeDetails);
@@ -1070,7 +1070,7 @@ public class SCMNodeManager implements NodeManager {
           freeSpaceToSpare);
     } catch (NodeNotFoundException e) {
       LOG.warn("Cannot generate NodeStat, datanode {} not found.",
-          datanodeDetails.getUuidString());
+          datanodeDetails);
       return null;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
@@ -75,7 +75,7 @@ public class PipelineActionHandler
     final PipelineID pid = PipelineID.getFromProtobuf(info.getPipelineID());
 
     final String logMsg = "Received pipeline action " + action + " for " + pid +
-        " from datanode " + datanode.getUuidString() + "." +
+        " from datanode " + datanode + "." +
         " Reason : " + info.getDetailedReason();
 
     // We can skip processing Pipeline Action if the current SCM is not leader.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -546,8 +546,7 @@ public class PipelineManagerImpl implements PipelineManager {
     List<Pipeline> pipelinesWithStaleIpOrHostname =
             getStalePipelines(datanodeDetails);
     if (pipelinesWithStaleIpOrHostname.isEmpty()) {
-      LOG.debug("No stale pipelines for datanode {}",
-              datanodeDetails);
+      LOG.debug("No stale pipelines for datanode {}", datanodeDetails);
       return;
     }
     LOG.info("Found {} stale pipelines",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -547,7 +547,7 @@ public class PipelineManagerImpl implements PipelineManager {
             getStalePipelines(datanodeDetails);
     if (pipelinesWithStaleIpOrHostname.isEmpty()) {
       LOG.debug("No stale pipelines for datanode {}",
-              datanodeDetails.getUuidString());
+              datanodeDetails);
       return;
     }
     LOG.info("Found {} stale pipelines",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -201,7 +201,7 @@ public class RatisPipelineProvider
 
     dns.forEach(node -> {
       LOG.info("Sending CreatePipelineCommand for pipeline:{} to datanode:{}",
-          pipeline.getId(), node.getUuidString());
+          pipeline.getId(), node);
       eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
           new CommandForDatanode<>(node.getUuid(), createCommand));
     });

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -189,7 +189,7 @@ public class MockNodeManager implements NodeManager {
         } catch (NodeNotFoundException e) {
           LOG.warn("Could not find Datanode {} for adding containers to it. " +
                   "Skipping this node.", usageInfo
-              .getDatanodeDetails().getUuidString());
+              .getDatanodeDetails());
           continue;
         }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -188,8 +188,7 @@ public class MockNodeManager implements NodeManager {
           setContainers(usageInfo.getDatanodeDetails(), entry.getValue());
         } catch (NodeNotFoundException e) {
           LOG.warn("Could not find Datanode {} for adding containers to it. " +
-                  "Skipping this node.", usageInfo
-              .getDatanodeDetails());
+                  "Skipping this node.", usageInfo.getDatanodeDetails());
           continue;
         }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -409,7 +409,7 @@ public class TestHDDSUpgrade {
           new ArrayList<>(cluster.getHddsDatanodes());
       for (HddsDatanodeService ds: currentDataNodes) {
         DatanodeDetails dn = ds.getDatanodeDetails();
-        LOG.info("Restarting datanode {}", dn.getUuidString());
+        LOG.info("Restarting datanode {}", dn);
         cluster.restartHddsDatanode(dn, false);
       }
       cluster.waitForClusterToBeReady();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
@@ -44,8 +44,7 @@ public class ReconNewNodeHandler implements EventHandler<DatanodeDetails> {
     try {
       nodeManager.addNodeToDB(datanodeDetails);
     } catch (IOException e) {
-      LOG.error("Unable to add new node {} to Node DB.",
-          datanodeDetails);
+      LOG.error("Unable to add new node {} to Node DB.", datanodeDetails);
     }
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
@@ -45,7 +45,7 @@ public class ReconNewNodeHandler implements EventHandler<DatanodeDetails> {
       nodeManager.addNodeToDB(datanodeDetails);
     } catch (IOException e) {
       LOG.error("Unable to add new node {} to Node DB.",
-          datanodeDetails.getUuidString());
+          datanodeDetails);
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulator.java
@@ -337,7 +337,7 @@ public class DatanodeSimulator implements Callable<Void>, FreonSubcommand {
       throws IOException {
     if (!registerDataNode(dn)) {
       LOGGER.info("Failed to register datanode to SCM: {}",
-          dn.getDatanodeDetails().getUuidString());
+          dn.getDatanodeDetails());
       return false;
     }
 
@@ -359,7 +359,7 @@ public class DatanodeSimulator implements Callable<Void>, FreonSubcommand {
         reconHeartbeatInterval, TimeUnit.MILLISECONDS);
 
     LOGGER.info("Successfully registered datanode to SCM: {}",
-        dn.getDatanodeDetails().getUuidString());
+        dn.getDatanodeDetails());
     return true;
   }
 
@@ -418,7 +418,7 @@ public class DatanodeSimulator implements Callable<Void>, FreonSubcommand {
       }
     } catch (Exception e) {
       LOGGER.info("Error sending heartbeat for {}: {}",
-          dn.getDatanodeDetails().getUuidString(), e.getMessage(), e);
+          dn.getDatanodeDetails(), e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`DatanodeDetails#toString()` includes UUID, hostname, IP. We should use `DatanodeDetails` object in log messages instead of its `getUuidString()`.

## What is the link to the Apache JIRA
[HDDS-12846](https://issues.apache.org/jira/browse/HDDS-12846)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14493342437
