### PR TITLE
HDDS-13175. Leftover reference to OM-specific trash implementation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -621,7 +621,7 @@ public final class OzoneConfigKeys {
 
   public static final String FS_TRASH_CLASSNAME = "fs.trash.classname";
   public static final String FS_TRASH_CLASSNAME_DEFAULT =
-      "org.apache.hadoop.ozone.om.TrashPolicyOzone";
+      "org.apache.hadoop.fs.ozone.OzoneTrashPolicy";
 
   public static final String
       OZONE_OM_SNAPSHOT_COMPACTION_DAG_MAX_TIME_ALLOWED =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2789,7 +2789,7 @@
 
   <property>
     <name>fs.trash.classname</name>
-    <value>org.apache.hadoop.ozone.om.TrashPolicyOzone</value>
+    <value>org.apache.hadoop.fs.ozone.OzoneTrashPolicy</value>
     <tag>OZONE, OZONEFS, CLIENT</tag>
     <description>
       Trash Policy to be used.

--- a/hadoop-hdds/docs/content/interface/Ofs.md
+++ b/hadoop-hdds/docs/content/interface/Ofs.md
@@ -237,7 +237,7 @@ In order to enable trash in Ozone, Please add these configs to core-site.xml
 </property>
 <property>
   <name>fs.trash.classname</name>
-  <value>org.apache.hadoop.ozone.om.TrashPolicyOzone</value>
+  <value>org.apache.hadoop.fs.ozone.OzoneTrashPolicy</value>
 </property>
 {{< /highlight >}}
                                            

--- a/hadoop-hdds/docs/content/interface/Ofs.zh.md
+++ b/hadoop-hdds/docs/content/interface/Ofs.zh.md
@@ -220,7 +220,7 @@ $ ozone fs -put ./NOTICE.txt ofs://om/tmp/key1
 </property>
 <property>
   <name>fs.trash.classname</name>
-  <value>org.apache.hadoop.ozone.om.TrashPolicyOzone</value>
+  <value>org.apache.hadoop.fs.ozone.OzoneTrashPolicy</value>
 </property>
 {{< /highlight >}}
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -111,7 +111,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmConfig;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
-import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -1685,7 +1684,7 @@ abstract class AbstractOzoneFileSystemTest {
     ContractTestUtils.touch(fs, path);
     assertTrue(trash.getConf().getClass(
         "fs.trash.classname", TrashPolicy.class).
-        isAssignableFrom(TrashPolicyOzone.class));
+        isAssignableFrom(OzoneTrashPolicy.class));
     assertEquals(TRASH_INTERVAL, trash.getConf().
         getFloat(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, 0), 0);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -117,7 +117,6 @@ import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmConfig;
-import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
@@ -1869,7 +1868,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
     assertTrue(trash.getConf().getClass(
         "fs.trash.classname", TrashPolicy.class).
-        isAssignableFrom(TrashPolicyOzone.class));
+        isAssignableFrom(OzoneTrashPolicy.class));
 
     long prevNumTrashDeletes = getOMMetrics().getNumTrashDeletes();
     long prevNumTrashFileDeletes = getOMMetrics().getNumTrashFilesDeletes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TrashPolicy;
 import org.apache.hadoop.fs.ozone.OzoneFsShell;
+import org.apache.hadoop.fs.ozone.OzoneTrashPolicy;
 import org.apache.hadoop.hdds.JsonTestUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -92,7 +93,6 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -991,17 +991,17 @@ public class TestOzoneShellHA {
 
   /**
    * Helper function to retrieve Ozone client configuration for ozone
-   * trash testing with TrashPolicyOzone.
+   * trash testing with OzoneTrashPolicy.
    * @param hostPrefix Scheme + Authority. e.g. ofs://om-service-test1
    * @param configuration Server config to generate client config from.
    * @return Config ofs configuration added with fs.trash.classname
-   * = TrashPolicyOzone.
+   * = OzoneTrashPolicy.
    */
   private OzoneConfiguration getClientConfForOzoneTrashPolicy(
           String hostPrefix, OzoneConfiguration configuration) {
     OzoneConfiguration clientConf =
             getClientConfForOFS(hostPrefix, configuration);
-    clientConf.setClass("fs.trash.classname", TrashPolicyOzone.class,
+    clientConf.setClass("fs.trash.classname", OzoneTrashPolicy.class,
             TrashPolicy.class);
     return clientConf;
   }
@@ -1186,7 +1186,7 @@ public class TestOzoneShellHA {
 
     // Test delete from Trash directory removes item from filesystem
 
-    // setup configuration to use TrashPolicyOzone
+    // setup configuration to use OzoneTrashPolicy
     // (default is TrashPolicyDefault)
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     OzoneConfiguration clientConf =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  *  of TrashPolicy ozone-specific trash optimizations are/will be made such as
  *  having a multithreaded TrashEmptier.
  */
-public class TrashPolicyOzone extends OzoneTrashPolicy {
+class TrashPolicyOzone extends OzoneTrashPolicy {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TrashPolicyOzone.class);
@@ -60,10 +60,7 @@ public class TrashPolicyOzone extends OzoneTrashPolicy {
       new SimpleDateFormat("yyMMddHHmm");
   private long emptierInterval;
 
-  private OzoneManager om;
-
-  public TrashPolicyOzone() {
-  }
+  private final OzoneManager om;
 
   @Override
   public void initialize(Configuration conf, FileSystem fs) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11749 moved Ozone's trash policy to client-side, but left some references to the OM-specific implementation.  This PR replaces those.

https://issues.apache.org/jira/browse/HDDS-13175

## How was this patch tested?

CI (pending):
https://github.com/adoroszlai/ozone/actions/runs/15440018671