### PR TITLE
HDDS-12902. Shutdown executor in CloseContainerCommandHandler and ECReconstructionCoordinator

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -227,4 +227,9 @@ public class CloseContainerCommandHandler implements CommandHandler {
   public int getThreadPoolActivePoolSize() {
     return executor.getActiveCount();
   }
+
+  @Override
+  public void stop() {
+    executor.shutdownNow();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -464,6 +464,7 @@ public class ECReconstructionCoordinator implements Closeable {
     if (ecReconstructWriteExecutor.isInitialized()) {
       ecReconstructWriteExecutor.get().shutdownNow();
     }
+    ecReconstructReadExecutor.shutdownNow();
   }
 
   private Pipeline rebuildInputPipeline(ECReplicationConfig repConfig,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shutdown the executor explicitly when its owner is closing.
- CloseContainerCommandHandler.java
- ECReconstructionCoordinator.java

btw I think the mission doing in executor is quite critical, so I didn't change to setting it to deamon(your first suggestion.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12902

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/14680161320