### PR TITLE
HDDS-12993. Use DatanodeID in ReconNodeManager.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -90,7 +90,7 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public String getName() throws IOException {
+  public String getName() {
     return table.getName();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
@@ -26,8 +26,7 @@ import org.apache.hadoop.hdds.server.events.IdentifiableEventPayload;
 /**
  * Command for the datanode with the destination address.
  */
-public class CommandForDatanode<T extends Message> implements
-    IdentifiableEventPayload {
+public final class CommandForDatanode<T extends Message> implements IdentifiableEventPayload {
 
   private final DatanodeID datanodeId;
   private final SCMCommand<T> command;
@@ -53,5 +52,10 @@ public class CommandForDatanode<T extends Message> implements
   @Override
   public long getId() {
     return command.getId();
+  }
+
+  @Override
+  public String toString() {
+    return "CommandForDatanode{" + datanodeId + ", " + command + '}';
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
@@ -127,4 +127,9 @@ public abstract class SCMCommand<T extends Message> implements
   public boolean contributesToQueueSize() {
     return true;
   }
+
+  @Override
+  public String toString() {
+    return getType() + "(id=" + id + ", term=" + term + ')';
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -173,9 +173,8 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   /**
    * Returns the Name of this Table.
    * @return - Table Name.
-   * @throws IOException on failure.
    */
-  String getName() throws IOException;
+  String getName();
 
   /**
    * Returns the key count of this Table.  Note the result can be inaccurate.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 
 /**
  * Metadata object that represents a Datanode.
@@ -214,11 +215,6 @@ public final class DatanodeMetadata {
       return this;
     }
 
-    public Builder setOperationalState(NodeOperationalState operationalState) {
-      this.opState = operationalState;
-      return this;
-    }
-
     public Builder setLastHeartbeat(long lastHeartbeat) {
       this.lastHeartbeat = lastHeartbeat;
       return this;
@@ -255,28 +251,18 @@ public final class DatanodeMetadata {
       return this;
     }
 
-    public Builder setVersion(String version) {
-      this.version = version;
-      return this;
-    }
+    public Builder setDatanode(DatanodeInfo datanode) {
+      this.uuid = datanode.getUuidString();
+      this.hostname = datanode.getHostName();
+      this.networkLocation = datanode.getNetworkLocation();
 
-    public Builder setSetupTime(long setupTime) {
-      this.setupTime = setupTime;
-      return this;
-    }
+      this.opState = datanode.getPersistedOpState();
 
-    public Builder setRevision(String revision) {
-      this.revision = revision;
-      return this;
-    }
+      this.version = datanode.getVersion();
+      this.revision = datanode.getRevision();
+      this.layoutVersion = datanode.getLastKnownLayoutVersion().getMetadataLayoutVersion();
 
-    public Builder setLayoutVersion(int layoutVersion) {
-      this.layoutVersion = layoutVersion;
-      return this;
-    }
-
-    public Builder setNetworkLocation(String networkLocation) {
-      this.networkLocation = networkLocation;
+      this.setupTime = datanode.getSetupTime();
       return this;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ReconNodeManager,
- change `datanodeHeartbeatMap` to use DatanodeID  instead of UUID, and
- remove `inMemDatanodeDetails` since it is not needed.

## What is the link to the Apache JIRA

HDDS-12993

## How was this patch tested?

By existing tests