### PR TITLE
HDDS-12892. OM Tagging Request is incorrectly setting full path as key name

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3DeleteObjectTaggingRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3DeleteObjectTaggingRequestWithFSO.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -106,6 +107,9 @@ public class S3DeleteObjectTaggingRequestWithFSO extends S3DeleteObjectTaggingRe
       }
 
       OmKeyInfo omKeyInfo = keyStatus.getKeyInfo();
+      // Reverting back the full path to key name
+      // Eg: a/b/c/d/e/file1 -> file1
+      omKeyInfo.setKeyName(OzoneFSUtils.getFileName(keyName));
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
       final long bucketId = omMetadataManager.getBucketId(volumeName, bucketName);
       final String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3PutObjectTaggingRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3PutObjectTaggingRequestWithFSO.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -107,6 +108,9 @@ public class S3PutObjectTaggingRequestWithFSO extends S3PutObjectTaggingRequest 
       }
 
       OmKeyInfo omKeyInfo = keyStatus.getKeyInfo();
+      // Reverting back the full path to key name
+      // Eg: a/b/c/d/e/file1 -> file1
+      omKeyInfo.setKeyName(OzoneFSUtils.getFileName(keyName));
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
       final long bucketId = omMetadataManager.getBucketId(volumeName, bucketName);
       final String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3DeleteObjectTaggingRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3DeleteObjectTaggingRequestWithFSO.java
@@ -44,7 +44,7 @@ public class TestS3DeleteObjectTaggingRequestWithFSO extends TestS3DeleteObjectT
         bucketName, PARENT_DIR, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY, RatisReplicationConfig.getInstance(ONE))
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_NAME, RatisReplicationConfig.getInstance(ONE))
             .setObjectID(parentId + 1L)
             .setParentObjectID(parentId)
             .setUpdateID(1L)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3PutObjectTaggingRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3PutObjectTaggingRequestWithFSO.java
@@ -65,7 +65,7 @@ public class TestS3PutObjectTaggingRequestWithFSO extends TestS3PutObjectTagging
         bucketName, PARENT_DIR, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY, RatisReplicationConfig.getInstance(ONE))
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_NAME, RatisReplicationConfig.getInstance(ONE))
             .setObjectID(parentId + 1L)
             .setParentObjectID(parentId)
             .setUpdateID(1L)


### PR DESCRIPTION
## What changes were proposed in this pull request?

These requests S3PutObjectTaggingResponseWithFSO and S3DeleteObjectTaggingRequestWithFSO are setting the key name for FSO bucket keys as full path name. It should be just the file name.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12892

## How was this patch tested?

Updated unit tests.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/14698516236