### PR TITLE
HDDS-12776. ozone debug CLI command to list all Duplicate open containers

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ContainerLogController.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ContainerLogController.java
@@ -33,6 +33,7 @@ import picocli.CommandLine;
     subcommands = {
         ContainerInfoCommand.class,    
         ContainerLogParser.class,
+        DuplicateOpenContainersCommand.class,
         ListContainers.class
     },
     description = "Tool to parse and store container logs from datanodes into a temporary SQLite database." +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ContainerLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ContainerLogParser.java
@@ -89,6 +89,7 @@ public class ContainerLogParser extends AbstractSubcommand implements Callable<V
     parser.processLogEntries(path, cdd, threadCount);
 
     cdd.insertLatestContainerLogData();
+    cdd.createIndexes();
     out().println("Successfully parsed the log files and updated the respective tables");
 
     return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/DuplicateOpenContainersCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/DuplicateOpenContainersCommand.java
@@ -20,44 +20,34 @@ package org.apache.hadoop.ozone.debug.logs.container;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.debug.logs.container.utils.ContainerDatanodeDatabase;
-import org.apache.hadoop.ozone.shell.ListOptions;
 import picocli.CommandLine;
 
-
 /**
- * List containers based on the parameter given.
+ * Subcommand to list containers that have duplicate OPEN states.
  */
 
 @CommandLine.Command(
-    name = "list",
-    description = "Finds containers from the database based on the option provided."
+    name = "duplicate-open",
+    description = "List all containers which have duplicate open states." +
+        "Outputs the container ID along with the count of OPEN state entries."
 )
-public class ListContainers extends AbstractSubcommand implements Callable<Void> {
-
-  @CommandLine.Option(names = {"--state"},
-      description = "Life cycle state of the container.",
-      required = true)
-  private HddsProtos.LifeCycleState state;
-
-  @CommandLine.Mixin
-  private ListOptions listOptions;
+public class DuplicateOpenContainersCommand extends AbstractSubcommand implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private ContainerLogController parent;
 
   @Override
   public Void call() throws Exception {
-    
     Path dbPath = parent.resolveDbPath();
     if (dbPath == null) {
       return null;
     }
 
     ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase(dbPath.toString());
+    cdd.findDuplicateOpenContainer();
 
-    cdd.listContainersByState(state.name(), listOptions.getLimit());
     return null;
   }
 }
+

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/DuplicateOpenContainersCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/DuplicateOpenContainersCommand.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.debug.logs.container;
 
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
-import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.ozone.debug.logs.container.utils.ContainerDatanodeDatabase;
 import picocli.CommandLine;
 
@@ -32,7 +31,7 @@ import picocli.CommandLine;
     description = "List all containers which have duplicate open states." +
         "Outputs the container ID along with the count of OPEN state entries."
 )
-public class DuplicateOpenContainersCommand extends AbstractSubcommand implements Callable<Void> {
+public class DuplicateOpenContainersCommand implements Callable<Void> {
 
   @CommandLine.ParentCommand
   private ContainerLogController parent;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.debug.logs.container;
 
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
-import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.debug.logs.container.utils.ContainerDatanodeDatabase;
 import org.apache.hadoop.ozone.shell.ListOptions;
@@ -34,8 +33,8 @@ import picocli.CommandLine;
     name = "list",
     description = "Finds containers from the database based on the option provided."
 )
-public class ListContainers extends AbstractSubcommand implements Callable<Void> {
-
+public class ListContainers implements Callable<Void> {
+  
   @CommandLine.Option(names = {"--state"},
       description = "Life cycle state of the container.",
       required = true)
@@ -58,6 +57,7 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
     ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase(dbPath.toString());
 
     cdd.listContainersByState(state.name(), listOptions.getLimit());
+    
     return null;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -35,20 +35,25 @@ import picocli.CommandLine;
     description = "Finds containers from the database based on the option provided."
 )
 public class ListContainers extends AbstractSubcommand implements Callable<Void> {
-  
-  @CommandLine.Option(names = {"--state"},
-      description = "Life cycle state of the container.")
-  private HddsProtos.LifeCycleState state;
+
+  @CommandLine.ArgGroup(multiplicity = "1")
+  private ExclusiveOptions exclusiveOptions;
 
   @CommandLine.Mixin
   private ListOptions listOptions;
 
-  @CommandLine.Option(names = {"--duplicate-open"},
-          description = "List all the containers which have duplicate open states.")
-  private boolean duplicateOpen;
-
   @CommandLine.ParentCommand
   private ContainerLogController parent;
+
+  private static final class ExclusiveOptions {
+    @CommandLine.Option(names = {"--state"},
+            description = "Life cycle state of the container.")
+    private HddsProtos.LifeCycleState state;
+
+    @CommandLine.Option(names = {"--duplicate-open"},
+            description = "List all the containers which have duplicate open states.")
+    private boolean duplicateOpen;
+  }
 
   @Override
   public Void call() throws Exception {
@@ -60,12 +65,10 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
 
     ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase(dbPath.toString());
 
-    if (duplicateOpen) {
+    if (exclusiveOptions.duplicateOpen) {
       cdd.findDuplicateOpenContainer();
-    } else if (state != null) {
-      cdd.listContainersByState(state.name(), listOptions.getLimit());
-    } else {
-      err().println("Please provide either a container state or use --double-open.");
+    } else if (exclusiveOptions.state != null) {
+      cdd.listContainersByState(exclusiveOptions.state.name(), listOptions.getLimit());
     }
     
     return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -43,9 +43,9 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
   @CommandLine.Mixin
   private ListOptions listOptions;
 
-  @CommandLine.Option(names = {"--double-open"},
+  @CommandLine.Option(names = {"--duplicate-open"},
           description = "List all the containers which have duplicate open states.")
-  private boolean doubleOpen;
+  private boolean duplicateOpen;
 
   @CommandLine.ParentCommand
   private ContainerLogController parent;
@@ -60,8 +60,8 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
 
     ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase(dbPath.toString());
 
-    if (doubleOpen) {
-      cdd.findDoubleOpenContainer();
+    if (duplicateOpen) {
+      cdd.findDuplicateOpenContainer();
     } else if (state != null) {
       cdd.listContainersByState(state.name(), listOptions.getLimit());
     } else {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -37,12 +37,15 @@ import picocli.CommandLine;
 public class ListContainers extends AbstractSubcommand implements Callable<Void> {
   
   @CommandLine.Option(names = {"--state"},
-      description = "Life cycle state of the container.",
-      required = true)
+      description = "Life cycle state of the container.")
   private HddsProtos.LifeCycleState state;
 
   @CommandLine.Mixin
   private ListOptions listOptions;
+
+  @CommandLine.Option(names = {"--double-open"},
+          description = "List all the containers which have duplicate open states.")
+  private boolean doubleOpen;
 
   @CommandLine.ParentCommand
   private ContainerLogController parent;
@@ -57,7 +60,13 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
 
     ContainerDatanodeDatabase cdd = new ContainerDatanodeDatabase(dbPath.toString());
 
-    cdd.listContainersByState(state.name(), listOptions.getLimit());
+    if (doubleOpen) {
+      cdd.findDoubleOpenContainer();
+    } else if (state != null) {
+      cdd.listContainersByState(state.name(), listOptions.getLimit());
+    } else {
+      err().println("Please provide either a container state or use --double-open.");
+    }
     
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
@@ -129,6 +129,21 @@ public class ContainerDatanodeDatabase {
     }
   }
 
+  private void createIdxDclContainerStateTime(Statement stmt) throws SQLException {
+    String createIndexSQL = SQLDBConstants.CREATE_DCL_CONTAINER_STATE_TIME_INDEX;
+    stmt.execute(createIndexSQL);
+  }
+
+  private void createContainerLogIndex(Statement stmt) throws SQLException {
+    String createIndexSQL = SQLDBConstants.CREATE_INDEX_LATEST_STATE;
+    stmt.execute(createIndexSQL);
+  }
+
+  private void createIdxContainerlogContainerId(Statement stmt) throws SQLException {
+    String createIndexSQL = SQLDBConstants.CREATE_CONTAINER_ID_INDEX;
+    stmt.execute(createIndexSQL);
+  }
+
   /**
    * Inserts a list of container log entries into the DatanodeContainerLogTable.
    *
@@ -241,11 +256,6 @@ public class ContainerDatanodeDatabase {
     stmt.executeUpdate(dropTableSQL);
   }
 
-  private void createContainerLogIndex(Statement stmt) throws SQLException {
-    String createIndexSQL = SQLDBConstants.CREATE_INDEX_LATEST_STATE;
-    stmt.execute(createIndexSQL);
-  }
-
   /**
    * Lists containers filtered by the specified state and writes their details to stdout 
    * unless redirected to a file explicitly.
@@ -312,11 +322,6 @@ public class ContainerDatanodeDatabase {
     } catch (Exception e) {
       throw new RuntimeException("Unexpected error: "  + e);
     }
-  }
-
-  private void createIdxDclContainerStateTime(Statement stmt) throws SQLException {
-    String createIndexSQL = SQLDBConstants.CREATE_DCL_CONTAINER_STATE_TIME_INDEX;
-    stmt.execute(createIndexSQL);
   }
 
   /**
@@ -548,11 +553,6 @@ public class ContainerDatanodeDatabase {
     }
 
     return logEntries;
-  }
-
-  private void createIdxContainerlogContainerId(Statement stmt) throws SQLException {
-    String createIndexSQL = SQLDBConstants.CREATE_CONTAINER_ID_INDEX;
-    stmt.execute(createIndexSQL);
   }
 
   public void findDuplicateOpenContainer() throws SQLException {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
@@ -549,7 +549,7 @@ public class ContainerDatanodeDatabase {
     }
   }
 
-  public void findDoubleOpenContainer() throws SQLException {
+  public void findDuplicateOpenContainer() throws SQLException {
     String sql = SQLDBConstants.SELECT_DISTINCT_CONTAINER_IDS_QUERY;
 
     try (Connection connection = getConnection()) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
@@ -129,7 +129,6 @@ public class ContainerDatanodeDatabase {
     }
   }
 
-
   /**
    * Inserts a list of container log entries into the DatanodeContainerLogTable.
    *

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/ContainerDatanodeDatabase.java
@@ -562,7 +562,7 @@ public class ContainerDatanodeDatabase {
 
         while (resultSet.next()) {
           Long containerID = resultSet.getLong("container_id");
-          List<DatanodeContainerInfo> logEntries = getContainerLogDataFoOpen(containerID, connection);
+          List<DatanodeContainerInfo> logEntries = getContainerLogDataForOpenContainers(containerID, connection);
           boolean hasIssue = checkForMultipleOpenStates(logEntries);
           if (hasIssue) {
             int openStateCount = (int) logEntries.stream()
@@ -583,7 +583,7 @@ public class ContainerDatanodeDatabase {
     }
   }
 
-  private List<DatanodeContainerInfo> getContainerLogDataFoOpen(Long containerID, Connection connection)
+  private List<DatanodeContainerInfo> getContainerLogDataForOpenContainers(Long containerID, Connection connection)
       throws SQLException {
     String query = SQLDBConstants.SELECT_CONTAINER_DETAILS_OPEN_STATE;
     List<DatanodeContainerInfo> logEntries = new ArrayList<>();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/SQLDBConstants.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/SQLDBConstants.java
@@ -72,6 +72,9 @@ public final class SQLDBConstants {
       "ON ContainerLogTable(container_id);";
   public static final String SELECT_DISTINCT_CONTAINER_IDS_QUERY =
       "SELECT DISTINCT container_id FROM ContainerLogTable";
+  public static final String SELECT_CONTAINER_DETAILS_OPEN_STATE = "SELECT d.timestamp, d.container_id, " +
+      "d.datanode_id, d.container_state FROM DatanodeContainerLogTable d " +
+      "WHERE d.container_id = ? AND d.container_state = 'OPEN' ORDER BY d.timestamp ASC;";
   
   private SQLDBConstants() {
     //Never constructed

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/SQLDBConstants.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/utils/SQLDBConstants.java
@@ -68,6 +68,10 @@ public final class SQLDBConstants {
       "WHERE d.container_id = ? ORDER BY d.datanode_id ASC, d.timestamp ASC;";
   public static final String CREATE_DCL_CONTAINER_STATE_TIME_INDEX = "CREATE INDEX IF NOT EXISTS " +
       "idx_dcl_container_state_time ON DatanodeContainerLogTable(container_id, container_state, timestamp);";
+  public static final String CREATE_CONTAINER_ID_INDEX = "CREATE INDEX IF NOT EXISTS idx_containerlog_container_id " +
+      "ON ContainerLogTable(container_id);";
+  public static final String SELECT_DISTINCT_CONTAINER_IDS_QUERY =
+      "SELECT DISTINCT container_id FROM ContainerLogTable";
   
   private SQLDBConstants() {
     //Never constructed


### PR DESCRIPTION
## What changes were proposed in this pull request?
This ozone debug CLI command helps to identify containers which were opened more than the required number by tracking the first three "OPEN" states and flag any subsequent "OPEN" state as problematic if it occurs on the same datanode or on a different datanode after these initial events.

This command provides the Container ID of such containers along with the count of OPEN states for each container.

Command is as follows:
`ozone debug log container --db=<path to db> list --duplicate-open=true`

sample output for the command:
```
Container ID: 2187256 - OPEN state count: 4
.
.
.
.
Container ID: 12377064 - OPEN state count: 5
Container ID: 12377223 - OPEN state count: 5
Container ID: 12377631 - OPEN state count: 4
Container ID: 12377904 - OPEN state count: 5
Container ID: 12378161 - OPEN state count: 4
Container ID: 12378352 - OPEN state count: 5
Container ID: 12378789 - OPEN state count: 5
Container ID: 12379337 - OPEN state count: 5
Container ID: 12379489 - OPEN state count: 5
Container ID: 12380526 - OPEN state count: 5
Container ID: 12380898 - OPEN state count: 5
Container ID: 12642718 - OPEN state count: 4
Container ID: 12644806 - OPEN state count: 4
Total containers that might have duplicate OPEN state : 1579
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12776

## How was this patch tested?
Below is the workflow link that passed successfully:
https://github.com/sreejasahithi/ozone/actions/runs/14875062929