### PR TITLE
HDDS-13062. Upon OM startup, verify ozone.metadata.dirs and ozone.om.db.dirs are in the same mount

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -307,4 +307,6 @@ public final class ServerUtils {
     File metaDirPath = ServerUtils.getOzoneMetaDirPath(conf);
     return (new File(metaDirPath, "ratis")).getPath();
   }
+
+  // TODO: Move helpers here instead
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -44,6 +44,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -983,4 +985,40 @@ public final class OmUtils {
       throw e;
     }
   }
+
+  /**
+   * Return true if both File inputs are under the same mount point.
+   * @param file1 First File
+   * @param file2 Second File
+   * @return true if both File inputs are under the same mount point, false otherwise.
+   * @throws IOException
+   */
+  public static boolean isUnderSameMountPoint(File file1, File file2) throws IOException {
+    if (file1 == null || file2 == null) {
+      return false;
+    }
+    // Get and compare mount points of file1 and file2
+    java.nio.file.Path mountPoint1 = mountOf(file1.toPath());
+    java.nio.file.Path mountPoint2 = mountOf(file2.toPath());
+    return mountPoint1.equals(mountPoint2);
+  }
+
+  /**
+   * Get top level mount point for the given path.
+   * From https://stackoverflow.com/a/64169740
+   * @param p java.nio.file.Path
+   * @return Top level mount point for p.
+   * @throws IOException
+   */
+  private static java.nio.file.Path mountOf(java.nio.file.Path p) throws IOException {
+    FileStore fs = Files.getFileStore(p);
+    java.nio.file.Path temp = p.toAbsolutePath();
+    java.nio.file.Path mountp = temp;
+
+    while( (temp = temp.getParent()) != null && fs.equals(Files.getFileStore(temp)) ) {
+      mountp = temp;
+    }
+    return mountp;
+  }
+
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -218,5 +218,14 @@ public class TestOmUtils {
     assertEquals("0.0.0.0", addr.getHostString());
     assertEquals(OMConfigKeys.OZONE_OM_PORT_DEFAULT, addr.getPort());
   }
-}
 
+  @Test
+  void testIsUnderSameMountPoint() throws IOException {
+    // Note: This test assumes that /tmp/ is under a different mount point as /etc/, which should usually be the case
+    File testFile1 = File.createTempFile("testIsSameMountPoint", ".tmp");
+    assertFalse(OmUtils.isUnderSameMountPoint(testFile1, new File("/etc/")));
+
+    File testFile2 = File.createTempFile("testIsSameMountPoint", ".tmp");
+    assertTrue(OmUtils.isUnderSameMountPoint(testFile1, testFile2));
+  }
+}


### PR DESCRIPTION
WIP. Review not recommended yet.

## What changes were proposed in this pull request?

OM bootstrapping relies on hard links to work. This implies snapshot dir must be on the same filesystem as the OM DB's. Otherwise it throws exception and gets stuck in the retry loop as seen in HDDS-13062 JIRA description.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13062

## How was this patch tested?

- Additional tests are added at each level.