### PR TITLE
HDDS-12891. OMKeyAclRequestWithFSO is incorrectly setting full path as key name.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.ObjectParser;
@@ -96,6 +97,9 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
         throw new OMException("Key not found. Key:" + key, KEY_NOT_FOUND);
       }
       omKeyInfo = keyStatus.getKeyInfo();
+      // Reverting back the full path to key name
+      // Eg: a/b/c/d/e/file1 -> file1
+      omKeyInfo.setKeyName(OzoneFSUtils.getFileName(key));
       final long volumeId = omMetadataManager.getVolumeId(volume);
       final long bucketId = omMetadataManager.getBucketId(volume, bucket);
       final String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
@@ -83,6 +83,10 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
     assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
+    // Verify result of adding acl.
+    OmKeyInfo newKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(1, newKeyInfo.getAcls().size());
+    assertEquals(omKeyInfo.getKeyName(), newKeyInfo.getKeyName());
   }
 
   @Test
@@ -141,10 +145,9 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         omRemoveAclResponse.getStatus());
 
     // Verify result of removing acl.
-    List<OzoneAcl> newAcls =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
-            .getAcls();
-    assertEquals(0, newAcls.size());
+    OmKeyInfo newKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(0, newKeyInfo.getAcls().size());
+    assertEquals(omKeyInfo.getKeyName(), newKeyInfo.getKeyName());
   }
 
   @Test
@@ -182,10 +185,9 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         omSetAclResponse.getStatus());
 
     // Verify result of setting acl.
-    List<OzoneAcl> newAcls =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
-            .getAcls();
-    assertEquals(newAcls.get(0), acl);
+    OmKeyInfo newKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(newKeyInfo.getAcls().get(0), acl);
+    assertEquals(omKeyInfo.getKeyName(), newKeyInfo.getKeyName());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
@@ -38,8 +38,7 @@ public class TestOMKeyAclRequestWithFSO extends TestOMKeyAclRequest {
   protected String addKeyToTable() throws Exception {
     String parentDir = "c/d/e";
     String fileName = "file1";
-    String key = parentDir + "/" + fileName;
-    keyName = key; // updated key name
+    keyName = parentDir + "/" + fileName; // updated key name
 
     // Create parent dirs for the path
     long parentId = OMRequestTestUtils
@@ -47,7 +46,7 @@ public class TestOMKeyAclRequestWithFSO extends TestOMKeyAclRequest {
             omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key, RatisReplicationConfig.getInstance(ONE))
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, fileName, RatisReplicationConfig.getInstance(ONE))
             .setObjectID(parentId + 1L)
             .setParentObjectID(parentId)
             .setUpdateID(100L)


### PR DESCRIPTION
## What changes were proposed in this pull request?
When setting, removing, and adding an ACL, we incorrectly set the full key path as the key name. It should only be the leaf node name. This patch fixes it by reverting the full path to the key name.
.
For eg:
`a/b/c/d/e/file1 `is set as the key name, thus corrupting the metadata table. Instead, we should only set `file1` as the key name.


### Repro in Docker
```
ozone freon ockg -n=2 -v=vol1 -b=bucket1 -p=test1/test2
ozone sh key setacl vol1/bucket1/test1/test2/0 -a=user:user1:rw
ozone debug ldb --db=/data/metadata/om.db scan --column_family=fileTable | grep keyName

```
### Without fix
```
sh-5.1$ ozone debug ldb --db=/data/metadata/om.db scan --column_family=fileTable | grep keyName
  "keyName" : "test1/test2/0",
  "keyName" : "1",
```

###With fix
```
sh-5.1$ ozone debug ldb --db=/data/metadata/om.db scan --column_family=fileTable | grep keyName
  "keyName" : "0",
  "keyName" : "1",
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12891

## How was this patch tested?

Updated unit tests.
