### PR TITLE
HDDS-13011. Disable Snapshot DAG Pruner Thread.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4350,15 +4350,6 @@
       Interval in MINUTES by Recon to request SCM DB Snapshot.
     </description>
   </property>
-  <property>
-    <name>ozone.om.snapshot.compaction.dag.max.time.allowed</name>
-    <value>30d</value>
-    <tag>OZONE, OM</tag>
-    <description>
-      Maximum time a snapshot is allowed to be in compaction DAG before it gets pruned out by pruning daemon.
-      Uses millisecond by default when no time unit is specified.
-    </description>
-  </property>
 
   <property>
     <name>ozone.om.snapshot.prune.compaction.backup.batch.size</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After snapshot compaction is implemented although the content of the snapshot dbs will remain the same, the file names might change. We will need to disable DAG pruner and not remove source files of older compactions to be able to perform diff.
With [#8214](https://github.com/apache/ozone/pull/8214) the storage footprint of the SST backup dir will be reduced so we this change shouldn't affect the storage footprint adversely.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13011

## How was this patch tested?

Manual test
