### PR TITLE
HDDS-12938. Refactor OneReplicaPipelineSafeModeRule to not use PipelineReportFromDatanode

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -49,6 +50,7 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -335,6 +337,22 @@ public final class Pipeline {
           String.format("Datanode=%s not part of pipeline=%s", dn, id));
     }
     nodeStatus.put(dn, System.currentTimeMillis());
+  }
+
+  @VisibleForTesting
+  public DatanodeDetails removeFirstFromNodeStatus() {
+    Iterator<DatanodeDetails> iterator = nodeStatus.keySet().iterator();
+    DatanodeDetails firstKey = null;
+    if (iterator.hasNext()) {
+      firstKey = iterator.next();
+      nodeStatus.remove(firstKey);
+    }
+    return firstKey;
+  }
+
+  @VisibleForTesting
+  public void setInNodeStatus(DatanodeDetails dd) {
+    nodeStatus.put(dd, Time.now());
   }
 
   public boolean isHealthy() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.safemode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -51,7 +52,7 @@ public class OneReplicaPipelineSafeModeRule extends
   private static final String NAME = "AtleastOneDatanodeReportedRule";
 
   private int thresholdCount;
-  private final Set<PipelineID> reportedPipelineIDSet = new HashSet<>();
+  private Set<PipelineID> reportedPipelineIDSet = new HashSet<>();
   private Set<PipelineID> oldPipelineIDSet;
   private int currentReportedPipelineCount = 0;
   private PipelineManager pipelineManager;
@@ -85,11 +86,19 @@ public class OneReplicaPipelineSafeModeRule extends
 
   @Override
   protected synchronized boolean validate() {
+    if (validateBasedOnReportProcessing()) {
+      return currentReportedPipelineCount >= thresholdCount;
+    }
+
+    updateReportedPipelineSet();
     return currentReportedPipelineCount >= thresholdCount;
   }
 
   @Override
   protected synchronized void process(PipelineReportFromDatanode report) {
+    if (!validateBasedOnReportProcessing()) {
+      return;
+    }
     Preconditions.checkNotNull(report);
     for (PipelineReport report1 : report.getReport().getPipelineReportList()) {
       Pipeline pipeline;
@@ -137,6 +146,11 @@ public class OneReplicaPipelineSafeModeRule extends
     return currentReportedPipelineCount;
   }
 
+  @VisibleForTesting
+  public Set<PipelineID> getReportedPipelineIDSet() {
+    return reportedPipelineIDSet;
+  }
+
   @Override
   public String getStatusText() {
     String status = String.format(
@@ -167,6 +181,25 @@ public class OneReplicaPipelineSafeModeRule extends
     } else {
       if (!validate()) {
         initializeRule(true);
+      }
+    }
+  }
+
+  private void updateReportedPipelineSet() {
+    List<Pipeline> openRatisPipelines =
+        pipelineManager.getPipelines(RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+            Pipeline.PipelineState.OPEN);
+
+    for (Pipeline pipeline : openRatisPipelines) {
+      PipelineID pipelineID = pipeline.getId();
+      boolean allDNsPipelineReported = pipeline.getNodeSet().size() == 3;
+      boolean notAlreadyReported = !reportedPipelineIDSet.contains(pipelineID);
+      boolean wasExistingPipeline = oldPipelineIDSet.contains(pipelineID);
+
+      if (allDNsPipelineReported && notAlreadyReported && wasExistingPipeline) {
+        getSafeModeMetrics().incCurrentHealthyPipelinesWithAtleastOneReplicaReportedCount();
+        currentReportedPipelineCount++;
+        reportedPipelineIDSet.add(pipelineID);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, OneReplicaPipelineSafeModeRule depends on processing of PipelineReportFromDatanode to validate the rule. We should avoid processing any reports in Safamode rule and depend on the PipelineManager here.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12938

## How was this patch tested?

Tested Manually.