### PR TITLE
Hdds 12706

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -332,6 +332,14 @@ public interface ScmClient extends Closeable {
   boolean forceExitSafeMode() throws IOException;
 
   /**
+   * Allow SCM to enter safe mode.
+   *
+   * @return returns true if operation is successful.
+   * @throws IOException
+   */
+  boolean enterSafeMode() throws IOException;
+
+  /**
    * Start ReplicationManager.
    */
   void startReplicationManager() throws IOException;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -69,7 +69,8 @@ public interface StorageContainerLocationProtocol extends Closeable {
   Set<Type> ADMIN_COMMAND_TYPE = Collections.unmodifiableSet(EnumSet.of(
       Type.StartReplicationManager,
       Type.StopReplicationManager,
-      Type.ForceExitSafeMode));
+      Type.ForceExitSafeMode,
+      Type.InManualSafeMode));
 
   /**
    * Asks SCM where a container should be allocated. SCM responds with the
@@ -375,6 +376,14 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * @throws IOException
    */
   boolean forceExitSafeMode() throws IOException;
+
+  /**
+   * Allow SCM to enter Safe mode.
+   *
+   * @return returns true if operation is successful.
+   * @throws IOException
+   */
+  boolean enterSafeMode() throws IOException;
 
   /**
    * Start ReplicationManager.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -63,6 +63,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionNodesResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.EnterSafeModeRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.EnterSafeModeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeRequestProto;
@@ -862,6 +864,23 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
 
     return resp.getExitedSafeMode();
 
+  }
+
+  /**
+   * Allow SCM to enter Safe mode.
+   *
+   * @return returns true if operation is successful.
+   */
+  @Override
+  public boolean enterSafeMode() throws IOException {
+    EnterSafeModeRequestProto request =
+        EnterSafeModeRequestProto.getDefaultInstance();
+
+    EnterSafeModeResponseProto resp =
+        submitRequest(Type.InManualSafeMode,
+            builder -> builder.setEnterSafeModeRequest(request))
+            .getEnterSafeModeResponse();
+    return resp.getEnteredSafeMode();
   }
 
   @Override

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -85,6 +85,7 @@ message ScmContainerLocationRequest {
   optional GetContainersOnDecomNodeRequestProto getContainersOnDecomNodeRequest = 46;
   optional GetMetricsRequestProto getMetricsRequest = 47;
   optional ContainerBalancerStatusInfoRequestProto containerBalancerStatusInfoRequest = 48;
+  optional EnterSafeModeRequestProto enterSafeModeRequest = 49;
 }
 
 message ScmContainerLocationResponse {
@@ -141,6 +142,7 @@ message ScmContainerLocationResponse {
   optional GetContainersOnDecomNodeResponseProto getContainersOnDecomNodeResponse = 46;
   optional GetMetricsResponseProto getMetricsResponse = 47;
   optional ContainerBalancerStatusInfoResponseProto containerBalancerStatusInfoResponse = 48;
+  optional EnterSafeModeResponseProto enterSafeModeResponse = 49;
 
   enum Status {
     OK = 1;
@@ -196,6 +198,7 @@ enum Type {
   GetContainersOnDecomNode = 42;
   GetMetrics = 43;
   GetContainerBalancerStatusInfo = 44;
+  InManualSafeMode = 45;
 }
 
 /**
@@ -490,6 +493,14 @@ message ForceExitSafeModeRequestProto {
 
 message ForceExitSafeModeResponseProto {
   required bool exitedSafeMode = 1;
+}
+
+message EnterSafeModeRequestProto {
+  optional string traceID = 1;
+}
+
+message EnterSafeModeResponseProto {
+  required bool enteredSafeMode = 1;
 }
 
 message StartReplicationManagerRequestProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -66,6 +66,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionNodesResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.EnterSafeModeRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.EnterSafeModeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeRequestProto;
@@ -552,6 +554,13 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setForceExitSafeModeResponse(forceExitSafeMode(
                 request.getForceExitSafeModeRequest()))
+            .build();
+      case InManualSafeMode:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setEnterSafeModeResponse(enterSafeMode(
+                request.getEnterSafeModeRequest()))
             .build();
       case StartReplicationManager:
         return ScmContainerLocationResponse.newBuilder()
@@ -1075,6 +1084,13 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     return ForceExitSafeModeResponseProto.newBuilder()
         .setExitedSafeMode(impl.forceExitSafeMode()).build();
 
+  }
+
+  public EnterSafeModeResponseProto enterSafeMode(
+      EnterSafeModeRequestProto request)
+      throws IOException {
+    return EnterSafeModeResponseProto.newBuilder()
+        .setEnteredSafeMode(impl.enterSafeMode()).build();
   }
 
   public StartReplicationManagerResponseProto startReplicationManager(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1048,6 +1048,25 @@ public class SCMClientProtocolServer implements
     }
   }
 
+  /**
+   * Allow SCM to enter Safe mode.
+   *
+   * @return returns true if operation is successful.
+   * @throws IOException
+   */
+  @Override
+  public boolean enterSafeMode() throws IOException {
+    try {
+      getScm().checkAdminAccess(getRemoteUser(), false);
+      boolean result = scm.enterSafeMode();
+      AUDIT.logWriteSuccess(buildAuditMessageForSuccess(SCMAction.IN_SAFE_MODE, null));
+      return result;
+    } catch (Exception ex) {
+      AUDIT.logWriteFailure(buildAuditMessageForFailure(SCMAction.IN_SAFE_MODE, null, ex));
+      throw ex;
+    }
+  }
+
   @Override
   public void startReplicationManager() throws IOException {
     try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1974,6 +1974,14 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     return true;
   }
 
+  /**
+   * Allow SCM into safe mode.
+   */
+  public boolean enterSafeMode() {
+    scmSafeModeManager.enterManualSafeMode(eventQueue);
+    return true;
+  }
+
   @VisibleForTesting
   public double getCurrentContainerThreshold() {
     return scmSafeModeManager.getCurrentContainerThreshold();

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -473,6 +473,11 @@ public class ContainerOperationClient implements ScmClient {
   public boolean forceExitSafeMode() throws IOException {
     return storageContainerLocationClient.forceExitSafeMode();
   }
+  
+  @Override
+  public boolean enterSafeMode() throws IOException {
+    return storageContainerLocationClient.enterSafeMode();
+  }
 
   @Override
   public void startReplicationManager() throws IOException {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeEnterSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeEnterSubcommand.java
@@ -17,26 +17,26 @@
 
 package org.apache.hadoop.hdds.scm.cli;
 
-import org.apache.hadoop.hdds.cli.AdminSubcommand;
+import java.io.IOException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.kohsuke.MetaInfServices;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine.Command;
 
 /**
- * Subcommand to group safe mode related operations.
+ * This is the handler that process safe mode exit command.
  */
 @Command(
-    name = "safemode",
-    description = "Safe mode specific operations",
+    name = "enter",
+    description = "Allow SCM to enter safe mode",
     mixinStandardHelpOptions = true,
-    versionProvider = HddsVersionProvider.class,
-    subcommands = {
-        SafeModeCheckSubcommand.class,
-        SafeModeExitSubcommand.class,
-        SafeModeWaitSubcommand.class,
-        SafeModeEnterSubcommand.class
-    })
-@MetaInfServices(AdminSubcommand.class)
-public class SafeModeCommands implements AdminSubcommand {
+    versionProvider = HddsVersionProvider.class)
+public class SafeModeEnterSubcommand extends ScmSubcommand {
 
+  @Override
+  public void execute(ScmClient scmClient) throws IOException {
+    boolean execReturn = scmClient.enterSafeMode();
+    if (execReturn) {
+      System.out.println("SCM entered to safe mode successfully.");
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Operators sometimes need to freeze SCM on‑demand (maintenance, troubleshooting) without restarting the service.  
This patch provides an explicit, audited switch to enter/exit Safe Mode at any time.

* **CLI** – new command `ozone admin safemode enter`  
* **Protocol** – added `EnterSafeMode*` request/response to *ScmAdminProtocol* and client `enterSafeMode()`  
* **SCM logic** – `SCMSafeModeManager` tracks a new `inManualSafeMode` flag; composite safe‑mode is `auto || manual`  
* **Security / audit** – command uses existing admin ACL checks and is logged like other admin ops  
* **Tests** – new JUnit tests in `TestScmSafeMode` cover manual entry and force exit


## What is the link to the Apache JIRA

[HDDS-12706](https://issues.apache.org/jira/browse/HDDS-12706)

## How was this patch tested?

* New integration tests added to `TestScmSafeMode`  
* Validated via CI actions.
* Manual verification on a 3‑node cluster (writes blocked after **enter**, resume after **exit**)
