### PR TITLE
HDDS-12944. Reduce timeout for integration check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
       script-args: -Ptest-${{ matrix.profile }} -Drocks_tools_native
       sha: ${{ needs.build-info.outputs.sha }}
       split: ${{ matrix.profile }}
-      timeout-minutes: 150
+      timeout-minutes: 90
       with-coverage: ${{ fromJSON(needs.build-info.outputs.with-coverage) }}
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fork timeout intermittently happens for subclasses of `OzoneRpcClientTests` (HDDS-12943), but surefire plugin cannot reliably kill forks (HDDS-10552).  With recent integration test speedups, the slowest split of integration check finishes in ~45 minutes, but timeout is still set to 150 minutes (2.5 hours).  This PR proposes to reduce timeout to 90 minutes (1.5 hours) to save some CI time in case of runaway fork.

https://issues.apache.org/jira/browse/HDDS-12944

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14771413562