### PR TITLE
HDDS-13099. ozone admin datanode list ignores --json flag when --id filter is used

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import com.google.common.base.Strings;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -87,7 +88,13 @@ public class ListInfoSubcommand extends ScmSubcommand {
           .getFromProtoBuf(node.getNodeID()),
           node.getNodeOperationalStates(0),
           node.getNodeStates(0));
-      printDatanodeInfo(dwa);
+      
+      if (json) {
+        List<DatanodeWithAttributes> singleList = Collections.singletonList(dwa);
+        System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(singleList));
+      } else {
+        printDatanodeInfo(dwa);
+      }
       return;
     }
     Stream<DatanodeWithAttributes> allNodes = getAllNodes(scmClient).stream();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `ozone admin datanode list` command does not provide the output in json format when` --json `flag is used along with `--id `filter.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13099

## How was this patch tested?
https://github.com/sreejasahithi/ozone/actions/runs/15179925820

Before:(--json flag was ingnored)
```
Datanode: 47f85235-fc2e-4a56-ba2c-5351456b2d13 (/default-rack/X.X.X.X/ozone-datanode-1.ozone_default/1 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Related pipelines:
97263595-69e5-42dc-83ab-67bb6379844c/RATIS/ONE/RATIS/OPEN/Leader
```

After:(--json flag is considered)
```
[ {
  "datanodeDetails" : {
    "level" : 3,
    "cost" : 0,
    "id" : {
      "uuid" : "47f85235-fc2e-4a56-ba2c-5351456b2d13",
      "id" : "47f85235-fc2e-4a56-ba2c-5351456b2d13",
      "byteString" : {
        "validUtf8" : true,
        "empty" : false
      }
    },
    "ipAddress" : "X.X.X.X",
    "hostName" : "ozone-datanode-1.ozone_default",
    "ports" : [ {
      "name" : "HTTP",
      "value" : 9882
    }, {
      "name" : "CLIENT_RPC",
      "value" : 19864
    }, {
      "name" : "REPLICATION",
      "value" : 9886
    }, {
      "name" : "RATIS",
      "value" : 9858
    }, {
      "name" : "RATIS_ADMIN",
      "value" : 9857
    }, {
      "name" : "RATIS_SERVER",
      "value" : 9856
    }, {
      "name" : "RATIS_DATASTREAM",
      "value" : 9855
    }, {
      "name" : "STANDALONE",
      "value" : 9859
    } ],
    "setupTime" : 0,
    "persistedOpState" : "IN_SERVICE",
    "persistedOpStateExpiryEpochSec" : 0,
    "initialVersion" : 0,
    "currentVersion" : 2,
    "uuid" : "47f85235-fc2e-4a56-ba2c-5351456b2d13",
    "uuidString" : "47f85235-fc2e-4a56-ba2c-5351456b2d13",
    "ipAddressAsByteString" : {
      "string" : "X.X.X.X",
      "bytes" : {
        "validUtf8" : true,
        "empty" : false
      }
    },
    "hostNameAsByteString" : {
      "string" : "ozone-datanode-1.ozone_default",
      "bytes" : {
        "validUtf8" : true,
        "empty" : false
      }
    },
    "ratisPort" : {
      "name" : "RATIS",
      "value" : 9858
    },
    "standalonePort" : {
      "name" : "STANDALONE",
      "value" : 9859
    },
    "decommissioned" : false,
    "maintenance" : false,
    "networkLocation" : "/default-rack",
    "networkName" : "47f85235-fc2e-4a56-ba2c-5351456b2d13",
    "networkFullPath" : "/default-rack/47f85235-fc2e-4a56-ba2c-5351456b2d13",
    "numOfLeaves" : 1,
    "networkLocationAsByteString" : {
      "string" : "/default-rack",
      "bytes" : {
        "validUtf8" : true,
        "empty" : false
      }
    },
    "networkNameAsByteString" : {
      "string" : "47f85235-fc2e-4a56-ba2c-5351456b2d13",
      "bytes" : {
        "validUtf8" : true,
        "empty" : false
      }
    }
  },
  "healthState" : "HEALTHY",
  "opState" : "IN_SERVICE"
} ]
```
