### PR TITLE
HDDS-13089. [snapshot] Add an integration test to verify snapshotted data can be read by S3 SDK client

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -478,6 +478,53 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
     }
   }
 
+  /**
+   * Tests the functionality to create a snapshot of an Ozone bucket and then read files
+   * from the snapshot directory using the S3 SDK.
+   *
+   * <p>The test follows these steps:
+   * <ol>
+   *   <li>Create a bucket and upload a file via the S3 client.</li>
+   *   <li>Create a snapshot on the bucket using the Ozone client.</li>
+   *   <li>Construct the snapshot object key using the ".snapshot" directory format.</li>
+   *   <li>Retrieve the object from the snapshot and verify that its content matches
+   *       the originally uploaded content.</li>
+   * </ol>
+   * </p>
+   *
+   * @throws Exception if the test fails due to any errors during bucket creation, snapshot creation,
+   *         file upload, or retrieval.
+   */
+  @Test
+  public void testReadSnapshotDirectoryUsingS3SDK() throws Exception {
+    final String bucketName = getBucketName("snapshot");
+    final String keyName = getKeyName("snapshotfile");
+    final String content = "snapshot test content";
+
+    // Create the bucket and upload an object using S3 SDK.
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName),
+        RequestBody.fromString(content));
+
+    String snapshotName = "snap1";
+    // Create a snapshot using the Ozone client.
+    // Snapshots in Ozone are created on the bucket and are exposed via the ".snapshot" directory.
+    try (OzoneClient ozoneClient = cluster.newClient()) {
+      ObjectStore store = ozoneClient.getObjectStore();
+      OzoneVolume volume = store.getS3Volume();
+
+      store.createSnapshot(volume.getName(), bucketName, snapshotName);
+    }
+
+    // Use the S3 SDK to read the file from the snapshot directory.
+    // The key in the snapshot is constructed using the special ".snapshot" prefix.
+    String snapshotKey = ".snapshot/" + snapshotName + "/" + keyName;
+    ResponseBytes<GetObjectResponse> snapshotResponse = s3Client.getObjectAsBytes(
+        b -> b.bucket(bucketName).key(snapshotKey));
+
+    assertEquals(content, snapshotResponse.asUtf8String());
+  }
+
   private String getBucketName() {
     return getBucketName("");
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13089. [snapshot] Add an integration test to verify snapshotted data can be read by S3 SDK client

Please describe your PR in detail:
* Tests the functionality to create a snapshot of an Ozone bucket and then read files from the snapshot directory using the S3 SDK.

The test follows these steps:

1. Create a bucket and upload a file via the S3 client.
2. Create a snapshot on the bucket using the Ozone client.
3. Construct the snapshot object key using the ".snapshot" directory format.
4. Retrieve the object from the snapshot and verify that its content matches the originally uploaded content.

Generated-by: GitHub Copilot o3-mini

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13089

## How was this patch tested?

Test only addition.