### PR TITLE
HDDS-12340. Remove unnecessary findbugs exclusions

### DIFF
--- a/hadoop-hdds/rocks-native/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/rocks-native/dev-support/findbugsExcludeFile.xml
@@ -15,8 +15,4 @@
    limitations under the License.
 -->
 <FindBugsFilter>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.utils.db.managed.ManagedSSTDumpIterator$KeyValue"/>
-    <Bug pattern="EI_EXPOSE_REP" />
-  </Match>
 </FindBugsFilter>

--- a/hadoop-ozone/client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/client/dev-support/findbugsExcludeFile.xml
@@ -16,9 +16,4 @@
    limitations under the License.
 -->
 <FindBugsFilter>
-  <!-- Test -->
-  <Match>
-    <Class name="org.apache.hadoop.ozone.client.TestHddsClientUtils"/>
-    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
-  </Match>
 </FindBugsFilter>

--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -53,7 +53,7 @@
     <Bug pattern="RV_RETURN_VALUE_IGNORED" />
   </Match>
   <Match>
-    <Class name="org.apache.hadoop.ozone.client.rpc.read.TestKeyInputStream"/>
+    <Class name="org.apache.hadoop.ozone.client.rpc.TestKeyInputStream"/>
     <Bug pattern="SR_NOT_CHECKED" />
   </Match>
   <Match>

--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -53,7 +53,7 @@
     <Bug pattern="RV_RETURN_VALUE_IGNORED" />
   </Match>
   <Match>
-    <Class name="org.apache.hadoop.ozone.client.rpc.TestKeyInputStream"/>
+    <Class name="org.apache.hadoop.ozone.client.rpc.read.TestKeyInputStream"/>
     <Bug pattern="SR_NOT_CHECKED" />
   </Match>
   <Match>

--- a/hadoop-ozone/s3gateway/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/s3gateway/dev-support/findbugsExcludeFile.xml
@@ -13,9 +13,4 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 <FindBugsFilter>
-    <!-- Test -->
-    <Match>
-      <Class name=""/>
-      <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-    </Match>
- </FindBugsFilter>
+</FindBugsFilter>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR removes unused findbugs exclusions and fixes a path to `TestKeyInputStream`.

## What is the link to the Apache JIRA
[HDDS-12340](https://issues.apache.org/jira/browse/HDDS-12340)

## How was this patch tested?
CI:
https://github.com/kostacie/ozone/actions/runs/14534927524
P.S. Build's name contains 'HDDS-10247' instead of 'HDDS-12340' by mistake.
