### PR TITLE
HDDS-12883. Close file descriptor of block file in datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.ozone.container.common.interfaces;
 import static org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.time.Clock;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -232,6 +232,6 @@ public abstract class Handler {
     this.clusterId = clusterID;
   }
 
-  public abstract FileDescriptor getBlockFileDescriptor(ContainerCommandRequestProto request)
+  public abstract RandomAccessFile getBlockFile(ContainerCommandRequestProto request)
       throws IOException;
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -23,8 +23,8 @@ import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersi
 
 import com.google.common.base.Preconditions;
 import jakarta.annotation.Nonnull;
-import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.EnumMap;
 import java.util.Map;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -142,7 +142,7 @@ public class ChunkManagerDispatcher implements ChunkManager {
   }
 
   @Override
-  public FileDescriptor getShortCircuitFd(Container container, BlockID blockID)
+  public RandomAccessFile getShortCircuitFd(Container container, BlockID blockID)
       throws StorageContainerException {
     return selectHandler(container).getShortCircuitFd(container, blockID);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.container.keyvalue.interfaces;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 
-import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -79,14 +79,14 @@ public interface ChunkManager {
       DispatcherContext dispatcherContext) throws StorageContainerException;
 
   /**
-   * Get the FileDescriptor of a given chunk, to share with client for short circuit read.
+   * Get the RandomAccessFile of a given chunk, to share with client for short circuit read.
    *
    * @param container - Container for the chunk
    * @param blockID - ID of the block.
-   * @return FileDescriptor  - input file descriptor of block file
+   * @return RandomAccessFile  - file for block file
    * @throws StorageContainerException
    */
-  default FileDescriptor getShortCircuitFd(Container container, BlockID blockID)
+  default RandomAccessFile getShortCircuitFd(Container container, BlockID blockID)
       throws StorageContainerException {
     throw new StorageContainerException("Operation is not supported for " + this.getClass().getSimpleName(),
         UNSUPPORTED_REQUEST);


### PR DESCRIPTION
## What changes were proposed in this pull request?

close the file descriptor in datanode after the fd is send to client. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12883

## How was this patch tested?

manual test with docker cluster, before the patch, there will be open block files output in "lsof" command after read key from local when short-circuit is enabled. With the patch, there is more open block files open after the key read. 