### PR TITLE
HDDS-13055. [DiskBalancer] Add micro benchmark to test container choosing efficiency

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/ContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/ContainerChoosingPolicy.java
@@ -28,7 +28,10 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 public interface ContainerChoosingPolicy {
   /**
    * Choose a container for balancing.
-   *
+   * @param ozoneContainer the OzoneContainer instance to get all containers of a particular volume.
+   * @param volume the HddsVolume instance to choose containers from.
+   * @param inProgressContainerIDs containerIDs present in this set should be
+   - avoided as these containers are already under move by diskBalancer.
    * @return a Container
    */
   ContainerData chooseContainer(OzoneContainer ozoneContainer,


### PR DESCRIPTION
## What changes were proposed in this pull request?
This JIRA tracks the addition of a micro-benchmark test to evaluate the performance and efficiency of container selection logic in DiskBalancer.
There is no any code changes in this PR.

Test Scenario: Test the container choosing efficiency.
SetUp:
Set up a cluster with one DN with 20 volume, and total 100 containers.
Then run the diskbalancer command to test the container choosing efficiency. 
Expected Behaviour: 
Containers should be effectively chosen for balancing. No empty containers, open containers, containers under replication and container balancing containers should not be chosen.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13055

## How was this patch tested?

Ran performance test.
