### PR TITLE
HDDS-12833. Remove the CodecRegistry field from DBStoreBuilder.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
@@ -72,7 +72,7 @@ public abstract class AbstractRDBStore<DEF extends DBDefinition> implements DBSt
       options.setInfoLogLevel(level);
       options.setMaxLogFileSize(dc.getRocksdbLogMaxFileSize());
       options.setKeepLogFileNum(dc.getRocksdbLogMaxFileNum());
-      this.store = initDBStore(DBStoreBuilder.newBuilder(config, dbDef)
+      this.store = initDBStore(DBStoreBuilder.newBuilder(config, dbDef, null, null)
           .setDBOptions(options)
           .setDefaultCFOptions(cfOptions)
           .setOpenReadOnly(openReadOnly), options, config);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -32,7 +32,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,11 +58,9 @@ import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.proxy.SCMContainerLocationFailoverProxyProvider;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -250,9 +247,7 @@ public final class HAUtils {
       DBDefinition definition)
       throws IOException {
 
-    try (DBStore dbStore = loadDB(tempConfig, dbDir.toFile(),
-        dbName, definition)) {
-
+    try (DBStore dbStore = DBStoreBuilder.newBuilder(tempConfig, definition, dbName, dbDir).build()) {
       // Get the table name with TransactionInfo as the value. The transaction
       // info table name are different in SCM and SCM.
 
@@ -305,27 +300,6 @@ public final class HAUtils {
       return false;
     }
     return true;
-  }
-
-  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
-      String dbName, DBDefinition definition) throws IOException {
-    RocksDBConfiguration rocksDBConfiguration =
-        configuration.getObject(RocksDBConfiguration.class);
-    DBStoreBuilder dbStoreBuilder =
-        DBStoreBuilder.newBuilder(configuration, rocksDBConfiguration)
-            .setName(dbName)
-            .setPath(Paths.get(metaDir.getPath()));
-    // Add column family names and codecs.
-    for (DBColumnFamilyDefinition columnFamily : definition
-        .getColumnFamilies()) {
-
-      dbStoreBuilder.addTable(columnFamily.getName());
-      dbStoreBuilder
-          .addCodec(columnFamily.getKeyType(), columnFamily.getKeyCodec());
-      dbStoreBuilder
-          .addCodec(columnFamily.getValueType(), columnFamily.getValueCodec());
-    }
-    return dbStoreBuilder.build();
   }
 
   public static File getMetaDir(DBDefinition definition,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -29,7 +29,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_DELTA_UPDATE_DATA
 import static org.rocksdb.RocksDB.DEFAULT_COLUMN_FAMILY;
 
 import com.google.common.base.Preconditions;
-import com.google.protobuf.MessageLite;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -91,7 +90,6 @@ public final class DBStoreBuilder {
   // any options. On build, this will be replaced with defaultCfOptions.
   private Map<String, ManagedColumnFamilyOptions> cfOptions;
   private ConfigurationSource configuration;
-  private final CodecRegistry.Builder registry = CodecRegistry.newBuilder();
   private String rocksDbStat;
   // RocksDB column family write buffer size
   private long rocksDbCfWriteBufferSize;
@@ -112,26 +110,21 @@ public final class DBStoreBuilder {
    */
   public static DBStore createDBStore(ConfigurationSource configuration,
       DBDefinition definition) throws IOException {
-    return newBuilder(configuration, definition).build();
+    return newBuilder(configuration, definition, null, null).build();
   }
 
-  public static DBStoreBuilder newBuilder(ConfigurationSource configuration,
-      DBDefinition definition) {
+  public static DBStoreBuilder newBuilder(ConfigurationSource conf, DBDefinition definition, File dbDir) {
+    return newBuilder(conf, definition, dbDir.getName(), dbDir.getParentFile().toPath());
+  }
 
-    DBStoreBuilder builder = newBuilder(configuration);
-    builder.applyDBDefinition(definition);
-
-    return builder;
+  public static DBStoreBuilder newBuilder(ConfigurationSource conf, DBDefinition definition,
+      String name, Path metadataDir) {
+    return newBuilder(conf).apply(definition, name, metadataDir);
   }
 
   public static DBStoreBuilder newBuilder(ConfigurationSource configuration) {
-    return newBuilder(configuration,
+    return new DBStoreBuilder(configuration,
         configuration.getObject(RocksDBConfiguration.class));
-  }
-
-  public static DBStoreBuilder newBuilder(ConfigurationSource configuration,
-      RocksDBConfiguration rocksDBConfiguration) {
-    return new DBStoreBuilder(configuration, rocksDBConfiguration);
   }
 
   private DBStoreBuilder(ConfigurationSource configuration,
@@ -173,21 +166,23 @@ public final class DBStoreBuilder {
     return metadataDir;
   }
 
-  private void applyDBDefinition(DBDefinition definition) {
-    // Set metadata dirs.
-    File metadataDir = getDBDirPath(definition, configuration);
+  private DBStoreBuilder apply(DBDefinition definition, String name, Path metadataDir) {
+    if (name == null) {
+      name = definition.getName();
+    }
+    setName(name);
 
-    setName(definition.getName());
-    setPath(Paths.get(metadataDir.getPath()));
+    // Set metadata dirs.
+    if (metadataDir == null) {
+      metadataDir = getDBDirPath(definition, configuration).toPath();
+    }
+    setPath(metadataDir);
 
     // Add column family names and codecs.
-    for (DBColumnFamilyDefinition columnFamily :
-        definition.getColumnFamilies()) {
-
+    for (DBColumnFamilyDefinition<?, ?> columnFamily : definition.getColumnFamilies()) {
       addTable(columnFamily.getName(), columnFamily.getCfOptions());
-      addCodec(columnFamily.getKeyType(), columnFamily.getKeyCodec());
-      addCodec(columnFamily.getValueType(), columnFamily.getValueCodec());
     }
+    return this;
   }
 
   private void setDBOptionsProps(ManagedDBOptions dbOptions) {
@@ -206,7 +201,7 @@ public final class DBStoreBuilder {
    *
    * @return DBStore
    */
-  public DBStore build() throws IOException {
+  public RDBStore build() throws IOException {
     if (StringUtil.isBlank(dbname) || (dbPath == null)) {
       LOG.error("Required Parameter missing.");
       throw new IOException("Required parameter is missing. Please make sure "
@@ -229,7 +224,7 @@ public final class DBStoreBuilder {
       }
 
       return new RDBStore(dbFile, rocksDBOption, statistics, writeOptions, tableConfigs,
-          registry.build(), openReadOnly, dbJmxBeanNameName, enableCompactionDag,
+          openReadOnly, dbJmxBeanNameName, enableCompactionDag,
           maxDbUpdatesSizeThreshold, createCheckpointDirs, configuration,
           enableRocksDbMetrics);
     } finally {
@@ -255,15 +250,6 @@ public final class DBStoreBuilder {
       ManagedColumnFamilyOptions options) {
     cfOptions.put(tableName, options);
     return this;
-  }
-
-  public <T> DBStoreBuilder addCodec(Class<T> type, Codec<T> codec) {
-    registry.addCodec(type, codec);
-    return this;
-  }
-
-  public <T extends MessageLite> DBStoreBuilder addProto2Codec(T type) {
-    return addCodec((Class<T>)type.getClass(), Proto2Codec.get(type));
   }
 
   public DBStoreBuilder setDBOptions(ManagedDBOptions option) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -75,9 +75,9 @@ public class RDBStore implements DBStore {
   private final ManagedStatistics statistics;
 
   @SuppressWarnings("parameternumber")
-  public RDBStore(File dbFile, ManagedDBOptions dbOptions, ManagedStatistics statistics,
+  RDBStore(File dbFile, ManagedDBOptions dbOptions, ManagedStatistics statistics,
                   ManagedWriteOptions writeOptions, Set<TableConfig> families,
-                  CodecRegistry registry, boolean readOnly,
+                  boolean readOnly,
                   String dbJmxBeanName, boolean enableCompactionDag,
                   long maxDbUpdatesSizeThreshold,
                   boolean createCheckpointDirs,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -203,11 +202,7 @@ public class TestDBStoreBuilder {
       }
     };
 
-    try (DBStore dbStore = DBStoreBuilder.newBuilder(conf, sampleDB)
-        .setName("SampleStore").setPath(newFolder.toPath()).build()) {
-      assertInstanceOf(RDBStore.class, dbStore);
-
-      RDBStore rdbStore = (RDBStore) dbStore;
+    try (RDBStore rdbStore = DBStoreBuilder.newBuilder(conf, sampleDB, "SampleStore", newFolder.toPath()).build()) {
       Collection<RocksDatabase.ColumnFamily> cfFamilies =
           rdbStore.getColumnFamilies();
 
@@ -267,13 +262,9 @@ public class TestDBStoreBuilder {
       }
     };
 
-    try (DBStore dbStore = DBStoreBuilder.newBuilder(conf, sampleDB)
-            .setName("SampleStore")
-            .disableDefaultCFAutoCompaction(disableAutoCompaction)
-            .setPath(newFolder.toPath()).build()) {
-      assertInstanceOf(RDBStore.class, dbStore);
-
-      RDBStore rdbStore = (RDBStore) dbStore;
+    try (RDBStore rdbStore = DBStoreBuilder.newBuilder(conf, sampleDB, "SampleStore", newFolder.toPath())
+        .disableDefaultCFAutoCompaction(disableAutoCompaction)
+        .build()) {
       Collection<RocksDatabase.ColumnFamily> cfFamilies =
               rdbStore.getColumnFamilies();
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -88,7 +88,7 @@ public class TestRDBStore {
       long maxDbUpdatesSizeThreshold)
       throws IOException {
     return new RDBStore(dbFile, options, null, new ManagedWriteOptions(), families,
-        CodecRegistry.newBuilder().build(), false, null, false,
+        false, null, false,
         maxDbUpdatesSizeThreshold, true, null, true);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.jupiter.api.AfterAll;
@@ -130,8 +131,7 @@ public class TestSCMInstallSnapshot {
     assertNotNull(parent);
     Path fileName = location.getFileName();
     assertNotNull(fileName);
-    final DBStore db = HAUtils.loadDB(conf, parent.toFile(),
-        fileName.toString(), SCMDBDefinition.get());
+    final DBStore db = DBStoreBuilder.newBuilder(conf, SCMDBDefinition.get(), location.toFile()).build();
     // Hack the transaction index in the checkpoint so as to ensure the
     // checkpointed transaction index is higher than when it was downloaded
     // from.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -92,13 +93,7 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
    */
   private void initializeNewRdbStore(File dbFile) throws IOException {
     try {
-      DBStoreBuilder dbStoreBuilder =
-          DBStoreBuilder.newBuilder(ozoneConfiguration)
-          .setName(dbFile.getName())
-          .setPath(dbFile.toPath().getParent());
-      addOMTablesAndCodecs(dbStoreBuilder);
-      dbStoreBuilder.addCodec(KeyEntityInfoProtoWrapper.class, KeyEntityInfoProtoWrapper.getCodec());
-      setStore(dbStoreBuilder.build());
+      setStore(DBStoreBuilder.newBuilder(ozoneConfiguration, OMDBDefinition.get(), dbFile).build());
       LOG.info("Created OM DB handle from snapshot at {}.",
           dbFile.getAbsolutePath());
     } catch (IOException ioEx) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorOm.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorOm.java
@@ -35,12 +35,10 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.freon.FreonSubcommand;
 import org.apache.hadoop.ozone.om.OMStorage;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -96,18 +94,8 @@ public class GeneratorOm extends BaseGenerator implements
 
     File metaDir = OMStorage.getOmDbDir(config);
 
-    RocksDBConfiguration rocksDBConfiguration =
-        config.getObject(RocksDBConfiguration.class);
+    omDb = DBStoreBuilder.newBuilder(config, OMDBDefinition.get(), OM_DB_NAME, metaDir.toPath()).build();
 
-    DBStoreBuilder dbStoreBuilder =
-        DBStoreBuilder.newBuilder(config,
-            rocksDBConfiguration)
-            .setName(OM_DB_NAME)
-            .setPath(metaDir.toPath());
-
-    OmMetadataManagerImpl.addOMTablesAndCodecs(dbStoreBuilder);
-
-    omDb = dbStoreBuilder.build();
 
     // initialization: create one bucket and volume in OM.
     writeOmBucketVolume();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `codecRegistry` field in RDBStore was removed by [HDDS-12922](https://issues.apache.org/jira/browse/HDDS-12922). We should also remove the CodecRegistry field from `DBStoreBuilder`.

## What is the link to the Apache JIRA

HDDS-12833

## How was this patch tested?

By updating existing tests.