### PR TITLE
HDDS-12649. Include name in length validation error

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -71,7 +71,7 @@ public final class HddsClientUtils {
     if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH ||
         resName.length() > OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH) {
       throw new IllegalArgumentException(resType +
-          " length is illegal, " + "valid length is 3-63 characters");
+          " name '" + resName + "' is of illegal length, " + "valid length is 3-63 characters");
     }
 
     if (resName.charAt(0) == '.' || resName.charAt(0) == '-') {
@@ -150,9 +150,6 @@ public final class HddsClientUtils {
    * @throws IllegalArgumentException
    */
   public static void verifyResourceName(String resName, String resType, boolean isStrictS3) {
-
-    doNameChecks(resName, resType);
-
     boolean isIPv4 = true;
     char prev = (char) 0;
 
@@ -169,6 +166,8 @@ public final class HddsClientUtils {
       throw new IllegalArgumentException(resType +
           " name cannot be an IPv4 address or all numeric");
     }
+
+    doNameChecks(resName, resType);
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -51,6 +51,11 @@ public final class HddsClientUtils {
   static final int MAX_BUCKET_NAME_LENGTH_IN_LOG =
       2 * OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH;
 
+  private static final String VALID_LENGTH_MESSAGE = String.format(
+      "valid length is %d-%d characters",
+      OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH,
+      OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH);
+
   private static final List<Class<? extends Exception>> EXCEPTION_LIST =
       ImmutableList.<Class<? extends Exception>>builder()
           .add(TimeoutException.class)
@@ -74,7 +79,7 @@ public final class HddsClientUtils {
     if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH) {
       throw new IllegalArgumentException(resType +
           " name '" + resName + "' is too short, " +
-          "valid length is 3-63 characters");
+          VALID_LENGTH_MESSAGE);
     }
 
     if (resName.length() > OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH) {
@@ -90,7 +95,7 @@ public final class HddsClientUtils {
 
       throw new IllegalArgumentException(resType +
           " name '" + nameToReport + "' is too long, " +
-          "valid length is 3-63 characters");
+          VALID_LENGTH_MESSAGE);
     }
 
     if (resName.charAt(0) == '.' || resName.charAt(0) == '-') {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
@@ -49,7 +48,6 @@ import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
 public final class HddsClientUtils {
-  @VisibleForTesting
   static final int MAX_BUCKET_NAME_LENGTH_IN_LOG =
       2 * OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH;
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
@@ -234,9 +234,9 @@ public class TestHddsClientUtils {
     }
   }
 
-  private void doTestBadResourceNameReported(String name, String reason) {
-    // The message should include the name, resource type, and expected reason
-    // for rejecting the name.
+  private void doTestBadResourceNameLengthReported(String name, String reason) {
+    // The message should include the name, resource type, range for acceptable
+    // length, and expected reason for rejecting the name.
     List<String> resourceTypes = ImmutableList.of("bucket", "volume");
     for (int i = 0; i < 2; i++) {
       String resType = resourceTypes.get(i);
@@ -252,6 +252,10 @@ public class TestHddsClientUtils {
       assertThat(message).doesNotContain(otherResType);
       assertThat(message).contains(name);
       assertThat(message).contains(reason);
+      assertThat(message).contains(
+          Integer.toString(OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH));
+      assertThat(message).contains(
+          Integer.toString(OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH));
     }
   }
 
@@ -260,7 +264,7 @@ public class TestHddsClientUtils {
     final String tooShort = StringUtils.repeat("a",
         OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH - 1);
 
-    doTestBadResourceNameReported(tooShort, "too short");
+    doTestBadResourceNameLengthReported(tooShort, "too short");
   }
 
   @Test
@@ -269,7 +273,7 @@ public class TestHddsClientUtils {
     final String tooLong = StringUtils.repeat("a",
         OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH + 1);
 
-    doTestBadResourceNameReported(tooLong, "too long");
+    doTestBadResourceNameLengthReported(tooLong, "too long");
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the client, in most cases when the specified volume or bucket name is shorter or longer than the allowed range, the resulting error does not include the name itself. This can make troubleshooting difficult in situations where the name is not implied by the context.

This PR addresses the difficulty by adding the name itself, and the resource type (volume or bucket), to the message of the innermost `IllegalArgumentException`.

In the case of buckets, also adding the volume name seems to have a disproportionate cost in terms of clarity (at each usage). Accordingly, this PR proposes to accept a bucket name as unique enough for debugging purposes. A user of the client may still choose to add this information as desired.

Since adding the name to the message could theoretically be used as an attack vector through logging unsanitized user input verbatim, the length check is moved to after the character check as a precautionary measure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12649

## How was this patch tested?

- Unit test for the new expectations about the message: includes the resource type and name, does not include the name if it fails the character check.
- Manually through the CLI.
- CI on fork: https://github.com/octachoron/ozone/actions/runs/14590841497