### PR TITLE
HDDS-12728. Add Ozone 2.0.0 to compatibility acceptance tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,8 +33,10 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
-run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
+run_test non-ha non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
+run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
+#run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
+#run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.4.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.2.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,7 +33,6 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test non-ha non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 #run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 #run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -65,6 +65,10 @@ services:
     image: ${OZONE_IMAGE}:1.4.1${OZONE_IMAGE_FLAVOR}
     <<: *old-config
 
+  old_client_2_0_0:
+    image: ${OZONE_IMAGE}:2.0.0${OZONE_IMAGE_FLAVOR}
+    <<: *old-config
+
   new_client:
     <<: *new-config
     environment:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -24,7 +24,7 @@ source "${COMPOSE_DIR}/../testlib.sh"
 
 current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
-old_versions="1.1.0 1.2.1 1.3.0 1.4.0 1.4.1" # container is needed for each version in clients.yaml
+old_versions="1.1.0 1.2.1 1.3.0 1.4.0 1.4.1 2.0.0" # container is needed for each version in clients.yaml
 
 export SECURITY_ENABLED=true
 : ${OZONE_BUCKET_KEY_NAME:=key1}

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -24,7 +24,7 @@ source "${COMPOSE_DIR}/../testlib.sh"
 
 current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
-old_versions="1.1.0 1.2.1 1.3.0 1.4.0 1.4.1 2.0.0" # container is needed for each version in clients.yaml
+old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0" # container is needed for each version in clients.yaml
 
 export SECURITY_ENABLED=true
 : ${OZONE_BUCKET_KEY_NAME:=key1}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since the `Ozone 2.0.0` image has been published, we should add `Ozone 2.0.0` to compatibility acceptance tests.

## What is the link to the Apache JIRA
[HDDS-12728](https://issues.apache.org/jira/browse/HDDS-12728)

## How was this patch tested?
CI:
https://github.com/chiacyu/ozone/actions/runs/14734736285
