### PR TITLE
HDDS-12917. cp: option '--update' doesn't allow an argument

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -130,23 +130,17 @@ run cp -p -r "${ROOT}/hadoop-ozone/dist/target/Dockerfile" .
 
 run mkdir compose/_keytabs
 
-# Determine CPFLAGS based on system type
-if [ "$(uname)" = "Darwin" ]; then
-  CPFLAGS="-n"
-else
-  CPFLAGS="--update=none"
-fi
-
 for file in $(find "${ROOT}" -path '*/target/classes/*.classpath' | sort); do
   # We need to add the artifact manually as it's not part the generated classpath desciptor
   module=$(basename "${file%.classpath}")
   sed -i -e "s;$;:\$HDDS_LIB_JARS_DIR/${module}-${HDDS_VERSION}.jar;" "$file"
 
-  cp $CPFLAGS -p -v "$file" share/ozone/classpath/
+  run cp -p "$file" share/ozone/classpath/
 done
 
 for file in $(find "${ROOT}" -path '*/share/ozone/lib/*jar' | sort); do
-  cp $CPFLAGS -p -v "$file" share/ozone/lib/
+  # copy without printing to output due to large number of files
+  cp -p "$file" share/ozone/lib/
 done
 
 #workaround for https://issues.apache.org/jira/browse/MRESOURCES-236


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12893 changed `cp -n` to `cp --update=none` to get rid of warning:

```
cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead
```

Now on Ubuntu 22.04 we get error:

```
cp: option '--update' doesn't allow an argument
```

Since `-n`, `--update=none` etc. are version/platform dependent, we can simply remove it and overwrite files.  The original reason for using `-n` was to not generate multiple lines of output from `cp` for the same target jar.  We can turn off verbose mode and avoid the problem.

https://issues.apache.org/jira/browse/HDDS-12917

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/14702995761/job/41256275097#step:13:5932