### PR TITLE
HDDS-9585. Improved import/export log in ContainerLogger

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -128,7 +128,7 @@ public final class ContainerLogger {
    * @param containerData The container that was imported to this datanode.
    */
   public static void logImported(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData, "Container imported"));
   }
 
   /**
@@ -137,7 +137,7 @@ public final class ContainerLogger {
    * @param containerData The container that was exported from this datanode.
    */
   public static void logExported(ContainerData containerData) {
-    LOG.info(getMessage(containerData));
+    LOG.info(getMessage(containerData, "Container exported"));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds a message to import and export logs in `ContainerLogger` as there was no log message telling about both importing and exporting a container.

## What is the link to the Apache JIRA
[HDDS-9585](https://issues.apache.org/jira/browse/HDDS-9585)

## How was this patch tested?

CI:
https://github.com/kostacie/ozone/actions/runs/14635913888
