### PR TITLE
HDDS-13046. Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.vcxproj.user
 *.patch
 .idea
+.vscode
 .svn
 .classpath
 .project


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds .vscode to .gitignore so that git can ignore it. Similar to .idea.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13046

## How was this patch tested?

Git is ignoring .vscode after adding it to .gitignore.