### PR TITLE
HDDS-13073. Set pipeline ID in checksums verifier to avoid cached pipeline with different node

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ChecksumVerifier.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ChecksumVerifier.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactoryImpl;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -60,6 +61,7 @@ public class ChecksumVerifier implements ReplicaVerifier {
   public BlockVerificationResult verifyBlock(DatanodeDetails datanode, OmKeyLocationInfo keyLocation,
                                              int replicaIndex) {
     Pipeline pipeline = Pipeline.newBuilder(keyLocation.getPipeline())
+        .setId(PipelineID.randomId())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setNodes(Collections.singletonList(datanode))
         .setReplicaIndexes(Collections.singletonMap(datanode, replicaIndex))

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ChecksumVerifier.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ChecksumVerifier.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactoryImpl;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -61,7 +60,7 @@ public class ChecksumVerifier implements ReplicaVerifier {
   public BlockVerificationResult verifyBlock(DatanodeDetails datanode, OmKeyLocationInfo keyLocation,
                                              int replicaIndex) {
     Pipeline pipeline = Pipeline.newBuilder(keyLocation.getPipeline())
-        .setId(PipelineID.randomId())
+        .setId(datanode.getID())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setNodes(Collections.singletonList(datanode))
         .setReplicaIndexes(Collections.singletonMap(datanode, replicaIndex))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please describe your PR in detail:

This PR sets the datanode-id as the pipeline-id when a new pipeline is created for the checksums verification tool.

### Background
For a 3 way Ratis replicated key, the checksums tool returns the wrong results. 

The checksum verification for each key on each node is always the same for all three replicas. i.e., all replicas fail the checksums or none fail when one replica should. 

The checksums verifier provides incorrect results. 

This can be traced down to the way the pipeline is created for the checksum verification.  

https://github.com/apache/ozone/blob/1825cdf6057ae4ac2d0bcbdcfb0bed1302054e9e/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ChecksumVerifier.java#L62-L66 

When a client is created using this pipeline, it is cached https://github.com/apache/ozone/blob/1825cdf6057ae4ac2d0bcbdcfb0bed1302054e9e/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java#L150-L161 

The key for the cached entry is generated in `getPipelineCacheKey` https://github.com/apache/ozone/blob/1825cdf6057ae4ac2d0bcbdcfb0bed1302054e9e/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java#L163-L165 

When the pipeline is created via Pipeline.newBuilder(keyLocation.getPipeline()), it inherits the original pipeline's id. This results in the first cached client being reused for subsequent checksums verification.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13073

## How was this patch tested?
Manual testing using https://issues.apache.org/jira/browse/HDDS-12715
CI: https://github.com/ptlrs/ozone/actions/runs/15143755688