### PR TITLE
HDDS-12817. Addendum rename ecIndex to replicaIndex in chunkinfo output

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
@@ -196,7 +196,7 @@ public class ChunkKeyHandler extends KeyHandler {
               // e.g. for RS-3-2 we will have data indexes 1,2,3 and parity indexes 4,5
               ChunkType chunkType = (replicaIndex > dataCount) ? ChunkType.PARITY : ChunkType.DATA;
               jsonObj.put("chunkType", chunkType.name());
-              jsonObj.put("ecIndex", replicaIndex);
+              jsonObj.put("replicaIndex", replicaIndex);
             }
           }
         } catch (InterruptedException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Renaming key name from ecIndex to replicaIndex as suggested in the previous PR.
Output JSON after the change https://github.com/apache/ozone/pull/8515

```
bash-5.1$ ozone debug replicas chunk-info vol/buck-ec/key
{
  "volumeName" : "vol",
  "bucketName" : "buck-ec",
  "name" : "key",
  "keyLocations" : [ [ {
    "datanode" : {..},
    "file" : "",
    "blockData" : {..},
    "chunkType" : "DATA",
    "replicaIndex" : 2
  }, {
    "datanode" : {..},
    "file" : "/data/hdds/hdds/CID-4a301702-9de4-4168-b933-74e2ba22f337/current/containerDir0/1/chunks/115816896921600001.block",
    "blockData" : {..},
    "chunkType" : "PARITY",
    "replicaIndex" : 5
  }, {
    "datanode" : {..},
    "file" : "/data/hdds/hdds/CID-4a301702-9de4-4168-b933-74e2ba22f337/current/containerDir0/1/chunks/115816896921600001.block",
    "blockData" : {..},
    "chunkType" : "DATA",
    "replicaIndex" : 1
  }, {
    "datanode" : {..},
    "file" : "",
    "blockData" : {..},
    "chunkType" : "DATA",
    "replicaIndex" : 3
  }, {
    "datanode" : {..},
    "file" : "/data/hdds/hdds/CID-4a301702-9de4-4168-b933-74e2ba22f337/current/containerDir0/1/chunks/115816896921600001.block",
    "blockData" : {..},
    "chunkType" : "PARITY",
    "replicaIndex" : 4
  } ] ]
}
```

What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-12817?filter=-1

How was this patch tested?
This was tested manually in a Docker setup.