### PR TITLE
HDDS-12963. Clean up io.grpc dependencies

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -80,16 +80,6 @@
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
     </dependency>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -83,6 +83,16 @@
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
     </dependency>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -61,10 +61,6 @@
       <artifactId>grpc-netty</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-stub</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
     </dependency>
@@ -135,6 +131,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <!-- required by OzoneManagerServiceBlockingStub in GrpcOmTransport -->
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -59,24 +59,6 @@
       <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-protobuf</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-stub</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix dependency warnings related to `io.grpc` artifacts:

```
[INFO] --- dependency:3.8.1:analyze-only (analyze) @ hdds-common ---
[WARNING] Unused declared dependencies found:
[WARNING]    io.grpc:grpc-api:jar:1.58.0:compile

[INFO] --- dependency:3.8.1:analyze-only (analyze) @ hdds-server-framework ---
[WARNING] Used undeclared dependencies found:
[WARNING]    io.grpc:grpc-api:jar:1.58.0:compile

[INFO] --- dependency:3.8.1:analyze-only (analyze) @ ozone-common ---
[WARNING] Non-test scoped test only dependencies found:
[WARNING]    io.grpc:grpc-stub:jar:1.58.0:compile

[INFO] --- dependency:3.8.1:analyze-only (analyze) @ ozone-s3gateway ---
[WARNING] Unused declared dependencies found:
[WARNING]    io.grpc:grpc-netty:jar:1.58.0:compile
[WARNING]    io.grpc:grpc-protobuf:jar:1.58.0:compile
[WARNING]    io.grpc:grpc-stub:jar:1.58.0:compile
```

(The warning in `ozone-common` is wrong, the plugin does not detect that generated `OzoneManagerServiceBlockingStub` requires `grpc-stub` at runtime.)

https://issues.apache.org/jira/browse/HDDS-12963

## How was this patch tested?

Build.  Verified the warnings related to `io.grpc` are gone.

https://github.com/adoroszlai/ozone/actions/runs/14810026256