### PR TITLE
HDDS-12996. Workaround for Docker Compose concurrent map writes

### DIFF
--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -35,6 +35,9 @@ REPORT_FILE="$REPORT_DIR/summary.txt"
 OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
 DIST_DIR="${OZONE_ROOT}/hadoop-ozone/dist/target/ozone-$OZONE_VERSION"
 
+# workaround attempt for https://github.com/docker/compose/issues/12747
+export COMPOSE_PARALLEL_LIMIT=1
+
 if [ ! -d "$DIST_DIR" ]; then
     echo "Distribution dir is missing. Doing a full build"
     "$DIR/build.sh" -Pcoverage


### PR DESCRIPTION
## What changes were proposed in this pull request?

Try to workaround a concurrency bug in Docker Compose 2.35.1 by limiting parallel operations to 1.

This is temporary, until GitHub rolls out runner image with Docker Compose 2.36 or newer, or rolls back to previous working version.

```
fatal error: concurrent map writes

goroutine 38 [running]:
github.com/docker/compose/v2/pkg/compose.(*composeService).pullRequiredImages.func1.1()
	github.com/docker/compose/v2/pkg/compose/pull.go:328 +0x236
...
```

https://docs.docker.com/reference/cli/docker/compose/#configuring-parallelism

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12996

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/14900471630
https://github.com/apache/ozone/actions/runs/14900886395?pr=8412