### PR TITLE
HDDS-12504. Replace calls to deprecated RandomStringUtils methods

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -52,7 +52,7 @@ public class TestChecksum {
   public void testVerifyChecksum(boolean useChecksumCache) throws Exception {
     Checksum checksum = getChecksum(null, useChecksumCache);
     int dataLen = 55;
-    byte[] data = RandomStringUtils.randomAlphabetic(dataLen).getBytes(UTF_8);
+    byte[] data = RandomStringUtils.secure().nextAlphanumeric(dataLen).getBytes(UTF_8);
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
 
     ChecksumData checksumData = checksum.computeChecksum(byteBuffer, useChecksumCache);
@@ -73,7 +73,7 @@ public class TestChecksum {
   @ValueSource(booleans = {true, false})
   public void testIncorrectChecksum(boolean useChecksumCache) throws Exception {
     Checksum checksum = getChecksum(null, useChecksumCache);
-    byte[] data = RandomStringUtils.randomAlphabetic(55).getBytes(UTF_8);
+    byte[] data = RandomStringUtils.secure().nextAlphanumeric(55).getBytes(UTF_8);
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
     ChecksumData originalChecksumData = checksum.computeChecksum(byteBuffer, useChecksumCache);
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -52,7 +52,7 @@ public class TestChecksum {
   public void testVerifyChecksum(boolean useChecksumCache) throws Exception {
     Checksum checksum = getChecksum(null, useChecksumCache);
     int dataLen = 55;
-    byte[] data = RandomStringUtils.secure().nextAlphanumeric(dataLen).getBytes(UTF_8);
+    byte[] data = RandomStringUtils.secure().nextAlphabetic(dataLen).getBytes(UTF_8);
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
 
     ChecksumData checksumData = checksum.computeChecksum(byteBuffer, useChecksumCache);
@@ -73,7 +73,7 @@ public class TestChecksum {
   @ValueSource(booleans = {true, false})
   public void testIncorrectChecksum(boolean useChecksumCache) throws Exception {
     Checksum checksum = getChecksum(null, useChecksumCache);
-    byte[] data = RandomStringUtils.secure().nextAlphanumeric(55).getBytes(UTF_8);
+    byte[] data = RandomStringUtils.secure().nextAlphabetic(55).getBytes(UTF_8);
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
     ChecksumData originalChecksumData = checksum.computeChecksum(byteBuffer, useChecksumCache);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.container.common;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 import static org.apache.hadoop.ozone.OzoneConsts.BLOCK_COUNT;
 import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_BYTES_USED;
 import static org.apache.hadoop.ozone.OzoneConsts.PENDING_DELETE_BLOCK_COUNT;
@@ -112,7 +112,7 @@ public class TestSchemaTwoBackwardsCompatibility {
   private static final int BLOCKS_PER_TXN = 2;
   private static final int CHUNK_LENGTH = 1024;
   private static final byte[] SAMPLE_DATA =
-      randomAlphanumeric(1024).getBytes(UTF_8);
+      secure().nextAlphanumeric(1024).getBytes(UTF_8);
 
   @BeforeEach
   public void setup() throws Exception {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerImplTestUtils.newContainerSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -221,21 +221,21 @@ public class TestVolumeSetDiskChecks {
     final OzoneConfiguration ozoneConf = new OzoneConfiguration();
     final List<String> dirs = new ArrayList<>();
     for (int i = 0; i < numDirs; ++i) {
-      dirs.add(new File(dir, randomAlphanumeric(10)).toString());
+      dirs.add(new File(dir, secure().nextAlphanumeric(10)).toString());
     }
     ozoneConf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY,
         String.join(",", dirs));
 
     final List<String> metaDirs = new ArrayList<>();
     for (int i = 0; i < numDirs; ++i) {
-      metaDirs.add(new File(dir, randomAlphanumeric(10)).toString());
+      metaDirs.add(new File(dir, secure().nextAlphanumeric(10)).toString());
     }
     ozoneConf.set(OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATANODE_STORAGE_DIR,
         String.join(",", metaDirs));
 
     final List<String> dbDirs = new ArrayList<>();
     for (int i = 0; i < numDirs; ++i) {
-      dbDirs.add(new File(dir, randomAlphanumeric(10)).toString());
+      dbDirs.add(new File(dir, secure().nextAlphanumeric(10)).toString());
     }
     ozoneConf.set(OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR,
         String.join(",", dbDirs));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -124,7 +124,7 @@ public class TestKeyValueContainerIntegrityChecks {
     int bytesPerChecksum = 2 * UNIT_LEN;
     Checksum checksum = new Checksum(ContainerProtos.ChecksumType.SHA256,
         bytesPerChecksum);
-    byte[] chunkData = RandomStringUtils.randomAscii(CHUNK_LEN).getBytes(UTF_8);
+    byte[] chunkData = RandomStringUtils.secure().nextAscii(CHUNK_LEN).getBytes(UTF_8);
     ChecksumData checksumData = checksum.computeChecksum(chunkData);
 
     KeyValueContainerData containerData = new KeyValueContainerData(containerId,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -68,7 +68,7 @@ public abstract class CommonChunkManagerTestCases extends AbstractTestChunkManag
     ChunkManager chunkManager = createTestSubject();
     KeyValueContainer container = getKeyValueContainer();
     int tooLarge = OZONE_SCM_CHUNK_MAX_SIZE + 1;
-    byte[] array = RandomStringUtils.randomAscii(tooLarge).getBytes(UTF_8);
+    byte[] array = RandomStringUtils.secure().nextAscii(tooLarge).getBytes(UTF_8);
     assertThat(array.length).isGreaterThanOrEqualTo(tooLarge);
 
     BlockID blockID = getBlockID();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -93,8 +93,8 @@ public class TestDefaultCAServer {
   @Test
   public void testInit() throws Exception {
     CertificateServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.secure().nextAlphanumeric(4),
-        RandomStringUtils.secure().nextAlphanumeric(4), caStore,
+        RandomStringUtils.secure().nextAlphabetic(4),
+        RandomStringUtils.secure().nextAlphabetic(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
@@ -109,8 +109,8 @@ public class TestDefaultCAServer {
   @Test
   public void testMissingCertificate() throws Exception {
     CertificateServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.secure().nextAlphanumeric(4),
-        RandomStringUtils.secure().nextAlphanumeric(4), caStore,
+        RandomStringUtils.secure().nextAlphabetic(4),
+        RandomStringUtils.secure().nextAlphabetic(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
@@ -128,8 +128,8 @@ public class TestDefaultCAServer {
   @Test
   public void testMissingKey() {
     DefaultCAServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.secure().nextAlphanumeric(4),
-        RandomStringUtils.secure().nextAlphanumeric(4), caStore,
+        RandomStringUtils.secure().nextAlphabetic(4),
+        RandomStringUtils.secure().nextAlphabetic(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     Consumer<SecurityConfig> caInitializer =
@@ -152,8 +152,8 @@ public class TestDefaultCAServer {
    */
   @Test
   public void testRequestCertificate() throws Exception {
-    String scmId = RandomStringUtils.secure().nextAlphanumeric(4);
-    String clusterId = RandomStringUtils.secure().nextAlphanumeric(4);
+    String scmId = RandomStringUtils.secure().nextAlphabetic(4);
+    String clusterId = RandomStringUtils.secure().nextAlphabetic(4);
     KeyPair keyPair =
         new HDDSKeyGenerator(securityConfig).generateKey();
     //TODO: generateCSR!

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -93,8 +93,8 @@ public class TestDefaultCAServer {
   @Test
   public void testInit() throws Exception {
     CertificateServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.randomAlphabetic(4),
-        RandomStringUtils.randomAlphabetic(4), caStore,
+        RandomStringUtils.secure().nextAlphanumeric(4),
+        RandomStringUtils.secure().nextAlphanumeric(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
@@ -109,8 +109,8 @@ public class TestDefaultCAServer {
   @Test
   public void testMissingCertificate() throws Exception {
     CertificateServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.randomAlphabetic(4),
-        RandomStringUtils.randomAlphabetic(4), caStore,
+        RandomStringUtils.secure().nextAlphanumeric(4),
+        RandomStringUtils.secure().nextAlphanumeric(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
@@ -128,8 +128,8 @@ public class TestDefaultCAServer {
   @Test
   public void testMissingKey() {
     DefaultCAServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.randomAlphabetic(4),
-        RandomStringUtils.randomAlphabetic(4), caStore,
+        RandomStringUtils.secure().nextAlphanumeric(4),
+        RandomStringUtils.secure().nextAlphanumeric(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     Consumer<SecurityConfig> caInitializer =
@@ -152,8 +152,8 @@ public class TestDefaultCAServer {
    */
   @Test
   public void testRequestCertificate() throws Exception {
-    String scmId = RandomStringUtils.randomAlphabetic(4);
-    String clusterId = RandomStringUtils.randomAlphabetic(4);
+    String scmId = RandomStringUtils.secure().nextAlphanumeric(4);
+    String clusterId = RandomStringUtils.secure().nextAlphanumeric(4);
     KeyPair keyPair =
         new HDDSKeyGenerator(securityConfig).generateKey();
     //TODO: generateCSR!
@@ -221,8 +221,8 @@ public class TestDefaultCAServer {
         .generateCSR();
 
     CertificateServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.randomAlphabetic(4),
-        RandomStringUtils.randomAlphabetic(4), caStore,
+        RandomStringUtils.secure().nextAlphabetic(4),
+        RandomStringUtils.secure().nextAlphabetic(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
@@ -253,8 +253,8 @@ public class TestDefaultCAServer {
         .generateCSR();
 
     CertificateServer testCA = new DefaultCAServer("testCA",
-        RandomStringUtils.randomAlphabetic(4),
-        RandomStringUtils.randomAlphabetic(4), caStore,
+        RandomStringUtils.secure().nextAlphabetic(4),
+        RandomStringUtils.secure().nextAlphabetic(4), caStore,
         new DefaultProfile(),
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
@@ -275,8 +275,8 @@ public class TestDefaultCAServer {
   public void testIntermediaryCAWithEmpty() {
 
     CertificateServer scmCA = new DefaultCAServer("testCA",
-        RandomStringUtils.randomAlphabetic(4),
-        RandomStringUtils.randomAlphabetic(4), caStore,
+        RandomStringUtils.secure().nextAlphabetic(4),
+        RandomStringUtils.secure().nextAlphabetic(4), caStore,
         new DefaultProfile(), Paths.get("scm").toString());
 
     assertThrows(IllegalStateException.class,
@@ -305,8 +305,8 @@ public class TestDefaultCAServer {
           CertificateCodec.getPEMEncodedString(externalCert));
 
       CertificateServer testCA = new DefaultCAServer("testCA",
-          RandomStringUtils.randomAlphabetic(4),
-          RandomStringUtils.randomAlphabetic(4), caStore,
+          RandomStringUtils.secure().nextAlphabetic(4),
+          RandomStringUtils.secure().nextAlphabetic(4), caStore,
           new DefaultProfile(),
           Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
       //When initializing a CA server with external cert
@@ -335,8 +335,8 @@ public class TestDefaultCAServer {
         securityConfig);
     try (SCMCertificateClient scmCertificateClient =
         new SCMCertificateClient(securityConfig, null, null)) {
-      String scmId = RandomStringUtils.randomAlphabetic(4);
-      String clusterId = RandomStringUtils.randomAlphabetic(4);
+      String scmId = RandomStringUtils.secure().nextAlphabetic(4);
+      String clusterId = RandomStringUtils.secure().nextAlphabetic(4);
       KeyPair keyPair = new HDDSKeyGenerator(securityConfig).generateKey();
       KeyStorage keyStorage = new KeyStorage(securityConfig, "");
       keyStorage.storeKeyPair(keyPair);
@@ -370,8 +370,8 @@ public class TestDefaultCAServer {
           CertificateCodec.getPEMEncodedString(certPath));
 
       CertificateServer testCA = new DefaultCAServer("testCA",
-          RandomStringUtils.randomAlphabetic(4),
-          RandomStringUtils.randomAlphabetic(4), caStore,
+          RandomStringUtils.secure().nextAlphabetic(4),
+          RandomStringUtils.secure().nextAlphabetic(4), caStore,
           new DefaultProfile(),
           Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
       //When initializing a CA server with external cert
@@ -387,8 +387,8 @@ public class TestDefaultCAServer {
     conf.set(HddsConfigKeys.HDDS_X509_MAX_DURATION, "P3650D");
     securityConfig = new SecurityConfig(conf);
 
-    String clusterId = RandomStringUtils.randomAlphanumeric(4);
-    String scmId = RandomStringUtils.randomAlphanumeric(4);
+    String clusterId = RandomStringUtils.secure().nextAlphanumeric(4);
+    String scmId = RandomStringUtils.secure().nextAlphanumeric(4);
 
     CertificateServer rootCA = new DefaultCAServer("rootCA",
         clusterId, scmId, caStore, new DefaultProfile(),

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -191,7 +191,7 @@ public class TestDefaultCertificateClient {
 
   @Test
   public void testSignDataStream() throws Exception {
-    String data = RandomStringUtils.random(100);
+    String data = RandomStringUtils.secure().next(100);
     FileUtils.deleteQuietly(Paths.get(
         dnSecurityConfig.getKeyLocation(DN_COMPONENT).toString(),
         dnSecurityConfig.getPrivateKeyFileName()).toFile());
@@ -228,7 +228,7 @@ public class TestDefaultCertificateClient {
    */
   @Test
   public void verifySignatureStream() throws Exception {
-    String data = RandomStringUtils.random(500);
+    String data = RandomStringUtils.secure().next(500);
     byte[] sign = dnCertClient.signData(data.getBytes(UTF_8));
 
     // Positive tests.
@@ -246,7 +246,7 @@ public class TestDefaultCertificateClient {
    */
   @Test
   public void verifySignatureDataArray() throws Exception {
-    String data = RandomStringUtils.random(500);
+    String data = RandomStringUtils.secure().next(500);
     byte[] sign = dnCertClient.signData(data.getBytes(UTF_8));
 
     // Positive tests.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
@@ -188,9 +188,9 @@ public class TestCertificateCodec {
     LocalDateTime startDate = LocalDateTime.now();
     LocalDateTime endDate = startDate.plusDays(1);
     return SelfSignedCertificate.newBuilder()
-        .setSubject(RandomStringUtils.randomAlphabetic(4))
-        .setClusterID(RandomStringUtils.randomAlphabetic(4))
-        .setScmID(RandomStringUtils.randomAlphabetic(4))
+        .setSubject(RandomStringUtils.secure().nextAlphabetic(4))
+        .setClusterID(RandomStringUtils.secure().nextAlphabetic(4))
+        .setScmID(RandomStringUtils.secure().nextAlphabetic(4))
         .setBeginDate(startDate)
         .setEndDate(endDate)
         .setConfiguration(securityConfig)

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -228,9 +228,9 @@ public class TestRDBSnapshotProvider {
       assertNotNull(firstTable, "Table cannot be null");
       for (int x = 0; x < 100; x++) {
         byte[] key =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         byte[] value =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         firstTable.put(key, value);
       }
     } catch (Exception e) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -99,9 +99,9 @@ public class TestDBStoreBuilder {
 
     try (Table<byte[], byte[]> firstTable = dbStore.getTable("FIRST")) {
       byte[] key =
-          RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
       byte[] value =
-          RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
       firstTable.put(key, value);
       byte[] temp = firstTable.get(key);
       assertArrayEquals(value, temp);
@@ -121,9 +121,9 @@ public class TestDBStoreBuilder {
         .build()) {
       try (Table<byte[], byte[]> firstTable = dbStore.getTable("First")) {
         byte[] key =
-            RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
         byte[] value =
-            RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
         firstTable.put(key, value);
         byte[] temp = firstTable.get(key);
         assertArrayEquals(value, temp);
@@ -148,9 +148,9 @@ public class TestDBStoreBuilder {
         .build()) {
       try (Table<byte[], byte[]> firstTable = dbStore.getTable("First")) {
         byte[] key =
-            RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
         byte[] value =
-            RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
         firstTable.put(key, value);
         byte[] temp = firstTable.get(key);
         assertArrayEquals(value, temp);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -121,9 +121,9 @@ public class TestRDBStore {
       assertNotNull(firstTable, "Table cannot be null");
       for (int x = 0; x < 100; x++) {
         byte[] key =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         byte[] value =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         firstTable.put(key, value);
       }
     } catch (Exception e) {
@@ -169,9 +169,9 @@ public class TestRDBStore {
   @Test
   public void moveKey() throws Exception {
     byte[] key =
-        RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+        RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
     byte[] value =
-        RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+        RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
 
     try (Table firstTable = rdbStore.getTable(families.get(1))) {
       firstTable.put(key, value);
@@ -192,12 +192,12 @@ public class TestRDBStore {
   @Test
   public void moveWithValue() throws Exception {
     byte[] key =
-        RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+        RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
     byte[] value =
-        RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+        RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
 
     byte[] nextValue =
-        RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+        RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
     try (Table firstTable = rdbStore.getTable(families.get(1))) {
       firstTable.put(key, value);
       try (Table<byte[], byte[]> secondTable = rdbStore
@@ -355,7 +355,7 @@ public class TestRDBStore {
       try (Table table = rdbStore.getTable(family)) {
         byte[] key = family.getBytes(StandardCharsets.UTF_8);
         byte[] value =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         table.put(key, value);
       }
     }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -150,9 +150,9 @@ public class TestRDBTableStore {
   public void putGetAndEmpty() throws Exception {
     try (Table<byte[], byte[]> testTable = rdbStore.getTable("First")) {
       byte[] key =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       byte[] value =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       testTable.put(key, value);
       assertFalse(testTable.isEmpty());
       byte[] readValue = testTable.get(key);
@@ -168,15 +168,15 @@ public class TestRDBTableStore {
     List<byte[]> deletedKeys = new ArrayList<>();
     List<byte[]> validKeys = new ArrayList<>();
     byte[] value =
-        RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+        RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
     for (int x = 0; x < 100; x++) {
       deletedKeys.add(
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8));
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8));
     }
 
     for (int x = 0; x < 100; x++) {
       validKeys.add(
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8));
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8));
     }
 
     // Write all the keys and delete the keys scheduled for delete.
@@ -208,11 +208,11 @@ public class TestRDBTableStore {
     List<byte[]> keys = new ArrayList<>();
     for (int x = 0; x < 100; x++) {
       // Left pad DB keys with zeros
-      String k = String.format("%03d", x) + "-" + RandomStringUtils.random(6);
+      String k = String.format("%03d", x) + "-" + RandomStringUtils.secure().next(6);
       keys.add(k.getBytes(StandardCharsets.UTF_8));
     }
     // Some random value
-    byte[] val = RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+    byte[] val = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
 
     try (Table testTable = rdbStore.getTable("Ninth")) {
 
@@ -270,9 +270,9 @@ public class TestRDBTableStore {
         BatchOperation batch = rdbStore.initBatchOperation()) {
       //given
       byte[] key =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       byte[] value =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       assertNull(testTable.get(key));
 
       //when
@@ -291,9 +291,9 @@ public class TestRDBTableStore {
 
       //given
       byte[] key =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       byte[] value =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       testTable.put(key, value);
       assertNotNull(testTable.get(key));
 
@@ -326,9 +326,9 @@ public class TestRDBTableStore {
     try (Table testTable = rdbStore.getTable("Sixth")) {
       for (int x = 0; x < iterCount; x++) {
         byte[] key =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         byte[] value =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         testTable.put(key, value);
       }
       int localCount = 0;
@@ -349,9 +349,9 @@ public class TestRDBTableStore {
 
   @Test
   public void testIsExist() throws Exception {
-    byte[] key = RandomStringUtils.random(10, true, false)
+    byte[] key = RandomStringUtils.secure().next(10, true, false)
         .getBytes(StandardCharsets.UTF_8);
-    byte[] value = RandomStringUtils.random(10, true, false)
+    byte[] value = RandomStringUtils.secure().next(10, true, false)
         .getBytes(StandardCharsets.UTF_8);
     final byte[] zeroSizeKey = {(byte) (key[0] + 1)};
     final byte[] zeroSizeValue = {};
@@ -373,7 +373,7 @@ public class TestRDBTableStore {
       assertEquals(0, testTable.get(zeroSizeKey).length);
 
       byte[] invalidKey =
-          RandomStringUtils.random(5).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(5).getBytes(StandardCharsets.UTF_8);
       // Test if isExist returns false for a key that is definitely not present.
       assertFalse(testTable.isExist(invalidKey));
 
@@ -414,7 +414,7 @@ public class TestRDBTableStore {
         final int valueSize = TypedTable.BUFFER_SIZE_DEFAULT * i / 4;
         final String key = "key" + i;
         final byte[] keyBytes = codec.toPersistedFormat(key);
-        final String value = RandomStringUtils.random(valueSize, true, false);
+        final String value = RandomStringUtils.secure().next(valueSize, true, false);
         final byte[] valueBytes = codec.toPersistedFormat(value);
 
         testTable.put(keyBytes, valueBytes);
@@ -428,9 +428,9 @@ public class TestRDBTableStore {
 
   @Test
   public void testGetIfExist() throws Exception {
-    byte[] key = RandomStringUtils.random(10, true, false)
+    byte[] key = RandomStringUtils.secure().next(10, true, false)
         .getBytes(StandardCharsets.UTF_8);
-    byte[] value = RandomStringUtils.random(10, true, false)
+    byte[] value = RandomStringUtils.secure().next(10, true, false)
         .getBytes(StandardCharsets.UTF_8);
 
     final String tableName = families.get(0);
@@ -445,7 +445,7 @@ public class TestRDBTableStore {
       assertNull(testTable.getIfExist(key));
 
       byte[] invalidKey =
-          RandomStringUtils.random(5).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(5).getBytes(StandardCharsets.UTF_8);
       // Test if isExist returns null for a key that is definitely not present.
       assertNull(testTable.getIfExist(invalidKey));
 
@@ -476,9 +476,9 @@ public class TestRDBTableStore {
       final int numKeys = 12345;
       for (int i = 0; i < numKeys; i++) {
         byte[] key =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         byte[] value =
-            RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
         testTable.put(key, value);
       }
       long keyCount = testTable.getEstimatedKeyCount();
@@ -547,7 +547,7 @@ public class TestRDBTableStore {
     for (int i = 1; i <= num; i++) {
       byte[] key = bytesOf[i];
       byte[] value =
-          RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
       testTable.put(key, value);
     }
   }
@@ -602,7 +602,7 @@ public class TestRDBTableStore {
         assertIterator(keyCount, prefix, table);
       }
 
-      final String nonExistingPrefix = RandomStringUtils.random(
+      final String nonExistingPrefix = RandomStringUtils.secure().next(
           PREFIX_LENGTH + 2, false, false);
       assertIterator(0, nonExistingPrefix, table);
     }
@@ -776,7 +776,7 @@ public class TestRDBTableStore {
     for (int i = 0; i < prefixCount; i++) {
       // use alphabetic chars so we get fixed length prefix when
       // convert to byte[]
-      prefixes.add(RandomStringUtils.randomAlphabetic(PREFIX_LENGTH));
+      prefixes.add(RandomStringUtils.secure().nextAlphabetic(PREFIX_LENGTH));
     }
     return prefixes;
   }
@@ -788,7 +788,7 @@ public class TestRDBTableStore {
       Map<String, String> kvs = new HashMap<>();
       for (int i = 0; i < keyCount; i++) {
         String key = prefix + i;
-        String val = RandomStringUtils.random(10);
+        String val = RandomStringUtils.secure().next(10);
         kvs.put(key, val);
       }
       data.add(kvs);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -109,8 +109,8 @@ public class TestTypedRDBTableStore {
     try (Table<String, String> testTable = createTypedTable(
         "First")) {
       String key =
-          RandomStringUtils.random(10);
-      String value = RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
+      String value = RandomStringUtils.secure().next(10);
       testTable.put(key, value);
       assertFalse(testTable.isEmpty());
       String readValue = testTable.get(key);
@@ -134,15 +134,15 @@ public class TestTypedRDBTableStore {
     List<String> deletedKeys = new LinkedList<>();
     List<String> validKeys = new LinkedList<>();
     String value =
-        RandomStringUtils.random(10);
+        RandomStringUtils.secure().next(10);
     for (int x = 0; x < 100; x++) {
       deletedKeys.add(
-          RandomStringUtils.random(10));
+          RandomStringUtils.secure().next(10));
     }
 
     for (int x = 0; x < 100; x++) {
       validKeys.add(
-          RandomStringUtils.random(10));
+          RandomStringUtils.secure().next(10));
     }
 
     // Write all the keys and delete the keys scheduled for delete.
@@ -176,9 +176,9 @@ public class TestTypedRDBTableStore {
         BatchOperation batch = rdbStore.initBatchOperation()) {
       //given
       String key =
-          RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
       String value =
-          RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
 
       //when
       testTable.putWithBatch(batch, key, value);
@@ -197,9 +197,9 @@ public class TestTypedRDBTableStore {
 
       //given
       String key =
-          RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
       String value =
-          RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
       testTable.put(key, value);
 
       //when
@@ -224,9 +224,9 @@ public class TestTypedRDBTableStore {
         "Sixth")) {
       for (int x = 0; x < iterCount; x++) {
         String key =
-            RandomStringUtils.random(10);
+            RandomStringUtils.secure().next(10);
         String value =
-            RandomStringUtils.random(10);
+            RandomStringUtils.secure().next(10);
         testTable.put(key, value);
       }
       int localCount = 0;
@@ -341,12 +341,12 @@ public class TestTypedRDBTableStore {
     try (Table<String, String> testTable = createTypedTable(
         "Eighth")) {
       String key =
-          RandomStringUtils.random(10);
-      String value = RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
+      String value = RandomStringUtils.secure().next(10);
       testTable.put(key, value);
       assertTrue(testTable.isExist(key));
 
-      String invalidKey = key + RandomStringUtils.random(1);
+      String invalidKey = key + RandomStringUtils.secure().next(1);
       assertFalse(testTable.isExist(invalidKey));
 
       testTable.delete(key);
@@ -359,12 +359,12 @@ public class TestTypedRDBTableStore {
     try (Table<String, String> testTable = createTypedTable(
         "Eighth")) {
       String key =
-          RandomStringUtils.random(10);
-      String value = RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
+      String value = RandomStringUtils.secure().next(10);
       testTable.put(key, value);
       assertNotNull(testTable.getIfExist(key));
 
-      String invalidKey = key + RandomStringUtils.random(1);
+      String invalidKey = key + RandomStringUtils.secure().next(1);
       assertNull(testTable.getIfExist(invalidKey));
 
       testTable.delete(key);
@@ -377,8 +377,8 @@ public class TestTypedRDBTableStore {
     try (Table<String, String> testTable = createTypedTable(
         "Eighth")) {
       String key =
-          RandomStringUtils.random(10);
-      String value = RandomStringUtils.random(10);
+          RandomStringUtils.secure().next(10);
+      String value = RandomStringUtils.secure().next(10);
       testTable.addCacheEntry(new CacheKey<>(key),
           CacheValue.get(1L, value));
       assertTrue(testTable.isExist(key));
@@ -397,8 +397,8 @@ public class TestTypedRDBTableStore {
       final int numKeys = 12345;
       for (int i = 0; i < numKeys; i++) {
         String key =
-            RandomStringUtils.random(10);
-        String value = RandomStringUtils.random(10);
+            RandomStringUtils.secure().next(10);
+        String value = RandomStringUtils.secure().next(10);
         testTable.put(key, value);
       }
       long keyCount = testTable.getEstimatedKeyCount();

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -822,7 +822,7 @@ public class TestRocksDBCheckpointDiffer {
 
   private void writeKeysAndCheckpointing() throws RocksDBException {
     for (int i = 0; i < NUM_ROW; ++i) {
-      String generatedString = RandomStringUtils.randomAlphabetic(7);
+      String generatedString = RandomStringUtils.secure().nextAlphabetic(7);
       String keyStr = "Key-" + i + "-" + generatedString;
       String valueStr = "Val-" + i + "-" + generatedString;
       byte[] key = keyStr.getBytes(UTF_8);
@@ -2010,7 +2010,7 @@ public class TestRocksDBCheckpointDiffer {
 
     try (ManagedFlushOptions flushOptions = new ManagedFlushOptions()) {
       for (int i = 0; i < numberOfKeys; ++i) {
-        String generatedString = RandomStringUtils.randomAlphabetic(7);
+        String generatedString = RandomStringUtils.secure().nextAlphabetic(7);
         String keyStr = keyPrefix + i + "-" + generatedString;
         String valueStr = valuePrefix + i + "-" + generatedString;
         byte[] key = keyStr.getBytes(UTF_8);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAMetrics.java
@@ -32,7 +32,7 @@ class TestSCMHAMetrics {
   private static final MetricsCollectorImpl METRICS_COLLECTOR =
       new MetricsCollectorImpl();
   private static final String NODE_ID =
-      "scm" + RandomStringUtils.randomNumeric(5);
+      "scm" + RandomStringUtils.secure().nextNumeric(5);
   private String leaderId;
   private SCMHAMetrics scmhaMetrics;
 
@@ -57,7 +57,7 @@ class TestSCMHAMetrics {
   @Test
   public void testGetMetricsWithFollower() {
     // GIVEN
-    leaderId = "scm" + RandomStringUtils.randomNumeric(5);
+    leaderId = "scm" + RandomStringUtils.secure().nextNumeric(5);
 
     // WHEN
     scmhaMetrics = SCMHAMetrics.create(NODE_ID, leaderId);

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -114,7 +114,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     init(incrementalChunkList);
 
     int size = 1024;
-    String s = RandomStringUtils.randomAlphabetic(1024);
+    String s = RandomStringUtils.secure().nextAlphabetic(1024);
     ByteBuffer byteBuffer = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
 
     try (OzoneOutputStream out = bucket.createKey(keyName, size,

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
@@ -45,7 +45,7 @@ public class TestGDPRSymmetricKey {
   @Test
   public void testKeyGenerationWithValidInput() throws Exception {
     GDPRSymmetricKey gkey = new GDPRSymmetricKey(
-        RandomStringUtils.randomAlphabetic(16),
+        RandomStringUtils.secure().nextAlphabetic(16),
         OzoneConsts.GDPR_ALGORITHM_NAME);
 
     assertTrue(gkey.getCipher().getAlgorithm()
@@ -58,7 +58,7 @@ public class TestGDPRSymmetricKey {
   @Test
   public void testKeyGenerationWithInvalidInput() throws Exception {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new GDPRSymmetricKey(RandomStringUtils.randomAlphabetic(5), OzoneConsts.GDPR_ALGORITHM_NAME));
+        () -> new GDPRSymmetricKey(RandomStringUtils.secure().nextAlphabetic(5), OzoneConsts.GDPR_ALGORITHM_NAME));
     assertTrue(e.getMessage().equalsIgnoreCase("Secret must be exactly 16 characters"));
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSelector.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSelector.java
@@ -39,10 +39,10 @@ public class TestOzoneDelegationTokenSelector {
 
     // set dummy details for identifier and password in token.
     byte[] identifier =
-        RandomStringUtils.randomAlphabetic(10)
+        RandomStringUtils.secure().nextAlphabetic(10)
             .getBytes(StandardCharsets.UTF_8);
     byte[] password =
-        RandomStringUtils.randomAlphabetic(10)
+        RandomStringUtils.secure().nextAlphabetic(10)
             .getBytes(StandardCharsets.UTF_8);
 
     Token<OzoneTokenIdentifier> tokenIdentifierToken =

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -69,7 +69,7 @@ public final class MiniOzoneLoadGenerator {
 
   private void addLoads(Class<? extends LoadGenerator> clazz,
                         DataBuffer buffer) throws Exception {
-    String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    String bucketName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
 
     volume.createBucket(bucketName, bucketArgs);
     LoadBucket ozoneBucket = new LoadBucket(volume.getBucket(bucketName),

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -144,7 +144,7 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
 
     client = cluster.newClient();
     ObjectStore store = client.getObjectStore();
-    String volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    String volumeName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
 

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -296,7 +296,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
 
     // Upload some objects to the bucket
     for (int i = 1; i <= 10; i++) {
-      s3Client.putObject(bucketName, "key-" + i, RandomStringUtils.randomAlphanumeric(1024));
+      s3Client.putObject(bucketName, "key-" + i, RandomStringUtils.secure().nextAlphanumeric(1024));
     }
 
     // Bucket deletion should fail if there are still keys in the bucket
@@ -542,7 +542,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
     );
 
     for (String keyName: keyNames) {
-      s3Client.putObject(bucketName, keyName, RandomStringUtils.randomAlphanumeric(5));
+      s3Client.putObject(bucketName, keyName, RandomStringUtils.secure().nextAlphanumeric(5));
     }
 
     ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
@@ -581,7 +581,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
     );
 
     for (String keyName: keyNames) {
-      s3Client.putObject(bucketName, keyName, RandomStringUtils.randomAlphanumeric(5));
+      s3Client.putObject(bucketName, keyName, RandomStringUtils.secure().nextAlphanumeric(5));
     }
 
     ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
@@ -948,7 +948,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
     // Upload some objects to the bucket
     AmazonServiceException ase = assertThrows(AmazonServiceException.class,
         () -> s3Client.putObject(bucketName, keyName,
-            RandomStringUtils.randomAlphanumeric(1024)));
+            RandomStringUtils.secure().nextAlphanumeric(1024)));
 
     assertEquals(ErrorType.Client, ase.getErrorType());
     assertEquals(403, ase.getStatusCode());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -744,7 +744,7 @@ abstract class AbstractOzoneFileSystemTest {
         .setAcls(Collections.emptyList())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setLocationInfoList(new ArrayList<>())
-        .setOwnerName("user" + RandomStringUtils.randomNumeric(5))
+        .setOwnerName("user" + RandomStringUtils.secure().nextNumeric(5))
         .build();
 
     OpenKeySession session = writeClient.openKey(keyArgs);
@@ -1928,8 +1928,8 @@ abstract class AbstractOzoneFileSystemTest {
     String lev2key = metadataManager.getOzoneDirKey(volumeName, bucketName,
         o3fs.pathToKey(lev2path));
 
-    String data = RandomStringUtils.randomAlphanumeric(stringLen);
-    String filePath = RandomStringUtils.randomAlphanumeric(5);
+    String data = RandomStringUtils.secure().nextAlphanumeric(stringLen);
+    String filePath = RandomStringUtils.secure().nextAlphanumeric(5);
 
     Path path = createPath("/" + lev1dir + "/" + lev2dir + "/" + filePath);
     String fileKey = metadataManager.getOzoneDirKey(volumeName, bucketName,
@@ -1998,8 +1998,8 @@ abstract class AbstractOzoneFileSystemTest {
     assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
 
     int stringLen = 20;
-    String data = RandomStringUtils.randomAlphanumeric(stringLen);
-    String filePath = RandomStringUtils.randomAlphanumeric(5);
+    String data = RandomStringUtils.secure().nextAlphanumeric(stringLen);
+    String filePath = RandomStringUtils.secure().nextAlphanumeric(5);
 
     Path pathIllegal = createPath("/" + filePath + "illegal");
     try (FSDataOutputStream streamIllegal = fs.create(pathIllegal, (short)2)) {
@@ -2025,7 +2025,7 @@ abstract class AbstractOzoneFileSystemTest {
   public void testDirectory() throws IOException {
     assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
 
-    String leafName = RandomStringUtils.randomAlphanumeric(5);
+    String leafName = RandomStringUtils.secure().nextAlphanumeric(5);
     OMMetadataManager metadataManager = cluster.getOzoneManager()
         .getMetadataManager();
 
@@ -2080,7 +2080,7 @@ abstract class AbstractOzoneFileSystemTest {
   @Test
   void testListStatus2() throws IOException {
     List<Path> paths = new ArrayList<>();
-    String dirPath = RandomStringUtils.randomAlphanumeric(5);
+    String dirPath = RandomStringUtils.secure().nextAlphanumeric(5);
     Path path = createPath("/" + dirPath);
     paths.add(path);
 
@@ -2095,7 +2095,7 @@ abstract class AbstractOzoneFileSystemTest {
     assertEquals(initialListStatusCount + 2, omMetrics.getNumListStatus());
     assertEquals(fs.getFileStatus(path), statusList[0]);
 
-    dirPath = RandomStringUtils.randomAlphanumeric(5);
+    dirPath = RandomStringUtils.secure().nextAlphanumeric(5);
     path = createPath("/" + dirPath);
     paths.add(path);
     assertTrue(fs.mkdirs(path));
@@ -2112,9 +2112,9 @@ abstract class AbstractOzoneFileSystemTest {
 
   @Test
   public void testOzoneManagerListLocatedStatusAndListStatus() throws IOException {
-    String data = RandomStringUtils.randomAlphanumeric(20);
-    String directory = RandomStringUtils.randomAlphanumeric(5);
-    String filePath = RandomStringUtils.randomAlphanumeric(5);
+    String data = RandomStringUtils.secure().nextAlphanumeric(20);
+    String directory = RandomStringUtils.secure().nextAlphanumeric(5);
+    String filePath = RandomStringUtils.secure().nextAlphanumeric(5);
     Path path = createPath("/" + directory + "/" + filePath);
     try (FSDataOutputStream stream = fs.create(path)) {
       stream.writeBytes(data);
@@ -2147,7 +2147,7 @@ abstract class AbstractOzoneFileSystemTest {
 
   @Test
   void testOzoneManagerFileSystemInterface() throws IOException {
-    String dirPath = RandomStringUtils.randomAlphanumeric(5);
+    String dirPath = RandomStringUtils.secure().nextAlphanumeric(5);
 
     Path path = createPath("/" + dirPath);
     assertTrue(fs.mkdirs(path));
@@ -2186,8 +2186,8 @@ abstract class AbstractOzoneFileSystemTest {
 
   @Test
   public void testOzoneManagerLocatedFileStatus() throws IOException {
-    String data = RandomStringUtils.randomAlphanumeric(20);
-    String filePath = RandomStringUtils.randomAlphanumeric(5);
+    String data = RandomStringUtils.secure().nextAlphanumeric(20);
+    String filePath = RandomStringUtils.secure().nextAlphanumeric(5);
     Path path = createPath("/" + filePath);
     try (FSDataOutputStream stream = fs.create(path)) {
       stream.writeBytes(data);
@@ -2211,8 +2211,8 @@ abstract class AbstractOzoneFileSystemTest {
         OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT,
         StorageUnit.BYTES
     );
-    String data = RandomStringUtils.randomAlphanumeric(2 * blockSize + 837);
-    String filePath = RandomStringUtils.randomAlphanumeric(5);
+    String data = RandomStringUtils.secure().nextAlphanumeric(2 * blockSize + 837);
+    String filePath = RandomStringUtils.secure().nextAlphanumeric(5);
     Path path = createPath("/" + filePath);
     try (FSDataOutputStream stream = fs.create(path)) {
       stream.writeBytes(data);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -604,7 +604,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     long retriesLeft = Math.round(Math.pow(10, 5));
     String name = null;
     while (name == null && retriesLeft-- > 0) {
-      name = "volume-" + RandomStringUtils.randomNumeric(numDigit);
+      name = "volume-" + RandomStringUtils.secure().nextNumeric(numDigit);
       // Check volume existence.
       Iterator<? extends OzoneVolume> iter =
           objectStore.listVolumesByUser(null, name, null);
@@ -632,7 +632,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
             "tuned for FS Path yet");
 
     String volumeNameLocal = getRandomNonExistVolumeName();
-    String bucketNameLocal = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String bucketNameLocal = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
     Path root = new Path("/" + volumeNameLocal + "/" + bucketNameLocal);
     Path dir1 = new Path(root, "dir1");
     Path dir12 = new Path(dir1, "dir12");
@@ -673,7 +673,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   @Test
   void testMkdirNonExistentVolumeBucket() throws Exception {
     String volumeNameLocal = getRandomNonExistVolumeName();
-    String bucketNameLocal = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String bucketNameLocal = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
     Path newVolBucket = new Path(
         "/" + volumeNameLocal + "/" + bucketNameLocal);
     fs.mkdirs(newVolBucket);
@@ -917,7 +917,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    */
   private Path createRandomVolumeBucketWithDirs() throws IOException {
     String volume1 = getRandomNonExistVolumeName();
-    String bucket1 = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String bucket1 = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
     Path bucketPath1 = new Path(OZONE_URI_DELIMITER + volume1 +
         OZONE_URI_DELIMITER + bucket1);
 
@@ -956,9 +956,9 @@ abstract class AbstractRootedOzoneFileSystemTest {
     objectStore.createVolume(volName);
     OzoneVolume ozoneVolume = objectStore.getVolume(volName);
 
-    String buckName = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String buckName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
     UserGroupInformation currUgi = UserGroupInformation.getCurrentUser();
-    String bucketOwner = currUgi.getUserName() + RandomStringUtils.randomNumeric(5);
+    String bucketOwner = currUgi.getUserName() + RandomStringUtils.secure().nextNumeric(5);
     BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setOwner(bucketOwner)
         .build();
@@ -2188,7 +2188,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   @Test
   void testGetFileStatus() throws Exception {
     String volumeNameLocal = getRandomNonExistVolumeName();
-    String bucketNameLocal = RandomStringUtils.randomNumeric(5);
+    String bucketNameLocal = RandomStringUtils.secure().nextNumeric(5);
     Path volume = new Path("/" + volumeNameLocal);
     ofs.mkdirs(volume);
     assertThrows(OMException.class,
@@ -2401,7 +2401,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     // page size is 4.
     for (int fileCount = 0; fileCount < 10; fileCount++) {
       Path file =
-          new Path(bucketPath1, "key" + RandomStringUtils.randomAlphabetic(5));
+          new Path(bucketPath1, "key" + RandomStringUtils.secure().nextAlphabetic(5));
       ContractTestUtils.touch(fs, file);
     }
     Path snap3 = fs.createSnapshot(bucketPath1);
@@ -2413,7 +2413,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     assertEquals(10, diff.getDiffList().size());
 
     Path file =
-        new Path(bucketPath1, "key" + RandomStringUtils.randomAlphabetic(5));
+        new Path(bucketPath1, "key" + RandomStringUtils.secure().nextAlphabetic(5));
     ContractTestUtils.touch(fs, file);
     diff = ofs.getSnapshotDiffReport(bucketPath1, toSnap, "");
     assertEquals(1, diff.getDiffList().size());
@@ -2555,7 +2555,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   private List<String> createFiles(Path srcBucketPath, int fileCount, short factor) throws IOException {
     List<String> createdFiles = new ArrayList<>();
     for (int i = 1; i <= fileCount; i++) {
-      String keyName = "key" + RandomStringUtils.randomNumeric(5);
+      String keyName = "key" + RandomStringUtils.secure().nextNumeric(5);
       Path file = new Path(srcBucketPath, keyName);
       try (FSDataOutputStream fsDataOutputStream = fs.create(file, factor)) {
         fsDataOutputStream.writeBytes("Hello");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -551,7 +551,7 @@ public class TestDirectoryDeletingServiceWithFSO {
 
   private void createFileKey(OzoneBucket bucket, String key)
       throws Exception {
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
     OzoneOutputStream fileKey = bucket.createKey(key, value.length);
     fileKey.write(value);
     fileKey.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -723,7 +723,8 @@ public class TestHSync {
     // test file with all blocks pre-allocated
     omMetrics.resetNumKeyHSyncs();
     long writtenSize = 0;
-    try (OzoneOutputStream outputStream = bucket.createKey("key-" + RandomStringUtils.randomNumeric(5),
+    try (OzoneOutputStream outputStream = bucket.createKey("key-" +
+            RandomStringUtils.secure().nextNumeric(5),
         BLOCK_SIZE * 2, ReplicationType.RATIS, ReplicationFactor.THREE, new HashMap<>())) {
       // make sure at least writing 2 blocks data
       while (writtenSize <= BLOCK_SIZE) {
@@ -1205,7 +1206,7 @@ public class TestHSync {
 
     final String keyName = UUID.randomUUID().toString();
     int fileSize = 16 << 11;
-    String s = RandomStringUtils.randomAlphabetic(bufferSize);
+    String s = RandomStringUtils.secure().nextAlphabetic(bufferSize);
     ByteBuffer byteBuffer = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
 
     int writtenSize = 0;
@@ -1328,7 +1329,7 @@ public class TestHSync {
       outputStream1.write(data2.getBytes(UTF_8), 0, data2.length());
       outputStream1.hsync();
       // write more data
-      String s = RandomStringUtils.randomAlphabetic(BLOCK_SIZE);
+      String s = RandomStringUtils.secure().nextAlphabetic(BLOCK_SIZE);
       byte[] newData = s.getBytes(StandardCharsets.UTF_8);
       outputStream1.write(newData);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -83,8 +83,8 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
         OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
     fs =  FileSystem.get(URI.create(uri), cluster().getConf());
     int fileLen = 30 * 1024 * 1024;
-    data = string2Bytes(RandomStringUtils.randomAlphanumeric(fileLen));
-    filePath = new Path("/" + RandomStringUtils.randomAlphanumeric(5));
+    data = string2Bytes(RandomStringUtils.secure().nextAlphanumeric(fileLen));
+    filePath = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
     try (FSDataOutputStream stream = fs.create(filePath)) {
       stream.write(data);
     }
@@ -286,7 +286,7 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
   @Test
   public void testSequenceFileReaderSync() throws IOException {
     File srcfile = new File("src/test/resources/testSequenceFile");
-    Path path = new Path("/" + RandomStringUtils.randomAlphanumeric(5));
+    Path path = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
     InputStream input = new BufferedInputStream(Files.newInputStream(srcfile.toPath()));
 
     // Upload test SequenceFile file
@@ -308,7 +308,7 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
   @Test
   public void testSequenceFileReaderSyncEC() throws IOException {
     File srcfile = new File("src/test/resources/testSequenceFile");
-    Path path = new Path("/" + RandomStringUtils.randomAlphanumeric(5));
+    Path path = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
     InputStream input = new BufferedInputStream(Files.newInputStream(srcfile.toPath()));
 
     // Upload test SequenceFile file

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -102,8 +102,8 @@ public abstract class TestOzoneFSWithObjectStoreCreate implements NonHATests.Tes
 
   @BeforeEach
   public void init() throws Exception {
-    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    volumeName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
+    bucketName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.fs.ozone;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
@@ -37,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileChecksum;
@@ -155,7 +155,7 @@ public class TestOzoneFileChecksum {
     Map<Integer, String> replicatedChecksums = new HashMap<>();
 
     for (int dataLen : dataSizes) {
-      byte[] data = randomAlphabetic(dataLen).getBytes(UTF_8);
+      byte[] data = RandomStringUtils.secure().nextAlphabetic(dataLen).getBytes(UTF_8);
 
       try (OutputStream file = adapter.createFile(volumeName + "/"
           + legacyBucket + "/test" + dataLen, (short) 3, true, false)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -108,11 +108,11 @@ public abstract class TestOzoneFileSystemMetrics implements NonHATests.TestCase 
         .getOzoneManager().getMetrics().getNumKeys();
 
     int fileLen = 30 * 1024 * 1024;
-    byte[] data = string2Bytes(RandomStringUtils.randomAlphanumeric(fileLen));
+    byte[] data = string2Bytes(RandomStringUtils.secure().nextAlphanumeric(fileLen));
 
-    Path parentDir = new Path("/" + RandomStringUtils.randomAlphanumeric(5));
+    Path parentDir = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
     Path filePath = new Path(parentDir,
-        RandomStringUtils.randomAlphanumeric(5));
+        RandomStringUtils.secure().nextAlphanumeric(5));
 
     switch (op) {
     case Key:

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -60,8 +60,8 @@ public class TestOzoneFileSystemPrefixParser {
 
   @BeforeAll
   public static void init() throws Exception {
-    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    volumeName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
+    bucketName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
 
     configuration = new OzoneConfiguration();
 
@@ -125,7 +125,7 @@ public class TestOzoneFileSystemPrefixParser {
   private void testPrefixParseWithInvalidPaths() throws Exception {
     PrefixParser invalidVolumeParser = new PrefixParser();
     String invalidVolumeName =
-        RandomStringUtils.randomAlphabetic(10).toLowerCase();
+        RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
     invalidVolumeParser.parse(invalidVolumeName, bucketName,
         OMStorage.getOmDbDir(configuration).getPath(),
         file.toString());
@@ -133,7 +133,7 @@ public class TestOzoneFileSystemPrefixParser {
 
     PrefixParser invalidBucketParser = new PrefixParser();
     String invalidBucketName =
-        RandomStringUtils.randomAlphabetic(10).toLowerCase();
+        RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
     invalidBucketParser.parse(volumeName, invalidBucketName,
         OMStorage.getOmDbDir(configuration).getPath(),
         file.toString());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
@@ -105,12 +105,12 @@ public abstract class TestOzoneFsHAURLs implements HATests.TestCase {
 
     assertEquals(LifeCycle.State.RUNNING, om.getOmRatisServerState());
 
-    volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(volumeName);
 
     OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
-    bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
     retVolumeinfo.createBucket(bucketName);
 
     rootPath = String.format("%s://%s.%s.%s/", OzoneConsts.OZONE_URI_SCHEME,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerOperations.java
@@ -96,7 +96,7 @@ public abstract class TestContainerOperations implements NonHATests.TestCase {
     // call create Container again
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
     byte[] data =
-        RandomStringUtils.random(RandomUtils.secure().randomInt(0, 1024)).getBytes(UTF_8);
+        RandomStringUtils.secure().next(RandomUtils.secure().randomInt(0, 1024)).getBytes(UTF_8);
     ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
         ContainerTestHelper
             .getWriteChunkRequest(container.getPipeline(), blockID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestContainerReportWithKeys.java
@@ -71,9 +71,9 @@ public abstract class TestContainerReportWithKeys implements NonHATests.TestCase
 
   @Test
   public void testContainerReportKeyWrite() throws Exception {
-    final String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    final String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-    final String keyName = "key" + RandomStringUtils.randomNumeric(5);
+    final String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    final String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
+    final String keyName = "key" + RandomStringUtils.secure().nextNumeric(5);
     final int keySize = 100;
 
     ObjectStore objectStore = client.getObjectStore();
@@ -83,7 +83,7 @@ public abstract class TestContainerReportWithKeys implements NonHATests.TestCase
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey(keyName, keySize, ReplicationType.RATIS,
                 ReplicationFactor.ONE, new HashMap<>());
-    String dataString = RandomStringUtils.randomAlphabetic(keySize);
+    String dataString = RandomStringUtils.secure().nextAlphabetic(keySize);
     key.write(dataString.getBytes(UTF_8));
     key.close();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -90,7 +90,7 @@ public abstract class TestGetCommittedBlockLengthAndPutKey implements NonHATests
 
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
     byte[] data =
-        RandomStringUtils.random(RandomUtils.secure().randomInt(1, 1024)).getBytes(UTF_8);
+        RandomStringUtils.secure().next(RandomUtils.secure().randomInt(1, 1024)).getBytes(UTF_8);
     ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
         ContainerTestHelper
             .getWriteChunkRequest(container.getPipeline(), blockID,
@@ -154,7 +154,7 @@ public abstract class TestGetCommittedBlockLengthAndPutKey implements NonHATests
 
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
     byte[] data =
-        RandomStringUtils.random(RandomUtils.secure().randomInt(1, 1024)).getBytes(UTF_8);
+        RandomStringUtils.secure().next(RandomUtils.secure().randomInt(1, 1024)).getBytes(UTF_8);
     ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
         ContainerTestHelper
             .getWriteChunkRequest(container.getPipeline(), blockID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -79,7 +79,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.randomAlphabetic(numBytes);
+    String value = RandomStringUtils.secure().nextAlphabetic(numBytes);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
@@ -140,7 +140,7 @@ public final class TestBlockTokens {
   private static void createTestData() throws IOException {
     client.getProxy().createVolume(TEST_VOLUME);
     client.getProxy().createBucket(TEST_VOLUME, TEST_BUCKET);
-    byte[] data = string2Bytes(RandomStringUtils.randomAlphanumeric(1024));
+    byte[] data = string2Bytes(RandomStringUtils.secure().nextAlphanumeric(1024));
     OzoneBucket bucket = client.getObjectStore().getVolume(TEST_VOLUME)
         .getBucket(TEST_BUCKET);
     try (OzoneOutputStream out = bucket.createKey(TEST_FILE, data.length)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -91,8 +91,8 @@ public final class TestDataUtil {
 
   public static OzoneVolume createVolume(OzoneClient client,
                                          String volumeName) throws IOException {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
     VolumeArgs volumeArgs = VolumeArgs.newBuilder()
         .setAdmin(adminName)
         .setOwner(userName)
@@ -166,7 +166,7 @@ public final class TestDataUtil {
     OzoneVolume volume = objectStore.getVolume(vol);
     String sourceBucket = bukName;
     if (createLinkedBucket) {
-      sourceBucket = bukName + RandomStringUtils.randomNumeric(5);
+      sourceBucket = bukName + RandomStringUtils.secure().nextNumeric(5);
     }
     volume.createBucket(sourceBucket, bucketArgs);
     OzoneBucket ozoneBucket = volume.getBucket(sourceBucket);
@@ -197,12 +197,12 @@ public final class TestDataUtil {
     final int attempts = 5;
     for (int i = 0; i < attempts; i++) {
       try {
-        String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-        String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+        String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+        String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
         OzoneBucket ozoneBucket = createVolumeAndBucket(client, volumeName, bucketName,
             bucketLayout);
         if (createLinkedBucket) {
-          String targetBucketName = ozoneBucket.getName() + RandomStringUtils.randomNumeric(5);
+          String targetBucketName = ozoneBucket.getName() + RandomStringUtils.secure().nextNumeric(5);
           ozoneBucket = createLinkedBucket(client, volumeName, bucketName, targetBucketName);
         }
         return ozoneBucket;
@@ -225,10 +225,10 @@ public final class TestDataUtil {
     try (OzoneClient client = cluster.newClient()) {
       OzoneBucket bucket = createVolumeAndBucket(client);
       for (int i = 0; i < numOfKeys; i++) {
-        String keyName = RandomStringUtils.randomAlphabetic(5) + i;
+        String keyName = RandomStringUtils.secure().nextAlphabetic(5) + i;
         createKey(bucket, keyName, ReplicationConfig
             .fromTypeAndFactor(ReplicationType.RATIS, ReplicationFactor.ONE),
-            RandomStringUtils.randomAlphabetic(5).getBytes(UTF_8));
+            RandomStringUtils.secure().nextAlphabetic(5).getBytes(UTF_8));
         keyLocationMap.put(keyName, lookupOmKeyInfo(cluster, bucket, keyName));
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -317,7 +317,7 @@ public final class TestDelegationToken {
       // Get first OM client which will authenticate via Kerberos
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, ugi, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
 
       // Assert if auth was successful via Kerberos
       assertThat(logs.getOutput()).doesNotContain(
@@ -350,7 +350,7 @@ public final class TestDelegationToken {
       testUser.doAs((PrivilegedExceptionAction<Void>) () -> {
         omClient = new OzoneManagerProtocolClientSideTranslatorPB(
             OmTransportFactory.create(conf, testUser, null),
-            RandomStringUtils.randomAscii(5));
+            RandomStringUtils.secure().nextAscii(5));
         return null;
       });
 
@@ -378,7 +378,7 @@ public final class TestDelegationToken {
       UserGroupInformation.setLoginUser(ugi);
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, ugi, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
 
       // Case 5: Test success of token cancellation.
       omClient.cancelDelegationToken(token);
@@ -394,7 +394,7 @@ public final class TestDelegationToken {
       // token is not in cache anymore.
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, testUser, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
       ex = assertThrows(OMException.class,
           () -> omClient.cancelDelegationToken(token));
       assertEquals(TOKEN_ERROR_OTHER, ex.getResult());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -650,7 +650,7 @@ final class TestSecureOzoneCluster {
       // Get first OM client which will authenticate via Kerberos
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, ugi, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
 
       // Since client is already connected get a delegation token
       Token<OzoneTokenIdentifier> token = omClient.getDelegationToken(
@@ -738,7 +738,7 @@ final class TestSecureOzoneCluster {
       // Get first OM client which will authenticate via Kerberos
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, ugi, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
 
       // Creates a secret since it does not exist
       S3SecretValue attempt1 = omClient.getS3Secret(username);
@@ -799,7 +799,7 @@ final class TestSecureOzoneCluster {
       final OzoneManagerProtocolClientSideTranslatorPB omClientNonAdmin =
           new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, ugiNonAdmin, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
 
       OMException omException = assertThrows(OMException.class,
           () -> omClientNonAdmin.getS3Secret("HADOOP/JOHN"));
@@ -1188,7 +1188,7 @@ final class TestSecureOzoneCluster {
       // Get first OM client which will authenticate via Kerberos
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(newConf, ugi, null),
-          RandomStringUtils.randomAscii(5));
+          RandomStringUtils.secure().nextAscii(5));
 
       // Since client is already connected get a delegation token
       Token<OzoneTokenIdentifier> token1 = omClient.getDelegationToken(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -1983,7 +1983,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(RandomUtils.secure().randomInt(1, 1024));
+    String value = RandomStringUtils.secure().next(RandomUtils.secure().randomInt(1, 1024));
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -2231,7 +2231,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     String keyName = UUID.randomUUID().toString();
-    String keyValue = RandomStringUtils.random(128);
+    String keyValue = RandomStringUtils.secure().next(128);
     //String keyValue = "this is a test value.glx";
     // create the initial key with size 0, write will allocate the first block.
     TestDataUtil.createKey(bucket, keyName,
@@ -2668,13 +2668,13 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volBaseNameA = volBase + "a-";
     for (int i = 0; i < 10; i++) {
       store.createVolume(
-          volBaseNameA + i + "-" + RandomStringUtils.randomNumeric(5));
+          volBaseNameA + i + "-" + RandomStringUtils.secure().nextNumeric(5));
     }
     //Create 10 volume vol-list-b-0-<random> to vol-list-b-9-<random>
     String volBaseNameB = volBase + "b-";
     for (int i = 0; i < 10; i++) {
       store.createVolume(
-          volBaseNameB + i + "-" + RandomStringUtils.randomNumeric(5));
+          volBaseNameB + i + "-" + RandomStringUtils.secure().nextNumeric(5));
     }
     Iterator<? extends OzoneVolume> volIterator = store.listVolumes(volBase);
     int totalVolumeCount = 0;
@@ -2706,8 +2706,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   @Test
   public void testListBucket()
       throws IOException {
-    String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
-    String volumeB = "vol-b-" + RandomStringUtils.randomNumeric(5);
+    String volumeA = "vol-a-" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeB = "vol-b-" + RandomStringUtils.secure().nextNumeric(5);
     store.createVolume(volumeA);
     store.createVolume(volumeB);
     OzoneVolume volA = store.getVolume(volumeA);
@@ -2718,11 +2718,11 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String bucketBaseNameA = "bucket-a-";
     for (int i = 0; i < 10; i++) {
       String bucketName = bucketBaseNameA +
-          i + "-" + RandomStringUtils.randomNumeric(5);
+          i + "-" + RandomStringUtils.secure().nextNumeric(5);
       volA.createBucket(bucketName);
       store.createSnapshot(volumeA, bucketName, null);
       bucketName = bucketBaseNameA +
-          i + "-" + RandomStringUtils.randomNumeric(5);
+          i + "-" + RandomStringUtils.secure().nextNumeric(5);
       volB.createBucket(bucketName);
       store.createSnapshot(volumeB, bucketName, null);
     }
@@ -2730,11 +2730,11 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String bucketBaseNameB = "bucket-b-";
     for (int i = 0; i < 10; i++) {
       String bucketName = bucketBaseNameB +
-          i + "-" + RandomStringUtils.randomNumeric(5);
+          i + "-" + RandomStringUtils.secure().nextNumeric(5);
       volA.createBucket(bucketName);
       store.createSnapshot(volumeA, bucketName, null);
       volB.createBucket(
-          bucketBaseNameB + i + "-" + RandomStringUtils.randomNumeric(5));
+          bucketBaseNameB + i + "-" + RandomStringUtils.secure().nextNumeric(5));
     }
     assertBucketCount(volA, "bucket-", null, false, 20);
     assertBucketCount(volA, "bucket-", null, true, 20);
@@ -2803,10 +2803,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   @Test
   public void testListKey()
       throws IOException {
-    String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
-    String volumeB = "vol-b-" + RandomStringUtils.randomNumeric(5);
-    String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);
-    String bucketB = "buc-b-" + RandomStringUtils.randomNumeric(5);
+    String volumeA = "vol-a-" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeB = "vol-b-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketA = "buc-a-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketB = "buc-b-" + RandomStringUtils.secure().nextNumeric(5);
     store.createVolume(volumeA);
     store.createVolume(volumeB);
     OzoneVolume volA = store.getVolume(volumeA);
@@ -2827,18 +2827,18 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
      */
     String keyBaseA = "key-a-";
     for (int i = 0; i < 10; i++) {
-      byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+      byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
       TestDataUtil.createKey(volAbucketA,
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseA + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volAbucketB,
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseA + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketA,
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseA + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketB,
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseA + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
     }
     /*
@@ -2848,18 +2848,18 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
      */
     String keyBaseB = "key-b-";
     for (int i = 0; i < 10; i++) {
-      byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+      byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
       TestDataUtil.createKey(volAbucketA,
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseB + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volAbucketB,
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseB + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketA,
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseB + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
       TestDataUtil.createKey(volBbucketB,
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
+          keyBaseB + i + "-" + RandomStringUtils.secure().nextNumeric(5),
           ReplicationConfig.fromTypeAndFactor(RATIS, ONE), value);
     }
     Iterator<? extends OzoneKey> volABucketAIter =
@@ -2914,8 +2914,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   @Test
   public void testListKeyOnEmptyBucket()
       throws IOException {
-    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    String volume = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.secure().nextNumeric(5);
     store.createVolume(volume);
     OzoneVolume vol = store.getVolume(volume);
     vol.createBucket(bucket);
@@ -4196,7 +4196,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   private void writeKey(String key1, OzoneBucket bucket) throws IOException {
     TestDataUtil.createKey(bucket, key1,
         ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
-        RandomStringUtils.random(1024).getBytes(UTF_8));
+        RandomStringUtils.secure().next(1024).getBytes(UTF_8));
   }
 
   private byte[] generateData(int size, byte val) {
@@ -4358,7 +4358,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       OzoneBucket bucket, String keyName, byte[] bytes
   ) throws IOException {
     RatisReplicationConfig replication = RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE);
-    Map<String, String> metadata = singletonMap("key", RandomStringUtils.randomAscii(10));
+    Map<String, String> metadata = singletonMap("key", RandomStringUtils.secure().nextAscii(10));
     try (OzoneOutputStream out = bucket.createKey(keyName, bytes.length, replication, metadata)) {
       out.write(bytes);
     }
@@ -4744,10 +4744,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
   @Test
   public void testListSnapshot() throws IOException {
-    String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
-    String volumeB = "vol-b-" + RandomStringUtils.randomNumeric(5);
-    String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);
-    String bucketB = "buc-b-" + RandomStringUtils.randomNumeric(5);
+    String volumeA = "vol-a-" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeB = "vol-b-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketA = "buc-a-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketB = "buc-b-" + RandomStringUtils.secure().nextNumeric(5);
     store.createVolume(volumeA);
     store.createVolume(volumeB);
     OzoneVolume volA = store.getVolume(volumeA);
@@ -4760,23 +4760,23 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String snapshotPrefixB = "snapshot-b-";
     for (int i = 0; i < 10; i++) {
       store.createSnapshot(volumeA, bucketA,
-          snapshotPrefixA + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixA + i + "-" + RandomStringUtils.secure().nextNumeric(5));
       store.createSnapshot(volumeA, bucketB,
-          snapshotPrefixA + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixA + i + "-" + RandomStringUtils.secure().nextNumeric(5));
       store.createSnapshot(volumeB, bucketA,
-          snapshotPrefixA + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixA + i + "-" + RandomStringUtils.secure().nextNumeric(5));
       store.createSnapshot(volumeB, bucketB,
-          snapshotPrefixA + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixA + i + "-" + RandomStringUtils.secure().nextNumeric(5));
     }
     for (int i = 0; i < 10; i++) {
       store.createSnapshot(volumeA, bucketA,
-          snapshotPrefixB + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixB + i + "-" + RandomStringUtils.secure().nextNumeric(5));
       store.createSnapshot(volumeA, bucketB,
-          snapshotPrefixB + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixB + i + "-" + RandomStringUtils.secure().nextNumeric(5));
       store.createSnapshot(volumeB, bucketA,
-          snapshotPrefixB + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixB + i + "-" + RandomStringUtils.secure().nextNumeric(5));
       store.createSnapshot(volumeB, bucketB,
-          snapshotPrefixB + i + "-" + RandomStringUtils.randomNumeric(5));
+          snapshotPrefixB + i + "-" + RandomStringUtils.secure().nextNumeric(5));
     }
 
     Iterator<OzoneSnapshot> snapshotIter = store.listSnapshot(volumeA, bucketA, null, null);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
@@ -175,7 +175,7 @@ public class TestOzoneRpcClientForAclAuditLog {
 
     String userName = ugi.getUserName();
     String adminName = ugi.getUserName();
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setAdmin(adminName)
@@ -223,7 +223,7 @@ public class TestOzoneRpcClientForAclAuditLog {
 
     String userName = "bilbo";
     String adminName = "bilbo";
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setAdmin(adminName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -212,7 +212,7 @@ public class TestBlockDeletion {
     String bucketName = UUID.randomUUID().toString();
     LogCapturer logCapturer = LogCapturer.captureLogs(DeleteBlocksCommandHandler.class);
 
-    String value = RandomStringUtils.random(1024 * 1024);
+    String value = RandomStringUtils.secure().next(1024 * 1024);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -346,7 +346,7 @@ public class TestBlockDeletion {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(1024 * 1024);
+    String value = RandomStringUtils.secure().next(1024 * 1024);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -457,7 +457,7 @@ public class TestBlockDeletion {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(10 * 10);
+    String value = RandomStringUtils.secure().next(10 * 10);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -587,7 +587,7 @@ public class TestBlockDeletion {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(1024 * 1024);
+    String value = RandomStringUtils.secure().next(1024 * 1024);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -788,7 +788,7 @@ public class TestBlockDeletion {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(64 * 1024);
+    String value = RandomStringUtils.secure().next(64 * 1024);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -194,7 +194,7 @@ public class TestContainerServer {
     ContainerSet containerSet = newContainerSet();
     conf.set(HDDS_DATANODE_DIR_KEY,
         Paths.get(testDir.toString(), "dfs", "data", "hdds",
-            RandomStringUtils.randomAlphabetic(4)).toString());
+            RandomStringUtils.secure().nextAlphabetic(4)).toString());
     conf.set(OZONE_METADATA_DIRS, testDir.toString());
     VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null,
         StorageVolume.VolumeType.DATA_VOLUME, null);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -168,7 +168,7 @@ public class TestSecureContainerServer {
     ContainerSet containerSet = newContainerSet();
     conf.set(HDDS_DATANODE_DIR_KEY,
         Paths.get(testDir.toString(), "dfs", "data", "hdds",
-            RandomStringUtils.randomAlphabetic(4)).toString());
+            RandomStringUtils.secure().nextAlphabetic(4)).toString());
     conf.set(OZONE_METADATA_DIRS, testDir.toString());
     VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null,
         StorageVolume.VolumeType.DATA_VOLUME, null);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -84,8 +84,8 @@ public class TestAddRemoveOzoneManager {
   private static final String BUCKET_NAME;
 
   static {
-    VOLUME_NAME = "volume" + RandomStringUtils.randomNumeric(5);
-    BUCKET_NAME = "bucket" + RandomStringUtils.randomNumeric(5);
+    VOLUME_NAME = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    BUCKET_NAME = "bucket" + RandomStringUtils.secure().nextNumeric(5);
   }
 
   private OzoneClient client;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
@@ -18,13 +18,13 @@
 package org.apache.hadoop.ozone.om;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -121,13 +121,13 @@ public final class TestBucket {
       ObjectStore objectStore = client.getObjectStore();
       if (volume == null) { // TODO add setVolume
         if (volumeName == null) { // TODO add setVolumeName
-          volumeName = "vol" + randomNumeric(10);
+          volumeName = "vol" + RandomStringUtils.secure().nextNumeric(10);
         }
         objectStore.createVolume(volumeName);
         volume = objectStore.getVolume(volumeName);
       }
       if (bucketName == null) { // TODO add setBucketName
-        bucketName = "bucket" + randomNumeric(10);
+        bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(10);
       }
       volume.createBucket(bucketName);
       return new TestBucket(volume.getBucket(bucketName));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -356,12 +356,12 @@ public class TestKeyManagerImpl {
   public void testCreateDirectory() throws IOException {
     // Create directory where the parent directory does not exist
     StringBuffer keyNameBuf = new StringBuffer();
-    keyNameBuf.append(RandomStringUtils.randomAlphabetic(5));
+    keyNameBuf.append(RandomStringUtils.secure().nextAlphabetic(5));
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyNameBuf.toString())
         .build();
     for (int i = 0; i < 5; i++) {
-      keyNameBuf.append("/").append(RandomStringUtils.randomAlphabetic(5));
+      keyNameBuf.append("/").append(RandomStringUtils.secure().nextAlphabetic(5));
     }
     String keyName = keyNameBuf.toString();
     writeClient.createDirectory(keyArgs);
@@ -373,7 +373,7 @@ public class TestKeyManagerImpl {
     }
 
     // make sure create directory fails where parent is a file
-    keyName = RandomStringUtils.randomAlphabetic(5);
+    keyName = RandomStringUtils.secure().nextAlphabetic(5);
     keyArgs = createBuilder()
         .setKeyName(keyName)
         .build();
@@ -388,7 +388,7 @@ public class TestKeyManagerImpl {
     assertEquals(e.getResult(), OMException.ResultCodes.FILE_ALREADY_EXISTS);
 
     // create directory where parent is root
-    keyName = RandomStringUtils.randomAlphabetic(5);
+    keyName = RandomStringUtils.secure().nextAlphabetic(5);
     keyArgs = createBuilder()
         .setKeyName(keyName)
         .build();
@@ -402,7 +402,7 @@ public class TestKeyManagerImpl {
   @Test
   public void testOpenFile() throws IOException {
     // create key
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyName)
         .build();
@@ -426,9 +426,9 @@ public class TestKeyManagerImpl {
     // try to create a file where parent directories do not exist and
     // recursive flag is set to false
     StringBuffer keyNameBuf = new StringBuffer();
-    keyNameBuf.append(RandomStringUtils.randomAlphabetic(5));
+    keyNameBuf.append(RandomStringUtils.secure().nextAlphabetic(5));
     for (int i = 0; i < 5; i++) {
-      keyNameBuf.append("/").append(RandomStringUtils.randomAlphabetic(5));
+      keyNameBuf.append("/").append(RandomStringUtils.secure().nextAlphabetic(5));
     }
     keyName = keyNameBuf.toString();
     keyArgs = createBuilder()
@@ -716,7 +716,7 @@ public class TestKeyManagerImpl {
 
   @Test
   public void testLookupFile() throws IOException {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyName)
         .build();
@@ -756,7 +756,7 @@ public class TestKeyManagerImpl {
 
   @Test
   public void testLookupKeyWithLocation() throws IOException {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyName)
         .setSortDatanodesInPipeline(true)
@@ -848,7 +848,7 @@ public class TestKeyManagerImpl {
 
   @Test
   public void testLatestLocationVersion() throws IOException {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder(VERSIONED_BUCKET_NAME)
         .setKeyName(keyName)
         .setLatestVersionLocation(true)
@@ -1192,7 +1192,7 @@ public class TestKeyManagerImpl {
   @ValueSource(booleans = {true, false})
   public void testListStatus(boolean enablePath) throws IOException {
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, enablePath);
-    String superDir = RandomStringUtils.randomAlphabetic(5);
+    String superDir = RandomStringUtils.secure().nextAlphabetic(5);
 
     int numDirectories = 5;
     int numFiles = 5;
@@ -1274,7 +1274,7 @@ public class TestKeyManagerImpl {
   @Test
   public void testGetFileStatus() throws IOException {
     // create a key
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyName)
         .setLatestVersionLocation(true)
@@ -1515,7 +1515,7 @@ public class TestKeyManagerImpl {
 
   @Test
   void testGetAllPartsWhenZeroPartNumber() throws IOException {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
 
     String volume = VOLUME_NAME;
 
@@ -1541,7 +1541,7 @@ public class TestKeyManagerImpl {
 
   @Test
   void testGetParticularPart() throws IOException {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
 
     String volume = VOLUME_NAME;
 
@@ -1565,7 +1565,7 @@ public class TestKeyManagerImpl {
 
   @Test
   void testGetNotExistedPart() throws IOException {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
 
     String volume = VOLUME_NAME;
 
@@ -1706,7 +1706,7 @@ public class TestKeyManagerImpl {
       throws IOException {
     Set<String> keyNames = new TreeSet<>();
     for (int i = 0; i < numDirectories; i++) {
-      String keyName = parent + "/" + RandomStringUtils.randomAlphabetic(5);
+      String keyName = parent + "/" + RandomStringUtils.secure().nextAlphabetic(5);
       OmKeyArgs keyArgs = createBuilder().setKeyName(keyName).build();
       writeClient.createDirectory(keyArgs);
       keyNames.add(keyName);
@@ -1719,7 +1719,7 @@ public class TestKeyManagerImpl {
       Map<String, List<String>> fileMap, int numFiles) throws IOException {
     List<String> keyNames = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
-      String keyName = parent + "/" + RandomStringUtils.randomAlphabetic(5);
+      String keyName = parent + "/" + RandomStringUtils.secure().nextAlphabetic(5);
       OmKeyArgs keyArgs = createBuilder().setKeyName(keyName).build();
       OpenKeySession keySession = writeClient.createFile(keyArgs, false, false);
       keyArgs.setLocationInfoList(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -95,15 +95,15 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
     builder.setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED);
     omBucketArgs = builder.build();
 
-    String fsoBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String fsoBucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
     ozoneVolume.createBucket(fsoBucketName, omBucketArgs);
     fsoOzoneBucket = ozoneVolume.getBucket(fsoBucketName);
 
-    fsoBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    fsoBucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
     ozoneVolume.createBucket(fsoBucketName, omBucketArgs);
     fsoOzoneBucket2 = ozoneVolume.getBucket(fsoBucketName);
 
-    fsoBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    fsoBucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
     ozoneVolume.createBucket(fsoBucketName, omBucketArgs);
     emptyFsoOzoneBucket = ozoneVolume.getBucket(fsoBucketName);
 
@@ -111,11 +111,11 @@ public abstract class TestListKeysWithFSO implements NonHATests.TestCase {
     builder.setStorageType(StorageType.DISK);
     builder.setBucketLayout(BucketLayout.LEGACY);
     omBucketArgs = builder.build();
-    String legacyBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String legacyBucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
     ozoneVolume.createBucket(legacyBucketName, omBucketArgs);
     legacyOzoneBucket2 = ozoneVolume.getBucket(legacyBucketName);
 
-    legacyBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    legacyBucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
     ozoneVolume.createBucket(legacyBucketName, omBucketArgs);
     emptyLegacyOzoneBucket = ozoneVolume.getBucket(legacyBucketName);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
@@ -195,7 +195,7 @@ class TestOMBucketLayoutUpgrade {
    */
   private String createBucketWithLayout(BucketLayout bucketLayout)
       throws Exception {
-    String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    String bucketName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
     omClient.createBucket(
         new OmBucketInfo.Builder()
             .setVolumeName(VOLUME_NAME)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -164,12 +164,12 @@ public class TestOMRatisSnapshots {
     client = OzoneClientFactory.getRpcClient(omServiceId, conf);
     objectStore = client.getObjectStore();
 
-    volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
-        .setOwner("user" + RandomStringUtils.randomNumeric(5))
-        .setAdmin("admin" + RandomStringUtils.randomNumeric(5))
+        .setOwner("user" + RandomStringUtils.secure().nextNumeric(5))
+        .setAdmin("admin" + RandomStringUtils.secure().nextNumeric(5))
         .build();
 
     objectStore.createVolume(volumeName, createVolumeArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -151,7 +151,7 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
   @Test
   public void testCreateKey() throws Exception {
     String parent = "a/b/c/";
-    String file = "key" + RandomStringUtils.randomNumeric(5);
+    String file = "key" + RandomStringUtils.secure().nextNumeric(5);
     String key = parent + file;
 
     ObjectStore objectStore = client.getObjectStore();
@@ -219,7 +219,7 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
     String testBucketName = testBucket.getName();
 
     String parent = "a/b/c/";
-    String file = "key" + RandomStringUtils.randomNumeric(5);
+    String file = "key" + RandomStringUtils.secure().nextNumeric(5);
     String key = parent + file;
 
     ObjectStore objectStore = client.getObjectStore();
@@ -271,7 +271,7 @@ public abstract class TestObjectStoreWithFSO implements NonHATests.TestCase {
   @Test
   public void testLookupKey() throws Exception {
     String parent = "a/b/c/";
-    String fileName = "key" + RandomStringUtils.randomNumeric(5);
+    String fileName = "key" + RandomStringUtils.secure().nextNumeric(5);
     String key = parent + fileName;
 
     ObjectStore objectStore = client.getObjectStore();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -99,8 +99,8 @@ public abstract class TestObjectStoreWithLegacyFS implements NonHATests.TestCase
 
   @BeforeEach
   public void init() throws Exception {
-    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    volumeName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
+    bucketName = RandomStringUtils.secure().nextAlphabetic(10).toLowerCase();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -69,9 +69,9 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
 
   @Test
   public void testAllocateCommit() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-    String keyName = "key" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
+    String keyName = "key" + RandomStringUtils.secure().nextNumeric(5);
 
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
@@ -85,7 +85,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
         .setDataSize(1000)
         .setAcls(new ArrayList<>())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
-        .setOwnerName("user" + RandomStringUtils.randomNumeric(5))
+        .setOwnerName("user" + RandomStringUtils.secure().nextNumeric(5))
         .build();
 
     // 1st update, version 0
@@ -151,9 +151,9 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
   @Test
   public void testReadLatestVersion() throws Exception {
 
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-    String keyName = "key" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
+    String keyName = "key" + RandomStringUtils.secure().nextNumeric(5);
 
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
@@ -165,7 +165,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
         .setDataSize(1000)
         .build();
 
-    String dataString = RandomStringUtils.randomAlphabetic(100);
+    String dataString = RandomStringUtils.secure().nextAlphabetic(100);
 
     TestDataUtil.createKey(bucket, keyName, dataString.getBytes(StandardCharsets.UTF_8));
     assertEquals(dataString, TestDataUtil.getKey(bucket, keyName));
@@ -184,7 +184,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     assertEquals(1,
         keyInfo.getLatestVersionLocations().getLocationList().size());
 
-    dataString = RandomStringUtils.randomAlphabetic(200);
+    dataString = RandomStringUtils.secure().nextAlphabetic(200);
     TestDataUtil.createKey(bucket, keyName, dataString.getBytes(StandardCharsets.UTF_8));
 
     keyInfo = ozoneManager.lookupKey(omKeyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -200,13 +200,13 @@ public abstract class TestOzoneManagerHA {
    * @return the key name.
    */
   public static String createKey(OzoneBucket ozoneBucket) throws IOException {
-    String keyName = "key" + RandomStringUtils.randomNumeric(5);
+    String keyName = "key" + RandomStringUtils.secure().nextNumeric(5);
     createKey(ozoneBucket, keyName);
     return keyName;
   }
 
   public static void createKey(OzoneBucket ozoneBucket, String keyName) throws IOException {
-    String data = "data" + RandomStringUtils.randomNumeric(5);
+    String data = "data" + RandomStringUtils.secure().nextNumeric(5);
     OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(keyName, data.length(), ReplicationType.RATIS,
         ReplicationFactor.ONE, new HashMap<>());
     ozoneOutputStream.write(data.getBytes(UTF_8), 0, data.length());
@@ -214,7 +214,7 @@ public abstract class TestOzoneManagerHA {
   }
 
   public static String createPrefixName() {
-    return "prefix" + RandomStringUtils.randomNumeric(5) + OZONE_URI_DELIMITER;
+    return "prefix" + RandomStringUtils.secure().nextNumeric(5) + OZONE_URI_DELIMITER;
   }
 
   public static void createPrefix(OzoneObj prefixObj) throws IOException {
@@ -222,8 +222,8 @@ public abstract class TestOzoneManagerHA {
   }
 
   protected OzoneBucket setupBucket() throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
     String volumeName = "volume" + UUID.randomUUID();
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
@@ -250,9 +250,9 @@ public abstract class TestOzoneManagerHA {
   }
 
   protected OzoneBucket linkBucket(OzoneBucket srcBuk) throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String linkedVolName = "volume-link-" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String linkedVolName = "volume-link-" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)
@@ -304,9 +304,9 @@ public abstract class TestOzoneManagerHA {
    * Create a volume and test its attribute.
    */
   protected void createVolumeTest(boolean checkSuccess) throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)
@@ -394,9 +394,9 @@ public abstract class TestOzoneManagerHA {
   }
 
   protected void createKeyTest(boolean checkSuccess) throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -209,8 +209,8 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
   private OzoneVolume createAndCheckVolume(String volumeName)
       throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)
         .setAdmin(adminName)
@@ -230,7 +230,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
   @Test
   public void testAllVolumeOperations() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     createAndCheckVolume(volumeName);
 
@@ -247,8 +247,8 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
   @Test
   public void testAllBucketOperations() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "volume" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     OzoneVolume retVolume = createAndCheckVolume(volumeName);
 
@@ -399,7 +399,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
   @Test
   public void testReadRequest() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
     ObjectStore objectStore = getObjectStore();
     objectStore.createVolume(volumeName);
 
@@ -661,7 +661,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testAddPrefixAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    String prefixName = RandomStringUtils.randomAlphabetic(5) + "/";
+    String prefixName = RandomStringUtils.secure().nextAlphabetic(5) + "/";
     OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
@@ -674,7 +674,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testRemovePrefixAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    String prefixName = RandomStringUtils.randomAlphabetic(5) + "/";
+    String prefixName = RandomStringUtils.secure().nextAlphabetic(5) + "/";
     OzoneAcl userAcl = OzoneAcl.of(USER, remoteUserName,
         ACCESS, READ);
     OzoneAcl userAcl1 = OzoneAcl.of(USER, "remote",
@@ -706,7 +706,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   void testSetPrefixAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
-    String prefixName = RandomStringUtils.randomAlphabetic(5) + "/";
+    String prefixName = RandomStringUtils.secure().nextAlphabetic(5) + "/";
     OzoneAcl defaultUserAcl = OzoneAcl.of(USER, remoteUserName,
         DEFAULT, READ);
 
@@ -1079,10 +1079,10 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
   @Test
   void testOMRatisSnapshot() throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -279,10 +279,10 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
         leaderOM.getPeerNodes().get(1).getNodeId());
 
     // Do some transactions so that the log index increases
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)
@@ -584,7 +584,7 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
     String userName = UserGroupInformation.getCurrentUser().getUserName();
     ObjectStore objectStore = getObjectStore();
 
-    String prefix = "vol-" + RandomStringUtils.randomNumeric(10) + "-";
+    String prefix = "vol-" + RandomStringUtils.secure().nextNumeric(10) + "-";
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)
         .setAdmin(userName)
@@ -611,9 +611,9 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
   @Test
   void testRetryCacheWithDownedOM() throws Exception {
     // Create a volume, a bucket and a key
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
     String bucketName = UUID.randomUUID().toString();
     String keyTo = UUID.randomUUID().toString();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
@@ -208,7 +208,7 @@ public class TestOzoneManagerListVolumesSecure {
     OzoneManagerProtocolClientSideTranslatorPB omClient =
         new OzoneManagerProtocolClientSideTranslatorPB(
             OmTransportFactory.create(conf, this.adminUGI, null),
-            RandomStringUtils.randomAscii(5));
+            RandomStringUtils.secure().nextAscii(5));
 
     // Create volume with ACL
     /* r = READ, w = WRITE, c = CREATE, d = DELETE
@@ -254,7 +254,7 @@ public class TestOzoneManagerListVolumesSecure {
         new OzoneManagerProtocolClientSideTranslatorPB(
             OmTransportFactory.create(conf,
                 UserGroupInformation.getCurrentUser(), null),
-            RandomStringUtils.randomAscii(5));
+            RandomStringUtils.secure().nextAscii(5));
 
     // `ozone sh volume list` shall return volumes with LIST permission of user.
     List<OmVolumeArgs> volumeList;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -96,7 +96,7 @@ public class TestOzoneManagerRestart {
 
   @Test
   public void testRestartOMWithVolumeOperation() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
 
     ObjectStore objectStore = client.getObjectStore();
 
@@ -121,8 +121,8 @@ public class TestOzoneManagerRestart {
 
   @Test
   public void testRestartOMWithBucketOperation() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
 
     ObjectStore objectStore = client.getObjectStore();
 
@@ -152,13 +152,13 @@ public class TestOzoneManagerRestart {
 
   @Test
   public void testRestartOMWithKeyOperation() throws Exception {
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-    String key1 = "key1" + RandomStringUtils.randomNumeric(5);
-    String key2 = "key2" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
+    String key1 = "key1" + RandomStringUtils.secure().nextNumeric(5);
+    String key2 = "key2" + RandomStringUtils.secure().nextNumeric(5);
 
-    String newKey1 = "key1new" + RandomStringUtils.randomNumeric(5);
-    String newKey2 = "key2new" + RandomStringUtils.randomNumeric(5);
+    String newKey1 = "key1new" + RandomStringUtils.secure().nextNumeric(5);
+    String newKey2 = "key2new" + RandomStringUtils.secure().nextNumeric(5);
 
     ObjectStore objectStore = client.getObjectStore();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -127,8 +127,8 @@ public abstract class TestRecursiveAclWithFSO implements NonHATests.TestCase {
       String keyf4 = "a/b2/d2/d21/f4";
       String keyf5 = "/a/b3/e1/f5";
       String keyf6 = "/a/b3/e2/f6";
-      String file1 = "a/" + "file" + RandomStringUtils.randomNumeric(5);
-      String file2 = "a/b2/d2/" + "file" + RandomStringUtils.randomNumeric(5);
+      String file1 = "a/" + "file" + RandomStringUtils.secure().nextNumeric(5);
+      String file2 = "a/b2/d2/" + "file" + RandomStringUtils.secure().nextNumeric(5);
 
       keys.add(keyf1);
       keys.add(keyf2);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -142,9 +142,9 @@ public class TestScmSafeMode {
         .getStorageContainerManager().getContainerManager().getContainers();
     GenericTestUtils.waitFor(() -> containers.size() >= 3, 100, 1000);
 
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-    String keyName = "key" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
+    String keyName = "key" + RandomStringUtils.secure().nextNumeric(5);
 
     ObjectStore store = client.getObjectStore();
     store.createVolume(volumeName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -612,7 +612,7 @@ public abstract class TestOmSnapshot {
    */
   @Test
   public void testSnapDiffHandlingReclaimWithLatestUse() throws Exception {
-    String testVolumeName = "vol" + RandomStringUtils.randomNumeric(5);
+    String testVolumeName = "vol" + RandomStringUtils.secure().nextNumeric(5);
     String testBucketName = "bucket1";
     store.createVolume(testVolumeName);
     OzoneVolume volume = store.getVolume(testVolumeName);
@@ -650,7 +650,7 @@ public abstract class TestOmSnapshot {
    */
   @Test
   public void testSnapDiffHandlingReclaimWithPreviousUse() throws Exception {
-    String testVolumeName = "vol" + RandomStringUtils.randomNumeric(5);
+    String testVolumeName = "vol" + RandomStringUtils.secure().nextNumeric(5);
     String testBucketName = "bucket1";
     store.createVolume(testVolumeName);
     OzoneVolume volume = store.getVolume(testVolumeName);
@@ -697,7 +697,7 @@ public abstract class TestOmSnapshot {
    */
   @Test
   public void testSnapDiffReclaimWithKeyRecreation() throws Exception {
-    String testVolumeName = "vol" + RandomStringUtils.randomNumeric(5);
+    String testVolumeName = "vol" + RandomStringUtils.secure().nextNumeric(5);
     String testBucketName = "bucket1";
     store.createVolume(testVolumeName);
     OzoneVolume volume = store.getVolume(testVolumeName);
@@ -751,7 +751,7 @@ public abstract class TestOmSnapshot {
    */
   @Test
   public void testSnapDiffReclaimWithKeyRename() throws Exception {
-    String testVolumeName = "vol" + RandomStringUtils.randomNumeric(5);
+    String testVolumeName = "vol" + RandomStringUtils.secure().nextNumeric(5);
     String testBucketName = "bucket1";
     store.createVolume(testVolumeName);
     OzoneVolume volume = store.getVolume(testVolumeName);
@@ -1630,7 +1630,7 @@ public abstract class TestOmSnapshot {
    */
   @Test
   public void testSnapDiffWithKeyOverwrite() throws Exception {
-    String testVolumeName = "vol" + RandomStringUtils.randomNumeric(5);
+    String testVolumeName = "vol" + RandomStringUtils.secure().nextNumeric(5);
     String testBucketName = "bucket1";
     store.createVolume(testVolumeName);
     OzoneVolume volume = store.getVolume(testVolumeName);
@@ -1719,8 +1719,8 @@ public abstract class TestOmSnapshot {
   @Test
   public void testListSnapshotDiffWithInvalidParameters()
       throws Exception {
-    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucket = "buck-" + RandomStringUtils.randomNumeric(5);
+    String volume = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucket = "buck-" + RandomStringUtils.secure().nextNumeric(5);
 
     String volErrorMessage = "Volume not found: " + volume;
 
@@ -1742,14 +1742,14 @@ public abstract class TestOmSnapshot {
 
     OzoneBucket ozBucket = ozVolume.getBucket(bucket);
     // Create keys and take snapshots.
-    String key1 = "key-1-" + RandomStringUtils.randomNumeric(5);
+    String key1 = "key-1-" + RandomStringUtils.secure().nextNumeric(5);
     createFileKey(ozBucket, key1);
-    String snap1 = "snap-1-" + RandomStringUtils.randomNumeric(5);
+    String snap1 = "snap-1-" + RandomStringUtils.secure().nextNumeric(5);
     createSnapshot(volume, bucket, snap1);
 
-    String key2 = "key-2-" + RandomStringUtils.randomNumeric(5);
+    String key2 = "key-2-" + RandomStringUtils.secure().nextNumeric(5);
     createFileKey(ozBucket, key2);
-    String snap2 = "snap-2-" + RandomStringUtils.randomNumeric(5);
+    String snap2 = "snap-2-" + RandomStringUtils.secure().nextNumeric(5);
     createSnapshot(volume, bucket, snap2);
 
     store.snapshotDiff(volume, bucket, snap1, snap2, null, 0,
@@ -1990,7 +1990,7 @@ public abstract class TestOmSnapshot {
 
   private String createFileKey(OzoneBucket bucket, String key)
           throws Exception {
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
     OzoneOutputStream fileKey = bucket.createKey(key, value.length);
     fileKey.write(value);
     fileKey.close();
@@ -2008,7 +2008,7 @@ public abstract class TestOmSnapshot {
   private void createFileKey(FileSystem fs,
                              String path)
       throws IOException, InterruptedException, TimeoutException {
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
     Path pathVal = new Path(path);
     FSDataOutputStream fileKey = fs.create(pathVal);
     fileKey.write(value);
@@ -2042,8 +2042,8 @@ public abstract class TestOmSnapshot {
   // in_progress when it restarts.
   @Test
   public void testSnapshotDiffWhenOmRestart() throws Exception {
-    String snapshot1 = "snap-" + RandomStringUtils.randomNumeric(5);
-    String snapshot2 = "snap-" + RandomStringUtils.randomNumeric(5);
+    String snapshot1 = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String snapshot2 = "snap-" + RandomStringUtils.secure().nextNumeric(5);
     createSnapshots(snapshot1, snapshot2);
 
     SnapshotDiffResponse response = store.snapshotDiff(volumeName, bucketName,
@@ -2087,8 +2087,8 @@ public abstract class TestOmSnapshot {
   public void testSnapshotDiffWhenOmRestartAndReportIsPartiallyFetched()
       throws Exception {
     int pageSize = 10;
-    String snapshot1 = "snap-" + RandomStringUtils.randomNumeric(5);
-    String snapshot2 = "snap-" + RandomStringUtils.randomNumeric(5);
+    String snapshot1 = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String snapshot2 = "snap-" + RandomStringUtils.secure().nextNumeric(5);
     createSnapshots(snapshot1, snapshot2);
 
     SnapshotDiffReportOzone diffReport = fetchReportPage(volumeName,
@@ -2170,8 +2170,8 @@ public abstract class TestOmSnapshot {
   @Test
   @Slow("HDDS-9299")
   public void testDayWeekMonthSnapshotCreationAndExpiration() throws Exception {
-    String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
-    String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);
+    String volumeA = "vol-a-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketA = "buc-a-" + RandomStringUtils.secure().nextNumeric(5);
     store.createVolume(volumeA);
     OzoneVolume volA = store.getVolume(volumeA);
     createBucket(volA, bucketA);
@@ -2376,10 +2376,10 @@ public abstract class TestOmSnapshot {
   // column families are used in SST diff calculation.
   @Test
   public void testSnapshotCompactionDag() throws Exception {
-    String volume1 = "volume-1-" + RandomStringUtils.randomNumeric(5);
-    String bucket1 = "bucket-1-" + RandomStringUtils.randomNumeric(5);
-    String bucket2 = "bucket-2-" + RandomStringUtils.randomNumeric(5);
-    String bucket3 = "bucket-3-" + RandomStringUtils.randomNumeric(5);
+    String volume1 = "volume-1-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucket1 = "bucket-1-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucket2 = "bucket-2-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucket3 = "bucket-3-" + RandomStringUtils.secure().nextNumeric(5);
 
     store.createVolume(volume1);
     OzoneVolume ozoneVolume = store.getVolume(volume1);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotDisabled.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotDisabled.java
@@ -78,9 +78,9 @@ public class TestOmSnapshotDisabled {
 
   @Test
   public void testExceptionThrown() throws Exception {
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "buck-" + RandomStringUtils.randomNumeric(5);
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "buck-" + RandomStringUtils.secure().nextNumeric(5);
+    String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotDisabledRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotDisabledRestart.java
@@ -78,9 +78,9 @@ public class TestOmSnapshotDisabledRestart {
     // Verify that OM start up will indeed fail when there are still snapshots
     // while snapshot feature is disabled.
 
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "buck-" + RandomStringUtils.randomNumeric(5);
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "buck-" + RandomStringUtils.secure().nextNumeric(5);
+    String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFileSystem.java
@@ -103,11 +103,11 @@ import org.slf4j.LoggerFactory;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TestOmSnapshotFileSystem {
   protected static final String VOLUME_NAME =
-      "volume" + RandomStringUtils.randomNumeric(5);
+      "volume" + RandomStringUtils.secure().nextNumeric(5);
   protected static final String BUCKET_NAME_FSO =
-      "bucket-fso-" + RandomStringUtils.randomNumeric(5);
+      "bucket-fso-" + RandomStringUtils.secure().nextNumeric(5);
   protected static final String BUCKET_NAME_LEGACY =
-      "bucket-legacy-" + RandomStringUtils.randomNumeric(5);
+      "bucket-legacy-" + RandomStringUtils.secure().nextNumeric(5);
 
   private MiniOzoneCluster cluster = null;
   private OzoneClient client;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
@@ -107,14 +107,14 @@ public class TestOzoneManagerHASnapshot {
   @Test
   public void testSnapshotDiffWhenOmLeaderRestart()
       throws Exception {
-    String snapshot1 = "snap-" + RandomStringUtils.randomNumeric(10);
-    String snapshot2 = "snap-" + RandomStringUtils.randomNumeric(10);
+    String snapshot1 = "snap-" + RandomStringUtils.secure().nextNumeric(10);
+    String snapshot2 = "snap-" + RandomStringUtils.secure().nextNumeric(10);
 
-    createFileKey(ozoneBucket, "key-" + RandomStringUtils.randomNumeric(10));
+    createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
     store.createSnapshot(volumeName, bucketName, snapshot1);
 
     for (int i = 0; i < 100; i++) {
-      createFileKey(ozoneBucket, "key-" + RandomStringUtils.randomNumeric(10));
+      createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
     }
 
     store.createSnapshot(volumeName, bucketName, snapshot2);
@@ -162,9 +162,9 @@ public class TestOzoneManagerHASnapshot {
 
   @Test
   public void testSnapshotIdConsistency() throws Exception {
-    createFileKey(ozoneBucket, "key-" + RandomStringUtils.randomNumeric(10));
+    createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
 
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(10);
+    String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(10);
 
     store.createSnapshot(volumeName, bucketName, snapshotName);
     List<OzoneManager> ozoneManagers = cluster.getOzoneManagersList();
@@ -247,8 +247,8 @@ public class TestOzoneManagerHASnapshot {
     for (int i = 0; i < 100; i++) {
       int index = i % 10;
       createFileKey(ozoneBuckets.get(index),
-          "key-" + RandomStringUtils.randomNumeric(10));
-      String snapshot1 = "snapshot-" + RandomStringUtils.randomNumeric(10);
+          "key-" + RandomStringUtils.secure().nextNumeric(10));
+      String snapshot1 = "snapshot-" + RandomStringUtils.secure().nextNumeric(10);
       store.createSnapshot(volumeNames.get(index),
           bucketNames.get(index), snapshot1);
     }
@@ -269,7 +269,7 @@ public class TestOzoneManagerHASnapshot {
 
   private void createFileKey(OzoneBucket bucket, String keyName)
       throws IOException {
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
     try (OzoneOutputStream fileKey = bucket.createKey(keyName, value.length)) {
       fileKey.write(value);
     }
@@ -293,7 +293,7 @@ public class TestOzoneManagerHASnapshot {
     int numKeys = 5;
     List<String> keys = new ArrayList<>();
     for (int i = 0; i < numKeys; i++) {
-      String keyName = "key-" + RandomStringUtils.randomNumeric(10);
+      String keyName = "key-" + RandomStringUtils.secure().nextNumeric(10);
       createFileKey(ozoneBucket, keyName);
       keys.add(keyName);
     }
@@ -308,7 +308,7 @@ public class TestOzoneManagerHASnapshot {
       ozoneBucket.deleteKey(keys.get(i));
     }
 
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(10);
+    String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(10);
     createSnapshot(volumeName, bucketName, snapshotName);
 
     store.deleteSnapshot(volumeName, bucketName, snapshotName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -106,7 +106,7 @@ public class TestOzoneManagerSnapshotAcl {
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.set(OZONE_ACL_AUTHORIZER_CLASS, OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
     final String omServiceId = "om-service-test-1"
-        + RandomStringUtils.randomNumeric(32);
+        + RandomStringUtils.secure().nextNumeric(32);
 
     cluster = MiniOzoneCluster.newHABuilder(conf)
         .setOMServiceId(omServiceId)
@@ -219,7 +219,7 @@ public class TestOzoneManagerSnapshotAcl {
     // GIVEN
     setup(bucketLayout);
     final OmKeyArgs snapshotKeyArgs = getOmKeyArgs(true);
-    final long numEntries = Long.parseLong(RandomStringUtils.randomNumeric(1));
+    final long numEntries = Long.parseLong(RandomStringUtils.secure().nextNumeric(1));
 
     // WHEN-THEN
     assertDoesNotThrow(
@@ -237,7 +237,7 @@ public class TestOzoneManagerSnapshotAcl {
     setup(bucketLayout);
     final OmKeyArgs snapshotKeyArgs = getOmKeyArgs(true);
     final OmKeyArgs keyArgs = getOmKeyArgs(false);
-    final long numEntries = Long.parseLong(RandomStringUtils.randomNumeric(1));
+    final long numEntries = Long.parseLong(RandomStringUtils.secure().nextNumeric(1));
 
     // when reading from snapshot, read disallowed.
     UserGroupInformation.setLoginUser(UGI2);
@@ -296,7 +296,7 @@ public class TestOzoneManagerSnapshotAcl {
     // GIVEN
     setup(bucketLayout);
     final OmKeyArgs snapshotKeyArgs = getOmKeyArgs(true);
-    final int maxKeys = Integer.parseInt(RandomStringUtils.randomNumeric(1));
+    final int maxKeys = Integer.parseInt(RandomStringUtils.secure().nextNumeric(1));
 
     // WHEN-THEN
     assertDoesNotThrow(() -> ozoneManager.listKeys(volumeName,
@@ -310,7 +310,7 @@ public class TestOzoneManagerSnapshotAcl {
     // GIVEN
     setup(bucketLayout);
     final OmKeyArgs snapshotKeyArgs = getOmKeyArgs(true);
-    final int maxKeys = Integer.parseInt(RandomStringUtils.randomNumeric(1));
+    final int maxKeys = Integer.parseInt(RandomStringUtils.secure().nextNumeric(1));
 
     // WHEN
     UserGroupInformation.setLoginUser(UGI2);
@@ -562,8 +562,8 @@ public class TestOzoneManagerSnapshotAcl {
   }
 
   private void createKey(OzoneBucket bucket) throws IOException {
-    keyName = KEY_PREFIX + RandomStringUtils.randomNumeric(32);
-    byte[] data = RandomStringUtils.randomAscii(1).getBytes(UTF_8);
+    keyName = KEY_PREFIX + RandomStringUtils.secure().nextNumeric(32);
+    byte[] data = RandomStringUtils.secure().nextAscii(1).getBytes(UTF_8);
     final OzoneOutputStream fileKey = bucket.createKey(keyName, data.length);
     fileKey.write(data);
     fileKey.close();
@@ -573,7 +573,7 @@ public class TestOzoneManagerSnapshotAcl {
       throws IOException {
     final String snapshotPrefix = "snapshot-";
     final String snapshotName =
-        snapshotPrefix + RandomStringUtils.randomNumeric(32);
+        snapshotPrefix + RandomStringUtils.secure().nextNumeric(32);
     objectStore.createSnapshot(volumeName, bucketName, snapshotName);
     snapshotKeyPrefix = OmSnapshotManager
         .getSnapshotPrefix(snapshotName);
@@ -616,7 +616,7 @@ public class TestOzoneManagerSnapshotAcl {
   private void createBucket(BucketLayout bucketLayout,
       OzoneVolume volume) throws IOException {
     final String bucketPrefix = "bucket-";
-    bucketName = bucketPrefix + RandomStringUtils.randomNumeric(32);
+    bucketName = bucketPrefix + RandomStringUtils.secure().nextNumeric(32);
     final BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setOwner(ADMIN)
         .setBucketLayout(bucketLayout).build();
@@ -625,7 +625,7 @@ public class TestOzoneManagerSnapshotAcl {
 
   private void createVolume() throws IOException {
     final String volumePrefix = "volume-";
-    volumeName = volumePrefix + RandomStringUtils.randomNumeric(32);
+    volumeName = volumePrefix + RandomStringUtils.secure().nextNumeric(32);
     final VolumeArgs volumeArgs = VolumeArgs.newBuilder()
         .setAdmin(ADMIN)
         .setOwner(ADMIN)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotProvider.java
@@ -84,10 +84,10 @@ public class TestOzoneManagerSnapshotProvider {
 
   @Test
   public void testDownloadCheckpoint() throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String userName = "user" + RandomStringUtils.secure().nextNumeric(5);
+    String adminName = "admin" + RandomStringUtils.secure().nextNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.secure().nextNumeric(5);
 
     VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
         .setOwner(userName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -100,7 +100,7 @@ public class TestOzoneSnapshotRestore {
     // Enable filesystem snapshot feature for the test regardless of the default
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
 
-    String serviceID = OM_SERVICE_ID + RandomStringUtils.randomNumeric(5);
+    String serviceID = OM_SERVICE_ID + RandomStringUtils.secure().nextNumeric(5);
 
     cluster = MiniOzoneCluster.newHABuilder(conf)
             .setOMServiceId(serviceID)
@@ -136,7 +136,7 @@ public class TestOzoneSnapshotRestore {
 
   private void createFileKey(OzoneBucket bucket, String key)
           throws IOException {
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    byte[] value = RandomStringUtils.secure().nextAscii(10240).getBytes(UTF_8);
     OzoneOutputStream fileKey = bucket.createKey(key, value.length);
     fileKey.write(value);
     fileKey.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.reconfig;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
@@ -27,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.ozone.om.OmConfig;
@@ -59,7 +59,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
 
   @Test
   void adminUsernames() throws ReconfigurationException {
-    final String newValue = randomAlphabetic(10);
+    final String newValue = RandomStringUtils.secure().nextAlphabetic(10);
 
     getSubject().reconfigurePropertyImpl(OZONE_ADMINISTRATORS, newValue);
 
@@ -70,7 +70,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
 
   @Test
   void readOnlyAdmins() throws ReconfigurationException {
-    final String newValue = randomAlphabetic(10);
+    final String newValue = RandomStringUtils.secure().nextAlphabetic(10);
 
     getSubject().reconfigurePropertyImpl(OZONE_READONLY_ADMINISTRATORS,
         newValue);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.reconfig;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.scm.ScmConfig;
@@ -61,7 +61,7 @@ public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
 
   @Test
   void adminUsernames() throws ReconfigurationException {
-    final String newValue = randomAlphabetic(10);
+    final String newValue = RandomStringUtils.secure().nextAlphabetic(10);
 
     getSubject().reconfigurePropertyImpl(OZONE_ADMINISTRATORS, newValue);
 
@@ -72,7 +72,7 @@ public abstract class TestScmReconfiguration extends ReconfigurationTestBase {
 
   @Test
   void readOnlyAdminUsernames() throws ReconfigurationException {
-    final String newValue = randomAlphabetic(10);
+    final String newValue = RandomStringUtils.secure().nextAlphabetic(10);
 
     getSubject().reconfigurePropertyImpl(OZONE_READONLY_ADMINISTRATORS,
         newValue);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestChunkStreams.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestChunkStreams.java
@@ -41,7 +41,7 @@ public class TestChunkStreams {
 
   @Test
   public void testReadGroupInputStream() throws Exception {
-    String dataString = RandomStringUtils.randomAscii(500);
+    String dataString = RandomStringUtils.secure().nextAscii(500);
     try (KeyInputStream groupInputStream =
              new KeyInputStream("key", createInputStreams(dataString))) {
 
@@ -55,7 +55,7 @@ public class TestChunkStreams {
 
   @Test
   public void testErrorReadGroupInputStream() throws Exception {
-    String dataString = RandomStringUtils.randomAscii(500);
+    String dataString = RandomStringUtils.secure().nextAscii(500);
     try (KeyInputStream groupInputStream =
              new KeyInputStream("key", createInputStreams(dataString))) {
       byte[] resBuf = new byte[600];

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.om;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.hdds.client.ReplicationConfig.fromTypeAndFactor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -184,8 +184,8 @@ public class TestScmClient {
   private DatanodeDetails randomDatanode() {
     return DatanodeDetails.newBuilder()
         .setUuid(UUID.randomUUID())
-        .setHostName(randomAlphabetic(5))
-        .setIpAddress(randomAlphabetic(5))
+        .setHostName(RandomStringUtils.secure().nextAlphabetic(5))
+        .setIpAddress(RandomStringUtils.secure().nextAlphabetic(5))
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMHAMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMHAMetrics.java
@@ -32,7 +32,7 @@ public class TestOMHAMetrics {
   private static final MetricsCollectorImpl METRICS_COLLECTOR =
       new MetricsCollectorImpl();
   private static final String NODE_ID =
-      "om" + RandomStringUtils.randomNumeric(5);
+      "om" + RandomStringUtils.secure().nextNumeric(5);
   private OMHAMetrics omhaMetrics;
   private String leaderId;
 
@@ -52,7 +52,7 @@ public class TestOMHAMetrics {
 
   @Test
   public void testGetMetricsWithFollower() {
-    leaderId = "om" + RandomStringUtils.randomNumeric(5);
+    leaderId = "om" + RandomStringUtils.secure().nextNumeric(5);
     omhaMetrics = OMHAMetrics.create(NODE_ID, leaderId);
 
     omhaMetrics.getMetrics(METRICS_COLLECTOR, true);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -1064,7 +1064,7 @@ public final class OMRequestTestUtils {
             .setValue(DatatypeConverter.printHexBinary(
                 new DigestInputStream(
                     new ByteArrayInputStream(
-                        RandomStringUtils.randomAlphanumeric((int) size)
+                        RandomStringUtils.secure().nextAlphanumeric((int) size)
                             .getBytes(StandardCharsets.UTF_8)),
                     eTagProvider)
                     .getMessageDigest().digest()))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -537,9 +537,9 @@ public class TestOMDirectoryCreateRequest {
 
   private String genRandomKeyName() {
     StringBuilder keyNameBuilder = new StringBuilder();
-    keyNameBuilder.append(RandomStringUtils.randomAlphabetic(5));
+    keyNameBuilder.append(RandomStringUtils.secure().nextAlphabetic(5));
     for (int i = 0; i < 3; i++) {
-      keyNameBuilder.append("/").append(RandomStringUtils.randomAlphabetic(5));
+      keyNameBuilder.append("/").append(RandomStringUtils.secure().nextAlphabetic(5));
     }
     return keyNameBuilder.toString();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -741,11 +741,11 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Nonnull
   private String createDirKey(List<String> dirs, int depth) {
-    String keyName = RandomStringUtils.randomAlphabetic(5);
+    String keyName = RandomStringUtils.secure().nextAlphabetic(5);
     dirs.add(keyName);
     StringBuffer buf = new StringBuffer(keyName);
     for (int i = 0; i < depth; i++) {
-      String dirName = RandomStringUtils.randomAlphabetic(5);
+      String dirName = RandomStringUtils.secure().nextAlphabetic(5);
       dirs.add(dirName);
       buf.append(OzoneConsts.OM_KEY_PREFIX);
       buf.append(dirName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -826,7 +826,7 @@ class TestKeyDeletingService extends OzoneTestBase {
             .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
             .setDataSize(1000L)
             .setLocationInfoList(new ArrayList<>())
-            .setOwnerName("user" + RandomStringUtils.randomNumeric(5))
+            .setOwnerName("user" + RandomStringUtils.secure().nextNumeric(5))
             .build();
     //Open and Commit the Key in the Key Manager.
     OpenKeySession session = writeClient.openKey(keyArg);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDiffCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDiffCleanupService.java
@@ -288,12 +288,12 @@ public class TestSnapshotDiffCleanupService {
                                           long noOfEntries)
       throws IOException, RocksDBException {
 
-    String jobId = "jobId-" + RandomStringUtils.randomAlphanumeric(10);
-    String volume = "volume-" + RandomStringUtils.randomAlphanumeric(10);
-    String bucket = "bucket-" + RandomStringUtils.randomAlphanumeric(10);
+    String jobId = "jobId-" + RandomStringUtils.secure().nextAlphanumeric(10);
+    String volume = "volume-" + RandomStringUtils.secure().nextAlphanumeric(10);
+    String bucket = "bucket-" + RandomStringUtils.secure().nextAlphanumeric(10);
     String fromSnapshot = "fromSnap-" +
-        RandomStringUtils.randomAlphanumeric(10);
-    String toSnapshot = "toSnap-" + RandomStringUtils.randomAlphanumeric(10);
+        RandomStringUtils.secure().nextAlphanumeric(10);
+    String toSnapshot = "toSnap-" + RandomStringUtils.secure().nextAlphanumeric(10);
     String jobKey = fromSnapshot + DELIMITER + toSnapshot;
 
     SnapshotDiffJob job = new SnapshotDiffJob(creationTime, jobId, jobStatus,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -427,7 +427,7 @@ public class TestSnapshotDiffManager {
     String diffDir = snapDiffDir.getAbsolutePath();
     String diffJobKey = snap1 + DELIMITER + snap2;
     Set<String> randomStrings = IntStream.range(0, numberOfFiles)
-        .mapToObj(i -> RandomStringUtils.randomAlphabetic(10))
+        .mapToObj(i -> RandomStringUtils.secure().nextAlphabetic(10))
         .collect(Collectors.toSet());
 
     when(differ.getSSTDiffListWithFullPath(
@@ -450,7 +450,7 @@ public class TestSnapshotDiffManager {
          MockedStatic<RocksDiffUtils> mockedRocksDiffUtils = Mockito.mockStatic(RocksDiffUtils.class,
              Mockito.CALLS_REAL_METHODS)) {
       mockedRdbUtil.when(() -> RdbUtil.getSSTFilesForComparison(any(), any()))
-          .thenReturn(Collections.singleton(RandomStringUtils.randomAlphabetic(10)));
+          .thenReturn(Collections.singleton(RandomStringUtils.secure().nextAlphabetic(10)));
       mockedRocksDiffUtils.when(() -> RocksDiffUtils.filterRelevantSstFiles(any(), any())).thenAnswer(i -> null);
       SnapshotDiffManager spy = spy(snapshotDiffManager);
       doNothing().when(spy).recordActivity(any(), any());
@@ -483,7 +483,7 @@ public class TestSnapshotDiffManager {
               () -> RdbUtil.getSSTFilesForComparison(any(), anyList()))
           .thenAnswer((Answer<Set<String>>) invocation -> {
             Set<String> retVal = IntStream.range(0, numberOfFiles)
-                .mapToObj(i -> RandomStringUtils.randomAlphabetic(10))
+                .mapToObj(i -> RandomStringUtils.secure().nextAlphabetic(10))
                 .collect(Collectors.toSet());
             deltaStrings.addAll(retVal);
             return retVal;
@@ -555,7 +555,7 @@ public class TestSnapshotDiffManager {
               () -> RdbUtil.getSSTFilesForComparison(any(), anyList()))
           .thenAnswer((Answer<Set<String>>) invocation -> {
             Set<String> retVal = IntStream.range(0, numberOfFiles)
-                .mapToObj(i -> RandomStringUtils.randomAlphabetic(10))
+                .mapToObj(i -> RandomStringUtils.secure().nextAlphabetic(10))
                 .collect(Collectors.toSet());
             deltaStrings.addAll(retVal);
             return retVal;
@@ -976,11 +976,11 @@ public class TestSnapshotDiffManager {
   @Test
   public void testGetSnapshotDiffReportForCancelledJob() throws IOException {
 
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
 
-    String fromSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
-    String toSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     UUID fromSnapshotUUID = UUID.randomUUID();
     UUID toSnapshotUUID = UUID.randomUUID();
@@ -1060,11 +1060,11 @@ public class TestSnapshotDiffManager {
                                             CancelMessage cancelMessage)
       throws IOException {
 
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
 
-    String fromSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
-    String toSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     UUID fromSnapshotUUID = UUID.randomUUID();
     UUID toSnapshotUUID = UUID.randomUUID();
@@ -1095,11 +1095,11 @@ public class TestSnapshotDiffManager {
 
   @Test
   public void testCancelNewSnapshotDiff() throws IOException {
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
 
-    String fromSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
-    String toSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     UUID fromSnapshotUUID = UUID.randomUUID();
     UUID toSnapshotUUID = UUID.randomUUID();
@@ -1138,10 +1138,10 @@ public class TestSnapshotDiffManager {
                                        boolean listAllStatus,
                                        boolean containsJob)
       throws IOException {
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
-    String fromSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
-    String toSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     UUID fromSnapshotUUID = UUID.randomUUID();
     UUID toSnapshotUUID = UUID.randomUUID();
@@ -1200,10 +1200,10 @@ public class TestSnapshotDiffManager {
 
   @Test
   public void testListSnapDiffWithInvalidStatus() throws IOException {
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
-    String fromSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
-    String toSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     UUID fromSnapshotUUID = UUID.randomUUID();
     UUID toSnapshotUUID = UUID.randomUUID();
@@ -1256,10 +1256,10 @@ public class TestSnapshotDiffManager {
 
   @Test
   public void testGenerateDiffReportFailure() throws IOException {
-    String volumeName = "vol-" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
-    String fromSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
-    String toSnapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
 
     PersistentMap<byte[], Boolean> objectIdToIsDirectoryMap =
         new SnapshotTestUtils.StubbedPersistentMap<>();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSstFilteringService.java
@@ -335,7 +335,7 @@ public class TestSstFilteringService {
                           int keyCount)
       throws IOException {
     for (int x = 0; x < keyCount; x++) {
-      String keyName = "key-" + RandomStringUtils.randomAlphanumeric(5);
+      String keyName = "key-" + RandomStringUtils.secure().nextAlphanumeric(5);
       createKey(writeClient, volumeName, bucketName, keyName);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -142,9 +142,9 @@ public class TestOzoneTokenIdentifier {
 
   OzoneTokenIdentifier generateTestToken() {
     OzoneTokenIdentifier tokenIdentifier = new OzoneTokenIdentifier(
-        new Text(RandomStringUtils.randomAlphabetic(6)),
-        new Text(RandomStringUtils.randomAlphabetic(5)),
-        new Text(RandomStringUtils.randomAlphabetic(4)));
+        new Text(RandomStringUtils.secure().nextAlphabetic(6)),
+        new Text(RandomStringUtils.secure().nextAlphabetic(5)),
+        new Text(RandomStringUtils.secure().nextAlphabetic(4)));
     tokenIdentifier.setOmCertSerialId("123");
     return tokenIdentifier;
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayAuditLog.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayAuditLog.java
@@ -143,7 +143,7 @@ public class TestS3GatewayAuditLog {
 
   @Test
   public void testHeadObject() throws Exception {
-    String value = RandomStringUtils.randomAlphanumeric(32);
+    String value = RandomStringUtils.secure().nextAlphanumeric(32);
     OzoneOutputStream out = bucket.createKey("key1",
         value.getBytes(UTF_8).length,
         ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -68,7 +68,7 @@ public class TestObjectHead {
   @Test
   public void testHeadObject() throws Exception {
     //GIVEN
-    String value = RandomStringUtils.randomAlphanumeric(32);
+    String value = RandomStringUtils.secure().nextAlphanumeric(32);
     OzoneOutputStream out = bucket.createKey("key1",
         value.getBytes(UTF_8).length,
         ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -151,7 +151,7 @@ class TestObjectPut {
   @MethodSource("argumentsForPutObject")
   void testPutObject(int length, ReplicationConfig replication) throws IOException, OS3Exception {
     //GIVEN
-    final String content = RandomStringUtils.randomAlphanumeric(length);
+    final String content = RandomStringUtils.secure().nextAlphanumeric(length);
     ByteArrayInputStream body = new ByteArrayInputStream(content.getBytes(UTF_8));
     bucket.setReplicationConfig(replication);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/AbstractOmBucketReadWriteOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/AbstractOmBucketReadWriteOps.java
@@ -214,7 +214,7 @@ public abstract class AbstractOmBucketReadWriteOps extends BaseFreonGenerator
       throws Exception {
     for (int i = 0; i < keyCount; i++) {
       String keyName = path.concat(OzoneConsts.OM_KEY_PREFIX)
-          .concat(RandomStringUtils.randomAlphanumeric(length));
+          .concat(RandomStringUtils.secure().nextAlphanumeric(length));
       if (LOG.isDebugEnabled()) {
         LOG.debug("Key/FileName : {}", keyName);
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -282,7 +282,7 @@ public class BaseFreonGenerator implements FreonSubcommand {
     attemptCounter = new AtomicLong(0);
 
     if (prefix.isEmpty()) {
-      prefix = !allowEmptyPrefix() ? RandomStringUtils.randomAlphanumeric(10).toLowerCase() : "";
+      prefix = !allowEmptyPrefix() ? RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase() : "";
     } else {
       //replace environment variables to support multi-node execution
       prefix = resolvePrefix(prefix);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.freon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.RandomStringUtils.randomAscii;
 
 import com.codahale.metrics.Timer;
 import java.io.UncheckedIOException;
@@ -28,6 +27,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -136,7 +136,7 @@ public class ChunkManagerDiskWrite extends BaseFreonGenerator implements
       }
 
       blockSize = chunkSize * chunksPerBlock;
-      data = randomAscii(chunkSize).getBytes(UTF_8);
+      data = RandomStringUtils.secure().nextAscii(chunkSize).getBytes(UTF_8);
 
       chunkManager = ChunkManagerFactory.createChunkManager(ozoneConfiguration,
           null, null);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -68,7 +68,7 @@ public class ContentGenerator {
     this.keySize = keySize;
     this.bufferSize = bufferSize;
     this.copyBufferSize = copyBufferSize;
-    buffer = RandomStringUtils.randomAscii(bufferSize)
+    buffer = RandomStringUtils.secure().nextAscii(bufferSize)
         .getBytes(StandardCharsets.UTF_8);
     this.flushOrSync = SyncOptions.NONE;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeBlockPutter.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeBlockPutter.java
@@ -107,7 +107,7 @@ public class DatanodeBlockPutter extends BaseFreonGenerator implements
 
         timer = getMetrics().timer("put-block");
 
-        byte[] data = RandomStringUtils.randomAscii(chunkSize)
+        byte[] data = RandomStringUtils.secure().nextAscii(chunkSize)
             .getBytes(StandardCharsets.UTF_8);
         Checksum checksum = new Checksum(ChecksumType.CRC32, 1024 * 1024);
         checksumProtobuf = checksum.computeChecksum(data).getProtoBufMessage();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkGenerator.java
@@ -187,7 +187,7 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
 
     timer = getMetrics().timer("chunk-write");
 
-    byte[] data = RandomStringUtils.randomAscii(chunkSize)
+    byte[] data = RandomStringUtils.secure().nextAscii(chunkSize)
         .getBytes(StandardCharsets.UTF_8);
 
     dataToWrite = ByteString.copyFrom(data);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
@@ -150,7 +150,7 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
     inFlightMessages = new LinkedBlockingQueue<>(inflightLimit);
 
     timer = getMetrics().timer("append-entry");
-    byte[] data = RandomStringUtils.randomAscii(chunkSize)
+    byte[] data = RandomStringUtils.secure().nextAscii(chunkSize)
         .getBytes(StandardCharsets.UTF_8);
 
     dataToWrite = ByteString.copyFrom(data);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -184,7 +184,7 @@ public class HadoopDirTreeGenerator extends HadoopBaseFreonGenerator
 
   private String makeDirWithGivenNumberOfFiles(String parent)
           throws Exception {
-    String dir = RandomStringUtils.randomAlphanumeric(length);
+    String dir = RandomStringUtils.secure().nextAlphanumeric(length);
     dir = parent.concat("/").concat(dir);
     getFileSystem().mkdirs(new Path(dir));
     totalDirsCnt.incrementAndGet();
@@ -195,7 +195,7 @@ public class HadoopDirTreeGenerator extends HadoopBaseFreonGenerator
 
   private void createFile(String dir, long counter) throws Exception {
     String fileName = dir.concat("/").concat(RandomStringUtils.
-            randomAlphanumeric(length));
+            secure().nextAlphanumeric(length));
     Path file = new Path(fileName);
     if (LOG.isDebugEnabled()) {
       LOG.debug("FilePath:{}", file);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -93,10 +93,10 @@ public class HadoopNestedDirGenerator extends HadoopBaseFreonGenerator
 
    */
   private void createDir(long counter) throws Exception {
-    String dirString = RandomStringUtils.randomAlphanumeric(length);
+    String dirString = RandomStringUtils.secure().nextAlphanumeric(length);
     for (int i = 1; i <= depth; i++) {
       dirString = dirString.concat("/").concat(RandomStringUtils.
-          randomAlphanumeric(length));
+          secure().nextAlphanumeric(length));
     }
     Path file = new Path(getRootPath().concat("/").concat(dirString));
     getFileSystem().mkdirs(file.getParent());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
@@ -133,7 +133,7 @@ public class LeaderAppendLogEntryGenerator extends BaseAppendLogGenerator
 
     OzoneConfiguration conf = createOzoneConfiguration();
 
-    byte[] data = RandomStringUtils.randomAscii(chunkSize)
+    byte[] data = RandomStringUtils.secure().nextAscii(chunkSize)
         .getBytes(StandardCharsets.UTF_8);
     dataToWrite = ByteString.copyFrom(data);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -301,7 +301,7 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
     replicationConfig = replication.fromParamsOrConfig(ozoneConfiguration);
 
     keyValueBuffer = StringUtils.string2Bytes(
-        RandomStringUtils.randomAscii(bufferSize));
+        RandomStringUtils.secure().nextAscii(bufferSize));
 
     // Compute the common initial digest for all keys without their UUID
     if (validateWrites) {
@@ -725,7 +725,7 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
 
   private boolean createVolume(int volumeNumber) {
     String volumeName = "vol-" + volumeNumber + "-"
-        + RandomStringUtils.randomNumeric(5);
+        + RandomStringUtils.secure().nextNumeric(5);
     LOG.trace("Creating volume: {}", volumeName);
     try (AutoCloseable scope = TracingUtil
         .createActivatedSpan("createVolume")) {
@@ -756,7 +756,7 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
       return false;
     }
     String bucketName = "bucket-" + bucketNumber + "-" +
-        RandomStringUtils.randomNumeric(5);
+        RandomStringUtils.secure().nextNumeric(5);
     LOG.trace("Creating bucket: {} in volume: {}",
         bucketName, volume.getName());
     try (AutoCloseable scope = TracingUtil
@@ -791,7 +791,7 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
     String bucketName = bucket.getName();
     String volumeName = bucket.getVolumeName();
     String keyName = "key-" + keyNumber + "-"
-        + RandomStringUtils.randomNumeric(5);
+        + RandomStringUtils.secure().nextNumeric(5);
     LOG.trace("Adding key: {} in bucket: {} of volume: {}",
         keyName, bucketName, volumeName);
     try {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
@@ -97,7 +97,7 @@ public class S3KeyGenerator extends S3EntityGenerator
 
     s3ClientInit();
 
-    content = RandomStringUtils.randomAscii(fileSize);
+    content = RandomStringUtils.secure().nextAscii(fileSize);
 
     timer = getMetrics().timer("key-create");
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/audit/parser/TestAuditParser.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/audit/parser/TestAuditParser.java
@@ -206,7 +206,7 @@ public class TestAuditParser {
 
   private static File getRandomTempDir() throws IOException {
     File tempDir = new File(outputBaseDir,
-        RandomStringUtils.randomAlphanumeric(5));
+        RandomStringUtils.secure().nextAlphanumeric(5));
     FileUtils.forceMkdir(tempDir);
     return tempDir;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Among the code base we can see there're many usage of `RandomStringUtils` ,however, many of the methods in `RandomStringUtils` are depreciated, can be check [here](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/RandomStringUtils.html) we should replace it with the available ones.

## What is the link to the Apache JIRA
[HDDS-12504](https://issues.apache.org/jira/browse/HDDS-12504)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14556096087