### PR TITLE
HDDS-12994. Use DatanodeID in ReconSCMDBDefinition.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -66,7 +67,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
   private final PipelineManager pipelineManager;
   private final ContainerHealthSchemaManager containerHealthSchemaManager;
   private final ReconContainerMetadataManager cdbServiceProvider;
-  private final Table<UUID, DatanodeDetails> nodeDB;
+  private final Table<DatanodeID, DatanodeDetails> nodeDB;
   // Container ID -> Datanode UUID -> Timestamp
   private final Map<Long, Map<UUID, ContainerReplicaHistory>> replicaHistoryMap;
   // Pipeline -> # of open containers
@@ -376,7 +377,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
       // Attempt to retrieve hostname from NODES table
       if (nodeDB != null) {
         try {
-          DatanodeDetails dnDetails = nodeDB.get(uuid);
+          final DatanodeDetails dnDetails = nodeDB.get(DatanodeID.of(uuid));
           if (dnDetails != null) {
             hostname = dnDetails.getHostName();
           }
@@ -446,7 +447,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
     }
   }
 
-  public Table<UUID, DatanodeDetails> getNodeDB() {
+  public Table<DatanodeID, DatanodeDetails> getNodeDB() {
     return nodeDB;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.ozone.recon.scm;
 
 import java.util.Map;
-import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
@@ -31,14 +31,14 @@ import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
  * Recon SCM db file for ozone.
  */
 public final class ReconSCMDBDefinition extends SCMDBDefinition {
-  private static final Codec<UUID> UUID_CODEC = new DelegatedCodec<>(
-      StringCodec.get(), UUID::fromString, UUID::toString,
-      UUID.class, DelegatedCodec.CopyType.SHALLOW);
+  private static final Codec<DatanodeID> DATANODE_ID_CODEC = new DelegatedCodec<>(
+      StringCodec.get(), DatanodeID::fromUuidString, DatanodeID::toString,
+      DatanodeID.class, DelegatedCodec.CopyType.SHALLOW);
 
   public static final String RECON_SCM_DB_NAME = "recon-scm.db";
 
-  public static final DBColumnFamilyDefinition<UUID, DatanodeDetails> NODES
-      = new DBColumnFamilyDefinition<>("nodes", UUID_CODEC, DatanodeDetails.getCodec());
+  public static final DBColumnFamilyDefinition<DatanodeID, DatanodeDetails> NODES
+      = new DBColumnFamilyDefinition<>("nodes", DATANODE_ID_CODEC, DatanodeDetails.getCodec());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>
       COLUMN_FAMILIES = DBColumnFamilyDefinition.newUnmodifiableMap(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -49,7 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -63,6 +62,7 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmUtils;
@@ -619,14 +619,11 @@ public class ReconStorageContainerManagerFacade
     try {
       final DBStore newStore = DBStoreBuilder.newBuilder(ozoneConfiguration, ReconSCMDBDefinition.get(), dbFile)
           .build();
-      Table<UUID, DatanodeDetails> nodeTable =
-          ReconSCMDBDefinition.NODES.getTable(dbStore);
-      Table<UUID, DatanodeDetails> newNodeTable =
-          ReconSCMDBDefinition.NODES.getTable(newStore);
-      try (TableIterator<UUID, ? extends KeyValue<UUID,
-          DatanodeDetails>> iterator = nodeTable.iterator()) {
+      final Table<DatanodeID, DatanodeDetails> nodeTable = ReconSCMDBDefinition.NODES.getTable(dbStore);
+      final Table<DatanodeID, DatanodeDetails> newNodeTable = ReconSCMDBDefinition.NODES.getTable(newStore);
+      try (TableIterator<DatanodeID, ? extends KeyValue<DatanodeID, DatanodeDetails>> iterator = nodeTable.iterator()) {
         while (iterator.hasNext()) {
-          KeyValue<UUID, DatanodeDetails> keyValue = iterator.next();
+          final KeyValue<DatanodeID, DatanodeDetails> keyValue = iterator.next();
           newNodeTable.put(keyValue.getKey(), keyValue.getValue());
         }
       }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -1053,7 +1054,7 @@ public class TestContainerEndpoint {
 
   UUID newDatanode(String hostName, String ipAddress) throws IOException {
     final UUID uuid = UUID.randomUUID();
-    reconContainerManager.getNodeDB().put(uuid,
+    reconContainerManager.getNodeDB().put(DatanodeID.of(uuid),
         DatanodeDetails.newBuilder()
             .setUuid(uuid)
             .setHostName(hostName)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
@@ -101,8 +100,7 @@ public class TestReconNodeManager {
         new ReconStorageConfig(conf, reconUtils);
     EventQueue eventQueue = new EventQueue();
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
-    Table<UUID, DatanodeDetails> nodeTable =
-        ReconSCMDBDefinition.NODES.getTable(store);
+    final Table<DatanodeID, DatanodeDetails> nodeTable = ReconSCMDBDefinition.NODES.getTable(store);
     ReconNodeManager reconNodeManager = new ReconNodeManager(conf,
         scmStorageConfig, eventQueue, clusterMap, nodeTable, versionManager, reconContext);
     assertThat(reconNodeManager.getAllNodes()).isEmpty();
@@ -130,8 +128,7 @@ public class TestReconNodeManager {
         new ReconStorageConfig(conf, new ReconUtils());
     EventQueue eventQueue = new EventQueue();
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
-    Table<UUID, DatanodeDetails> nodeTable =
-        ReconSCMDBDefinition.NODES.getTable(store);
+    final Table<DatanodeID, DatanodeDetails> nodeTable = ReconSCMDBDefinition.NODES.getTable(store);
     ReconNodeManager reconNodeManager = new ReconNodeManager(conf,
         scmStorageConfig, eventQueue, clusterMap, nodeTable, versionManager, reconContext);
     ReconNewNodeHandler reconNewNodeHandler =
@@ -212,8 +209,7 @@ public class TestReconNodeManager {
         new ReconStorageConfig(conf, new ReconUtils());
     EventQueue eventQueue = new EventQueue();
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
-    Table<UUID, DatanodeDetails> nodeTable =
-        ReconSCMDBDefinition.NODES.getTable(store);
+    final Table<DatanodeID, DatanodeDetails> nodeTable = ReconSCMDBDefinition.NODES.getTable(store);
     ReconNodeManager reconNodeManager = new ReconNodeManager(conf,
         scmStorageConfig, eventQueue, clusterMap, nodeTable, versionManager, reconContext);
 
@@ -246,8 +242,7 @@ public class TestReconNodeManager {
         new ReconStorageConfig(conf, new ReconUtils());
     EventQueue eventQueue = new EventQueue();
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
-    Table<UUID, DatanodeDetails> nodeTable =
-        ReconSCMDBDefinition.NODES.getTable(store);
+    final Table<DatanodeID, DatanodeDetails> nodeTable = ReconSCMDBDefinition.NODES.getTable(store);
     ReconNodeManager reconNodeManager = new ReconNodeManager(conf,
         scmStorageConfig, eventQueue, clusterMap, nodeTable, versionManager, reconContext);
     ReconNewNodeHandler reconNewNodeHandler =


### PR DESCRIPTION
## What changes were proposed in this pull request?

The nodes table in ReconSCMDBDefinition uses UUID as the key. It is better to use DatanodeID.

## What is the link to the Apache JIRA

HDDS-12994

## How was this patch tested?

By updating existing tests