### PR TITLE
HDDS-13103. Correct transaction metrics in SCMBlockDeletingService.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -344,6 +344,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     ContainerBlocksDeletionACKProto blockDeletionACK = null;
     long startTime = Time.monotonicNow();
     boolean cmdExecuted = false;
+    int successCount = 0, failedCount = 0;
     try {
       // move blocks to deleting state.
       // this is a metadata update, the actual deletion happens in another
@@ -381,7 +382,6 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       // Send ACK back to SCM as long as meta updated
       // TODO Or we should wait until the blocks are actually deleted?
       if (!containerBlocks.isEmpty()) {
-        int successCount = 0, failedCount = 0;
 
         for (DeleteBlockTransactionResult result : blockDeletionACK.getResultsList()) {
           boolean success = result.getSuccess();
@@ -399,8 +399,6 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
             blockDeleteMetrics.incrProcessedTransactionFailCount(1);
           }
         }
-        LOG.info("Sending deletion ACK to SCM, successTransactionCount = {}," +
-            "failedTransactionCount= {}", successCount, failedCount);
       }
       cmdExecuted = true;
     } finally {
@@ -418,6 +416,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       updateCommandStatus(cmd.getContext(), cmd.getCmd(), statusUpdater, LOG);
       long endTime = Time.monotonicNow();
       this.opsLatencyMs.add(endTime - startTime);
+      LOG.info("Sending deletion ACK to SCM, successTransactionCount = {}," +
+          "failedTransactionCount = {}, time elapsed = {}", successCount, failedCount, opsLatencyMs);
       invocationCount++;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -336,13 +336,17 @@ public class DeletedBlockLogImpl
         DeletedBlocksTransaction.newBuilder(tx)
             .setCount(transactionStatusManager.getRetryCount(tx.getTxID()))
             .build();
+    boolean flag = false;
     for (ContainerReplica replica : replicas) {
       final DatanodeID datanodeID = replica.getDatanodeDetails().getID();
       if (!transactionStatusManager.isDuplication(
           datanodeID, tx.getTxID(), commandStatus)) {
         transactions.addTransactionToDN(datanodeID, updatedTxn);
-        metrics.incrProcessedTransaction();
+        flag = true;
       }
+    }
+    if (flag) {
+      metrics.incrProcessedTransaction();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -217,6 +217,7 @@ public class SCMBlockDeletingService extends BackgroundService
               }
             }
           }
+          metrics.incrTotalBlockSentToDNForDeletion(transactions.getBlocksDeleted());
           LOG.info("Totally added {} blocks to be deleted for"
               + " {} datanodes / {} totalnodes, limit per iteration : {}blocks, task elapsed time: {}ms",
               transactions.getBlocksDeleted(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -199,7 +199,7 @@ public class SCMBlockDeletingService extends BackgroundService
               eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
                   new CommandForDatanode<>(dnId, command));
               metrics.incrBlockDeletionCommandSent();
-              metrics.incrBlockDeletionTransactionSent(dnTXs.size());
+              metrics.incrBlockDeletionTransactionsOnDatanodes(dnTXs.size());
               metrics.incrDNCommandsSent(dnId, 1);
               if (LOG.isDebugEnabled()) {
                 LOG.debug(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -455,11 +455,11 @@ public class SCMDeletedBlockTransactionStatusManager {
     for (DeleteBlockTransactionResult transactionResult :
         transactionResults) {
       if (isTransactionFailed(transactionResult)) {
-        metrics.incrBlockDeletionTransactionFailure();
+        metrics.incrBlockDeletionTransactionFailureOnDatanodes();
         continue;
       }
       try {
-        metrics.incrBlockDeletionTransactionSuccess();
+        metrics.incrBlockDeletionTransactionSuccessOnDatanodes();
         long txID = transactionResult.getTxID();
         // set of dns which have successfully committed transaction txId.
         final Set<DatanodeID> dnsWithCommittedTxn = transactionToDNsCommitMap.get(txID);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -393,7 +393,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         .append(numBlockDeletionTransactionSuccessOnDatanodes.value()).append('\t')
         .append("numBlockDeletionTransactionFailureOnDatanodes = ")
         .append(numBlockDeletionTransactionFailureOnDatanodes.value()).append('\t')
-        .append("numBlockAddedForDeletionToDN = " + numBlockAddedForDeletionToDN.value()).append("\t")
+        .append("numBlockAddedForDeletionToDN = " + numBlockAddedForDeletionToDN.value()).append('\t')
         .append("numDeletionCommandsPerDatanode = ").append(numCommandsDatanode);
     return buffer.toString();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -393,7 +393,8 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         .append(numBlockDeletionTransactionSuccessOnDatanodes.value()).append('\t')
         .append("numBlockDeletionTransactionFailureOnDatanodes = ")
         .append(numBlockDeletionTransactionFailureOnDatanodes.value()).append('\t')
-        .append("numBlockAddedForDeletionToDN = " + numBlockAddedForDeletionToDN.value()).append('\t')
+        .append("numBlockAddedForDeletionToDN = ")
+        .append(numBlockAddedForDeletionToDN.value()).append('\t')
         .append("numDeletionCommandsPerDatanode = ").append(numCommandsDatanode);
     return buffer.toString();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -95,6 +95,9 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @Metric(about = "The number of dataNodes of delete transactions.")
   private MutableGaugeLong numBlockDeletionTransactionDataNodes;
 
+  @Metric(about = "Total blocks sent to DN for deletion.")
+  private MutableGaugeLong numBlockAddedForDeletionToDN;
+
   private final Map<DatanodeID, DatanodeCommandDetails> numCommandsDatanode = new ConcurrentHashMap<>();
 
   private ScmBlockDeletingServiceMetrics() {
@@ -189,6 +192,10 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         .incrBlocksSent(delta);
   }
 
+  public void incrTotalBlockSentToDNForDeletion(long count) {
+    this.numBlockAddedForDeletionToDN.incr(count);
+  }
+
   public long getNumBlockDeletionCommandSent() {
     return numBlockDeletionCommandSent.value();
   }
@@ -247,6 +254,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     numSkippedTransactions.snapshot(builder, all);
     numProcessedTransactions.snapshot(builder, all);
     numBlockDeletionTransactionDataNodes.snapshot(builder, all);
+    numBlockAddedForDeletionToDN.snapshot(builder, all);
 
     MetricsRecordBuilder recordBuilder = builder;
     for (Map.Entry<DatanodeID, DatanodeCommandDetails> e : numCommandsDatanode.entrySet()) {
@@ -385,6 +393,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         .append(numBlockDeletionTransactionSuccessOnDatanodes.value()).append('\t')
         .append("numBlockDeletionTransactionFailureOnDatanodes = ")
         .append(numBlockDeletionTransactionFailureOnDatanodes.value()).append('\t')
+        .append("numBlockAddedForDeletionToDN = " + numBlockAddedForDeletionToDN.value()).append("\t")
         .append("numDeletionCommandsPerDatanode = ").append(numCommandsDatanode);
     return buffer.toString();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -72,13 +72,13 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
 
   @Metric(about = "The number of individual delete transactions sent to " +
       "all DN.")
-  private MutableCounterLong numBlockDeletionTransactionSent;
+  private MutableCounterLong numBlockDeletionTransactionsOnDatanodes;
 
   @Metric(about = "The number of success execution of delete transactions.")
-  private MutableCounterLong numBlockDeletionTransactionSuccess;
+  private MutableCounterLong numBlockDeletionTransactionSuccessOnDatanodes;
 
   @Metric(about = "The number of failure execution of delete transactions.")
-  private MutableCounterLong numBlockDeletionTransactionFailure;
+  private MutableCounterLong numBlockDeletionTransactionFailureOnDatanodes;
 
   @Metric(about = "The number of completed txs which are removed from DB.")
   private MutableCounterLong numBlockDeletionTransactionCompleted;
@@ -132,16 +132,16 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     this.numBlockDeletionCommandFailure.incr();
   }
 
-  public void incrBlockDeletionTransactionSent(long count) {
-    this.numBlockDeletionTransactionSent.incr(count);
+  public void incrBlockDeletionTransactionsOnDatanodes(long count) {
+    this.numBlockDeletionTransactionsOnDatanodes.incr(count);
   }
 
-  public void incrBlockDeletionTransactionFailure() {
-    this.numBlockDeletionTransactionFailure.incr();
+  public void incrBlockDeletionTransactionFailureOnDatanodes() {
+    this.numBlockDeletionTransactionFailureOnDatanodes.incr();
   }
 
-  public void incrBlockDeletionTransactionSuccess() {
-    this.numBlockDeletionTransactionSuccess.incr();
+  public void incrBlockDeletionTransactionSuccessOnDatanodes() {
+    this.numBlockDeletionTransactionSuccessOnDatanodes.incr();
   }
 
   public void incrBlockDeletionTransactionCompleted(long count) {
@@ -196,16 +196,16 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     return numBlockDeletionCommandFailure.value();
   }
 
-  public long getNumBlockDeletionTransactionSent() {
-    return numBlockDeletionTransactionSent.value();
+  public long getNumBlockDeletionTransactionsOnDatanodes() {
+    return numBlockDeletionTransactionsOnDatanodes.value();
   }
 
-  public long getNumBlockDeletionTransactionFailure() {
-    return numBlockDeletionTransactionFailure.value();
+  public long getNumBlockDeletionTransactionFailureOnDatanodes() {
+    return numBlockDeletionTransactionFailureOnDatanodes.value();
   }
 
-  public long getNumBlockDeletionTransactionSuccess() {
-    return numBlockDeletionTransactionSuccess.value();
+  public long getNumBlockDeletionTransactionSuccessOnDatanodes() {
+    return numBlockDeletionTransactionSuccessOnDatanodes.value();
   }
 
   public long getNumBlockDeletionTransactionCompleted() {
@@ -234,9 +234,9 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     numBlockDeletionCommandSent.snapshot(builder, all);
     numBlockDeletionCommandSuccess.snapshot(builder, all);
     numBlockDeletionCommandFailure.snapshot(builder, all);
-    numBlockDeletionTransactionSent.snapshot(builder, all);
-    numBlockDeletionTransactionSuccess.snapshot(builder, all);
-    numBlockDeletionTransactionFailure.snapshot(builder, all);
+    numBlockDeletionTransactionsOnDatanodes.snapshot(builder, all);
+    numBlockDeletionTransactionSuccessOnDatanodes.snapshot(builder, all);
+    numBlockDeletionTransactionFailureOnDatanodes.snapshot(builder, all);
     numBlockDeletionTransactionCompleted.snapshot(builder, all);
     numBlockDeletionTransactionCreated.snapshot(builder, all);
     numSkippedTransactions.snapshot(builder, all);
@@ -363,9 +363,12 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         .append("numBlockDeletionCommandSent = ").append(numBlockDeletionCommandSent.value()).append('\t')
         .append("numBlockDeletionCommandSuccess = ").append(numBlockDeletionCommandSuccess.value()).append('\t')
         .append("numBlockDeletionCommandFailure = ").append(numBlockDeletionCommandFailure.value()).append('\t')
-        .append("numBlockDeletionTransactionSent = ").append(numBlockDeletionTransactionSent.value()).append('\t')
-        .append("numBlockDeletionTransactionSuccess = ").append(numBlockDeletionTransactionSuccess.value()).append('\t')
-        .append("numBlockDeletionTransactionFailure = ").append(numBlockDeletionTransactionFailure.value()).append('\t')
+        .append("numBlockDeletionTransactionsOnDatanodes = ").append(numBlockDeletionTransactionsOnDatanodes.value())
+        .append('\t')
+        .append("numBlockDeletionTransactionSuccessOnDatanodes = ")
+        .append(numBlockDeletionTransactionSuccessOnDatanodes.value()).append('\t')
+        .append("numBlockDeletionTransactionFailureOnDatanodes = ")
+        .append(numBlockDeletionTransactionFailureOnDatanodes.value()).append('\t')
         .append("numDeletionCommandsPerDatanode = ").append(numCommandsDatanode);
     return buffer.toString();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestSCMBlockDeletingService.java
@@ -130,7 +130,7 @@ public class TestSCMBlockDeletingService {
         metrics.getNumBlockDeletionCommandSent());
     // Echo Command has one Transaction
     assertEquals(datanodeDetails.size() * 1,
-        metrics.getNumBlockDeletionTransactionSent());
+        metrics.getNumBlockDeletionTransactionsOnDatanodes());
   }
 
   private void callDeletedBlockTransactionScanner() throws Exception {

--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
@@ -2779,7 +2779,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "(scm_block_deleting_service_num_block_deletion_transaction_success / clamp_min(scm_block_deleting_service_num_block_deletion_transaction_sent, 1)) * 100",
+              "expr": "(scm_block_deleting_service_num_block_deletion_transaction_success_on_datanodes / clamp_min(scm_block_deleting_service_num_block_deletion_transactions_on_datanodes, 1)) * 100",
               "legendFormat": "{{hostname}}",
               "range": true,
               "refId": "A"
@@ -3262,7 +3262,7 @@
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "scm_block_deleting_service_num_block_deletion_transaction_sent",
+              "expr": "scm_block_deleting_service_num_block_deletion_transactions_on_datanodes",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{hostname}}",
@@ -3544,7 +3544,7 @@
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "scm_block_deleting_service_num_block_deletion_transaction_failure",
+              "expr": "scm_block_deleting_service_num_block_deletion_transaction_failure_on_datanodes",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -262,7 +262,7 @@ public class TestBlockDeletion {
     assertTrue(
         e.getMessage().startsWith("expected: <null> but was:"));
 
-    assertEquals(0L, metrics.getNumBlockDeletionTransactionSent());
+    assertEquals(0L, metrics.getNumBlockDeletionTransactionsOnDatanodes());
     // close the containers which hold the blocks for the key
     OzoneTestUtils.closeAllContainers(scm.getEventQueue(), scm);
 
@@ -322,9 +322,9 @@ public class TestBlockDeletion {
     assertThat(metrics.getNumBlockDeletionCommandSent())
         .isGreaterThanOrEqualTo(metrics.getNumBlockDeletionCommandSuccess() +
             metrics.getBNumBlockDeletionCommandFailure());
-    assertThat(metrics.getNumBlockDeletionTransactionSent())
-        .isGreaterThanOrEqualTo(metrics.getNumBlockDeletionTransactionFailure() +
-            metrics.getNumBlockDeletionTransactionSuccess());
+    assertThat(metrics.getNumBlockDeletionTransactionsOnDatanodes())
+        .isGreaterThanOrEqualTo(metrics.getNumBlockDeletionTransactionFailureOnDatanodes() +
+            metrics.getNumBlockDeletionTransactionSuccessOnDatanodes());
     LOG.info(metrics.toString());
 
     // Datanode should receive retried requests with continuous retry counts.


### PR DESCRIPTION
## What changes were proposed in this pull request?


NumBlockDeletionTransactionCreated and NumBlockDeletionTransactionCompleted metrics are updated at each transaction level.

Whereas NumBlockDeletionTransactionSent, NumBlockDeletionTransactionSuccess and NumBlockDeletionTransactionFailure are updated depending on the transactions sent to DN. If the same transaction is sent to 3 DN(as blocks will reside in 3 DNs for Ratis-3), these metrics are updated 3 times.

By looking into below metrics it looks, 1731 transactions are sent and only 577 are completed. But actually 1731 = 577 * 3.

```
    "name" : "Hadoop:service=StorageContainerManager,name=SCMBlockDeletingService",
    "modelerType" : "SCMBlockDeletingService",
    "tag.Hostname" : "ccycloud-3.obsdeletion-719.root.comops.site",
    "NumBlockDeletionCommandSent" : 3,
    "NumBlockDeletionCommandSuccess" : 3,
    "NumBlockDeletionCommandFailure" : 0,
    "NumBlockDeletionTransactionSent" : 1731,
    "NumBlockDeletionTransactionSuccess" : 1731,
    "NumBlockDeletionTransactionFailure" : 0,
    "NumBlockDeletionTransactionCompleted" : 577,
    "NumBlockDeletionTransactionCreated" : 5672,
    "NumSkippedTransactions" : 23909618,
    "NumProcessedTransactions" : 1731, 
```
We should have proper naming or have consistent metrics for user to understand.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13103

## How was this patch tested?

Tested Manually.
