### PR TITLE
HDDS-13027. Workaround for GitHub connection failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,7 @@ jobs:
     secrets: inherit
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}
+      pre-script: sudo hostname localhost
       ratis-args: ${{ inputs.ratis_args }}
       script: integration
       script-args: -Ptest-${{ matrix.profile }} -Drocks_tools_native


### PR DESCRIPTION
## What changes were proposed in this pull request?

Connections to public address of GitHub runner are no longer allowed (https://github.com/actions/runner-images/issues/12178#issuecomment-2869825173):

```
Connection to localhost (127.0.0.1) 12345 port [tcp/*] succeeded!
Connection to 127.0.0.1 12346 port [tcp/*] succeeded!
Connect to pkrvmberfyhpb9w.ndtsheiqjcounhtwo050w5fsih.bx.internal.cloudapp.net:12347 failed
Connect to 10.1.0.18:12348 failed
```

breaking several integration tests:

```
org.apache.hadoop.ozone.recon.TestReconAndAdminContainerCLI
org.apache.hadoop.ozone.recon.TestReconScmSnapshot
org.apache.hadoop.ozone.recon.TestReconWithOzoneManager
org.apache.hadoop.ozone.s3.awssdk.v1.TestS3SDKV1
org.apache.hadoop.ozone.s3.awssdk.v1.TestS3SDKV1WithRatisStreaming
org.apache.hadoop.ozone.s3.awssdk.v2.TestS3SDKV2
org.apache.hadoop.ozone.shell.TestNSSummaryAdmin
org.apache.hadoop.ozone.TestSecureOzoneCluster
org.apache.ozone.test.NonHATests$OzoneManagerRestInterface
```

This change is a workaround to force integration tests to use loopback address, by setting hostname to localhost.

https://issues.apache.org/jira/browse/HDDS-13027

## How was this patch tested?

Being tested in this PR.