### PR TITLE
HDDS-12964. Add required docker compose version on Building From Sources Document

### DIFF
--- a/hadoop-hdds/docs/content/start/FromSource.md
+++ b/hadoop-hdds/docs/content/start/FromSource.md
@@ -25,7 +25,6 @@ weight: 30
 * JDK 1.8 or higher
 * [Maven 3.6 or later](https://maven.apache.org/download.cgi)
 * Internet connection for first build (to fetch all Maven and Ozone dependencies)
-* [Docker Compose v2.32.1 or higher](https://docs.docker.com/compose/install/) (to prevent unexpected character “-” in variable name issue)
 
 You will also need to install the following dependencies to build native code (optional):
 * gcc

--- a/hadoop-hdds/docs/content/start/FromSource.md
+++ b/hadoop-hdds/docs/content/start/FromSource.md
@@ -25,6 +25,7 @@ weight: 30
 * JDK 1.8 or higher
 * [Maven 3.6 or later](https://maven.apache.org/download.cgi)
 * Internet connection for first build (to fetch all Maven and Ozone dependencies)
+* [Docker Compose v2.32.1 or higher](https://docs.docker.com/compose/install/) (to prevent unexpected character “-” in variable name issue)
 
 You will also need to install the following dependencies to build native code (optional):
 * gcc

--- a/hadoop-hdds/docs/content/start/FromSource.md
+++ b/hadoop-hdds/docs/content/start/FromSource.md
@@ -25,7 +25,7 @@ weight: 30
 * JDK 1.8 or higher
 * [Maven 3.6 or later](https://maven.apache.org/download.cgi)
 * Internet connection for first build (to fetch all Maven and Ozone dependencies)
-* [Docker Compose v2.30 or newer](https://docs.docker.com/compose/install/)
+* [Docker Compose v2.32.1 or higher](https://docs.docker.com/compose/install/) (to prevent unexpected character “-” in variable name issue)
 
 You will also need to install the following dependencies to build native code (optional):
 * gcc

--- a/hadoop-hdds/docs/content/start/FromSource.md
+++ b/hadoop-hdds/docs/content/start/FromSource.md
@@ -25,7 +25,7 @@ weight: 30
 * JDK 1.8 or higher
 * [Maven 3.6 or later](https://maven.apache.org/download.cgi)
 * Internet connection for first build (to fetch all Maven and Ozone dependencies)
-* [Docker Compose v2.32.1 or higher](https://docs.docker.com/compose/install/) (to prevent unexpected character “-” in variable name issue)
+* [Docker Compose v2.30 or newer](https://docs.docker.com/compose/install/)
 
 You will also need to install the following dependencies to build native code (optional):
 * gcc

--- a/hadoop-hdds/docs/content/start/RunningViaDocker.md
+++ b/hadoop-hdds/docs/content/start/RunningViaDocker.md
@@ -21,7 +21,8 @@ weight: 23
 -->
 
 {{< requirements >}}
- * docker and docker-compose
+ * [Docker Engine](https://docs.docker.com/engine/install/) latest stable version
+ * [Docker Compose](https://docs.docker.com/compose/install/) at least v2.30
 {{< /requirements >}}
 
 * Download the Ozone binary tarball and untar it.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Docker Compose v2.32.1+ requirement to documentation

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12964

## How was this patch tested?

Run command locally

[Github Action Pass](https://github.com/Jimmyweng006/ozone/actions/runs/14819591010)