### PR TITLE
HDDS-13057. Increment block delete processed transaction counts regardless of log level

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -381,18 +381,20 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       // Send ACK back to SCM as long as meta updated
       // TODO Or we should wait until the blocks are actually deleted?
       if (!containerBlocks.isEmpty()) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Sending following block deletion ACK to SCM");
-          for (DeleteBlockTransactionResult result : blockDeletionACK
-              .getResultsList()) {
-            boolean success = result.getSuccess();
-            LOG.debug("TxId = {} : ContainerId = {} : {}",
-                result.getTxID(), result.getContainerID(), success);
-            if (success) {
-              blockDeleteMetrics.incrProcessedTransactionSuccessCount(1);
-            } else {
-              blockDeleteMetrics.incrProcessedTransactionFailCount(1);
-            }
+        LOG.debug("Sending following block deletion ACK to SCM");
+
+        for (DeleteBlockTransactionResult result : blockDeletionACK.getResultsList()) {
+          boolean success = result.getSuccess();
+
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("TxId = {} : ContainerId = {} : {}", result.getTxID(),
+                result.getContainerID(), success);
+          }
+
+          if (success) {
+            blockDeleteMetrics.incrProcessedTransactionSuccessCount(1);
+          } else {
+            blockDeleteMetrics.incrProcessedTransactionFailCount(1);
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

processedTransactionSuccessCount and processedTransactionFailCount metrics shouldn't depend on log level.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13057

## How was this patch tested?

Tested Manually.