### PR TITLE
HDDS-12867. Replace hard-coded namespace URL with constant S3_XML_NAMESPACE

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -277,7 +277,6 @@ public final class OzoneConsts {
   public static final String S3_GETSECRET_USER = "S3GetSecretUser";
   public static final String S3_SETSECRET_USER = "S3SetSecretUser";
   public static final String S3_REVOKESECRET_USER = "S3RevokeSecretUser";
-  public static final String S3_NAMESPACE_URL = "http://s3.amazonaws.com/doc/2006-03-01/";
   public static final String RENAMED_KEYS_MAP = "renamedKeysMap";
   public static final String UNRENAMED_KEYS_MAP = "unRenamedKeysMap";
   public static final String MULTIPART_UPLOAD_PART_NUMBER = "partNumber";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -277,6 +277,7 @@ public final class OzoneConsts {
   public static final String S3_GETSECRET_USER = "S3GetSecretUser";
   public static final String S3_SETSECRET_USER = "S3SetSecretUser";
   public static final String S3_REVOKESECRET_USER = "S3RevokeSecretUser";
+  public static final String S3_NAMESPACE_URL = "http://s3.amazonaws.com/doc/2006-03-01/";
   public static final String RENAMED_KEYS_MAP = "renamedKeysMap";
   public static final String UNRENAMED_KEYS_MAP = "unRenamedKeysMap";
   public static final String MULTIPART_UPLOAD_PART_NUMBER = "partNumber";

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/package-info.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/package-info.java
@@ -19,10 +19,10 @@
  * Common classes required for S3 rest API's.
  */
 @javax.xml.bind.annotation.XmlSchema(
-    namespace = "http://s3.amazonaws"
-        + ".com/doc/2006-03-01/", elementFormDefault =
+    namespace = S3Consts.S3_XML_NAMESPACE, elementFormDefault =
     javax.xml.bind.annotation.XmlNsForm.QUALIFIED,
     xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = "http://s3.amazonaws"
-            + ".com/doc/2006-03-01/", prefix = "")})
+        @javax.xml.bind.annotation.XmlNs(namespaceURI = S3Consts.S3_XML_NAMESPACE, prefix = "")})
 package org.apache.hadoop.ozone.s3.commontypes;
+
+import org.apache.hadoop.ozone.s3.util.S3Consts;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
@@ -24,13 +24,14 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Request for Complete Multipart Upload request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CompleteMultipartUpload", namespace =
-    "http://s3.amazonaws.com/doc/2006-03-01/")
+    S3Consts.S3_XML_NAMESPACE)
 public class CompleteMultipartUploadRequest {
 
   @XmlElement(name = "Part")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
@@ -30,10 +30,10 @@ import org.apache.hadoop.ozone.OzoneConsts;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CompleteMultipartUpload", namespace =
-    "http://s3.amazonaws.com/doc/2006-03-01/")
+    OzoneConsts.S3_NAMESPACE_URL)
 public class CompleteMultipartUploadRequest {
 
-  @XmlElement(name = "Part", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Part", namespace = OzoneConsts.S3_NAMESPACE_URL)
   private List<Part> partList = new ArrayList<>();
 
   public List<Part> getPartList() {
@@ -51,10 +51,10 @@ public class CompleteMultipartUploadRequest {
   @XmlRootElement(name = "Part")
   public static class Part {
 
-    @XmlElement(name = "PartNumber", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "PartNumber", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private int partNumber;
 
-    @XmlElement(name = OzoneConsts.ETAG, namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = OzoneConsts.ETAG, namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String eTag;
 
     public int getPartNumber() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
     "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CompleteMultipartUploadRequest {
 
-  @XmlElement(name = "Part")
+  @XmlElement(name = "Part", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private List<Part> partList = new ArrayList<>();
 
   public List<Part> getPartList() {
@@ -51,10 +51,10 @@ public class CompleteMultipartUploadRequest {
   @XmlRootElement(name = "Part")
   public static class Part {
 
-    @XmlElement(name = "PartNumber")
+    @XmlElement(name = "PartNumber", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private int partNumber;
 
-    @XmlElement(name = OzoneConsts.ETAG)
+    @XmlElement(name = OzoneConsts.ETAG, namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String eTag;
 
     public int getPartNumber() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
@@ -30,10 +30,10 @@ import org.apache.hadoop.ozone.OzoneConsts;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CompleteMultipartUpload", namespace =
-    OzoneConsts.S3_NAMESPACE_URL)
+    "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CompleteMultipartUploadRequest {
 
-  @XmlElement(name = "Part", namespace = OzoneConsts.S3_NAMESPACE_URL)
+  @XmlElement(name = "Part", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private List<Part> partList = new ArrayList<>();
 
   public List<Part> getPartList() {
@@ -51,10 +51,10 @@ public class CompleteMultipartUploadRequest {
   @XmlRootElement(name = "Part")
   public static class Part {
 
-    @XmlElement(name = "PartNumber", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "PartNumber", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private int partNumber;
 
-    @XmlElement(name = OzoneConsts.ETAG, namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = OzoneConsts.ETAG, namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String eTag;
 
     public int getPartNumber() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
     "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CompleteMultipartUploadRequest {
 
-  @XmlElement(name = "Part", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Part")
   private List<Part> partList = new ArrayList<>();
 
   public List<Part> getPartList() {
@@ -51,10 +51,10 @@ public class CompleteMultipartUploadRequest {
   @XmlRootElement(name = "Part")
   public static class Part {
 
-    @XmlElement(name = "PartNumber", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "PartNumber")
     private int partNumber;
 
-    @XmlElement(name = OzoneConsts.ETAG, namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = OzoneConsts.ETAG)
     private String eTag;
 
     public int getPartNumber() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadResponse.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Complete Multipart Upload request response.
@@ -29,7 +30,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CompleteMultipartUploadResult", namespace =
-    "http://s3.amazonaws.com/doc/2006-03-01/")
+    S3Consts.S3_XML_NAMESPACE)
 public class CompleteMultipartUploadResponse {
 
   @XmlElement(name = "Location")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadResponse.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CompleteMultipartUploadResult", namespace =
-    OzoneConsts.S3_NAMESPACE_URL)
+    "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CompleteMultipartUploadResponse {
 
   @XmlElement(name = "Location")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadResponse.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CompleteMultipartUploadResult", namespace =
-    "http://s3.amazonaws.com/doc/2006-03-01/")
+    OzoneConsts.S3_NAMESPACE_URL)
 public class CompleteMultipartUploadResponse {
 
   @XmlElement(name = "Location")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CopyObjectResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class CopyObjectResponse {
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CopyObjectResult",
-    namespace = OzoneConsts.S3_NAMESPACE_URL)
+    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CopyObjectResponse {
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
@@ -25,13 +25,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Copy object Response.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CopyObjectResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = S3Consts.S3_XML_NAMESPACE)
 public class CopyObjectResponse {
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
@@ -25,13 +25,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Copy object Response.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CopyPartResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = S3Consts.S3_XML_NAMESPACE)
 public class CopyPartResult {
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CopyPartResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class CopyPartResult {
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "CopyPartResult",
-    namespace = OzoneConsts.S3_NAMESPACE_URL)
+    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CopyPartResult {
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
@@ -26,13 +26,14 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.hadoop.ozone.s3.commontypes.BucketMetadata;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Response from the ListBucket RPC Call.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "ListAllMyBucketsResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = S3Consts.S3_XML_NAMESPACE)
 public class ListBucketResponse {
   @XmlElementWrapper(name = "Buckets")
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
@@ -25,7 +25,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.BucketMetadata;
 
 /**
@@ -33,7 +32,7 @@ import org.apache.hadoop.ozone.s3.commontypes.BucketMetadata;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "ListAllMyBucketsResult",
-    namespace = OzoneConsts.S3_NAMESPACE_URL)
+    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class ListBucketResponse {
   @XmlElementWrapper(name = "Buckets")
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.BucketMetadata;
 
 /**
@@ -32,7 +33,7 @@ import org.apache.hadoop.ozone.s3.commontypes.BucketMetadata;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "ListAllMyBucketsResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class ListBucketResponse {
   @XmlElementWrapper(name = "Buckets")
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.apache.hadoop.ozone.s3.util.S3StorageType;
 
 /**
@@ -33,7 +34,7 @@ import org.apache.hadoop.ozone.s3.util.S3StorageType;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "ListMultipartUploadsResult", namespace =
-    "http://s3.amazonaws.com/doc/2006-03-01/")
+    S3Consts.S3_XML_NAMESPACE)
 public class ListMultipartUploadsResult {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
@@ -27,14 +27,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
 import org.apache.hadoop.ozone.s3.util.S3StorageType;
-import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * AWS compatible REST response for list multipart upload.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "ListMultipartUploadsResult", namespace =
-    OzoneConsts.S3_NAMESPACE_URL)
+    "http://s3.amazonaws.com/doc/2006-03-01/")
 public class ListMultipartUploadsResult {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
@@ -25,9 +25,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
 import org.apache.hadoop.ozone.s3.util.S3StorageType;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * AWS compatible REST response for list multipart upload.

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
@@ -25,9 +25,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
 import org.apache.hadoop.ozone.s3.util.S3StorageType;
-import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * AWS compatible REST response for list multipart upload.

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsResult.java
@@ -27,13 +27,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
 import org.apache.hadoop.ozone.s3.util.S3StorageType;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * AWS compatible REST response for list multipart upload.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "ListMultipartUploadsResult", namespace =
-    "http://s3.amazonaws.com/doc/2006-03-01/")
+    OzoneConsts.S3_NAMESPACE_URL)
 public class ListMultipartUploadsResult {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
@@ -28,13 +28,13 @@ import org.apache.hadoop.ozone.s3.commontypes.CommonPrefix;
 import org.apache.hadoop.ozone.s3.commontypes.EncodingTypeObject;
 import org.apache.hadoop.ozone.s3.commontypes.KeyMetadata;
 import org.apache.hadoop.ozone.s3.commontypes.ObjectKeyNameAdapter;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Response from the ListObject RPC Call.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "ListBucketResult", namespace = "http://s3.amazonaws"
-    + ".com/doc/2006-03-01/")
+@XmlRootElement(name = "ListBucketResult", namespace = S3Consts.S3_XML_NAMESPACE)
 public class ListObjectResponse {
 
   @XmlElement(name = "Name")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListPartsResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListPartsResponse.java
@@ -27,13 +27,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.commontypes.IsoDateAdapter;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Request for list parts of a multipart upload request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "ListPartsResult", namespace = "http://s3.amazonaws"
-    + ".com/doc/2006-03-01/")
+@XmlRootElement(name = "ListPartsResult", namespace = S3Consts.S3_XML_NAMESPACE)
 public class ListPartsResponse {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -23,14 +23,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Request for multi object delete request.
  */
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "Delete", namespace = "http://s3.amazonaws"
-    + ".com/doc/2006-03-01/")
+@XmlRootElement(name = "Delete", namespace = S3Consts.S3_XML_NAMESPACE)
 public class MultiDeleteRequest {
 
   @XmlElement(name = "Quiet")
@@ -60,8 +60,7 @@ public class MultiDeleteRequest {
    * JAXB entity for child element.
    */
   @XmlAccessorType(XmlAccessType.FIELD)
-  @XmlRootElement(name = "Object", namespace = "http://s3.amazonaws"
-      + ".com/doc/2006-03-01/")
+  @XmlRootElement(name = "Object", namespace = S3Consts.S3_XML_NAMESPACE)
   public static class DeleteObject {
 
     @XmlElement(name = "Key")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -33,10 +33,10 @@ import javax.xml.bind.annotation.XmlRootElement;
     + ".com/doc/2006-03-01/")
 public class MultiDeleteRequest {
 
-  @XmlElement(name = "Quiet")
+  @XmlElement(name = "Quiet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private Boolean quiet = Boolean.FALSE;
 
-  @XmlElement(name = "Object")
+  @XmlElement(name = "Object", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private List<DeleteObject> objects = new ArrayList<>();
 
   public boolean isQuiet() {
@@ -64,10 +64,10 @@ public class MultiDeleteRequest {
       + ".com/doc/2006-03-01/")
   public static class DeleteObject {
 
-    @XmlElement(name = "Key")
+    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String key;
 
-    @XmlElement(name = "VersionId")
+    @XmlElement(name = "VersionId", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String versionId;
 
     public DeleteObject() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -23,20 +23,20 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Request for multi object delete request.
  */
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "Delete", namespace = OzoneConsts.S3_NAMESPACE_URL)
+@XmlRootElement(name = "Delete", namespace = "http://s3.amazonaws"
+    + ".com/doc/2006-03-01/")
 public class MultiDeleteRequest {
 
-  @XmlElement(name = "Quiet", namespace = OzoneConsts.S3_NAMESPACE_URL)
+  @XmlElement(name = "Quiet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private Boolean quiet = Boolean.FALSE;
 
-  @XmlElement(name = "Object", namespace = OzoneConsts.S3_NAMESPACE_URL)
+  @XmlElement(name = "Object", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private List<DeleteObject> objects = new ArrayList<>();
 
   public boolean isQuiet() {
@@ -64,10 +64,10 @@ public class MultiDeleteRequest {
       + ".com/doc/2006-03-01/")
   public static class DeleteObject {
 
-    @XmlElement(name = "Key", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String key;
 
-    @XmlElement(name = "VersionId", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "VersionId", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String versionId;
 
     public DeleteObject() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -23,20 +23,20 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Request for multi object delete request.
  */
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "Delete", namespace = "http://s3.amazonaws"
-    + ".com/doc/2006-03-01/")
+@XmlRootElement(name = "Delete", namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class MultiDeleteRequest {
 
-  @XmlElement(name = "Quiet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Quiet", namespace = OzoneConsts.S3_NAMESPACE_URL)
   private Boolean quiet = Boolean.FALSE;
 
-  @XmlElement(name = "Object", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Object", namespace = OzoneConsts.S3_NAMESPACE_URL)
   private List<DeleteObject> objects = new ArrayList<>();
 
   public boolean isQuiet() {
@@ -64,10 +64,10 @@ public class MultiDeleteRequest {
       + ".com/doc/2006-03-01/")
   public static class DeleteObject {
 
-    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Key", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String key;
 
-    @XmlElement(name = "VersionId", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "VersionId", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String versionId;
 
     public DeleteObject() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -33,10 +33,10 @@ import javax.xml.bind.annotation.XmlRootElement;
     + ".com/doc/2006-03-01/")
 public class MultiDeleteRequest {
 
-  @XmlElement(name = "Quiet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Quiet")
   private Boolean quiet = Boolean.FALSE;
 
-  @XmlElement(name = "Object", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Object")
   private List<DeleteObject> objects = new ArrayList<>();
 
   public boolean isQuiet() {
@@ -64,10 +64,10 @@ public class MultiDeleteRequest {
       + ".com/doc/2006-03-01/")
   public static class DeleteObject {
 
-    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Key")
     private String key;
 
-    @XmlElement(name = "VersionId", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "VersionId")
     private String versionId;
 
     public DeleteObject() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteResponse.java
@@ -23,13 +23,13 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Response for multi object delete request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "DeleteResult", namespace = "http://s3.amazonaws"
-    + ".com/doc/2006-03-01/")
+@XmlRootElement(name = "DeleteResult", namespace = S3Consts.S3_XML_NAMESPACE)
 public class MultiDeleteResponse {
 
   @XmlElement(name = "Deleted")
@@ -68,8 +68,7 @@ public class MultiDeleteResponse {
    * JAXB entity for child element.
    */
   @XmlAccessorType(XmlAccessType.FIELD)
-  @XmlRootElement(name = "Deleted", namespace = "http://s3.amazonaws"
-      + ".com/doc/2006-03-01/")
+  @XmlRootElement(name = "Deleted", namespace = S3Consts.S3_XML_NAMESPACE)
   public static class DeletedObject {
 
     @XmlElement(name = "Key")
@@ -105,8 +104,7 @@ public class MultiDeleteResponse {
    * JAXB entity for child element.
    */
   @XmlAccessorType(XmlAccessType.FIELD)
-  @XmlRootElement(name = "Error", namespace = "http://s3.amazonaws"
-      + ".com/doc/2006-03-01/")
+  @XmlRootElement(name = "Error", namespace = S3Consts.S3_XML_NAMESPACE)
   public static class Error {
 
     @XmlElement(name = "Key")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultipartUploadInitiateResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultipartUploadInitiateResponse.java
@@ -21,13 +21,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Response for Initiate Multipart Upload request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "InitiateMultipartUploadResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = S3Consts.S3_XML_NAMESPACE)
 public class MultipartUploadInitiateResponse {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultipartUploadInitiateResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultipartUploadInitiateResponse.java
@@ -21,14 +21,13 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Response for Initiate Multipart Upload request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "InitiateMultipartUploadResult",
-    namespace = OzoneConsts.S3_NAMESPACE_URL)
+    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class MultipartUploadInitiateResponse {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultipartUploadInitiateResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultipartUploadInitiateResponse.java
@@ -21,13 +21,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Response for Initiate Multipart Upload request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "InitiateMultipartUploadResult",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class MultipartUploadInitiateResponse {
 
   @XmlElement(name = "Bucket")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
@@ -25,13 +25,14 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * Bucket ACL.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "AccessControlPolicy",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = S3Consts.S3_XML_NAMESPACE)
 public class S3BucketAcl {
 
   @XmlElement(name = "Owner")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
@@ -25,20 +25,19 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Bucket ACL.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "AccessControlPolicy",
-    namespace = OzoneConsts.S3_NAMESPACE_URL)
+    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3BucketAcl {
 
-  @XmlElement(name = "Owner", namespace = OzoneConsts.S3_NAMESPACE_URL)
+  @XmlElement(name = "Owner", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private S3Owner owner;
 
-  @XmlElement(name = "AccessControlList", namespace = OzoneConsts.S3_NAMESPACE_URL)
+  @XmlElement(name = "AccessControlList", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private AccessControlList aclList;
 
   public S3Owner getOwner() {
@@ -72,7 +71,7 @@ public class S3BucketAcl {
   @XmlRootElement(name = "AccessControlList")
   public static class AccessControlList {
 
-    @XmlElement(name = "Grant", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Grant", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private List<Grant> grantList = new ArrayList<>();
 
     public void addGrant(Grant grant) {
@@ -106,10 +105,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grant")
   public static class Grant {
 
-    @XmlElement(name = "Grantee", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Grantee", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private Grantee grantee;
 
-    @XmlElement(name = "Permission", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Permission", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String permission;
 
     public String getPermission() {
@@ -163,10 +162,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grantee")
   public static class Grantee {
 
-    @XmlElement(name = "DisplayName", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "DisplayName", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String displayName;
 
-    @XmlElement(name = "ID", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "ID", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String id;
 
     @XmlAttribute(name = "xsi:type")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
@@ -25,19 +25,20 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Bucket ACL.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "AccessControlPolicy",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class S3BucketAcl {
 
-  @XmlElement(name = "Owner", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Owner", namespace = OzoneConsts.S3_NAMESPACE_URL)
   private S3Owner owner;
 
-  @XmlElement(name = "AccessControlList", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "AccessControlList", namespace = OzoneConsts.S3_NAMESPACE_URL)
   private AccessControlList aclList;
 
   public S3Owner getOwner() {
@@ -71,7 +72,7 @@ public class S3BucketAcl {
   @XmlRootElement(name = "AccessControlList")
   public static class AccessControlList {
 
-    @XmlElement(name = "Grant", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Grant", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private List<Grant> grantList = new ArrayList<>();
 
     public void addGrant(Grant grant) {
@@ -105,10 +106,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grant")
   public static class Grant {
 
-    @XmlElement(name = "Grantee", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Grantee", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private Grantee grantee;
 
-    @XmlElement(name = "Permission", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Permission", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String permission;
 
     public String getPermission() {
@@ -162,10 +163,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grantee")
   public static class Grantee {
 
-    @XmlElement(name = "DisplayName", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "DisplayName", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String displayName;
 
-    @XmlElement(name = "ID", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "ID", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String id;
 
     @XmlAttribute(name = "xsi:type")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
@@ -34,10 +34,10 @@ import javax.xml.bind.annotation.XmlRootElement;
     namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3BucketAcl {
 
-  @XmlElement(name = "Owner")
+  @XmlElement(name = "Owner", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private S3Owner owner;
 
-  @XmlElement(name = "AccessControlList")
+  @XmlElement(name = "AccessControlList", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private AccessControlList aclList;
 
   public S3Owner getOwner() {
@@ -71,7 +71,7 @@ public class S3BucketAcl {
   @XmlRootElement(name = "AccessControlList")
   public static class AccessControlList {
 
-    @XmlElement(name = "Grant")
+    @XmlElement(name = "Grant", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private List<Grant> grantList = new ArrayList<>();
 
     public void addGrant(Grant grant) {
@@ -105,10 +105,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grant")
   public static class Grant {
 
-    @XmlElement(name = "Grantee")
+    @XmlElement(name = "Grantee", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private Grantee grantee;
 
-    @XmlElement(name = "Permission")
+    @XmlElement(name = "Permission", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String permission;
 
     public String getPermission() {
@@ -162,10 +162,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grantee")
   public static class Grantee {
 
-    @XmlElement(name = "DisplayName")
+    @XmlElement(name = "DisplayName", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String displayName;
 
-    @XmlElement(name = "ID")
+    @XmlElement(name = "ID", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String id;
 
     @XmlAttribute(name = "xsi:type")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3BucketAcl.java
@@ -34,10 +34,10 @@ import javax.xml.bind.annotation.XmlRootElement;
     namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3BucketAcl {
 
-  @XmlElement(name = "Owner", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "Owner")
   private S3Owner owner;
 
-  @XmlElement(name = "AccessControlList", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "AccessControlList")
   private AccessControlList aclList;
 
   public S3Owner getOwner() {
@@ -71,7 +71,7 @@ public class S3BucketAcl {
   @XmlRootElement(name = "AccessControlList")
   public static class AccessControlList {
 
-    @XmlElement(name = "Grant", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Grant")
     private List<Grant> grantList = new ArrayList<>();
 
     public void addGrant(Grant grant) {
@@ -105,10 +105,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grant")
   public static class Grant {
 
-    @XmlElement(name = "Grantee", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Grantee")
     private Grantee grantee;
 
-    @XmlElement(name = "Permission", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Permission")
     private String permission;
 
     public String getPermission() {
@@ -162,10 +162,10 @@ public class S3BucketAcl {
   @XmlRootElement(name = "Grantee")
   public static class Grantee {
 
-    @XmlElement(name = "DisplayName", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "DisplayName")
     private String displayName;
 
-    @XmlElement(name = "ID", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "ID")
     private String id;
 
     @XmlAttribute(name = "xsi:type")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
@@ -25,13 +25,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 
 /**
  * S3 tagging.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "Tagging",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = S3Consts.S3_XML_NAMESPACE)
 public class S3Tagging {
 
   @XmlElement(name = "TagSet")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
@@ -25,17 +25,16 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * S3 tagging.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "Tagging",
-    namespace = OzoneConsts.S3_NAMESPACE_URL)
+    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3Tagging {
 
-  @XmlElement(name = "TagSet", namespace = OzoneConsts.S3_NAMESPACE_URL)
+  @XmlElement(name = "TagSet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private TagSet tagSet;
 
   public S3Tagging() {
@@ -60,7 +59,7 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "TagSet")
   public static class TagSet {
-    @XmlElement(name = "Tag", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Tag", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private List<Tag> tags = new ArrayList<>();
 
     public TagSet() {
@@ -85,10 +84,10 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "Tag")
   public static class Tag {
-    @XmlElement(name = "Key", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String key;
 
-    @XmlElement(name = "Value", namespace = OzoneConsts.S3_NAMESPACE_URL)
+    @XmlElement(name = "Value", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String value;
 
     public Tag() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.XmlRootElement;
     namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3Tagging {
 
-  @XmlElement(name = "TagSet")
+  @XmlElement(name = "TagSet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
   private TagSet tagSet;
 
   public S3Tagging() {
@@ -59,7 +59,7 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "TagSet")
   public static class TagSet {
-    @XmlElement(name = "Tag")
+    @XmlElement(name = "Tag", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private List<Tag> tags = new ArrayList<>();
 
     public TagSet() {
@@ -84,10 +84,10 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "Tag")
   public static class Tag {
-    @XmlElement(name = "Key")
+    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String key;
 
-    @XmlElement(name = "Value")
+    @XmlElement(name = "Value", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
     private String value;
 
     public Tag() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
@@ -25,16 +25,17 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * S3 tagging.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "Tagging",
-    namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    namespace = OzoneConsts.S3_NAMESPACE_URL)
 public class S3Tagging {
 
-  @XmlElement(name = "TagSet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "TagSet", namespace = OzoneConsts.S3_NAMESPACE_URL)
   private TagSet tagSet;
 
   public S3Tagging() {
@@ -59,7 +60,7 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "TagSet")
   public static class TagSet {
-    @XmlElement(name = "Tag", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Tag", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private List<Tag> tags = new ArrayList<>();
 
     public TagSet() {
@@ -84,10 +85,10 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "Tag")
   public static class Tag {
-    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Key", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String key;
 
-    @XmlElement(name = "Value", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Value", namespace = OzoneConsts.S3_NAMESPACE_URL)
     private String value;
 
     public Tag() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.XmlRootElement;
     namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3Tagging {
 
-  @XmlElement(name = "TagSet", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+  @XmlElement(name = "TagSet")
   private TagSet tagSet;
 
   public S3Tagging() {
@@ -59,7 +59,7 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "TagSet")
   public static class TagSet {
-    @XmlElement(name = "Tag", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Tag")
     private List<Tag> tags = new ArrayList<>();
 
     public TagSet() {
@@ -84,10 +84,10 @@ public class S3Tagging {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlRootElement(name = "Tag")
   public static class Tag {
-    @XmlElement(name = "Key", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Key")
     private String key;
 
-    @XmlElement(name = "Value", namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
+    @XmlElement(name = "Value")
     private String value;
 
     public Tag() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/package-info.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/package-info.java
@@ -19,11 +19,11 @@
  * Rest endpoint implementation for the s3 gateway.
  */
 @javax.xml.bind.annotation.XmlSchema(
-    namespace = "http://s3.amazonaws"
-        + ".com/doc/2006-03-01/", elementFormDefault =
+    namespace = S3Consts.S3_XML_NAMESPACE, elementFormDefault =
     javax.xml.bind.annotation.XmlNsForm.QUALIFIED,
     xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = "http://s3.amazonaws"
-            + ".com/doc/2006-03-01/", prefix = "")})
+        @javax.xml.bind.annotation.XmlNs(namespaceURI = S3Consts.S3_XML_NAMESPACE, prefix = "")})
 
 package org.apache.hadoop.ozone.s3.endpoint;
+
+import org.apache.hadoop.ozone.s3.util.S3Consts;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
@@ -71,8 +71,7 @@ public final class S3Consts {
   //Error code 416 is Range Not Satisfiable
   public static final int RANGE_NOT_SATISFIABLE = 416;
 
-  public static final String S3_XML_NAMESPACE = "http://s3.amazonaws" +
-      ".com/doc/2006-03-01/";
+  public static final String S3_XML_NAMESPACE = "http://s3.amazonaws.com/doc/2006-03-01/";
 
   // Constants related to custom metadata
   public static final String CUSTOM_METADATA_HEADER_PREFIX = "x-amz-meta-";

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,8 +42,7 @@ public class TestCompleteMultipartUploadRequestUnmarshaller {
     //GIVEN
     ByteArrayInputStream inputBody =
         new ByteArrayInputStream(
-            ("<CompleteMultipartUpload xmlns=\"http://s3.amazonaws" +
-                ".com/doc/2006-03-01/\">" +
+            ("<CompleteMultipartUpload xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
                 "<Part><ETag>" + part1 + "</ETag><PartNumber>1" +
                 "</PartNumber></Part><Part><ETag>" + part2 +
                 "</ETag><PartNumber>2</PartNumber></Part>" +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultiDeleteRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultiDeleteRequestUnmarshaller.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,8 +35,7 @@ public class TestMultiDeleteRequestUnmarshaller {
     //GIVEN
     ByteArrayInputStream inputBody =
         new ByteArrayInputStream(
-            ("<Delete xmlns=\"http://s3.amazonaws"
-                + ".com/doc/2006-03-01/\"><Object>key1</Object><Object>key2"
+            ("<Delete xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\"><Object>key1</Object><Object>key2"
                 + "</Object><Object>key3"
                 + "</Object></Delete>")
                 .getBytes(UTF_8));

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingPut.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -196,7 +197,7 @@ public class TestObjectTaggingPut {
 
   private InputStream invalidXmlStructure() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "   </Ta" +
             "Tagging>";
@@ -206,7 +207,7 @@ public class TestObjectTaggingPut {
 
   private InputStream twoTags() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "      <Tag>" +
             "         <Key>tag1</Key>" +
@@ -224,14 +225,14 @@ public class TestObjectTaggingPut {
 
   private InputStream noTagSet() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "</Tagging>";
     return new ByteArrayInputStream(xml.getBytes(UTF_8));
   }
 
   private InputStream emptyTags() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "   </TagSet>" +
             "</Tagging>";
@@ -241,7 +242,7 @@ public class TestObjectTaggingPut {
 
   public InputStream tagKeyNotSpecified() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "      <Tag>" +
             "         <Value>val1</Value>" +
@@ -254,7 +255,7 @@ public class TestObjectTaggingPut {
 
   public InputStream tagValueNotSpecified() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "      <Tag>" +
             "         <Key>tag1</Key>" +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.ErrorInfo;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -318,7 +319,7 @@ public class TestPermissionCheck {
         .setClient(client)
         .build();
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "      <Tag>" +
             "         <Key>tag1</Key>" +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.ozone.s3.endpoint.RootEndpoint;
 import org.apache.hadoop.ozone.s3.endpoint.TestBucketAcl;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -669,7 +670,7 @@ public class TestS3GatewayMetrics {
 
   private static InputStream getPutTaggingBody() {
     String xml =
-        "<Tagging xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Tagging xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">" +
             "   <TagSet>" +
             "      <Tag>" +
             "         <Key>tag1</Key>" +

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11734. Specify namespace in `@XmlElement` annotations for correct XML deserialization

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11734

## How was this patch tested?

All mentioned failed unit tests pass.

<img width="761" alt="HDDS-11734-TestBucketAcl" src="https://github.com/user-attachments/assets/b2c33293-e1c1-4cab-82da-da49346008e8" />
<img width="762" alt="HDDS-11734-TestCompleteMultipartUploadRequestUnmarshaller" src="https://github.com/user-attachments/assets/1b0546d0-aefe-40ac-ab63-364b4e1a9d3e" />
<img width="757" alt="HDDS-11734-TestMultiDeleteRequestUnmarshaller" src="https://github.com/user-attachments/assets/b0a342ee-976c-4459-b53b-d1596f05c464" />
<img width="751" alt="HDDS-11734-TestS3GatewayMetrics" src="https://github.com/user-attachments/assets/f0037ac7-3d87-4dea-b8c9-6de3daa23264" />

