### PR TITLE
HDDS-12893. cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -130,16 +130,23 @@ run cp -p -r "${ROOT}/hadoop-ozone/dist/target/Dockerfile" .
 
 run mkdir compose/_keytabs
 
+# Determine CPFLAGS based on system type
+if [ "$(uname)" = "Darwin" ]; then
+  CPFLAGS="--no-clobber"
+else
+  CPFLAGS="--update=none"
+fi
+
 for file in $(find "${ROOT}" -path '*/target/classes/*.classpath' | sort); do
   # We need to add the artifact manually as it's not part the generated classpath desciptor
   module=$(basename "${file%.classpath}")
   sed -i -e "s;$;:\$HDDS_LIB_JARS_DIR/${module}-${HDDS_VERSION}.jar;" "$file"
 
-  cp --update=none -p -v "$file" share/ozone/classpath/
+  cp $CPFLAGS -p -v "$file" share/ozone/classpath/
 done
 
 for file in $(find "${ROOT}" -path '*/share/ozone/lib/*jar' | sort); do
-  cp --update=none -p -v "$file" share/ozone/lib/
+  cp $CPFLAGS -p -v "$file" share/ozone/lib/
 done
 
 #workaround for https://issues.apache.org/jira/browse/MRESOURCES-236

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -135,11 +135,11 @@ for file in $(find "${ROOT}" -path '*/target/classes/*.classpath' | sort); do
   module=$(basename "${file%.classpath}")
   sed -i -e "s;$;:\$HDDS_LIB_JARS_DIR/${module}-${HDDS_VERSION}.jar;" "$file"
 
-  cp -n -p -v "$file" share/ozone/classpath/
+  cp --update=none -p -v "$file" share/ozone/classpath/
 done
 
 for file in $(find "${ROOT}" -path '*/share/ozone/lib/*jar' | sort); do
-  cp -n -p -v "$file" share/ozone/lib/
+  cp --update=none -p -v "$file" share/ozone/lib/
 done
 
 #workaround for https://issues.apache.org/jira/browse/MRESOURCES-236


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pull request resolves HDDS-12893 by replacing `cp -n` with` --update=none` in the dist-layout-stitching script to eliminate the non-portable -n warning.

Please describe your PR in detail:
This PR updated the build script (hadoop-ozone/dist/src/main/bin/dist-layout-stitching) to replace all cp -n usages with` cp --update=none. `

## What is the link to the Apache JIRA
[HDDS-12893](https://issues.apache.org/jira/browse/HDDS-12893)

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
-  Run the script on Ubuntu 22.04; no cp -n warnings appeared.
-  Test in Docker containers (Alpine Linux, CentOS 7); script executed without warnings.
(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
