### PR TITLE
HDDS-12873. Improve ContainerData statistics synchronization.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -30,7 +30,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.STATE;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
@@ -40,14 +39,16 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.ratis.util.Preconditions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -55,6 +56,152 @@ import org.yaml.snakeyaml.Yaml;
  * represented on disk by the .container file.
  */
 public abstract class ContainerData {
+  /**
+   * Block byte used, block count and pending deletion count.
+   * This class is immutable.
+   */
+  public static class BlockByteAndCounts {
+    private final long bytes;
+    private final long count;
+    private final long pendingDeletion;
+
+    public BlockByteAndCounts(long bytes, long count, long pendingDeletion) {
+      this.bytes = bytes;
+      this.count = count;
+      this.pendingDeletion = pendingDeletion;
+    }
+
+    public long getBytes() {
+      return bytes;
+    }
+
+    public long getCount() {
+      return count;
+    }
+
+    public long getPendingDeletion() {
+      return pendingDeletion;
+    }
+  }
+
+  /**
+   * Read/write/block statistics of a container.
+   * This class is thread-safe -- all methods are synchronized.
+   */
+  public static class Statistics {
+    private long readBytes;
+    private long readCount;
+
+    private long writeBytes;
+    private long writeCount;
+
+    private long blockBytes;
+    private long blockCount;
+    private long blockPendingDeletion;
+
+    public synchronized long getWriteBytes() {
+      return writeBytes;
+    }
+
+    public synchronized long getBlockBytes() {
+      return blockBytes;
+    }
+
+    public synchronized BlockByteAndCounts getBlockByteAndCounts() {
+      return new BlockByteAndCounts(blockBytes, blockCount, blockPendingDeletion);
+    }
+
+    public synchronized long getBlockPendingDeletion() {
+      return blockPendingDeletion;
+    }
+
+    public synchronized void incrementBlockCount() {
+      blockCount++;
+    }
+
+    /** Update for reading a block with the given length. */
+    public synchronized void updateRead(long length) {
+      readCount++;
+      readBytes += length;
+    }
+
+    /** Update for writing a block with the given length. */
+    public synchronized void updateWrite(long length, boolean overwrite) {
+      if (!overwrite) {
+        blockBytes += length;
+      }
+      writeCount++;
+      writeBytes += length;
+    }
+
+    public synchronized void updateDeletion(long deletedBytes, long deletedBlockCount, long processedBlockCount) {
+      blockBytes -= deletedBytes;
+      blockCount -= deletedBlockCount;
+      blockPendingDeletion -= processedBlockCount;
+    }
+
+    public synchronized void updateBlocks(long bytes, long count, long pendingDeletionIncrement) {
+      blockBytes = bytes;
+      blockCount = count;
+      blockPendingDeletion += pendingDeletionIncrement;
+    }
+
+    public synchronized ContainerDataProto.Builder setContainerDataProto(ContainerDataProto.Builder b) {
+      if (blockBytes > 0) {
+        b.setBytesUsed(blockBytes);
+      }
+      return b.setBlockCount(blockCount);
+    }
+
+    public synchronized ContainerReplicaProto.Builder setContainerReplicaProto(ContainerReplicaProto.Builder b) {
+      return b.setReadBytes(readBytes)
+          .setReadCount(readCount)
+          .setWriteBytes(writeBytes)
+          .setWriteCount(writeCount)
+          .setUsed(blockBytes)
+          .setKeyCount(blockCount);
+    }
+
+    public synchronized void addBlockPendingDeletion(long count) {
+      blockPendingDeletion += count;
+    }
+
+    public synchronized void resetBlockPendingDeletion() {
+      blockPendingDeletion = 0;
+    }
+
+    public synchronized void assertRead(long expectedBytes, long expectedCount) {
+      Preconditions.assertSame(expectedBytes, readBytes, "readBytes");
+      Preconditions.assertSame(expectedCount, readCount, "readCount");
+    }
+
+    public synchronized void assertWrite(long expectedBytes, long expectedCount) {
+      Preconditions.assertSame(expectedBytes, writeBytes, "writeBytes");
+      Preconditions.assertSame(expectedCount, writeCount, "writeCount");
+    }
+
+    public synchronized void assertBlock(long expectedBytes, long expectedCount, long expectedPendingDeletion) {
+      Preconditions.assertSame(expectedBytes, blockBytes, "blockBytes");
+      Preconditions.assertSame(expectedCount, blockCount, "blockCount");
+      Preconditions.assertSame(expectedPendingDeletion, blockPendingDeletion, "blockPendingDeletion");
+    }
+
+    public synchronized void setBlockCountForTesting(long count) {
+      blockCount = count;
+    }
+
+    public synchronized void setBlockBytesForTesting(long bytes) {
+      blockBytes = bytes;
+    }
+
+    @Override
+    public synchronized String toString() {
+      return "Statistics{read(" + readBytes + " bytes, #" + readCount + ")"
+          + ", write(" + writeBytes + " bytes, #" + writeCount + ")"
+          + ", block(" + blockBytes + " bytes, #" + blockCount
+          + ", pendingDelete=" + blockPendingDeletion + ")}";
+    }
+  }
 
   //Type of the container.
   // For now, we support only KeyValueContainer.
@@ -85,13 +232,8 @@ public abstract class ContainerData {
   //ID of the datanode where this container is created
   private final String originNodeId;
 
-  /** parameters for read/write statistics on the container. **/
-  private final AtomicLong readBytes;
-  private final AtomicLong writeBytes;
-  private final AtomicLong readCount;
-  private final AtomicLong writeCount;
-  private final AtomicLong bytesUsed;
-  private final AtomicLong blockCount;
+  /** Read/write/block statistics of this container. **/
+  private final Statistics statistics = new Statistics();
 
   private HddsVolume volume;
 
@@ -138,20 +280,14 @@ public abstract class ContainerData {
                           ContainerLayoutVersion layoutVersion, long size,
                           String originPipelineId,
                           String originNodeId) {
-    Preconditions.checkNotNull(type);
-
-    this.containerType = type;
+    this.containerType = Objects.requireNonNull(type, "type == null");
     this.containerID = containerId;
     this.layOutVersion = layoutVersion.getVersion();
     this.metadata = new TreeMap<>();
     this.state = ContainerDataProto.State.OPEN;
-    this.readCount = new AtomicLong(0L);
-    this.readBytes =  new AtomicLong(0L);
-    this.writeCount =  new AtomicLong(0L);
-    this.writeBytes =  new AtomicLong(0L);
-    this.bytesUsed = new AtomicLong(0L);
-    this.blockCount = new AtomicLong(0L);
     this.maxSize = size;
+    Preconditions.assertTrue(maxSize > 0, () -> "maxSize = " + maxSize + " <= 0");
+
     this.originPipelineId = originPipelineId;
     this.originNodeId = originNodeId;
     this.isEmpty = false;
@@ -222,7 +358,6 @@ public abstract class ContainerData {
      */
     if ((state == ContainerDataProto.State.OPEN) &&
         (state != oldState)) {
-      Preconditions.checkState(getMaxSize() > 0);
       commitSpace();
     }
   }
@@ -377,7 +512,7 @@ public abstract class ContainerData {
     HddsVolume cVol;
 
     //we don't expect duplicate calls
-    Preconditions.checkState(!committedSpace);
+    Preconditions.assertTrue(!committedSpace);
 
     // Only Open Containers have Committed Space
     if (myState != ContainerDataProto.State.OPEN) {
@@ -392,43 +527,8 @@ public abstract class ContainerData {
     }
   }
 
-  /**
-   * Get the number of bytes read from the container.
-   * @return the number of bytes read from the container.
-   */
-  public long getReadBytes() {
-    return readBytes.get();
-  }
-
-  /**
-   * Increase the number of bytes read from the container.
-   * @param bytes number of bytes read.
-   */
-  public void incrReadBytes(long bytes) {
-    this.readBytes.addAndGet(bytes);
-  }
-
-  /**
-   * Get the number of times the container is read.
-   * @return the number of times the container is read.
-   */
-  public long getReadCount() {
-    return readCount.get();
-  }
-
-  /**
-   * Increase the number of container read count by 1.
-   */
-  public void incrReadCount() {
-    this.readCount.incrementAndGet();
-  }
-
-  /**
-   * Get the number of bytes write into the container.
-   * @return the number of bytes write into the container.
-   */
-  public long getWriteBytes() {
-    return writeBytes.get();
+  public Statistics getStatistics() {
+    return statistics;
   }
 
   /**
@@ -436,8 +536,7 @@ public abstract class ContainerData {
    * Also decrement committed bytes against the bytes written.
    * @param bytes the number of bytes write into the container.
    */
-  public void incrWriteBytes(long bytes) {
-    this.writeBytes.addAndGet(bytes);
+  private void incrWriteBytes(long bytes) {
     /*
        Increase the cached Used Space in VolumeInfo as it
        maybe not updated, DU or DedicatedDiskSpaceUsage runs
@@ -458,52 +557,11 @@ public abstract class ContainerData {
   }
 
   /**
-   * Get the number of writes into the container.
-   * @return the number of writes into the container.
-   */
-  public long getWriteCount() {
-    return writeCount.get();
-  }
-
-  /**
-   * Increase the number of writes into the container by 1.
-   */
-  public void incrWriteCount() {
-    this.writeCount.incrementAndGet();
-  }
-
-  /**
-   * Sets the number of bytes used by the container.
-   * @param used
-   */
-  public void setBytesUsed(long used) {
-    this.bytesUsed.set(used);
-  }
-
-  /**
    * Get the number of bytes used by the container.
    * @return the number of bytes used by the container.
    */
   public long getBytesUsed() {
-    return bytesUsed.get();
-  }
-
-  /**
-   * Increase the number of bytes used by the container.
-   * @param used number of bytes used by the container.
-   * @return the current number of bytes used by the container afert increase.
-   */
-  public long incrBytesUsed(long used) {
-    return this.bytesUsed.addAndGet(used);
-  }
-
-  /**
-   * Decrease the number of bytes used by the container.
-   * @param reclaimed the number of bytes reclaimed from the container.
-   * @return the current number of bytes used by the container after decrease.
-   */
-  public long decrBytesUsed(long reclaimed) {
-    return this.bytesUsed.addAndGet(-1L * reclaimed);
+    return getStatistics().getBlockBytes();
   }
 
   /**
@@ -524,35 +582,10 @@ public abstract class ContainerData {
     return volume;
   }
 
-  /**
-   * Increments the number of blocks in the container.
-   */
-  public void incrBlockCount() {
-    this.blockCount.incrementAndGet();
-  }
-
-  /**
-   * Decrements number of blocks in the container.
-   */
-  public void decrBlockCount() {
-    this.blockCount.decrementAndGet();
-  }
-
-  /**
-   * Decrease the count of blocks (blocks) in the container.
-   *
-   * @param deletedBlockCount
-   */
-  public void decrBlockCount(long deletedBlockCount) {
-    this.blockCount.addAndGet(-1 * deletedBlockCount);
-  }
-
-  /**
-   * Returns number of blocks in the container.
-   * @return block count
-   */
+  /** For testing only. */
+  @VisibleForTesting
   public long getBlockCount() {
-    return this.blockCount.get();
+    return getStatistics().getBlockByteAndCounts().getCount();
   }
 
   public boolean isEmpty() {
@@ -565,14 +598,6 @@ public abstract class ContainerData {
    */
   public void markAsEmpty() {
     this.isEmpty = true;
-  }
-
-  /**
-   * Set's number of blocks in the container.
-   * @param count
-   */
-  public void setBlockCount(long count) {
-    this.blockCount.set(count);
   }
 
   public void setChecksumTo0ByteArray() {
@@ -663,16 +688,8 @@ public abstract class ContainerData {
    */
   public abstract long getBlockCommitSequenceId();
 
-  public void updateReadStats(long length) {
-    incrReadCount();
-    incrReadBytes(length);
-  }
-
   public void updateWriteStats(long bytesWritten, boolean overwrite) {
-    if (!overwrite) {
-      incrBytesUsed(bytesWritten);
-    }
-    incrWriteCount();
+    getStatistics().updateWrite(bytesWritten, overwrite);
     incrWriteBytes(bytesWritten);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
@@ -80,8 +80,10 @@ public abstract class ContainerDeletionChoosingPolicyTemplate
         }
       }
     }
-    LOG.info("Chosen {}/{} blocks from {} candidate containers.",
-        (originalBlockCount - blockCount), blockCount, orderedList.size());
+    if (!orderedList.isEmpty()) {
+      LOG.info("Chosen {}/{} blocks from {} candidate containers.",
+          (originalBlockCount - blockCount), blockCount, orderedList.size());
+    }
     return result;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -780,7 +780,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
       ContainerData containerData = container.getContainerData();
       if (containerData.getOriginPipelineId()
           .compareTo(pipelineID.getId()) == 0) {
-        bytesWritten += containerData.getWriteBytes();
+        bytesWritten += containerData.getStatistics().getWriteBytes();
       }
     }
     return bytesWritten;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -849,57 +849,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
    * Returns KeyValueContainerReport for the KeyValueContainer.
    */
   @Override
-  public ContainerReplicaProto getContainerReport()
-      throws StorageContainerException {
-    ContainerReplicaProto.Builder ciBuilder =
-        ContainerReplicaProto.newBuilder();
-    ciBuilder.setContainerID(containerData.getContainerID())
-        .setReadCount(containerData.getReadCount())
-        .setWriteCount(containerData.getWriteCount())
-        .setReadBytes(containerData.getReadBytes())
-        .setWriteBytes(containerData.getWriteBytes())
-        .setKeyCount(containerData.getBlockCount())
-        .setUsed(containerData.getBytesUsed())
-        .setState(getHddsState())
-        .setReplicaIndex(containerData.getReplicaIndex())
-        .setDeleteTransactionId(containerData.getDeleteTransactionId())
-        .setBlockCommitSequenceId(containerData.getBlockCommitSequenceId())
-        .setOriginNodeId(containerData.getOriginNodeId())
-        .setIsEmpty(containerData.isEmpty());
-    return ciBuilder.build();
-  }
-
-  /**
-   * Returns LifeCycle State of the container.
-   * @return LifeCycle State of the container in HddsProtos format
-   * @throws StorageContainerException
-   */
-  private ContainerReplicaProto.State getHddsState()
-      throws StorageContainerException {
-    ContainerReplicaProto.State state;
-    switch (containerData.getState()) {
-    case OPEN:
-      state = ContainerReplicaProto.State.OPEN;
-      break;
-    case CLOSING:
-      state = ContainerReplicaProto.State.CLOSING;
-      break;
-    case QUASI_CLOSED:
-      state = ContainerReplicaProto.State.QUASI_CLOSED;
-      break;
-    case CLOSED:
-      state = ContainerReplicaProto.State.CLOSED;
-      break;
-    case UNHEALTHY:
-      state = ContainerReplicaProto.State.UNHEALTHY;
-      break;
-    case DELETED:
-      state = ContainerReplicaProto.State.DELETED;
-      break;
-    default:
-      throw new StorageContainerException("Invalid Container state: " + containerData, INVALID_CONTAINER_STATE);
-    }
-    return state;
+  public ContainerReplicaProto getContainerReport() throws StorageContainerException {
+    return containerData.buildContainerReplicaProto();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container.keyvalue;
 
 import static java.lang.Math.max;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.INVALID_CONTAINER_STATE;
 import static org.apache.hadoop.ozone.OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.BLOCK_COUNT;
 import static org.apache.hadoop.ozone.OzoneConsts.CHUNKS_PATH;
@@ -44,9 +45,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -79,10 +81,6 @@ public class KeyValueContainerData extends ContainerData {
 
   private String schemaVersion;
 
-  /**
-   * Number of pending deletion blocks in KeyValueContainer.
-   */
-  private final AtomicLong numPendingDeletionBlocks;
 
   private long deleteTransactionId;
 
@@ -110,7 +108,6 @@ public class KeyValueContainerData extends ContainerData {
       long size, String originPipelineId, String originNodeId) {
     super(ContainerProtos.ContainerType.KeyValueContainer, id, layoutVersion,
         size, originPipelineId, originNodeId);
-    this.numPendingDeletionBlocks = new AtomicLong(0);
     this.deleteTransactionId = 0;
     finalizedBlockSet =  ConcurrentHashMap.newKeySet();
   }
@@ -119,7 +116,6 @@ public class KeyValueContainerData extends ContainerData {
     super(source);
     Preconditions.checkArgument(source.getContainerType()
         == ContainerProtos.ContainerType.KeyValueContainer);
-    this.numPendingDeletionBlocks = new AtomicLong(0);
     this.deleteTransactionId = 0;
     this.schemaVersion = source.getSchemaVersion();
     finalizedBlockSet = ConcurrentHashMap.newKeySet();
@@ -240,23 +236,14 @@ public class KeyValueContainerData extends ContainerData {
    * @param numBlocks increment number
    */
   public void incrPendingDeletionBlocks(long numBlocks) {
-    this.numPendingDeletionBlocks.addAndGet(numBlocks);
-  }
-
-  /**
-   * Decrease the count of pending deletion blocks.
-   *
-   * @param numBlocks decrement number
-   */
-  public void decrPendingDeletionBlocks(long numBlocks) {
-    this.numPendingDeletionBlocks.addAndGet(-1 * numBlocks);
+    getStatistics().addBlockPendingDeletion(numBlocks);
   }
 
   /**
    * Get the number of pending deletion blocks.
    */
   public long getNumPendingDeletionBlocks() {
-    return this.numPendingDeletionBlocks.get();
+    return getStatistics().getBlockPendingDeletion();
   }
 
   /**
@@ -273,6 +260,39 @@ public class KeyValueContainerData extends ContainerData {
    */
   public long getDeleteTransactionId() {
     return deleteTransactionId;
+  }
+
+  ContainerReplicaProto buildContainerReplicaProto() throws StorageContainerException {
+    return getStatistics().setContainerReplicaProto(ContainerReplicaProto.newBuilder())
+        .setContainerID(getContainerID())
+        .setState(getContainerReplicaProtoState(getState()))
+        .setIsEmpty(isEmpty())
+        .setOriginNodeId(getOriginNodeId())
+        .setReplicaIndex(getReplicaIndex())
+        .setBlockCommitSequenceId(getBlockCommitSequenceId())
+        .setDeleteTransactionId(getDeleteTransactionId())
+        .build();
+  }
+
+  // TODO remove one of the State from proto
+  static ContainerReplicaProto.State getContainerReplicaProtoState(ContainerDataProto.State state)
+      throws StorageContainerException {
+    switch (state) {
+    case OPEN:
+      return ContainerReplicaProto.State.OPEN;
+    case CLOSING:
+      return ContainerReplicaProto.State.CLOSING;
+    case QUASI_CLOSED:
+      return ContainerReplicaProto.State.QUASI_CLOSED;
+    case CLOSED:
+      return ContainerReplicaProto.State.CLOSED;
+    case UNHEALTHY:
+      return ContainerReplicaProto.State.UNHEALTHY;
+    case DELETED:
+      return ContainerReplicaProto.State.DELETED;
+    default:
+      throw new StorageContainerException("Invalid container state: " + state, INVALID_CONTAINER_STATE);
+    }
   }
 
   /**
@@ -315,7 +335,6 @@ public class KeyValueContainerData extends ContainerData {
     builder.setContainerID(this.getContainerID());
     builder.setContainerPath(this.getContainerPath());
     builder.setState(this.getState());
-    builder.setBlockCount(this.getBlockCount());
 
     for (Map.Entry<String, String> entry : getMetadata().entrySet()) {
       ContainerProtos.KeyValue.Builder keyValBuilder =
@@ -324,9 +343,7 @@ public class KeyValueContainerData extends ContainerData {
           .setValue(entry.getValue()).build());
     }
 
-    if (this.getBytesUsed() >= 0) {
-      builder.setBytesUsed(this.getBytesUsed());
-    }
+    getStatistics().setContainerDataProto(builder);
 
     if (this.getContainerType() != null) {
       builder.setContainerType(ContainerProtos.ContainerType.KeyValueContainer);
@@ -353,20 +370,18 @@ public class KeyValueContainerData extends ContainerData {
     Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
     // Set Bytes used and block count key.
-    metadataTable.putWithBatch(batchOperation, getBytesUsedKey(),
-            getBytesUsed() - releasedBytes);
-    metadataTable.putWithBatch(batchOperation, getBlockCountKey(),
-            getBlockCount() - deletedBlockCount);
-    metadataTable.putWithBatch(batchOperation,
-        getPendingDeleteBlockCountKey(),
-        getNumPendingDeletionBlocks() - deletedBlockCount);
+    final BlockByteAndCounts b = getStatistics().getBlockByteAndCounts();
+    metadataTable.putWithBatch(batchOperation, getBytesUsedKey(), b.getBytes() - releasedBytes);
+    metadataTable.putWithBatch(batchOperation, getBlockCountKey(), b.getCount() - deletedBlockCount);
+    metadataTable.putWithBatch(batchOperation, getPendingDeleteBlockCountKey(),
+        b.getPendingDeletion() - deletedBlockCount);
 
     db.getStore().getBatchHandler().commitBatchOperation(batchOperation);
   }
 
   public void resetPendingDeleteBlockCount(DBHandle db) throws IOException {
     // Reset the in memory metadata.
-    numPendingDeletionBlocks.set(0);
+    getStatistics().resetBlockPendingDeletion();
     // Reset the metadata on disk.
     Table<String, Long> metadataTable = db.getStore().getMetadataTable();
     metadataTable.put(getPendingDeleteBlockCountKey(), 0L);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1448,6 +1448,7 @@ public class KeyValueHandler extends Handler {
     long startTime = clock.millis();
     container.writeLock();
     try {
+      final ContainerData data = container.getContainerData();
       if (container.getContainerData().getVolume().isFailed()) {
         // if the  volume in which the container resides fails
         // don't attempt to delete/move it. When a volume fails,
@@ -1472,10 +1473,7 @@ public class KeyValueHandler extends Handler {
         // container is unhealthy or over-replicated).
         if (container.hasBlocks()) {
           metrics.incContainerDeleteFailedNonEmpty();
-          LOG.error("Received container deletion command for container {} but" +
-                  " the container is not empty with blockCount {}",
-              container.getContainerData().getContainerID(),
-              container.getContainerData().getBlockCount());
+          LOG.error("Received container deletion command for non-empty {}: {}", data, data.getStatistics());
           // blocks table for future debugging.
           // List blocks
           logBlocksIfNonZero(container);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
@@ -176,15 +177,12 @@ public class BlockManagerImpl implements BlockManager {
         // block length is used, And also on restart the blocks committed to DB
         // is only used to compute the bytes used. This is done to keep the
         // current behavior and avoid DB write during write chunk operation.
-        db.getStore().getMetadataTable().putWithBatch(
-            batch, containerData.getBytesUsedKey(),
-            containerData.getBytesUsed());
+        final ContainerData.BlockByteAndCounts b = containerData.getStatistics().getBlockByteAndCounts();
+        db.getStore().getMetadataTable().putWithBatch(batch, containerData.getBytesUsedKey(), b.getBytes());
 
         // Set Block Count for a container.
         if (incrBlockCount) {
-          db.getStore().getMetadataTable().putWithBatch(
-              batch, containerData.getBlockCountKey(),
-              containerData.getBlockCount() + 1);
+          db.getStore().getMetadataTable().putWithBatch(batch, containerData.getBlockCountKey(), b.getCount() + 1);
         }
 
         db.getStore().getBatchHandler().commitBatchOperation(batch);
@@ -197,7 +195,7 @@ public class BlockManagerImpl implements BlockManager {
       // Increment block count and add block to pendingPutBlockCache
       // in-memory after the DB update.
       if (incrBlockCount) {
-        containerData.incrBlockCount();
+        containerData.getStatistics().incrementBlockCount();
       }
 
       // If the Block is not in PendingPutBlockCache (and it is not endOfBlock),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -108,7 +108,7 @@ public class ChunkManagerDispatcher implements ChunkManager {
         .readChunk(container, blockID, info, dispatcherContext);
 
     Preconditions.checkState(data != null);
-    container.getContainerData().updateReadStats(info.getLen());
+    container.getContainerData().getStatistics().updateRead(info.getLen());
 
     return data;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -194,8 +194,7 @@ public class BlockDeletingTask implements BackgroundTask {
       }
 
       List<String> succeedBlocks = new LinkedList<>();
-      LOG.debug("Container : {}, To-Delete blocks : {}",
-          containerData.getContainerID(), toDeleteBlocks.size());
+      LOG.debug("{}, toDeleteBlocks: {}", containerData, toDeleteBlocks.size());
 
       Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
           .getHandler(container.getContainerType()));
@@ -247,9 +246,7 @@ public class BlockDeletingTask implements BackgroundTask {
 
         // update count of pending deletion blocks, block count and used
         // bytes in in-memory container status.
-        containerData.decrPendingDeletionBlocks(deletedBlocksCount);
-        containerData.decrBlockCount(deletedBlocksCount);
-        containerData.decrBytesUsed(releasedBytes);
+        containerData.getStatistics().updateDeletion(releasedBytes, deletedBlocksCount, deletedBlocksCount);
         containerData.getVolume().decrementUsedSpace(releasedBytes);
         metrics.incrSuccessCount(deletedBlocksCount);
         metrics.incrSuccessBytes(releasedBytes);
@@ -337,10 +334,7 @@ public class BlockDeletingTask implements BackgroundTask {
         delBlocks.add(delTx);
       }
       if (delBlocks.isEmpty()) {
-        LOG.info("No transaction found in container {} with pending delete " +
-                "block count {}",
-            containerData.getContainerID(),
-            containerData.getNumPendingDeletionBlocks());
+        LOG.info("Pending block deletion not found in {}: {}", containerData, containerData.getStatistics());
         // If the container was queued for delete, it had a positive
         // pending delete block count. After checking the DB there were
         // actually no delete transactions for the container, so reset the
@@ -349,8 +343,7 @@ public class BlockDeletingTask implements BackgroundTask {
         return crr;
       }
 
-      LOG.debug("Container : {}, To-Delete blocks : {}",
-          containerData.getContainerID(), delBlocks.size());
+      LOG.debug("{}, delBlocks: {}", containerData, delBlocks.size());
 
       Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
           .getHandler(container.getContainerType()));
@@ -398,9 +391,7 @@ public class BlockDeletingTask implements BackgroundTask {
 
         // update count of pending deletion blocks, block count and used
         // bytes in in-memory container status and used space in volume.
-        containerData.decrPendingDeletionBlocks(deletedBlocksProcessed);
-        containerData.decrBlockCount(deletedBlocksCount);
-        containerData.decrBytesUsed(releasedBytes);
+        containerData.getStatistics().updateDeletion(releasedBytes, deletedBlocksCount, deletedBlocksProcessed);
         containerData.getVolume().decrementUsedSpace(releasedBytes);
         metrics.incrSuccessCount(deletedBlocksCount);
         metrics.incrSuccessBytes(releasedBytes);
@@ -478,13 +469,8 @@ public class BlockDeletingTask implements BackgroundTask {
         }
 
         if (deleted) {
-          try {
-            bytesReleased += KeyValueContainerUtil.getBlockLength(blkInfo);
-          } catch (IOException e) {
-            // TODO: handle the bytesReleased correctly for the unexpected
-            //  exception.
-            LOG.error("Failed to get block length for block {}", blkLong, e);
-          }
+          bytesReleased += KeyValueContainerUtil.getBlockLengthTryCatch(blkInfo);
+          // TODO: handle the bytesReleased correctly for the unexpected exception.
         }
       }
       deletedBlocksTxs.add(entry);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -331,7 +331,7 @@ public class TestBlockDeletingService {
       int numOfChunksPerBlock) {
     long chunkLength = 100;
     try (DBHandle metadata = BlockUtils.getDB(data, conf)) {
-      container.getContainerData().setBlockCount(numOfBlocksPerContainer);
+      container.getContainerData().getStatistics().setBlockCountForTesting(numOfBlocksPerContainer);
       // Set block count, bytes used and pending delete block count.
       metadata.getStore().getMetadataTable()
           .put(data.getBlockCountKey(), (long) numOfBlocksPerContainer);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -851,11 +851,9 @@ public class TestContainerPersistence {
     info.addMetadata(OzoneConsts.CHUNK_OVERWRITE, "true");
     chunkManager.writeChunk(container, blockID, info, data,
         DispatcherContext.getHandleWriteChunk());
-    long bytesUsed = container.getContainerData().getBytesUsed();
-    assertEquals(datalen, bytesUsed);
-
-    long bytesWrite = container.getContainerData().getWriteBytes();
-    assertEquals(datalen * 3, bytesWrite);
+    final ContainerData.Statistics statistics = container.getContainerData().getStatistics();
+    statistics.assertWrite(datalen * 3, 3);
+    statistics.assertBlock(datalen, 0, 0);
   }
 
   /**
@@ -992,14 +990,10 @@ public class TestContainerPersistence {
       chunkList.add(info);
     }
 
-    long bytesUsed = container.getContainerData().getBytesUsed();
-    assertEquals(totalSize, bytesUsed);
-    long writeBytes = container.getContainerData().getWriteBytes();
-    assertEquals(chunkCount * datalen, writeBytes);
-    long readCount = container.getContainerData().getReadCount();
-    assertEquals(0, readCount);
-    long writeCount = container.getContainerData().getWriteCount();
-    assertEquals(chunkCount, writeCount);
+    final ContainerData.Statistics statistics = container.getContainerData().getStatistics();
+    statistics.assertRead(0, 0);
+    statistics.assertWrite(chunkCount * datalen, chunkCount);
+    statistics.assertBlock(totalSize, 0, 0);
 
     BlockData blockData = new BlockData(blockID);
     List<ContainerProtos.ChunkInfo> chunkProtoList = new LinkedList<>();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -168,7 +168,7 @@ public class TestHddsDispatcher {
           responseOne.getResult());
       verify(context, times(0))
           .addContainerActionIfAbsent(any(ContainerAction.class));
-      containerData.setBytesUsed(Double.valueOf(
+      containerData.getStatistics().setBlockBytesForTesting(Double.valueOf(
           StorageUnit.MB.toBytes(950)).longValue());
       ContainerCommandResponseProto responseTwo = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 2L), null);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -127,9 +127,9 @@ public class TestKeyValueContainerIntegrityChecks {
     byte[] chunkData = RandomStringUtils.randomAscii(CHUNK_LEN).getBytes(UTF_8);
     ChecksumData checksumData = checksum.computeChecksum(chunkData);
 
+    final long size = totalBlocks > 0 ? CHUNKS_PER_BLOCK * CHUNK_LEN * totalBlocks : 1;
     KeyValueContainerData containerData = new KeyValueContainerData(containerId,
-        containerLayoutTestInfo.getLayout(),
-        (long) CHUNKS_PER_BLOCK * CHUNK_LEN * totalBlocks,
+        containerLayoutTestInfo.getLayout(), size,
         UUID.randomUUID().toString(), UUID.randomUUID().toString());
     KeyValueContainer container = new KeyValueContainer(containerData, conf);
     container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -167,7 +167,7 @@ public class TestTarContainerPacker {
 
     KeyValueContainerData containerData = new KeyValueContainerData(
         id, layout,
-        -1, UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        1, UUID.randomUUID().toString(), UUID.randomUUID().toString());
     containerData.setSchemaVersion(schemaVersion);
     containerData.setChunksPath(dataDir.toString());
     containerData.setMetadataPath(metaDir.toString());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -375,7 +375,7 @@ public class TestReplicationSupervisor {
         ContainerLayoutVersion.FILE_PER_BLOCK, 100, "test", "test");
     HddsVolume vol = mock(HddsVolume.class);
     containerData.setVolume(vol);
-    containerData.incrBytesUsed(100);
+    containerData.getStatistics().updateWrite(100, false);
     KeyValueContainer container = new KeyValueContainer(containerData, conf);
     ContainerController controllerMock = mock(ContainerController.class);
     Semaphore semaphore = new Semaphore(1);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -222,7 +222,7 @@ public class TestDeleteContainerHandler {
 
     // Set container blockCount to 0 to mock that it is empty as per RocksDB
     getContainerfromDN(hddsDatanodeService, containerId.getId())
-        .getContainerData().setBlockCount(0);
+        .getContainerData().getStatistics().setBlockCountForTesting(0);
 
     // send delete container to the datanode
     SCMCommand<?> command = new DeleteContainerCommand(containerId.getId(),
@@ -432,8 +432,7 @@ public class TestDeleteContainerHandler {
     // Check the log for the error message when deleting non-empty containers
     LogCapturer logCapturer = LogCapturer.captureLogs(KeyValueHandler.class);
     GenericTestUtils.waitFor(() ->
-            logCapturer.getOutput().
-                contains("the container is not empty with blockCount"),
+            logCapturer.getOutput().contains("Received container deletion command for non-empty"),
         500,
         5 * 2000);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
```java
 /** parameters for read/write statistics on the container. **/
  private final AtomicLong readBytes;
  private final AtomicLong writeBytes;
  private final AtomicLong readCount;
  private final AtomicLong writeCount;
  private final AtomicLong bytesUsed;
  private final AtomicLong blockCount;
```
In ContainerData, the fields shown above are for statistics. The synchronization in current code is incorrect when updating multiple fields.

It is better to create a class for them and then synchronize the new class.

## What is the link to the Apache JIRA

HDDS-12873

## How was this patch tested?

By updating existing tests