### PR TITLE
HDDS-13170. Reclaimable filter should always reclaim entries when buckets and volumes have already been deleted

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
@@ -48,12 +48,14 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.hadoop.ozone.om.BucketManager;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -159,19 +161,28 @@ public abstract class AbstractReclaimableFilterTest {
 
   private void mockOzoneManager(BucketLayout bucketLayout) throws IOException {
     OMMetadataManager metadataManager = mock(OMMetadataManager.class);
+    BucketManager bucketManager = mock(BucketManager.class);
     when(ozoneManager.getMetadataManager()).thenReturn(metadataManager);
+    when(ozoneManager.getBucketManager()).thenReturn(bucketManager);
     long volumeCount = 0;
-    long bucketCount = 0;
     for (String volume : volumes) {
       when(metadataManager.getVolumeId(eq(volume))).thenReturn(volumeCount);
-      for (String bucket : buckets) {
-        when(ozoneManager.getBucketInfo(eq(volume), eq(bucket)))
-            .thenReturn(OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
-                .setObjectID(bucketCount).setBucketLayout(bucketLayout).build());
-        bucketCount++;
-      }
       volumeCount++;
     }
+
+    when(bucketManager.getBucketInfo(anyString(), anyString())).thenAnswer(i -> {
+      String volume = i.getArgument(0, String.class);
+      String bucket = i.getArgument(1, String.class);
+      if (!volumes.contains(volume)) {
+        throw new OMException("Volume " + volume + " already exists", OMException.ResultCodes.VOLUME_NOT_FOUND);
+      }
+      if (!buckets.contains(bucket)) {
+        throw new OMException("Bucket " + bucket + " already exists", OMException.ResultCodes.BUCKET_NOT_FOUND);
+      }
+      return OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
+          .setObjectID((long) volumes.indexOf(volume) * buckets.size() + buckets.indexOf(bucket))
+          .setBucketLayout(bucketLayout).build();
+    });
   }
 
   private void mockOmSnapshotManager(OzoneManager om) throws RocksDBException, IOException {
@@ -232,7 +243,7 @@ public abstract class AbstractReclaimableFilterTest {
 
   protected List<SnapshotInfo> getLastSnapshotInfos(
       String volume, String bucket, int numberOfSnapshotsInChain, int index) {
-    List<SnapshotInfo> infos = getSnapshotInfos().get(getKey(volume, bucket));
+    List<SnapshotInfo> infos = getSnapshotInfos().getOrDefault(getKey(volume, bucket), Collections.emptyList());
     int endIndex = Math.min(index - 1, infos.size() - 1);
     return IntStream.range(endIndex - numberOfSnapshotsInChain + 1, endIndex + 1).mapToObj(i -> i >= 0 ?
         infos.get(i) : null).collect(Collectors.toList());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
@@ -174,10 +174,10 @@ public abstract class AbstractReclaimableFilterTest {
       String volume = i.getArgument(0, String.class);
       String bucket = i.getArgument(1, String.class);
       if (!volumes.contains(volume)) {
-        throw new OMException("Volume " + volume + " already exists", OMException.ResultCodes.VOLUME_NOT_FOUND);
+        throw new OMException("Volume " + volume + " doesn't exist", OMException.ResultCodes.VOLUME_NOT_FOUND);
       }
       if (!buckets.contains(bucket)) {
-        throw new OMException("Bucket " + bucket + " already exists", OMException.ResultCodes.BUCKET_NOT_FOUND);
+        throw new OMException("Bucket " + bucket + " doesn't exist", OMException.ResultCodes.BUCKET_NOT_FOUND);
       }
       return OmBucketInfo.newBuilder().setVolumeName(volume).setBucketName(bucket)
           .setObjectID((long) volumes.indexOf(volume) * buckets.size() + buckets.indexOf(bucket))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableDirFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableDirFilter.java
@@ -72,7 +72,7 @@ public class TestReclaimableDirFilter extends AbstractReclaimableFilterTest {
     List<SnapshotInfo> snapshotInfos = getLastSnapshotInfos(volume, bucket, 1, index);
     assertEquals(snapshotInfos.size(), 1);
     SnapshotInfo prevSnapshotInfo = snapshotInfos.get(0);
-    OmBucketInfo bucketInfo = getOzoneManager().getBucketInfo(volume, bucket);
+    OmBucketInfo bucketInfo = getOzoneManager().getBucketManager().getBucketInfo(volume, bucket);
     long volumeId = getOzoneManager().getMetadataManager().getVolumeId(volume);
     KeyManager keyManager = getKeyManager();
     if (prevSnapshotInfo != null) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableFilter.java
@@ -132,6 +132,36 @@ public class TestReclaimableFilter extends AbstractReclaimableFilterTest {
 
   @ParameterizedTest
   @MethodSource("testReclaimableFilterArguments")
+  public void testReclaimableFilterSnapshotChainInitializationWithInvalidVolume(
+      int numberOfPreviousSnapshotsFromChain, int actualNumberOfSnapshots)
+      throws IOException, RocksDBException {
+    SnapshotInfo currentSnapshotInfo =
+        setup(numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots, actualNumberOfSnapshots + 1, 4, 2);
+    String volume = "volume" + 6;
+    String bucket = getBuckets().get(1);
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, true, true);
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, false, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testReclaimableFilterArguments")
+  public void testReclaimableFilterSnapshotChainInitializationWithInvalidBucket(
+      int numberOfPreviousSnapshotsFromChain, int actualNumberOfSnapshots)
+      throws IOException, RocksDBException {
+    SnapshotInfo currentSnapshotInfo =
+        setup(numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots, actualNumberOfSnapshots + 1, 4, 2);
+    String volume = getVolumes().get(3);
+    String bucket = "bucket" + 6;
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, true, true);
+    testSnapshotInitAndLocking(volume, bucket, numberOfPreviousSnapshotsFromChain, actualNumberOfSnapshots + 1,
+        currentSnapshotInfo, false, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testReclaimableFilterArguments")
   public void testReclaimableFilterWithBucketVolumeMismatch(
       int numberOfPreviousSnapshotsFromChain, int actualNumberOfSnapshots, int index)
       throws IOException, RocksDBException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
@@ -101,7 +101,7 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
     List<SnapshotInfo> snapshotInfos = getLastSnapshotInfos(volume, bucket, 2, index);
     SnapshotInfo previousToPreviousSapshotInfo = snapshotInfos.get(0);
     SnapshotInfo prevSnapshotInfo = snapshotInfos.get(1);
-    OmBucketInfo bucketInfo = getOzoneManager().getBucketInfo(volume, bucket);
+    OmBucketInfo bucketInfo = getOzoneManager().getBucketManager().getBucketInfo(volume, bucket);
     long volumeId = getOzoneManager().getMetadataManager().getVolumeId(volume);
 
     UncheckedAutoCloseableSupplier<OmSnapshot> prevSnap = Optional.ofNullable(prevSnapshotInfo)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableRenameEntryFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableRenameEntryFilter.java
@@ -80,7 +80,7 @@ public class TestReclaimableRenameEntryFilter extends AbstractReclaimableFilterT
       throws IOException {
     List<SnapshotInfo> snapshotInfos = getLastSnapshotInfos(volume, bucket, 1, index);
     SnapshotInfo prevSnapshotInfo = snapshotInfos.get(0);
-    OmBucketInfo bucketInfo = getOzoneManager().getBucketInfo(volume, bucket);
+    OmBucketInfo bucketInfo = getOzoneManager().getBucketManager().getBucketInfo(volume, bucket);
     if (prevSnapshotInfo != null) {
       UncheckedAutoCloseableSupplier<OmSnapshot> prevSnap = Optional.ofNullable(prevSnapshotInfo)
           .map(info -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently ReclaimableFilter expects the bucket info to be present while initializing the snapshot chain but it could so happen that the bucket could have been deleted with all the entries belonging to the bucket present in the deletedTable & deleted directory table. Reclaimable filter should always return a true if the bucket or volume is not present.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13170

## How was this patch tested?
Additional unit tests 