### PR TITLE
HDDS-12919. Remove redundant FileLock from ChunkWrite

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -38,7 +38,6 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -181,10 +180,7 @@ public final class ChunkUtils {
       FileChannel channel = null;
       try {
         channel = open(path, WRITE_OPTIONS, NO_ATTRIBUTES);
-
-        try (FileLock ignored = channel.lock()) {
-          return writeDataToChannel(channel, data, offset);
-        }
+        return writeDataToChannel(channel, data, offset);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the redundant FileLock during chunk write. 

Currently before chunk read and write, it will acquire a read or write lock from fileStripedLock in ChunkUtils, so that read and write are welly controlled in Datanode.

For chunk write, it further acquires an exclusive FileLock after acquire the write lock from fileStripedLock. As the FileLock mainly acts as inter-process lock purpose, to prevent another process from reading or writing to the same lock region, which is not a case in Ozone, there are no other processes which will read/write the same block file as Datanode. So acquire this exclusive FileLock after already holding the write lock from fileStripedLock is not necessary.

BTW, it took ~2ms to acquire a FileLock, ~0.15ms to acquire a LOCK from fileStripedLock.
And FileLock doesn't prevent file get deleted by another thread/process.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12919

## How was this patch tested?
Existing unit tests
