### PR TITLE
HDDS-13040. Add user doc highlighting the difference between Ozone ACL and S3 ACL.

### DIFF
--- a/hadoop-hdds/docs/content/security/SecurityAcls.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.md
@@ -172,3 +172,16 @@ $ ozone sh bucket removeacl -a user:testuser:r[DEFAULT] /vol1/bucket2
 ACL user:testuser:r[DEFAULT] removed successfully.
 ```
 
+## Differences Between Ozone ACL and S3 ACL
+
+Ozone ACLs and S3 ACLs differ primarily in their scope and support.
+
+- **S3 ACLs**: Currently, only S3 Bucket ACL is supported in Ozone. S3 Object ACL is not yet implemented. Any `PutObjectAcl` request will result in a `501: Not Implemented` response code.
+- **Ozone ACLs**: Ozone ACLs provide a more comprehensive and flexible access control mechanism. They are designed to work seamlessly with Ozone's native architecture and support various rights and scopes as mentioned above.
+
+## Ozone File System ACL API
+
+- ACL-related APIs in Ozone file system implementation (`ofs` and `o3fs`), such as `getAclStatus`, `setAcl`, `modifyAclEntries`, `removeAclEntries`, `removeDefaultAcl`, and `removeAcl` are not supported. These operations will throw an UnsupportedOperationException.
+- Similarly, HttpFS ACL-related APIs.
+
+These limitations should be taken into account when integrating Ozone with applications that rely on S3 or file system ACL operations.


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13040. Add user doc highlighting the difference between Ozone ACL and S3 ACL.

Please describe your PR in detail:
* Compare and contrast Ozone ACL and S3 ACL.
* Reminder user that Ozone does not support ACL related operations in the file system API implementations.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13040

## How was this patch tested?

User doc only change.