### PR TITLE
HDDS-12906. Move field declarations to start of class in ozone-manager module

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -62,6 +62,16 @@ import org.slf4j.Logger;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public interface OMMultiTenantManager {
+
+  String OZONE_TENANT_RANGER_POLICY_DESCRIPTION =
+      "Created by Ozone. WARNING: "
+          + "Changes will be lost when this tenant is deleted.";
+
+  String OZONE_TENANT_RANGER_ROLE_DESCRIPTION =
+      "Managed by Ozone. WARNING: "
+          + "Changes will be overridden. "
+          + "Use Ozone tenant CLI to manage users in this tenant role instead.";
+
   /* TODO: Outdated
    * Init multi-tenant manager. Performs initialization e.g.
    *  - Initialize Multi-Tenant-Gatekeeper-Plugin
@@ -340,15 +350,6 @@ public interface OMMultiTenantManager {
 
     return true;
   }
-
-  String OZONE_TENANT_RANGER_POLICY_DESCRIPTION =
-      "Created by Ozone. WARNING: "
-          + "Changes will be lost when this tenant is deleted.";
-
-  String OZONE_TENANT_RANGER_ROLE_DESCRIPTION =
-      "Managed by Ozone. WARNING: "
-          + "Changes will be overridden. "
-          + "Use Ozone tenant CLI to manage users in this tenant role instead.";
 
   /**
    * Returns default VolumeAccess policy given tenant and role names.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -31,18 +31,6 @@ public class OMPerformanceMetrics {
   private static final String SOURCE_NAME =
       OMPerformanceMetrics.class.getSimpleName();
 
-  public static OMPerformanceMetrics register() {
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(SOURCE_NAME,
-            "OzoneManager Request Performance",
-            new OMPerformanceMetrics());
-  }
-
-  public static void unregister() {
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.unregisterSource(SOURCE_NAME);
-  }
-
   @Metric(about = "Overall lookupKey in nanoseconds")
   private MutableRate lookupLatencyNs;
 
@@ -159,6 +147,18 @@ public class OMPerformanceMetrics {
 
   @Metric(about = "Latency of each iteration of OpenKeyCleanupService in ms")
   private MutableGaugeLong openKeyCleanupServiceLatencyMs;
+
+  public static OMPerformanceMetrics register() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(SOURCE_NAME,
+        "OzoneManager Request Performance",
+        new OMPerformanceMetrics());
+  }
+
+  public static void unregister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(SOURCE_NAME);
+  }
 
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPolicyProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPolicyProvider.java
@@ -46,15 +46,6 @@ public final class OMPolicyProvider extends PolicyProvider {
   private static final Supplier<OMPolicyProvider> SUPPLIER =
       MemoizedSupplier.valueOf(OMPolicyProvider::new);
 
-  private OMPolicyProvider() {
-  }
-
-  @Private
-  @Unstable
-  public static OMPolicyProvider getInstance() {
-    return SUPPLIER.get();
-  }
-
   private static final List<Service> OM_SERVICES =
       Arrays.asList(
           new Service(OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL,
@@ -66,6 +57,16 @@ public final class OMPolicyProvider extends PolicyProvider {
           new Service(OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL,
               ReconfigureProtocol.class)
       );
+
+  private OMPolicyProvider() {
+  }
+
+  @Private
+  @Unstable
+  public static OMPolicyProvider getInstance() {
+    return SUPPLIER.get();
+  }
+
 
   @Override
   public Service[] getServices() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPolicyProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPolicyProvider.java
@@ -67,7 +67,6 @@ public final class OMPolicyProvider extends PolicyProvider {
     return SUPPLIER.get();
   }
 
-
   @Override
   public Service[] getServices() {
     return OM_SERVICES.toArray(new Service[0]);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -50,15 +50,6 @@ import org.slf4j.LoggerFactory;
  * Helper class for fetching List Status for a path.
  */
 public class OzoneListStatusHelper {
-  /**
-   * Interface to get the File Status for a path.
-   */
-  @FunctionalInterface
-  public interface GetFileStatusHelper {
-    OzoneFileStatus apply(OmKeyArgs args, String clientAddress,
-                          boolean skipFileNotFoundError) throws IOException;
-  }
-
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneListStatusHelper.class);
 
@@ -77,6 +68,15 @@ public class OzoneListStatusHelper {
     this.scmBlockSize = scmBlockSize;
     this.getStatusHelper = func;
     this.omDefaultReplication = omDefaultReplication;
+  }
+
+  /**
+   * Interface to get the File Status for a path.
+   */
+  @FunctionalInterface
+  public interface GetFileStatusHelper {
+    OzoneFileStatus apply(OmKeyArgs args, String clientAddress,
+                          boolean skipFileNotFoundError) throws IOException;
   }
 
   public Collection<OzoneFileStatus> listStatusFSO(OmKeyArgs args,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -481,22 +481,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private String omHostName;
 
-  /**
-   * OM Startup mode.
-   */
-  public enum StartupOption {
-    REGUALR,
-    BOOTSTRAP,
-    FORCE_BOOTSTRAP
-  }
-
-  private enum State {
-    INITIALIZED,
-    BOOTSTRAPPING,
-    RUNNING,
-    STOPPED
-  }
-
   // Used in MiniOzoneCluster testing
   private State omState;
   private Thread emptier;
@@ -5156,5 +5140,21 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   public OMExecutionFlow getOmExecutionFlow() {
     return omExecutionFlow;
+  }
+
+  /**
+   * OM Startup mode.
+   */
+  public enum StartupOption {
+    REGUALR,
+    BOOTSTRAP,
+    FORCE_BOOTSTRAP
+  }
+
+  private enum State {
+    INITIALIZED,
+    BOOTSTRAPPING,
+    RUNNING,
+    STOPPED
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -83,6 +83,8 @@ public class SstFilteringService extends BackgroundService
 
   private AtomicBoolean running;
 
+  private final BootstrapStateHandler.Lock lock = new BootstrapStateHandler.Lock();
+
   public static boolean isSstFiltered(OzoneConfiguration ozoneConfiguration, SnapshotInfo snapshotInfo) {
     Path sstFilteredFile = Paths.get(OmSnapshotManager.getSnapshotPath(ozoneConfiguration,
         snapshotInfo), SST_FILTERED_FILE);
@@ -100,9 +102,6 @@ public class SstFilteringService extends BackgroundService
     snapshotFilteredCount = new AtomicLong(0);
     running = new AtomicBoolean(false);
   }
-
-  private final BootstrapStateHandler.Lock lock =
-      new BootstrapStateHandler.Lock();
 
   @Override
   public void start() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHAMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHAMetrics.java
@@ -35,13 +35,10 @@ import org.apache.hadoop.ozone.OzoneConsts;
 public final class OMHAMetrics implements MetricsSource {
 
   public static final String SOURCE_NAME = OMHAMetrics.class.getSimpleName();
-
   private final OMHAMetricsInfo omhaMetricsInfo = new OMHAMetricsInfo();
-
   private MetricsRegistry metricsRegistry;
 
   private String currNodeId;
-
   private String leaderId;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHAMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHAMetrics.java
@@ -34,6 +34,16 @@ import org.apache.hadoop.ozone.OzoneConsts;
 @Metrics(about = "OzoneManager HA Metrics", context = OzoneConsts.OZONE)
 public final class OMHAMetrics implements MetricsSource {
 
+  public static final String SOURCE_NAME = OMHAMetrics.class.getSimpleName();
+
+  private final OMHAMetricsInfo omhaMetricsInfo = new OMHAMetricsInfo();
+
+  private MetricsRegistry metricsRegistry;
+
+  private String currNodeId;
+
+  private String leaderId;
+
   /**
    * Private nested class to hold the values
    * of MetricsInfo for OMHAMetrics.
@@ -71,14 +81,6 @@ public final class OMHAMetrics implements MetricsSource {
       this.nodeId = nodeId;
     }
   }
-
-  public static final String SOURCE_NAME =
-      OMHAMetrics.class.getSimpleName();
-  private final OMHAMetricsInfo omhaMetricsInfo = new OMHAMetricsInfo();
-  private MetricsRegistry metricsRegistry;
-
-  private String currNodeId;
-  private String leaderId;
 
   private OMHAMetrics(String currNodeId, String leaderId) {
     this.currNodeId = currNodeId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
@@ -37,14 +37,16 @@ import org.slf4j.LoggerFactory;
  * This class is used for OM Audit logs.
  */
 public final class OMAuditLogger {
-  private OMAuditLogger() {
-  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(OMAuditLogger.class);
 
   private static final Map<Type, OMAction> CMD_AUDIT_ACTION_MAP = new HashMap<>();
-  private static final Logger LOG = LoggerFactory.getLogger(OMAuditLogger.class);
 
   static {
     init();
+  }
+
+  private OMAuditLogger() {
   }
 
   private static void init() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServerConfig.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServerConfig.java
@@ -44,14 +44,6 @@ public class OzoneManagerRatisServerConfig {
   )
   private long logAppenderWaitTimeMin;
 
-  public long getLogAppenderWaitTimeMin() {
-    return logAppenderWaitTimeMin;
-  }
-
-  public void setLogAppenderWaitTimeMin(long logAppenderWaitTimeMin) {
-    this.logAppenderWaitTimeMin = logAppenderWaitTimeMin;
-  }
-
   @Config(key = "retrycache.expirytime",
       defaultValue = "300s",
       type = ConfigType.TIME,
@@ -59,6 +51,14 @@ public class OzoneManagerRatisServerConfig {
       description = "The timeout duration of the retry cache."
   )
   private long retryCacheTimeout = Duration.ofSeconds(300).toMillis();
+
+  public long getLogAppenderWaitTimeMin() {
+    return logAppenderWaitTimeMin;
+  }
+
+  public void setLogAppenderWaitTimeMin(long logAppenderWaitTimeMin) {
+    this.logAppenderWaitTimeMin = logAppenderWaitTimeMin;
+  }
 
   public long getRetryCacheTimeout() {
     return retryCacheTimeout;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
@@ -56,11 +56,8 @@ public class OMKeySetTimesRequest extends OMKeyRequest {
       LoggerFactory.getLogger(OMKeySetTimesRequest.class);
 
   private final String volumeName;
-
   private final String bucketName;
-
   private final String keyName;
-
   private final long modificationTime;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
@@ -55,6 +55,14 @@ public class OMKeySetTimesRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeySetTimesRequest.class);
 
+  private final String volumeName;
+
+  private final String bucketName;
+
+  private final String keyName;
+
+  private final long modificationTime;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     OMRequest request = super.preExecute(ozoneManager);
@@ -80,11 +88,6 @@ public class OMKeySetTimesRequest extends OMKeyRequest {
                 .setMtime(getModificationTime()))
         .build();
   }
-
-  private final String volumeName;
-  private final String bucketName;
-  private final String keyName;
-  private final long modificationTime;
 
   public OMKeySetTimesRequest(OMRequest omRequest, BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -57,6 +57,10 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyAddAclRequest.class);
 
+  private String path;
+  private List<OzoneAcl> ozoneAcls;
+  private OzoneObj obj;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
@@ -69,11 +73,6 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
-
-  private String path;
-  private List<OzoneAcl> ozoneAcls;
-  private OzoneObj obj;
-
   public OMKeyAddAclRequest(OMRequest omRequest, OzoneManager ozoneManager) {
     super(omRequest);
     OzoneManagerProtocolProtos.AddAclRequest addAclRequest =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -73,6 +73,7 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
+
   public OMKeyAddAclRequest(OMRequest omRequest, OzoneManager ozoneManager) {
     super(omRequest);
     OzoneManagerProtocolProtos.AddAclRequest addAclRequest =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
@@ -49,9 +49,7 @@ public class OMKeyAddAclRequestWithFSO extends OMKeyAclRequestWithFSO {
       LoggerFactory.getLogger(OMKeyAddAclRequestWithFSO.class);
 
   private String path;
-
   private List<OzoneAcl> ozoneAcls;
-
   private OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
@@ -48,6 +48,12 @@ public class OMKeyAddAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyAddAclRequestWithFSO.class);
 
+  private String path;
+
+  private List<OzoneAcl> ozoneAcls;
+
+  private OzoneObj obj;
+
   @Override
   public OzoneManagerProtocolProtos.OMRequest preExecute(
       OzoneManager ozoneManager) throws IOException {
@@ -59,10 +65,6 @@ public class OMKeyAddAclRequestWithFSO extends OMKeyAclRequestWithFSO {
     return getOmRequest().toBuilder().setAddAclRequest(addAclRequestBuilder)
         .setUserInfo(getUserInfo()).build();
   }
-
-  private String path;
-  private List<OzoneAcl> ozoneAcls;
-  private OzoneObj obj;
 
   public OMKeyAddAclRequestWithFSO(
       OzoneManagerProtocolProtos.OMRequest omReq, BucketLayout bucketLayout) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -57,6 +57,12 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyRemoveAclRequest.class);
 
+  private String path;
+
+  private List<OzoneAcl> ozoneAcls;
+
+  private OzoneObj obj;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
@@ -69,10 +75,6 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
-
-  private String path;
-  private List<OzoneAcl> ozoneAcls;
-  private OzoneObj obj;
 
   public OMKeyRemoveAclRequest(OMRequest omRequest, OzoneManager ozoneManager) {
     super(omRequest);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -58,9 +58,7 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
       LoggerFactory.getLogger(OMKeyRemoveAclRequest.class);
 
   private String path;
-
   private List<OzoneAcl> ozoneAcls;
-
   private OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
@@ -49,9 +49,7 @@ public class OMKeyRemoveAclRequestWithFSO extends OMKeyAclRequestWithFSO {
       LoggerFactory.getLogger(OMKeyRemoveAclRequestWithFSO.class);
 
   private String path;
-
   private List<OzoneAcl> ozoneAcls;
-
   private OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
@@ -48,6 +48,12 @@ public class OMKeyRemoveAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyRemoveAclRequestWithFSO.class);
 
+  private String path;
+
+  private List<OzoneAcl> ozoneAcls;
+
+  private OzoneObj obj;
+
   @Override
   public OzoneManagerProtocolProtos.OMRequest preExecute(
       OzoneManager ozoneManager) throws IOException {
@@ -61,10 +67,6 @@ public class OMKeyRemoveAclRequestWithFSO extends OMKeyAclRequestWithFSO {
         .setRemoveAclRequest(removeAclRequestBuilder).setUserInfo(getUserInfo())
         .build();
   }
-
-  private String path;
-  private List<OzoneAcl> ozoneAcls;
-  private OzoneObj obj;
 
   public OMKeyRemoveAclRequestWithFSO(
       OzoneManagerProtocolProtos.OMRequest omRequest,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -59,9 +59,7 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
       LoggerFactory.getLogger(OMKeySetAclRequest.class);
 
   private String path;
-
   private List<OzoneAcl> ozoneAcls;
-
   private OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -58,6 +58,12 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeySetAclRequest.class);
 
+  private String path;
+
+  private List<OzoneAcl> ozoneAcls;
+
+  private OzoneObj obj;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
@@ -70,10 +76,6 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
-
-  private String path;
-  private List<OzoneAcl> ozoneAcls;
-  private OzoneObj obj;
 
   public OMKeySetAclRequest(OMRequest omRequest, OzoneManager ozoneManager) {
     super(omRequest);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
@@ -49,6 +49,12 @@ public class OMKeySetAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeySetAclRequestWithFSO.class);
 
+  private String path;
+
+  private List<OzoneAcl> ozoneAcls;
+
+  private OzoneObj obj;
+
   @Override
   public OzoneManagerProtocolProtos.OMRequest preExecute(
       OzoneManager ozoneManager) throws IOException {
@@ -60,10 +66,6 @@ public class OMKeySetAclRequestWithFSO extends OMKeyAclRequestWithFSO {
     return getOmRequest().toBuilder().setSetAclRequest(setAclRequestBuilder)
         .setUserInfo(getUserInfo()).build();
   }
-
-  private String path;
-  private List<OzoneAcl> ozoneAcls;
-  private OzoneObj obj;
 
   public OMKeySetAclRequestWithFSO(
       OzoneManagerProtocolProtos.OMRequest omReq, BucketLayout bucketLayout) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
@@ -50,9 +50,7 @@ public class OMKeySetAclRequestWithFSO extends OMKeyAclRequestWithFSO {
       LoggerFactory.getLogger(OMKeySetAclRequestWithFSO.class);
 
   private String path;
-
   private List<OzoneAcl> ozoneAcls;
-
   private OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -47,14 +47,6 @@ import org.apache.ratis.util.function.CheckedBiConsumer;
  */
 public abstract class OMVolumeAclRequest extends OMVolumeRequest {
 
-  /**
-   * Volume ACL operation.
-   */
-  public interface VolumeAclOp extends
-      CheckedBiConsumer<List<OzoneAcl>, OmVolumeArgs, IOException> {
-    // just a shortcut to avoid having to repeat long list of generic parameters
-  }
-
   private final VolumeAclOp omVolumeAclOp;
 
   OMVolumeAclRequest(OzoneManagerProtocolProtos.OMRequest omRequest,
@@ -200,4 +192,12 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
    */
   abstract void onComplete(Result result, Exception ex, long trxnLogIndex,
       AuditLogger auditLogger, Map<String, String> auditMap);
+
+  /**
+   * Volume ACL operation.
+   */
+  public interface VolumeAclOp extends
+      CheckedBiConsumer<List<OzoneAcl>, OmVolumeArgs, IOException> {
+    // just a shortcut to avoid having to repeat long list of generic parameters
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -51,9 +51,7 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
       (acls, volArgs) -> volArgs.addAcl(acls.get(0));
 
   private final List<OzoneAcl> ozoneAcls;
-
   private final String volumeName;
-
   private final OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -50,6 +50,12 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
   private static final VolumeAclOp VOLUME_ADD_ACL_OP =
       (acls, volArgs) -> volArgs.addAcl(acls.get(0));
 
+  private final List<OzoneAcl> ozoneAcls;
+
+  private final String volumeName;
+
+  private final OzoneObj obj;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
@@ -62,10 +68,6 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
-
-  private final List<OzoneAcl> ozoneAcls;
-  private final String volumeName;
-  private final OzoneObj obj;
 
   public OMVolumeAddAclRequest(OMRequest omRequest) {
     super(omRequest, VOLUME_ADD_ACL_OP);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -51,9 +51,7 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
       (acls, volArgs) -> volArgs.removeAcl(acls.get(0));
 
   private final List<OzoneAcl> ozoneAcls;
-
   private final String volumeName;
-
   private final OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -50,6 +50,12 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
   private static final VolumeAclOp VOLUME_REMOVE_ACL_OP =
       (acls, volArgs) -> volArgs.removeAcl(acls.get(0));
 
+  private final List<OzoneAcl> ozoneAcls;
+
+  private final String volumeName;
+
+  private final OzoneObj obj;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
@@ -62,10 +68,6 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
-
-  private final List<OzoneAcl> ozoneAcls;
-  private final String volumeName;
-  private final OzoneObj obj;
 
   public OMVolumeRemoveAclRequest(OMRequest omRequest) {
     super(omRequest, VOLUME_REMOVE_ACL_OP);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -50,6 +50,12 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
   private static final VolumeAclOp VOLUME_SET_ACL_OP =
       (acls, volArgs) -> volArgs.setAcls(acls);
 
+  private final List<OzoneAcl> ozoneAcls;
+
+  private final String volumeName;
+
+  private final OzoneObj obj;
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
@@ -62,10 +68,6 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
         .setUserInfo(getUserInfo())
         .build();
   }
-
-  private final List<OzoneAcl> ozoneAcls;
-  private final String volumeName;
-  private final OzoneObj obj;
 
   public OMVolumeSetAclRequest(OMRequest omRequest) {
     super(omRequest, VOLUME_SET_ACL_OP);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -51,9 +51,7 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
       (acls, volArgs) -> volArgs.setAcls(acls);
 
   private final List<OzoneAcl> ozoneAcls;
-
   private final String volumeName;
-
   private final OzoneObj obj;
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/s3/S3SecretCacheProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/s3/S3SecretCacheProvider.java
@@ -25,6 +25,10 @@ import org.apache.hadoop.ozone.om.S3SecretCache;
  * Provider of {@link S3SecretCache}.
  */
 public interface S3SecretCacheProvider {
+  /**
+   * In-memory cache implementation.
+   */
+  S3SecretCacheProvider IN_MEMORY = conf -> new S3InMemoryCache();
 
   /**
    * Returns S3 secret cache instance constructed by provided configuration.
@@ -33,11 +37,4 @@ public interface S3SecretCacheProvider {
    * @return S3 secret cache instance.
    */
   S3SecretCache get(Configuration conf);
-
-  /**
-   * In-memory cache implementation.
-   */
-  S3SecretCacheProvider IN_MEMORY = conf -> {
-    return new S3InMemoryCache();
-  };
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OMRangerBGSyncService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OMRangerBGSyncService.java
@@ -100,85 +100,6 @@ public class OMRangerBGSyncService extends BackgroundService {
 
   private volatile boolean isServiceStarted = false;
 
-  static class BGRole {
-    private final String name;
-    private String id;
-    private final HashSet<String> userSet;
-
-    BGRole(String n) {
-      this.name = n;
-      userSet = new HashSet<>();
-    }
-
-    public void setId(String id) {
-      this.id = id;
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    public void addUserPrincipal(String userPrincipal) {
-      userSet.add(userPrincipal);
-    }
-
-    public HashSet<String> getUserSet() {
-      return userSet;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name, id, userSet);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      BGRole bgRole = (BGRole) o;
-      return name.equals(bgRole.name)
-          && id.equals(bgRole.id)
-          && userSet.equals(bgRole.userSet);
-    }
-  }
-
-  enum PolicyType {
-    BUCKET_NAMESPACE_POLICY,
-    BUCKET_POLICY
-  }
-
-  /**
-   * Helper class that stores the tenant name and policy type.
-   */
-  static class PolicyInfo {
-
-    private final String tenantId;
-    private final PolicyType policyType;
-
-    PolicyInfo(String tenantId, PolicyType policyType) {
-      this.tenantId = tenantId;
-      this.policyType = policyType;
-    }
-
-    public String getTenantId() {
-      return tenantId;
-    }
-
-    public PolicyType getPolicyType() {
-      return policyType;
-    }
-
-    @Override
-    public String toString() {
-      return "PolicyInfo{" +
-          "tenantId='" + tenantId + '\'' + ", policyType=" + policyType + '}';
-    }
-  }
-
   // This map keeps all the policies found in OM DB. These policies should be
   // in Ranger. If not, the default policy will be (re)created.
   //
@@ -867,5 +788,83 @@ public class OMRangerBGSyncService extends BackgroundService {
    */
   public long getRangerSyncRunCount() {
     return runCount.get();
+  }
+
+  static class BGRole {
+    private final String name;
+    private String id;
+    private final HashSet<String> userSet;
+
+    BGRole(String n) {
+      this.name = n;
+      userSet = new HashSet<>();
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void addUserPrincipal(String userPrincipal) {
+      userSet.add(userPrincipal);
+    }
+
+    public HashSet<String> getUserSet() {
+      return userSet;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, id, userSet);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BGRole bgRole = (BGRole) o;
+      return name.equals(bgRole.name)
+                 && id.equals(bgRole.id)
+                 && userSet.equals(bgRole.userSet);
+    }
+  }
+
+  enum PolicyType {
+    BUCKET_NAMESPACE_POLICY,
+    BUCKET_POLICY
+  }
+
+  /**
+   * Helper class that stores the tenant name and policy type.
+   */
+  static class PolicyInfo {
+
+    private final String tenantId;
+    private final PolicyType policyType;
+
+    PolicyInfo(String tenantId, PolicyType policyType) {
+      this.tenantId = tenantId;
+      this.policyType = policyType;
+    }
+
+    public String getTenantId() {
+      return tenantId;
+    }
+
+    public PolicyType getPolicyType() {
+      return policyType;
+    }
+
+    @Override
+    public String toString() {
+      return "PolicyInfo{tenantId='" + tenantId + '\'' + ", policyType=" + policyType + '}';
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -39,9 +39,6 @@ final class AWSV4AuthValidator {
       LoggerFactory.getLogger(AWSV4AuthValidator.class);
   private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
 
-  private AWSV4AuthValidator() {
-  }
-
   /**
    * ThreadLocal cache of Mac instances.
    */
@@ -55,6 +52,9 @@ final class AWSV4AuthValidator {
                   HMAC_SHA256_ALGORITHM + " algorithm.", nsa);
         }
       });
+
+  private AWSV4AuthValidator() {
+  }
 
   public static String hash(String payload) throws NoSuchAlgorithmException {
     MessageDigest md = MessageDigest.getInstance("SHA-256");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Code for the ozone-manager module made compliant with PMD.FieldDeclarationsShouldBeAtStartOfClass verification rule.
It is done before enabling the rule itself to prevent us reviewing a very huge PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12906

## How was this patch tested?

Patch tested using standard verification pipeline.