### PR TITLE
HDDS-13020. Change LinkedBlockingQueue to ConcurrentLinkedQueue in ContainerReportQueue

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
@@ -76,8 +77,8 @@ public class TestEventQueue {
       throws Exception {
 
     TestHandler testHandler = new TestHandler();
-    BlockingQueue<Long> eventQueue = new LinkedBlockingQueue<>();
-    List<BlockingQueue<Long>> queues = new ArrayList<>();
+    Queue<Long> eventQueue = new LinkedBlockingQueue<>();
+    List<Queue<Long>> queues = new ArrayList<>();
     queues.add(eventQueue);
     Map<String, FixedThreadPoolWithAffinityExecutor> reportExecutorMap
         = new ConcurrentHashMap<>();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ScmUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ScmUtils.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -205,7 +206,7 @@ public final class ScmUtils {
   }
 
   @NotNull
-  public static List<BlockingQueue<ContainerReport>> initContainerReportQueue(
+  public static List<Queue<ContainerReport>> initContainerReportQueue(
       OzoneConfiguration configuration) {
     int threadPoolSize = configuration.getInt(getContainerReportConfPrefix()
             + ".thread.pool.size",
@@ -213,7 +214,7 @@ public final class ScmUtils {
     int queueSize = configuration.getInt(getContainerReportConfPrefix()
             + ".queue.size",
         OZONE_SCM_EVENT_CONTAINER_REPORT_QUEUE_SIZE_DEFAULT);
-    List<BlockingQueue<ContainerReport>> queues = new ArrayList<>();
+    List<Queue<ContainerReport>> queues = new ArrayList<>();
     for (int i = 0; i < threadPoolSize; ++i) {
       queues.add(new ContainerReportQueue(queueSize));
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/ContainerReportQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/ContainerReportQueue.java
@@ -24,8 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReport;
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
  * avoiding duplicate FCR reports.
  */
 public class ContainerReportQueue
-    implements BlockingQueue<ContainerReport>, IQueueMetrics {
+    implements Queue<ContainerReport>, IQueueMetrics {
 
   private final Integer maxCapacity;
 
@@ -48,8 +48,8 @@ public class ContainerReportQueue
    * i.e. report execution from multiple datanode will be executed in same
    * order as added to queue.
    */
-  private LinkedBlockingQueue<String> orderingQueue
-      = new LinkedBlockingQueue<>();
+  private ConcurrentLinkedQueue<String> orderingQueue
+      = new ConcurrentLinkedQueue<>();
   private Map<String, List<ContainerReport>> dataMap = new HashMap<>();
 
   private int capacity = 0;
@@ -257,16 +257,6 @@ public class ContainerReportQueue
   @Override
   public ContainerReport take() throws InterruptedException {
     String uuid = orderingQueue.take();
-    synchronized (this) {
-      return removeAndGet(uuid);
-    }
-  }
-
-  @Nullable
-  @Override
-  public ContainerReport poll(long timeout, @NotNull TimeUnit unit)
-      throws InterruptedException {
-    String uuid = orderingQueue.poll(timeout, unit);
     synchronized (this) {
       return removeAndGet(uuid);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.BlockingService;
 
 import java.util.Collections;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -524,7 +525,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     long execWaitThreshold = configuration.getInt(
         ScmUtils.getContainerReportConfPrefix() + ".execute.wait.threshold",
         OZONE_SCM_EVENT_REPORT_EXEC_WAIT_THRESHOLD_DEFAULT);
-    List<BlockingQueue<ContainerReport>> queues
+    List<Queue<ContainerReport>> queues
         = ScmUtils.initContainerReportQueue(configuration);
     List<ThreadPoolExecutor> executors
         = FixedThreadPoolWithAffinityExecutor.initializeExecutorPool(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -132,6 +132,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -941,7 +942,7 @@ public class TestStorageContainerManager {
   @Test
   public void testContainerReportQueueWithDrop() throws Exception {
     EventQueue eventQueue = new EventQueue();
-    List<BlockingQueue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>
+    List<Queue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>
         queues = new ArrayList<>();
     for (int i = 0; i < 1; ++i) {
       queues.add(new ContainerReportQueue());
@@ -987,7 +988,7 @@ public class TestStorageContainerManager {
   @Category(FlakyTest.class) @Flaky("HDDS-8470")
   public void testContainerReportQueueTakingMoreTime() throws Exception {
     EventQueue eventQueue = new EventQueue();
-    List<BlockingQueue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>
+    List<Queue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>
         queues = new ArrayList<>();
     for (int i = 0; i < 1; ++i) {
       queues.add(new ContainerReportQueue());
@@ -1038,7 +1039,7 @@ public class TestStorageContainerManager {
   @Test
   public void testIncrementalContainerReportQueue() throws Exception {
     EventQueue eventQueue = new EventQueue();
-    List<BlockingQueue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>
+    List<Queue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>
         queues = new ArrayList<>();
     for (int i = 0; i < 1; ++i) {
       queues.add(new ContainerReportQueue());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -101,7 +102,7 @@ public class ReconUtils {
   }
 
   @NotNull
-  public static List<BlockingQueue<SCMDatanodeHeartbeatDispatcher
+  public static List<Queue<SCMDatanodeHeartbeatDispatcher
       .ContainerReport>> initContainerReportQueue(
       OzoneConfiguration configuration) {
     int threadPoolSize =
@@ -111,7 +112,7 @@ public class ReconUtils {
     int queueSize = configuration.getInt(
         ScmUtils.getContainerReportConfPrefix() + ".queue.size",
         OZONE_SCM_EVENT_CONTAINER_REPORT_QUEUE_SIZE_DEFAULT);
-    List<BlockingQueue<SCMDatanodeHeartbeatDispatcher.ContainerReport>> queues =
+    List<Queue<SCMDatanodeHeartbeatDispatcher.ContainerReport>> queues =
         new ArrayList<>();
     for (int i = 0; i < threadPoolSize; ++i) {
       queues.add(new ReconContainerReportQueue(queueSize));

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -309,7 +309,7 @@ public class ReconStorageContainerManagerFacade
     long execWaitThreshold = ozoneConfiguration.getInt(
         ScmUtils.getContainerReportConfPrefix() + ".execute.wait.threshold",
         OZONE_SCM_EVENT_REPORT_EXEC_WAIT_THRESHOLD_DEFAULT);
-    List<BlockingQueue<ContainerReport>> queues
+    List<Queue<ContainerReport>> queues
         = ReconUtils.initContainerReportQueue(ozoneConfiguration);
     List<ThreadPoolExecutor> executors
         = FixedThreadPoolWithAffinityExecutor.initializeExecutorPool(


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerReportQueue uses LinkedBlockingQueue, which can cause excess contention between the executors at runtime. This can get bad when there are a lot of timeout and retries because contention itself can cause retries.

Changing the LinkedBlockingQueue to ConcurrentLinkedQueue can solve the problem

## What is the link to the Apache JIRA

[HDDS-13020](https://issues.apache.org/jira/browse/HDDS-13020)

## How was this patch tested?

unit tests
