### PR TITLE
HDDS-13030. Snapshot Purge should unset deep cleaning flag for next 2 snapshots in the chain

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -101,9 +101,11 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
           continue;
         }
         SnapshotInfo nextSnapshot = SnapshotUtils.getNextSnapshot(ozoneManager, snapshotChainManager, fromSnapshot);
-
-        // Step 1: Update the deep clean flag for the next active snapshot
+        SnapshotInfo nextToNextSnapshot = SnapshotUtils.getNextSnapshot(ozoneManager, snapshotChainManager,
+            nextSnapshot);
+        // Step 1: Update the deep clean flag for the next snapshot
         updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager, trxnLogIndex);
+        updateSnapshotInfoAndCache(nextToNextSnapshot, omMetadataManager, trxnLogIndex);
         // Step 2: Update the snapshot chain.
         updateSnapshotChainAndCache(omMetadataManager, fromSnapshot, trxnLogIndex);
         // Step 3: Purge the snapshot from SnapshotInfoTable cache and also remove from the map.
@@ -140,6 +142,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
       // current snapshot is deleted. We can potentially
       // reclaim more keys in the next snapshot.
       snapInfo.setDeepClean(false);
+      snapInfo.setDeepCleanedDeletedDir(false);
 
       // Update table cache first
       omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(snapInfo.getTableKey()),


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a snapshot gets purged, currently we only unset the next snapshot's deep cleaning flag. The deep cleaning flag of the next to next snapshot in the chain should also be unset so that the exclusive size of the next snapshot gets updated properly. Exclusive size calculation for a snapshot requires deep cleaning to run on the next snapshot in the chain

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13030

## How was this patch tested?
Additional Unit tests