### PR TITLE
HDDS-12568. Implement MiniOzoneCluster.Service for Recon

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -72,7 +72,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
       List<HddsDatanodeService> hddsDatanodes, String clusterPath,
       Set<Class<? extends Failures>> clazzes) {
     super(conf, new SCMConfigurator(), omService, scmService, hddsDatanodes,
-        clusterPath, null);
+        clusterPath, Collections.emptyList());
     this.numDatanodes = getHddsDatanodes().size();
     this.numOzoneManagers = omService.getServices().size();
     this.numStorageContainerManagers = scmService.getServices().size();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/ReconService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/ReconService.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon;
+
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
+
+import java.io.File;
+import java.util.Objects;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.ozone.recon.schema.ReconSqlDbConfig;
+import org.apache.ratis.util.Preconditions;
+
+/** Recon for {@link MiniOzoneCluster}. */
+public class ReconService implements MiniOzoneCluster.Service {
+
+  private static final String[] NO_ARGS = new String[0];
+
+  private final String httpAddress;
+  private final String datanodeAddress;
+
+  private ReconServer reconServer;
+
+  public ReconService(OzoneConfiguration conf) {
+    httpAddress = localhostWithFreePort();
+    datanodeAddress = localhostWithFreePort();
+    setReconAddress(conf);
+  }
+
+  @Override
+  public void start(OzoneConfiguration conf) {
+    Preconditions.assertNull(reconServer, "Recon already started");
+
+    ConfigurationProvider.resetConfiguration();
+    ConfigurationProvider.setConfiguration(conf);
+    configureRecon(conf);
+
+    reconServer = new ReconServer();
+    reconServer.execute(NO_ARGS);
+  }
+
+  @Override
+  public void stop() {
+    final ReconServer instance = reconServer;
+    Preconditions.assertNotNull(instance, "Recon not running");
+    instance.stop();
+    instance.join();
+    reconServer = null;
+  }
+
+  @Override
+  public String toString() {
+    final ReconServer instance = reconServer;
+    return instance != null
+        ? "Recon(http=" + instance.getHttpServer().getHttpAddress()
+            + ", https=" + instance.getHttpServer().getHttpsAddress() + ")"
+        : "Recon";
+  }
+
+  ReconServer getReconServer() {
+    return reconServer;
+  }
+
+  private void configureRecon(OzoneConfiguration conf) {
+    String metadataDir = Objects.requireNonNull(conf.get(OZONE_METADATA_DIRS), OZONE_METADATA_DIRS + " must be set");
+    File dir = new File(metadataDir, "recon");
+    conf.set(OZONE_RECON_DB_DIR, dir.getAbsolutePath());
+    conf.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, dir.getAbsolutePath());
+    conf.set(OZONE_RECON_SCM_DB_DIR, dir.getAbsolutePath());
+
+    ReconSqlDbConfig dbConfig = conf.getObject(ReconSqlDbConfig.class);
+    dbConfig.setJdbcUrl("jdbc:derby:" + dir.getAbsolutePath()
+        + "/ozone_recon_derby.db");
+    conf.setFromObject(dbConfig);
+
+    conf.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10s");
+
+    setReconAddress(conf);
+  }
+
+  private void setReconAddress(OzoneConfiguration conf) {
+    conf.set(OZONE_RECON_ADDRESS_KEY, datanodeAddress);
+    conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, datanodeAddress);
+    conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, httpAddress);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
@@ -82,6 +82,7 @@ public class TestReconInsightsForDeletedDirectories {
   private static String volumeName;
   private static String bucketName;
   private static OzoneClient client;
+  private static ReconService recon;
 
   @BeforeAll
   public static void init() throws Exception {
@@ -90,9 +91,10 @@ public class TestReconInsightsForDeletedDirectories {
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 10000000,
         TimeUnit.MILLISECONDS);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
+    recon = new ReconService(conf);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
-        .includeRecon(true)
+        .addService(recon)
         .build();
     cluster.waitForClusterToBeReady();
     client = cluster.newClient();
@@ -174,7 +176,7 @@ public class TestReconInsightsForDeletedDirectories {
 
     // Retrieve tables from Recon's OM-DB.
     ReconOMMetadataManager reconOmMetadataManagerInstance =
-        (ReconOMMetadataManager) cluster.getReconServer()
+        (ReconOMMetadataManager) recon.getReconServer()
             .getOzoneManagerServiceProvider().getOMMetadataManagerInstance();
     Table<String, OmKeyInfo> reconFileTable =
         reconOmMetadataManagerInstance.getKeyTable(getFSOBucketLayout());
@@ -203,7 +205,7 @@ public class TestReconInsightsForDeletedDirectories {
     } else {
       // Retrieve Namespace Summary for dir1 from Recon.
       ReconNamespaceSummaryManagerImpl namespaceSummaryManager =
-          (ReconNamespaceSummaryManagerImpl) cluster.getReconServer()
+          (ReconNamespaceSummaryManagerImpl) recon.getReconServer()
               .getReconNamespaceSummaryManager();
       NSSummary summary =
           namespaceSummaryManager.getNSSummary(directoryObjectId);
@@ -222,9 +224,9 @@ public class TestReconInsightsForDeletedDirectories {
 
     // Create an Instance of OMDBInsightEndpoint.
     OzoneStorageContainerManager reconSCM =
-        cluster.getReconServer().getReconStorageContainerManager();
+        recon.getReconServer().getReconStorageContainerManager();
     ReconNamespaceSummaryManagerImpl reconNamespaceSummaryManager =
-        (ReconNamespaceSummaryManagerImpl) cluster.getReconServer()
+        (ReconNamespaceSummaryManagerImpl) recon.getReconServer()
             .getReconNamespaceSummaryManager();
 
     OMDBInsightEndpoint omdbInsightEndpoint =
@@ -286,7 +288,7 @@ public class TestReconInsightsForDeletedDirectories {
 
     // Retrieve tables from Recon's OM-DB.
     ReconOMMetadataManager reconOmMetadataManagerInstance =
-        (ReconOMMetadataManager) cluster.getReconServer()
+        (ReconOMMetadataManager) recon.getReconServer()
             .getOzoneManagerServiceProvider().getOMMetadataManagerInstance();
     Table<String, OmKeyInfo> reconFileTable =
         reconOmMetadataManagerInstance.getKeyTable(getFSOBucketLayout());
@@ -302,9 +304,9 @@ public class TestReconInsightsForDeletedDirectories {
 
     // Create an Instance of OMDBInsightEndpoint.
     OzoneStorageContainerManager reconSCM =
-        cluster.getReconServer().getReconStorageContainerManager();
+        recon.getReconServer().getReconStorageContainerManager();
     ReconNamespaceSummaryManagerImpl namespaceSummaryManager =
-        (ReconNamespaceSummaryManagerImpl) cluster.getReconServer()
+        (ReconNamespaceSummaryManagerImpl) recon.getReconServer()
             .getReconNamespaceSummaryManager();
 
     OMDBInsightEndpoint omdbInsightEndpoint =
@@ -373,12 +375,12 @@ public class TestReconInsightsForDeletedDirectories {
 
     // Fetch the deleted directory info from Recon OmDbInsightEndpoint.
     OzoneStorageContainerManager reconSCM =
-        cluster.getReconServer().getReconStorageContainerManager();
+        recon.getReconServer().getReconStorageContainerManager();
     ReconNamespaceSummaryManagerImpl namespaceSummaryManager =
-        (ReconNamespaceSummaryManagerImpl) cluster.getReconServer()
+        (ReconNamespaceSummaryManagerImpl) recon.getReconServer()
             .getReconNamespaceSummaryManager();
     ReconOMMetadataManager reconOmMetadataManagerInstance =
-        (ReconOMMetadataManager) cluster.getReconServer()
+        (ReconOMMetadataManager) recon.getReconServer()
             .getOzoneManagerServiceProvider().getOMMetadataManagerInstance();
     OMDBInsightEndpoint omdbInsightEndpoint =
         new OMDBInsightEndpoint(reconSCM, reconOmMetadataManagerInstance,
@@ -467,7 +469,7 @@ public class TestReconInsightsForDeletedDirectories {
     AtomicLong count = new AtomicLong(0L);
     assertDoesNotThrow(() -> {
       if (isRecon) {
-        count.set(cluster.getReconServer().getOzoneManagerServiceProvider()
+        count.set(recon.getReconServer().getOzoneManagerServiceProvider()
             .getOMMetadataManagerInstance().countRowsInTable(table));
       } else {
         count.set(cluster.getOzoneManager().getMetadataManager()
@@ -482,7 +484,7 @@ public class TestReconInsightsForDeletedDirectories {
   private void syncDataFromOM() throws IOException {
     // Sync data from Ozone Manager to Recon.
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
-        cluster.getReconServer().getOzoneManagerServiceProvider();
+        recon.getReconServer().getOzoneManagerServiceProvider();
     impl.syncDataFromOM();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
@@ -46,7 +46,8 @@ import org.junit.jupiter.api.Test;
  */
 public class TestReconScmSnapshot {
   private OzoneConfiguration conf;
-  private MiniOzoneCluster ozoneCluster = null;
+  private MiniOzoneCluster cluster;
+  private ReconService recon;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -56,33 +57,30 @@ public class TestReconScmSnapshot {
     conf.setBoolean(
         ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_ENABLED, true);
     conf.setInt(ReconServerConfigKeys.OZONE_RECON_SCM_CONTAINER_THRESHOLD, 0);
-    ozoneCluster = MiniOzoneCluster.newBuilder(conf)
+    recon = new ReconService(conf);
+    cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(4)
-        .includeRecon(true)
+        .addService(recon)
         .build();
-    ozoneCluster.waitForClusterToBeReady();
+    cluster.waitForClusterToBeReady();
   }
 
   @Test
   public void testScmSnapshot() throws Exception {
-    testSnapshot(ozoneCluster);
-  }
-
-  public static void testSnapshot(MiniOzoneCluster cluster) throws Exception {
     LogCapturer logCapturer = LogCapturer.captureLogs(ReconStorageContainerManagerFacade.class);
 
-    List<ContainerInfo> reconContainers = cluster.getReconServer()
+    List<ContainerInfo> reconContainers = recon.getReconServer()
         .getReconStorageContainerManager().getContainerManager()
         .getContainers();
     assertEquals(0, reconContainers.size());
 
     ReconNodeManager nodeManager;
-    nodeManager = (ReconNodeManager) cluster.getReconServer()
+    nodeManager = (ReconNodeManager) recon.getReconServer()
         .getReconStorageContainerManager().getScmNodeManager();
     long keyCountBefore = nodeManager.getNodeDBKeyCount();
 
     //Stopping Recon to add Containers in SCM
-    cluster.stopRecon();
+    recon.stop();
 
     ContainerManager containerManager;
     containerManager = cluster.getStorageContainerManager()
@@ -93,12 +91,12 @@ public class TestReconScmSnapshot {
           HddsProtos.ReplicationFactor.ONE), "testOwner");
     }
 
-    cluster.startRecon();
+    recon.start(conf);
 
     //ContainerCount after Recon DB is updated with SCM DB
     containerManager = cluster.getStorageContainerManager()
         .getContainerManager();
-    ContainerManager reconContainerManager = cluster.getReconServer()
+    ContainerManager reconContainerManager = recon.getReconServer()
         .getReconStorageContainerManager().getContainerManager();
     assertTrue(logCapturer.getOutput()
         .contains("Recon Container Count: " + reconContainers.size() +
@@ -109,13 +107,13 @@ public class TestReconScmSnapshot {
     //PipelineCount after Recon DB is updated with SCM DB
     PipelineManager scmPipelineManager = cluster.getStorageContainerManager()
         .getPipelineManager();
-    PipelineManager reconPipelineManager = cluster.getReconServer()
+    PipelineManager reconPipelineManager = recon.getReconServer()
         .getReconStorageContainerManager().getPipelineManager();
     assertEquals(scmPipelineManager.getPipelines().size(),
         reconPipelineManager.getPipelines().size());
 
     //NodeCount after Recon DB updated with SCM DB
-    nodeManager = (ReconNodeManager) cluster.getReconServer()
+    nodeManager = (ReconNodeManager) recon.getReconServer()
         .getReconStorageContainerManager().getScmNodeManager();
     long keyCountAfter = nodeManager.getNodeDBKeyCount();
     assertEquals(keyCountAfter, keyCountBefore);
@@ -124,14 +122,14 @@ public class TestReconScmSnapshot {
   @Test
   @Flaky("HDDS-11645")
   public void testExplicitRemovalOfNode() throws Exception {
-    ReconNodeManager nodeManager = (ReconNodeManager) ozoneCluster.getReconServer()
+    ReconNodeManager nodeManager = (ReconNodeManager) recon.getReconServer()
         .getReconStorageContainerManager().getScmNodeManager();
     long nodeDBCountBefore = nodeManager.getNodeDBKeyCount();
     List<? extends DatanodeDetails> allNodes = nodeManager.getAllNodes();
     assertEquals(nodeDBCountBefore, allNodes.size());
 
     DatanodeDetails datanodeDetails = allNodes.get(3);
-    ozoneCluster.shutdownHddsDatanode(datanodeDetails);
+    cluster.shutdownHddsDatanode(datanodeDetails);
 
     GenericTestUtils.waitFor(() -> {
       try {
@@ -168,8 +166,8 @@ public class TestReconScmSnapshot {
 
   @AfterEach
   public void shutdown() throws Exception {
-    if (ozoneCluster != null) {
-      ozoneCluster.shutdown();
+    if (cluster != null) {
+      cluster.shutdown();
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -60,6 +60,7 @@ import org.slf4j.event.Level;
 public class TestReconTasks {
   private MiniOzoneCluster cluster = null;
   private OzoneConfiguration conf;
+  private ReconService recon;
 
   @BeforeEach
   public void init() throws Exception {
@@ -73,8 +74,10 @@ public class TestReconTasks {
 
     conf.set("ozone.scm.stale.node.interval", "6s");
     conf.set("ozone.scm.dead.node.interval", "8s");
+    recon = new ReconService(conf);
     cluster =  MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1)
-        .includeRecon(true).build();
+        .addService(recon)
+        .build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(ONE, 30000);
     GenericTestUtils.setLogLevel(SCMDatanodeHeartbeatDispatcher.class,
@@ -92,7 +95,7 @@ public class TestReconTasks {
   public void testSyncSCMContainerInfo() throws Exception {
     ReconStorageContainerManagerFacade reconScm =
         (ReconStorageContainerManagerFacade)
-            cluster.getReconServer().getReconStorageContainerManager();
+            recon.getReconServer().getReconStorageContainerManager();
     StorageContainerManager scm = cluster.getStorageContainerManager();
     ContainerManager scmContainerManager = scm.getContainerManager();
     ContainerManager reconContainerManager = reconScm.getContainerManager();
@@ -124,9 +127,9 @@ public class TestReconTasks {
   public void testMissingContainerDownNode() throws Exception {
     ReconStorageContainerManagerFacade reconScm =
         (ReconStorageContainerManagerFacade)
-            cluster.getReconServer().getReconStorageContainerManager();
+            recon.getReconServer().getReconStorageContainerManager();
     ReconContainerMetadataManager reconContainerMetadataManager =
-        cluster.getReconServer().getReconContainerMetadataManager();
+        recon.getReconServer().getReconContainerMetadataManager();
 
     StorageContainerManager scm = cluster.getStorageContainerManager();
     PipelineManager reconPipelineManager = reconScm.getPipelineManager();
@@ -205,9 +208,9 @@ public class TestReconTasks {
   public void testEmptyMissingContainerDownNode() throws Exception {
     ReconStorageContainerManagerFacade reconScm =
         (ReconStorageContainerManagerFacade)
-            cluster.getReconServer().getReconStorageContainerManager();
+            recon.getReconServer().getReconStorageContainerManager();
     ReconContainerMetadataManager reconContainerMetadataManager =
-        cluster.getReconServer().getReconContainerMetadataManager();
+        recon.getReconServer().getReconContainerMetadataManager();
     StorageContainerManager scm = cluster.getStorageContainerManager();
     PipelineManager reconPipelineManager = reconScm.getPipelineManager();
     PipelineManager scmPipelineManager = scm.getPipelineManager();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
@@ -55,17 +55,18 @@ public class TestReconWithOzoneManagerFSO {
   private static MiniOzoneCluster cluster = null;
   private static OzoneConfiguration conf;
   private static ObjectStore store;
+  private static ReconService recon;
 
   @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED);
-    cluster =
-            MiniOzoneCluster.newBuilder(conf)
-                    .setNumDatanodes(3)
-                    .includeRecon(true)
-                    .build();
+    recon = new ReconService(conf);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .addService(recon)
+        .build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 30000);
 
@@ -98,16 +99,16 @@ public class TestReconWithOzoneManagerFSO {
     // add a vol, bucket and key
     addKeys(0, 10, "dir");
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
-            cluster.getReconServer().getOzoneManagerServiceProvider();
+            recon.getReconServer().getOzoneManagerServiceProvider();
     impl.syncDataFromOM();
     ReconNamespaceSummaryManager namespaceSummaryManager =
-            cluster.getReconServer().getReconNamespaceSummaryManager();
+            recon.getReconServer().getReconNamespaceSummaryManager();
     ReconOMMetadataManager omMetadataManagerInstance =
             (ReconOMMetadataManager)
-                    cluster.getReconServer().getOzoneManagerServiceProvider()
+                    recon.getReconServer().getOzoneManagerServiceProvider()
                             .getOMMetadataManagerInstance();
     OzoneStorageContainerManager reconSCM =
-            cluster.getReconServer().getReconStorageContainerManager();
+            recon.getReconServer().getReconStorageContainerManager();
     NSSummaryEndpoint endpoint = new NSSummaryEndpoint(namespaceSummaryManager,
             omMetadataManagerInstance, reconSCM);
     Response basicInfo = endpoint.getBasicInfo("/vol1/bucket1/dir1");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -59,6 +59,7 @@ public class TestReconWithOzoneManagerHA {
   private static final String OM_SERVICE_ID = "omService1";
   private static final String VOL_NAME = "testrecon";
   private OzoneClient client;
+  private ReconService recon;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -70,10 +71,11 @@ public class TestReconWithOzoneManagerHA {
     conf.setFromObject(dbConf);
 
     MiniOzoneHAClusterImpl.Builder builder = MiniOzoneCluster.newHABuilder(conf);
+    recon = new ReconService(conf);
     builder.setOMServiceId(OM_SERVICE_ID)
         .setNumOfOzoneManagers(3)
         .setNumDatanodes(1)
-        .includeRecon(true);
+        .addService(recon);
     cluster = builder.build();
     cluster.waitForClusterToBeReady();
     client = OzoneClientFactory.getRpcClient(OM_SERVICE_ID, conf);
@@ -108,7 +110,7 @@ public class TestReconWithOzoneManagerHA {
     assertTrue(ozoneManager.get().isLeaderReady(), "Should have gotten the leader!");
 
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
-        cluster.getReconServer().getOzoneManagerServiceProvider();
+        recon.getReconServer().getOzoneManagerServiceProvider();
 
     String hostname =
         ozoneManager.get().getHttpServer().getHttpAddress().getHostName();
@@ -131,7 +133,7 @@ public class TestReconWithOzoneManagerHA {
     impl.syncDataFromOM();
 
     ReconContainerMetadataManager reconContainerMetadataManager =
-        cluster.getReconServer().getReconContainerMetadataManager();
+        recon.getReconServer().getReconContainerMetadataManager();
     try (TableIterator iterator =
         reconContainerMetadataManager.getContainerTableIterator()) {
       String reconKeyPrefix = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.recon.ReconService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,9 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
     OMRequestTestUtils.configureFSOptimizedPaths(conf, true);
     conf.set(OZONE_RECON_ADDRESS_KEY, "localhost:9888");
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .withoutDatanodes().includeRecon(true).build();
+        .withoutDatanodes()
+        .addService(new ReconService(conf))
+        .build();
     cluster.waitForClusterToBeReady();
     client = cluster.newClient();
     store = client.getObjectStore();

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.security.symmetric.SecretKeyClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.function.CheckedFunction;
@@ -138,13 +137,6 @@ public interface MiniOzoneCluster extends AutoCloseable {
   HddsDatanodeService getHddsDatanode(DatanodeDetails dn) throws IOException;
 
   /**
-   * Returns a {@link ReconServer} instance.
-   *
-   * @return {@link ReconServer} instance if it is initialized, otherwise null.
-   */
-  ReconServer getReconServer();
-
-  /**
    * Returns an {@link OzoneClient} to access the {@link MiniOzoneCluster}.
    * The caller is responsible for closing the client after use.
    *
@@ -170,11 +162,6 @@ public interface MiniOzoneCluster extends AutoCloseable {
    * Restarts OzoneManager instance.
    */
   void restartOzoneManager() throws IOException;
-
-  /**
-   * Restarts Recon instance.
-   */
-  void restartReconServer() throws Exception;
 
   /**
    * Restart a particular HddsDatanode.
@@ -207,16 +194,6 @@ public interface MiniOzoneCluster extends AutoCloseable {
    * @param dn HddsDatanode in the MiniOzoneCluster
    */
   void shutdownHddsDatanode(DatanodeDetails dn) throws IOException;
-
-  /**
-   * Start Recon.
-   */
-  void startRecon();
-
-  /**
-   * Stop Recon.
-   */
-  void stopRecon();
 
   /**
    * Shutdown the MiniOzoneCluster and delete the storage dirs.
@@ -275,8 +252,6 @@ public interface MiniOzoneCluster extends AutoCloseable {
 
     protected String scmId = UUID.randomUUID().toString();
     protected String omId = UUID.randomUUID().toString();
-
-    protected boolean includeRecon = false;
 
     protected int numOfDatanodes = 3;
     protected boolean  startDataNodes = true;
@@ -374,11 +349,6 @@ public interface MiniOzoneCluster extends AutoCloseable {
 
     public Builder setDatanodeFactory(DatanodeFactory factory) {
       this.dnFactory = factory;
-      return this;
-    }
-
-    public Builder includeRecon(boolean include) {
-      this.includeRecon = include;
       return this;
     }
 

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -19,14 +19,6 @@ package org.apache.hadoop.ozone;
 
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 
@@ -63,7 +55,6 @@ import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.proxy.SCMContainerLocationFailoverProxyProvider;
 import org.apache.hadoop.hdds.scm.safemode.HealthyPipelineSafeModeRule;
 import org.apache.hadoop.hdds.scm.safemode.SafeModeRuleFactory;
-import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -82,10 +73,7 @@ import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.recon.ConfigurationProvider;
-import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.ozone.recon.schema.ReconSqlDbConfig;
 import org.apache.ozone.test.GenericTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,7 +100,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   private StorageContainerManager scm;
   private OzoneManager ozoneManager;
   private final List<HddsDatanodeService> hddsDatanodes;
-  private ReconServer reconServer;
   private final List<Service> services;
 
   // Timeout for the cluster to be ready
@@ -121,20 +108,16 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   private final Set<AutoCloseable> clients = ConcurrentHashMap.newKeySet();
   private SecretKeyClient secretKeyClient;
 
-  /**
-   * Creates a new MiniOzoneCluster with Recon.
-   */
   private MiniOzoneClusterImpl(OzoneConfiguration conf,
       SCMConfigurator scmConfigurator,
       OzoneManager ozoneManager,
       StorageContainerManager scm,
       List<HddsDatanodeService> hddsDatanodes,
-      ReconServer reconServer, List<Service> services) {
+      List<Service> services) {
     this.conf = conf;
     this.ozoneManager = ozoneManager;
     this.scm = scm;
     this.hddsDatanodes = hddsDatanodes;
-    this.reconServer = reconServer;
     this.scmConfigurator = scmConfigurator;
     this.services = services;
   }
@@ -146,11 +129,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
    * OzoneManagers and StorageContainerManagers.
    */
   MiniOzoneClusterImpl(OzoneConfiguration conf, SCMConfigurator scmConfigurator,
-      List<HddsDatanodeService> hddsDatanodes, ReconServer reconServer, List<Service> services) {
+      List<HddsDatanodeService> hddsDatanodes, List<Service> services) {
     this.scmConfigurator = scmConfigurator;
     this.conf = conf;
     this.hddsDatanodes = hddsDatanodes;
-    this.reconServer = reconServer;
     this.services = services;
   }
 
@@ -257,11 +239,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   }
 
   @Override
-  public ReconServer getReconServer() {
-    return this.reconServer;
-  }
-
-  @Override
   public int getHddsDatanodeIndex(DatanodeDetails dn) throws IOException {
     for (HddsDatanodeService service : hddsDatanodes) {
       if (service.getDatanodeDetails().equals(dn)) {
@@ -319,12 +296,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   public void restartOzoneManager() throws IOException {
     stopOM(ozoneManager);
     ozoneManager.restart();
-  }
-
-  @Override
-  public void restartReconServer() {
-    stopRecon(reconServer);
-    startRecon();
   }
 
   private void waitForHddsDatanodeToStop(DatanodeDetails dn)
@@ -411,7 +382,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     stopOM(ozoneManager);
     stopDatanodes(hddsDatanodes);
     stopSCM(scm);
-    stopRecon(reconServer);
     stopServices(services);
   }
 
@@ -439,17 +409,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         LOG.error("Exception while trying to shutdown datanodes:", e);
       }
     });
-  }
-
-  @Override
-  public void startRecon() {
-    reconServer = new ReconServer();
-    reconServer.execute(NO_ARGS);
-  }
-
-  @Override
-  public void stopRecon() {
-    stopRecon(reconServer);
   }
 
   public void startServices() throws Exception {
@@ -500,18 +459,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     }
   }
 
-  private static void stopRecon(ReconServer reconServer) {
-    try {
-      if (reconServer != null) {
-        LOG.info("Stopping Recon");
-        reconServer.stop();
-        reconServer.join();
-      }
-    } catch (Exception e) {
-      LOG.error("Exception while shutting down Recon.", e);
-    }
-  }
-
   private static void stopServices(List<Service> services) {
     // stop in reverse order
     List<Service> reverse = new ArrayList<>(services);
@@ -548,32 +495,27 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       initializeConfiguration();
       StorageContainerManager scm = null;
       OzoneManager om = null;
-      ReconServer reconServer = null;
       List<HddsDatanodeService> hddsDatanodes = Collections.emptyList();
       try {
         scm = createAndStartSingleSCM();
         om = createAndStartSingleOM();
-        reconServer = createRecon();
         hddsDatanodes = createHddsDatanodes();
 
         MiniOzoneClusterImpl cluster = new MiniOzoneClusterImpl(conf,
             scmConfigurator, om, scm,
-            hddsDatanodes, reconServer, getServices());
+            hddsDatanodes, getServices());
+        cluster.startServices();
 
         cluster.setCAClient(certClient);
         cluster.setSecretKeyClient(secretKeyClient);
         if (startDataNodes) {
           cluster.startHddsDatanodes();
         }
-        cluster.startServices();
 
         prepareForNextBuild();
         return cluster;
       } catch (Exception ex) {
         stopOM(om);
-        if (includeRecon) {
-          stopRecon(reconServer);
-        }
         stopServices(getServices());
         if (startDataNodes) {
           stopDatanodes(hddsDatanodes);
@@ -727,22 +669,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, getSCMAddresses(scms));
     }
 
-    protected ReconServer createRecon() {
-      ReconServer reconServer = null;
-      if (includeRecon) {
-        configureRecon();
-        reconServer = new ReconServer();
-        reconServer.execute(NO_ARGS);
-
-        OzoneStorageContainerManager reconScm =
-            reconServer.getReconStorageContainerManager();
-        conf.set(OZONE_RECON_ADDRESS_KEY,
-            reconScm.getDatanodeRpcAddress().getHostString() + ":" +
-                reconScm.getDatanodeRpcAddress().getPort());
-      }
-      return reconServer;
-    }
-
     /**
      * Creates HddsDatanodeService(s) instance.
      *
@@ -786,27 +712,5 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       conf.setInt(OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, getFreePort());
     }
 
-    protected void configureRecon() {
-      ConfigurationProvider.resetConfiguration();
-
-      File tempNewFolder = new File(path, "recon");
-      conf.set(OZONE_RECON_DB_DIR,
-          tempNewFolder.getAbsolutePath());
-      conf.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, tempNewFolder
-          .getAbsolutePath());
-      conf.set(OZONE_RECON_SCM_DB_DIR,
-          tempNewFolder.getAbsolutePath());
-
-      ReconSqlDbConfig dbConfig = conf.getObject(ReconSqlDbConfig.class);
-      dbConfig.setJdbcUrl("jdbc:derby:" + tempNewFolder.getAbsolutePath()
-          + "/ozone_recon_derby.db");
-      conf.setFromObject(dbConfig);
-
-      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, anyHostWithFreePort());
-      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, anyHostWithFreePort());
-      conf.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10s");
-
-      ConfigurationProvider.setConfiguration(conf);
-    }
   }
 }

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
@@ -52,7 +51,6 @@ import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
-import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -87,8 +85,8 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       SCMHAService scmhaService,
       List<HddsDatanodeService> hddsDatanodes,
       String clusterPath,
-      ReconServer reconServer) {
-    super(conf, scmConfigurator, hddsDatanodes, reconServer, emptyList());
+      List<Service> services) {
+    super(conf, scmConfigurator, hddsDatanodes, services);
     this.omhaService = omhaService;
     this.scmhaService = scmhaService;
     this.clusterMetaPath = clusterPath;
@@ -421,11 +419,9 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       initOMRatisConf();
       SCMHAService scmService;
       OMHAService omService;
-      ReconServer reconServer;
       try {
         scmService = createSCMService();
         omService = createOMService();
-        reconServer = createRecon();
       } catch (AuthenticationException ex) {
         throw new IOException("Unable to build MiniOzoneCluster. ", ex);
       }
@@ -433,8 +429,12 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       final List<HddsDatanodeService> hddsDatanodes = createHddsDatanodes();
 
       MiniOzoneHAClusterImpl cluster = new MiniOzoneHAClusterImpl(conf,
-          scmConfigurator, omService, scmService, hddsDatanodes, path,
-          reconServer);
+          scmConfigurator, omService, scmService, hddsDatanodes, path, getServices());
+      try {
+        cluster.startServices();
+      } catch (Exception e) {
+        throw new IOException("Unable to start services", e);
+      }
 
       if (startDataNodes) {
         cluster.startHddsDatanodes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove Recon from `MiniOzoneCluster` interface, adding it as an implementation of `MiniOzoneCluster.Service` instead (like HDDS-12527 for S3 Gateway)

After this, Recon integration tests can be moved to their own submodule in the next subtask (like HDDS-12528 for S3 Gateway).

https://issues.apache.org/jira/browse/HDDS-12568

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/15020426918