### PR TITLE
HDDS-12972. Use DatanodeID in ContainerReplica.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -356,7 +356,7 @@ abstract class AbstractContainerReportHandler {
         .setContainerID(containerId)
         .setContainerState(replicaProto.getState())
         .setDatanodeDetails(datanodeDetails)
-        .setOriginNodeId(UUID.fromString(replicaProto.getOriginNodeId()))
+        .setOriginNodeId(DatanodeID.fromUuidString(replicaProto.getOriginNodeId()))
         .setSequenceId(replicaProto.getBlockCommitSequenceId())
         .setKeyCount(replicaProto.getKeyCount())
         .setReplicaIndex(replicaProto.getReplicaIndex())

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -17,13 +17,12 @@
 
 package org.apache.hadoop.hdds.scm.container;
 
-import com.google.common.base.Preconditions;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 
 /**
@@ -34,7 +33,12 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
   private final ContainerID containerID;
   private final ContainerReplicaProto.State state;
   private final DatanodeDetails datanodeDetails;
-  private final UUID placeOfBirth;
+  /**
+   * The origin creation of this replica.
+   * null: origin is the same as {@link #datanodeDetails}.
+   */
+  private final DatanodeID originDatanodeId;
+  /** The position at the pipeline. */
   private final int replicaIndex;
 
   private final Long sequenceId;
@@ -43,15 +47,15 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
   private final boolean isEmpty;
 
   private ContainerReplica(ContainerReplicaBuilder b) {
-    containerID = b.containerID;
-    state = b.state;
-    datanodeDetails = b.datanode;
-    placeOfBirth = Optional.ofNullable(b.placeOfBirth).orElse(datanodeDetails.getUuid());
-    keyCount = b.keyCount;
-    bytesUsed = b.bytesUsed;
-    replicaIndex = b.replicaIndex;
-    isEmpty = b.isEmpty;
-    sequenceId = b.sequenceId;
+    this.containerID = Objects.requireNonNull(b.containerID, "containerID == null");
+    this.state = Objects.requireNonNull(b.state, "state == null");
+    this.datanodeDetails = Objects.requireNonNull(b.datanode, "datanode == null");
+    this.originDatanodeId = b.placeOfBirth;
+    this.keyCount = b.keyCount;
+    this.bytesUsed = b.bytesUsed;
+    this.replicaIndex = b.replicaIndex;
+    this.isEmpty = b.isEmpty;
+    this.sequenceId = b.sequenceId;
   }
 
   public ContainerID getContainerID() {
@@ -72,8 +76,8 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
    *
    * @return UUID
    */
-  public UUID getOriginDatanodeId() {
-    return placeOfBirth;
+  public DatanodeID getOriginDatanodeId() {
+    return originDatanodeId != null ? originDatanodeId : datanodeDetails.getID();
   }
 
   /**
@@ -144,7 +148,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
 
   @Override
   public int compareTo(ContainerReplica that) {
-    Preconditions.checkNotNull(that);
+    Objects.requireNonNull(that);
     return new CompareToBuilder()
         .append(this.containerID, that.containerID)
         .append(this.datanodeDetails, that.datanodeDetails)
@@ -167,7 +171,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
         .setContainerState(state)
         .setDatanodeDetails(datanodeDetails)
         .setKeyCount(keyCount)
-        .setOriginNodeId(placeOfBirth)
+        .setOriginNodeId(originDatanodeId)
         .setReplicaIndex(replicaIndex)
         .setSequenceId(sequenceId)
         .setEmpty(isEmpty);
@@ -175,18 +179,16 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
 
   @Override
   public String toString() {
-    return "ContainerReplica{" +
-        "containerID=" + containerID +
-        ", state=" + state +
-        ", datanodeDetails=" + datanodeDetails +
-        ", placeOfBirth=" + placeOfBirth +
-        ", sequenceId=" + sequenceId +
-        ", keyCount=" + keyCount +
-        ", bytesUsed=" + bytesUsed + ((replicaIndex > 0) ?
-        ",replicaIndex=" + replicaIndex :
-        "") +
-        ", isEmpty=" + isEmpty +
-        '}';
+    return "ContainerReplica{" + containerID
+        + " (" + state
+        + ") currentDN=" + datanodeDetails
+        + (originDatanodeId != null ? ", originDN=" + originDatanodeId : " (origin)")
+        + ", bcsid=" + sequenceId
+        + (replicaIndex > 0 ? ", replicaIndex=" + replicaIndex : "")
+        + ", keyCount=" + keyCount
+        + ", bytesUsed=" + bytesUsed
+        + ", " + (isEmpty ? "empty" : "non-empty")
+        + '}';
   }
 
   /**
@@ -197,7 +199,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     private ContainerID containerID;
     private ContainerReplicaProto.State state;
     private DatanodeDetails datanode;
-    private UUID placeOfBirth;
+    private DatanodeID placeOfBirth;
     private Long sequenceId;
     private long bytesUsed;
     private long keyCount;
@@ -246,7 +248,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
      * @param originNodeId origin node UUID
      * @return ContainerReplicaBuilder
      */
-    public ContainerReplicaBuilder setOriginNodeId(UUID originNodeId) {
+    public ContainerReplicaBuilder setOriginNodeId(DatanodeID originNodeId) {
       placeOfBirth = originNodeId;
       return this;
     }
@@ -283,12 +285,6 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
      * @return ContainerReplicaBuilder
      */
     public ContainerReplica build() {
-      Preconditions.checkNotNull(containerID,
-          "Container Id can't be null");
-      Preconditions.checkNotNull(state,
-          "Container state can't be null");
-      Preconditions.checkNotNull(datanode,
-          "DatanodeDetails can't be null");
       return new ContainerReplica(this);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckReplicaCount.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -34,18 +34,20 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
  */
 public class QuasiClosedStuckReplicaCount {
 
-  private final Map<UUID, Set<ContainerReplica>> replicasByOrigin = new HashMap<>();
-  private final Map<UUID, Set<ContainerReplica>> inServiceReplicasByOrigin = new HashMap<>();
-  private final Map<UUID, Set<ContainerReplica>> maintenanceReplicasByOrigin = new HashMap<>();
-  private boolean hasOutOfServiceReplicas = false;
-  private int minHealthyForMaintenance;
-  private boolean hasHealthyReplicas = false;
+  private final Map<DatanodeID, Set<ContainerReplica>> replicasByOrigin = new HashMap<>();
+  private final Map<DatanodeID, Set<ContainerReplica>> inServiceReplicasByOrigin = new HashMap<>();
+  private final Map<DatanodeID, Set<ContainerReplica>> maintenanceReplicasByOrigin = new HashMap<>();
+  private final int minHealthyForMaintenance;
+  private final boolean hasHealthyReplicas;
+  private final boolean hasOutOfServiceReplicas;
 
   public QuasiClosedStuckReplicaCount(Set<ContainerReplica> replicas, int minHealthyForMaintenance) {
     this.minHealthyForMaintenance = minHealthyForMaintenance;
+    boolean hasHealthy = false;
+    boolean hasOutOfService = false;
     for (ContainerReplica r : replicas) {
       if (r.getState() != StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.UNHEALTHY) {
-        hasHealthyReplicas = true;
+        hasHealthy = true;
       }
       replicasByOrigin.computeIfAbsent(r.getOriginDatanodeId(), k -> new HashSet<>()).add(r);
       HddsProtos.NodeOperationalState opState = r.getDatanodeDetails().getPersistedOpState();
@@ -54,11 +56,14 @@ public class QuasiClosedStuckReplicaCount {
       } else if (opState == HddsProtos.NodeOperationalState.IN_MAINTENANCE
           || opState == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE) {
         maintenanceReplicasByOrigin.computeIfAbsent(r.getOriginDatanodeId(), k -> new HashSet<>()).add(r);
-        hasOutOfServiceReplicas = true;
+        hasOutOfService = true;
       } else {
-        hasOutOfServiceReplicas = true;
+        hasOutOfService = true;
       }
     }
+
+    this.hasHealthyReplicas = hasHealthy;
+    this.hasOutOfServiceReplicas = hasOutOfService;
   }
 
   public int availableOrigins() {
@@ -77,17 +82,23 @@ public class QuasiClosedStuckReplicaCount {
     return !getUnderReplicatedReplicas().isEmpty();
   }
 
+  private Set<ContainerReplica> getInService(DatanodeID origin) {
+    final Set<ContainerReplica> set = inServiceReplicasByOrigin.get(origin);
+    return set == null ? Collections.emptySet() : set;
+  }
+
+  private int getMaintenanceCount(DatanodeID origin) {
+    final Set<ContainerReplica> maintenance = maintenanceReplicasByOrigin.get(origin);
+    return maintenance == null ? 0 : maintenance.size();
+  }
+
   public List<MisReplicatedOrigin> getUnderReplicatedReplicas() {
     List<MisReplicatedOrigin> misReplicatedOrigins = new ArrayList<>();
 
     if (replicasByOrigin.size() == 1) {
-      Map.Entry<UUID, Set<ContainerReplica>> entry = replicasByOrigin.entrySet().iterator().next();
-      Set<ContainerReplica> inService = inServiceReplicasByOrigin.get(entry.getKey());
-      if (inService == null) {
-        inService = Collections.emptySet();
-      }
-      Set<ContainerReplica> maintenance = maintenanceReplicasByOrigin.get(entry.getKey());
-      int maintenanceCount = maintenance == null ? 0 : maintenance.size();
+      final Map.Entry<DatanodeID, Set<ContainerReplica>> entry = replicasByOrigin.entrySet().iterator().next();
+      final Set<ContainerReplica> inService = getInService(entry.getKey());
+      final int maintenanceCount = getMaintenanceCount(entry.getKey());
 
       if (maintenanceCount > 0) {
         if (inService.size() < minHealthyForMaintenance) {
@@ -105,13 +116,9 @@ public class QuasiClosedStuckReplicaCount {
 
     // If there are multiple origins, we expect 2 copies of each origin
     // For maintenance, we expect 1 copy of each origin and ignore the minHealthyForMaintenance parameter
-    for (Map.Entry<UUID, Set<ContainerReplica>> entry : replicasByOrigin.entrySet()) {
-      Set<ContainerReplica> inService = inServiceReplicasByOrigin.get(entry.getKey());
-      if (inService == null) {
-        inService = Collections.emptySet();
-      }
-      Set<ContainerReplica> maintenance = maintenanceReplicasByOrigin.get(entry.getKey());
-      int maintenanceCount = maintenance == null ? 0 : maintenance.size();
+    for (Map.Entry<DatanodeID, Set<ContainerReplica>> entry : replicasByOrigin.entrySet()) {
+      final Set<ContainerReplica> inService = getInService(entry.getKey());
+      final int maintenanceCount = getMaintenanceCount(entry.getKey());
 
       if (inService.size() < 2) {
         if (maintenanceCount > 0) {
@@ -142,9 +149,9 @@ public class QuasiClosedStuckReplicaCount {
   public List<MisReplicatedOrigin> getOverReplicatedOrigins() {
     // If there is only a single origin, we expect 3 copies, otherwise we expect 2 copies of each origin
     if (replicasByOrigin.size() == 1) {
-      UUID origin = replicasByOrigin.keySet().iterator().next();
-      Set<ContainerReplica> inService = inServiceReplicasByOrigin.get(origin);
-      if (inService != null && inService.size() > 3) {
+      final DatanodeID origin = replicasByOrigin.keySet().iterator().next();
+      final Set<ContainerReplica> inService = getInService(origin);
+      if (inService.size() > 3) {
         return Collections.singletonList(new MisReplicatedOrigin(inService, inService.size() - 3));
       }
       return Collections.emptyList();
@@ -152,9 +159,9 @@ public class QuasiClosedStuckReplicaCount {
 
     // If there are multiple origins, we expect 2 copies of each origin
     List<MisReplicatedOrigin> overReplicatedOrigins = new ArrayList<>();
-    for (UUID origin : replicasByOrigin.keySet()) {
-      Set<ContainerReplica> replicas = inServiceReplicasByOrigin.get(origin);
-      if (replicas != null && replicas.size() > 2) {
+    for (DatanodeID origin : replicasByOrigin.keySet()) {
+      final Set<ContainerReplica> replicas = getInService(origin);
+      if (replicas.size() > 2) {
         overReplicatedOrigins.add(new MisReplicatedOrigin(replicas, replicas.size() - 2));
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -30,10 +30,10 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -511,7 +511,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
     vulnerable and need to be saved.
      */
     // TODO should we also consider pending deletes?
-    Set<UUID> originsOfInServiceReplicas = new HashSet<>();
+    final Set<DatanodeID> originsOfInServiceReplicas = new HashSet<>();
     for (ContainerReplica replica : replicas) {
       if (replica.getDatanodeDetails().getPersistedOpState()
           .equals(IN_SERVICE) && replica.getSequenceId().equals(container.getSequenceId())) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
@@ -25,10 +25,10 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
@@ -331,7 +331,7 @@ public final class ReplicationManagerUtil {
       Function<DatanodeDetails, NodeStatus> nodeStatusFn) {
     // Gather the origin node IDs of replicas which are not candidates for
     // deletion.
-    Set<UUID> existingOriginNodeIDs = allReplicas.stream()
+    final Set<DatanodeID> existingOriginNodeIDs = allReplicas.stream()
         .filter(r -> !deleteCandidates.contains(r))
         .filter(r -> {
           NodeStatus status = nodeStatusFn.apply(r.getDatanodeDetails());
@@ -374,7 +374,7 @@ public final class ReplicationManagerUtil {
     return nonUniqueDeleteCandidates;
   }
 
-  private static void checkUniqueness(Set<UUID> existingOriginNodeIDs,
+  private static void checkUniqueness(Set<DatanodeID> existingOriginNodeIDs,
       List<ContainerReplica> nonUniqueDeleteCandidates,
       ContainerReplica replica) {
     if (existingOriginNodeIDs.contains(replica.getOriginDatanodeId())) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -679,7 +679,7 @@ public final class HddsTestUtils {
     List<ContainerReplica> replicas = new ArrayList<>();
     for (DatanodeDetails datanode : datanodeDetails) {
       replicas.add(getReplicas(containerId, state,
-          sequenceId, datanode.getUuid(), datanode));
+          sequenceId, datanode.getID(), datanode));
     }
     return replicas;
   }
@@ -688,11 +688,11 @@ public final class HddsTestUtils {
       final ContainerID containerId,
       final ContainerReplicaProto.State state,
       final long sequenceId,
-      final UUID originNodeId,
+      final DatanodeID originNodeId,
       final DatanodeDetails datanodeDetails) {
-    return getReplicas(containerId, state, CONTAINER_USED_BYTES_DEFAULT,
+    return getReplicaBuilder(containerId, state, CONTAINER_USED_BYTES_DEFAULT,
             CONTAINER_NUM_KEYS_DEFAULT, sequenceId, originNodeId,
-            datanodeDetails);
+            datanodeDetails).build();
   }
 
   public static ContainerReplica.ContainerReplicaBuilder getReplicaBuilder(
@@ -701,7 +701,7 @@ public final class HddsTestUtils {
           final long usedBytes,
           final long keyCount,
           final long sequenceId,
-          final UUID originNodeId,
+          final DatanodeID originNodeId,
           final DatanodeDetails datanodeDetails) {
     return ContainerReplica.newBuilder()
             .setContainerID(containerId).setContainerState(state)
@@ -710,20 +710,6 @@ public final class HddsTestUtils {
             .setBytesUsed(usedBytes)
             .setKeyCount(keyCount)
             .setEmpty(keyCount == 0);
-  }
-
-  public static ContainerReplica getReplicas(
-      final ContainerID containerId,
-      final ContainerReplicaProto.State state,
-      final long usedBytes,
-      final long keyCount,
-      final long sequenceId,
-      final UUID originNodeId,
-      final DatanodeDetails datanodeDetails) {
-    ContainerReplica.ContainerReplicaBuilder builder =
-            getReplicaBuilder(containerId, state, usedBytes, keyCount,
-                    sequenceId, originNodeId, datanodeDetails);
-    return builder.build();
   }
 
   public static List<ContainerReplica> getReplicasWithReplicaIndex(
@@ -737,7 +723,7 @@ public final class HddsTestUtils {
     int replicaIndex = 1;
     for (DatanodeDetails datanode : datanodeDetails) {
       replicas.add(getReplicaBuilder(containerId, state,
-              usedBytes, keyCount, sequenceId, datanode.getUuid(), datanode)
+              usedBytes, keyCount, sequenceId, datanode.getID(), datanode)
               .setReplicaIndex(replicaIndex).build());
       replicaIndex += 1;
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -357,10 +357,10 @@ public class TestSCMCommonPlacementPolicy {
             ContainerID.valueOf(1), CLOSED, 0, 0, 0, list.subList(3, 6)));
     Set<ContainerReplica> replicasToBeRemoved = Sets.newHashSet(
             HddsTestUtils.getReplicaBuilder(ContainerID.valueOf(1), CLOSED, 0, 0, 0,
-                    list.get(7).getUuid(), list.get(7))
+                    list.get(7).getID(), list.get(7))
                     .setReplicaIndex(1).build(),
             HddsTestUtils.getReplicaBuilder(ContainerID.valueOf(1), CLOSED, 0, 0, 0,
-                    list.get(8).getUuid(), list.get(8)).setReplicaIndex(1)
+                    list.get(8).getID(), list.get(8)).setReplicaIndex(1)
                     .build());
     replicas.addAll(replicasToBeRemoved);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplica.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.scm.container;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ class TestContainerReplica {
             ThreadLocalRandom.current().nextLong(Long.MAX_VALUE - 1) + 1))
         .setContainerState(CLOSED)
         .setKeyCount(ThreadLocalRandom.current().nextLong())
-        .setOriginNodeId(UUID.randomUUID())
+        .setOriginNodeId(DatanodeID.randomID())
         .setSequenceId(ThreadLocalRandom.current().nextLong())
         .setReplicaIndex(ThreadLocalRandom.current().nextInt())
         .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -573,7 +573,7 @@ public class TestContainerBalancerTask {
         .setContainerID(containerID)
         .setContainerState(ContainerReplicaProto.State.CLOSED)
         .setDatanodeDetails(datanodeDetails)
-        .setOriginNodeId(datanodeDetails.getUuid())
+        .setOriginNodeId(datanodeDetails.getID())
         .setSequenceId(1000L)
         .setBytesUsed(usedBytes)
         .build();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
@@ -248,7 +248,7 @@ public final class TestableCluster {
         .setContainerID(containerID)
         .setContainerState(ContainerReplicaProto.State.CLOSED)
         .setDatanodeDetails(datanodeDetails)
-        .setOriginNodeId(datanodeDetails.getUuid())
+        .setOriginNodeId(datanodeDetails.getID())
         .setSequenceId(1000L)
         .setBytesUsed(usedBytes)
         .build();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -32,13 +32,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -121,7 +121,7 @@ public final class ReplicationTestUtil {
       DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
       replicas.add(createContainerReplica(containerID, i, IN_SERVICE,
           replicaState, keyCount, bytesUsed,
-          dn, dn.getUuid()));
+          dn, dn.getID()));
     }
     return replicas;
   }
@@ -130,7 +130,7 @@ public final class ReplicationTestUtil {
       ContainerID containerID, ContainerReplicaProto.State replicaState,
       int... indexes) {
     Set<ContainerReplica> replicas = new HashSet<>();
-    UUID originNodeId = MockDatanodeDetails.randomDatanodeDetails().getUuid();
+    final DatanodeID originNodeId = DatanodeID.randomID();
     for (int i : indexes) {
       replicas.add(createContainerReplica(
           containerID, i, IN_SERVICE, replicaState, 123L, 1234L,
@@ -146,14 +146,14 @@ public final class ReplicationTestUtil {
         = MockDatanodeDetails.randomDatanodeDetails();
     return createContainerReplica(containerID, replicaIndex, opState,
         replicaState, 0L, 0L,
-        datanodeDetails, datanodeDetails.getUuid());
+        datanodeDetails, datanodeDetails.getID());
   }
 
   public static Set<ContainerReplica> createReplicasWithOriginAndOpState(
       ContainerID containerID, ContainerReplicaProto.State replicaState,
-      Pair<UUID, HddsProtos.NodeOperationalState>... nodes) {
+      Pair<DatanodeID, HddsProtos.NodeOperationalState>... nodes) {
     Set<ContainerReplica> replicas = new HashSet<>();
-    for (Pair<UUID, HddsProtos.NodeOperationalState> i : nodes) {
+    for (Pair<DatanodeID, HddsProtos.NodeOperationalState> i : nodes) {
       replicas.add(createContainerReplica(
           containerID, 0, i.getRight(), replicaState, 123L, 1234L,
           MockDatanodeDetails.randomDatanodeDetails(), i.getLeft()));
@@ -168,7 +168,7 @@ public final class ReplicationTestUtil {
         = MockDatanodeDetails.randomDatanodeDetails();
     return createContainerReplica(containerID, replicaIndex, opState,
         replicaState, 123L, 1234L,
-        datanodeDetails, datanodeDetails.getUuid());
+        datanodeDetails, datanodeDetails.getID());
   }
 
   public static ContainerReplica createContainerReplica(ContainerID containerID,
@@ -178,14 +178,14 @@ public final class ReplicationTestUtil {
         = MockDatanodeDetails.randomDatanodeDetails();
     return createContainerReplica(containerID, replicaIndex, opState,
         replicaState, 123L, 1234L,
-        datanodeDetails, datanodeDetails.getUuid(), seqId);
+        datanodeDetails, datanodeDetails.getID(), seqId);
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public static ContainerReplica createContainerReplica(ContainerID containerID,
       int replicaIndex, HddsProtos.NodeOperationalState opState,
       ContainerReplicaProto.State replicaState, long keyCount, long bytesUsed,
-      DatanodeDetails datanodeDetails, UUID originNodeId) {
+      DatanodeDetails datanodeDetails, DatanodeID originNodeId) {
     ContainerReplica.ContainerReplicaBuilder builder
         = ContainerReplica.newBuilder();
     datanodeDetails.setPersistedOpState(opState);
@@ -205,7 +205,7 @@ public final class ReplicationTestUtil {
   public static ContainerReplica createContainerReplica(ContainerID containerID,
       int replicaIndex, HddsProtos.NodeOperationalState opState,
       ContainerReplicaProto.State replicaState, long keyCount, long bytesUsed,
-      DatanodeDetails datanodeDetails, UUID originNodeId, long seqId) {
+      DatanodeDetails datanodeDetails, DatanodeID originNodeId, long seqId) {
     ContainerReplica.ContainerReplicaBuilder builder
         = ContainerReplica.newBuilder();
     datanodeDetails.setPersistedOpState(opState);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
@@ -30,12 +30,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -59,8 +59,8 @@ public class TestQuasiClosedStuckOverReplicationHandler {
   private ReplicationManagerMetrics metrics;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
   private QuasiClosedStuckOverReplicationHandler handler;
-  private UUID origin1 = UUID.randomUUID();
-  private UUID origin2 = UUID.randomUUID();
+  private final DatanodeID origin1 = DatanodeID.randomID();
+  private final DatanodeID origin2 = DatanodeID.randomID();
 
   @BeforeEach
   void setup() throws NodeNotFoundException,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckReplicaCount.java
@@ -29,11 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,16 +40,9 @@ import org.junit.jupiter.api.Test;
  */
 public class TestQuasiClosedStuckReplicaCount {
 
-  private UUID origin1;
-  private UUID origin2;
-  private UUID origin3;
-
-  @BeforeEach
-  public void setUp() {
-    origin1 = UUID.randomUUID();
-    origin2 = UUID.randomUUID();
-    origin3 = UUID.randomUUID();
-  }
+  private final DatanodeID origin1 = DatanodeID.randomID();
+  private final DatanodeID origin2 = DatanodeID.randomID();
+  private final DatanodeID origin3 = DatanodeID.randomID();
 
   @Test
   public void testCorrectlyReplicationWithThreeOrigins() {
@@ -122,7 +114,7 @@ public class TestQuasiClosedStuckReplicaCount {
     assertTrue(misReplicatedOrigins.size() == 2);
 
     for (QuasiClosedStuckReplicaCount.MisReplicatedOrigin misReplicatedOrigin : misReplicatedOrigins) {
-      UUID source = misReplicatedOrigin.getSources().iterator().next().getOriginDatanodeId();
+      final DatanodeID source = misReplicatedOrigin.getSources().iterator().next().getOriginDatanodeId();
       assertTrue(source.equals(origin1) || source.equals(origin3));
     }
   }
@@ -336,7 +328,7 @@ public class TestQuasiClosedStuckReplicaCount {
 
   private void validateMisReplicatedOrigins(
       List<QuasiClosedStuckReplicaCount.MisReplicatedOrigin> misReplicatedOrigins,
-      int expectedUnderRepOrigins, int expectedSources, int expectedDelta, UUID expectedOrigin) {
+      int expectedUnderRepOrigins, int expectedSources, int expectedDelta, DatanodeID expectedOrigin) {
 
     assertTrue(misReplicatedOrigins.size() == expectedUnderRepOrigins);
     Set<ContainerReplica> sources = misReplicatedOrigins.get(0).getSources();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
@@ -31,12 +31,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -114,7 +114,7 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
 
   @Test
   public void testReturnsZeroIfNotUnderReplicated() throws IOException {
-    UUID origin = UUID.randomUUID();
+    final DatanodeID origin = DatanodeID.randomID();
     Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
         StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
         Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
@@ -127,7 +127,7 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
 
   @Test
   public void testNoCommandsScheduledIfPendingOps() throws IOException {
-    UUID origin = UUID.randomUUID();
+    final DatanodeID origin = DatanodeID.randomID();
     Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
         StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
         Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE),
@@ -142,7 +142,7 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
 
   @Test
   public void testCommandScheduledForUnderReplicatedContainer() throws IOException {
-    UUID origin = UUID.randomUUID();
+    final DatanodeID origin = DatanodeID.randomID();
     Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
         StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
         Pair.of(origin, HddsProtos.NodeOperationalState.IN_SERVICE));
@@ -154,8 +154,8 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
 
   @Test
   public void testOverloadedExceptionContinuesAndThrows() throws NotLeaderException, CommandTargetOverloadedException {
-    UUID origin1 = UUID.randomUUID();
-    UUID origin2 = UUID.randomUUID();
+    final DatanodeID origin1 = DatanodeID.randomID();
+    final DatanodeID origin2 = DatanodeID.randomID();
     Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
         StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
         Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
@@ -170,8 +170,8 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
 
   @Test
   public void testInsufficientNodesExceptionThrown() {
-    UUID origin1 = UUID.randomUUID();
-    UUID origin2 = UUID.randomUUID();
+    final DatanodeID origin1 = DatanodeID.randomID();
+    final DatanodeID origin2 = DatanodeID.randomID();
     Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
         StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
         Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE),
@@ -187,7 +187,7 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
 
   @Test
   public void testPartialReplicationExceptionThrown() {
-    UUID origin1 = UUID.randomUUID();
+    final DatanodeID origin1 = DatanodeID.randomID();
     Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicasWithOriginAndOpState(container.containerID(),
         StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED,
         Pair.of(origin1, HddsProtos.NodeOperationalState.IN_SERVICE));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -415,7 +415,7 @@ class TestRatisContainerReplicaCount {
           .setContainerID(ContainerID.valueOf(1))
           .setContainerState(OPEN)
           .setDatanodeDetails(dn)
-          .setOriginNodeId(dn.getUuid())
+          .setOriginNodeId(dn.getID())
           .setSequenceId(1)
           .build();
       replica.remove(r);
@@ -841,7 +841,7 @@ class TestRatisContainerReplicaCount {
           .setContainerID(ContainerID.valueOf(1))
           .setContainerState(State.CLOSED)
           .setDatanodeDetails(dn)
-          .setOriginNodeId(dn.getUuid())
+          .setOriginNodeId(dn.getID())
           .setSequenceId(1)
           .build());
     }
@@ -850,7 +850,7 @@ class TestRatisContainerReplicaCount {
 
   private ContainerInfo createContainer(HddsProtos.LifeCycleState state) {
     return new ContainerInfo.Builder()
-        .setContainerID(ContainerID.valueOf(1).getId())
+        .setContainerID(1)
         .setState(state)
         .build();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -373,7 +374,7 @@ public class TestReplicationManager {
     Set<ContainerReplica> replicas =
         createReplicasWithSameOrigin(container.containerID(),
             ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
-    UUID origin = replicas.iterator().next().getOriginDatanodeId();
+    final DatanodeID origin = replicas.iterator().next().getOriginDatanodeId();
     ContainerReplica unhealthy =
         createContainerReplica(container.containerID(), 0, IN_SERVICE,
             ContainerReplicaProto.State.UNHEALTHY, 1, 123,
@@ -660,7 +661,7 @@ public class TestReplicationManager {
 
     ContainerReplica replica  = createContainerReplica(container.containerID(),
         1, IN_SERVICE, ContainerReplicaProto.State.CLOSED,
-        0, 0, MockDatanodeDetails.randomDatanodeDetails(), UUID.randomUUID());
+        0, 0, MockDatanodeDetails.randomDatanodeDetails(), DatanodeID.randomID());
 
     storeContainerAndReplicas(container, Collections.singleton(replica));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -89,7 +90,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 
 public class TestReplicationManagerScenarios {
-  private static final Map<String, UUID> ORIGINS = new HashMap<>();
+  private static final Map<String, DatanodeID> ORIGINS = new HashMap<>();
   private static final Map<String, DatanodeDetails> DATANODE_ALIASES
       = new HashMap<>();
   private static final Map<DatanodeDetails, NodeStatus> NODE_STATUS_MAP
@@ -238,8 +239,8 @@ public class TestReplicationManagerScenarios {
     };
   }
 
-  protected static UUID getOrCreateOrigin(String origin) {
-    return ORIGINS.computeIfAbsent(origin, (k) -> UUID.randomUUID());
+  protected static DatanodeID getOrCreateOrigin(String origin) {
+    return ORIGINS.computeIfAbsent(origin, k -> DatanodeID.randomID());
   }
 
   private static Stream<Scenario> getTestScenarios() {
@@ -382,7 +383,7 @@ public class TestReplicationManagerScenarios {
     private long used = 10;
     private boolean isEmpty = false;
     private String origin;
-    private UUID originId;
+    private DatanodeID originId;
 
     public void setContainerId(long containerId) {
       this.containerId = containerId;
@@ -481,7 +482,7 @@ public class TestReplicationManagerScenarios {
       if (origin != null) {
         originId = getOrCreateOrigin(origin);
       } else {
-        originId = UUID.randomUUID();
+        originId = DatanodeID.randomID();
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -231,7 +231,7 @@ public class TestEmptyContainerHandler {
         ReplicationTestUtil.createContainerReplica(containerInfo.containerID(),
             5, HddsProtos.NodeOperationalState.IN_SERVICE,
             ContainerReplicaProto.State.CLOSED, 1L, 100L, mockDn,
-            mockDn.getUuid()));
+            mockDn.getID()));
 
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.emptyList())

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
@@ -228,11 +228,11 @@ public class TestQuasiClosedContainerHandler {
 
     // 1001 is the highest sequence id
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, dnOne.getUuid(), dnOne);
+        id, State.QUASI_CLOSED, 1000L, dnOne.getID(), dnOne);
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, dnTwo.getUuid(), dnTwo);
+        id, State.QUASI_CLOSED, 1000L, dnTwo.getID(), dnTwo);
     final ContainerReplica replicaThree = getReplicas(
-        id, State.UNHEALTHY, 1001L, dnThree.getUuid(), dnThree);
+        id, State.UNHEALTHY, 1001L, dnThree.getID(), dnThree);
     Set<ContainerReplica> containerReplicas = new HashSet<>();
     containerReplicas.add(replicaOne);
     containerReplicas.add(replicaTwo);
@@ -332,11 +332,11 @@ public class TestQuasiClosedContainerHandler {
 
     // 1001 is the highest sequence id
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, dnOne.getUuid(), dnOne);
+        id, State.QUASI_CLOSED, 1000L, dnOne.getID(), dnOne);
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1001L, dnTwo.getUuid(), dnTwo);
+        id, State.QUASI_CLOSED, 1001L, dnTwo.getID(), dnTwo);
     final ContainerReplica replicaThree = getReplicas(
-        id, State.QUASI_CLOSED, 1001L, dnThree.getUuid(), dnThree);
+        id, State.QUASI_CLOSED, 1001L, dnThree.getID(), dnThree);
     Set<ContainerReplica> containerReplicas = new HashSet<>();
     containerReplicas.add(replicaOne);
     containerReplicas.add(replicaTwo);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
@@ -30,9 +30,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -51,9 +51,10 @@ import org.junit.jupiter.api.Test;
 public class TestQuasiClosedStuckReplicationCheck {
 
   private QuasiClosedStuckReplicationCheck handler;
-  private final UUID origin1 = UUID.randomUUID();
-  private final UUID origin2 = UUID.randomUUID();
-  private final UUID origin3 = UUID.randomUUID();
+  private final DatanodeID origin1 = DatanodeID.randomID();
+  private final DatanodeID origin2 = DatanodeID.randomID();
+  private final DatanodeID origin3 = DatanodeID.randomID();
+
   private ReplicationManagerReport report;
   private ReplicationQueue queue;
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -41,12 +41,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -992,23 +992,23 @@ public class TestRatisReplicationCheckHandler {
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.QUASI_CLOSED, 1, 1,
         MockDatanodeDetails.randomDatanodeDetails(),
-        MockDatanodeDetails.randomDatanodeDetails().getUuid(),
+        DatanodeID.randomID(),
         sequenceID - 1));
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.QUASI_CLOSED, 1, 1,
         MockDatanodeDetails.randomDatanodeDetails(),
-        MockDatanodeDetails.randomDatanodeDetails().getUuid(),
+        DatanodeID.randomID(),
         sequenceID - 1));
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.QUASI_CLOSED, 1, 1,
         MockDatanodeDetails.randomDatanodeDetails(),
-        MockDatanodeDetails.randomDatanodeDetails().getUuid(),
+        DatanodeID.randomID(),
         sequenceID - 1));
 
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.UNHEALTHY, 1, 1,
         MockDatanodeDetails.randomDatanodeDetails(),
-        MockDatanodeDetails.randomDatanodeDetails().getUuid(),
+        DatanodeID.randomID(),
         sequenceID));
 
     requestBuilder.setContainerReplicas(replicas)
@@ -1030,17 +1030,17 @@ public class TestRatisReplicationCheckHandler {
         repConfig, 1, HddsProtos.LifeCycleState.QUASI_CLOSED,
         sequenceID);
 
-    UUID origin = UUID.randomUUID();
+    final DatanodeID origin = DatanodeID.randomID();
     final Set<ContainerReplica> replicas = new HashSet<>(2);
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.QUASI_CLOSED, 1, 1,
         MockDatanodeDetails.randomDatanodeDetails(),
-        MockDatanodeDetails.randomDatanodeDetails().getUuid(),
+        DatanodeID.randomID(),
         sequenceID - 1));
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.QUASI_CLOSED, 1, 1,
         MockDatanodeDetails.randomDatanodeDetails(),
-        MockDatanodeDetails.randomDatanodeDetails().getUuid(),
+        DatanodeID.randomID(),
         sequenceID - 1));
     replicas.add(createContainerReplica(container.containerID(), 0,
         IN_SERVICE, State.QUASI_CLOSED, 1, 1,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -257,7 +257,7 @@ public class TestDatanodeAdminMonitor {
         ReplicationTestUtil.createContainerReplica(containerID, 0,
             dn1.getPersistedOpState(), State.UNHEALTHY,
             container.getNumberOfKeys(), container.getUsedBytes(), dn1,
-            dn1.getUuid(), container.getSequenceId());
+            dn1.getID(), container.getSequenceId());
     replicas.add(unhealthy);
     nodeManager.setContainers(dn1, ImmutableSet.of(containerID));
 
@@ -321,7 +321,7 @@ public class TestDatanodeAdminMonitor {
         ReplicationTestUtil.createContainerReplica(containerID, 0,
             dn1.getPersistedOpState(), State.UNHEALTHY,
             container.getNumberOfKeys(), container.getUsedBytes(), dn1,
-            dn1.getUuid(), container.getSequenceId());
+            dn1.getID(), container.getSequenceId());
     replicas.add(unhealthy);
     nodeManager.setContainers(dn1, ImmutableSet.of(containerID));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -41,11 +41,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
@@ -213,7 +213,7 @@ public class TestECPipelineProvider {
           .setContainerState(StorageContainerDatanodeProtocolProtos
               .ContainerReplicaProto.State.CLOSED)
           .setKeyCount(1)
-          .setOriginNodeId(UUID.randomUUID())
+          .setOriginNodeId(DatanodeID.randomID())
           .setSequenceId(1)
           .setReplicaIndex(i + 1)
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -945,7 +946,7 @@ public class TestPipelineManagerImpl {
           .setContainerState(StorageContainerDatanodeProtocolProtos
               .ContainerReplicaProto.State.CLOSED)
           .setKeyCount(1)
-          .setOriginNodeId(UUID.randomUUID())
+          .setOriginNodeId(DatanodeID.randomID())
           .setSequenceId(1)
           .setReplicaIndex(0)
           .setDatanodeDetails(dn)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -43,6 +42,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -419,7 +419,7 @@ public class TestRatisPipelineProvider {
           .setContainerState(StorageContainerDatanodeProtocolProtos
               .ContainerReplicaProto.State.CLOSED)
           .setKeyCount(1)
-          .setOriginNodeId(UUID.randomUUID())
+          .setOriginNodeId(DatanodeID.randomID())
           .setSequenceId(1)
           .setReplicaIndex(0)
           .setDatanodeDetails(dn)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ContainerReplica, the type of placeOfBirth is UUID. It is better to use DatanodeID.

We also rename placeOfBirth to originDatanodeId to match the getOriginDatanodeId() method.

## What is the link to the Apache JIRA

HDDS-12972

## How was this patch tested?

By updating existing tests.