### PR TITLE
HDDS-12722. EC duplicate replica handling for same index in datanodes

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -275,11 +275,10 @@ public class ContainerReader implements Runnable {
       // This is an EC container. BCSID for both replica will be 0. If replica index of both replica is different,
       // then knowing which EC container to keep is not possible, so we leave both on disk.
       // Delete one of the replica only if replica index is same.
-      LOG.warn("Container {} is present at {} and at {}. Both are EC " +
-              "containers. Leaving both containers on disk.",
-          existing.getContainerData().getContainerID(),
-          existing.getContainerData().getContainerPath(),
-          toAdd.getContainerData().getContainerPath());
+      LOG.warn("EC Container {} is present at {} with index {} and at {} with index {}. " +
+              "Leaving both containers on disk.", existing.getContainerData().getContainerID(),
+          existing.getContainerData().getContainerPath(), toAdd.getContainerData().getContainerPath(),
+          existing.getContainerData().getReplicaIndex(), toAdd.getContainerData().getReplicaIndex());
       return false;
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -453,7 +453,7 @@ public class TestContainerReader {
         conflict22.close();
       } else if (i == 3) {
         ec1 = createContainerWithId(i, volumeSets, policy, baseBCSID, 1);
-        ec2 = createContainerWithId(i, volumeSets, policy, baseBCSID, 1);
+        ec2 = createContainerWithId(i, volumeSets, policy, baseBCSID, 2);
       } else {
         createContainerWithId(i, volumeSets, policy, baseBCSID, 0);
       }
@@ -516,7 +516,7 @@ public class TestContainerReader {
     assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
         containerSet.getContainer(2).getContainerData().getState());
 
-    // For the EC conflict, both containers should be left on disk
+    // For the EC conflict and index is different, then both containers should be left on disk
     assertTrue(Files.exists(Paths.get(ec1.getContainerData().getContainerPath())));
     assertTrue(Files.exists(Paths.get(ec2.getContainerData().getContainerPath())));
     assertNotNull(containerSet.getContainer(3));


### PR DESCRIPTION
## What changes were proposed in this pull request?

For EC container, if duplicate container is present, having same index, then it will delete the duplicate container.

Other case for different index, it will be handled as part of [HDDS-13174](https://issues.apache.org/jira/browse/HDDS-13174)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12722

## How was this patch tested?

- Test case added
