### PR TITLE
HDDS-12893. cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -132,7 +132,7 @@ run mkdir compose/_keytabs
 
 # Determine CPFLAGS based on system type
 if [ "$(uname)" = "Darwin" ]; then
-  CPFLAGS="--no-clobber"
+  CPFLAGS="-n"
 else
   CPFLAGS="--update=none"
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12893. cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead

* #8328 does not support Mac
* Attempt to support copy file without overwrite on both Mac and Linux

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12893

## How was this patch tested?

Tested on Mac