### PR TITLE
Revert "HDDS-11232. Spare InfoBucket RPC call for the FileSystem#getFileStatus calls for the general case. (#6988)"

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2154,8 +2154,6 @@ public class RpcClient implements ClientProtocol {
   @Override
   public OzoneFileStatus getOzoneFileStatus(String volumeName,
       String bucketName, String keyName) throws IOException {
-    verifyVolumeName(volumeName);
-    verifyBucketName(bucketName);
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
@@ -51,6 +51,11 @@ Verify ls fails on OBS bucket
 Create key in OBS bucket
     Execute             ozone sh key put /${volume}/${bucket}/testfile NOTICE.txt
 
+Verify ls fails on OBS bucket key
+    ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
+    ${result} =         Execute and checkrc   ozone fs -ls ${url}     255
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+
 Verify rm fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
     ${result} =         Execute and checkrc   ozone fs -rm ${url}     255

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -683,19 +683,20 @@ public class BasicRootedOzoneClientAdapterImpl
    * valid bucket path or valid snapshot path.
    * Throws exception in case of failure.
    */
-  private FileStatusAdapter getFileStatusForKeyOrSnapshot(OFSPath ofsPath, URI uri, Path qualifiedPath, String userName)
+  private FileStatusAdapter getFileStatusForKeyOrSnapshot(
+      OFSPath ofsPath, URI uri, Path qualifiedPath, String userName)
       throws IOException {
-    String volumeName = ofsPath.getVolumeName();
-    String bucketName = ofsPath.getBucketName();
     String key = ofsPath.getKeyName();
     try {
+      OzoneBucket bucket = getBucket(ofsPath, false);
       if (ofsPath.isSnapshotPath()) {
-        OzoneVolume volume = objectStore.getVolume(volumeName);
-        OzoneBucket bucket = getBucket(volumeName, bucketName, false);
-        return getFileStatusAdapterWithSnapshotIndicator(volume, bucket, uri);
+        OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
+        return getFileStatusAdapterWithSnapshotIndicator(
+            volume, bucket, uri);
       } else {
-        OzoneFileStatus status = proxy.getOzoneFileStatus(volumeName, bucketName, key);
-        return toFileStatusAdapter(status, userName, uri, qualifiedPath, ofsPath.getNonKeyPath());
+        OzoneFileStatus status = bucket.getFileStatus(key);
+        return toFileStatusAdapter(status, userName, uri, qualifiedPath,
+            ofsPath.getNonKeyPath());
       }
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.FILE_NOT_FOUND) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This reverts commit https://github.com/apache/ozone/commit/7a07625101d54b067d1acbee2e4057ea03587da3 due to a regression reported in [HDDS-12930](https://issues.apache.org/jira/browse/HDDS-12930).

Listing keys using the FS API (`fs -ls` command) should not be allowed for OBS buckets:

```
bash-4.4$ ozone sh bucket info vol1/buck1
{
  "metadata" : \{ },
  "volumeName" : "vol1",
  "name" : "buck1",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 15892,
  "usedNamespace" : 1,
  "creationTime" : "2025-04-29T06:02:09.195Z",
  "modificationTime" : "2025-04-29T06:02:09.195Z",
  "sourcePathExist" : true,
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "hadoop",
  "link" : false
}

bash-4.4$ ozone fs -ls ofs://om/vol1/buck1/testfile
-rw-rw-rw-   1 hadoop hadoop      15892 2025-04-29 06:02 ofs://om/vol1/buck1/testfile
```

The same is not allowed at the bucket-level:

```
bash-4.4$ ozone fs -ls ofs://om/vol1/buck1
-ls: Bucket: buck1 has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
```

Expected behaviour:
```
bash-4.4$ ozone fs -ls ofs://om/vol1/buck1/testfile
-ls: Bucket: buck1 has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12930

## How was this patch tested?

- Patch reverts a commit, existing tests should pass (green CI: https://github.com/tanvipenumudy/ozone/actions/runs/14724711024/).
- Added robot tests.