### PR TITLE
HDDS-13075. Fix default value in description of container placement policy configs

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -915,8 +915,8 @@
     <description>
       The full name of class which implements
       org.apache.hadoop.hdds.scm.PlacementPolicy.
-      The class decides which datanode will be used to host the container replica. If not set,
-      org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRandom will be used as default
+      The class decides which datanode will be used to host the container replica.
+      org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware will be used as default
       value.
     </description>
   </property>
@@ -928,7 +928,7 @@
       The full name of class which implements
       org.apache.hadoop.hdds.scm.PlacementPolicy.
       The class decides which datanode will be used to host the container replica in EC mode. If not set,
-      org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRandom will be used as default
+      org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware will be used as default
       value.
     </description>
   </property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -915,7 +915,7 @@
     <description>
       The full name of class which implements
       org.apache.hadoop.hdds.scm.PlacementPolicy.
-      The class decides which datanode will be used to host the container replica.
+      The class decides which datanode will be used to host the container replica. If not set,
       org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware will be used as default
       value.
     </description>
@@ -928,7 +928,7 @@
       The full name of class which implements
       org.apache.hadoop.hdds.scm.PlacementPolicy.
       The class decides which datanode will be used to host the container replica in EC mode. If not set,
-      org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware will be used as default
+      org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackScatter will be used as default
       value.
     </description>
   </property>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
@@ -62,7 +62,6 @@ public final class ContainerPlacementPolicyFactory {
       ConfigurationSource conf, final NodeManager nodeManager,
       NetworkTopology clusterMap, final boolean fallback,
       SCMContainerPlacementMetrics metrics) throws SCMException {
-    // TODO: Change default placement policy for EC
     final Class<? extends PlacementPolicy> placementClass = conf
         .getClass(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_EC_IMPL_KEY,
             OZONE_SCM_CONTAINER_PLACEMENT_EC_IMPL_DEFAULT,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
@@ -38,7 +38,7 @@ public final class ContainerPlacementPolicyFactory {
 
   private static final Class<? extends PlacementPolicy>
       OZONE_SCM_CONTAINER_PLACEMENT_IMPL_DEFAULT =
-      SCMContainerPlacementRandom.class;
+      SCMContainerPlacementRackAware.class;
   private static final Class<? extends PlacementPolicy>
       OZONE_SCM_CONTAINER_PLACEMENT_EC_IMPL_DEFAULT =
       SCMContainerPlacementRackScatter.class;


### PR DESCRIPTION

## What changes were proposed in this pull request?
The description of` ozone.scm.container.placement.impl` and `ozone.scm.container.placement.ec.impl `has been updated to show that the default property used is` SCMContainerPlacementRackAware`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13075

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/15186737895
