### PR TITLE
HDDS-12912. Remove deprecated `PipelineManager#closePipeline(Pipeline, boolean)`

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -112,10 +112,6 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
 
   void openPipeline(PipelineID pipelineId) throws IOException;
 
-  @Deprecated
-  void closePipeline(Pipeline pipeline, boolean onTimeout)
-      throws IOException;
-
   void closePipeline(PipelineID pipelineID) throws IOException;
 
   void deletePipeline(PipelineID pipelineID) throws IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -489,20 +489,6 @@ public class PipelineManagerImpl implements PipelineManager {
   }
 
   /**
-   * put pipeline in CLOSED state.
-   * @param pipeline - ID of the pipeline.
-   * @param onTimeout - whether to remove pipeline after some time.
-   * @throws IOException throws exception in case of failure
-   * @deprecated Do not use this method, onTimeout is not honored.
-   */
-  @Override
-  @Deprecated
-  public void closePipeline(Pipeline pipeline, boolean onTimeout)
-          throws IOException {
-    closePipeline(pipeline.getId());
-  }
-
-  /**
    * Move the Pipeline to CLOSED state.
    * @param pipelineID ID of the Pipeline to be closed
    * @throws IOException In case of exception while closing the Pipeline

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -137,7 +137,7 @@ public class WritableECContainerProvider
           if (containerInfo == null
               || !containerHasSpace(containerInfo, size)) {
             existingPipelines.remove(pipelineIndex);
-            pipelineManager.closePipeline(pipeline, true);
+            pipelineManager.closePipeline(pipeline.getId());
             openPipelineCount--;
           } else {
             if (pipelineIsExcluded(pipeline, containerInfo, excludeList)) {
@@ -151,7 +151,7 @@ public class WritableECContainerProvider
           LOG.warn("Pipeline or container not found when selecting a writable "
               + "container", e);
           existingPipelines.remove(pipelineIndex);
-          pipelineManager.closePipeline(pipeline, true);
+          pipelineManager.closePipeline(pipeline.getId());
           openPipelineCount--;
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -882,7 +882,7 @@ public class SCMClientProtocolServer implements
       PipelineManager pipelineManager = scm.getPipelineManager();
       Pipeline pipeline =
           pipelineManager.getPipeline(PipelineID.getFromProtobuf(pipelineID));
-      pipelineManager.closePipeline(pipeline, true);
+      pipelineManager.closePipeline(pipeline.getId());
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
           SCMAction.CLOSE_PIPELINE, auditMap));
     } catch (Exception ex) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -150,7 +150,7 @@ public class SCMUpgradeFinalizer extends
 
     for (Pipeline pipeline : pipelineManager.getPipelines()) {
       if (pipeline.getPipelineState() != CLOSED) {
-        pipelineManager.closePipeline(pipeline, true);
+        pipelineManager.closePipeline(pipeline.getId());
       }
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -575,7 +575,7 @@ public class TestBlockManager {
   public void testBlockAllocationWithNoAvailablePipelines()
       throws IOException {
     for (Pipeline pipeline : pipelineManager.getPipelines()) {
-      pipelineManager.closePipeline(pipeline, false);
+      pipelineManager.closePipeline(pipeline.getId());
     }
     assertEquals(0, pipelineManager.getPipelines(replicationConfig).size());
     assertNotNull(blockManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -236,15 +236,10 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
-  public void closePipeline(final Pipeline pipeline, final boolean onTimeout)
+  public void closePipeline(final PipelineID pipelineId)
       throws IOException {
-    stateManager.updatePipelineState(pipeline.getId().getProtobuf(),
+    stateManager.updatePipelineState(pipelineId.getProtobuf(),
         HddsProtos.PipelineState.PIPELINE_CLOSED);
-  }
-
-  @Override
-  public void closePipeline(PipelineID pipelineID) throws IOException {
-
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -350,7 +350,7 @@ public class TestPipelineManagerImpl {
       Pipeline pipeline = assertAllocate(pipelineManager);
       changeToFollower(pipelineManager);
       assertFailsNotLeader(
-          () -> pipelineManager.closePipeline(pipeline, false));
+          () -> pipelineManager.closePipeline(pipeline.getId()));
     }
   }
 
@@ -521,7 +521,7 @@ public class TestPipelineManagerImpl {
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE));
     pipelineManager.openPipeline(closedPipeline.getId());
-    pipelineManager.closePipeline(closedPipeline, true);
+    pipelineManager.closePipeline(closedPipeline.getId());
 
     // pipeline should be seen in pipelineManager as CLOSED.
     assertTrue(pipelineManager

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -276,7 +276,7 @@ public class TestWatchForCommit {
         cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
         // emulate closing pipeline when SCM detects DEAD datanodes
         cluster.getStorageContainerManager()
-            .getPipelineManager().closePipeline(pipeline, false);
+            .getPipelineManager().closePipeline(pipeline.getId());
         // again write data with more than max buffer limit. This wi
         // just watch for a log index which in not updated in the commitInfo Map
         // as well as there is no logIndex generate in Ratis.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestScmApplyTransactionFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestScmApplyTransactionFailure.java
@@ -69,7 +69,7 @@ public abstract class TestScmApplyTransactionFailure implements HATests.TestCase
     Pipeline pipeline = pipelines.get(0);
 
     // if testing for not-found pipeline, remove pipeline when closing.
-    pipelineManager.closePipeline(pipeline, true);
+    pipelineManager.closePipeline(pipeline.getId());
 
     // adding container to a closed pipeline should yield an error.
     ContainerInfoProto containerInfo = createContainer(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
@@ -184,7 +184,7 @@ public class TestLeaderChoosePolicy {
 
       int destroyNum = RandomUtils.secure().randomInt(0, pipelines.size());
       for (int k = 0; k <= destroyNum; k++) {
-        pipelineManager.closePipeline(pipelines.get(k), false);
+        pipelineManager.closePipeline(pipelines.get(k).getId());
       }
 
       waitForPipelines(pipelineNum);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -167,7 +167,7 @@ public class TestPipelineClose {
     assertEquals(1, setOpen.size());
 
     pipelineManager
-        .closePipeline(ratisContainer.getPipeline(), false);
+        .closePipeline(ratisContainer.getPipeline().getId());
     GenericTestUtils.waitFor(() -> {
       try {
         return containerManager

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -90,7 +90,7 @@ public class TestRatisPipelineCreateAndDestroy {
         .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
     for (Pipeline pipeline : pipelines) {
-      pipelineManager.closePipeline(pipeline, false);
+      pipelineManager.closePipeline(pipeline.getId());
     }
     // make sure two pipelines are created
     waitForPipelines(2);
@@ -112,7 +112,7 @@ public class TestRatisPipelineCreateAndDestroy {
         .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
     for (Pipeline pipeline : pipelines) {
-      pipelineManager.closePipeline(pipeline, false);
+      pipelineManager.closePipeline(pipeline.getId());
     }
 
     // make sure two pipelines are created
@@ -155,7 +155,7 @@ public class TestRatisPipelineCreateAndDestroy {
 
     // destroy the existing pipelines
     for (Pipeline pipeline : pipelines) {
-      pipelineManager.closePipeline(pipeline, false);
+      pipelineManager.closePipeline(pipeline.getId());
     }
 
     if (cluster.getStorageContainerManager()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -239,7 +239,7 @@ public class TestContainerCommandsEC {
             Pipeline.PipelineState.OPEN)
         .forEach(p -> {
           try {
-            scm.getPipelineManager().closePipeline(p, false);
+            scm.getPipelineManager().closePipeline(p.getId());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -271,7 +271,7 @@ public class TestContainerCommandsEC {
             ANY_USER, ContainerID.valueOf(orphanContainerID));
 
     // Close the container by closing the pipeline
-    scm.getPipelineManager().closePipeline(orphanPipeline, false);
+    scm.getPipelineManager().closePipeline(orphanPipeline.getId());
 
     // Find the datanode hosting Replica index = 2
     HddsDatanodeService dn2Service = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -155,7 +155,7 @@ public final class OzoneTestUtils {
       throws IOException, TimeoutException, InterruptedException {
     Pipeline pipeline = scm.getPipelineManager()
         .getPipeline(container.getPipelineID());
-    scm.getPipelineManager().closePipeline(pipeline, true);
+    scm.getPipelineManager().closePipeline(pipeline.getId());
     GenericTestUtils.waitFor(() ->
             container.getState() == HddsProtos.LifeCycleState.CLOSED,
         200, 30000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -441,7 +441,7 @@ public class TestECKeyOutputStream {
     PipelineManager pm =
         cluster.getStorageContainerManager().getPipelineManager();
     for (Pipeline p : pm.getPipelines(repConfig)) {
-      pm.closePipeline(p, true);
+      pm.closePipeline(p.getId());
     }
 
     String keyName = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -289,7 +289,7 @@ public final class TestHelper {
     for (Pipeline pipeline1 : pipelineList) {
       // issue pipeline destroy command
       cluster.getStorageContainerManager()
-          .getPipelineManager().closePipeline(pipeline1, false);
+          .getPipelineManager().closePipeline(pipeline1.getId());
     }
 
     // wait for the pipeline to get destroyed in the datanodes

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -213,7 +213,7 @@ public class TestCloseContainerByPipeline {
     assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
 
     cluster.getStorageContainerManager().getPipelineManager()
-        .closePipeline(pipeline, false);
+        .closePipeline(pipeline.getId());
     Thread.sleep(5000);
     // Pipeline close should not affect a container in CLOSED state
     assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
@@ -317,7 +317,7 @@ public class TestCloseContainerByPipeline {
 
     // close the pipeline
     cluster.getStorageContainerManager()
-        .getPipelineManager().closePipeline(pipeline, false);
+        .getPipelineManager().closePipeline(pipeline.getId());
 
     // All the containers in OPEN or CLOSING state should transition to
     // QUASI-CLOSED after pipeline close

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
@@ -128,6 +128,6 @@ public class TestFreonWithPipelineDestroy {
     PipelineManager pipelineManager =
         cluster.getStorageContainerManager().getPipelineManager();
     Pipeline pipeline = pipelineManager.getPipeline(id);
-    pipelineManager.closePipeline(pipeline, false);
+    pipelineManager.closePipeline(pipeline.getId());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `closePipeline(Pipeline pipeline, boolean onTimeout)` has been deprecated since https://github.com/apache/ozone/pull/5604/files#r1400539952 . We can remove it completely. Please take a look, thanks!

## What is the link to the Apache JIRA
[HDDS-12912](https://issues.apache.org/jira/browse/HDDS-12912)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14679988038
