### PR TITLE
HDDS-13060. Change NodeManager.addDatanodeCommand(..) to use DatanodeID.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CommandForDatanode.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.protocol.commands;
 
 import com.google.protobuf.Message;
-import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.server.events.IdentifiableEventPayload;
@@ -40,9 +39,8 @@ public final class CommandForDatanode<T extends Message> implements Identifiable
     this.command = command;
   }
 
-  @Deprecated
-  public UUID getDatanodeId() {
-    return datanodeId.getUuid();
+  public DatanodeID getDatanodeId() {
+    return datanodeId;
   }
 
   public SCMCommand<T> getCommand() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -666,7 +666,7 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
         scmDeadlineEpochMs);
     command.setTerm(getScmTerm());
     command.setDeadline(datanodeDeadline);
-    nodeManager.addDatanodeCommand(target.getUuid(), command);
+    nodeManager.addDatanodeCommand(target.getID(), command);
     adjustPendingOpsAndMetrics(containerInfo, command, target,
         scmDeadlineEpochMs);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -270,13 +270,10 @@ public interface NodeManager extends StorageContainerNodeProtocol,
       throws NodeNotFoundException;
 
   /**
-   * Add a {@link SCMCommand} to the command queue, which are
-   * handled by HB thread asynchronously.
-   * @param dnId datanode uuid
-   * @param command
+   * Add a {@link SCMCommand} to the command queue of the given datanode.
+   * The command will be handled by the HB thread asynchronously.
    */
-  void addDatanodeCommand(UUID dnId, SCMCommand<?> command);
-
+  void addDatanodeCommand(DatanodeID datanodeID, SCMCommand<?> command);
 
   /**
    * send refresh command to all the healthy datanodes to refresh

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -611,7 +611,7 @@ public class SCMNodeManager implements NodeManager {
               scmStatus.getOperationalState(),
               scmStatus.getOpStateExpiryEpochSeconds());
           command.setTerm(scmContext.getTermOfLeader());
-          addDatanodeCommand(reportedDn.getUuid(), command);
+          addDatanodeCommand(reportedDn.getID(), command);
         } catch (NotLeaderException nle) {
           LOG.warn("Skip sending SetNodeOperationalStateCommand,"
               + " since current SCM is not leader.", nle);
@@ -1646,7 +1646,8 @@ public class SCMNodeManager implements NodeManager {
   }
 
   @Override
-  public void addDatanodeCommand(UUID dnId, SCMCommand<?> command) {
+  public void addDatanodeCommand(DatanodeID datanodeID, SCMCommand<?> command) {
+    final UUID dnId = datanodeID.getUuid();
     writeLock().lock();
     try {
       this.commandQueue.addCommand(dnId, command);
@@ -1671,7 +1672,7 @@ public class SCMNodeManager implements NodeManager {
       return;
     }
     getNodes(IN_SERVICE, HEALTHY).forEach(datanode ->
-        addDatanodeCommand(datanode.getUuid(), refreshVolumeUsageCommand));
+        addDatanodeCommand(datanode.getID(), refreshVolumeUsageCommand));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -91,7 +91,7 @@ public final class SCMDatanodeHeartbeatDispatcher {
       LOG.info("SCM received heartbeat from an unregistered datanode {}. " +
           "Asking datanode to re-register.", datanodeDetails);
       UUID dnID = datanodeDetails.getUuid();
-      nodeManager.addDatanodeCommand(dnID, new ReregisterCommand());
+      nodeManager.addDatanodeCommand(datanodeDetails.getID(), new ReregisterCommand());
 
       commands = nodeManager.getCommandQueue(dnID);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMBlockDeletingService.java
@@ -32,14 +32,13 @@ import static org.mockito.Mockito.when;
 import java.time.Clock;
 import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
@@ -120,13 +119,13 @@ public class TestSCMBlockDeletingService {
     verify(eventPublisher, times(3)).fireEvent(
         eq(SCMEvents.DATANODE_COMMAND), argumentCaptor.capture());
     List<CommandForDatanode> actualCommands = argumentCaptor.getAllValues();
-    List<UUID> actualDnIds = actualCommands.stream()
+    final Set<DatanodeID> actualDnIds = actualCommands.stream()
         .map(CommandForDatanode::getDatanodeId)
-        .collect(Collectors.toList());
-    Set<UUID> expectedDnIdsSet = datanodeDetails.stream()
-        .map(DatanodeDetails::getUuid).collect(Collectors.toSet());
+        .collect(Collectors.toSet());
+    final Set<DatanodeID> expectedDnIdsSet = datanodeDetails.stream()
+        .map(DatanodeDetails::getID).collect(Collectors.toSet());
 
-    assertEquals(expectedDnIdsSet, new HashSet<>(actualDnIds));
+    assertEquals(expectedDnIdsSet, actualDnIds);
     assertEquals(datanodeDetails.size(),
         metrics.getNumBlockDeletionCommandSent());
     // Echo Command has one Transaction

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -519,7 +519,8 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
-  public void addDatanodeCommand(UUID dnId, SCMCommand<?> command) {
+  public void addDatanodeCommand(DatanodeID datanodeID, SCMCommand<?> command) {
+    final UUID dnId = datanodeID.getUuid();
     if (commandMap.containsKey(dnId)) {
       List<SCMCommand<?>> commandList = commandMap.get(dnId);
       Preconditions.checkNotNull(commandList);
@@ -819,7 +820,7 @@ public class MockNodeManager implements NodeManager {
   @Override
   public void onMessage(CommandForDatanode commandForDatanode,
                         EventPublisher publisher) {
-    addDatanodeCommand(commandForDatanode.getDatanodeId(),
+    this.addDatanodeCommand(commandForDatanode.getDatanodeId(),
         commandForDatanode.getCommand());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -267,7 +267,7 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public void addDatanodeCommand(UUID dnId, SCMCommand<?> command) {
+  public void addDatanodeCommand(DatanodeID datanodeID, SCMCommand<?> command) {
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -44,6 +43,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -201,10 +201,10 @@ public class TestCloseContainerEventHandler {
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
 
     List<CommandForDatanode> cmds = commandCaptor.getAllValues();
-    Set<UUID> pipelineDNs = pipeline
+    final Set<DatanodeID> pipelineDNs = pipeline
         .getNodes()
         .stream()
-        .map(d -> d.getUuid())
+        .map(DatanodeDetails::getID)
         .collect(Collectors.toSet());
     for (CommandForDatanode c : cmds) {
       assertThat(pipelineDNs).contains(c.getDatanodeId());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -101,7 +100,7 @@ public class TestReplicationManagerScenarios {
   private Map<ContainerID, Set<ContainerReplica>> containerReplicaMap;
   private Set<ContainerInfo> containerInfoSet;
   private ContainerReplicaPendingOps containerReplicaPendingOps;
-  private Set<Pair<UUID, SCMCommand<?>>> commandsSent;
+  private Set<Pair<DatanodeID, SCMCommand<?>>> commandsSent;
 
   private OzoneConfiguration configuration;
   private ReplicationManager replicationManager;
@@ -332,11 +331,11 @@ public class TestReplicationManagerScenarios {
     // datanodes.
     for (ExpectedCommands expectedCommand : expectedCommands) {
       boolean found = false;
-      for (Pair<UUID, SCMCommand<?>> command : commandsSent) {
+      for (Pair<DatanodeID, SCMCommand<?>> command : commandsSent) {
         if (command.getRight().getType() == expectedCommand.getType()) {
           if (expectedCommand.hasExpectedDatanode()) {
             // We need to assert against the command the datanode is sent to
-            DatanodeDetails commandDatanode = findDatanodeFromUUID(command.getKey());
+            DatanodeDetails commandDatanode = findDatanode(command.getKey());
             if (commandDatanode != null && expectedCommand.isTargetExpected(commandDatanode)) {
               found = true;
               commandsSent.remove(command);
@@ -354,9 +353,9 @@ public class TestReplicationManagerScenarios {
     }
   }
 
-  private DatanodeDetails findDatanodeFromUUID(UUID uuid) {
+  private DatanodeDetails findDatanode(DatanodeID uuid) {
     for (DatanodeDetails dn : DATANODE_ALIASES.values()) {
-      if (dn.getUuid().equals(uuid)) {
+      if (dn.getID().equals(uuid)) {
         return dn;
       }
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -255,7 +255,7 @@ public class TestDeadNodeHandler {
     // Now set the node to anything other than IN_MAINTENANCE and the relevant
     // replicas should be removed
     DeleteBlocksCommand cmd = new DeleteBlocksCommand(Collections.emptyList());
-    nodeManager.addDatanodeCommand(datanode1.getUuid(), cmd);
+    nodeManager.addDatanodeCommand(datanode1.getID(), cmd);
     nodeManager.setNodeOperationalState(datanode1,
         HddsProtos.NodeOperationalState.IN_SERVICE);
     deadNodeHandler.onMessage(datanode1, publisher);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -946,7 +946,7 @@ public class TestSCMNodeManager {
       // should be instructed to finalize.
       verify(eventPublisher, times(1))
           .fireEvent(eq(DATANODE_COMMAND), captor.capture());
-      assertEquals(captor.getValue().getDatanodeId(), node1.getUuid());
+      assertEquals(captor.getValue().getDatanodeId(), node1.getID());
       assertEquals(captor.getValue().getCommand().getType(),
           finalizeNewLayoutVersionCommand);
     } else {
@@ -976,11 +976,11 @@ public class TestSCMNodeManager {
     verify(eventPublisher,
         times(1)).fireEvent(NEW_NODE, node1);
     for (int i = 0; i < 3; i++) {
-      nodeManager.addDatanodeCommand(node1.getUuid(), ReplicateContainerCommand
+      nodeManager.addDatanodeCommand(node1.getID(), ReplicateContainerCommand
           .toTarget(1, MockDatanodeDetails.randomDatanodeDetails()));
     }
     for (int i = 0; i < 5; i++) {
-      nodeManager.addDatanodeCommand(node1.getUuid(),
+      nodeManager.addDatanodeCommand(node1.getID(),
           new DeleteBlocksCommand(emptyList()));
     }
 
@@ -1036,7 +1036,7 @@ public class TestSCMNodeManager {
 
     // Add a a few more commands to the queue and check the counts are the sum.
     for (int i = 0; i < 5; i++) {
-      nodeManager.addDatanodeCommand(node1.getUuid(),
+      nodeManager.addDatanodeCommand(node1.getID(),
           new CloseContainerCommand(1, PipelineID.randomId()));
     }
     assertEquals(0, nodeManager.getTotalDatanodeCommandCount(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -144,7 +143,7 @@ public class TestPipelinePlacementFactory {
   }
 
   @Test
-  public void testDefaultPolicy() throws IOException {
+  public void testDefaultPolicy() {
     PlacementPolicy policy = PipelinePlacementPolicyFactory
         .getPolicy(null, null, conf);
     assertSame(PipelinePlacementPolicy.class, policy.getClass());
@@ -315,14 +314,10 @@ public class TestPipelinePlacementFactory {
         policy.chooseDatanodes(usedNodes, excludeNodes, null, nodeNum, 15, 15);
     assertEquals(nodeNum, datanodeDetails.size());
     // policy should not return any of excluded node
-    assertNotSame(datanodeDetails.get(0).getUuid(),
-        excludeNodes.get(0).getUuid());
-    assertNotSame(datanodeDetails.get(0).getUuid(),
-        excludeNodes.get(1).getUuid());
-    assertNotSame(datanodeDetails.get(1).getUuid(),
-        excludeNodes.get(0).getUuid());
-    assertNotSame(datanodeDetails.get(1).getUuid(),
-        excludeNodes.get(1).getUuid());
+    assertNotSame(datanodeDetails.get(0).getID(), excludeNodes.get(0).getID());
+    assertNotSame(datanodeDetails.get(0).getID(), excludeNodes.get(1).getID());
+    assertNotSame(datanodeDetails.get(1).getID(), excludeNodes.get(0).getID());
+    assertNotSame(datanodeDetails.get(1).getID(), excludeNodes.get(1).getID());
     // One of the node should be in same rack as Node0
     assertTrue(cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(0)) || cluster.isSameParent(usedNodes.get(0),
@@ -339,10 +334,8 @@ public class TestPipelinePlacementFactory {
         policy.chooseDatanodes(usedNodes, excludeNodes, null, nodeNum, 15, 15);
     assertEquals(nodeNum, datanodeDetails.size());
     // policy should not return any of excluded node
-    assertNotSame(datanodeDetails.get(0).getUuid(),
-        excludeNodes.get(0).getUuid());
-    assertNotSame(datanodeDetails.get(0).getUuid(),
-        excludeNodes.get(1).getUuid());
+    assertNotSame(datanodeDetails.get(0).getID(), excludeNodes.get(0).getID());
+    assertNotSame(datanodeDetails.get(0).getID(), excludeNodes.get(1).getID());
     // Since rack0 has not enough node (node0 is used and node1 is excluded),
     // Anchor will change to node4(rack2) and will return another node
     // from rack2

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
@@ -30,9 +30,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
@@ -163,6 +163,6 @@ public class TestSCMDatanodeHeartbeatDispatcher {
     // If SCM receives heartbeat from a node after it restarts and the node
     // is not registered, it should send a Re-Register command back to the node.
     verify(mockNodeManager, times(1)).addDatanodeCommand(
-        any(UUID.class), any(ReregisterCommand.class));
+        any(DatanodeID.class), any(ReregisterCommand.class));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
@@ -708,8 +709,8 @@ public class TestStorageContainerManager {
       NodeManager nodeManager = mock(NodeManager.class);
       setInternalState(rm, "nodeManager", nodeManager);
 
-      UUID dnUuid = cluster.getHddsDatanodes().iterator().next()
-          .getDatanodeDetails().getUuid();
+      final DatanodeID dnUuid = cluster.getHddsDatanodes().iterator().next()
+          .getDatanodeDetails().getID();
 
       CloseContainerCommand closeContainerCommand =
           new CloseContainerCommand(selectedContainer.getContainerID(),
@@ -740,7 +741,7 @@ public class TestStorageContainerManager {
       queues.add(new ContainerReportQueue());
     }
     ContainerReportsProto report = ContainerReportsProto.getDefaultInstance();
-    DatanodeDetails dn = DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
+    DatanodeDetails dn = DatanodeDetails.newBuilder().setID(DatanodeID.randomID())
         .build();
     ContainerReportFromDatanode dndata
         = new ContainerReportFromDatanode(dn, report);
@@ -812,13 +813,13 @@ public class TestStorageContainerManager {
     eventQueue.addHandler(SCMEvents.CONTAINER_REPORT, containerReportExecutors,
         containerReportHandler);
     ContainerReportsProto report = ContainerReportsProto.getDefaultInstance();
-    DatanodeDetails dn = DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
+    DatanodeDetails dn = DatanodeDetails.newBuilder().setID(DatanodeID.randomID())
         .build();
     ContainerReportFromDatanode dndata1
         = new ContainerReportFromDatanode(dn, report);
     eventQueue.fireEvent(SCMEvents.CONTAINER_REPORT, dndata1);
 
-    dn = DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
+    dn = DatanodeDetails.newBuilder().setID(DatanodeID.randomID())
         .build();
     ContainerReportFromDatanode dndata2
         = new ContainerReportFromDatanode(dn, report);
@@ -838,7 +839,7 @@ public class TestStorageContainerManager {
     for (int i = 0; i < 1; ++i) {
       queues.add(new ContainerReportQueue());
     }
-    DatanodeDetails dn = DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
+    DatanodeDetails dn = DatanodeDetails.newBuilder().setID(DatanodeID.randomID())
         .build();
     IncrementalContainerReportProto report
         = IncrementalContainerReportProto.getDefaultInstance();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -248,7 +248,7 @@ public class TestContainerStateMachineFailures {
               .getScmContext()
               .getTermOfLeader());
       cluster.getStorageContainerManager().getScmNodeManager()
-          .addDatanodeCommand(dn.getDatanodeDetails().getUuid(), command);
+          .addDatanodeCommand(dn.getDatanodeDetails().getID(), command);
     }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -154,7 +154,7 @@ public class TestCloseContainerByPipeline {
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     cluster.getStorageContainerManager().getScmNodeManager()
-        .addDatanodeCommand(datanodeDetails.getUuid(), command);
+        .addDatanodeCommand(datanodeDetails.getID(), command);
     GenericTestUtils
         .waitFor(() -> isContainerClosed(cluster, containerID, datanodeDetails),
             500, 5 * 1000);
@@ -202,7 +202,7 @@ public class TestCloseContainerByPipeline {
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     cluster.getStorageContainerManager().getScmNodeManager()
-        .addDatanodeCommand(datanodeDetails.getUuid(), command);
+        .addDatanodeCommand(datanodeDetails.getID(), command);
 
     //double check if it's really closed (waitFor also throws an exception)
     // TODO: change the below line after implementing QUASI_CLOSED to CLOSED
@@ -257,7 +257,7 @@ public class TestCloseContainerByPipeline {
       command.setTerm(cluster.getStorageContainerManager()
           .getScmContext().getTermOfLeader());
       cluster.getStorageContainerManager().getScmNodeManager()
-          .addDatanodeCommand(details.getUuid(), command);
+          .addDatanodeCommand(details.getID(), command);
       int index = cluster.getHddsDatanodeIndex(details);
       Container dnContainer = cluster.getHddsDatanodes().get(index)
           .getDatanodeStateMachine().getContainer().getContainerSet()
@@ -334,7 +334,7 @@ public class TestCloseContainerByPipeline {
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     cluster.getStorageContainerManager().getScmNodeManager()
-        .addDatanodeCommand(datanodeDetails.getUuid(), command);
+        .addDatanodeCommand(datanodeDetails.getID(), command);
     GenericTestUtils
         .waitFor(() -> isContainerClosed(
             cluster, containerID, datanodeDetails), 500, 5 * 1000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -124,7 +124,7 @@ public class TestCloseContainerHandler {
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     cluster.getStorageContainerManager().getScmNodeManager()
-        .addDatanodeCommand(datanodeDetails.getUuid(), command);
+        .addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerClosed(cluster, containerId.getId()),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -230,7 +230,7 @@ public class TestDeleteContainerHandler {
     // is zero there is a lingering block on disk.
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     // Check the log for the error message when deleting non-empty containers
     LogCapturer logCapturer = LogCapturer.captureLogs(KeyValueHandler.class);
@@ -250,7 +250,7 @@ public class TestDeleteContainerHandler {
 
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
@@ -344,7 +344,7 @@ public class TestDeleteContainerHandler {
     // there is a lingering block on disk but isEmpty container flag is true.
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
@@ -386,7 +386,7 @@ public class TestDeleteContainerHandler {
         containerId.getId(), pipeline.getId());
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     Container containerInternalObj =
         hddsDatanodeService.
@@ -424,7 +424,7 @@ public class TestDeleteContainerHandler {
     // flag is true, there is a lingering block on disk.
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
 
     // Check the log for the error message when deleting non-empty containers
@@ -456,7 +456,7 @@ public class TestDeleteContainerHandler {
     // Send the delete command.It should fail as still block table is non-empty
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
     Thread.sleep(5000);
     assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
     // Send the delete command. It should pass with force flag.
@@ -465,7 +465,7 @@ public class TestDeleteContainerHandler {
 
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
@@ -503,7 +503,7 @@ public class TestDeleteContainerHandler {
         containerId.getId(), pipeline.getId());
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerClosed(hddsDatanodeService, containerId.getId()),
@@ -539,7 +539,7 @@ public class TestDeleteContainerHandler {
     // is non-zero(Invalid).
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
@@ -629,7 +629,7 @@ public class TestDeleteContainerHandler {
         false);
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     // Deleting a non-empty container should fail on DN when the force flag
     // is false.
@@ -658,7 +658,7 @@ public class TestDeleteContainerHandler {
     // Send the delete command again. It should succeed this time.
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
@@ -694,7 +694,7 @@ public class TestDeleteContainerHandler {
         containerId.getId(), false);
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     // Here it should not delete it, and the container should exist in the
     // containerset
@@ -718,7 +718,7 @@ public class TestDeleteContainerHandler {
     command = new DeleteContainerCommand(containerId.getId(), true);
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
-    nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
+    nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -150,12 +150,12 @@ public class TestReconNodeManager {
     // interface, then they should be filtered out and not returned to the DN
     // when it heartbeats.
     // This command should never be returned by Recon
-    reconNodeManager.addDatanodeCommand(datanodeDetails.getUuid(),
+    reconNodeManager.addDatanodeCommand(datanodeDetails.getID(),
         new SetNodeOperationalStateCommand(1234,
         DECOMMISSIONING, 0));
 
     // This one should be returned
-    reconNodeManager.addDatanodeCommand(datanodeDetails.getUuid(),
+    reconNodeManager.addDatanodeCommand(datanodeDetails.getID(),
         new ReregisterCommand());
 
     // OperationalState sanity check


### PR DESCRIPTION
## What changes were proposed in this pull request?

```java
//NodeManager
  void addDatanodeCommand(UUID dnId, SCMCommand<?> command);
```
In this PR, we will change the type dnId to DatanodeID.  In the implementation, we will just get UUID and leave the further change to HDDS-12550.

## What is the link to the Apache JIRA

HDDS-13060

## How was this patch tested?

By existing tests.