### PR TITLE
HDDS-12879. Use AtomicFileOutputStream to write DiskBalancerYAML file

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerYaml.java
@@ -20,9 +20,10 @@ package org.apache.hadoop.ozone.container.diskbalancer;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Writer;
 import java.nio.file.Files;
 import org.apache.hadoop.hdds.server.YamlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -31,6 +32,9 @@ import org.yaml.snakeyaml.Yaml;
  */
 
 public final class DiskBalancerYaml {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DiskBalancerYaml.class);
 
   private DiskBalancerYaml() {
     // static helper methods only, no state.
@@ -50,9 +54,8 @@ public final class DiskBalancerYaml {
     options.setDefaultFlowStyle(DumperOptions.FlowStyle.FLOW);
     Yaml yaml = new Yaml(options);
 
-    try (Writer writer = Files.newBufferedWriter(path.toPath())) {
-      yaml.dump(getDiskBalancerInfoYaml(diskBalancerInfo), writer);
-    }
+    final DiskBalancerInfoYaml data = getDiskBalancerInfoYaml(diskBalancerInfo);
+    YamlUtils.dump(yaml, data, path, LOG);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use AtomicFileOutputStream to write DiskBalancerYaml file.

Because of the following reasons:

Using AtomicFileOutputStream prevents partial or corrupt writes by writing to a temp file and atomically replacing the original.
It will also be consistent with the other yaml files changed in [HDDS-12531](https://issues.apache.org/jira/browse/HDDS-12531)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12879

## How was this patch tested?

passed existing tests.
