### PR TITLE
HDDS-13114 MaxCompactionBytes and MaxSubCompactions should be configureable in RDBStore#compactTable

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -73,10 +73,12 @@ public class RDBStore implements DBStore {
   private final long maxDbUpdatesSizeThreshold;
   private final ManagedDBOptions dbOptions;
   private final ManagedStatistics statistics;
+  private final ManagedCompactRangeOptions rangeCompactionOptions;
 
   @SuppressWarnings("parameternumber")
   RDBStore(File dbFile, ManagedDBOptions dbOptions, ManagedStatistics statistics,
                   ManagedWriteOptions writeOptions, Set<TableConfig> families,
+                  ManagedCompactRangeOptions rangeCompactionOptions,
                   boolean readOnly,
                   String dbJmxBeanName, boolean enableCompactionDag,
                   long maxDbUpdatesSizeThreshold,
@@ -92,6 +94,7 @@ public class RDBStore implements DBStore {
     dbLocation = dbFile;
     this.dbOptions = dbOptions;
     this.statistics = statistics;
+    this.rangeCompactionOptions = rangeCompactionOptions;
 
     Exception exception = null;
     try {
@@ -216,17 +219,12 @@ public class RDBStore implements DBStore {
 
   @Override
   public void compactDB() throws IOException {
-    try (ManagedCompactRangeOptions options =
-             new ManagedCompactRangeOptions()) {
-      db.compactDB(options);
-    }
+    db.compactDB(rangeCompactionOptions);
   }
 
   @Override
   public void compactTable(String tableName) throws IOException {
-    try (ManagedCompactRangeOptions options = new ManagedCompactRangeOptions()) {
-      compactTable(tableName, options);
-    }
+    compactTable(tableName, rangeCompactionOptions);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -252,7 +252,10 @@ public class RDBStore implements DBStore {
     if (statistics != null) {
       IOUtils.close(LOG, statistics);
     }
-    IOUtils.close(LOG, db);
+    if (rangeCompactionOptions != null) {
+      IOUtils.close(LOG, rangeCompactionOptions);
+    }
+    IOUtils.close(LOG, db, dbOptions);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -84,6 +84,20 @@ public class RocksDBConfiguration {
           + "Default 0 means no limit.")
   private long walSizeLimit = 0;
 
+  @Config(key = "rocksdb.max.compaction.bytes",
+      type = ConfigType.SIZE,
+      defaultValue = "0",
+      tags = {OM, SCM, DATANODE},
+      description = "Maximum bytes allowed for a single compaction. 0 means no limit.")
+  private long maxCompactionBytes = 0;
+
+  @Config(key = "rocksdb.max.sub.compactions",
+      type = ConfigType.INT,
+      defaultValue = "0",
+      tags = {OM, SCM, DATANODE},
+      description = "Maximum number of sub compactions to use when compacting. 0 means no limit.")
+  private int maxSubCompactions = 0;
+
   public void setRocksdbLoggingEnabled(boolean enabled) {
     this.rocksdbLogEnabled = enabled;
   }
@@ -138,5 +152,21 @@ public class RocksDBConfiguration {
 
   public int getKeepLogFileNum() {
     return rocksdbKeepLogFileNum;
+  }
+
+  public void setMaxCompactionBytes(long bytes) {
+    this.maxCompactionBytes = bytes;
+  }
+
+  public long getMaxCompactionBytes() {
+    return maxCompactionBytes;
+  }
+
+  public void setMaxSubCompactions(int subCompactions) {
+    this.maxSubCompactions = subCompactions;
+  }
+
+  public int getMaxSubCompactions() {
+    return maxSubCompactions;
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.junit.jupiter.api.AfterEach;
@@ -88,6 +89,7 @@ public class TestRDBStore {
       long maxDbUpdatesSizeThreshold)
       throws IOException {
     return new RDBStore(dbFile, options, null, new ManagedWriteOptions(), families,
+        new ManagedCompactRangeOptions(),
         false, null, false,
         maxDbUpdatesSizeThreshold, true, null, true);
   }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedColumnFamilyOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedColumnFamilyOptions.java
@@ -99,6 +99,7 @@ public class ManagedColumnFamilyOptions extends ColumnFamilyOptions {
     options.close();
   }
 
+  @Override
   public ManagedColumnFamilyOptions setMaxCompactionBytes(long maxCompactionBytes) {
     if (maxCompactionBytes > 0) {
       super.setMaxCompactionBytes(maxCompactionBytes);

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedColumnFamilyOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedColumnFamilyOptions.java
@@ -98,4 +98,11 @@ public class ManagedColumnFamilyOptions extends ColumnFamilyOptions {
     }
     options.close();
   }
+
+  public ManagedColumnFamilyOptions setMaxCompactionBytes(long maxCompactionBytes) {
+    if (maxCompactionBytes > 0) {
+      super.setMaxCompactionBytes(maxCompactionBytes);
+    }
+    return this;
+  }
 }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedCompactRangeOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedCompactRangeOptions.java
@@ -37,6 +37,7 @@ public class ManagedCompactRangeOptions extends CompactRangeOptions {
     }
   }
 
+  @Override
   public ManagedCompactRangeOptions setMaxSubcompactions(int maxSubcompactions) {
     if (maxSubcompactions > 0) {
       super.setMaxSubcompactions(maxSubcompactions);

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedCompactRangeOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedCompactRangeOptions.java
@@ -36,4 +36,11 @@ public class ManagedCompactRangeOptions extends CompactRangeOptions {
       leakTracker.close();
     }
   }
+
+  public ManagedCompactRangeOptions setMaxSubcompactions(int maxSubcompactions) {
+    if (maxSubcompactions > 0) {
+      super.setMaxSubcompactions(maxSubcompactions);
+    }
+    return this;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/ozone/pull/8141#discussion_r2093792426

 
In https://github.com/apache/ozone/pull/8141 `RDBStore#compactTable` was introduced. 

We should set `options.setMaxCompactionBytes()` when we open the snapshot rocksdb this could be useful so that we ensure one sub compaction doesn't take up a lot of memory. Also look into making ManagedCompactRangeOptions.setMaxSubCompactions() configurable so that we don't use a lot of CPU for this operation. It is ok if the compactions take time.

This can be achieved by adding `ManagedRangeCompactionOption` into `AbstractRDBStore`, `RDBStore`, `RDBStoreBuilder`. Also the corresponding rocksdb config keys.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13114

## How was this patch tested?

CI:
https://github.com/peterxcli/ozone/actions/runs/15484301525