### PR TITLE
HDDS-12813. Replace calls to deprecated RandomUtils methods

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -193,7 +193,7 @@ public class TestBlockInputStream {
 
     // Seek to random positions between 0 and the block size.
     for (int i = 0; i < 10; i++) {
-      pos = RandomUtils.nextInt(0, blockSize);
+      pos = RandomUtils.secure().randomInt(0, blockSize);
       seekAndVerify(pos);
     }
   }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -69,7 +69,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class TestBlockOutputStreamCorrectness {
 
   private static final int DATA_SIZE = 256 * (int) OzoneConsts.MB;
-  private static final byte[] DATA = RandomUtils.nextBytes(DATA_SIZE);
+  private static final byte[] DATA = RandomUtils.secure().randomBytes(DATA_SIZE);
 
   @ParameterizedTest
   @ValueSource(ints = { 1, 1024, 1024 * 1024 })

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
@@ -647,7 +647,7 @@ public class TestECBlockReconstructedStripeInputStream {
   }
 
   private Integer getRandomStreamIndex(Set<Integer> set) {
-    return set.stream().skip(RandomUtils.nextInt(0, set.size()))
+    return set.stream().skip(RandomUtils.secure().randomInt(0, set.size()))
         .findFirst().orElse(null);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
@@ -362,7 +362,7 @@ public final class ContainerCommandResponseBuilders {
     ContainerProtos.EchoResponseProto.Builder echo =
         ContainerProtos.EchoResponseProto
             .newBuilder()
-            .setPayload(UnsafeByteOperations.unsafeWrap(RandomUtils.nextBytes(responsePayload)));
+            .setPayload(UnsafeByteOperations.unsafeWrap(RandomUtils.secure().randomBytes(responsePayload)));
 
     return getSuccessResponseBuilder(msg)
         .setEcho(echo)

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumByteBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumByteBuffer.java
@@ -79,7 +79,8 @@ public class TestChecksumByteBuffer {
 
       final int len = 1 << 10;
       for (int i = 0; i < 1000; i++) {
-        checkBytes(RandomUtils.nextBytes(len), RandomUtils.nextInt(0, len));
+        checkBytes(RandomUtils.secure().randomBytes(len),
+            RandomUtils.secure().randomInt(0, len));
       }
     }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumImplsComputeSameValues.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumImplsComputeSameValues.java
@@ -42,7 +42,7 @@ public class TestChecksumImplsComputeSameValues {
   @Test
   public void testCRC32ImplsMatch() {
     data.clear();
-    data.put(RandomUtils.nextBytes(data.remaining()));
+    data.put(RandomUtils.secure().randomBytes(data.remaining()));
     for (int bpc : bytesPerChecksum) {
       List<ChecksumByteBuffer> impls = new ArrayList<>();
       impls.add(new PureJavaCrc32ByteBuffer());
@@ -58,7 +58,7 @@ public class TestChecksumImplsComputeSameValues {
   @Test
   public void testCRC32CImplsMatch() {
     data.clear();
-    data.put(RandomUtils.nextBytes(data.remaining()));
+    data.put(RandomUtils.secure().randomBytes(data.remaining()));
     for (int bpc : bytesPerChecksum) {
       List<ChecksumByteBuffer> impls = new ArrayList<>();
       impls.add(new PureJavaCrc32CByteBuffer());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ContainerReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ContainerReportPublisher.java
@@ -69,7 +69,6 @@ public class ContainerReportPublisher extends
     return containerReportInterval + getRandomReportDelay();
   }
 
-  @SuppressWarnings("java:S2245") // no need for secure random
   private long getRandomReportDelay() {
     return RandomUtils.secure().randomLong(0, containerReportInterval);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ContainerReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ContainerReportPublisher.java
@@ -71,7 +71,7 @@ public class ContainerReportPublisher extends
 
   @SuppressWarnings("java:S2245") // no need for secure random
   private long getRandomReportDelay() {
-    return RandomUtils.nextLong(0, containerReportInterval);
+    return RandomUtils.secure().randomLong(0, containerReportInterval);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/PipelineReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/PipelineReportPublisher.java
@@ -61,7 +61,7 @@ public class PipelineReportPublisher extends
 
   @SuppressWarnings("java:S2245") // no need for secure random
   private long getRandomReportDelay() {
-    return RandomUtils.nextLong(0, pipelineReportInterval);
+    return RandomUtils.secure().randomLong(0, pipelineReportInterval);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/PipelineReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/PipelineReportPublisher.java
@@ -59,7 +59,6 @@ public class PipelineReportPublisher extends
     return pipelineReportInterval + getRandomReportDelay();
   }
 
-  @SuppressWarnings("java:S2245") // no need for secure random
   private long getRandomReportDelay() {
     return RandomUtils.secure().randomLong(0, pipelineReportInterval);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -151,7 +151,7 @@ public class TestContainerDeletionChoosingPolicy {
     List<Integer> numberOfBlocks = new ArrayList<Integer>();
     // create [numContainers + 1] containers
     for (int i = 0; i <= numContainers; i++) {
-      long containerId = RandomUtils.nextLong();
+      long containerId = RandomUtils.secure().randomLong();
       KeyValueContainerData data =
           new KeyValueContainerData(containerId,
               layout,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -609,7 +609,7 @@ public class TestHddsDispatcher {
   private ContainerCommandRequestProto getWriteChunkRequest0(
       String datanodeId, Long containerId, Long localId, int chunkNum) {
     final int lenOfBytes = 32;
-    ByteString chunkData = ByteString.copyFrom(RandomUtils.nextBytes(32));
+    ByteString chunkData = ByteString.copyFrom(RandomUtils.secure().randomBytes(32));
 
     ContainerProtos.ChunkInfo chunk = ContainerProtos.ChunkInfo
         .newBuilder()
@@ -638,7 +638,7 @@ public class TestHddsDispatcher {
   }
 
   static ContainerCommandRequestProto newPutSmallFile(Long containerId, Long localId) {
-    ByteString chunkData = ByteString.copyFrom(RandomUtils.nextBytes(32));
+    ByteString chunkData = ByteString.copyFrom(RandomUtils.secure().randomBytes(32));
     return newPutSmallFile(new BlockID(containerId, localId), chunkData);
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
@@ -89,7 +89,7 @@ class TestGrpcContainerUploader {
 
     // WHEN
     OutputStream out = startUpload(subject, callback);
-    out.write(RandomUtils.nextBytes(4));
+    out.write(RandomUtils.secure().randomBytes(4));
     out.close();
 
     // THEN

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -194,7 +194,7 @@ class TestCachingSpaceUsageSource {
   }
 
   private static long validInitialValue() {
-    return RandomUtils.nextLong(1, 100);
+    return RandomUtils.secure().randomLong(1, 100);
   }
 
   private static Builder paramsBuilder(AtomicLong savedValue) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestManagedSecretKey.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestManagedSecretKey.java
@@ -39,7 +39,7 @@ public class TestManagedSecretKey {
   @Test
   public void testSignAndVerifySuccess() throws Exception {
     // Data can be signed and verified by same key.
-    byte[] data = RandomUtils.nextBytes(100);
+    byte[] data = RandomUtils.secure().randomBytes(100);
     ManagedSecretKey secretKey = generateHmac(now(), ofDays(1));
     byte[] signature = secretKey.sign(data);
     assertTrue(secretKey.isValidSignature(data, signature));
@@ -62,10 +62,10 @@ public class TestManagedSecretKey {
 
   @Test
   public void testVerifyFailure() throws Exception {
-    byte[] data = RandomUtils.nextBytes(100);
+    byte[] data = RandomUtils.secure().randomBytes(100);
     ManagedSecretKey secretKey = generateHmac(now(), ofDays(1));
     // random signature is not valid.
-    assertFalse(secretKey.isValidSignature(data, RandomUtils.nextBytes(100)));
+    assertFalse(secretKey.isValidSignature(data, RandomUtils.secure().randomBytes(100)));
 
     // Data sign by one key can't be verified by another key.
     byte[] signature = secretKey.sign(data);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
@@ -65,7 +65,7 @@ public class TestOzoneBlockTokenIdentifier {
 
     // Verify an invalid signed OzoneMaster Token with Ozone Master.
     assertFalse(secretKey.isValidSignature(tokenId.getBytes(),
-        RandomUtils.nextBytes(128)));
+        RandomUtils.secure().randomBytes(128)));
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
@@ -56,10 +56,10 @@ public class TestHttpServer2Metrics {
   @Test
   public void testMetrics() {
     // crate mock metrics
-    int threadCount = RandomUtils.nextInt();
-    int maxThreadCount = RandomUtils.nextInt();
-    int idleThreadCount = RandomUtils.nextInt();
-    int threadQueueWaitingTaskCount = RandomUtils.nextInt();
+    int threadCount = RandomUtils.secure().randomInt();
+    int maxThreadCount = RandomUtils.secure().randomInt();
+    int idleThreadCount = RandomUtils.secure().randomInt();
+    int threadQueueWaitingTaskCount = RandomUtils.secure().randomInt();
     String name = "s3g";
 
     when(threadPool.getThreads()).thenReturn(threadCount);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -623,7 +623,7 @@ public final class HddsTestUtils {
   private static ContainerInfo.Builder getDefaultContainerInfoBuilder(
       final HddsProtos.LifeCycleState state) {
     return new ContainerInfo.Builder()
-        .setContainerID(RandomUtils.nextLong())
+        .setContainerID(RandomUtils.secure().randomLong())
         .setReplicationConfig(
             RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE))
@@ -816,7 +816,7 @@ public final class HddsTestUtils {
     for (int i = 0; i < numContainers; i++) {
       ContainerInfo.Builder builder = new ContainerInfo.Builder();
       containerInfoList.add(builder
-          .setContainerID(RandomUtils.nextLong())
+          .setContainerID(RandomUtils.secure().randomLong())
           .setReplicationConfig(ratisReplicationConfig)
           .build());
     }
@@ -837,7 +837,7 @@ public final class HddsTestUtils {
     for (int i = 0; i < numContainers; i++) {
       ContainerInfo.Builder builder = new ContainerInfo.Builder();
       containerInfoList.add(builder
-          .setContainerID(RandomUtils.nextLong())
+          .setContainerID(RandomUtils.secure().randomLong())
           .setOwner("test-owner")
           .setPipelineID(PipelineID.randomId())
           .setReplicationConfig(eCReplicationConfig)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -205,8 +205,8 @@ public class TestDeletedBlockLog {
   private Map<Long, List<Long>> generateData(int dataSize,
       HddsProtos.LifeCycleState state) throws IOException {
     Map<Long, List<Long>> blockMap = new HashMap<>();
-    int continerIDBase = RandomUtils.nextInt(0, 100);
-    int localIDBase = RandomUtils.nextInt(0, 1000);
+    int continerIDBase = RandomUtils.secure().randomInt(0, 100);
+    int localIDBase = RandomUtils.secure().randomInt(0, 1000);
     for (int i = 0; i < dataSize; i++) {
       long containerID = continerIDBase + i;
       updateContainerMetadata(containerID, state);
@@ -752,7 +752,7 @@ public class TestDeletedBlockLog {
     List<Long> txIDs;
     // Randomly add/get/commit/increase transactions.
     for (int i = 0; i < 100; i++) {
-      int state = RandomUtils.nextInt(0, 4);
+      int state = RandomUtils.secure().randomInt(0, 4);
       if (state == 0) {
         addTransactions(generateData(10), true);
         added += 10;
@@ -851,7 +851,7 @@ public class TestDeletedBlockLog {
     // add two transactions for same container
     containerID = blocks.get(0).getContainerID();
     Map<Long, List<Long>> deletedBlocksMap = new HashMap<>();
-    long localId = RandomUtils.nextLong();
+    long localId = RandomUtils.secure().randomLong();
     deletedBlocksMap.put(containerID, new LinkedList<>(
         Collections.singletonList(localId)));
     addTransactions(deletedBlocksMap, true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -621,7 +621,7 @@ public class TestSCMContainerPlacementRackAware {
 
     for (int i = 0; i < 10; i++) {
       // Set a random DN to in_service and ensure it is always picked
-      int index = RandomUtils.nextInt(0, dnInfos.size());
+      int index = RandomUtils.secure().randomInt(0, dnInfos.size());
       dnInfos.get(index).setNodeStatus(NodeStatus.inServiceHealthy());
       try {
         List<DatanodeDetails> datanodeDetails =

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedBlockChecksumComputer.java
@@ -39,7 +39,7 @@ public class TestReplicatedBlockChecksumComputer {
   @Test
   public void testComputeMd5Crc() throws IOException {
     final int lenOfBytes = 32;
-    byte[] randomChunkChecksum = RandomUtils.nextBytes(lenOfBytes);
+    byte[] randomChunkChecksum = RandomUtils.secure().randomBytes(lenOfBytes);
 
     MD5Hash emptyBlockMD5 = MD5Hash.digest(randomChunkChecksum);
     byte[] emptyBlockMD5Hash = emptyBlockMD5.getDigest();
@@ -54,7 +54,7 @@ public class TestReplicatedBlockChecksumComputer {
   @Test
   public void testComputeCompositeCrc() throws IOException {
     final int lenOfBytes = 32;
-    byte[] randomChunkChecksum = RandomUtils.nextBytes(lenOfBytes);
+    byte[] randomChunkChecksum = RandomUtils.secure().randomBytes(lenOfBytes);
 
     CrcComposer crcComposer =
         CrcComposer.newCrcComposer(DataChecksum.Type.CRC32C, 4);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -317,12 +317,12 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
     if (failedOmSet.size() >= numOzoneManagers / 2) {
       return false;
     }
-    return RandomUtils.nextBoolean();
+    return RandomUtils.secure().randomBoolean();
   }
 
   // Datanode specific
   private int getNumberOfDnToFail() {
-    return RandomUtils.nextBoolean() ? 1 : 2;
+    return RandomUtils.secure().randomBoolean() ? 1 : 2;
   }
 
   public Set<DatanodeDetails> dnToFail() {
@@ -395,7 +395,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
     if (failedScmSet.size() >= numStorageContainerManagers / 2) {
       return false;
     }
-    return RandomUtils.nextBoolean();
+    return RandomUtils.secure().randomBoolean();
   }
 
 }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/failure/FailureManager.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/failure/FailureManager.java
@@ -89,10 +89,10 @@ public class FailureManager {
   }
 
   public static boolean isFastRestart() {
-    return RandomUtils.nextBoolean();
+    return RandomUtils.secure().randomBoolean();
   }
 
   public static int getBoundedRandomIndex(int size) {
-    return RandomUtils.nextInt(0, size);
+    return RandomUtils.secure().randomInt(0, size);
   }
 }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedDirLoadGenerator.java
@@ -33,7 +33,7 @@ public class AgedDirLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt(0, maxDirIndex);
+    int index = RandomUtils.secure().randomInt(0, maxDirIndex);
     String keyName = getKeyName(index);
     fsBucket.readDirectory(keyName);
   }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedLoadGenerator.java
@@ -45,7 +45,7 @@ public class AgedLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    if (RandomUtils.nextInt(0, 100) <= 10) {
+    if (RandomUtils.secure().randomInt(0, 100) <= 10) {
       synchronized (agedFileAllocationIndex) {
         int index = agedFileAllocationIndex.getAndIncrement();
         ByteBuffer buffer = dataBuffer.getBuffer(index);
@@ -66,7 +66,7 @@ public class AgedLoadGenerator extends LoadGenerator {
   private Optional<Integer> randomKeyToRead() {
     int currentIndex = agedFileWrittenIndex.get();
     return currentIndex != 0
-        ? Optional.of(RandomUtils.nextInt(0, currentIndex))
+        ? Optional.of(RandomUtils.secure().randomInt(0, currentIndex))
         : Optional.empty();
   }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/DataBuffer.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/DataBuffer.java
@@ -39,7 +39,7 @@ public class DataBuffer {
     for (int i = 0; i < numBuffers; i++) {
       int size = (int) StorageUnit.KB.toBytes(1 << i);
       ByteBuffer buffer = ByteBuffer.allocate(size);
-      buffer.put(RandomUtils.nextBytes(size));
+      buffer.put(RandomUtils.secure().randomBytes(size));
       this.buffers.add(buffer);
     }
     // TODO: add buffers of sizes of prime numbers.

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/FilesystemLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/FilesystemLoadGenerator.java
@@ -38,7 +38,7 @@ public class FilesystemLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt();
+    int index = RandomUtils.secure().randomInt();
     ByteBuffer buffer = dataBuffer.getBuffer(index);
     String keyName = getKeyName(index);
     fsBucket.writeKey(true, buffer, keyName);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadBucket.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadBucket.java
@@ -63,7 +63,7 @@ public class LoadBucket {
   }
 
   private boolean isFsOp() {
-    return RandomUtils.nextBoolean();
+    return RandomUtils.secure().randomBoolean();
   }
 
   // Write ops.

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadExecutors.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadExecutors.java
@@ -57,7 +57,7 @@ public class LoadExecutors {
 
     while (Time.monotonicNow() - startTime < runTimeMillis) {
       LoadGenerator gen =
-          generators.get(RandomUtils.nextInt(0, numGenerators));
+          generators.get(RandomUtils.secure().randomInt(0, numGenerators));
 
       try {
         gen.generateLoad();

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/NestedDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/NestedDirLoadGenerator.java
@@ -42,7 +42,7 @@ public class NestedDirLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt(0, maxDirDepth);
+    int index = RandomUtils.secure().randomInt(0, maxDirDepth);
     String str = this.pathMap.compute(index, this::createNewPath);
     fsBucket.createDirectory(str);
     fsBucket.readDirectory(str);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomDirLoadGenerator.java
@@ -31,7 +31,7 @@ public class RandomDirLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt();
+    int index = RandomUtils.secure().randomInt();
     String keyName = getKeyName(index);
     fsBucket.createDirectory(keyName);
     fsBucket.readDirectory(keyName);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomLoadGenerator.java
@@ -36,7 +36,7 @@ public class RandomLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt();
+    int index = RandomUtils.secure().randomInt();
     ByteBuffer buffer = dataBuffer.getBuffer(index);
     String keyName = getKeyName(index);
     ozoneBucket.writeKey(buffer, keyName);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/ReadOnlyLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/ReadOnlyLoadGenerator.java
@@ -35,7 +35,7 @@ public class ReadOnlyLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt(0, NUM_KEYS);
+    int index = RandomUtils.secure().randomInt(0, NUM_KEYS);
     ByteBuffer buffer = dataBuffer.getBuffer(index);
     String keyName = getKeyName(index);
     replBucket.readKey(buffer, keyName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractSeekTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractSeekTest.java
@@ -349,8 +349,8 @@ public abstract class AbstractContractSeekTest extends AbstractFSContractTestBas
     int[] reads = new int[10];
     try (FSDataInputStream stm = getFileSystem().open(randomSeekFile)) {
       for (int i = 0; i < limit; i++) {
-        int seekOff = RandomUtils.nextInt(0, buf.length);
-        int toRead = RandomUtils.nextInt(0, Math.min(buf.length - seekOff, 32000));
+        int seekOff = RandomUtils.secure().randomInt(0, buf.length);
+        int toRead = RandomUtils.secure().randomInt(0, Math.min(buf.length - seekOff, 32000));
 
         seeks[i % seeks.length] = seekOff;
         reads[i % reads.length] = toRead;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1984,7 +1984,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
   @Test
   void testRenameFile() throws Exception {
-    final String dir = "/dir" + RandomUtils.nextInt(0, 1000);
+    final String dir = "/dir" + RandomUtils.secure().randomInt(0, 1000);
     Path dirPath = new Path(getBucketPath() + dir);
     Path file1Source = new Path(getBucketPath() + dir
         + "/file1_Copy");
@@ -2010,7 +2010,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    */
   @Test
   void testRenameFileToDir() throws Exception {
-    final String dir = "/dir" + RandomUtils.nextInt(0, 1000);
+    final String dir = "/dir" + RandomUtils.secure().randomInt(0, 1000);
     Path dirPath = new Path(getBucketPath() + dir);
     getFs().mkdirs(dirPath);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java
@@ -96,7 +96,7 @@ public abstract class TestContainerOperations implements NonHATests.TestCase {
     // call create Container again
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
     byte[] data =
-        RandomStringUtils.random(RandomUtils.nextInt(0, 1024)).getBytes(UTF_8);
+        RandomStringUtils.random(RandomUtils.secure().randomInt(0, 1024)).getBytes(UTF_8);
     ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
         ContainerTestHelper
             .getWriteChunkRequest(container.getPipeline(), blockID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -90,7 +90,7 @@ public abstract class TestGetCommittedBlockLengthAndPutKey implements NonHATests
 
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
     byte[] data =
-        RandomStringUtils.random(RandomUtils.nextInt(1, 1024)).getBytes(UTF_8);
+        RandomStringUtils.random(RandomUtils.secure().randomInt(1, 1024)).getBytes(UTF_8);
     ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
         ContainerTestHelper
             .getWriteChunkRequest(container.getPipeline(), blockID,
@@ -154,7 +154,7 @@ public abstract class TestGetCommittedBlockLengthAndPutKey implements NonHATests
 
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
     byte[] data =
-        RandomStringUtils.random(RandomUtils.nextInt(1, 1024)).getBytes(UTF_8);
+        RandomStringUtils.random(RandomUtils.secure().randomInt(1, 1024)).getBytes(UTF_8);
     ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
         ContainerTestHelper
             .getWriteChunkRequest(container.getPipeline(), blockID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -288,8 +288,8 @@ public class TestStorageContainerManager {
       // Add 2 TXs per container.
       Map<Long, List<Long>> deletedBlocks = new HashMap<>();
       List<Long> blocks = new ArrayList<>();
-      blocks.add(RandomUtils.nextLong());
-      blocks.add(RandomUtils.nextLong());
+      blocks.add(RandomUtils.secure().randomLong());
+      blocks.add(RandomUtils.secure().randomLong());
       deletedBlocks.put(containerID, blocks);
       addTransactions(cluster.getStorageContainerManager(), delLog,
           deletedBlocks);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -282,7 +282,8 @@ public class TestWatchForCommit {
         // as well as there is no logIndex generate in Ratis.
         // The basic idea here is just to test if its throws an exception.
         ExecutionException e = assertThrows(ExecutionException.class,
-            () -> xceiverClient.watchForCommit(index + RandomUtils.nextInt(0, 100) + 10).get());
+            () -> xceiverClient.watchForCommit(index + RandomUtils.secure().
+                randomInt(0, 100) + 10).get());
         // since the timeout value is quite long, the watch request will either
         // fail with NotReplicated exceptio, RetryFailureException or
         // RuntimeException
@@ -382,7 +383,8 @@ public class TestWatchForCommit {
         // as well as there is no logIndex generate in Ratis.
         // The basic idea here is just to test if its throws an exception.
         final Exception e = assertThrows(Exception.class,
-            () -> xceiverClient.watchForCommit(reply.getLogIndex() + RandomUtils.nextInt(0, 100) + 10).get());
+            () -> xceiverClient.watchForCommit(reply.getLogIndex() + RandomUtils.secure().
+                randomInt(0, 100) + 10).get());
         assertInstanceOf(GroupMismatchException.class, HddsClientUtils.checkForException(e));
       } finally {
         clientManager.releaseClient(xceiverClient, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -282,8 +282,8 @@ public class TestWatchForCommit {
         // as well as there is no logIndex generate in Ratis.
         // The basic idea here is just to test if its throws an exception.
         ExecutionException e = assertThrows(ExecutionException.class,
-            () -> xceiverClient.watchForCommit(index + RandomUtils.secure().
-                randomInt(0, 100) + 10).get());
+            () -> xceiverClient.watchForCommit(index + RandomUtils.secure().randomInt(0, 100) + 10)
+                .get());
         // since the timeout value is quite long, the watch request will either
         // fail with NotReplicated exceptio, RetryFailureException or
         // RuntimeException
@@ -383,8 +383,8 @@ public class TestWatchForCommit {
         // as well as there is no logIndex generate in Ratis.
         // The basic idea here is just to test if its throws an exception.
         final Exception e = assertThrows(Exception.class,
-            () -> xceiverClient.watchForCommit(reply.getLogIndex() + RandomUtils.secure().
-                randomInt(0, 100) + 10).get());
+            () -> xceiverClient.watchForCommit(reply.getLogIndex() + RandomUtils.secure().randomInt(0, 100) + 10)
+                .get());
         assertInstanceOf(GroupMismatchException.class, HddsClientUtils.checkForException(e));
       } finally {
         clientManager.releaseClient(xceiverClient, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -189,9 +189,11 @@ public class TestXceiverClientGrpc {
           node -> assertEquals(NodeOperationalState.IN_SERVICE, node.getPersistedOpState()));
 
       randomPipeline.getNodes().get(
-          RandomUtils.nextInt(0, nodeCount)).setPersistedOpState(NodeOperationalState.IN_MAINTENANCE);
+          RandomUtils.secure().randomInt(0, nodeCount)).
+          setPersistedOpState(NodeOperationalState.IN_MAINTENANCE);
       randomPipeline.getNodes().get(
-          RandomUtils.nextInt(0, nodeCount)).setPersistedOpState(NodeOperationalState.IN_MAINTENANCE);
+          RandomUtils.secure().randomInt(0, nodeCount)).
+          setPersistedOpState(NodeOperationalState.IN_MAINTENANCE);
       try (XceiverClientGrpc client = new XceiverClientGrpc(randomPipeline, conf) {
         @Override
         public XceiverClientReply sendCommandAsync(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -326,7 +326,7 @@ public class TestContainerStateManagerIntegration {
         .setUuid(UUID.randomUUID()).build();
 
     // Test 1: no replica's exist
-    ContainerID containerID = ContainerID.valueOf(RandomUtils.nextLong());
+    ContainerID containerID = ContainerID.valueOf(RandomUtils.secure().randomLong());
     Set<ContainerReplica> replicaSet =
         containerStateManager.getContainerReplicas(containerID);
     assertNull(replicaSet);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -111,7 +111,7 @@ public abstract class TestSCMContainerManagerMetrics implements NonHATests.TestC
 
     assertThrows(ContainerNotFoundException.class, () ->
         containerManager.deleteContainer(
-            ContainerID.valueOf(RandomUtils.nextLong(10000, 20000))));
+            ContainerID.valueOf(RandomUtils.secure().randomLong(10000, 20000))));
     // deleteContainer should fail, so it should have the old metric value.
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
     assertEquals(getLongCounter("NumSuccessfulDeleteContainers",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
@@ -182,7 +182,7 @@ public class TestLeaderChoosePolicy {
           .getPipelines(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
 
-      int destroyNum = RandomUtils.nextInt(0, pipelines.size());
+      int destroyNum = RandomUtils.secure().randomInt(0, pipelines.size());
       for (int k = 0; k <= destroyNum; k++) {
         pipelineManager.closePipeline(pipelines.get(k), false);
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -255,7 +255,7 @@ public class TestContainerCommandsEC {
     String keyName = UUID.randomUUID().toString();
     try (OutputStream out = classBucket
         .createKey(keyName, keyLen, repConfig, new HashMap<>())) {
-      out.write(RandomUtils.nextBytes(keyLen));
+      out.write(RandomUtils.secure().randomBytes(keyLen));
     }
     long orphanContainerID = classBucket.getKey(keyName)
         .getOzoneKeyLocations().get(0).getContainerID();
@@ -1023,8 +1023,8 @@ public class TestContainerCommandsEC {
         new ECReplicationConfig(EC_DATA, EC_PARITY, EC_CODEC, EC_CHUNK_SIZE);
     values = new byte[ranges.length][];
     for (int i = 0; i < ranges.length; i++) {
-      int keySize = RandomUtils.nextInt(ranges[i][0], ranges[i][1]);
-      values[i] = RandomUtils.nextBytes(keySize);
+      int keySize = RandomUtils.secure().randomInt(ranges[i][0], ranges[i][1]);
+      values[i] = RandomUtils.secure().randomBytes(keySize);
       final String keyName = UUID.randomUUID().toString();
       try (OutputStream out = classBucket
           .createKey(keyName, values[i].length, repConfig, new HashMap<>())) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestRocksObjectLeakDetector.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestRocksObjectLeakDetector.java
@@ -70,7 +70,7 @@ public class TestRocksObjectLeakDetector {
     testLeakDetector(() -> new ManagedLRUCache(1L));
     testLeakDetector(ManagedOptions::new);
     testLeakDetector(ManagedReadOptions::new);
-    testLeakDetector(() -> new ManagedSlice(RandomUtils.nextBytes(10)));
+    testLeakDetector(() -> new ManagedSlice(RandomUtils.secure().randomBytes(10)));
     testLeakDetector(ManagedStatistics::new);
     testLeakDetector(ManagedWriteBatch::new);
     testLeakDetector(ManagedWriteOptions::new);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
@@ -250,7 +250,7 @@ public final class TestBlockTokens {
     for (OmKeyLocationInfoGroup v : keyInfo.getKeyLocationVersions()) {
       for (OmKeyLocationInfo l : v.getLocationList()) {
         Token<OzoneBlockTokenIdentifier> token = l.getToken();
-        byte[] randomPassword = RandomUtils.nextBytes(100);
+        byte[] randomPassword = RandomUtils.secure().randomBytes(100);
         Token<OzoneBlockTokenIdentifier> override = new Token<>(
             token.getIdentifier(), randomPassword,
             token.getKind(), token.getService());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -218,7 +218,7 @@ public class TestMultipartObjectGet {
 
   private static String generateRandomContent(int sizeInMB) {
     int bytesToGenerate = sizeInMB * 1024 * 1024;
-    byte[] randomBytes = RandomUtils.nextBytes(bytesToGenerate);
+    byte[] randomBytes = RandomUtils.secure().randomBytes(bytesToGenerate);
     return Base64.getEncoder().encodeToString(randomBytes);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -1946,7 +1946,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     int blockSize = (int) ozoneManager.getConfiguration().getStorageSize(
         OZONE_SCM_BLOCK_SIZE, OZONE_SCM_BLOCK_SIZE_DEFAULT, StorageUnit.BYTES);
     String sampleData = Arrays.toString(generateData(blockSize + 100,
-        (byte) RandomUtils.nextLong()));
+        (byte) RandomUtils.secure().randomLong()));
     int valueLength = sampleData.getBytes(UTF_8).length;
 
     store.createVolume(volumeName);
@@ -1983,7 +1983,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(RandomUtils.nextInt(1, 1024));
+    String value = RandomStringUtils.random(RandomUtils.secure().randomInt(1, 1024));
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -2097,7 +2097,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         for (int i = 0; i < 5; i++) {
           String keyName = UUID.randomUUID().toString();
           String data = Arrays.toString(generateData(5 * 1024 * 1024,
-              (byte) RandomUtils.nextLong()));
+              (byte) RandomUtils.secure().randomLong()));
           TestDataUtil.createKey(bucket, keyName,
               ReplicationConfig.fromTypeAndFactor(RATIS, THREE),
               data.getBytes(UTF_8));
@@ -3645,7 +3645,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
     // upload part 1.
     byte[] data = generateData(5 * 1024 * 1024,
-        (byte) RandomUtils.nextLong());
+        (byte) RandomUtils.secure().randomLong());
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
         data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -200,7 +200,7 @@ class TestBlockOutputStream {
       OzoneOutputStream key = createKey(client, keyName);
       int dataLength = 50;
       final int totalWriteLength = dataLength * 2;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       KeyOutputStream keyOutputStream =
           assertInstanceOf(KeyOutputStream.class, key.getOutputStream());
@@ -298,7 +298,7 @@ class TestBlockOutputStream {
       OzoneOutputStream key = createKey(client, keyName);
       // write data equal to 2 chunks
       int dataLength = FLUSH_SIZE;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
 
       assertEquals(writeChunkCount + 2,
@@ -416,7 +416,7 @@ class TestBlockOutputStream {
       OzoneOutputStream key = createKey(client, keyName);
       // write data more than 1 chunk
       int dataLength = CHUNK_SIZE + 50;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       assertEquals(totalOpCount + 1, metrics.getTotalOpCount());
       KeyOutputStream keyOutputStream =
@@ -505,7 +505,7 @@ class TestBlockOutputStream {
       String keyName = getKeyName();
       OzoneOutputStream key = createKey(client, keyName);
       int dataLength = FLUSH_SIZE + 50;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
 
       assertEquals(totalOpCount + 3, metrics.getTotalOpCount());
@@ -594,7 +594,7 @@ class TestBlockOutputStream {
       String keyName = getKeyName();
       OzoneOutputStream key = createKey(client, keyName);
       int dataLength = MAX_FLUSH_SIZE;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
 
       KeyOutputStream keyOutputStream =
@@ -689,7 +689,7 @@ class TestBlockOutputStream {
       OzoneOutputStream key = createKey(client, keyName);
       int dataLength = MAX_FLUSH_SIZE + 50;
       // write data more than 1 chunk
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       KeyOutputStream keyOutputStream =
           assertInstanceOf(KeyOutputStream.class, key.getOutputStream());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -111,7 +111,7 @@ class TestBlockOutputStreamWithFailures {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(client, keyName);
     int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-    byte[] data1 = RandomUtils.nextBytes(dataLength);
+    byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
     key.write(data1);
 
     KeyOutputStream keyOutputStream =
@@ -196,7 +196,7 @@ class TestBlockOutputStreamWithFailures {
       String keyName = getKeyName();
       OzoneOutputStream key = createKey(client, keyName);
       int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       // since its hitting the full bufferCondition, it will call watchForCommit
       // and completes at least putBlock for first flushSize worth of data
@@ -280,7 +280,7 @@ class TestBlockOutputStreamWithFailures {
       String keyName = getKeyName();
       OzoneOutputStream key = createKey(client, keyName);
       int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       // since its hitting the full bufferCondition, it will call watchForCommit
       // and completes atleast putBlock for first flushSize worth of data
@@ -376,7 +376,7 @@ class TestBlockOutputStreamWithFailures {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(client, keyName);
     int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-    byte[] data1 = RandomUtils.nextBytes(dataLength);
+    byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
     key.write(data1);
 
     KeyOutputStream keyOutputStream =
@@ -433,7 +433,7 @@ class TestBlockOutputStreamWithFailures {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(client, keyName);
     int dataLength = 167;
-    byte[] data1 = RandomUtils.nextBytes(dataLength);
+    byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
     key.write(data1);
 
     KeyOutputStream keyOutputStream =
@@ -498,7 +498,7 @@ class TestBlockOutputStreamWithFailures {
     OzoneOutputStream key =
         createKey(client, keyName, 0, ReplicationFactor.ONE);
     int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-    byte[] data1 = RandomUtils.nextBytes(dataLength);
+    byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
     key.write(data1);
 
     KeyOutputStream keyOutputStream =
@@ -587,7 +587,7 @@ class TestBlockOutputStreamWithFailures {
       OzoneOutputStream key =
           createKey(client, keyName, 0, ReplicationFactor.ONE);
       int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       // since its hitting the full bufferCondition, it will call watchForCommit
       // and completes at least putBlock for first flushSize worth of data
@@ -678,7 +678,7 @@ class TestBlockOutputStreamWithFailures {
           createKey(client, keyName, 3 * BLOCK_SIZE,
               ReplicationFactor.ONE);
       int dataLength = MAX_FLUSH_SIZE + CHUNK_SIZE;
-      byte[] data1 = RandomUtils.nextBytes(dataLength);
+      byte[] data1 = RandomUtils.secure().randomBytes(dataLength);
       key.write(data1);
       // since its hitting the full bufferCondition, it will call watchForCommit
       // and completes at least putBlock for first flushSize worth of data

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -444,7 +444,7 @@ public abstract class TestOzoneClientMultipartUploadWithFSO implements NonHATest
 
     // upload part 1.
     byte[] data = generateData(5 * 1024 * 1024,
-        (byte) RandomUtils.nextLong());
+        (byte) RandomUtils.secure().randomLong());
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
         data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -76,8 +76,8 @@ public abstract class TestOzoneRpcClientWithKeyLatestVersion implements NonHATes
 
         OzoneBucket bucket = volume.getBucket(bucketName);
         String keyName = UUID.randomUUID().toString();
-        byte[] content = RandomUtils.nextBytes(128);
-        int versions = RandomUtils.nextInt(2, 5);
+        byte[] content = RandomUtils.secure().randomBytes(128);
+        int versions = RandomUtils.secure().randomInt(2, 5);
 
         createAndOverwriteKey(bucket, keyName, versions, content);
 
@@ -96,7 +96,7 @@ public abstract class TestOzoneRpcClientWithKeyLatestVersion implements NonHATes
       int versions, byte[] content) throws IOException {
     ReplicationConfig replication = RatisReplicationConfig.getInstance(THREE);
     for (int i = 1; i < versions; i++) {
-      writeKey(bucket, key, RandomUtils.nextBytes(content.length), replication);
+      writeKey(bucket, key, RandomUtils.secure().randomBytes(content.length), replication);
     }
     // overwrite it
     writeKey(bucket, key, content, replication);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -79,7 +79,7 @@ class TestReadRetries {
         OzoneBucket bucket = volume.getBucket(bucketName);
 
         String keyName = "a/b/c/" + UUID.randomUUID();
-        byte[] content = RandomUtils.nextBytes(128);
+        byte[] content = RandomUtils.secure().randomBytes(128);
         TestDataUtil.createKey(bucket, keyName,
             RatisReplicationConfig.getInstance(THREE), content);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -263,7 +263,7 @@ public class TestSecureContainerServer {
 
       Token<OzoneBlockTokenIdentifier> token =
           blockTokenSecretManager.generateToken(blockID,
-              EnumSet.allOf(AccessModeProto.class), RandomUtils.nextLong());
+              EnumSet.allOf(AccessModeProto.class), RandomUtils.secure().randomLong());
       String encodedToken = token.encodeToUrlString();
 
       ContainerCommandRequestProto.Builder writeChunk =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -277,7 +277,7 @@ class TestDatanodeHddsVolumeFailureDetection {
 
   private static long createKey(OzoneBucket bucket, String key)
       throws IOException {
-    byte[] bytes = RandomUtils.nextBytes(KEY_SIZE);
+    byte[] bytes = RandomUtils.secure().randomBytes(KEY_SIZE);
     RatisReplicationConfig replication =
         RatisReplicationConfig.getInstance(ReplicationFactor.ONE);
     TestDataUtil.createKey(bucket, key, replication, bytes);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -215,7 +215,7 @@ public abstract class TestObjectStoreWithLegacyFS implements NonHATests.TestCase
     String uploadID = omMultipartInfo.getUploadID();
 
     // upload part 1.
-    byte[] data = generateData(128, (byte) RandomUtils.nextLong());
+    byte[] data = generateData(128, (byte) RandomUtils.secure().randomLong());
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
         data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
@@ -120,8 +120,8 @@ public class TestDeletedBlocksTxnShell {
   //<containerID,  List<blockID>>
   private Map<Long, List<Long>> generateData(int dataSize) throws Exception {
     Map<Long, List<Long>> blockMap = new HashMap<>();
-    int continerIDBase = RandomUtils.nextInt(0, 100);
-    int localIDBase = RandomUtils.nextInt(0, 1000);
+    int continerIDBase = RandomUtils.secure().randomInt(0, 100);
+    int localIDBase = RandomUtils.secure().randomInt(0, 1000);
     for (int i = 0; i < dataSize; i++) {
       long containerID = continerIDBase + i;
       updateContainerMetadata(containerID);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -472,7 +472,7 @@ class TestKeyManagerUnit extends OzoneTestBase {
     metadataManager.getMultipartInfoTable().addCacheEntry(
         new CacheKey<>(metadataManager.getMultipartKey(volume, bucket, key,
             uploadID)),
-        CacheValue.get(RandomUtils.nextInt(), multipartKeyInfo));
+        CacheValue.get(RandomUtils.secure().randomInt(), multipartKeyInfo));
     return new OmMultipartInfo(volume, bucket, key, uploadID);
   }
 
@@ -480,7 +480,7 @@ class TestKeyManagerUnit extends OzoneTestBase {
       String volume, String bucket, String key, String uploadID) {
     metadataManager.getMultipartInfoTable().addCacheEntry(
         new CacheKey<>(metadataManager.getMultipartKey(volume, bucket, key,
-            uploadID)), CacheValue.get(RandomUtils.nextInt()));
+            uploadID)), CacheValue.get(RandomUtils.secure().randomInt()));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestMultipartUploadCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestMultipartUploadCleanupService.java
@@ -161,16 +161,16 @@ class TestMultipartUploadCleanupService {
     String volume = UUID.randomUUID().toString();
     String bucket = UUID.randomUUID().toString();
     for (int x = 0; x < mpuKeyCount; x++) {
-      if (RandomUtils.nextBoolean()) {
+      if (RandomUtils.secure().randomBoolean()) {
         bucket = UUID.randomUUID().toString();
-        if (RandomUtils.nextBoolean()) {
+        if (RandomUtils.secure().randomBoolean()) {
           volume = UUID.randomUUID().toString();
         }
       }
       String key = UUID.randomUUID().toString();
       createVolumeAndBucket(volume, bucket, bucketLayout);
 
-      final int numParts = RandomUtils.nextInt(0, 5);
+      final int numParts = RandomUtils.secure().randomInt(0, 5);
       // Create the MPU key
       createIncompleteMPUKey(volume, bucket, key, numParts);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -469,16 +469,16 @@ class TestOpenKeyCleanupService {
     String volume = UUID.randomUUID().toString();
     String bucket = UUID.randomUUID().toString();
     for (int x = 0; x < keyCount; x++) {
-      if (RandomUtils.nextBoolean()) {
+      if (RandomUtils.secure().randomBoolean()) {
         bucket = UUID.randomUUID().toString();
-        if (RandomUtils.nextBoolean()) {
+        if (RandomUtils.secure().randomBoolean()) {
           volume = UUID.randomUUID().toString();
         }
       }
       String key = withDir ? "dir1/dir2/" + UUID.randomUUID() : UUID.randomUUID().toString();
       createVolumeAndBucket(volume, bucket, bucketLayout);
 
-      final int numBlocks = RandomUtils.nextInt(1, 3);
+      final int numBlocks = RandomUtils.secure().randomInt(1, 3);
       // Create the key
       createOpenKey(volume, bucket, key, numBlocks, hsync, recovery);
     }
@@ -538,9 +538,9 @@ class TestOpenKeyCleanupService {
     String volume = UUID.randomUUID().toString();
     String bucket = UUID.randomUUID().toString();
     for (int x = 0; x < mpuKeyCount; x++) {
-      if (RandomUtils.nextBoolean()) {
+      if (RandomUtils.secure().randomBoolean()) {
         bucket = UUID.randomUUID().toString();
-        if (RandomUtils.nextBoolean()) {
+        if (RandomUtils.secure().randomBoolean()) {
           volume = UUID.randomUUID().toString();
         }
       }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -105,7 +105,7 @@ public class TestOzoneTokenIdentifier {
         new Text("rm"), new Text("client"));
     tokenId.setOmCertSerialId("123");
     LOG.info("Unsigned token {} is {}", tokenId,
-        verifyTokenAsymmetric(tokenId, RandomUtils.nextBytes(128), cert));
+        verifyTokenAsymmetric(tokenId, RandomUtils.secure().randomBytes(128), cert));
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -122,7 +122,7 @@ public class TestOzoneNativeAuthorizer {
   public void createAll(
       String keyName, String prefixName, ACLType userRight,
       ACLType groupRight, boolean expectedResult) throws IOException {
-    int randomInt = RandomUtils.nextInt();
+    int randomInt = RandomUtils.secure().randomInt();
     this.vol = "vol" + randomInt;
     this.buck = "bucket" + randomInt;
     this.key = keyName + randomInt;
@@ -427,7 +427,7 @@ public class TestOzoneNativeAuthorizer {
               + " name:" + (accessType == USER ? user : group));
 
           // Randomize next type.
-          int type = RandomUtils.nextInt(0, 3);
+          int type = RandomUtils.secure().randomInt(0, 3);
           ACLIdentityType identityType = ACLIdentityType.values()[type];
           // Add remaining acls one by one and then check access.
           OzoneAcl addAcl = OzoneAcl.of(identityType,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -119,7 +119,7 @@ public class TestParentAcl {
   public void testKeyAcl()
       throws IOException {
     OzoneObj keyObj;
-    int randomInt = RandomUtils.nextInt();
+    int randomInt = RandomUtils.secure().randomInt();
     String vol = "vol" + randomInt;
     String buck = "bucket" + randomInt;
     String key = "key" + randomInt;
@@ -165,7 +165,7 @@ public class TestParentAcl {
   public void testBucketAcl()
       throws IOException {
     OzoneObj bucketObj;
-    int randomInt = RandomUtils.nextInt();
+    int randomInt = RandomUtils.secure().randomInt();
     String vol = "vol" + randomInt;
     String buck = "bucket" + randomInt;
 

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -78,7 +78,7 @@ public class TestOzoneFSInputStream {
       IntFunction<ByteBuffer> bufferConstructor,
       int streamLength, int bufferCapacity,
       int bufferPosition) throws IOException {
-    final byte[] source = RandomUtils.nextBytes(streamLength);
+    final byte[] source = RandomUtils.secure().randomBytes(streamLength);
     final InputStream input = new ByteArrayInputStream(source);
     final OzoneFSInputStream subject = createTestSubject(input);
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -171,7 +171,7 @@ public class TestReconUtils {
     }
 
     for (int i = 0; i < 10; i++) {
-      assertNextClosestPowerIndexOfTwo(RandomUtils.nextLong());
+      assertNextClosestPowerIndexOfTwo(RandomUtils.secure().randomLong());
     }
   }
 
@@ -202,7 +202,7 @@ public class TestReconUtils {
   private static ContainerInfo.Builder getDefaultContainerInfoBuilder(
       final HddsProtos.LifeCycleState state) {
     return new ContainerInfo.Builder()
-        .setContainerID(RandomUtils.nextLong())
+        .setContainerID(RandomUtils.secure().randomLong())
         .setReplicationConfig(
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.THREE))

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulationState.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulationState.java
@@ -152,7 +152,7 @@ class DatanodeSimulationState {
       // to avoid peaks.
       if (state.nextFullContainerReport == Instant.MIN) {
         state.nextFullContainerReport = Instant.now().plusMillis(
-            RandomUtils.nextLong(1, fullContainerReportDurationMs));
+            RandomUtils.secure().randomLong(1, fullContainerReportDurationMs));
       } else {
         state.nextFullContainerReport = Instant.now()
             .plusMillis(fullContainerReportDurationMs);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeSimulator.java
@@ -345,7 +345,7 @@ public class DatanodeSimulator implements Callable<Void>, FreonSubcommand {
     long scmHeartbeatInterval = HddsServerUtil.getScmHeartbeatInterval(conf);
     scmClients.forEach((endpoint, client) -> {
       // Use random initial delay as a jitter to avoid peaks.
-      long initialDelay = RandomUtils.nextLong(0, scmHeartbeatInterval);
+      long initialDelay = RandomUtils.secure().randomLong(0, scmHeartbeatInterval);
       Runnable runnable = () -> heartbeat(endpoint, client, dn);
       heartbeatScheduler.scheduleAtFixedRate(runnable, initialDelay,
           scmHeartbeatInterval, TimeUnit.MILLISECONDS);
@@ -353,7 +353,7 @@ public class DatanodeSimulator implements Callable<Void>, FreonSubcommand {
 
     long reconHeartbeatInterval =
         HddsServerUtil.getReconHeartbeatInterval(conf);
-    long initialDelay = RandomUtils.nextLong(0, reconHeartbeatInterval);
+    long initialDelay = RandomUtils.secure().randomLong(0, reconHeartbeatInterval);
     Runnable runnable = () -> heartbeat(reconAddress, reconClient, dn);
     heartbeatScheduler.scheduleAtFixedRate(runnable, initialDelay,
         reconHeartbeatInterval, TimeUnit.MILLISECONDS);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
@@ -169,7 +169,7 @@ public class OzoneClientKeyReadWriteListOps extends BaseFreonGenerator
 
       timer = getMetrics().timer("key-read-write-list");
       if (objectSizeInBytes >= 0) {
-        keyContent = RandomUtils.nextBytes(objectSizeInBytes);
+        keyContent = RandomUtils.secure().randomBytes(objectSizeInBytes);
       }
       if (kg == null) {
         kg = new KeyGeneratorUtil();


### PR DESCRIPTION
## What changes were proposed in this pull request?
There're many usage of depreciated function call of `RandomUtils` in the code base, we should change it with the `secure()` ones.

## What is the link to the Apache JIRA
[HDDS-12813](https://issues.apache.org/jira/browse/HDDS-12813)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14546277631
