### PR TITLE
HDDS-13001. Use DatanodeID in SCMBlockDeletingService.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeID.java
@@ -114,7 +114,9 @@ public final class DatanodeID implements Comparable<DatanodeID> {
   }
 
   // TODO: Remove this in follow-up Jira. (HDDS-12015)
-  UUID getUuid() {
+  //   Exposing this temporarily to help with refactoring.
+  @Deprecated
+  public UUID getUuid() {
     return uuid;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
@@ -36,11 +36,6 @@ public class CommandForDatanode<T extends Message> implements
     this(datanode.getID(), command);
   }
 
-  // TODO: Command for datanode should take DatanodeDetails as parameter.
-  public CommandForDatanode(UUID datanodeId, SCMCommand<T> command) {
-    this(DatanodeID.of(datanodeId), command);
-  }
-
   public CommandForDatanode(DatanodeID datanodeId, SCMCommand<T> command) {
     this.datanodeId = datanodeId;
     this.command = command;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.protocol.commands;
 import com.google.protobuf.Message;
 import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.server.events.IdentifiableEventPayload;
 
 /**
@@ -28,22 +29,26 @@ import org.apache.hadoop.hdds.server.events.IdentifiableEventPayload;
 public class CommandForDatanode<T extends Message> implements
     IdentifiableEventPayload {
 
-  private final UUID datanodeId;
-
+  private final DatanodeID datanodeId;
   private final SCMCommand<T> command;
 
   public CommandForDatanode(DatanodeDetails datanode, SCMCommand<T> command) {
-    this(datanode.getUuid(), command);
+    this(datanode.getID(), command);
   }
 
   // TODO: Command for datanode should take DatanodeDetails as parameter.
   public CommandForDatanode(UUID datanodeId, SCMCommand<T> command) {
+    this(DatanodeID.of(datanodeId), command);
+  }
+
+  public CommandForDatanode(DatanodeID datanodeId, SCMCommand<T> command) {
     this.datanodeId = datanodeId;
     this.command = command;
   }
 
+  @Deprecated
   public UUID getDatanodeId() {
-    return datanodeId;
+    return datanodeId.getUuid();
   }
 
   public SCMCommand<T> getCommand() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
@@ -22,8 +22,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 
 /**
@@ -32,7 +32,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
  */
 class DatanodeDeletedBlockTransactions {
   // A list of TXs mapped to a certain datanode ID.
-  private final Map<UUID, List<DeletedBlocksTransaction>> transactions =
+  private final Map<DatanodeID, List<DeletedBlocksTransaction>> transactions =
       new HashMap<>();
   // counts blocks deleted across datanodes. Blocks deleted will be counted
   // for all the replicas and may not be unique.
@@ -41,7 +41,7 @@ class DatanodeDeletedBlockTransactions {
   DatanodeDeletedBlockTransactions() {
   }
 
-  void addTransactionToDN(UUID dnID, DeletedBlocksTransaction tx) {
+  void addTransactionToDN(DatanodeID dnID, DeletedBlocksTransaction tx) {
     transactions.computeIfAbsent(dnID, k -> new LinkedList<>()).add(tx);
     blocksDeleted += tx.getLocalIDCount();
     if (SCMBlockDeletingService.LOG.isDebugEnabled()) {
@@ -51,7 +51,7 @@ class DatanodeDeletedBlockTransactions {
     }
   }
 
-  Map<UUID, List<DeletedBlocksTransaction>> getDatanodeTransactionMap() {
+  Map<DatanodeID, List<DeletedBlocksTransaction>> getDatanodeTransactionMap() {
     return transactions;
   }
 
@@ -59,7 +59,7 @@ class DatanodeDeletedBlockTransactions {
     return blocksDeleted;
   }
 
-  List<String> getTransactionIDList(UUID dnId) {
+  List<String> getTransactionIDList(DatanodeID dnId) {
     return Optional.ofNullable(transactions.get(dnId))
         .orElse(new LinkedList<>())
         .stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -91,7 +91,7 @@ public interface DeletedBlockLog extends Closeable {
    * @param dnTxSet Set of transaction IDs for the DataNode.
    */
   void recordTransactionCreated(
-      UUID dnId, long scmCmdId, Set<Long> dnTxSet);
+      DatanodeID dnId, long scmCmdId, Set<Long> dnTxSet);
 
   /**
    * Handles the cleanup process when a DataNode is reported dead. This method
@@ -100,7 +100,7 @@ public interface DeletedBlockLog extends Closeable {
    *
    * @param dnId The identifier of the dead DataNode.
    */
-  void onDatanodeDead(UUID dnId);
+  void onDatanodeDead(DatanodeID dnId);
 
   /**
    * Records the event of sending a block deletion command to a DataNode. This

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
@@ -342,7 +343,7 @@ public class DeletedBlockLogImpl
       DatanodeDetails details = replica.getDatanodeDetails();
       if (!transactionStatusManager.isDuplication(
           details, updatedTxn.getTxID(), commandStatus)) {
-        transactions.addTransactionToDN(details.getUuid(), updatedTxn);
+        transactions.addTransactionToDN(details.getID(), updatedTxn);
         metrics.incrProcessedTransaction();
       }
     }
@@ -506,15 +507,15 @@ public class DeletedBlockLogImpl
   }
 
   @Override
-  public void recordTransactionCreated(UUID dnId, long scmCmdId,
+  public void recordTransactionCreated(DatanodeID dnId, long scmCmdId,
       Set<Long> dnTxSet) {
     getSCMDeletedBlockTransactionStatusManager()
-        .recordTransactionCreated(dnId, scmCmdId, dnTxSet);
+        .recordTransactionCreated(dnId.getUuid(), scmCmdId, dnTxSet);
   }
 
   @Override
-  public void onDatanodeDead(UUID dnId) {
-    getSCMDeletedBlockTransactionStatusManager().onDatanodeDead(dnId);
+  public void onDatanodeDead(DatanodeID dnId) {
+    getSCMDeletedBlockTransactionStatusManager().onDatanodeDead(dnId.getUuid());
   }
 
   @Override
@@ -531,7 +532,7 @@ public class DeletedBlockLogImpl
     }
 
     DatanodeDetails details = deleteBlockStatus.getDatanodeDetails();
-    UUID dnId = details.getUuid();
+    DatanodeID dnId = details.getID();
     for (CommandStatus commandStatus : deleteBlockStatus.getCmdStatus()) {
       CommandStatus.Status status = commandStatus.getStatus();
       lock.lock();
@@ -540,7 +541,7 @@ public class DeletedBlockLogImpl
           ContainerBlocksDeletionACKProto ackProto =
               commandStatus.getBlockDeletionAck();
           getSCMDeletedBlockTransactionStatusManager()
-              .commitTransactions(ackProto.getResultsList(), dnId);
+              .commitTransactions(ackProto.getResultsList(), dnId.getUuid());
           metrics.incrBlockDeletionCommandSuccess();
           metrics.incrDNCommandsSuccess(dnId, 1);
         } else if (status == CommandStatus.Status.FAILED) {
@@ -552,7 +553,7 @@ public class DeletedBlockLogImpl
         }
 
         getSCMDeletedBlockTransactionStatusManager()
-            .commitSCMCommandStatus(deleteBlockStatus.getCmdStatus(), dnId);
+            .commitSCMCommandStatus(deleteBlockStatus.getCmdStatus(), dnId.getUuid());
       } finally {
         lock.unlock();
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
 import org.apache.hadoop.hdds.scm.ScmConfig;
@@ -175,9 +175,9 @@ public class SCMBlockDeletingService extends BackgroundService
           }
 
           Set<Long> processedTxIDs = new HashSet<>();
-          for (Map.Entry<UUID, List<DeletedBlocksTransaction>> entry :
+          for (Map.Entry<DatanodeID, List<DeletedBlocksTransaction>> entry :
               transactions.getDatanodeTransactionMap().entrySet()) {
-            UUID dnId = entry.getKey();
+            DatanodeID dnId = entry.getKey();
             List<DeletedBlocksTransaction> dnTXs = entry.getValue();
             if (!dnTXs.isEmpty()) {
               Set<Long> dnTxSet = dnTXs.stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdds.scm.block;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -95,7 +95,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @Metric(about = "The number of dataNodes of delete transactions.")
   private MutableGaugeLong numBlockDeletionTransactionDataNodes;
 
-  private final Map<UUID, DatanodeCommandCounts> numCommandsDatanode = new ConcurrentHashMap<>();
+  private final Map<DatanodeID, DatanodeCommandCounts> numCommandsDatanode = new ConcurrentHashMap<>();
 
   private ScmBlockDeletingServiceMetrics() {
     this.registry = new MetricsRegistry(SOURCE_NAME);
@@ -164,17 +164,17 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     this.numBlockDeletionTransactionDataNodes.set(dataNodes);
   }
 
-  public void incrDNCommandsSent(UUID id, long delta) {
+  public void incrDNCommandsSent(DatanodeID id, long delta) {
     numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
         .incrCommandsSent(delta);
   }
 
-  public void incrDNCommandsSuccess(UUID id, long delta) {
+  public void incrDNCommandsSuccess(DatanodeID id, long delta) {
     numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
         .incrCommandsSuccess(delta);
   }
 
-  public void incrDNCommandsFailure(UUID id, long delta) {
+  public void incrDNCommandsFailure(DatanodeID id, long delta) {
     numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
         .incrCommandsFailure(delta);
   }
@@ -239,7 +239,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     numBlockDeletionTransactionDataNodes.snapshot(builder, all);
 
     MetricsRecordBuilder recordBuilder = builder;
-    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+    for (Map.Entry<DatanodeID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
       recordBuilder = recordBuilder.endRecord().addRecord(SOURCE_NAME)
           .add(new MetricsTag(Interns.info("datanode",
               "Datanode host for deletion commands"), e.getKey().toString()))

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -158,7 +158,7 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
       throws ContainerNotFoundException {
     getNodes(container).forEach(node ->
         publisher.fireEvent(DATANODE_COMMAND,
-            new CommandForDatanode<>(node.getUuid(), command)));
+            new CommandForDatanode<>(node, command)));
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -116,7 +116,7 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
       // remove DeleteBlocksCommand associated with the dead node unless it
       // is IN_MAINTENANCE
       if (deletedBlockLog != null && !isNodeInMaintenance) {
-        deletedBlockLog.onDatanodeDead(datanodeDetails.getUuid());
+        deletedBlockLog.onDatanodeDead(datanodeDetails.getID());
       }
 
       //move dead datanode out of ClusterNetworkTopology

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -781,7 +781,7 @@ public class SCMNodeManager implements NodeManager {
             // Send Finalize command to the data node. Its OK to
             // send Finalize command multiple times.
             scmNodeEventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
-                new CommandForDatanode<>(datanodeDetails.getUuid(),
+                new CommandForDatanode<>(datanodeDetails,
                     finalizeCmd));
           } catch (NotLeaderException ex) {
             LOG.warn("Skip sending finalize upgrade command since current SCM" +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
@@ -119,7 +119,7 @@ public class PipelineActionHandler
       SCMCommand<?> command = new ClosePipelineCommand(pid);
       command.setTerm(scmContext.getTermOfLeader());
       publisher.fireEvent(SCMEvents.DATANODE_COMMAND,
-          new CommandForDatanode<>(datanode.getUuid(), command));
+          new CommandForDatanode<>(datanode, command));
     } catch (NotLeaderException nle) {
       LOG.info("Cannot process Pipeline Action for pipeline {} as " +
           "current SCM is not leader anymore.", pid);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -101,7 +101,7 @@ public class PipelineReportHandler implements
         final SCMCommand<?> command = new ClosePipelineCommand(pipelineID);
         command.setTerm(scmContext.getTermOfLeader());
         publisher.fireEvent(SCMEvents.DATANODE_COMMAND,
-            new CommandForDatanode<>(dn.getUuid(), command));
+            new CommandForDatanode<>(dn, command));
       } catch (NotLeaderException ex) {
         // Do nothing if the leader has changed.
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -208,7 +208,7 @@ public class RatisPipelineProvider
       LOG.info("Sending CreatePipelineCommand for pipeline:{} to datanode:{}",
           pipeline.getId(), node);
       eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
-          new CommandForDatanode<>(node.getUuid(), createCommand));
+          new CommandForDatanode<>(node, createCommand));
     });
 
     return pipeline;
@@ -269,7 +269,7 @@ public class RatisPipelineProvider
     closeCommand.setTerm(scmContext.getTermOfLeader());
     pipeline.getNodes().forEach(node -> {
       final CommandForDatanode<?> datanodeCommand =
-          new CommandForDatanode<>(node.getUuid(), closeCommand);
+          new CommandForDatanode<>(node, closeCommand);
       LOG.info("Send pipeline:{} close command to datanode {}",
           pipeline.getId(), datanodeCommand.getDatanodeId());
       eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMBlockDeletingService.java
@@ -88,9 +88,9 @@ public class TestSCMBlockDeletingService {
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy())).thenReturn(
         datanodeDetails);
     DeletedBlocksTransaction tx1 = createTestDeleteTxn(1, Arrays.asList(1L), 1);
-    ddbt.addTransactionToDN(datanode1.getUuid(), tx1);
-    ddbt.addTransactionToDN(datanode2.getUuid(), tx1);
-    ddbt.addTransactionToDN(datanode3.getUuid(), tx1);
+    ddbt.addTransactionToDN(datanode1.getID(), tx1);
+    ddbt.addTransactionToDN(datanode2.getID(), tx1);
+    ddbt.addTransactionToDN(datanode3.getID(), tx1);
     DeletedBlockLog mockDeletedBlockLog = mock(DeletedBlockLog.class);
     when(mockDeletedBlockLog.getTransactions(
         anyInt(), anySet())).thenReturn(ddbt);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -237,7 +237,7 @@ public class TestDeadNodeHandler {
     clearInvocations(publisher);
 
     verify(deletedBlockLog, times(0))
-        .onDatanodeDead(datanode1.getUuid());
+        .onDatanodeDead(datanode1.getID());
 
     Set<ContainerReplica> container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));
@@ -266,7 +266,7 @@ public class TestDeadNodeHandler {
     assertEquals(0, nodeManager.getCommandQueueCount(datanode1.getUuid(), cmd.getType()));
 
     verify(publisher).fireEvent(SCMEvents.REPLICATION_MANAGER_NOTIFY, datanode1);
-    verify(deletedBlockLog).onDatanodeDead(datanode1.getUuid());
+    verify(deletedBlockLog).onDatanodeDead(datanode1.getID());
 
     container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -1070,11 +1070,11 @@ public class TestSCMNodeManager {
             HddsProtos.ReplicationFactor.THREE, emptyList());
 
     nodeManager.onMessage(
-        new CommandForDatanode<>(datanode1, closeContainerCommand), null);
+        new CommandForDatanode<>(DatanodeID.of(datanode1), closeContainerCommand), null);
     nodeManager.onMessage(
-        new CommandForDatanode<>(datanode1, closeContainerCommand), null);
+        new CommandForDatanode<>(DatanodeID.of(datanode1), closeContainerCommand), null);
     nodeManager.onMessage(
-        new CommandForDatanode<>(datanode1, createPipelineCommand), null);
+        new CommandForDatanode<>(DatanodeID.of(datanode1), createPipelineCommand), null);
 
     assertEquals(2, nodeManager.getCommandQueueCount(
         datanode1, SCMCommandProto.Type.closeContainerCommand));
@@ -1773,7 +1773,7 @@ public class TestSCMNodeManager {
               Arrays.asList(report), emptyList()),
                   HddsTestUtils.getRandomPipelineReports());
       eq.fireEvent(DATANODE_COMMAND,
-          new CommandForDatanode<>(datanodeDetails.getUuid(),
+          new CommandForDatanode<>(datanodeDetails,
               new CloseContainerCommand(1L,
                   PipelineID.randomId())));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use DatanodeID in SCMBlockDeletingService

Replace `UUID` with `DatanodeID` to represent a `Datanode` in `SCMBlockDeletingService`.



## What is the link to the Apache JIRA
HDDS-13001

## How was this patch tested?
CI Run: https://github.com/nandakumar131/ozone/actions/runs/14922726548
