### PR TITLE
HDDS-12958. [Snapshot] Add ACL check regression tests for snapshot operations.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -69,8 +69,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test for Snapshot feature with ACL.
@@ -96,8 +94,6 @@ public class TestOzoneManagerSnapshotAcl {
       UserGroupInformation.createUserForTesting(USER3, new String[] {GROUP3});
   private static final OzoneObj.ResourceType RESOURCE_TYPE_KEY =
       OzoneObj.ResourceType.KEY;
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestOzoneManagerSnapshotAcl.class);
   private static MiniOzoneCluster cluster;
   private static ObjectStore objectStore;
   private static OzoneManager ozoneManager;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3042,6 +3042,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       ResolvedBucket resolvedBucket = resolveBucketLink(Pair.of(volumeName, bucketName));
       auditMap = buildAuditMap(resolvedBucket.realVolume());
       auditMap.put(OzoneConsts.BUCKET, resolvedBucket.realBucket());
+      if (isAclEnabled) {
+        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+            ACLType.READ, resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
+      }
       SnapshotInfo snapshotInfo =
           metadataManager.getSnapshotInfo(resolvedBucket.realVolume(), resolvedBucket.realBucket(), snapshotName);
 
@@ -4995,6 +4999,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // Updating the volumeName & bucketName in case the bucket is a linked bucket. We need to do this before a
     // permission check, since linked bucket permissions and source bucket permissions could be different.
     ResolvedBucket resolvedBucket = resolveBucketLink(Pair.of(volume, bucket), false);
+    if (isAclEnabled) {
+      omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+          ACLType.READ, resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
+    }
     return omSnapshotManager.getSnapshotDiffReport(resolvedBucket.realVolume(), resolvedBucket.realBucket(),
         fromSnapshot, toSnapshot, token, pageSize, forceFullDiff, disableNativeDiff);
   }
@@ -5006,6 +5014,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
                                                        String toSnapshot)
       throws IOException {
     ResolvedBucket resolvedBucket = this.resolveBucketLink(Pair.of(volume, bucket), false);
+    if (isAclEnabled) {
+      omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+          ACLType.READ, resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
+    }
     return omSnapshotManager.cancelSnapshotDiff(resolvedBucket.realVolume(), resolvedBucket.realBucket(),
         fromSnapshot, toSnapshot);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-12958. [Snapshot] Add ACL check regression tests for snapshot operations.

Please describe your PR in detail:
* Added basic tests to verify permission checks takes effect for various snapshot operations.
   * Verifies that bucket owner can: create, rename and delete snapshots.
   * Verifies that non bucket owner can not create, rename and delete.
   * Verifies that user with bucket read permissions can: list snapshots, get snapshot info, snapshot diff, list snapshot diff jobs and cancel snapshot diff jobs.
   * Verifies that user with no permissions cannot do any of the above.
* Fixed a few ACL check bugs in getSnapshotInfo, snapshotDiff and cancelSnapshotDiff.

TODO:
* Audit logs for getSnapshotInfo , snapshotDiff, cancelSnapshotDiff are missing. I was about to add it but my IDE crashed, so I guess it's a cue to call it a day.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12958

## How was this patch tested?

Regression tests.