### PR TITLE
HDDS-13100. ozone admin datanode list --json should output a newline at the end of the list

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -111,7 +111,7 @@ public class ListInfoSubcommand extends ScmSubcommand {
     if (json) {
       List<DatanodeWithAttributes> datanodeList = allNodes.collect(
               Collectors.toList());
-      System.out.print(
+      System.out.println(
               JsonUtils.toJsonStringWithDefaultPrettyPrinter(datanodeList));
     } else {
       allNodes.forEach(this::printDatanodeInfo);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The shell prompt ends up on the same line as the last line of output of `ozone admin datanode list --json` command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13100

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/15179615710
