### PR TITLE
HDDS-11244. Keys should not be purged from file table while processing deleted directories in snapshot & should be purged from AOS instead

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -94,13 +94,13 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
         // Init Batch Operation for snapshot db.
         try (BatchOperation writeBatch =
             fromSnapshotStore.initBatchOperation()) {
-          processPaths(fromSnapshot.getMetadataManager(), writeBatch);
+          processPaths(metadataManager, fromSnapshot.getMetadataManager(), batchOp, writeBatch);
           fromSnapshotStore.commitBatchOperation(writeBatch);
         }
       }
       metadataManager.getSnapshotInfoTable().putWithBatch(batchOp, fromSnapshotInfo.getTableKey(), fromSnapshotInfo);
     } else {
-      processPaths(metadataManager, batchOp);
+      processPaths(metadataManager, metadataManager, batchOp, batchOp);
     }
 
     // update bucket quota in active db
@@ -111,8 +111,9 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
     }
   }
 
-  public void processPaths(OMMetadataManager omMetadataManager,
-      BatchOperation batchOperation) throws IOException {
+  public void processPaths(
+      OMMetadataManager keySpaceOmMetadataManager, OMMetadataManager deletedSpaceOmMetadataManager,
+      BatchOperation keySpaceBatchOperation, BatchOperation deletedSpaceBatchOperation) throws IOException {
     for (OzoneManagerProtocolProtos.PurgePathRequest path : paths) {
       final long volumeId = path.getVolumeId();
       final long bucketId = path.getBucketId();
@@ -125,14 +126,14 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
       // Add all sub-directories to deleted directory table.
       for (OzoneManagerProtocolProtos.KeyInfo key : markDeletedSubDirsList) {
         OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(key);
-        String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId,
+        String ozoneDbKey = keySpaceOmMetadataManager.getOzonePathKey(volumeId,
             bucketId, keyInfo.getParentObjectID(), keyInfo.getFileName());
-        String ozoneDeleteKey = omMetadataManager.getOzoneDeletePathKey(
+        String ozoneDeleteKey = deletedSpaceOmMetadataManager.getOzoneDeletePathKey(
             key.getObjectID(), ozoneDbKey);
-        omMetadataManager.getDeletedDirTable().putWithBatch(batchOperation,
+        deletedSpaceOmMetadataManager.getDeletedDirTable().putWithBatch(deletedSpaceBatchOperation,
             ozoneDeleteKey, keyInfo);
 
-        omMetadataManager.getDirectoryTable().deleteWithBatch(batchOperation,
+        keySpaceOmMetadataManager.getDirectoryTable().deleteWithBatch(keySpaceBatchOperation,
             ozoneDbKey);
 
         if (LOG.isDebugEnabled()) {
@@ -143,10 +144,10 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
 
       for (OzoneManagerProtocolProtos.KeyInfo key : deletedSubFilesList) {
         OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(key);
-        String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId,
+        String ozoneDbKey = keySpaceOmMetadataManager.getOzonePathKey(volumeId,
             bucketId, keyInfo.getParentObjectID(), keyInfo.getFileName());
-        omMetadataManager.getKeyTable(getBucketLayout())
-            .deleteWithBatch(batchOperation, ozoneDbKey);
+        keySpaceOmMetadataManager.getKeyTable(getBucketLayout())
+            .deleteWithBatch(keySpaceBatchOperation, ozoneDbKey);
 
         if (LOG.isDebugEnabled()) {
           LOG.info("Move keyName:{} to DeletedTable DBKey: {}",
@@ -156,26 +157,26 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
         RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
             keyInfo, keyInfo.getUpdateID());
 
-        String deletedKey = omMetadataManager
+        String deletedKey = keySpaceOmMetadataManager
             .getOzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),
                 keyInfo.getKeyName());
-        deletedKey = omMetadataManager.getOzoneDeletePathKey(
+        deletedKey = deletedSpaceOmMetadataManager.getOzoneDeletePathKey(
             keyInfo.getObjectID(), deletedKey);
 
-        omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
+        deletedSpaceOmMetadataManager.getDeletedTable().putWithBatch(deletedSpaceBatchOperation,
             deletedKey, repeatedOmKeyInfo);
       }
 
       if (!openKeyInfoMap.isEmpty()) {
         for (Map.Entry<String, OmKeyInfo> entry : openKeyInfoMap.entrySet()) {
-          omMetadataManager.getOpenKeyTable(getBucketLayout()).putWithBatch(
-              batchOperation, entry.getKey(), entry.getValue());
+          keySpaceOmMetadataManager.getOpenKeyTable(getBucketLayout()).putWithBatch(
+              keySpaceBatchOperation, entry.getKey(), entry.getValue());
         }
       }
 
       // Delete the visited directory from deleted directory table
       if (path.hasDeletedDir()) {
-        omMetadataManager.getDeletedDirTable().deleteWithBatch(batchOperation,
+        deletedSpaceOmMetadataManager.getDeletedDirTable().deleteWithBatch(deletedSpaceBatchOperation,
             path.getDeletedDir());
 
         if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.request;
 
+import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getOmKeyInfo;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
@@ -493,13 +494,8 @@ public final class OMRequestTestUtils {
    *
    * @throws Exception
    */
-  public static void addDirKeyToDirTable(boolean addToCache,
-                                         OmDirectoryInfo omDirInfo,
-                                         String volume,
-                                         String bucket,
-                                         long trxnLogIndex,
-                                         OMMetadataManager omMetadataManager)
-          throws Exception {
+  public static String addDirKeyToDirTable(boolean addToCache, OmDirectoryInfo omDirInfo, String volume, String bucket,
+      long trxnLogIndex, OMMetadataManager omMetadataManager) throws Exception {
     final long volumeId = omMetadataManager.getVolumeId(volume);
     final long bucketId = omMetadataManager.getBucketId(volume, bucket);
     final String ozoneKey = omMetadataManager.getOzonePathKey(volumeId,
@@ -510,6 +506,7 @@ public final class OMRequestTestUtils {
               CacheValue.get(trxnLogIndex, omDirInfo));
     }
     omMetadataManager.getDirectoryTable().put(ozoneKey, omDirInfo);
+    return ozoneKey;
   }
 
   /**
@@ -989,6 +986,22 @@ public final class OMRequestTestUtils {
         omKeyInfo, trxnLogIndex);
 
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
+
+    return ozoneKey;
+  }
+
+  /**
+   * Deletes directory from directory table and adds it to DeletedDirectory table.
+   * @return the deletedDirectoryTable key.
+   */
+  public static String deleteDir(String ozoneKey, String volume, String bucket,
+      OMMetadataManager omMetadataManager)
+      throws IOException {
+    // Retrieve the keyInfo
+    OmDirectoryInfo omDirectoryInfo = omMetadataManager.getDirectoryTable().get(ozoneKey);
+    OmKeyInfo omKeyInfo = getOmKeyInfo(volume, bucket, omDirectoryInfo,
+        omDirectoryInfo.getName());
+    omMetadataManager.getDeletedDirTable().put(ozoneKey, omKeyInfo);
 
     return ozoneKey;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getOmKeyInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,9 +26,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -36,6 +41,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -45,8 +51,11 @@ import org.apache.hadoop.ozone.om.response.key.OMDirectoriesPurgeResponseWithFSO
 import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests {@link OMKeyPurgeRequest} and {@link OMKeyPurgeResponse}.
@@ -110,20 +119,24 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     omMetadataManager.getBucketTable().put(bucketKey, omBucketInfo);
   }
 
+  private OMRequest createPurgeKeysRequest(String fromSnapshot, String purgeDeletedDir,
+      List<OmKeyInfo> keyList, OmBucketInfo bucketInfo) throws IOException {
+    return createPurgeKeysRequest(fromSnapshot, purgeDeletedDir, Collections.emptyList(), keyList, bucketInfo);
+  }
+
   /**
    * Create OMRequest which encapsulates DeleteKeyRequest.
    * @return OMRequest
    */
   private OMRequest createPurgeKeysRequest(String fromSnapshot, String purgeDeletedDir,
-      List<OmKeyInfo> keyList, OmBucketInfo bucketInfo) throws IOException {
+      List<OmKeyInfo> subDirs, List<OmKeyInfo> keyList, OmBucketInfo bucketInfo) throws IOException {
     List<OzoneManagerProtocolProtos.PurgePathRequest> purgePathRequestList
         = new ArrayList<>();
     List<OmKeyInfo> subFiles = new ArrayList<>();
     for (OmKeyInfo key : keyList) {
       subFiles.add(key);
     }
-    List<OmKeyInfo> subDirs = new ArrayList<>();
-    Long volumeId = 1L;
+    Long volumeId = omMetadataManager.getVolumeId(bucketInfo.getVolumeName());
     Long bucketId = bucketInfo.getObjectID();
     OzoneManagerProtocolProtos.PurgePathRequest request = wrapPurgeRequest(
         volumeId, bucketId, purgeDeletedDir, subFiles, subDirs);
@@ -182,6 +195,85 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     assertNotEquals(originalOmRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {"false,false", "false,true", "true,false", "true,true"})
+  public void testDirectoryPurge(boolean fromSnapshot, boolean purgeDirectory) throws Exception {
+    Random random = new Random();
+    String bucket = "bucket" + random.nextInt();
+    // Add volume, bucket and key entries to OM DB.
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucket,
+        omMetadataManager, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucket);
+    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    OmDirectoryInfo dir1 = new OmDirectoryInfo.Builder()
+        .setName("dir1")
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(1)
+        .setParentObjectID(bucketInfo.getObjectID())
+        .setUpdateID(0)
+        .build();
+    String dirKey = OMRequestTestUtils.addDirKeyToDirTable(false, dir1, volumeName, bucket,
+        1L, omMetadataManager);
+    List<OmKeyInfo> subFiles = new ArrayList<>();
+    List<OmKeyInfo> subDirs = new ArrayList<>();
+    List<String> deletedSubDirKeys = new ArrayList<>();
+    List<String> deletedSubFiles = new ArrayList<>();
+    for (int id = 1; id < 10; id++) {
+      OmDirectoryInfo subdir = new OmDirectoryInfo.Builder()
+          .setName("subdir" + id)
+          .setCreationTime(Time.now())
+          .setModificationTime(Time.now())
+          .setObjectID(2 * id)
+          .setParentObjectID(dir1.getObjectID())
+          .setUpdateID(0)
+          .build();
+      String subDirectoryPath = OMRequestTestUtils.addDirKeyToDirTable(false, subdir, volumeName, bucket,
+          2 * id, omMetadataManager);
+      System.out.println("Swaminathan " + subDirectoryPath);
+      OmKeyInfo subFile =
+          OMRequestTestUtils.createOmKeyInfo(volumeName, bucket, "file" + id, RatisReplicationConfig.getInstance(ONE))
+              .setObjectID(2 * id + 1)
+              .setParentObjectID(dir1.getObjectID())
+              .setUpdateID(100L)
+              .build();
+      String subFilePath = OMRequestTestUtils.addFileToKeyTable(false, true, keyName,
+          subFile, 1234L, 2 * id + 1, omMetadataManager);
+      subFile.setKeyName("dir1/" + subFile.getKeyName());
+      subFiles.add(subFile);
+      subDirs.add(getOmKeyInfo(volumeName, bucket, subdir,
+          "dir1/" + subdir.getName()));
+      deletedSubDirKeys.add(omMetadataManager.getOzoneDeletePathKey(subdir.getObjectID(), subDirectoryPath));
+      deletedSubFiles.add(omMetadataManager.getOzoneDeletePathKey(subFile.getObjectID(),
+          omMetadataManager.getOzoneKey(volumeName, bucket, subFile.getKeyName())));
+    }
+    String deletedDirKey = OMRequestTestUtils.deleteDir(dirKey, volumeName, bucket, omMetadataManager);
+    SnapshotInfo snapshotInfo = null;
+    if (fromSnapshot) {
+      snapshotInfo = createSnapshot(volumeName, bucket, "snapshot");
+    }
+
+    OMRequest omRequest = createPurgeKeysRequest(snapshotInfo == null ? null : snapshotInfo.getTableKey(),
+        purgeDirectory ? deletedDirKey : null, subDirs, subFiles, bucketInfo);
+    OMRequest preExecutedRequest = preExecute(omRequest);
+    OMDirectoriesPurgeRequestWithFSO omKeyPurgeRequest =
+        new OMDirectoriesPurgeRequestWithFSO(preExecutedRequest);
+    OMDirectoriesPurgeResponseWithFSO omClientResponse = (OMDirectoriesPurgeResponseWithFSO) omKeyPurgeRequest
+        .validateAndUpdateCache(ozoneManager, 100L);
+    performBatchOperationCommit(omClientResponse);
+    try (UncheckedAutoCloseableSupplier<OmSnapshot> snapshot = fromSnapshot ? ozoneManager.getOmSnapshotManager()
+        .getSnapshot(snapshotInfo.getSnapshotId()) : null) {
+      OMMetadataManager metadataManager = fromSnapshot ? snapshot.get().getMetadataManager() :
+          ozoneManager.getMetadataManager();
+      validateDeletedKeys(metadataManager, deletedSubFiles);
+      List<String> deletedDirs = new ArrayList<>(deletedSubDirKeys);
+      if (!purgeDirectory) {
+        deletedDirs.add(deletedDirKey);
+      }
+      validateDeletedDirs(metadataManager, deletedDirs);
+    }
   }
 
   @Test
@@ -340,6 +432,22 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
       deletedKeyNames.add(keyName);
     }
     return deletedKeyNames;
+  }
+
+  private void validateDeletedDirs(OMMetadataManager omMetadataManager,
+      List<String> deletedDirs) throws IOException {
+    omMetadataManager.getDeletedDirTable().iterator().forEachRemaining(i -> {
+      try {
+        System.out.println("Swami " + i.getKey());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    for (String deletedDir : deletedDirs) {
+      System.out.println("Rishi " + deletedDir);
+      assertTrue(omMetadataManager.getDeletedDirTable().isExist(
+          deletedDir));
+    }
   }
 
   private void validateDeletedKeys(OMMetadataManager omMetadataManager,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Keys should not be purged from file table while processing deleted directories in snapshot & should be purged from AOS instead on purge path request.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11244

## How was this patch tested?
https://issues.apache.org/jira/browse/HDDS-11244