### PR TITLE
HDDS-13169. Intermittent failure in testSnapshotOperationsNotBlockedDuringCompaction

### DIFF
--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -68,8 +68,13 @@ for i in $(seq 1 ${ITERATIONS}); do
     mkdir -p "${REPORT_DIR}"
   fi
 
-  mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" verify \
-    | tee "${REPORT_DIR}/output.log"
+  if [[ $i -eq 1 ]]; then
+    mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" verify \
+      | tee "${REPORT_DIR}/output.log"
+  else
+    mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" clean verify \
+      | tee "${REPORT_DIR}/output.log"
+  fi
   irc=$?
 
   # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh


### PR DESCRIPTION
## What changes were proposed in this pull request?

```java
Error:  Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.617 s <<< FAILURE! -- in org.apache.hadoop.ozone.om.snapshot.TestSnapshotCache
Error:  org.apache.hadoop.ozone.om.snapshot.TestSnapshotCache.testSnapshotOperationsNotBlockedDuringCompaction -- Time elapsed: 0.086 s <<< FAILURE!
Wanted but not invoked:
dBStore.compactTable("table2");
-> at org.apache.hadoop.ozone.om.snapshot.TestSnapshotCache.testSnapshotOperationsNotBlockedDuringCompaction(TestSnapshotCache.java:416)

However, there were exactly 2 interactions with this mock:
dBStore.listTables();
-> at org.apache.hadoop.ozone.om.snapshot.SnapshotCache.compactSnapshotDB(SnapshotCache.java:84)

dBStore.compactTable("table1");
-> at org.apache.hadoop.ozone.om.snapshot.SnapshotCache.compactSnapshotDB(SnapshotCache.java:87)


	at org.apache.hadoop.ozone.om.snapshot.TestSnapshotCache.testSnapshotOperationsNotBlockedDuringCompaction(TestSnapshotCache.java:416)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13169

## How was this patch tested?

CI: https://github.com/peterxcli/ozone/actions/runs/15414041027
Flaky test check: https://github.com/peterxcli/ozone/actions/runs/15414057843