### PR TITLE
HDDS-13150. Fixed SnapshotLimitCheck when failures occur.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -202,6 +202,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
       omClientResponse = new OMSnapshotCreateResponse(
           createErrorOMResponse(omResponse, exception));
     } finally {
+      ozoneManager.getOmSnapshotManager().decrementInFlightSnapshotCount();
       if (acquiredSnapshotLock) {
         mergeOmLockDetails(
             omMetadataManager.getLock().releaseWriteLock(SNAPSHOT_LOCK,
@@ -291,8 +292,6 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
         removeSnapshotInfoFromSnapshotChainManager(snapshotChainManager,
             snapshotInfo);
         throw new IOException(exception.getMessage(), exception);
-      } finally {
-        ozoneManager.getOmSnapshotManager().decrementInFlightSnapshotCount();
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -318,6 +318,7 @@ public class TestOMSnapshotCreateRequest extends TestSnapshotRequestAndResponse 
     assertEquals(OMException.ResultCodes.TOO_MANY_SNAPSHOTS, omException.getResult());
   }
 
+  @DisplayName("Snapshot limit is enforced even after failed creation attempts")
   @Test
   public void testSnapshotLimitWithFailures() throws Exception {
     when(getOzoneManager().isAdmin(any())).thenReturn(true);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In-flight snapshots requests are not decremented when a snapshot create request fails for ex., because snapshot already exists. This causes new snapshot requests to fail even though snapshots have not reached the limit. 
Provided a fix for this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13150

## How was this patch tested?

Unit Test: `org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest#testSnapshotLimitWithFailures`

Without this fix the test fails with 
```
// When snapshot_limit=2. We created 1 snapshot. 1 Snapshot create fails. We try to create a snapshot after a previous request fails.
[ERROR] org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest.testSnapshotLimitWithFailures -- Time elapsed: 3.833 s <<< ERROR!
TOO_MANY_SNAPSHOTS org.apache.hadoop.ozone.om.exceptions.OMException: Snapshot limit of 2 reached. Cannot create more snapshots. Current snapshots: 1, In-flight creations: 1 If you already deleted some snapshots, please wait for the background service to complete the cleanup.
...
org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotCreateRequest.preExecute(OMSnapshotCreateRequest.java:124)
	at org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest.doPreExecute(TestOMSnapshotCreateRequest.java:444)
	at org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest.doPreExecute(TestOMSnapshotCreateRequest.java:432)
	at org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest.testSnapshotLimitWithFailures(TestOMSnapshotCreateRequest.java:348)  
```
