### PR TITLE
HDDS-12926. remove *.tmp.* exclusion in DU

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/DUFactory.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/DUFactory.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 public class DUFactory implements SpaceUsageCheckFactory {
 
   private static final String DU_CACHE_FILE = "scmUsed";
-  private static final String EXCLUDE_PATTERN = "*.tmp.*";
 
   private Conf conf;
 
@@ -46,7 +45,7 @@ public class DUFactory implements SpaceUsageCheckFactory {
   public SpaceUsageCheckParams paramsFor(File dir) {
     Duration refreshPeriod = conf.getRefreshPeriod();
 
-    SpaceUsageSource source = new DU(dir, EXCLUDE_PATTERN);
+    SpaceUsageSource source = new DU(dir, null);
 
     SpaceUsagePersistence persistence = new SaveSpaceUsageToFile(
         new File(dir, DU_CACHE_FILE), refreshPeriod);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Exclusion of .tmp. is done in old implementation where chunk write happens in Schema V1. This is to ignore any tmp data.

Now, its Schema V3 where metadata is captured in volume DB. And further ozone used space report all data present as part of Volume path being configured in ozone.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12926

## How was this patch tested?

- NA, removal of code and no testcase is referring
