### PR TITLE
HDDS-12914. Validate AWS S3 Transfer Manager Resumable File Download

### DIFF
--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -114,6 +114,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3-transfer-manager</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/S3ClientFactory.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/S3ClientFactory.java
@@ -39,7 +39,11 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 /**
  * Factory class for creating S3 clients.
@@ -127,6 +131,23 @@ public class S3ClientFactory {
    * @throws Exception if there is an error creating the client
    */
   public S3Client createS3ClientV2(boolean enablePathStyle) throws Exception {
+    S3ClientBuilder builder = S3Client.builder();
+    configureCommon(builder, enablePathStyle);
+    return builder.build();
+  }
+
+  public S3AsyncClient createS3AsyncClientV2() throws Exception {
+    return createS3AsyncClientV2(true);
+  }
+
+  public S3AsyncClient createS3AsyncClientV2(boolean enablePathStyle) throws Exception {
+    S3AsyncClientBuilder builder = S3AsyncClient.builder();
+    configureCommon(builder, enablePathStyle);
+    return builder.build();
+  }
+
+  private <T extends S3BaseClientBuilder<T, ?>> void configureCommon(T builder, boolean enablePathStyle)
+      throws Exception {
     final String accessKey = "user";
     final String secretKey = "password";
     final Region region = Region.US_EAST_1;
@@ -151,11 +172,9 @@ public class S3ClientFactory {
 
     AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
-    return S3Client.builder()
-        .region(region)
+    builder.region(region)
         .endpointOverride(new URI(endpoint))
         .credentialsProvider(StaticCredentialsProvider.create(credentials))
-        .forcePathStyle(enablePathStyle)
-        .build();
+        .forcePathStyle(enablePathStyle);
   }
 }

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -122,8 +122,10 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
         .setNumDatanodes(5)
         .build();
     cluster.waitForClusterToBeReady();
-    s3Client = new S3ClientFactory(s3g.getConf()).createS3ClientV2();
-    s3AsyncClient = new S3ClientFactory(s3g.getConf()).createS3AsyncClientV2();
+
+    S3ClientFactory s3Factory = new S3ClientFactory(s3g.getConf());
+    s3Client = s3Factory.createS3ClientV2();
+    s3AsyncClient = s3Factory.createS3AsyncClientV2();
   }
 
   /**

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
@@ -83,6 +84,10 @@ import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.FileDownload;
+import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 
 /**
  * This is an abstract class to test the AWS Java S3 SDK operations.
@@ -103,6 +108,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
 
   private static MiniOzoneCluster cluster = null;
   private static S3Client s3Client = null;
+  private static S3AsyncClient s3AsyncClient = null;
 
   /**
    * Create a MiniOzoneCluster with S3G enabled for testing.
@@ -117,6 +123,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
         .build();
     cluster.waitForClusterToBeReady();
     s3Client = new S3ClientFactory(s3g.getConf()).createS3ClientV2();
+    s3AsyncClient = new S3ClientFactory(s3g.getConf()).createS3AsyncClientV2();
   }
 
   /**
@@ -338,6 +345,45 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
     HeadObjectResponse headObjectResponse = s3Client.headObject(b -> b.bucket(bucketName).key(keyName));
     assertTrue(headObjectResponse.hasMetadata());
     assertEquals(userMetadata, headObjectResponse.metadata());
+  }
+
+  @Test
+  public void testResumableDownloadWithEtagMismatch() throws Exception {
+    // Arrange
+    final String bucketName = getBucketName("resumable");
+    final String keyName = getKeyName("resumable");
+    final String fileContent = "This is a test file for resumable download.";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.fromString(fileContent));
+
+    // Prepare a temp file for download
+    Path tempDownloadPath = Files.createTempFile("downloaded", ".txt");
+    File downloadFile = tempDownloadPath.toFile();
+
+    // Set up S3TransferManager
+    try (S3TransferManager transferManager =
+             S3TransferManager.builder().s3Client(s3AsyncClient).build()) {
+
+      // First download
+      DownloadFileRequest downloadRequest = DownloadFileRequest.builder()
+          .getObjectRequest(b -> b.bucket(bucketName).key(keyName))
+          .destination(downloadFile.toPath())
+          .build();
+      FileDownload download = transferManager.downloadFile(downloadRequest);
+      ResumableFileDownload resumableFileDownload = download.pause();
+
+      // Simulate etag mismatch by modifying the file in S3
+      final String newContent = "This is new content to cause etag mismatch.";
+      s3Client.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.fromString(newContent));
+
+      // Resume download
+      FileDownload resumedDownload = transferManager.resumeDownloadFile(resumableFileDownload);
+      resumedDownload.completionFuture().get();
+
+      String downloadedContent = new String(Files.readAllBytes(downloadFile.toPath()), StandardCharsets.UTF_8);
+      assertEquals(newContent, downloadedContent);
+      assertTrue(downloadFile.delete());
+    }
   }
 
   private String getBucketName() {

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -359,8 +359,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
     s3Client.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.fromString(fileContent));
 
     // Prepare a temp file for download
-    Path tempDownloadPath = Files.createTempFile("downloaded", ".txt");
-    File downloadFile = tempDownloadPath.toFile();
+    Path downloadPath = Files.createTempFile("downloaded", ".txt");
 
     // Set up S3TransferManager
     try (S3TransferManager transferManager =
@@ -369,7 +368,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
       // First download
       DownloadFileRequest downloadRequest = DownloadFileRequest.builder()
           .getObjectRequest(b -> b.bucket(bucketName).key(keyName))
-          .destination(downloadFile.toPath())
+          .destination(downloadPath)
           .build();
       FileDownload download = transferManager.downloadFile(downloadRequest);
       ResumableFileDownload resumableFileDownload = download.pause();
@@ -382,8 +381,10 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
       FileDownload resumedDownload = transferManager.resumeDownloadFile(resumableFileDownload);
       resumedDownload.completionFuture().get();
 
-      String downloadedContent = new String(Files.readAllBytes(downloadFile.toPath()), StandardCharsets.UTF_8);
+      String downloadedContent = new String(Files.readAllBytes(downloadPath), StandardCharsets.UTF_8);
       assertEquals(newContent, downloadedContent);
+
+      File downloadFile = downloadPath.toFile();
       assertTrue(downloadFile.delete());
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <aspectj.version>1.9.7</aspectj.version>
     <assertj.version>3.27.3</assertj.version>
     <aws-java-sdk.version>1.12.661</aws-java-sdk.version>
-    <aws-java-sdk2.version>2.31.25</aws-java-sdk2.version>
+    <aws-java-sdk2.version>2.31.40</aws-java-sdk2.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <bouncycastle.version>1.80</bouncycastle.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add verification for resumable download ETag validation in integration tests.
- Since S3AsyncClient is required for this functionality, refactored S3ClientFactory to support both sync and async V2 client creation with shared configuration logic.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12914

## How was this patch tested?

[Latest CI](https://github.com/Jimmyweng006/ozone/actions/runs/15047263665)
[CI Pass](https://github.com/Jimmyweng006/ozone/actions/runs/15026061987)
