### PR TITLE
HDDS-12947. Add CodecException.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -45,7 +45,6 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
@@ -150,41 +149,32 @@ public class CertificateCodec {
    * containing multiple certificates. To get all certificates, use
    * {@link #getCertPathFromPemEncodedString(String)}.
    *
-   * @param pemEncodedString - PEM encoded String.
+   * @param pemEncoded - PEM encoded String.
    * @return X509Certificate  - Certificate.
    * @throws CertificateException - Thrown on Failure.
    */
-  public static X509Certificate getX509Certificate(String pemEncodedString)
+  public static X509Certificate getX509Certificate(String pemEncoded)
       throws CertificateException {
-    return getX509Certificate(pemEncodedString, Function.identity());
-  }
-
-  public static <E extends Exception> X509Certificate getX509Certificate(
-      String pemEncoded, Function<CertificateException, E> convertor)
-      throws E {
     // ByteArrayInputStream.close(), which is a noop, can be safely ignored.
     final ByteArrayInputStream input = new ByteArrayInputStream(
         pemEncoded.getBytes(DEFAULT_CHARSET));
-    return readX509Certificate(input, convertor);
+    return readX509Certificate(input);
   }
 
-  private static <E extends Exception> X509Certificate readX509Certificate(
-      InputStream input, Function<CertificateException, E> convertor)
-      throws E {
-    try {
-      return (X509Certificate) getCertFactory().generateCertificate(input);
-    } catch (CertificateException e) {
-      throw convertor.apply(e);
+  public static X509Certificate readX509Certificate(InputStream input) throws CertificateException {
+    final Certificate cert = getCertFactory().generateCertificate(input);
+    if (cert instanceof X509Certificate) {
+      return (X509Certificate) cert;
     }
+    throw new CertificateException("Certificate is not a X509Certificate: " + cert.getClass() + ", " + cert);
   }
 
-  public static X509Certificate readX509Certificate(InputStream input)
-      throws IOException {
-    return readX509Certificate(input, CertificateCodec::toIOException);
-  }
-
-  public static IOException toIOException(CertificateException e) {
-    return new IOException("Failed to engineGenerateCertificate", e);
+  public static X509Certificate readX509Certificate(String pemEncoded) throws IOException {
+    try {
+      return getX509Certificate(pemEncoded);
+    } catch (CertificateException e) {
+      throw new IOException("Failed to getX509Certificate from " + pemEncoded, e);
+    }
   }
 
   public static X509Certificate firstCertificateFrom(CertPath certificatePath) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -52,8 +52,7 @@ public interface Codec<T> {
    * @param allocator To allocate a buffer.
    * @return a buffer storing the serialized bytes.
    */
-  default CodecBuffer toCodecBuffer(@Nonnull T object,
-      CodecBuffer.Allocator allocator) throws IOException {
+  default CodecBuffer toCodecBuffer(@Nonnull T object, CodecBuffer.Allocator allocator) throws CodecException {
     throw new UnsupportedOperationException();
   }
 
@@ -63,8 +62,7 @@ public interface Codec<T> {
    * @param object The object to be serialized.
    * @return a direct buffer storing the serialized bytes.
    */
-  default CodecBuffer toDirectCodecBuffer(@Nonnull T object)
-      throws IOException {
+  default CodecBuffer toDirectCodecBuffer(@Nonnull T object) throws CodecException {
     return toCodecBuffer(object, CodecBuffer.Allocator.getDirect());
   }
 
@@ -74,8 +72,7 @@ public interface Codec<T> {
    * @param object The object to be serialized.
    * @return a heap buffer storing the serialized bytes.
    */
-  default CodecBuffer toHeapCodecBuffer(@Nonnull T object)
-      throws IOException {
+  default CodecBuffer toHeapCodecBuffer(@Nonnull T object) throws CodecException {
     return toCodecBuffer(object, CodecBuffer.Allocator.getHeap());
   }
 
@@ -85,7 +82,7 @@ public interface Codec<T> {
    * @param buffer Storing the serialized bytes of an object.
    * @return the deserialized object.
    */
-  default T fromCodecBuffer(@Nonnull CodecBuffer buffer) throws IOException {
+  default T fromCodecBuffer(@Nonnull CodecBuffer buffer) throws CodecException {
     throw new UnsupportedOperationException();
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -462,16 +462,16 @@ public class CodecBuffer implements UncheckedAutoCloseable {
    * @param source put bytes to an {@link OutputStream} and return the size.
    *               The returned size must be non-null and non-negative.
    * @return this object.
-   * @throws IOException in case the source throws an {@link IOException}.
+   * @throws CodecException in case the source throws an {@link IOException}.
    */
-  public CodecBuffer put(
-      CheckedFunction<OutputStream, Integer, IOException> source)
-      throws IOException {
+  public CodecBuffer put(CheckedFunction<OutputStream, Integer, IOException> source) throws CodecException {
     assertRefCnt(1);
     final int w = buf.writerIndex();
     final int size;
     try (ByteBufOutputStream out = new ByteBufOutputStream(buf)) {
       size = source.apply(out);
+    } catch (IOException e) {
+      throw new CodecException("Failed to apply source to " + this + ", " + source, e);
     }
     final ByteBuf returned = buf.setIndex(buf.readerIndex(), w + size);
     Preconditions.assertSame(buf, returned, "buf");

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import java.io.IOException;
+
+/**
+ * Exceptions thrown from the {@link Codec} subclasses.
+ */
+public class CodecException extends IOException {
+  public CodecException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public CodecException(String message) {
+    super(message);
+  }
+
+  public CodecException() {
+    super();
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.function.CheckedFunction;
 
 /**
@@ -29,10 +30,11 @@ import org.apache.ratis.util.function.CheckedFunction;
  */
 public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
   private final Codec<DELEGATE> delegate;
-  private final CheckedFunction<DELEGATE, T, IOException> forward;
-  private final CheckedFunction<T, DELEGATE, IOException> backward;
+  private final CheckedFunction<DELEGATE, T, CodecException> forward;
+  private final CheckedFunction<T, DELEGATE, CodecException> backward;
   private final Class<T> clazz;
   private final CopyType copyType;
+  private final String name;
 
   /**
    * Construct a {@link Codec} using the given delegate.
@@ -43,20 +45,21 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
    * @param copyType How to {@link #copyObject(Object)}?
    */
   public DelegatedCodec(Codec<DELEGATE> delegate,
-      CheckedFunction<DELEGATE, T, IOException> forward,
-      CheckedFunction<T, DELEGATE, IOException> backward,
+      CheckedFunction<DELEGATE, T, CodecException> forward,
+      CheckedFunction<T, DELEGATE, CodecException> backward,
       Class<T> clazz, CopyType copyType) {
     this.delegate = delegate;
     this.forward = forward;
     this.backward = backward;
     this.clazz = clazz;
     this.copyType = copyType;
+    this.name = JavaUtils.getClassSimpleName(getTypeClass()) + "-delegate: " + delegate;
   }
 
   /** The same as new DelegatedCodec(delegate, forward, backward, DEEP). */
   public DelegatedCodec(Codec<DELEGATE> delegate,
-      CheckedFunction<DELEGATE, T, IOException> forward,
-      CheckedFunction<T, DELEGATE, IOException> backward,
+      CheckedFunction<DELEGATE, T, CodecException> forward,
+      CheckedFunction<T, DELEGATE, CodecException> backward,
       Class<T> clazz) {
     this(delegate, forward, backward, clazz, CopyType.DEEP);
   }
@@ -72,14 +75,12 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
   }
 
   @Override
-  public final CodecBuffer toCodecBuffer(@Nonnull T message,
-      CodecBuffer.Allocator allocator) throws IOException {
+  public final CodecBuffer toCodecBuffer(@Nonnull T message, CodecBuffer.Allocator allocator) throws CodecException {
     return delegate.toCodecBuffer(backward.apply(message), allocator);
   }
 
   @Override
-  public final T fromCodecBuffer(@Nonnull CodecBuffer buffer)
-      throws IOException {
+  public final T fromCodecBuffer(@Nonnull CodecBuffer buffer) throws CodecException {
     return forward.apply(delegate.fromCodecBuffer(buffer));
   }
 
@@ -109,9 +110,14 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
     // Deep copy
     try {
       return forward.apply(delegate.copyObject(backward.apply(message)));
-    } catch (IOException e) {
+    } catch (CodecException e) {
       throw new IllegalStateException("Failed to copyObject", e);
     }
+  }
+
+  @Override
+  public String toString() {
+    return name;
   }
 
   /** How to {@link #copyObject(Object)}? */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.ratis.util.function.CheckedFunction;
 
 /**
@@ -64,24 +65,37 @@ public final class Proto2Codec<M extends MessageLite> implements Codec<M> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull M message,
-      CodecBuffer.Allocator allocator) throws IOException {
+      CodecBuffer.Allocator allocator) throws CodecException {
     final int size = message.getSerializedSize();
     return allocator.apply(size).put(writeTo(message, size));
   }
 
   private CheckedFunction<OutputStream, Integer, IOException> writeTo(
       M message, int size) {
-    return out -> {
-      message.writeTo(out);
-      return size;
+    return new CheckedFunction<OutputStream, Integer, IOException>() {
+      @Override
+      public Integer apply(OutputStream out) throws IOException {
+        message.writeTo(out);
+        return size;
+      }
+
+      @Override
+      public String toString() {
+        return "source: size=" + size + ", message=" + message;
+      }
     };
   }
 
   @Override
   public M fromCodecBuffer(@Nonnull CodecBuffer buffer)
-      throws IOException {
-    try (InputStream in = buffer.getInputStream()) {
+      throws CodecException {
+    final InputStream in = buffer.getInputStream();
+    try {
       return parser.parseFrom(in);
+    } catch (InvalidProtocolBufferException e) {
+      throw new CodecException("Failed to parse " + buffer, e);
+    } finally {
+      IOUtils.closeQuietly(in);
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -93,7 +93,7 @@ public final class Proto2Codec<M extends MessageLite> implements Codec<M> {
     try {
       return parser.parseFrom(in);
     } catch (InvalidProtocolBufferException e) {
-      throw new CodecException("Failed to parse " + buffer, e);
+      throw new CodecException("Failed to parse " + buffer + " for " + getTypeClass(), e);
     } finally {
       IOUtils.closeQuietly(in);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -169,12 +169,11 @@ abstract class StringCodecBase implements Codec<String> {
   }
 
   @Override
-  public CodecBuffer toCodecBuffer(@Nonnull String object,
-      CodecBuffer.Allocator allocator) throws IOException {
+  public CodecBuffer toCodecBuffer(@Nonnull String object, CodecBuffer.Allocator allocator) throws CodecException {
     // allocate a larger buffer to avoid encoding twice.
     final int upperBound = getSerializedSizeUpperBound(object);
     final CodecBuffer buffer = allocator.apply(upperBound);
-    buffer.putFromSource(encode(object, null, IOException::new));
+    buffer.putFromSource(encode(object, null, CodecException::new));
     return buffer;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -133,8 +133,7 @@ public final class OzoneSecurityUtil {
     List<X509Certificate> x509Certificates =
         new ArrayList<>(pemEncodedCerts.size());
     for (String cert : pemEncodedCerts) {
-      x509Certificates.add(CertificateCodec.getX509Certificate(
-          cert, CertificateCodec::toIOException));
+      x509Certificates.add(CertificateCodec.readX509Certificate(cert));
     }
     return x509Certificates;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdds.security.x509.certificate;
 
 import jakarta.annotation.Nonnull;
-import java.io.IOException;
 import java.io.Serializable;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Comparator;
 import java.util.Objects;
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.CertInfoProto;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CodecException;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 
@@ -56,27 +57,34 @@ public final class CertInfo implements Comparable<CertInfo>, Serializable {
     return CODEC;
   }
 
-  public static CertInfo fromProtobuf(CertInfoProto info) throws IOException {
+  public static CertInfo fromProtobuf(CertInfoProto info) throws CodecException {
+    final X509Certificate cert;
+    try {
+      cert = CertificateCodec.getX509Certificate(info.getX509Certificate());
+    } catch (CertificateException e) {
+      throw new CodecException("Failed to getX509Certificate from " + info.getX509Certificate(), e);
+    }
     return new CertInfo.Builder()
-        .setX509Certificate(info.getX509Certificate())
+        .setX509Certificate(cert)
         .setTimestamp(info.getTimestamp())
         .build();
   }
 
-  public CertInfoProto getProtobuf() throws SCMSecurityException {
+  public CertInfoProto getProtobuf() throws CodecException {
+    final String cert;
+    try {
+      cert = CertificateCodec.getPEMEncodedString(getX509Certificate());
+    } catch (SCMSecurityException e) {
+      throw new CodecException("Failed to getX509Certificate from " + getX509Certificate(), e);
+    }
     return CertInfoProto.newBuilder()
-        .setX509Certificate(getX509CertificatePEMEncodedString())
+        .setX509Certificate(cert)
         .setTimestamp(getTimestamp())
         .build();
   }
 
   public X509Certificate getX509Certificate() {
     return x509Certificate;
-  }
-
-  public String getX509CertificatePEMEncodedString()
-      throws SCMSecurityException {
-    return CertificateCodec.getPEMEncodedString(getX509Certificate());
   }
 
   public long getTimestamp() {
@@ -139,12 +147,6 @@ public final class CertInfo implements Comparable<CertInfo>, Serializable {
     public Builder setX509Certificate(X509Certificate x509Certificate) {
       this.x509Certificate = x509Certificate;
       return this;
-    }
-
-    public Builder setX509Certificate(String x509Certificate)
-        throws IOException {
-      return setX509Certificate(CertificateCodec.getX509Certificate(
-          x509Certificate, CertificateCodec::toIOException));
     }
 
     public Builder setTimestamp(long timestamp) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1577,8 +1577,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           getScmSecurityClientWithMaxRetry(configuration, getCurrentUser()).listCACertificate();
       // Write the primary SCM CA and Root CA during startup.
       for (String cert : pemEncodedCerts) {
-        X509Certificate x509Certificate = CertificateCodec.getX509Certificate(
-            cert, CertificateCodec::toIOException);
+        final X509Certificate x509Certificate = CertificateCodec.readX509Certificate(cert);
         if (certificateStore.getCertificateByID(x509Certificate.getSerialNumber()) == null) {
           LOG.info("Persist certificate serialId {} on Scm Bootstrap Node " +
                   "{}", x509Certificate.getSerialNumber(),

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
-import java.io.IOException;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
@@ -85,9 +84,7 @@ public final class OmDBAccessIdInfo {
   /**
    * Convert protobuf to OmDBAccessIdInfo.
    */
-  public static OmDBAccessIdInfo getFromProtobuf(
-      ExtendedUserAccessIdInfo infoProto)
-      throws IOException {
+  public static OmDBAccessIdInfo getFromProtobuf(ExtendedUserAccessIdInfo infoProto) {
     return new Builder()
         .setTenantId(infoProto.getTenantId())
         .setUserPrincipal(infoProto.getUserPrincipal())


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the db.Codec class (not to be confused with scm.ha.io.Codec), it is better to throw CodecException (a new class) than throw IOException.

We only change the CodeBuffer methods in this PR.  Will change the byte[] methods in HDDS-12989.

## What is the link to the Apache JIRA

HDDS-12947

## How was this patch tested?

By existing tests. 