### PR TITLE
HDDS-11633. Delete message body too large, causing SCM to fail writing raft log

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -308,9 +308,6 @@ public class DeletedBlockLogImpl
         deletedBlockLogStateManager.addTransactionsToDB(txsToBeAdded);
         metrics.incrBlockDeletionTransactionCreated(txsToBeAdded.size());
       }
-
-      deletedBlockLogStateManager.addTransactionsToDB(txsToBeAdded);
-      metrics.incrBlockDeletionTransactionCreated(txsToBeAdded.size());
     } finally {
       lock.unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -93,7 +93,7 @@ public class DeletedBlockLogImpl
 
   private static final int LIST_ALL_FAILED_TRANSACTIONS = -1;
   private long lastProcessedTransactionId = -1;
-  final int logAppenderQueueByteLimit;
+  private final int logAppenderQueueByteLimit;
 
   public DeletedBlockLogImpl(ConfigurationSource conf,
       StorageContainerManager scm,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -36,10 +36,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.command.CommandStatusReportHandler.DeleteBlockStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -61,7 +63,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A implement class of {@link DeletedBlockLog}, and it uses
+ * An implement class of {@link DeletedBlockLog}, and it uses
  * K/V db to maintain block deletion transactions between scm and datanode.
  * This is a very basic implementation, it simply scans the log and
  * memorize the position that scanned by last time, and uses this to
@@ -81,7 +83,7 @@ public class DeletedBlockLogImpl
   private final Lock lock;
   // The access to DeletedBlocksTXTable is protected by
   // DeletedBlockLogStateManager.
-  private final DeletedBlockLogStateManager deletedBlockLogStateManager;
+  private DeletedBlockLogStateManager deletedBlockLogStateManager;
   private final SCMContext scmContext;
   private final SequenceIdGenerator sequenceIdGen;
   private final ScmBlockDeletingServiceMetrics metrics;
@@ -91,6 +93,7 @@ public class DeletedBlockLogImpl
 
   private static final int LIST_ALL_FAILED_TRANSACTIONS = -1;
   private long lastProcessedTransactionId = -1;
+  final int logAppenderQueueByteLimit;
 
   public DeletedBlockLogImpl(ConfigurationSource conf,
       StorageContainerManager scm,
@@ -116,6 +119,16 @@ public class DeletedBlockLogImpl
     this.transactionStatusManager =
         new SCMDeletedBlockTransactionStatusManager(deletedBlockLogStateManager,
             containerManager, metrics, scmCommandTimeoutMs);
+    int limit = (int) conf.getStorageSize(
+        ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT,
+        ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
+        StorageUnit.BYTES);
+    this.logAppenderQueueByteLimit = (int) (limit * 0.9);
+  }
+
+  @VisibleForTesting
+  void setDeletedBlockLogStateManager(DeletedBlockLogStateManager manager) {
+    this.deletedBlockLogStateManager = manager;
   }
 
   @Override
@@ -286,18 +299,16 @@ public class DeletedBlockLogImpl
     try {
       ArrayList<DeletedBlocksTransaction> txsToBeAdded = new ArrayList<>();
       long currentBatchSizeBytes = 0;
-      final long maxBatchSizeBytes = 25 * 1024 * 1024; // 25MB
       for (Map.Entry< Long, List< Long > > entry :
           containerBlocksMap.entrySet()) {
         long nextTXID = sequenceIdGen.getNextId(DEL_TXN_ID);
         DeletedBlocksTransaction tx = constructNewTransaction(nextTXID,
             entry.getKey(), entry.getValue());
         txsToBeAdded.add(tx);
-        // Rough size estimation: 8 bytes txnId + 8 bytes containerId + (block count * 8 bytes) + 2 bytes(count)
-        long txSize = 8L + 8L + tx.getLocalIDList().size() * 8L + 2L;
+        long txSize = tx.getSerializedSize();
         currentBatchSizeBytes += txSize;
 
-        if (currentBatchSizeBytes >= maxBatchSizeBytes) {
+        if (currentBatchSizeBytes >= logAppenderQueueByteLimit) {
           deletedBlockLogStateManager.addTransactionsToDB(txsToBeAdded);
           metrics.incrBlockDeletionTransactionCreated(txsToBeAdded.size());
           txsToBeAdded.clear();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -21,12 +21,12 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,6 +50,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -57,6 +60,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
@@ -432,6 +436,21 @@ public class TestDeletedBlockLog {
     }
 
     assertEquals(30 * THREE, blocks.size());
+  }
+
+  @Test
+  public void testAddTransactionsIsBatched() throws Exception {
+    conf.setStorageSize(ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT, 1, StorageUnit.KB);
+
+    DeletedBlockLogStateManager mockStateManager = mock(DeletedBlockLogStateManager.class);
+    DeletedBlockLogImpl log = new DeletedBlockLogImpl(conf, scm, containerManager, scmHADBTransactionBuffer, metrics);
+
+    log.setDeletedBlockLogStateManager(mockStateManager);
+
+    Map<Long, List<Long>> containerBlocksMap = generateData(100);
+    log.addTransactions(containerBlocksMap);
+
+    verify(mockStateManager, atLeast(2)).addTransactionsToDB(any());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM uses KeyDeletingService to traverse the deletedtable data in rocksdb, packages the block information to be deleted, and sends it to SCM for recording. The SCM leader receives the record and records it in their rocksdb, and sends a draft request to other SCM follower nodes.

When the data read from om's deletedtable is too large, for example, it has exceeded 32MB, and the upper limit of the draft log size for SCM is 32MB, it will cause writing the draft log for SCM to fail.

```
java.io.IOException: Skip writing the deleted blocks info to the delLog because draft transaction fails. 88064 keys skipped
Caused by: org.apache.hadoop.hdds.scm.exceptions.SCMException:
    org.apache.ratis.server.raftlog.exceptions.StateMachineException:
    org.apache.ratis.server.raftlog.RaftLogIOException:
    Log entry size 34396942 exceeds the max buffer limit of 33554432
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11633

## How was this patch tested?

Tested Manually.
