### PR TITLE
HDDS-12967. Skip CommonChunkManagerTestCases.testFinishWrite if fuser cannot be started

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
@@ -147,12 +148,17 @@ public abstract class AbstractTestChunkManager {
         }
         LOG.debug("File is in use: {}", filePath);
         return false;
+      } catch (IOException e) {
+        LOG.warn("Failed to check if file is in use: {}", filePath, e);
+        return false;  // On failure, assume the file is in use
       } finally {
         process.destroy();
       }
     } catch (IOException e) {
+      // if process cannot be started, skip the test
       LOG.warn("Failed to check if file is in use: {}", filePath, e);
-      return false;  // On failure, assume the file is in use
+      abort(e.getMessage());
+      return false; // unreachable, abort() throws exception
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testFinishWrite` fails if external program `fuser` is not available.

```
Tests run: 12, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.136 s <<< FAILURE! -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestFilePerBlockStrategy
org.apache.hadoop.ozone.container.keyvalue.impl.TestFilePerBlockStrategy.testFinishWrite -- Time elapsed: 0.094 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at org.apache.hadoop.ozone.container.keyvalue.impl.CommonChunkManagerTestCases.testFinishWrite(CommonChunkManagerTestCases.java:242)
```

```
java.io.IOException: Cannot run program "fuser": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at org.apache.hadoop.ozone.container.keyvalue.impl.AbstractTestChunkManager.isFileNotInUse(AbstractTestChunkManager.java:142)
	at org.apache.hadoop.ozone.container.keyvalue.impl.AbstractTestChunkManager.checkChunkFilesClosed(AbstractTestChunkManager.java:179)
	at org.apache.hadoop.ozone.container.keyvalue.impl.AbstractTestChunkManager.checkChunkFilesClosed(AbstractTestChunkManager.java:160)
	at org.apache.hadoop.ozone.container.keyvalue.impl.CommonChunkManagerTestCases.testFinishWrite(CommonChunkManagerTestCases.java:242)
```

Skip the test case if this happens.

https://issues.apache.org/jira/browse/HDDS-12967

## How was this patch tested?

```
$ sudo chmod 644 /usr/bin/fuser
$ mvn -am -pl :hdds-container-service -Dtest='TestFilePer*Strategy' clean test
...
Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.979 s -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestFilePerBlockStrategy
Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.329 s -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestFilePerChunkStrategy
...

$ sudo chmod 755 /usr/bin/fuser
$ mvn -am -pl :hdds-container-service -Dtest='TestFilePer*Strategy' clean test
...
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.110 s -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestFilePerBlockStrategy
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.282 s -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestFilePerChunkStrategy
...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/14831498078
