### PR TITLE
HDDS-12888. Add negative test cases for FS operations on OBS buckets

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -54,6 +54,7 @@ execute_robot_test scm -v USERNAME:httpfs httpfs
 source "$COMPOSE_DIR/../common/replicas-test.sh"
 
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-o3fs-bucket ozonefs/ozonefs.robot
+execute_robot_test scm -v SCHEME:ofs -N ozonefs-obs ozonefs/ozonefs-obs.robot
 
 execute_robot_test s3g grpc/grpc-om-s3-metrics.robot
 

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
@@ -35,47 +35,50 @@ Create OBS bucket
 
 Verify mkdir fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testdir
-    ${result} =         Execute and checkrc   ozone fs -mkdir ${url}     1
+    ${result} =         Execute and checkrc   ozone fs -mkdir ${url}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify put fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -put NOTICE.txt ${url}     1
+    ${result} =         Execute and checkrc   ozone fs -put NOTICE.txt ${url}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify ls fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}
-    ${result} =         Execute and checkrc   ozone fs -ls ${url}     1
+    ${result} =         Execute and checkrc   ozone fs -ls ${url}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Create key in OBS bucket
+    Execute             ozone sh key put /${volume}/${bucket}/testfile NOTICE.txt
 
 Verify rm fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -rm ${url}     1
+    ${result} =         Execute and checkrc   ozone fs -rm ${url}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify mv fails on OBS bucket
-    ${url1} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile1
+    ${url1} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
     ${url2} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile2
-    ${result} =         Execute and checkrc   ozone fs -mv ${url1} ${url2}     1
+    ${result} =         Execute and checkrc   ozone fs -mv ${url1} ${url2}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify cp fails on OBS bucket
-    ${url1} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile1
+    ${url1} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
     ${url2} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile2
-    ${result} =         Execute and checkrc   ozone fs -cp ${url1} ${url2}     1
+    ${result} =         Execute and checkrc   ozone fs -cp ${url1} ${url2}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify touch fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -touch ${url}     1
+    ${result} =         Execute and checkrc   ozone fs -touch ${url}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify cat fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -cat ${url}     1
+    ${result} =         Execute and checkrc   ozone fs -cat ${url}     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify get fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -get ${url} /tmp/testfile     1
+    ${result} =         Execute and checkrc   ozone fs -get ${url} /tmp/testfilecopy     255
     Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test that FS operations fail on OBS buckets
+Library             OperatingSystem
+Library             String
+Resource            ../commonlib.robot
+Resource            ../lib/fs.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${SCHEME}           ofs
+${volume}           volume1
+${bucket}           obs-bucket1
+${PREFIX}           ozone
+
+*** Test Cases ***
+
+Create OBS bucket
+    Execute             ozone sh volume create /${volume}
+    Execute             ozone sh bucket create /${volume}/${bucket} --layout OBJECT_STORE
+
+Verify mkdir fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testdir
+    ${result} =         Execute and checkrc   ozone fs -mkdir ${url}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify put fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
+    ${result} =         Execute and checkrc   ozone fs -put NOTICE.txt ${url}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify ls fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}
+    ${result} =         Execute and checkrc   ozone fs -ls ${url}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify rm fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
+    ${result} =         Execute and checkrc   ozone fs -rm ${url}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify mv fails on OBS bucket
+    ${url1} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile1
+    ${url2} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile2
+    ${result} =         Execute and checkrc   ozone fs -mv ${url1} ${url2}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify cp fails on OBS bucket
+    ${url1} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile1
+    ${url2} =           Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile2
+    ${result} =         Execute and checkrc   ozone fs -cp ${url1} ${url2}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify touch fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
+    ${result} =         Execute and checkrc   ozone fs -touch ${url}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify cat fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
+    ${result} =         Execute and checkrc   ozone fs -cat ${url}     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
+Verify get fails on OBS bucket
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
+    ${result} =         Execute and checkrc   ozone fs -get ${url} /tmp/testfile     1
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, there are no automated tests validating the failure behaviour of `ozone fs` operations on buckets with `OBJECT_STORE` layout. Since OBS buckets do not support file system semantics, operations such as `mkdir`, `put`, `ls`, `rm`, `mv`, etc., are expected to fail with an `IllegalArgumentException`.

With these changes, behavioural regressions (like the ones below) that are not detected by the current CI can be identified:

- https://github.com/apache/ozone/pull/7122
- https://github.com/apache/ozone/pull/8288#issuecomment-2804412963

This patch adds a dedicated robot test suite to cover these negative scenarios, improving the overall test coverage for the ozone fs interface.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12888

## How was this patch tested?

- Added robot tests (green CI: https://github.com/tanvipenumudy/ozone/actions/runs/14614110211/)
