### PR TITLE
HDDS-12849. On demand container scanner should not be static

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -67,7 +67,7 @@ public class ContainerSet implements Iterable<Container<?>> {
   private Clock clock;
   private long recoveringTimeout;
   private final Table<Long, String> containerIdsTable;
-  // Handler that will be invoked when a user of a container reports an error.
+  // Handler that will be invoked when a scan of a container in this set is requested.
   private Consumer<Container<?>> containerScanHandler;
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -428,7 +428,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         // Create a specific exception that signals for on demand scanning
         // and move this general scan to where it is more appropriate.
         // Add integration tests to test the full functionality.
-        OnDemandContainerDataScanner.scanContainer(container);
+        containerSet.reportError(containerID);
         audit(action, eventType, msg, dispatcherContext, AuditEventStatus.FAILURE,
             new Exception(responseProto.getMessage()));
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -74,7 +74,6 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.VolumeUsage;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScanError;
 import org.apache.hadoop.ozone.container.ozoneimpl.DataScanResult;
-import org.apache.hadoop.ozone.container.ozoneimpl.OnDemandContainerDataScanner;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ProtocolMessageEnum;
@@ -428,7 +427,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         // Create a specific exception that signals for on demand scanning
         // and move this general scan to where it is more appropriate.
         // Add integration tests to test the full functionality.
-        containerSet.reportError(containerID);
+        containerSet.scanContainer(containerID);
         audit(action, eventType, msg, dispatcherContext, AuditEventStatus.FAILURE,
             new Exception(responseProto.getMessage()));
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -155,7 +155,6 @@ import org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl;
 import org.apache.hadoop.ozone.container.keyvalue.impl.ChunkManagerFactory;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
-import org.apache.hadoop.ozone.container.ozoneimpl.OnDemandContainerDataScanner;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
@@ -1582,7 +1581,7 @@ public class KeyValueHandler extends Handler {
     }
 
     // Trigger manual on demand scanner
-    containerSet.reportError(containerID);
+    containerSet.scanContainer(containerID);
     sendICR(container);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -54,7 +54,7 @@ public final class OnDemandContainerDataScanner {
   private final OnDemandScannerMetrics metrics;
   private final long minScanGap;
 
-  private OnDemandContainerDataScanner(
+  public OnDemandContainerDataScanner(
       ContainerScannerConfiguration conf, ContainerController controller) {
     containerController = controller;
     throttler = new DataTransferThrottler(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -45,8 +45,6 @@ public final class OnDemandContainerDataScanner {
   public static final Logger LOG =
       LoggerFactory.getLogger(OnDemandContainerDataScanner.class);
 
-  private static volatile OnDemandContainerDataScanner instance;
-
   private final ExecutorService scanExecutor;
   private final ContainerController containerController;
   private final DataTransferThrottler throttler;
@@ -68,26 +66,11 @@ public final class OnDemandContainerDataScanner {
     minScanGap = conf.getContainerScanMinGap();
   }
 
-  public static synchronized void init(
-      ContainerScannerConfiguration conf, ContainerController controller) {
-    if (instance != null) {
-      LOG.warn("Trying to initialize on demand scanner" +
-          " a second time on a datanode.");
-      return;
-    }
-    instance = new OnDemandContainerDataScanner(conf, controller);
-  }
-
-  private static boolean shouldScan(Container<?> container) {
+  private boolean shouldScan(Container<?> container) {
     if (container == null) {
       return false;
     }
     long containerID = container.getContainerData().getContainerID();
-    if (instance == null) {
-      LOG.debug("Skipping on demand scan for container {} since scanner was " +
-          "not initialized.", containerID);
-      return false;
-    }
 
     HddsVolume containerVolume = container.getContainerData().getVolume();
     if (containerVolume.isFailed()) {
@@ -96,11 +79,11 @@ public final class OnDemandContainerDataScanner {
       return false;
     }
 
-    return !ContainerUtils.recentlyScanned(container, instance.minScanGap,
+    return !ContainerUtils.recentlyScanned(container, minScanGap,
         LOG) && container.shouldScanData();
   }
 
-  public static Optional<Future<?>> scanContainer(Container<?> container) {
+  public Optional<Future<?>> scanContainer(Container<?> container) {
     if (!shouldScan(container)) {
       return Optional.empty();
     }
@@ -108,7 +91,7 @@ public final class OnDemandContainerDataScanner {
     Future<?> resultFuture = null;
     long containerId = container.getContainerData().getContainerID();
     if (addContainerToScheduledContainers(containerId)) {
-      resultFuture = instance.scanExecutor.submit(() -> {
+      resultFuture = scanExecutor.submit(() -> {
         performOnDemandScan(container);
         removeContainerFromScheduledContainers(containerId);
       });
@@ -116,16 +99,16 @@ public final class OnDemandContainerDataScanner {
     return Optional.ofNullable(resultFuture);
   }
 
-  private static boolean addContainerToScheduledContainers(long containerId) {
-    return instance.containerRescheduleCheckSet.add(containerId);
+  private boolean addContainerToScheduledContainers(long containerId) {
+    return containerRescheduleCheckSet.add(containerId);
   }
 
-  private static void removeContainerFromScheduledContainers(
+  private void removeContainerFromScheduledContainers(
       long containerId) {
-    instance.containerRescheduleCheckSet.remove(containerId);
+    containerRescheduleCheckSet.remove(containerId);
   }
 
-  private static void performOnDemandScan(Container<?> container) {
+  private void performOnDemandScan(Container<?> container) {
     if (!shouldScan(container)) {
       return;
     }
@@ -135,21 +118,21 @@ public final class OnDemandContainerDataScanner {
       ContainerData containerData = container.getContainerData();
       logScanStart(containerData);
 
-      ScanResult result = container.scanData(instance.throttler, instance.canceler);
+      ScanResult result = container.scanData(throttler, canceler);
       // Metrics for skipped containers should not be updated.
       if (result.isDeleted()) {
         LOG.debug("Container [{}] has been deleted during the data scan.", containerId);
       } else {
         if (!result.isHealthy()) {
           logUnhealthyScanResult(containerId, result, LOG);
-          boolean containerMarkedUnhealthy = instance.containerController
+          boolean containerMarkedUnhealthy = containerController
               .markContainerUnhealthy(containerId, result);
           if (containerMarkedUnhealthy) {
-            instance.metrics.incNumUnHealthyContainers();
+            metrics.incNumUnHealthyContainers();
           }
         }
         // TODO HDDS-10374 will need to update the merkle tree here as well.
-        instance.metrics.incNumContainersScanned();
+        metrics.incNumContainersScanned();
       }
 
       // Even if the container was deleted, mark the scan as completed since we already logged it as starting.
@@ -157,7 +140,7 @@ public final class OnDemandContainerDataScanner {
       logScanCompleted(containerData, now);
 
       if (!result.isDeleted()) {
-        instance.containerController.updateDataScanTimestamp(containerId, now);
+        containerController.updateDataScanTimestamp(containerId, now);
       }
     } catch (IOException e) {
       LOG.warn("Unexpected exception while scanning container "
@@ -169,7 +152,7 @@ public final class OnDemandContainerDataScanner {
     }
   }
 
-  private static void logScanStart(ContainerData containerData) {
+  private void logScanStart(ContainerData containerData) {
     if (LOG.isDebugEnabled()) {
       Optional<Instant> scanTimestamp = containerData.lastDataScanTime();
       Object lastScanTime = scanTimestamp.map(ts -> "at " + ts).orElse("never");
@@ -178,35 +161,27 @@ public final class OnDemandContainerDataScanner {
     }
   }
 
-  private static void logScanCompleted(
+  private void logScanCompleted(
       ContainerData containerData, Instant timestamp) {
     LOG.debug("Completed scan of container {} at {}",
         containerData.getContainerID(), timestamp);
   }
 
-  public static OnDemandScannerMetrics getMetrics() {
-    return instance.metrics;
+  public OnDemandScannerMetrics getMetrics() {
+    return metrics;
   }
 
   @VisibleForTesting
-  public static DataTransferThrottler getThrottler() {
-    return instance.throttler;
+  public DataTransferThrottler getThrottler() {
+    return throttler;
   }
 
   @VisibleForTesting
-  public static Canceler getCanceler() {
-    return instance.canceler;
+  public Canceler getCanceler() {
+    return canceler;
   }
 
-  public static synchronized void shutdown() {
-    if (instance == null) {
-      return;
-    }
-    instance.shutdownScanner();
-  }
-
-  private synchronized void shutdownScanner() {
-    instance = null;
+  public synchronized void shutdown() {
     metrics.unregister();
     String shutdownMessage = "On-demand container scanner is shutting down.";
     LOG.info(shutdownMessage);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -171,16 +171,6 @@ public final class OnDemandContainerDataScanner {
     return metrics;
   }
 
-  @VisibleForTesting
-  public DataTransferThrottler getThrottler() {
-    return throttler;
-  }
-
-  @VisibleForTesting
-  public Canceler getCanceler() {
-    return canceler;
-  }
-
   public synchronized void shutdown() {
     metrics.unregister();
     String shutdownMessage = "On-demand container scanner is shutting down.";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container.ozoneimpl;
 
 import static org.apache.hadoop.ozone.container.ozoneimpl.AbstractBackgroundContainerScanner.logUnhealthyScanResult;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -453,7 +453,7 @@ public class OzoneContainer {
     for (BackgroundContainerDataScanner s : dataScanners) {
       s.shutdown();
     }
-    OnDemandContainerDataScanner.shutdown();
+    onDemandScanner.shutdown();
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -121,6 +121,7 @@ public class OzoneContainer {
   private final XceiverServerSpi readChannel;
   private final ContainerController controller;
   private BackgroundContainerMetadataScanner metadataScanner;
+  private OnDemandContainerDataScanner onDemandScanner;
   private List<BackgroundContainerDataScanner> dataScanners;
   private List<AbstractBackgroundContainerScanner> backgroundScanners;
   private final BlockDeletingService blockDeletingService;
@@ -432,7 +433,8 @@ public class OzoneContainer {
           "so the on-demand container data scanner will not start.");
       return;
     }
-    OnDemandContainerDataScanner.init(c, controller);
+    onDemandScanner = new OnDemandContainerDataScanner(c, controller);
+    containerSet.registerContainerErrorHandler(onDemandScanner::scanContainer);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -434,7 +434,7 @@ public class OzoneContainer {
       return;
     }
     onDemandScanner = new OnDemandContainerDataScanner(c, controller);
-    containerSet.registerContainerErrorHandler(onDemandScanner::scanContainer);
+    containerSet.registerContainerScanHandler(onDemandScanner::scanContainer);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -289,13 +289,20 @@ public class TestContainerSet {
   public void testContainerScanHandler(ContainerLayoutVersion layout) throws Exception {
     setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
-    // Atomic long required since lambda modification must be effectively final.
+    // Scan when no handler is registered should not throw an exception.
+    containerSet.scanContainer(FIRST_ID);
+
+    // Scan of non-existent container should not throw exception or trigger the handler.
+    containerSet.scanContainer(FIRST_ID - 1);
     AtomicLong invocationCount = new AtomicLong();
     containerSet.registerContainerScanHandler(c -> {
+      // If the handler was incorrectly triggered for a non-existent container, this assert would fail.
       assertEquals(c.getContainerData().getContainerID(), FIRST_ID);
       invocationCount.getAndIncrement();
     });
+    assertEquals(0, invocationCount.get());
 
+    // Only scan of an existing container when a handler is registered should trigger a scan.
     containerSet.scanContainer(FIRST_ID);
     assertEquals(1, invocationCount.get());
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.junit.jupiter.api.Test;
 
 /**
  * Class used to test ContainerSet operations.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -292,18 +292,19 @@ public class TestContainerSet {
     // Scan when no handler is registered should not throw an exception.
     containerSet.scanContainer(FIRST_ID);
 
-    // Scan of non-existent container should not throw exception or trigger the handler.
-    containerSet.scanContainer(FIRST_ID - 1);
     AtomicLong invocationCount = new AtomicLong();
     containerSet.registerContainerScanHandler(c -> {
       // If the handler was incorrectly triggered for a non-existent container, this assert would fail.
-      assertEquals(c.getContainerData().getContainerID(), FIRST_ID);
+      assertEquals(FIRST_ID, c.getContainerData().getContainerID());
       invocationCount.getAndIncrement();
     });
-    assertEquals(0, invocationCount.get());
 
-    // Only scan of an existing container when a handler is registered should trigger a scan.
+    // Scan of an existing container when a handler is registered should trigger a scan.
     containerSet.scanContainer(FIRST_ID);
+    assertEquals(1, invocationCount.get());
+
+    // Scan of non-existent container should not throw exception or trigger an additional invocation.
+    containerSet.scanContainer(FIRST_ID - 1);
     assertEquals(1, invocationCount.get());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerDataScanner.java
@@ -104,8 +104,7 @@ public class TestOnDemandContainerDataScanner extends
 
   @Test
   public void testScanTimestampUpdated() throws Exception {
-    Optional<Future<?>> scanFuture =
-        onDemandScanner.scanContainer(healthy);
+    Optional<Future<?>> scanFuture = onDemandScanner.scanContainer(healthy);
     assertTrue(scanFuture.isPresent());
     scanFuture.get().get();
     verify(controller, atLeastOnce())
@@ -113,8 +112,7 @@ public class TestOnDemandContainerDataScanner extends
             eq(healthy.getContainerData().getContainerID()), any());
 
     // Metrics for deleted container should not be updated.
-    scanFuture =
-        onDemandScanner.scanContainer(healthy);
+    scanFuture = onDemandScanner.scanContainer(healthy);
     assertTrue(scanFuture.isPresent());
     scanFuture.get().get();
     verify(controller, never())
@@ -157,12 +155,9 @@ public class TestOnDemandContainerDataScanner extends
   @Override
   public void testScannerMetrics() throws Exception {
     ArrayList<Optional<Future<?>>> resultFutureList = Lists.newArrayList();
-    resultFutureList.add(onDemandScanner.scanContainer(
-        corruptData));
-    resultFutureList.add(
-        onDemandScanner.scanContainer(openContainer));
-    resultFutureList.add(
-        onDemandScanner.scanContainer(openCorruptMetadata));
+    resultFutureList.add(onDemandScanner.scanContainer(corruptData));
+    resultFutureList.add(onDemandScanner.scanContainer(openContainer));
+    resultFutureList.add(onDemandScanner.scanContainer(openCorruptMetadata));
     resultFutureList.add(onDemandScanner.scanContainer(healthy));
     // Deleted containers will not count towards the scan count metric.
     resultFutureList.add(onDemandScanner.scanContainer(deletedContainer));
@@ -286,8 +281,7 @@ public class TestOnDemandContainerDataScanner extends
   }
 
   private void scanContainer(Container<?> container) throws Exception {
-    Optional<Future<?>> scanFuture =
-        onDemandScanner.scanContainer(container);
+    Optional<Future<?>> scanFuture = onDemandScanner.scanContainer(container);
     if (scanFuture.isPresent()) {
       scanFuture.get().get();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The on demand container scanner was originally implemented as a static instance so that it could be easily triggered from anywhere in the code. This is now causing problems for reconciliation testing where multiple replicas exist in the same process. We are invoking on demand scans for each replica after it is reconciled, and these scans for different replicas are hitting the same container scanner concurrently. This is required for tests to pass in #7490.

Due to the layout of the datanode code, it is difficult to get items like this to all places where they are needed, which is why the on demand scanner was initially static. I have attempted to remedy this issue by adding a scan handler which can be triggered from the `ContainerSet`. `ContainerSet` was chosen because it is both created by the `OzoneContainer` which also initializes the scanners, and available in most locations in the datanode.

## What is the link to the Apache JIRA

HDDS-12849

## How was this patch tested?

Existing unit and integration tests for on demand container scanner pass. New unit test added.
