### PR TITLE
HDDS-12971. Use DatanodeID in Node2PipelineMap

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -354,7 +353,7 @@ public class NodeStateManager implements Runnable, Closeable {
    * @return number of pipelines associated with it
    */
   public int getPipelinesCount(DatanodeDetails datanodeDetails) {
-    return node2PipelineMap.getPipelinesCount(datanodeDetails.getUuid());
+    return node2PipelineMap.getPipelinesCount(datanodeDetails.getID());
   }
 
   /**
@@ -595,7 +594,7 @@ public class NodeStateManager implements Runnable, Closeable {
    * @param dnId - Datanode ID
    * @return Set of PipelineID
    */
-  public Set<PipelineID> getPipelineByDnID(UUID dnId) {
+  public Set<PipelineID> getPipelineByDnID(DatanodeID dnId) {
     return node2PipelineMap.getPipelines(dnId);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1550,7 +1550,7 @@ public class SCMNodeManager implements NodeManager {
     HashSet<DatanodeDetails> dns = new HashSet<>();
     Preconditions.checkNotNull(dn);
     Set<PipelineID> pipelines =
-        nodeStateManager.getPipelineByDnID(dn.getUuid());
+        nodeStateManager.getPipelineByDnID(dn.getID());
     PipelineManager pipelineManager = scmContext.getScm().getPipelineManager();
     if (!pipelines.isEmpty()) {
       pipelines.forEach(id -> {
@@ -1576,7 +1576,7 @@ public class SCMNodeManager implements NodeManager {
    */
   @Override
   public Set<PipelineID> getPipelines(DatanodeDetails datanodeDetails) {
-    return nodeStateManager.getPipelineByDnID(datanodeDetails.getUuid());
+    return nodeStateManager.getPipelineByDnID(datanodeDetails.getID());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/Node2PipelineMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/Node2PipelineMap.java
@@ -22,9 +22,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
  * on SCM restart
  */
 public class Node2PipelineMap {
-  private final Map<UUID, Set<PipelineID>> dn2PipelineMap = new ConcurrentHashMap<>();
+  private final Map<DatanodeID, Set<PipelineID>> dn2PipelineMap = new ConcurrentHashMap<>();
 
   /**
    * Constructs a Node2PipelineMap Object.
@@ -48,10 +48,10 @@ public class Node2PipelineMap {
   /**
    * Returns null if there are no pipelines associated with this datanode ID.
    *
-   * @param datanode - UUID
+   * @param datanode - DatanodeID
    * @return Set of pipelines or Null.
    */
-  public Set<PipelineID> getPipelines(@Nonnull UUID datanode) {
+  public Set<PipelineID> getPipelines(@Nonnull DatanodeID datanode) {
     final Set<PipelineID> s = dn2PipelineMap.get(datanode);
     return s != null ? new HashSet<>(s) : Collections.emptySet();
   }
@@ -59,10 +59,10 @@ public class Node2PipelineMap {
   /**
    * Return 0 if there are no pipelines associated with this datanode ID.
    *
-   * @param datanode - UUID
+   * @param datanode - DatanodeID
    * @return Number of pipelines or 0.
    */
-  public int getPipelinesCount(UUID datanode) {
+  public int getPipelinesCount(DatanodeID datanode) {
     return getPipelines(datanode).size();
   }
 
@@ -73,7 +73,7 @@ public class Node2PipelineMap {
    */
   public void addPipeline(Pipeline pipeline) {
     for (DatanodeDetails details : pipeline.getNodes()) {
-      UUID dnId = details.getUuid();
+      DatanodeID dnId = details.getID();
       dn2PipelineMap.computeIfAbsent(dnId, k -> ConcurrentHashMap.newKeySet())
           .add(pipeline.getId());
     }
@@ -81,7 +81,7 @@ public class Node2PipelineMap {
 
   public void removePipeline(Pipeline pipeline) {
     for (DatanodeDetails details : pipeline.getNodes()) {
-      UUID dnId = details.getUuid();
+      DatanodeID dnId = details.getID();
       dn2PipelineMap.computeIfPresent(dnId,
           (k, v) -> {
             v.remove(pipeline.getId());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -458,7 +458,7 @@ public class MockNodeManager implements NodeManager {
    */
   @Override
   public Set<PipelineID> getPipelines(DatanodeDetails dnId) {
-    return node2PipelineMap.getPipelines(dnId.getUuid());
+    return node2PipelineMap.getPipelines(dnId.getID());
   }
 
   /**
@@ -468,7 +468,7 @@ public class MockNodeManager implements NodeManager {
    */
   @Override
   public int getPipelinesCount(DatanodeDetails datanodeDetails) {
-    return node2PipelineMap.getPipelinesCount(datanodeDetails.getUuid());
+    return node2PipelineMap.getPipelinesCount(datanodeDetails.getID());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -214,7 +214,7 @@ public class TestOneReplicaPipelineSafeModeRule {
     for (DatanodeDetails dn : reportMap.keySet()) {
       List<PipelineReport> reports = new ArrayList<>();
       for (PipelineID pipeline : mockNodeManager.
-              getNode2PipelineMap().getPipelines(dn.getUuid())) {
+              getNode2PipelineMap().getPipelines(dn.getID())) {
         try {
           if (!pipelines.contains(pipelineManager.getPipeline(pipeline))) {
             continue;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use `DatanodeID` instead of `UUID` as key in `Node2PipelineMap`.

## What is the link to the Apache JIRA
[HDDS-12971](https://issues.apache.org/jira/browse/HDDS-12971)

## How was this patch tested?
Updated existing tests.