### PR TITLE
HDDS-13159. Refactor KeyManagerImpl for getting deleted subdirectories and deleted subFiles

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -720,6 +720,22 @@ public final class OMFileRequest {
     return null;
   }
 
+  public static OmKeyInfo getKeyInfoWithFullPath(OmKeyInfo parentInfo, OmDirectoryInfo directoryInfo) {
+    String dirName = OMFileRequest.getAbsolutePath(parentInfo.getKeyName(),
+        directoryInfo.getName());
+    return OMFileRequest.getOmKeyInfo(
+        parentInfo.getVolumeName(), parentInfo.getBucketName(), directoryInfo,
+        dirName);
+  }
+
+  public static OmKeyInfo getKeyInfoWithFullPath(OmKeyInfo parentInfo, OmKeyInfo omKeyInfo) {
+    omKeyInfo.setFileName(omKeyInfo.getKeyName());
+    String fullKeyPath = OMFileRequest.getAbsolutePath(
+        parentInfo.getKeyName(), omKeyInfo.getKeyName());
+    omKeyInfo.setKeyName(fullKeyPath);
+    return omKeyInfo;
+  }
+
   /**
    * Prepare OmKeyInfo from OmDirectoryInfo.
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the KeyManager class implementation function for getting subFiles and subDirectories are very similar to one another barring the transforming function. By modularising a lot of duplication in logic can be reduced simplifying the entire implementation.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13159

## How was this patch tested?
Just refactoring no tests required