### PR TITLE
HDDS-12817: Add EC block index in the ozone debug replicas chunk-info

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
@@ -190,9 +190,12 @@ public class ChunkKeyHandler extends KeyHandler {
             }
 
             if (isECKey) {
-              ChunkType blockChunksType = isECParityBlock(keyPipeline, entry.getKey()) ?
-                  ChunkType.PARITY : ChunkType.DATA;
-              jsonObj.put("chunkType", blockChunksType.name());
+              int replicaIndex = keyPipeline.getReplicaIndex(entry.getKey());
+              int dataCount = ((ECReplicationConfig) keyPipeline.getReplicationConfig()).getData();
+
+              ChunkType chunkType = (replicaIndex > dataCount) ? ChunkType.PARITY : ChunkType.DATA;
+              jsonObj.put("chunkType", chunkType.name());
+              jsonObj.put("ecIndex", replicaIndex);
             }
           }
         } catch (InterruptedException e) {
@@ -204,12 +207,5 @@ public class ChunkKeyHandler extends KeyHandler {
       String prettyJson = JsonUtils.toJsonStringWithDefaultPrettyPrinter(result);
       System.out.println(prettyJson);
     }
-  }
-
-  private boolean isECParityBlock(Pipeline pipeline, DatanodeDetails dn) {
-    //index is 1-based,
-    //e.g. for RS-3-2 we will have data indexes 1,2,3 and parity indexes 4,5
-    return pipeline.getReplicaIndex(dn) >
-        ((ECReplicationConfig) pipeline.getReplicationConfig()).getData();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current output of the chunk info of an EC key doesn't log the EC index.
As a result, it is impossible to determine if there has been any reconstruction of any node and if the DATA or PARITY block index has changed.
Adding the EC block index in the ozone debug replicas chunk-info output will give us an idea of the block placement across the datanodes.

Output json after the change
```
bash-5.1$ ozone debug replicas chunk-info vol/buck-ec/key
{
  "volumeName" : "vol",
  "bucketName" : "buck-ec",
  "name" : "key",
  "keyLocations" : [ [ {
    "datanode" : {..},
    "file" : "",
    "blockData" : {..},
    "chunkType" : "DATA",
    "ecIndex" : 2
  }, {
    "datanode" : {..},
    "file" : "/data/hdds/hdds/CID-4a301702-9de4-4168-b933-74e2ba22f337/current/containerDir0/1/chunks/115816896921600001.block",
    "blockData" : {..},
    "chunkType" : "PARITY",
    "ecIndex" : 5
  }, {
    "datanode" : {..},
    "file" : "/data/hdds/hdds/CID-4a301702-9de4-4168-b933-74e2ba22f337/current/containerDir0/1/chunks/115816896921600001.block",
    "blockData" : {..},
    "chunkType" : "DATA",
    "ecIndex" : 1
  }, {
    "datanode" : {..},
    "file" : "",
    "blockData" : {..},
    "chunkType" : "DATA",
    "ecIndex" : 3
  }, {
    "datanode" : {..},
    "file" : "/data/hdds/hdds/CID-4a301702-9de4-4168-b933-74e2ba22f337/current/containerDir0/1/chunks/115816896921600001.block",
    "blockData" : {..},
    "chunkType" : "PARITY",
    "ecIndex" : 4
  } ] ]
}
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12817?filter=-1

## How was this patch tested?

This was tested manually in Docker setup.
