### PR TITLE
HDDS-12974. Docker could not parse extra host IP

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -60,10 +60,10 @@ services:
       - 19864:9999
     command: ["/opt/hadoop/bin/ozone","datanode"]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
-      - "recon: 172.25.0.115"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
+      - "recon=172.25.0.115"
     environment:
       WAITFOR: scm3.org:9894
       OZONE_OPTS:
@@ -76,10 +76,10 @@ services:
       - 9866:9999
     command: ["/opt/hadoop/bin/ozone","datanode"]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
-      - "recon: 172.25.0.115"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
+      - "recon=172.25.0.115"
     environment:
       WAITFOR: scm3.org:9894
       OZONE_OPTS:
@@ -92,10 +92,10 @@ services:
       - 9868:9999
     command: ["/opt/hadoop/bin/ozone","datanode"]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
-      - "recon: 172.25.0.115"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
+      - "recon=172.25.0.115"
     environment:
       WAITFOR: scm3.org:9894
       OZONE_OPTS:
@@ -115,9 +115,9 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","om"]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.111
@@ -134,9 +134,9 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","om"]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.112
@@ -153,9 +153,9 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","om"]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.113
@@ -192,12 +192,12 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","scm"]
     extra_hosts:
-      - "om1: 172.25.0.111"
-      - "om2: 172.25.0.112"
-      - "om3: 172.25.0.113"
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "om1=172.25.0.111"
+      - "om2=172.25.0.112"
+      - "om3=172.25.0.113"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.116
@@ -214,12 +214,12 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","scm"]
     extra_hosts:
-      - "om1: 172.25.0.111"
-      - "om2: 172.25.0.112"
-      - "om3: 172.25.0.113"
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "om1=172.25.0.111"
+      - "om2=172.25.0.112"
+      - "om3=172.25.0.113"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.117
@@ -236,12 +236,12 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","scm"]
     extra_hosts:
-      - "om1: 172.25.0.111"
-      - "om2: 172.25.0.112"
-      - "om3: 172.25.0.113"
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "om1=172.25.0.111"
+      - "om2=172.25.0.112"
+      - "om3=172.25.0.113"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.118
@@ -254,12 +254,12 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","recon"]
     extra_hosts:
-      - "om1: 172.25.0.111"
-      - "om2: 172.25.0.112"
-      - "om3: 172.25.0.113"
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "om1=172.25.0.111"
+      - "om2=172.25.0.112"
+      - "om3=172.25.0.113"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.115

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/s3g-virtual-host.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/s3g-virtual-host.yaml
@@ -40,6 +40,6 @@ services:
   s3g:
     <<: *s3g-virtual-host-config
     extra_hosts:
-      - "bucket1.s3g.internal: 172.25.0.120"
+      - "bucket1.s3g.internal=172.25.0.120"
   recon:
     <<: *s3g-virtual-host-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/scm-decommission.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/scm-decommission.yaml
@@ -33,12 +33,12 @@ services:
       OZONE_OPTS:
     command: [ "/opt/hadoop/bin/ozone","scm" ]
     extra_hosts:
-      - "om1: 172.25.0.111"
-      - "om2: 172.25.0.112"
-      - "om3: 172.25.0.113"
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
+      - "om1=172.25.0.111"
+      - "om2=172.25.0.112"
+      - "om3=172.25.0.113"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
     networks:
       ozone_net:
         ipv4_address: 172.25.0.220
@@ -53,11 +53,11 @@ services:
       - 10008:9999
     command: [ "/opt/hadoop/bin/ozone","datanode" ]
     extra_hosts:
-      - "scm1.org: 172.25.0.116"
-      - "scm2.org: 172.25.0.117"
-      - "scm3.org: 172.25.0.118"
-      - "scm4.org: 172.25.0.220"
-      - "recon: 172.25.0.115"
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
+      - "scm4.org=172.25.0.220"
+      - "recon=172.25.0.115"
     env_file:
       - docker-config
       - docker-config-scm4


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some acceptance tests started failing with new Docker Compose version being rolled out by GitHub in runner version [20250504.1.0](https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250504.1).

```
Executing test ozonesecure-ha/test-s3a.sh
Using Docker Compose v2
Error response from daemon: could not parse extra host IP  172.25.0.115: ParseAddr(" 172.25.0.115"): unexpected character (at " 172.25.0.115")
```

```
Executing test ozonesecure-ha/test-scm-decommission.sh
Using Docker Compose v2
Error response from daemon: could not parse extra host IP  172.25.0.117: ParseAddr(" 172.25.0.117"): unexpected character (at " 172.25.0.117")
```

It looks like our usage of [`extra_hosts`](https://docs.docker.com/reference/compose-file/services/#extra_hosts) is no longer valid.

This change updates compose files to use the short syntax.

https://issues.apache.org/jira/browse/HDDS-12974

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/14853386105

Note: all affected acceptance checks used the old version of the runner, so it does not verify the fix for the problem.  But at least it validates the syntax with the old one.