### PR TITLE
HDDS-12995. Split ListOptions for better reuse

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.server.JsonUtils;
-import org.apache.hadoop.ozone.shell.ListPaginationOptions;
+import org.apache.hadoop.ozone.shell.ListLimitOptions;
 import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import picocli.CommandLine;
 
@@ -68,7 +68,7 @@ public class DiskUsageSubCommand implements Callable {
   private boolean noHeader;
 
   @CommandLine.Mixin
-  private ListPaginationOptions listOptions;
+  private ListLimitOptions listOptions;
 
   @CommandLine.Mixin
   private PrefixFilterOption prefixFilter;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import picocli.CommandLine;
 
 /**
@@ -68,6 +69,9 @@ public class DiskUsageSubCommand implements Callable {
 
   @CommandLine.Mixin
   private ListOptions listOptions;
+
+  @CommandLine.Mixin
+  private PrefixFilterOption prefixFilter;
 
   private static final String ENDPOINT = "/api/v1/namespace/du";
 
@@ -147,7 +151,7 @@ public class DiskUsageSubCommand implements Callable {
         printWithUnderline("DU", true);
         printDUHeader();
         int limit = listOptions.getLimit();
-        String seekStr = listOptions.getPrefix();
+        String seekStr = prefixFilter.getPrefix();
         if (seekStr == null) {
           seekStr = "";
         }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.server.JsonUtils;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import picocli.CommandLine;
 
@@ -68,7 +68,7 @@ public class DiskUsageSubCommand implements Callable {
   private boolean noHeader;
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @CommandLine.Mixin
   private PrefixFilterOption prefixFilter;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
@@ -21,6 +21,7 @@ import picocli.CommandLine;
 
 /**
  * Options for limiting the size of lists.
+ * <p>
  * Usage:
  * <pre>
  * {@code

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
@@ -20,28 +20,41 @@ package org.apache.hadoop.ozone.shell;
 import picocli.CommandLine;
 
 /**
- * Common options for 'list' commands.
+ * Options for limiting the size of lists.
+ * Usage:
+ * <pre>
+ * {@code
+ * @CommandLine.ArgGroup
+ * private ListLimitOptions limitOptions;
+ * }
+ * </pre>
  */
-public class ListPaginationOptions {
+public class ListLimitOptions {
 
-  @CommandLine.ArgGroup(exclusive = true)
-  private ListLimitOptions limitOptions = new ListLimitOptions();
+  @CommandLine.Option(names = {"--length", "-l"},
+      description = "Maximum number of items to list",
+      defaultValue = "100",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+  private int limit;
 
-  @CommandLine.Option(names = {"--start", "-s"},
-      description = "The item to start the listing from.\n" +
-          "This will be excluded from the result.")
-  private String startItem;
-
-  public int getLimit() {
-    return limitOptions.getLimit();
-  }
+  @CommandLine.Option(names = {"--all", "-a"},
+      description = "List all results",
+      defaultValue = "false")
+  private boolean all;
 
   public boolean isAll() {
-    return limitOptions.isAll();
+    return all;
   }
 
-  public String getStartItem() {
-    return startItem;
-  }
+  public int getLimit() {
+    if (all) {
+      return Integer.MAX_VALUE;
+    }
+    if (limit < 1) {
+      throw new IllegalArgumentException(
+          "List length should be a positive number");
+    }
 
+    return limit;
+  }
 }

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
@@ -19,17 +19,7 @@ package org.apache.hadoop.ozone.shell;
 
 import picocli.CommandLine;
 
-/**
- * Options for limiting the size of lists.
- * <p>
- * Usage:
- * <pre>
- * {@code
- * @CommandLine.Mixin
- * private ListLimitOptions limitOptions;
- * }
- * </pre>
- */
+/** Options for limiting the size of lists.  Use with {@link CommandLine.Mixin}. */
 public class ListLimitOptions {
 
   @CommandLine.ArgGroup

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
@@ -25,37 +25,42 @@ import picocli.CommandLine;
  * Usage:
  * <pre>
  * {@code
- * @CommandLine.ArgGroup
+ * @CommandLine.Mixin
  * private ListLimitOptions limitOptions;
  * }
  * </pre>
  */
 public class ListLimitOptions {
 
-  @CommandLine.Option(names = {"--length", "-l"},
-      description = "Maximum number of items to list",
-      defaultValue = "100",
-      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
-  private int limit;
-
-  @CommandLine.Option(names = {"--all", "-a"},
-      description = "List all results",
-      defaultValue = "false")
-  private boolean all;
+  @CommandLine.ArgGroup
+  private ExclusiveGroup group = new ExclusiveGroup();
 
   public boolean isAll() {
-    return all;
+    return group.all;
   }
 
   public int getLimit() {
-    if (all) {
+    if (group.all) {
       return Integer.MAX_VALUE;
     }
-    if (limit < 1) {
+    if (group.limit < 1) {
       throw new IllegalArgumentException(
           "List length should be a positive number");
     }
 
-    return limit;
+    return group.limit;
+  }
+
+  static class ExclusiveGroup {
+    @CommandLine.Option(names = {"--length", "-l"},
+        description = "Maximum number of items to list",
+        defaultValue = "100",
+        showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+    private int limit;
+
+    @CommandLine.Option(names = {"--all", "-a"},
+        description = "List all results",
+        defaultValue = "false")
+    private boolean all;
   }
 }

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
@@ -32,10 +32,6 @@ public class ListOptions {
           "This will be excluded from the result.")
   private String startItem;
 
-  @CommandLine.Option(names = {"--prefix", "-p"},
-      description = "Prefix to filter the items")
-  private String prefix;
-
   public int getLimit() {
     if (exclusiveLimit.all) {
       return Integer.MAX_VALUE;
@@ -54,10 +50,6 @@ public class ListOptions {
 
   public String getStartItem() {
     return startItem;
-  }
-
-  public String getPrefix() {
-    return prefix;
   }
 
   static class ExclusiveLimit {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
@@ -32,8 +32,8 @@ import picocli.CommandLine;
  */
 public class ListPaginationOptions {
 
-  @CommandLine.ArgGroup
-  private ListLimitOptions limitOptions = new ListLimitOptions();
+  @CommandLine.Mixin
+  private ListLimitOptions limitOptions;
 
   @CommandLine.Option(names = {"--start", "-s"},
       description = "The item to start the listing from.\n" +

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
@@ -22,7 +22,7 @@ import picocli.CommandLine;
 /**
  * Common options for 'list' commands.
  */
-public class ListOptions {
+public class ListPaginationOptions {
 
   @CommandLine.ArgGroup(exclusive = true)
   private ExclusiveLimit exclusiveLimit = new ExclusiveLimit();

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
@@ -20,7 +20,15 @@ package org.apache.hadoop.ozone.shell;
 import picocli.CommandLine;
 
 /**
- * Common options for 'list' commands.
+ * Options to provide pagination of lists.
+ * <p>
+ * Usage:
+ * <pre>
+ * {@code
+ * @CommandLine.Mixin
+ * private ListPaginationOptions listOptions;
+ * }
+ * </pre>
  */
 public class ListPaginationOptions {
 

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
@@ -24,7 +24,7 @@ import picocli.CommandLine;
  */
 public class ListPaginationOptions {
 
-  @CommandLine.ArgGroup(exclusive = true)
+  @CommandLine.ArgGroup
   private ListLimitOptions limitOptions = new ListLimitOptions();
 
   @CommandLine.Option(names = {"--start", "-s"},

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
@@ -19,17 +19,7 @@ package org.apache.hadoop.ozone.shell;
 
 import picocli.CommandLine;
 
-/**
- * Options to provide pagination of lists.
- * <p>
- * Usage:
- * <pre>
- * {@code
- * @CommandLine.Mixin
- * private ListPaginationOptions listOptions;
- * }
- * </pre>
- */
+/** Options to provide pagination of lists.  Use with {@link CommandLine.Mixin}. */
 public class ListPaginationOptions {
 
   @CommandLine.Mixin

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/PrefixFilterOption.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/PrefixFilterOption.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell;
+
+import picocli.CommandLine;
+
+/** Option for filtering lists by prefix. */
+public class PrefixFilterOption {
+
+  @CommandLine.Option(names = {"--prefix", "-p"},
+      description = "Prefix to filter the items")
+  private String prefix;
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+}

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/PrefixFilterOption.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/PrefixFilterOption.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.shell;
 
 import picocli.CommandLine;
 
-/** Option for filtering lists by prefix. */
+/** Option for filtering lists by prefix.  Use with {@link CommandLine.Mixin}. */
 public class PrefixFilterOption {
 
   @CommandLine.Option(names = {"--prefix", "-p"},

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/ListBucketHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/ListBucketHandler.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.volume.VolumeHandler;
@@ -41,7 +41,7 @@ import picocli.CommandLine.Command;
 public class ListBucketHandler extends VolumeHandler {
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @CommandLine.Mixin
   private PrefixFilterOption prefixFilter;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/ListBucketHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/ListBucketHandler.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.ListOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.volume.VolumeHandler;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -42,6 +43,9 @@ public class ListBucketHandler extends VolumeHandler {
   @CommandLine.Mixin
   private ListOptions listOptions;
 
+  @CommandLine.Mixin
+  private PrefixFilterOption prefixFilter;
+
   @CommandLine.Option(names = {"--has-snapshot"},
       description = "Only show buckets that have at least one active snapshot.")
   private boolean filterByHasSnapshot;
@@ -54,7 +58,7 @@ public class ListBucketHandler extends VolumeHandler {
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume vol = objectStore.getVolume(volumeName);
     Iterator<? extends OzoneBucket> bucketIterator =
-        vol.listBuckets(listOptions.getPrefix(),
+        vol.listBuckets(prefixFilter.getPrefix(),
             listOptions.getStartItem(), filterByHasSnapshot);
     List<Object> bucketList = new ArrayList<>();
     int counter = 0;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.common.VolumeBucketHandler;
@@ -40,7 +40,7 @@ import picocli.CommandLine.Command;
 public class ListKeyHandler extends VolumeBucketHandler {
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @CommandLine.Mixin
   private PrefixFilterOption prefixFilter;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.ListOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.common.VolumeBucketHandler;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -40,6 +41,9 @@ public class ListKeyHandler extends VolumeBucketHandler {
 
   @CommandLine.Mixin
   private ListOptions listOptions;
+
+  @CommandLine.Mixin
+  private PrefixFilterOption prefixFilter;
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
@@ -62,13 +66,13 @@ public class ListKeyHandler extends VolumeBucketHandler {
     if (!Strings.isNullOrEmpty(snapshotNameWithIndicator)) {
       keyPrefix += snapshotNameWithIndicator;
 
-      if (!Strings.isNullOrEmpty(listOptions.getPrefix())) {
+      if (!Strings.isNullOrEmpty(prefixFilter.getPrefix())) {
         keyPrefix += "/";
       }
     }
 
-    if (!Strings.isNullOrEmpty(listOptions.getPrefix())) {
-      keyPrefix += listOptions.getPrefix();
+    if (!Strings.isNullOrEmpty(prefixFilter.getPrefix())) {
+      keyPrefix += prefixFilter.getPrefix();
     }
 
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
@@ -111,8 +115,8 @@ public class ListKeyHandler extends VolumeBucketHandler {
         vol.listBuckets(null);
     int maxKeyLimit = listOptions.getLimit();
     String keyPrefix = "";
-    if (!Strings.isNullOrEmpty(listOptions.getPrefix())) {
-      keyPrefix += listOptions.getPrefix();
+    if (!Strings.isNullOrEmpty(prefixFilter.getPrefix())) {
+      keyPrefix += prefixFilter.getPrefix();
     }
 
     int totalKeys = 0;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneSnapshotDiff;
 import org.apache.hadoop.ozone.shell.Handler;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
 import picocli.CommandLine;
@@ -50,7 +50,7 @@ public class ListSnapshotDiffHandler extends Handler {
   private boolean listAllStatus;
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @Override
   protected OzoneAddress getAddress() {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.shell.Handler;
 import org.apache.hadoop.ozone.shell.ListOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
 import picocli.CommandLine;
 
@@ -42,6 +43,9 @@ public class ListSnapshotHandler extends Handler {
   @CommandLine.Mixin
   private ListOptions listOptions;
 
+  @CommandLine.Mixin
+  private PrefixFilterOption prefixFilter;
+
   @Override
   protected OzoneAddress getAddress() {
     return snapshotPath.getValue();
@@ -54,7 +58,7 @@ public class ListSnapshotHandler extends Handler {
     String bucketName = snapshotPath.getValue().getBucketName();
 
     Iterator<OzoneSnapshot> snapshotInfos = client.getObjectStore()
-        .listSnapshot(volumeName, bucketName, listOptions.getPrefix(),
+        .listSnapshot(volumeName, bucketName, prefixFilter.getPrefix(),
             listOptions.getStartItem());
     int counter = printAsJsonArray(snapshotInfos, listOptions.getLimit());
     if (isVerbose()) {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.shell.Handler;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
@@ -41,7 +41,7 @@ public class ListSnapshotHandler extends Handler {
   private BucketUri snapshotPath;
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @CommandLine.Mixin
   private PrefixFilterOption prefixFilter;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.Handler;
 import org.apache.hadoop.ozone.shell.ListOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.Shell;
 import org.apache.hadoop.security.UserGroupInformation;
 import picocli.CommandLine;
@@ -47,6 +48,9 @@ public class ListVolumeHandler extends Handler {
 
   @CommandLine.Mixin
   private ListOptions listOptions;
+
+  @CommandLine.Mixin
+  private PrefixFilterOption prefixFilter;
 
   @Option(names = {"--user", "-u"},
       description = "List accessible volumes of the user. This will be ignored"
@@ -71,10 +75,10 @@ public class ListVolumeHandler extends Handler {
     Iterator<? extends OzoneVolume> volumeIterator;
     if (userName != null && !listOptions.isAll()) {
       volumeIterator = client.getObjectStore().listVolumesByUser(userName,
-          listOptions.getPrefix(), listOptions.getStartItem());
+          prefixFilter.getPrefix(), listOptions.getStartItem());
     } else {
       volumeIterator = client.getObjectStore().listVolumes(
-          listOptions.getPrefix(), listOptions.getStartItem());
+          prefixFilter.getPrefix(), listOptions.getStartItem());
     }
 
     int counter = printAsJsonArray(volumeIterator, listOptions.getLimit());

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.Handler;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.PrefixFilterOption;
 import org.apache.hadoop.ozone.shell.Shell;
@@ -47,7 +47,7 @@ public class ListVolumeHandler extends Handler {
   private String uri;
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @CommandLine.Mixin
   private PrefixFilterOption prefixFilter;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.debug.logs.container.utils.ContainerDatanodeDatabase;
-import org.apache.hadoop.ozone.shell.ListPaginationOptions;
+import org.apache.hadoop.ozone.shell.ListLimitOptions;
 import picocli.CommandLine;
 
 
@@ -41,8 +41,8 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
       required = true)
   private HddsProtos.LifeCycleState state;
 
-  @CommandLine.Mixin
-  private ListPaginationOptions listOptions;
+  @CommandLine.ArgGroup
+  private ListLimitOptions listOptions;
 
   @CommandLine.ParentCommand
   private ContainerLogController parent;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -41,7 +41,7 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
       required = true)
   private HddsProtos.LifeCycleState state;
 
-  @CommandLine.ArgGroup
+  @CommandLine.Mixin
   private ListLimitOptions listOptions;
 
   @CommandLine.ParentCommand

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/logs/container/ListContainers.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.debug.logs.container.utils.ContainerDatanodeDatabase;
-import org.apache.hadoop.ozone.shell.ListOptions;
+import org.apache.hadoop.ozone.shell.ListPaginationOptions;
 import picocli.CommandLine;
 
 
@@ -42,7 +42,7 @@ public class ListContainers extends AbstractSubcommand implements Callable<Void>
   private HddsProtos.LifeCycleState state;
 
   @CommandLine.Mixin
-  private ListOptions listOptions;
+  private ListPaginationOptions listOptions;
 
   @CommandLine.ParentCommand
   private ContainerLogController parent;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve `ListOptions` for better reuse.

`ListOptions` currently provides the following options:

```
  -a, --all                 List all results
  -l, --length=<limit>      Maximum number of items to list
                              Default: 100
  -p, --prefix=<prefix>     Prefix to filter the items
  -s, --start=<startItem>   The item to start the listing from.
                            This will be excluded from the result.
```

This change:
- extract `--prefix` (to `PrefixFilterOption`) to allow using `ListOptions` in commands with different / more complex filters (e.g. datanode list can filter by hostname, IP or ID)
- rename `ListOptions` to `ListPaginationOptions`
- create separate class `ListLimitOptions` for grouping `--length` and `--all`, since `--start` is not supported by `ozone admin nssummary` and `ozone debug log container list`
- reuse `ListLimitOptions` in `ListPaginationOptions`

https://issues.apache.org/jira/browse/HDDS-12995

## How was this patch tested?

`ozone debug log container list` no longer shows `--start` or `--prefix`, but shows limit options (`--length` and `--all`):

```
$ ozone debug log container list --help
Usage: ozone debug log container list [-hV] [--verbose] [--db=<dbPath>]
                                      --state=<state> [[-l=<limit>] | [-a]]
Finds containers from the database based on the option provided.
  -a, --all              List all results
      --db=<dbPath>      Path to the SQLite database file where the parsed
                           information from logs is stored.
  -h, --help             Show this help message and exit.
  -l, --length=<limit>   Maximum number of items to list
                           Default: 100
      --state=<state>    Life cycle state of the container.
  -V, --version          Print version information and exit.
      --verbose          More verbose output. Show the stack trace of the
                           errors.
```

`ozone sh snapshot listDiff` no longer mentions `--prefix`, but shows pagination options:

```
$ ozone sh snapshot listDiff --help
Usage: ozone sh snapshot listDiff [-hV] [--all-status] [--verbose]
                                  [--job-status=<jobStatus>] [-s=<startItem>]
                                  [[-l=<limit>] | [-a]] <value>
List snapshotDiff jobs for a bucket.
      <value>               URI of the bucket (format: volume/bucket).
                            Ozone URI could either be a full URI or short URI.
                            Full URI should start with o3://, in case of non-HA
                            clusters it should be followed by the host name and
                            optionally the port number. In case of HA clusters
                            the service id should be used. Service id provides a
                            logical name for multiple hosts and it is defined
                            in the property ozone.om.service.ids.
                            Example of a full URI with host name and port number
                            for a key:
                            o3://omhostname:9862/vol1/bucket1/key1
                            With a service id for a volume:
                            o3://omserviceid/vol1/
                            Short URI should start from the volume.
                            Example of a short URI for a bucket:
                            vol1/bucket1
                            Any unspecified information will be identified from
                            the config files.

  -a, --all                 List all results
      --all-status          List all jobs regardless of status.
  -h, --help                Show this help message and exit.
      --job-status=<jobStatus>
                            List jobs based on status.
                            Accepted values are: queued, in_progress, done,
                              failed, rejected
  -l, --length=<limit>      Maximum number of items to list
                              Default: 100
  -s, --start=<startItem>   The item to start the listing from.
                            This will be excluded from the result.
  -V, --version             Print version information and exit.
      --verbose             More verbose output. Show the stack trace of the
                              errors.
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/14901599818
