### PR TITLE
HDDS-13166. Set pipeline ID in BlockExistenceVerifier to avoid cached pipeline with different node

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/BlockExistenceVerifier.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/BlockExistenceVerifier.java
@@ -56,6 +56,7 @@ public class BlockExistenceVerifier implements ReplicaVerifier {
     XceiverClientSpi client = null;
     try {
       Pipeline pipeline = Pipeline.newBuilder(keyLocation.getPipeline())
+          .setId(datanode.getID())
           .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
           .setNodes(Collections.singletonList(datanode))
           .setReplicaIndexes(Collections.singletonMap(datanode, replicaIndex))


### PR DESCRIPTION
## What changes were proposed in this pull request?
Set the datanode ID as the pipeline ID when a new pipeline is created for the block existence verification tool.

Refer: [HDDS-13073](https://issues.apache.org/jira/browse/HDDS-13073) [PR#8480](https://github.com/apache/ozone/pull/8480)
## What is the link to the Apache JIRA
[HDDS-13166](https://issues.apache.org/jira/browse/HDDS-13166)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/15409875349
