### PR TITLE
HDDS-13067. Container Balancer delete commands should not be sent with an expiration time in the past

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -69,8 +68,7 @@ public final class MoveManager implements
   private final ContainerManager containerManager;
   private final Clock clock;
 
-  private final Map<ContainerID,
-      Pair<CompletableFuture<MoveResult>, MoveDataNodePair>> pendingMoves =
+  private final Map<ContainerID, MoveOperation> pendingMoves =
       new ConcurrentHashMap<>();
 
   public MoveManager(final ReplicationManager replicationManager,
@@ -83,8 +81,7 @@ public final class MoveManager implements
   /**
    * get all the pending move operations.
    */
-  public Map<ContainerID,
-      Pair<CompletableFuture<MoveResult>, MoveDataNodePair>> getPendingMove() {
+  public Map<ContainerID, MoveOperation> getPendingMove() {
     return pendingMoves;
   }
 
@@ -98,10 +95,9 @@ public final class MoveManager implements
    * @param cid Container id to which the move option is finished
    */
   private void completeMove(final ContainerID cid, final MoveResult mr) {
-    Pair<CompletableFuture<MoveResult>, MoveDataNodePair> move =
-        pendingMoves.remove(cid);
+    MoveOperation move = pendingMoves.remove(cid);
     if (move != null) {
-      CompletableFuture<MoveResult> future = move.getLeft();
+      CompletableFuture<MoveResult> future = move.getResult();
       if (future != null && mr != null) {
         // when we know the future is null, and we want to complete
         // the move , then we set mr to null.
@@ -125,9 +121,8 @@ public final class MoveManager implements
   private void startMove(
       final ContainerInfo containerInfo, final DatanodeDetails src,
       final DatanodeDetails tgt, final CompletableFuture<MoveResult> ret) {
-    Pair<CompletableFuture<MoveResult>, MoveDataNodePair> move =
-        pendingMoves.putIfAbsent(containerInfo.containerID(),
-            Pair.of(ret, new MoveDataNodePair(src, tgt)));
+    MoveOperation move = pendingMoves.putIfAbsent(containerInfo.containerID(),
+        new MoveOperation(ret, new MoveDataNodePair(src, tgt)));
     if (move == null) {
       // A move for this container did not exist, so send a replicate command
       try {
@@ -264,10 +259,9 @@ public final class MoveManager implements
    */
   private void notifyContainerOpCompleted(ContainerReplicaOp containerReplicaOp,
       ContainerID containerID) {
-    Pair<CompletableFuture<MoveResult>, MoveDataNodePair> pair =
-        pendingMoves.get(containerID);
+    MoveOperation pair = pendingMoves.get(containerID);
     if (pair != null) {
-      MoveDataNodePair mdnp = pair.getRight();
+      MoveDataNodePair mdnp = pair.getMoveDataNodePair();
       PendingOpType opType = containerReplicaOp.getOpType();
       DatanodeDetails dn = containerReplicaOp.getTarget();
       if (opType.equals(PendingOpType.ADD) && mdnp.getTgt().equals(dn)) {
@@ -278,7 +272,7 @@ public final class MoveManager implements
           LOG.warn("Failed to handle successful Add for container {} being " +
               "moved from source {} to target {}.", containerID,
               mdnp.getSrc(), mdnp.getTgt(), e);
-          pair.getLeft().complete(MoveResult.FAIL_UNEXPECTED_ERROR);
+          pair.getResult().complete(MoveResult.FAIL_UNEXPECTED_ERROR);
         }
       } else if (
             opType.equals(PendingOpType.DELETE) && mdnp.getSrc().equals(dn)) {
@@ -295,10 +289,9 @@ public final class MoveManager implements
    */
   private void notifyContainerOpExpired(ContainerReplicaOp containerReplicaOp,
       ContainerID containerID) {
-    Pair<CompletableFuture<MoveResult>, MoveDataNodePair> pair =
-        pendingMoves.get(containerID);
+    MoveOperation pair = pendingMoves.get(containerID);
     if (pair != null) {
-      MoveDataNodePair mdnp = pair.getRight();
+      MoveDataNodePair mdnp = pair.getMoveDataNodePair();
       PendingOpType opType = containerReplicaOp.getOpType();
       DatanodeDetails dn = containerReplicaOp.getTarget();
       if (opType.equals(PendingOpType.ADD) && mdnp.getTgt().equals(dn)) {
@@ -314,12 +307,11 @@ public final class MoveManager implements
       throws ContainerNotFoundException,
       ContainerReplicaNotFoundException, NodeNotFoundException,
       NotLeaderException {
-    Pair<CompletableFuture<MoveResult>, MoveDataNodePair> pair =
-        pendingMoves.get(cid);
-    if (pair == null) {
+    MoveOperation moveOp = pendingMoves.get(cid);
+    if (moveOp == null) {
       return;
     }
-    MoveDataNodePair movePair = pair.getRight();
+    MoveDataNodePair movePair = moveOp.getMoveDataNodePair();
     final DatanodeDetails src = movePair.getSrc();
     final DatanodeDetails tgt = movePair.getTgt();
     LOG.debug("Handling successful addition of Container {} from" +
@@ -356,7 +348,7 @@ public final class MoveManager implements
 
       if (healthResult.getHealthState() ==
           ContainerHealthResult.HealthState.HEALTHY) {
-        sendDeleteCommand(containerInfo, src);
+        sendDeleteCommand(containerInfo, src, moveOp.getReplicateScheduledTime());
       } else {
         LOG.info("Cannot remove source replica as the container health would " +
             "be {}", healthResult.getHealthState());
@@ -403,6 +395,7 @@ public final class MoveManager implements
     long now = clock.millis();
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
         replicaIndex, src, tgt, now + replicationTimeout);
+    pendingMoves.get(containerInfo.containerID()).setReplicateScheduledTime(now);
   }
 
   /**
@@ -411,17 +404,18 @@ public final class MoveManager implements
    *
    * @param containerInfo Container to be deleted
    * @param datanode The datanode on which the replica should be deleted
+   * @param scheduledTime The time at which the replicate command for the container was scheduled
    */
   private void sendDeleteCommand(
-      final ContainerInfo containerInfo, final DatanodeDetails datanode)
+      final ContainerInfo containerInfo, final DatanodeDetails datanode,
+      long scheduledTime)
       throws ContainerReplicaNotFoundException, ContainerNotFoundException,
       NotLeaderException {
     int replicaIndex = getContainerReplicaIndex(
         containerInfo.containerID(), datanode);
     long deleteTimeout = moveTimeout - replicationTimeout;
-    long now = clock.millis();
     replicationManager.sendDeleteCommand(
-        containerInfo, replicaIndex, datanode, true, now + deleteTimeout);
+        containerInfo, replicaIndex, datanode, true, scheduledTime + deleteTimeout);
   }
 
   private int getContainerReplicaIndex(
@@ -452,6 +446,45 @@ public final class MoveManager implements
 
   void setReplicationTimeout(long replicationTimeout) {
     this.replicationTimeout = replicationTimeout;
+  }
+
+  /**
+   * All details about a move operation.
+   */
+  private static class MoveOperation {
+    private CompletableFuture<MoveResult> result;
+    private MoveDataNodePair moveDataNodePair;
+    private long replicateScheduledTime;
+
+    MoveOperation(CompletableFuture<MoveResult> result, MoveDataNodePair srcTgt) {
+      this.result = result;
+      this.moveDataNodePair = srcTgt;
+    }
+
+    public CompletableFuture<MoveResult> getResult() {
+      return result;
+    }
+
+    public MoveDataNodePair getMoveDataNodePair() {
+      return moveDataNodePair;
+    }
+
+    public long getReplicateScheduledTime() {
+      return replicateScheduledTime;
+    }
+
+    public void setResult(
+        CompletableFuture<MoveResult> result) {
+      this.result = result;
+    }
+
+    public void setMoveDataNodePair(MoveDataNodePair srcTgt) {
+      this.moveDataNodePair = srcTgt;
+    }
+
+    public void setReplicateScheduledTime(long replicatescheduledTime) {
+      this.replicateScheduledTime = replicatescheduledTime;
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -532,10 +532,14 @@ public class TestMoveManager {
         eq(containerInfo), eq(srcReplica.getReplicaIndex()), eq(src),
         eq(true), longCaptorDelete.capture());
 
-    // verify that command is sent with expiration time as (moveStartTime + moveTimeout)
+    // verify that command is sent with deadline as (moveStartTime + moveTimeout)
     // moveStartTime can be calculated as (expirationTime set for replication - replicationTimeout)
     assertEquals(longCaptorReplicate.getValue() - replicationTimeout + moveTimeout, longCaptorDelete.getValue());
+    // replicationManager sends a datanode command with the scm deadline as
+    // (scmDeadlineEpochMs - rmConf.getDatanodeTimeoutOffset()). The offset is 6 minutes by default.
+    // For the scm deadline to not be in the past, the below condition is checked.
     assertTrue((longCaptorDelete.getValue() - Duration.ofMinutes(6).toMillis()) > clock.millis());
+
     op = new ContainerReplicaOp(
         DELETE, src, srcReplica.getReplicaIndex(), null, clock.millis() + 1000);
     moveManager.opCompleted(op, containerInfo.containerID(), false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -535,7 +535,7 @@ public class TestMoveManager {
     // verify that command is sent with deadline as (moveStartTime + moveTimeout)
     // moveStartTime can be calculated as (expirationTime set for replication - replicationTimeout)
     assertEquals(longCaptorReplicate.getValue() - replicationTimeout + moveTimeout, longCaptorDelete.getValue());
-    // replicationManager sends a datanode command with the scm deadline as
+    // replicationManager sends a datanode command with the deadline as
     // (scmDeadlineEpochMs - rmConf.getDatanodeTimeoutOffset()). The offset is 6 minutes by default.
     // For the datanode deadline to not be in the past, the below condition is checked.
     assertTrue((longCaptorDelete.getValue() - Duration.ofMinutes(6).toMillis()) > clock.millis());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -537,7 +537,7 @@ public class TestMoveManager {
     assertEquals(longCaptorReplicate.getValue() - replicationTimeout + moveTimeout, longCaptorDelete.getValue());
     // replicationManager sends a datanode command with the scm deadline as
     // (scmDeadlineEpochMs - rmConf.getDatanodeTimeoutOffset()). The offset is 6 minutes by default.
-    // For the scm deadline to not be in the past, the below condition is checked.
+    // For the datanode deadline to not be in the past, the below condition is checked.
     assertTrue((longCaptorDelete.getValue() - Duration.ofMinutes(6).toMillis()) > clock.millis());
 
     op = new ContainerReplicaOp(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem
The method that sends the delete command for container balancer is MoveManager#sendDeleteCommand().
It calculates deleteTimeout as moveTimeout - replicationTimeout, and then sends the delete command with an SCM expiration timestamp of current time + deleteTimeout. This is wrong, the delete expiration timestamp should actually be "The time at which the move was started + moveTimeout."
This PR changes the timestamp considered for calculating the timeout duration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13067

## How was this patch tested?

Existing tests, added a unit test in TestMoveManager
