### PR TITLE
HDDS-12951. EC: Add a metric or log when readers falling back to reconstructional reads in EC

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -117,6 +117,8 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
     int expected = expectedDataLocations(repConfig, getLength());
     int available = availableDataLocations(blockInfo.getPipeline(), expected);
     reconstructionReader = available < expected;
+    LOG.info("Available data locations: {}, Expected data locations: {}. Based on this online reconstruction is: {}",
+        available, expected, reconstructionReader ? "triggered." : "not triggered.");
   }
 
   private void createBlockReader() {


### PR DESCRIPTION
In EC read latency can increase when online reconstruction is needed. It's hard for costumers to distinguish between that happening or something else increasing the latency. Some logging is added here so it's easier to see if online reconstruction is in progress.

https://issues.apache.org/jira/browse/HDDS-12951

Green CI: https://github.com/Galsza/ozone/actions/runs/14868559612
