### PR TITLE
HDDS-12896. ozone admin scm roles inconsistent command output

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMFailoverProxyProviderBase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMFailoverProxyProviderBase.java
@@ -117,7 +117,7 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
     this.maxRetryCount = scmClientConfig.getRetryCount();
     this.retryInterval = scmClientConfig.getRetryInterval();
 
-    getLogger().info("Created fail-over proxy for protocol {} with {} nodes: {}", protocol.getSimpleName(),
+    getLogger().debug("Created fail-over proxy for protocol {} with {} nodes: {}", protocol.getSimpleName(),
         scmNodeIds.size(), scmProxyInfoMap.values());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In Ozone 2.0, additional log messages (INFO level) were appearing in the terminal output of `ozone admin scm roles` and `ozone admin pipeline list`, making the command's output less readable. This change adjusts the logging level of those messages to DEBUG to restore the cleaner CLI output.
A sample of the issue is shown in the linked JIRA for reference.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12896

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/15384489838
