### PR TITLE
HDDS-12431. [DiskBalancer] Use committedBytes to reserve the space pre-allocated for container

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -93,13 +93,13 @@ public class DiskBalancerService extends BackgroundService {
   private Set<Long> inProgressContainers;
 
   /**
-   * A map that tracks the total bytes freed from each source volume
+   * A map that tracks the total bytes which will be freed from each source volume
    * during container moves in the current disk balancing cycle.
    *
    * Unlike committedBytes, which is used for pre-allocating space on
-   * destination volumes, deltaSizes helps track how much space has
-   * effectively been freed on the source volumes without modifying
-   * their committedBytes (which could otherwise go negative).
+   * destination volumes, deltaSizes helps track how many space will be
+   * freed on the source volumes without modifying their
+   * committedBytes (which could otherwise go negative).
    */
   private Map<HddsVolume, Long> deltaSizes;
   private MutableVolumeSet volumeSet;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -338,7 +338,7 @@ public class DiskBalancerService extends BackgroundService {
 
     for (int i = 0; i < availableTaskCount; i++) {
       Pair<HddsVolume, HddsVolume> pair = volumeChoosingPolicy
-          .chooseVolume(volumeSet, threshold);
+          .chooseVolume(volumeSet, threshold, deltaSizes);
       if (pair == null) {
         continue;
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container.diskbalancer.policy;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
@@ -37,7 +36,7 @@ public class DefaultVolumeChoosingPolicy implements VolumeChoosingPolicy {
 
   @Override
   public Pair<HddsVolume, HddsVolume> chooseVolume(MutableVolumeSet volumeSet,
-      double threshold, Map<HddsVolume, Long> deltaMap) {
+      double threshold) {
     double idealUsage = volumeSet.getIdealUsage();
 
     List<HddsVolume> volumes = StorageVolumeUtil
@@ -46,15 +45,15 @@ public class DefaultVolumeChoosingPolicy implements VolumeChoosingPolicy {
         .filter(volume ->
             Math.abs(
                 ((double)((volume.getCurrentUsage().getCapacity() - volume.getCurrentUsage().getAvailable())
-                    + deltaMap.getOrDefault(volume, 0L)))
+                    + volume.getCommittedBytes()))
                     / volume.getCurrentUsage().getCapacity() - idealUsage) >= threshold)
         .sorted((v1, v2) ->
             Double.compare(
                 (double) ((v2.getCurrentUsage().getCapacity() - v2.getCurrentUsage().getAvailable())
-                    + deltaMap.getOrDefault(v2, 0L)) /
+                    + v2.getCommittedBytes()) /
                     v2.getCurrentUsage().getCapacity(),
                 (double) ((v1.getCurrentUsage().getCapacity() - v1.getCurrentUsage().getAvailable())
-                    + deltaMap.getOrDefault(v1, 0L)) /
+                    + v1.getCommittedBytes()) /
                     v1.getCurrentUsage().getCapacity()))
         .collect(Collectors.toList());
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/VolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/VolumeChoosingPolicy.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.container.diskbalancer.policy;
 
-import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -31,9 +30,8 @@ public interface VolumeChoosingPolicy {
    *
    * @param volumeSet - volumes to choose from.
    * @param threshold - the threshold to choose source and dest volumes.
-   * @param deltaSizes - the sizes changes of inProgress balancing jobs.
    * @return Source volume and Dest volume.
    */
   Pair<HddsVolume, HddsVolume> chooseVolume(MutableVolumeSet volumeSet,
-      double threshold, Map<HddsVolume, Long> deltaSizes);
+      double threshold);
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/VolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/VolumeChoosingPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.container.diskbalancer.policy;
 
+import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -30,8 +31,9 @@ public interface VolumeChoosingPolicy {
    *
    * @param volumeSet - volumes to choose from.
    * @param threshold - the threshold to choose source and dest volumes.
+   * @param deltaSizes - the sizes changes of inProgress balancing jobs.
    * @return Source volume and Dest volume.
    */
   Pair<HddsVolume, HddsVolume> chooseVolume(MutableVolumeSet volumeSet,
-      double threshold);
+      double threshold, Map<HddsVolume, Long> deltaSizes);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently it uses deltaSizes to record the pre-allocated and pre-deleted bytes of each volume due to there is selected container to move.

But deltaSizes is not aware by other activities, such as container creation, container moving command by container balancer. So there is chance that data volume will be over allocated due to this.

This task aims to use HddsVolume#committedBytes to replace deltaSizes, so that the space pre-allocated by disk balancer will be fully awared by HddsVolume.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12431

## How was this patch tested?

Passed existing tests.
