### PR TITLE
HDDS-13104. Move auditparser acceptance tests under debug

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-debug-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-debug-tools.sh
@@ -25,6 +25,7 @@ export COMPOSE_DIR
 export SECURITY_ENABLED=true
 export OM_SERVICE_ID=omservice
 export SCM=scm1.org
+export OM=om1
 export COMPOSE_FILE=docker-compose.yaml:debug-tools.yaml
 export OZONE_DIR=/opt/hadoop
 
@@ -49,6 +50,10 @@ fi
 source "$COMPOSE_DIR/../testlib.sh"
 
 start_docker_env
+
+execute_robot_test ${OM} kinit.robot
+
+execute_robot_test ${OM} debug/auditparser.robot
 
 execute_robot_test ${SCM} kinit.robot
 

--- a/hadoop-ozone/dist/src/main/smoketest/debug/auditparser.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/auditparser.robot
@@ -22,16 +22,11 @@ Resource            ../ozone-lib/freon.robot
 Test Timeout        5 minutes
 
 *** Variables ***
-${user}              hadoop
+${user}              testuser/om@EXAMPLE.COM
 ${buckets}           5
 ${auditworkdir}      /tmp
 
 *** Keywords ***
-Set username
-    ${hostname} =          Execute         hostname
-    Set Suite Variable     ${user}         testuser/${hostname}@EXAMPLE.COM
-    [return]               ${user}
-
 Create data
     Freon OMBG    prefix=auditparser    n=${buckets}
     Freon OCKG    prefix=auditparser    n=100
@@ -46,7 +41,6 @@ Testing audit parser
     ${result} =        Execute              ozone debug auditparser "${auditworkdir}/audit.db" template top5cmds
                        Should Contain       ${result}  ALLOCATE_KEY
     ${result} =        Execute              ozone debug auditparser "${auditworkdir}/audit.db" template top5users
-    Run Keyword If     '${SECURITY_ENABLED}' == 'true'      Set username
                        Should Contain       ${result}  ${user}
     ${result} =        Execute              ozone debug auditparser "${auditworkdir}/audit.db" query "select count(*) from audit where op='CREATE_VOLUME' and RESULT='SUCCESS'"
     ${result} =        Convert To Number     ${result}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the `auditparser` robot tests have a separate directory in the smoketest folder. After the auditparser tool was moved under `ozone debug` in [HDDS-12520](https://issues.apache.org/jira/browse/HDDS-12520) we should move the robot tests to one place too.

## What is the link to the Apache JIRA
[HDDS-13104](https://issues.apache.org/jira/browse/HDDS-13104)

## How was this patch tested?
Tested locally on a docker cluster.
```
==============================================================================
Auditparser :: Smoketest ozone cluster startup                                
==============================================================================
Testing audit parser                                                  | PASS |
------------------------------------------------------------------------------
Auditparser :: Smoketest ozone cluster startup                        | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/ozonesecure-ha/result/robot-002.xml
```