### PR TITLE
HDDS-13074. Prevent linked buckets creation when source volume and/or bucket is missing

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -225,3 +225,13 @@ Setting bucket property on link not allowed
                         Should Contain              ${result}    NOT_SUPPORTED_OPERATION
     ${result} =         Execute                     ozone sh bucket info ${target}/link4
                         Should Contain              ${result}            sourceBucket
+
+Linked bucket creation - source volume and bucket do not exist
+    ${result} =         Execute And Ignore Error    ozone sh bucket link nonexistentvol/nonexistentbuck ${target}/link5
+                        Should Contain              ${result}    VOLUME_NOT_FOUND
+
+Linked bucket creation - source volume exists, source bucket does not exist
+                        Execute                     ozone sh volume create nonexistentvol
+    ${result} =         Execute And Ignore Error    ozone sh bucket link nonexistentvol/nonexistentbuck ${target}/link6
+                        Should Contain              ${result}    BUCKET_NOT_FOUND
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -131,6 +131,10 @@ public class OMBucketCreateRequest extends OMClientRequest {
           OMException.ResultCodes.INVALID_REQUEST);
     }
 
+    if (hasSourceVolume) {
+      ozoneManager.getBucketInfo(bucketInfo.getSourceVolume(), bucketInfo.getSourceBucket());
+    }
+
     if (bucketInfo.hasDefaultReplicationConfig()) {
       DefaultReplicationConfig drc = DefaultReplicationConfig.fromProto(
           bucketInfo.getDefaultReplicationConfig());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we allow the creation of linked buckets even if the source volume and/or bucket is missing. This should be prevented, and an appropriate `IOException` must be thrown to indicate the missing source volume or bucket.

[Wrong] Current behaviour:

```
// source volume does not exist
bash-4.4$ ozone sh volume info vol2
VOLUME_NOT_FOUND Volume vol2 is not found

// link bucket creation succeeds
bash-4.4$ ozone sh bucket link vol2/buck1 vol1/buck2
bash-4.4$ ozone sh bucket info vol1/buck2
{
  "volumeName" : "vol1",
  "name" : "buck2",
  "sourceVolume" : "vol2",
  "sourceBucket" : "buck1",
  "creationTime" : "2025-05-19T16:01:36.891Z",
  "modificationTime" : "2025-05-19T16:01:36.891Z",
  "owner" : "hadoop",
  "link" : true
}

// create source volume
bash-4.4$ ozone sh volume create vol2

// source volume exists but source bucket does not exist
bash-4.4$ ozone sh bucket info vol2/buck1
BUCKET_NOT_FOUND Bucket not found: vol2/buck1

// link bucket creation succeeds
bash-4.4$ ozone sh bucket link vol2/buck1 vol1/buck3
bash-4.4$ ozone sh bucket info vol1/buck3
{
  "volumeName" : "vol1",
  "name" : "buck3",
  "sourceVolume" : "vol2",
  "sourceBucket" : "buck1",
  "creationTime" : "2025-05-19T16:03:18.932Z",
  "modificationTime" : "2025-05-19T16:03:18.932Z",
  "owner" : "hadoop",
  "link" : true
}
```

[Correct] New behaviour:

```
// source volume does not exist
bash-4.4$ ozone sh volume info vol2
VOLUME_NOT_FOUND Volume vol2 is not found

// link bucket creation fails with VOLUME_NOT_FOUND
bash-4.4$ ozone sh bucket link vol2/buck1 vol1/buck2
VOLUME_NOT_FOUND Volume not found: vol2

// create source volume
bash-4.4$ ozone sh volume create vol2

// source volume exists but source bucket does not exist
bash-4.4$ ozone sh bucket info vol2/buck1
BUCKET_NOT_FOUND Bucket not found: vol2/buck1

// link bucket creation fails with BUCKET_NOT_FOUND
bash-4.4$ ozone sh bucket link vol2/buck1 vol1/buck2
BUCKET_NOT_FOUND Bucket not found: vol2/buck1

// create source bucket as well
bash-4.4$ ozone sh bucket create vol2/buck1

// link bucket creation succeeds
bash-4.4$ ozone sh bucket link vol2/buck1 vol1/buck2
bash-4.4$ ozone sh bucket info vol1/buck2
{
  "volumeName" : "vol1",
  "name" : "buck2",
  "sourceVolume" : "vol2",
  "sourceBucket" : "buck1",
  "creationTime" : "2025-05-19T15:54:21.239Z",
  "modificationTime" : "2025-05-19T15:54:21.239Z",
  "owner" : "hadoop",
  "link" : true
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13074

## How was this patch tested?

- Tested the changes locally.
- Added robot acceptance tests.
