### PR TITLE
HDDS-12877. Support StorageClass field in the S3 HeadObject request

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
@@ -60,3 +60,13 @@ Head non existing key
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/non-existent   255
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
+
+
+HeadObject Should Return StorageClass
+                        Execute                            echo "Randomtext" > /tmp/testfile
+    ${put_result} =     Execute AWSS3APICli and checkrc    put-object --bucket ${BUCKET} --key ${PREFIX}/object-exist --body /tmp/testfile    0
+
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/object-exist    0
+                        Should Contain          ${result}    "StorageClass": "STANDARD"
+
+    ${result} =         Execute AWSS3APICli and checkrc    delete-object --bucket ${BUCKET} --key ${PREFIX}/object-exist    0

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -646,7 +646,8 @@ public class ObjectEndpoint extends EndpointBase {
 
     ResponseBuilder response = Response.ok().status(HttpStatus.SC_OK)
         .header("Content-Length", key.getDataSize())
-        .header("Content-Type", "binary/octet-stream");
+        .header("Content-Type", "binary/octet-stream")
+        .header("x-amz-storage-class", "STANDARD");
 
     String eTag = key.getMetadata().get(ETAG);
     if (eTag != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support StorageClass field in the S3 HeadObject response

Please describe your PR in detail:

1. Ensure HeadObject response includes x-amz-storage-class with value "STANDARD"
2. Add smoketest to verify StorageClass field in AWS CLI output

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12877

## How was this patch tested?

Robot Test pass
![image](https://github.com/user-attachments/assets/859d13bf-f171-4c17-9021-24bf67782cb3)

[Github Action Pass](https://github.com/Jimmyweng006/ozone/actions/runs/14700205157)
