### PR TITLE
HDDS-13002. Use DatanodeID in ContainerBalancerTask

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
 
 /**
@@ -110,7 +110,7 @@ public class ContainerBalancerTaskIterationStatusInfo {
    * Get a map of the node IDs and the corresponding data sizes moved to each node.
    * @return nodeId to size entering from node map
    */
-  public Map<UUID, Long> getSizeEnteringNodes() {
+  public Map<DatanodeID, Long> getSizeEnteringNodes() {
     return dataMoveInfo.getSizeEnteringNodes();
   }
 
@@ -118,7 +118,7 @@ public class ContainerBalancerTaskIterationStatusInfo {
    * Get a map of the node IDs and the corresponding data sizes moved from each node.
    * @return nodeId to size leaving from node map
    */
-  public Map<UUID, Long> getSizeLeavingNodes() {
+  public Map<DatanodeID, Long> getSizeLeavingNodes() {
     return dataMoveInfo.getSizeLeavingNodes();
   }
 
@@ -160,7 +160,7 @@ public class ContainerBalancerTaskIterationStatusInfo {
    * @return node transfer info proto representation
    */
   private List<StorageContainerLocationProtocolProtos.NodeTransferInfoProto> mapToProtoNodeTransferInfo(
-      Map<UUID, Long> nodes
+      Map<DatanodeID, Long> nodes
   ) {
     return nodes.entrySet()
         .stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/DataMoveInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/DataMoveInfo.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdds.scm.container.balancer;
 
 import java.util.Map;
-import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 
 /**
  * Information about the process of moving data.
@@ -26,14 +26,14 @@ import java.util.UUID;
 public class DataMoveInfo {
   private final long sizeScheduledForMove;
   private final long dataSizeMoved;
-  private final Map<UUID, Long> sizeEnteringNodes;
-  private final Map<UUID, Long> sizeLeavingNodes;
+  private final Map<DatanodeID, Long> sizeEnteringNodes;
+  private final Map<DatanodeID, Long> sizeLeavingNodes;
 
   public DataMoveInfo(
       long sizeScheduledForMove,
       long dataSizeMoved,
-      Map<UUID, Long> sizeEnteringNodes,
-      Map<UUID, Long> sizeLeavingNodes) {
+      Map<DatanodeID, Long> sizeEnteringNodes,
+      Map<DatanodeID, Long> sizeLeavingNodes) {
     this.sizeScheduledForMove = sizeScheduledForMove;
     this.dataSizeMoved = dataSizeMoved;
     this.sizeEnteringNodes = sizeEnteringNodes;
@@ -48,11 +48,11 @@ public class DataMoveInfo {
     return dataSizeMoved;
   }
 
-  public Map<UUID, Long> getSizeEnteringNodes() {
+  public Map<DatanodeID, Long> getSizeEnteringNodes() {
     return sizeEnteringNodes;
   }
 
-  public Map<UUID, Long> getSizeLeavingNodes() {
+  public Map<DatanodeID, Long> getSizeLeavingNodes() {
     return sizeLeavingNodes;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerStatusInfo.java
@@ -25,10 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.apache.commons.math3.util.ArithmeticUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.LambdaTestUtils;
@@ -229,7 +229,7 @@ class TestContainerBalancerStatusInfo {
     assertTrue(iteration.getSizeLeavingNodes().isEmpty());
   }
 
-  private static Long getTotalMovedData(Map<UUID, Long> iteration) {
+  private static Long getTotalMovedData(Map<DatanodeID, Long> iteration) {
     return iteration.values().stream().reduce(0L, ArithmeticUtils::addAndCheck);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use DatanodeID in ContainerBalancerTask.

Replace UUID with DatanodeID to represent a Datanode in ContainerBalancerTask.

## What is the link to the Apache JIRA
HDDS-13002

## How was this patch tested?
CI: https://github.com/nandakumar131/ozone/actions/runs/14924339017
