### PR TITLE
HDDS-12689. Import BOM for AWS SDK, declare dependencies

### DIFF
--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -94,7 +94,27 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws-java-sdk2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 
       <dependency>
         <groupId>aopalliance</groupId>
@@ -1282,11 +1289,6 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>s3</artifactId>
-        <version>${aws-java-sdk2.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ozone-integration-test-s3` module has some undeclared direct dependencies on AWS SDK v2 modules. A warning is issued at build time about this:

```
[WARNING] Used undeclared dependencies found:
...
[WARNING]    software.amazon.awssdk:sdk-core:jar:2.31.25:test
[WARNING]    software.amazon.awssdk:regions:jar:2.31.25:test
[WARNING]    software.amazon.awssdk:aws-core:jar:2.31.25:test
[WARNING]    software.amazon.awssdk:auth:jar:2.31.25:test
```

This PR addresses these warnings by making the following changes:
- In the root POM, import the AWS SDK BOM instead of declaring a dependency on just the `s3` module.
- In `ozone-integration-test-s3`, add missing direct dependencies on its individual artifacts as listed in the warning.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12689

## How was this patch tested?

- `mvn install -pl hadoop-ozone/integration-test-s3 -DskipTests` before and after the change, observing the warning.
- CI on fork: https://github.com/octachoron/ozone/actions/runs/14872694664
