### PR TITLE
HDDS-13118. Deduplicate mockito-core dependency import in hdds-test-utils

### DIFF
--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -58,11 +58,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Deduplicate mockito-core dependency import in hdds-test-utils

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13118

## How was this patch tested?

CI: https://github.com/chungen0126/ozone/actions/runs/15241685452
