### PR TITLE
HDDS-13059. Use DatanodeID in SCM Block deletion flow.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -332,7 +331,7 @@ public class DeletedBlockLogImpl
   private void getTransaction(DeletedBlocksTransaction tx,
       DatanodeDeletedBlockTransactions transactions,
       Set<DatanodeDetails> dnList, Set<ContainerReplica> replicas,
-      Map<UUID, Map<Long, CmdStatus>> commandStatus) {
+      Map<DatanodeID, Map<Long, CmdStatus>> commandStatus) {
     DeletedBlocksTransaction updatedTxn =
         DeletedBlocksTransaction.newBuilder(tx)
             .setCount(transactionStatusManager.getOrDefaultRetryCount(
@@ -373,7 +372,7 @@ public class DeletedBlockLogImpl
       if (!dnList.contains(datanodeDetails)) {
         DatanodeDetails dnDetail = replica.getDatanodeDetails();
         LOG.debug("Skip Container = {}, because DN = {} is not in dnList.",
-            containerId, dnDetail.getUuid());
+            containerId, dnDetail.getID());
         return true;
       }
     }
@@ -426,10 +425,10 @@ public class DeletedBlockLogImpl
 
         // Get the CmdStatus status of the aggregation, so that the current
         // status of the specified transaction can be found faster
-        Map<UUID, Map<Long, CmdStatus>> commandStatus =
+        Map<DatanodeID, Map<Long, CmdStatus>> commandStatus =
             getSCMDeletedBlockTransactionStatusManager()
                 .getCommandStatusByTxId(dnList.stream().
-                map(DatanodeDetails::getUuid).collect(Collectors.toSet()));
+                map(DatanodeDetails::getID).collect(Collectors.toSet()));
         ArrayList<Long> txIDs = new ArrayList<>();
         metrics.setNumBlockDeletionTransactionDataNodes(dnList.size());
         Table.KeyValue<Long, DeletedBlocksTransaction> keyValue = null;
@@ -510,7 +509,7 @@ public class DeletedBlockLogImpl
   public void recordTransactionCreated(DatanodeID dnId, long scmCmdId,
       Set<Long> dnTxSet) {
     getSCMDeletedBlockTransactionStatusManager()
-        .recordTransactionCreated(dnId.getUuid(), scmCmdId, dnTxSet);
+        .recordTransactionCreated(dnId, scmCmdId, dnTxSet);
   }
 
   @Override
@@ -520,7 +519,7 @@ public class DeletedBlockLogImpl
 
   @Override
   public void onDatanodeDead(DatanodeID dnId) {
-    getSCMDeletedBlockTransactionStatusManager().onDatanodeDead(dnId.getUuid());
+    getSCMDeletedBlockTransactionStatusManager().onDatanodeDead(dnId);
   }
 
   @Override
@@ -546,7 +545,7 @@ public class DeletedBlockLogImpl
           ContainerBlocksDeletionACKProto ackProto =
               commandStatus.getBlockDeletionAck();
           getSCMDeletedBlockTransactionStatusManager()
-              .commitTransactions(ackProto.getResultsList(), dnId.getUuid());
+              .commitTransactions(ackProto.getResultsList(), dnId);
           metrics.incrBlockDeletionCommandSuccess();
           metrics.incrDNCommandsSuccess(dnId, 1);
         } else if (status == CommandStatus.Status.FAILED) {
@@ -558,7 +557,7 @@ public class DeletedBlockLogImpl
         }
 
         getSCMDeletedBlockTransactionStatusManager()
-            .commitSCMCommandStatus(deleteBlockStatus.getCmdStatus(), dnId.getUuid());
+            .commitSCMCommandStatus(deleteBlockStatus.getCmdStatus(), dnId);
       } finally {
         lock.unlock();
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -35,10 +35,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto.DeleteBlockTransactionResult;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -58,7 +58,7 @@ public class SCMDeletedBlockTransactionStatusManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMDeletedBlockTransactionStatusManager.class);
   // Maps txId to set of DNs which are successful in committing the transaction
-  private final Map<Long, Set<UUID>> transactionToDNsCommitMap;
+  private final Map<Long, Set<DatanodeID>> transactionToDNsCommitMap;
   // Maps txId to its retry counts;
   private final Map<Long, Integer> transactionToRetryCountMap;
   // The access to DeletedBlocksTXTable is protected by
@@ -100,7 +100,7 @@ public class SCMDeletedBlockTransactionStatusManager {
   protected static class SCMDeleteBlocksCommandStatusManager {
     private static final Logger LOG =
         LoggerFactory.getLogger(SCMDeleteBlocksCommandStatusManager.class);
-    private final Map<UUID, Map<Long, CmdStatusData>> scmCmdStatusRecord;
+    private final Map<DatanodeID, Map<Long, CmdStatusData>> scmCmdStatusRecord;
 
     private static final CmdStatus DEFAULT_STATUS = TO_BE_SENT;
     private static final Set<CmdStatus> STATUSES_REQUIRING_TIMEOUT =
@@ -128,14 +128,14 @@ public class SCMDeletedBlockTransactionStatusManager {
     }
 
     protected static final class CmdStatusData {
-      private final UUID dnId;
+      private final DatanodeID dnId;
       private final long scmCmdId;
       private final Set<Long> deletedBlocksTxIds;
       private Instant updateTime;
       private CmdStatus status;
 
       private CmdStatusData(
-          UUID dnId, long scmTxID, Set<Long> deletedBlocksTxIds) {
+          DatanodeID dnId, long scmTxID, Set<Long> deletedBlocksTxIds) {
         this.dnId = dnId;
         this.scmCmdId = scmTxID;
         this.deletedBlocksTxIds = deletedBlocksTxIds;
@@ -146,7 +146,7 @@ public class SCMDeletedBlockTransactionStatusManager {
         return Collections.unmodifiableSet(deletedBlocksTxIds);
       }
 
-      public UUID getDnId() {
+      public DatanodeID getDnId() {
         return dnId;
       }
 
@@ -180,7 +180,7 @@ public class SCMDeletedBlockTransactionStatusManager {
     }
 
     protected static CmdStatusData createScmCmdStatusData(
-        UUID dnId, long scmCmdId, Set<Long> deletedBlocksTxIds) {
+        DatanodeID dnId, long scmCmdId, Set<Long> deletedBlocksTxIds) {
       return new CmdStatusData(dnId, scmCmdId, deletedBlocksTxIds);
     }
 
@@ -190,22 +190,22 @@ public class SCMDeletedBlockTransactionStatusManager {
           new ConcurrentHashMap<>()).put(statusData.getScmCmdId(), statusData);
     }
 
-    protected void onSent(UUID dnId, long scmCmdId) {
+    protected void onSent(DatanodeID dnId, long scmCmdId) {
       updateStatus(dnId, scmCmdId, CommandStatus.Status.PENDING);
     }
 
-    protected void onDatanodeDead(UUID dnId) {
+    protected void onDatanodeDead(DatanodeID dnId) {
       LOG.info("Clean SCMCommand record for Datanode: {}", dnId);
       scmCmdStatusRecord.remove(dnId);
     }
 
-    protected void updateStatusByDNCommandStatus(UUID dnId, long scmCmdId,
+    protected void updateStatusByDNCommandStatus(DatanodeID dnId, long scmCmdId,
         CommandStatus.Status newState) {
       updateStatus(dnId, scmCmdId, newState);
     }
 
     protected void cleanAllTimeoutSCMCommand(long timeoutMs) {
-      for (UUID dnId : scmCmdStatusRecord.keySet()) {
+      for (DatanodeID dnId : scmCmdStatusRecord.keySet()) {
         for (CmdStatus status : STATUSES_REQUIRING_TIMEOUT) {
           removeTimeoutScmCommand(
               dnId, getScmCommandIds(dnId, status), timeoutMs);
@@ -213,14 +213,14 @@ public class SCMDeletedBlockTransactionStatusManager {
       }
     }
 
-    public void cleanTimeoutSCMCommand(UUID dnId, long timeoutMs) {
+    public void cleanTimeoutSCMCommand(DatanodeID dnId, long timeoutMs) {
       for (CmdStatus status : STATUSES_REQUIRING_TIMEOUT) {
         removeTimeoutScmCommand(
             dnId, getScmCommandIds(dnId, status), timeoutMs);
       }
     }
 
-    private Set<Long> getScmCommandIds(UUID dnId, CmdStatus status) {
+    private Set<Long> getScmCommandIds(DatanodeID dnId, CmdStatus status) {
       Set<Long> scmCmdIds = new HashSet<>();
       Map<Long, CmdStatusData> record = scmCmdStatusRecord.get(dnId);
       if (record == null) {
@@ -234,7 +234,7 @@ public class SCMDeletedBlockTransactionStatusManager {
       return scmCmdIds;
     }
 
-    private Instant getUpdateTime(UUID dnId, long scmCmdId) {
+    private Instant getUpdateTime(DatanodeID dnId, long scmCmdId) {
       Map<Long, CmdStatusData> record = scmCmdStatusRecord.get(dnId);
       if (record == null || record.get(scmCmdId) == null) {
         return null;
@@ -242,7 +242,7 @@ public class SCMDeletedBlockTransactionStatusManager {
       return record.get(scmCmdId).getUpdateTime();
     }
 
-    private void updateStatus(UUID dnId, long scmCmdId,
+    private void updateStatus(DatanodeID dnId, long scmCmdId,
         CommandStatus.Status newStatus) {
       Map<Long, CmdStatusData> recordForDn = scmCmdStatusRecord.get(dnId);
       if (recordForDn == null) {
@@ -309,7 +309,7 @@ public class SCMDeletedBlockTransactionStatusManager {
       }
     }
 
-    private void removeTimeoutScmCommand(UUID dnId,
+    private void removeTimeoutScmCommand(DatanodeID dnId,
         Set<Long> scmCmdIds, long timeoutMs) {
       Instant now = Instant.now();
       for (Long scmCmdId : scmCmdIds) {
@@ -323,7 +323,7 @@ public class SCMDeletedBlockTransactionStatusManager {
       }
     }
 
-    private CmdStatusData removeScmCommand(UUID dnId, long scmCmdId) {
+    private CmdStatusData removeScmCommand(DatanodeID dnId, long scmCmdId) {
       Map<Long, CmdStatusData> record = scmCmdStatusRecord.get(dnId);
       if (record == null || record.get(scmCmdId) == null) {
         return null;
@@ -333,12 +333,12 @@ public class SCMDeletedBlockTransactionStatusManager {
       return statusData;
     }
 
-    public Map<UUID, Map<Long, CmdStatus>> getCommandStatusByTxId(
-        Set<UUID> dnIds) {
-      Map<UUID, Map<Long, CmdStatus>> result =
+    public Map<DatanodeID, Map<Long, CmdStatus>> getCommandStatusByTxId(
+        Set<DatanodeID> dnIds) {
+      Map<DatanodeID, Map<Long, CmdStatus>> result =
           new HashMap<>(scmCmdStatusRecord.size());
 
-      for (UUID dnId : dnIds) {
+      for (DatanodeID dnId : dnIds) {
         Map<Long, CmdStatusData> record = scmCmdStatusRecord.get(dnId);
         if (record == null) {
           continue;
@@ -361,7 +361,7 @@ public class SCMDeletedBlockTransactionStatusManager {
     }
 
     @VisibleForTesting
-    Map<UUID, Map<Long, CmdStatusData>> getScmCmdStatusRecord() {
+    Map<DatanodeID, Map<Long, CmdStatusData>> getScmCmdStatusRecord() {
       return scmCmdStatusRecord;
     }
   }
@@ -401,16 +401,16 @@ public class SCMDeletedBlockTransactionStatusManager {
 
   public void onSent(DatanodeDetails dnId, SCMCommand<?> scmCommand) {
     scmDeleteBlocksCommandStatusManager.onSent(
-        dnId.getUuid(), scmCommand.getId());
+        dnId.getID(), scmCommand.getId());
   }
 
-  public Map<UUID, Map<Long, CmdStatus>> getCommandStatusByTxId(
-      Set<UUID> dnIds) {
+  public Map<DatanodeID, Map<Long, CmdStatus>> getCommandStatusByTxId(
+      Set<DatanodeID> dnIds) {
     return scmDeleteBlocksCommandStatusManager.getCommandStatusByTxId(dnIds);
   }
 
   public void recordTransactionCreated(
-      UUID dnId, long scmCmdId, Set<Long> dnTxSet) {
+      DatanodeID dnId, long scmCmdId, Set<Long> dnTxSet) {
     scmDeleteBlocksCommandStatusManager.recordScmCommand(
         SCMDeleteBlocksCommandStatusManager
             .createScmCmdStatusData(dnId, scmCmdId, dnTxSet));
@@ -428,20 +428,20 @@ public class SCMDeletedBlockTransactionStatusManager {
     scmDeleteBlocksCommandStatusManager.cleanAllTimeoutSCMCommand(timeoutMs);
   }
 
-  public void onDatanodeDead(UUID dnId) {
+  public void onDatanodeDead(DatanodeID dnId) {
     scmDeleteBlocksCommandStatusManager.onDatanodeDead(dnId);
   }
 
   public boolean isDuplication(DatanodeDetails dnDetail, long tx,
-      Map<UUID, Map<Long, CmdStatus>> commandStatus) {
-    if (alreadyExecuted(dnDetail.getUuid(), tx)) {
+      Map<DatanodeID, Map<Long, CmdStatus>> commandStatus) {
+    if (alreadyExecuted(dnDetail.getID(), tx)) {
       return true;
     }
-    return inProcessing(dnDetail.getUuid(), tx, commandStatus);
+    return inProcessing(dnDetail.getID(), tx, commandStatus);
   }
 
-  public boolean alreadyExecuted(UUID dnId, long txId) {
-    Set<UUID> dnsWithTransactionCommitted =
+  public boolean alreadyExecuted(DatanodeID dnId, long txId) {
+    Set<DatanodeID> dnsWithTransactionCommitted =
         transactionToDNsCommitMap.get(txId);
     return dnsWithTransactionCommitted != null && dnsWithTransactionCommitted
         .contains(dnId);
@@ -456,10 +456,10 @@ public class SCMDeletedBlockTransactionStatusManager {
    */
   @VisibleForTesting
   public void commitTransactions(
-      List<DeleteBlockTransactionResult> transactionResults, UUID dnId) {
+      List<DeleteBlockTransactionResult> transactionResults, DatanodeID dnId) {
 
     ArrayList<Long> txIDsToBeDeleted = new ArrayList<>();
-    Set<UUID> dnsWithCommittedTxn;
+    Set<DatanodeID> dnsWithCommittedTxn;
     for (DeleteBlockTransactionResult transactionResult :
         transactionResults) {
       if (isTransactionFailed(transactionResult)) {
@@ -494,9 +494,9 @@ public class SCMDeletedBlockTransactionStatusManager {
         // the nodes returned in the pipeline match the replication factor.
         if (min(replicas.size(), dnsWithCommittedTxn.size())
             >= container.getReplicationConfig().getRequiredNodes()) {
-          List<UUID> containerDns = replicas.stream()
+          List<DatanodeID> containerDns = replicas.stream()
               .map(ContainerReplica::getDatanodeDetails)
-              .map(DatanodeDetails::getUuid)
+              .map(DatanodeDetails::getID)
               .collect(Collectors.toList());
           if (dnsWithCommittedTxn.containsAll(containerDns)) {
             transactionToDNsCommitMap.remove(txID);
@@ -527,21 +527,21 @@ public class SCMDeletedBlockTransactionStatusManager {
 
   @VisibleForTesting
   public void commitSCMCommandStatus(List<CommandStatus> deleteBlockStatus,
-      UUID dnId) {
+      DatanodeID dnId) {
     processSCMCommandStatus(deleteBlockStatus, dnId);
     scmDeleteBlocksCommandStatusManager.
         cleanTimeoutSCMCommand(dnId, scmCommandTimeoutMs);
   }
 
-  private boolean inProcessing(UUID dnId, long deletedBlocksTxId,
-      Map<UUID, Map<Long, CmdStatus>> commandStatus) {
+  private boolean inProcessing(DatanodeID dnId, long deletedBlocksTxId,
+      Map<DatanodeID, Map<Long, CmdStatus>> commandStatus) {
     Map<Long, CmdStatus> deletedBlocksTxStatus = commandStatus.get(dnId);
     return deletedBlocksTxStatus != null &&
         deletedBlocksTxStatus.get(deletedBlocksTxId) != null;
   }
 
   private void processSCMCommandStatus(List<CommandStatus> deleteBlockStatus,
-      UUID dnID) {
+      DatanodeID dnID) {
     Map<Long, CommandStatus> lastStatus = new HashMap<>();
     Map<Long, CommandStatus.Status> summary = new HashMap<>();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -22,10 +22,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -81,9 +81,9 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
     if (ret != 0) {
       return ret;
     }
-    UUID uuidA = a.getDatanodeDetails().getUuid();
-    UUID uuidB = b.getDatanodeDetails().getUuid();
-    return uuidA.compareTo(uuidB);
+    DatanodeID idA = a.getDatanodeDetails().getID();
+    DatanodeID idB = b.getDatanodeDetails().getID();
+    return idA.compareTo(idB);
   }
 
   private void setConfiguration(ContainerBalancerConfiguration conf) {
@@ -228,8 +228,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
       }
       return;
     }
-    logger.warn("Cannot find {} in the candidates target nodes",
-        target.getUuid());
+    logger.warn("Cannot find {} in the candidates target nodes", target.getID());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
@@ -23,9 +23,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.slf4j.Logger;
@@ -56,9 +56,9 @@ public class FindSourceGreedy implements FindSourceStrategy {
       if (ret != 0) {
         return ret;
       }
-      UUID uuidA = a.getDatanodeDetails().getUuid();
-      UUID uuidB = b.getDatanodeDetails().getUuid();
-      return uuidA.compareTo(uuidB);
+      DatanodeID idA = a.getDatanodeDetails().getID();
+      DatanodeID idB = b.getDatanodeDetails().getID();
+      return idA.compareTo(idB);
     });
     this.nodeManager = nodeManager;
   }
@@ -110,8 +110,7 @@ public class FindSourceGreedy implements FindSourceStrategy {
       addBackSourceDataNode(dui);
       return;
     }
-    LOG.warn("Cannot find datanode {} in candidate source datanodes",
-        dui.getUuid());
+    LOG.warn("Cannot find datanode {} in candidate source datanodes", dui.getID());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -254,7 +254,7 @@ public class TestDeletedBlockLog {
       DatanodeDetails... dns) throws IOException {
     for (DatanodeDetails dnDetails : dns) {
       deletedBlockLog.getSCMDeletedBlockTransactionStatusManager()
-          .commitTransactions(transactionResults, dnDetails.getUuid());
+          .commitTransactions(transactionResults, dnDetails.getID());
     }
     scmHADBTransactionBuffer.flush();
   }
@@ -619,7 +619,7 @@ public class TestDeletedBlockLog {
         .getProtoBufMessage());
 
     deletedBlockLog.getSCMDeletedBlockTransactionStatusManager()
-        .commitSCMCommandStatus(deleteBlockStatus, dnID.getUuid());
+        .commitSCMCommandStatus(deleteBlockStatus, dnID);
   }
 
   private void createDeleteBlocksCommandAndAction(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMDeleteBlocksCommandStatusManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMDeleteBlocksCommandStatusManager.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,8 +41,8 @@ import org.junit.jupiter.api.Test;
 public class TestSCMDeleteBlocksCommandStatusManager {
 
   private SCMDeleteBlocksCommandStatusManager manager;
-  private UUID dnId1;
-  private UUID dnId2;
+  private DatanodeID dnId1;
+  private DatanodeID dnId2;
   private long scmCmdId1;
   private long scmCmdId2;
   private long scmCmdId3;
@@ -56,8 +56,8 @@ public class TestSCMDeleteBlocksCommandStatusManager {
   public void setup() throws Exception {
     manager = new SCMDeleteBlocksCommandStatusManager();
     // Create test data
-    dnId1 = UUID.randomUUID();
-    dnId2 = UUID.randomUUID();
+    dnId1 = DatanodeID.randomID();
+    dnId2 = DatanodeID.randomID();
     scmCmdId1 = 1L;
     scmCmdId2 = 2L;
     scmCmdId3 = 3L;
@@ -238,7 +238,7 @@ public class TestSCMDeleteBlocksCommandStatusManager {
 
   private void recordAndSentCommand(
       SCMDeleteBlocksCommandStatusManager statusManager,
-      UUID dnId, List<Long> scmCmdIds, List<Set<Long>> txIds) {
+      DatanodeID dnId, List<Long> scmCmdIds, List<Set<Long>> txIds) {
     assertEquals(scmCmdIds.size(), txIds.size());
     for (int i = 0; i < scmCmdIds.size(); i++) {
       long scmCmdId = scmCmdIds.get(i);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use DatanodeID in SCM Block deletion flow.

Replace the use of UUID with DatanodeID in the block deletion flow of SCM.


## What is the link to the Apache JIRA
HDDS-13059

## How was this patch tested?
CI Run: <TO ADD>
