### PR TITLE
HDDS-11539. OzoneClientCache `@PreDestroy` is never called

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/S3GatewayService.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/S3GatewayService.java
@@ -42,8 +42,6 @@ public class S3GatewayService implements MiniOzoneCluster.Service {
   public void stop() throws Exception {
     Preconditions.assertNotNull(s3g, "S3 Gateway not running");
     s3g.stop();
-    // TODO (HDDS-11539): Remove this workaround once the @PreDestroy issue is fixed
-    OzoneClientCache.closeClient();
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
@@ -26,10 +26,13 @@ import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -37,30 +40,49 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
+import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Cached ozone client for s3 requests.
  */
-@ApplicationScoped
-public final class OzoneClientCache {
+@Singleton
+public class OzoneClientCache {
+
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneClientCache.class);
-  // single, cached OzoneClient established on first connection
-  // for s3g gRPC OmTransport, OmRequest - OmResponse channel
-  private static OzoneClientCache instance;
-  private OzoneClient client;
-  private SecurityConfig secConfig;
 
-  private OzoneClientCache(OzoneConfiguration ozoneConfiguration)
-      throws IOException {
+  private final OzoneConfiguration conf;
+  private OzoneClient client;
+
+  @Inject
+  OzoneClientCache(OzoneConfiguration conf) {
+    this.conf = conf;
+    LOG.debug("{}: Created", this);
+  }
+
+  @PostConstruct
+  public void initialize() throws IOException {
+    conf.set("ozone.om.group.rights", "NONE");
     // Set the expected OM version if not set via config.
-    ozoneConfiguration.setIfUnset(OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY,
+    conf.setIfUnset(OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY,
         OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT);
+    conf.setBoolean(S3Auth.S3_AUTH_CHECK, true);
+
+    client = createClient(conf);
+    Preconditions.assertTrue(conf.getBoolean(S3Auth.S3_AUTH_CHECK, false), S3Auth.S3_AUTH_CHECK);
+
+    LOG.debug("{}: Initialized", this);
+  }
+
+  public OzoneClient getClient() {
+    return client;
+  }
+
+  public static OzoneClient createClient(OzoneConfiguration ozoneConfiguration) throws IOException {
     String omServiceID = OmUtils.getOzoneManagerServiceId(ozoneConfiguration);
-    secConfig = new SecurityConfig(ozoneConfiguration);
-    client = null;
+    SecurityConfig secConfig = new SecurityConfig(ozoneConfiguration);
     try {
       if (secConfig.isGrpcTlsEnabled()) {
         if (ozoneConfiguration
@@ -70,43 +92,23 @@ public final class OzoneClientCache {
           // Grpc transport selected
           // need to get certificate for TLS through
           // hadoop rpc first via ServiceInfo
-          setCertificate(omServiceID,
-              ozoneConfiguration);
+          setCertificate(secConfig, omServiceID, ozoneConfiguration);
         }
       }
       if (omServiceID == null) {
-        client = OzoneClientFactory.getRpcClient(ozoneConfiguration);
+        return OzoneClientFactory.getRpcClient(ozoneConfiguration);
       } else {
         // As in HA case, we need to pass om service ID.
-        client = OzoneClientFactory.getRpcClient(omServiceID,
+        return OzoneClientFactory.getRpcClient(omServiceID,
             ozoneConfiguration);
       }
     } catch (IOException e) {
       LOG.warn("cannot create OzoneClient", e);
       throw e;
     }
-    // S3 Gateway should always set the S3 Auth.
-    ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
   }
 
-  public static OzoneClient getOzoneClientInstance(OzoneConfiguration
-                                                      ozoneConfiguration)
-      throws IOException {
-    if (instance == null) {
-      instance = new OzoneClientCache(ozoneConfiguration);
-    }
-    return instance.client;
-  }
-
-  public static void closeClient() throws IOException {
-    if (instance != null) {
-      instance.client.close();
-      instance = null;
-    }
-  }
-
-  private void setCertificate(String omServiceID,
-                              OzoneConfiguration conf)
+  private static void setCertificate(SecurityConfig secConfig, String omServiceID, OzoneConfiguration conf)
       throws IOException {
 
     // create local copy of config incase exception occurs
@@ -119,6 +121,7 @@ public final class OzoneClientCache {
       // get certificates with service list request
       config.set(OZONE_OM_TRANSPORT_CLASS,
           OZONE_OM_TRANSPORT_CLASS_DEFAULT);
+      config.setBoolean(S3Auth.S3_AUTH_CHECK, false);
 
       if (omServiceID == null) {
         certClient = OzoneClientFactory.getRpcClient(config);
@@ -161,7 +164,8 @@ public final class OzoneClientCache {
   }
 
   @PreDestroy
-  public void destroy() throws IOException {
-    OzoneClientCache.closeClient();
+  public void cleanup() {
+    LOG.debug("{}: Closing cached client", this);
+    IOUtils.close(LOG, client);
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3secret/S3SecretEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3secret/S3SecretEndpointBase.java
@@ -18,10 +18,13 @@
 package org.apache.hadoop.ozone.s3secret;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
 import java.util.Map;
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -29,6 +32,8 @@ import org.apache.hadoop.ozone.audit.AuditLoggerType;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.audit.Auditor;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
+import org.apache.hadoop.ozone.s3.OzoneClientCache;
 import org.apache.hadoop.ozone.s3.util.AuditUtils;
 
 /**
@@ -36,14 +41,25 @@ import org.apache.hadoop.ozone.s3.util.AuditUtils;
  */
 public class S3SecretEndpointBase implements Auditor {
 
+  private final OzoneConfiguration conf;
+  private OzoneClient client;
+
   @Context
   private ContainerRequestContext context;
 
-  @Inject
-  private OzoneClient client;
-
   protected static final AuditLogger AUDIT =
       new AuditLogger(AuditLoggerType.S3GLOGGER);
+
+  @Inject
+  S3SecretEndpointBase(OzoneConfiguration conf) {
+    this.conf = new OzoneConfiguration(conf);
+    this.conf.setBoolean(S3Auth.S3_AUTH_CHECK, false);
+  }
+
+  @PostConstruct
+  void initialize() throws IOException {
+    client = OzoneClientCache.createClient(conf);
+  }
 
   protected String userNameFromRequest() {
     return context.getSecurityContext().getUserPrincipal().getName();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3secret/S3SecretManagementEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3secret/S3SecretManagementEndpoint.java
@@ -22,11 +22,13 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
 import jakarta.annotation.Nullable;
 import java.io.IOException;
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
@@ -42,6 +44,11 @@ import org.slf4j.LoggerFactory;
 public class S3SecretManagementEndpoint extends S3SecretEndpointBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(S3SecretManagementEndpoint.class);
+
+  @Inject
+  S3SecretManagementEndpoint(OzoneConfiguration conf) {
+    super(conf);
+  }
 
   @PUT
   public Response generate() throws IOException {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3secret/TestSecretGenerate.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3secret/TestSecretGenerate.java
@@ -79,7 +79,7 @@ class TestSecretGenerate {
     when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
     when(context.getUriInfo()).thenReturn(uriInfo);
 
-    endpoint = new S3SecretManagementEndpoint();
+    endpoint = new S3SecretManagementEndpoint(conf);
     endpoint.setClient(client);
     endpoint.setContext(context);
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3secret/TestSecretRevoke.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3secret/TestSecretRevoke.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.ObjectStoreStub;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
@@ -70,13 +71,14 @@ public class TestSecretRevoke {
 
   @BeforeEach
   void setUp() {
+    OzoneConfiguration conf = new OzoneConfiguration();
     OzoneClient client = new OzoneClientStub(objectStore);
 
     when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>());
     when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
     when(context.getUriInfo()).thenReturn(uriInfo);
 
-    endpoint = new S3SecretManagementEndpoint();
+    endpoint = new S3SecretManagementEndpoint(conf);
     endpoint.setClient(client);
     endpoint.setContext(context);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the problem that `@PreDestroy` is not called on `OzoneClientCache` instance.

- Use `@Singleton` instead of `@ApplicationScoped`
- Avoid static state
- Improve encapsulation (remove `setConfiguration` exposed for testing, use constructor injection instead)
- Create separate client for S3 secret endpoint, which does not have `S3Auth`

https://issues.apache.org/jira/browse/HDDS-11539

## How was this patch tested?

Existing tests.  Added debug log.

```
$ docker compose logs s3g | grep OzoneClientCache
s3g-1  | 2025-05-20 19:02:16,079 [qtp1658980982-156] DEBUG s3.OzoneClientCache: org.apache.hadoop.ozone.s3.OzoneClientCache@5b3f64: Created
s3g-1  | 2025-05-20 19:02:16,298 [qtp1658980982-156] DEBUG s3.OzoneClientCache: org.apache.hadoop.ozone.s3.OzoneClientCache@5b3f64: Initialized
s3g-1  | 2025-05-20 19:03:14,746 [shutdown-hook-0] DEBUG s3.OzoneClientCache: org.apache.hadoop.ozone.s3.OzoneClientCache@5b3f64: Closing cached client
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/15144265837