### PR TITLE
HDDS-12975. Fix percentage of blocks deleted in grafana dashboard

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
@@ -4407,7 +4407,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "(block_deleting_service_metrics_processed_transaction_success_count / clamp_min(block_deleting_service_metrics_received_block_count, 1)) * 100",
+              "expr": "(block_deleting_service_metrics_success_count / clamp_min(block_deleting_service_metrics_received_block_count, 1)) * 100",
               "legendFormat": "{{hostname}}",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the "Percentage of successfully deleted blocks" panel of the deletion dashboard, the expression is:
```
"expr": "(block_deleting_service_metrics_processed_transaction_success_count / clamp_min(block_deleting_service_metrics_received_block_count, 1)) * 100",     
```
But it should be:
```
"expr": "(block_deleting_service_metrics_success_count / clamp_min(block_deleting_service_metrics_received_block_count, 1)) * 100", 
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12975

## How was this patch tested?

Manually tested using docker+grafana
![image](https://github.com/user-attachments/assets/8e5f0b7c-bc41-40e6-b8aa-7df2deb8376e)