### PR TITLE
HDDS-12973. Add java doc for CompactionNode constructor and make getCompactionNodeGraph return ConcurrentMap

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/CompactionNode.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/CompactionNode.java
@@ -32,6 +32,11 @@ public class CompactionNode {
   private final String endKey;
   private final String columnFamily;
 
+  /**
+   * CompactionNode constructor.
+   * @param file SST file (filename without extension)
+   * @param seqNum Snapshot generation (sequence number)
+   */
   public CompactionNode(String file, long seqNum, String startKey, String endKey, String columnFamily) {
     fileName = file;
     totalNumberOfKeys = 0L;

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1205,8 +1205,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   }
 
   @VisibleForTesting
-  public ConcurrentHashMap<String, CompactionNode> getCompactionNodeMap() {
-    return (ConcurrentHashMap<String, CompactionNode>) compactionDag.getCompactionMap();
+  public ConcurrentMap<String, CompactionNode> getCompactionNodeMap() {
+    return compactionDag.getCompactionMap();
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -62,7 +62,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -1146,7 +1145,7 @@ public class TestRocksDBCheckpointDiffer {
   }
 
   private void printMutableGraphFromAGivenNode(
-      ConcurrentHashMap<String, CompactionNode> compactionNodeMap,
+      ConcurrentMap<String, CompactionNode> compactionNodeMap,
       String fileName,
       int sstLevel,
       MutableGraph<CompactionNode> mutableGraph) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the refactoring done in the [PR](https://github.com/apache/ozone/pull/8016) for [HDDS-12053](https://issues.apache.org/jira/browse/HDDS-12053), a couple of minor review comments from were left out:

1. Add back the java doc for CompactionNode constructor
2. Make getCompactionNodeGraph return ConcurrentMap instead of ConcurrentHashMap

These are addressed in this PR

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12973

## How was this patch tested?

Existing tests
