### PR TITLE
HDDS-12625. EC related changes for atomic container import

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -91,15 +91,19 @@ public class ECBlockOutputStream extends BlockOutputStream {
 
   @Override
   public synchronized void write(byte[] b, int off, int len) throws IOException {
+    write(b, off, len, true);
+  }
+
+  public synchronized void write(byte[] b, int off, int len, boolean shouldCreateMissingContainer) throws IOException {
     this.currentChunkRspFuture =
         writeChunkToContainer(
-            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)));
+            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)), shouldCreateMissingContainer);
     updateWrittenDataLength(len);
   }
 
   public CompletableFuture<ContainerProtos.ContainerCommandResponseProto> write(
-      ByteBuffer buff) throws IOException {
-    return writeChunkToContainer(ChunkBuffer.wrap(buff));
+      ByteBuffer buff, boolean shouldCreateMissingContainer) throws IOException {
+    return writeChunkToContainer(ChunkBuffer.wrap(buff), shouldCreateMissingContainer);
   }
 
   public CompletableFuture<ContainerProtos.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -434,13 +434,14 @@ public final class ContainerProtocolCalls  {
    * @param blockID ID of the block
    * @param data the data of the chunk to write
    * @param tokenString serialized block token
+   * @param shouldCreateMissingContainer create the container for accommodating the write chunk request if it is missing
    * @throws IOException if there is an I/O error while performing the call
    */
   @SuppressWarnings("parameternumber")
   public static XceiverClientReply writeChunkAsync(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
       ByteString data, String tokenString,
-      int replicationIndex, BlockData blockData, boolean close)
+      int replicationIndex, BlockData blockData, boolean close, boolean shouldCreateMissingContainer)
       throws IOException, ExecutionException, InterruptedException {
 
     WriteChunkRequestProto.Builder writeChunkRequest =
@@ -452,7 +453,8 @@ public final class ContainerProtocolCalls  {
                 .setReplicaIndex(replicationIndex)
                 .build())
             .setChunkData(chunk)
-            .setData(data);
+            .setData(data)
+            .setShouldCreateMissingContainer(shouldCreateMissingContainer);
     if (blockData != null) {
       PutBlockRequestProto.Builder createBlockRequest =
           PutBlockRequestProto.newBuilder()

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -287,7 +287,12 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
        * to get the container created in non writing nodes. If replica index is
        * >0 then we know it's for ec container.
        */
-      if (container == null && ((isWriteStage || isCombinedStage)
+      boolean shouldWriteChunkCreateMissingContainer = (isWriteStage || isCombinedStage);
+      if (shouldWriteChunkCreateMissingContainer && msg.getWriteChunk().hasShouldCreateMissingContainer()) {
+        shouldWriteChunkCreateMissingContainer = msg.getWriteChunk().getShouldCreateMissingContainer();
+      }
+
+      if (container == null && (shouldWriteChunkCreateMissingContainer
           || cmdType == Type.PutSmallFile
           || cmdType == Type.PutBlock)) {
         // If container does not exist, create one for WriteChunk and

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -325,7 +325,7 @@ public class ECReconstructionCoordinator implements Closeable {
                 // If the buffer is empty, we don't need to write it as it will cause
                 // an empty chunk to be added to the end of the block.
                 CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
-                    future = targetBlockStreams[i].write(bufs[i]);
+                    future = targetBlockStreams[i].write(bufs[i], false);
                 checkFailures(targetBlockStreams[i], future);
               }
               bufs[i].clear();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -211,15 +211,7 @@ public class ContainerReader implements Runnable {
             config);
         if (kvContainer.getContainerState() == RECOVERING) {
           if (shouldDelete) {
-            // delete Ratis replicated RECOVERING containers
-            if (kvContainer.getContainerData().getReplicaIndex() == 0) {
-              cleanupContainer(hddsVolume, kvContainer);
-            } else {
-              kvContainer.markContainerUnhealthy();
-              LOG.info("Stale recovering container {} marked UNHEALTHY",
-                  kvContainerData.getContainerID());
-              containerSet.addContainer(kvContainer);
-            }
+            cleanupContainer(hddsVolume, kvContainer);
           }
           return;
         }

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -438,6 +438,7 @@ message WriteChunkRequestProto  {
   optional ChunkInfo chunkData = 2;
   optional bytes data = 3;
   optional PutBlockRequestProto block = 4;
+  optional bool shouldCreateMissingContainer = 5;
 }
 
 message WriteChunkResponseProto {


### PR DESCRIPTION
Please describe your PR in detail:
1. Delete EC containers in `RECOVERING` state upon datanode startup
2. Do not create missing containers when reconstructing EC containers

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12625

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/14601045928