### PR TITLE
HDDS-12905. Move field declarations to start of class in ozone-common module

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/client/io/SelectorOutputStream.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/client/io/SelectorOutputStream.java
@@ -38,6 +38,10 @@ import org.apache.ratis.util.function.CheckedFunction;
  */
 public class SelectorOutputStream<OUT extends OutputStream>
     extends OutputStream implements Syncable, StreamCapabilities {
+
+  private final ByteArrayBuffer buffer;
+  private final Underlying underlying;
+
   /** A buffer backed by a byte[]. */
   static final class ByteArrayBuffer {
     private byte[] array;
@@ -107,9 +111,6 @@ public class SelectorOutputStream<OUT extends OutputStream>
       return out;
     }
   }
-
-  private final ByteArrayBuffer buffer;
-  private final Underlying underlying;
 
   /**
    * Construct a {@link SelectorOutputStream} which first writes to a buffer.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -48,10 +48,6 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
       OmBucketInfo::getProtobuf,
       OmBucketInfo.class);
 
-  public static Codec<OmBucketInfo> getCodec() {
-    return CODEC;
-  }
-
   /**
    * Name of the volume in which the bucket belongs to.
    */
@@ -127,6 +123,10 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     this.bucketLayout = b.bucketLayout;
     this.owner = b.owner;
     this.defaultReplicationConfig = b.defaultReplicationConfig;
+  }
+
+  public static Codec<OmBucketInfo> getCodec() {
+    return CODEC;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -36,10 +36,6 @@ public final class OmDBAccessIdInfo {
       OmDBAccessIdInfo.class,
       DelegatedCodec.CopyType.SHALLOW);
 
-  public static Codec<OmDBAccessIdInfo> getCodec() {
-    return CODEC;
-  }
-
   /**
    * Name of the tenant.
    */
@@ -64,6 +60,10 @@ public final class OmDBAccessIdInfo {
     this.userPrincipal = userPrincipal;
     this.isAdmin = isAdmin;
     this.isDelegatedAdmin = isDelegatedAdmin;
+  }
+
+  public static Codec<OmDBAccessIdInfo> getCodec() {
+    return CODEC;
   }
 
   public String getTenantId() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -36,10 +36,6 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
       OmDBTenantState.class,
       DelegatedCodec.CopyType.SHALLOW);
 
-  public static Codec<OmDBTenantState> getCodec() {
-    return CODEC;
-  }
-
   /**
    * Name of the tenant.
    */
@@ -74,6 +70,10 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     this.adminRoleName = adminRoleName;
     this.bucketNamespacePolicyName = bucketNamespacePolicyName;
     this.bucketPolicyName = bucketPolicyName;
+  }
+
+  public static Codec<OmDBTenantState> getCodec() {
+    return CODEC;
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
@@ -38,10 +38,6 @@ public final class OmDBUserPrincipalInfo {
       OmDBUserPrincipalInfo::getProtobuf,
       OmDBUserPrincipalInfo.class);
 
-  public static Codec<OmDBUserPrincipalInfo> getCodec() {
-    return CODEC;
-  }
-
   /**
    * A set of accessIds.
    */
@@ -49,6 +45,10 @@ public final class OmDBUserPrincipalInfo {
 
   public OmDBUserPrincipalInfo(Set<String> accessIds) {
     this.accessIds = new HashSet<>(accessIds);
+  }
+
+  public static Codec<OmDBUserPrincipalInfo> getCodec() {
+    return CODEC;
   }
 
   public Set<String> getAccessIds() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -42,10 +42,6 @@ public class OmDirectoryInfo extends WithParentObjectId
       OmDirectoryInfo::getProtobuf,
       OmDirectoryInfo.class);
 
-  public static Codec<OmDirectoryInfo> getCodec() {
-    return CODEC;
-  }
-
   private final String name; // directory name
   private String owner;
 
@@ -61,6 +57,10 @@ public class OmDirectoryInfo extends WithParentObjectId
     this.acls = builder.acls;
     this.creationTime = builder.creationTime;
     this.modificationTime = builder.modificationTime;
+  }
+
+  public static Codec<OmDirectoryInfo> getCodec() {
+    return CODEC;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -59,19 +59,6 @@ public final class OmKeyInfo extends WithParentObjectId
   private static final Codec<OmKeyInfo> CODEC_TRUE = newCodec(true);
   private static final Codec<OmKeyInfo> CODEC_FALSE = newCodec(false);
 
-  private static Codec<OmKeyInfo> newCodec(boolean ignorePipeline) {
-    return new DelegatedCodec<>(
-        Proto2Codec.get(KeyInfo.getDefaultInstance()),
-        OmKeyInfo::getFromProtobuf,
-        k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION),
-        OmKeyInfo.class);
-  }
-
-  public static Codec<OmKeyInfo> getCodec(boolean ignorePipeline) {
-    LOG.debug("OmKeyInfo.getCodec ignorePipeline = {}", ignorePipeline);
-    return ignorePipeline ? CODEC_TRUE : CODEC_FALSE;
-  }
-
   private final String volumeName;
   private final String bucketName;
   // name of key client specified
@@ -132,6 +119,19 @@ public final class OmKeyInfo extends WithParentObjectId
     this.ownerName = b.ownerName;
     this.tags = b.tags;
     this.expectedDataGeneration = b.expectedDataGeneration;
+  }
+
+  private static Codec<OmKeyInfo> newCodec(boolean ignorePipeline) {
+    return new DelegatedCodec<>(
+        Proto2Codec.get(KeyInfo.getDefaultInstance()),
+        OmKeyInfo::getFromProtobuf,
+        k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION),
+        OmKeyInfo.class);
+  }
+
+  public static Codec<OmKeyInfo> getCodec(boolean ignorePipeline) {
+    LOG.debug("OmKeyInfo.getCodec ignorePipeline = {}", ignorePipeline);
+    return ignorePipeline ? CODEC_TRUE : CODEC_FALSE;
   }
 
   public String getVolumeName() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -45,6 +45,35 @@ public final class OmMultipartKeyInfo extends WithObjectID implements CopyObject
       OmMultipartKeyInfo::getProto,
       OmMultipartKeyInfo.class);
 
+  private final String uploadID;
+  private final long creationTime;
+  private final ReplicationConfig replicationConfig;
+  private PartKeyInfoMap partKeyInfoMap;
+
+  /**
+   * A pointer to parent directory used for path traversal. ParentID will be
+   * used only when the multipart key is created into a FileSystemOptimized(FSO)
+   * bucket.
+   * <p>
+   * For example, if a key "a/b/multiKey1" created into a FSOBucket then each
+   * path component will be assigned an ObjectId and linked to its parent path
+   * component using parent's objectID.
+   * <p>
+   * Say, Bucket's ObjectID = 512, which is the parent for its immediate child
+   * element.
+   * <p>
+   * ------------------------------------------|
+   * PathComponent |   ObjectID   |   ParentID |
+   * ------------------------------------------|
+   *      a        |     1024     |     512    |
+   * ------------------------------------------|
+   *      b        |     1025     |     1024   |
+   * ------------------------------------------|
+   *   multiKey1   |     1026     |     1025   |
+   * ------------------------------------------|
+   */
+  private final long parentID;
+
   public static Codec<OmMultipartKeyInfo> getCodec() {
     return CODEC;
   }
@@ -62,6 +91,8 @@ public final class OmMultipartKeyInfo extends WithObjectID implements CopyObject
           ((PartKeyInfo) o2).getPartNumber() : (int) o2;
       return Integer.compare(partNumber1, partNumber2);
     };
+
+    private final List<PartKeyInfo> sorted;
 
     /**
      * Adds a PartKeyInfo to sortedPartKeyInfoList.
@@ -92,8 +123,6 @@ public final class OmMultipartKeyInfo extends WithObjectID implements CopyObject
       put(partKeyInfo, list);
       return new PartKeyInfoMap(list);
     }
-
-    private final List<PartKeyInfo> sorted;
 
     PartKeyInfoMap(List<PartKeyInfo> sorted) {
       this.sorted = Collections.unmodifiableList(sorted);
@@ -129,35 +158,6 @@ public final class OmMultipartKeyInfo extends WithObjectID implements CopyObject
       return sorted.get(size() - 1);
     }
   }
-
-  private final String uploadID;
-  private final long creationTime;
-  private final ReplicationConfig replicationConfig;
-  private PartKeyInfoMap partKeyInfoMap;
-
-  /**
-   * A pointer to parent directory used for path traversal. ParentID will be
-   * used only when the multipart key is created into a FileSystemOptimized(FSO)
-   * bucket.
-   * <p>
-   * For example, if a key "a/b/multiKey1" created into a FSOBucket then each
-   * path component will be assigned an ObjectId and linked to its parent path
-   * component using parent's objectID.
-   * <p>
-   * Say, Bucket's ObjectID = 512, which is the parent for its immediate child
-   * element.
-   * <p>
-   * ------------------------------------------|
-   * PathComponent |   ObjectID   |   ParentID |
-   * ------------------------------------------|
-   *      a        |     1024     |     512    |
-   * ------------------------------------------|
-   *      b        |     1025     |     1024   |
-   * ------------------------------------------|
-   *   multiKey1   |     1026     |     1025   |
-   * ------------------------------------------|
-   */
-  private final long parentID;
 
   /**
    * Construct OmMultipartKeyInfo object which holds multipart upload

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
@@ -46,10 +46,6 @@ public final class OmVolumeArgs extends WithObjectID
       OmVolumeArgs::getProtobuf,
       OmVolumeArgs.class);
 
-  public static Codec<OmVolumeArgs> getCodec() {
-    return CODEC;
-  }
-
   private final String adminName;
   private String ownerName;
   private final String volume;
@@ -85,6 +81,10 @@ public final class OmVolumeArgs extends WithObjectID
     this.creationTime = b.creationTime;
     this.modificationTime = b.modificationTime;
     this.refCount = b.refCount;
+  }
+
+  public static Codec<OmVolumeArgs> getCodec() {
+    return CODEC;
   }
 
   public long getRefCount() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -46,11 +46,11 @@ import org.slf4j.LoggerFactory;
 public final class OzoneAclUtil {
   static final Logger LOG = LoggerFactory.getLogger(OzoneAclUtil.class);
 
-  private OzoneAclUtil() {
-  }
-
   private static ACLType[] userRights;
   private static ACLType[] groupRights;
+
+  private OzoneAclUtil() {
+  }
 
   /**
    * Helper function to get default access acl list for current user.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -41,6 +41,8 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
   private static final Codec<RepeatedOmKeyInfo> CODEC_TRUE = newCodec(true);
   private static final Codec<RepeatedOmKeyInfo> CODEC_FALSE = newCodec(false);
 
+  private final List<OmKeyInfo> omKeyInfoList;
+
   private static Codec<RepeatedOmKeyInfo> newCodec(boolean ignorePipeline) {
     return new DelegatedCodec<>(
         Proto2Codec.get(RepeatedKeyInfo.getDefaultInstance()),
@@ -52,8 +54,6 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
   public static Codec<RepeatedOmKeyInfo> getCodec(boolean ignorePipeline) {
     return ignorePipeline ? CODEC_TRUE : CODEC_FALSE;
   }
-
-  private final List<OmKeyInfo> omKeyInfoList;
 
   public RepeatedOmKeyInfo() {
     this.omKeyInfoList = new ArrayList<>();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
@@ -33,15 +33,15 @@ public final class S3SecretValue {
       S3SecretValue::getProtobuf,
       S3SecretValue.class);
 
-  public static Codec<S3SecretValue> getCodec() {
-    return CODEC;
-  }
-
   // TODO: This field should be renamed to accessId for generalization.
   private final String kerberosID;
   private final String awsSecret;
   private final boolean isDeleted;
   private final long transactionLogIndex;
+
+  public static Codec<S3SecretValue> getCodec() {
+    return CODEC;
+  }
 
   public static S3SecretValue of(String kerberosID, String awsSecret) {
     return of(kerberosID, awsSecret, 0);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
@@ -36,10 +36,6 @@ public class SnapshotDiffJob {
   private static final Codec<SnapshotDiffJob> CODEC =
       new SnapshotDiffJobCodec();
 
-  public static Codec<SnapshotDiffJob> getCodec() {
-    return CODEC;
-  }
-
   private long creationTime;
   private String jobId;
   private JobStatus status;
@@ -93,6 +89,10 @@ public class SnapshotDiffJob {
     this.reason = StringUtils.EMPTY;
     this.subStatus = subStatus;
     this.keysProcessedPct = keysProcessedPct;
+  }
+
+  public static Codec<SnapshotDiffJob> getCodec() {
+    return CODEC;
   }
 
   public String getJobId() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -57,44 +57,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       SnapshotInfo::getProtobuf,
       SnapshotInfo.class);
 
-  public static Codec<SnapshotInfo> getCodec() {
-    return CODEC;
-  }
-
-  /**
-   * SnapshotStatus enum composed of active and deleted statuses.
-   */
-  public enum SnapshotStatus {
-    SNAPSHOT_ACTIVE,
-    SNAPSHOT_DELETED;
-
-    public static final SnapshotStatus DEFAULT = SNAPSHOT_ACTIVE;
-
-    public SnapshotStatusProto toProto() {
-      switch (this) {
-      case SNAPSHOT_ACTIVE:
-        return SnapshotStatusProto.SNAPSHOT_ACTIVE;
-      case SNAPSHOT_DELETED:
-        return SnapshotStatusProto.SNAPSHOT_DELETED;
-      default:
-        throw new IllegalStateException(
-            "BUG: missing valid SnapshotStatus, found status=" + this);
-      }
-    }
-
-    public static SnapshotStatus valueOf(SnapshotStatusProto status) {
-      switch (status) {
-      case SNAPSHOT_ACTIVE:
-        return SNAPSHOT_ACTIVE;
-      case SNAPSHOT_DELETED:
-        return SNAPSHOT_DELETED;
-      default:
-        throw new IllegalStateException(
-            "BUG: missing valid SnapshotStatus, found status=" + status);
-      }
-    }
-  }
-
   private static final String SEPARATOR = "-";
   private static final long INVALID_TIMESTAMP = -1;
   private static final UUID INITIAL_SNAPSHOT_ID = UUID.randomUUID();
@@ -144,6 +106,10 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.exclusiveReplicatedSize = b.exclusiveReplicatedSize;
     this.deepCleanedDeletedDir = b.deepCleanedDeletedDir;
     this.lastTransactionInfo = b.lastTransactionInfo;
+  }
+
+  public static Codec<SnapshotInfo> getCodec() {
+    return CODEC;
   }
 
   public void setName(String name) {
@@ -744,5 +710,39 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         ", deepCleanedDeletedDir: '" + deepCleanedDeletedDir + '\'' +
         ", lastTransactionInfo: '" + lastTransactionInfo + '\'' +
         '}';
+  }
+
+  /**
+   * SnapshotStatus enum composed of active and deleted statuses.
+   */
+  public enum SnapshotStatus {
+    SNAPSHOT_ACTIVE,
+    SNAPSHOT_DELETED;
+
+    public static final SnapshotStatus DEFAULT = SNAPSHOT_ACTIVE;
+
+    public SnapshotStatusProto toProto() {
+      switch (this) {
+      case SNAPSHOT_ACTIVE:
+        return SnapshotStatusProto.SNAPSHOT_ACTIVE;
+      case SNAPSHOT_DELETED:
+        return SnapshotStatusProto.SNAPSHOT_DELETED;
+      default:
+        throw new IllegalStateException(
+            "BUG: missing valid SnapshotStatus, found status=" + this);
+      }
+    }
+
+    public static SnapshotStatus valueOf(SnapshotStatusProto status) {
+      switch (status) {
+      case SNAPSHOT_ACTIVE:
+        return SNAPSHOT_ACTIVE;
+      case SNAPSHOT_DELETED:
+        return SNAPSHOT_DELETED;
+      default:
+        throw new IllegalStateException(
+            "BUG: missing valid SnapshotStatus, found status=" + status);
+      }
+    }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -85,14 +85,14 @@ public class GrpcOmTransport implements OmTransport {
   private final int maxSize;
   private SecurityConfig secConfig;
 
-  public static void setCaCerts(List<X509Certificate> x509Certificates) {
-    caCerts = x509Certificates;
-  }
-
   private RetryPolicy retryPolicy;
   private int failoverCount = 0;
   private GrpcOMFailoverProxyProvider<OzoneManagerProtocolPB>
       omFailoverProxyProvider;
+
+  public static void setCaCerts(List<X509Certificate> x509Certificates) {
+    caCerts = x509Certificates;
+  }
 
   public GrpcOmTransport(ConfigurationSource conf,
                           UserGroupInformation ugi, String omServiceId)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/grpc/GrpcClientConstants.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/grpc/GrpcClientConstants.java
@@ -24,10 +24,6 @@ import io.grpc.Metadata;
  * Constants to store grpc-client specific header values.
  */
 public final class GrpcClientConstants {
-
-  private GrpcClientConstants() {
-  }
-
   public static final Context.Key<String> CLIENT_HOSTNAME_CTX_KEY =
       Context.key("CLIENT_HOSTNAME");
 
@@ -40,4 +36,6 @@ public final class GrpcClientConstants {
   public static final Metadata.Key<String> CLIENT_IP_ADDRESS_METADATA_KEY =
       Metadata.Key.of("CLIENT_IP_ADDRESS", Metadata.ASCII_STRING_MARSHALLER);
 
+  private GrpcClientConstants() {
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/GDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/GDPRSymmetricKey.java
@@ -34,6 +34,11 @@ public class GDPRSymmetricKey {
   private static final ThreadLocal<SecureRandom> RANDOM
       = ThreadLocal.withInitial(SecureRandom::new);
 
+  private final SecretKeySpec secretKey;
+  private final Cipher cipher;
+  private final String algorithm;
+  private final String secret;
+
   /** @return a new instance with default parameters. */
   public static GDPRSymmetricKey newDefaultInstance() {
     try {
@@ -49,11 +54,6 @@ public class GDPRSymmetricKey {
         OzoneConsts.GDPR_DEFAULT_RANDOM_SECRET_LENGTH,
         0, 0, true, true, null, secureRandom);
   }
-
-  private final SecretKeySpec secretKey;
-  private final Cipher cipher;
-  private final String algorithm;
-  private final String secret;
 
   public SecretKeySpec getSecretKey() {
     return secretKey;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSelector.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSelector.java
@@ -33,12 +33,11 @@ import org.slf4j.LoggerFactory;
 public class OzoneDelegationTokenSelector
     extends AbstractDelegationTokenSelector<OzoneTokenIdentifier> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(OzoneDelegationTokenSelector.class);
+
   public OzoneDelegationTokenSelector() {
     super(OzoneTokenIdentifier.KIND_NAME);
   }
-
-  private static final Logger LOG = LoggerFactory
-      .getLogger(OzoneDelegationTokenSelector.class);
 
   @Override
   public Token<OzoneTokenIdentifier> selectToken(Text service,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -41,19 +41,14 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Snapsho
 public class SnapshotDiffReportOzone
     extends org.apache.hadoop.hdfs.protocol.SnapshotDiffReport {
 
+  private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
+
   private static final Codec<DiffReportEntry> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(DiffReportEntryProto.getDefaultInstance()),
       SnapshotDiffReportOzone::fromProtobufDiffReportEntry,
       SnapshotDiffReportOzone::toProtobufDiffReportEntry,
       DiffReportEntry.class,
       DelegatedCodec.CopyType.SHALLOW);
-
-  public static Codec<DiffReportEntry> getDiffReportEntryCodec() {
-    return CODEC;
-  }
-
-  private static final String LINE_SEPARATOR = System.getProperty(
-      "line.separator", "\n");
 
   /**
    * Volume name to which the snapshot bucket belongs.
@@ -80,6 +75,10 @@ public class SnapshotDiffReportOzone
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.token = token;
+  }
+
+  public static Codec<DiffReportEntry> getDiffReportEntryCodec() {
+    return CODEC;
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/RadixNode.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/RadixNode.java
@@ -25,6 +25,13 @@ import java.util.HashMap;
  */
 public class RadixNode<T> {
 
+  private HashMap<String, RadixNode> children;
+
+  private String name;
+
+  // TODO: k/v pairs for more metadata as needed
+  private T value;
+
   public RadixNode(String name) {
     this.name = name;
     this.children = new HashMap<>();
@@ -49,11 +56,4 @@ public class RadixNode<T> {
   public T getValue() {
     return value;
   }
-
-  private HashMap<String, RadixNode> children;
-
-  private String name;
-
-  // TODO: k/v pairs for more metadata as needed
-  private T value;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/RadixTree.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/RadixTree.java
@@ -31,6 +31,11 @@ import org.apache.hadoop.ozone.OzoneConsts;
  */
 public class RadixTree<T> {
 
+  private static final String PATH_DELIMITER = OzoneConsts.OZONE_URI_DELIMITER;
+
+  // root of a radix tree has a name of "/" and may optionally has it value.
+  private RadixNode root;
+
   /**
    * create a empty radix tree with root only.
    */
@@ -211,9 +216,4 @@ public class RadixTree<T> {
       return root.getName();
     }
   }
-
-  // root of a radix tree has a name of "/" and may optionally has it value.
-  private RadixNode root;
-
-  private static final String PATH_DELIMITER = OzoneConsts.OZONE_URI_DELIMITER;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/web/utils/OzoneUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/web/utils/OzoneUtils.java
@@ -42,10 +42,6 @@ public final class OzoneUtils {
 
   public static final Charset ENCODING = StandardCharsets.UTF_8;
 
-  private OzoneUtils() {
-    // Never constructed
-  }
-
   /**
    * Date format that used in ozone. Here the format is thread safe to use.
    */
@@ -60,6 +56,10 @@ public final class OzoneUtils {
           return format;
         }
       };
+
+  private OzoneUtils() {
+    // Never constructed
+  }
 
   /**
    * Verifies that max key length is a valid value.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Code for the ozone-common module made compliant with PMD.FieldDeclarationsShouldBeAtStartOfClass verification rule.
It is done before enabling the rule itself to prevent us reviewing a very huge PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12905

## How was this patch tested?

Patch tested using standard verification pipeline.