### PR TITLE
HDDS-12977. Fail build on dependency problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,10 @@ jobs:
   integration:
     needs:
       - build-info
+      - build
       - basic
+      - dependency
+      - license
     if: needs.build-info.outputs.needs-integration-tests == 'true'
     uses: ./.github/workflows/check.yml
     secrets: inherit

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/ReconfigurableBase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/ReconfigurableBase.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.ConfigRedactor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -42,7 +41,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReconfigurableBase extends Configured implements Reconfigurable {
   private static final Logger LOG = LoggerFactory.getLogger(ReconfigurableBase.class);
-  private final ReconfigurationUtil reconfigurationUtil = new ReconfigurationUtil();
   private Thread reconfigThread = null;
   private volatile boolean shouldRun = true;
   private final Object reconfigLock = new Object();
@@ -56,12 +54,6 @@ public abstract class ReconfigurableBase extends Configured implements Reconfigu
   }
 
   protected abstract Configuration getNewConf();
-
-  @VisibleForTesting
-  public Collection<ReconfigurationUtil.PropertyChange> getChangedProperties(Configuration newConf,
-      Configuration oldConf) {
-    return this.reconfigurationUtil.parseChangedProperties(newConf, oldConf);
-  }
 
   public void startReconfigurationTask() throws IOException {
     synchronized (this.reconfigLock) {
@@ -150,7 +142,8 @@ public abstract class ReconfigurableBase extends Configured implements Reconfigu
       LOG.info("Starting reconfiguration task.");
       Configuration oldConf = this.parent.getConf();
       Configuration newConf = this.parent.getNewConf();
-      Collection<ReconfigurationUtil.PropertyChange> changes = this.parent.getChangedProperties(newConf, oldConf);
+      Collection<ReconfigurationUtil.PropertyChange> changes =
+          ReconfigurationUtil.getChangedProperties(newConf, oldConf);
       Map<ReconfigurationUtil.PropertyChange, Optional<String>> results = Maps.newHashMap();
       ConfigRedactor oldRedactor = new ConfigRedactor(oldConf);
       ConfigRedactor newRedactor = new ConfigRedactor(newConf);

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -24,6 +24,7 @@
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 2.x compatibility</name>
   <properties>
+    <mdep.analyze.skip>true</mdep.analyze.skip>
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
   </properties>
   <dependencies>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -26,6 +26,7 @@
   <properties>
     <!-- no tests in this module so far -->
     <maven.test.skip>true</maven.test.skip>
+    <mdep.analyze.skip>true</mdep.analyze.skip>
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
   </properties>
   <dependencies>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <!-- no tests in this module so far -->
     <maven.test.skip>true</maven.test.skip>
+    <mdep.analyze.skip>true</mdep.analyze.skip>
     <ozone.shaded.native.prefix>org_apache_ozone_shaded</ozone.shaded.native.prefix>
     <!-- refer to ratis thirdparty ratis.thirdparty.shaded.native.prefix -->
     <ratis.thirdparty.shaded.native.prefix>org_apache_ratis_thirdparty_</ratis.thirdparty.shaded.native.prefix>

--- a/pom.xml
+++ b/pom.xml
@@ -2178,6 +2178,7 @@
               <goal>analyze-only</goal>
             </goals>
             <configuration>
+              <failOnWarning>true</failOnWarning>
               <ignoreNonCompile>true</ignoreNonCompile>
               <excludedClasses>
                 <!-- disabled test -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix dependency warning added in HDDS-12554.
- Fail the build for dependency warnings, to prevent the introduction of any more.
- Skip dependency analysis in `ozonefs-shaded` and `ozonefs-hadoop?` modules.  The former is a common dependency for the latter, but does not use any of its dependencies directly.  See HDDS-13058 for a list of problems.  So far I have not found a good way to make both `maven-dependency-plugin` and the build happy.  We could merge `ozonefs-shaded` and `ozonefs-hadoop3` to fix most problems, but only after Hadoop 2 support is dropped.
- Wait for successful build/dependency/license checks before starting integration check.  This adds only few minutes of delay, because it already waited for `basic`, of which `findbugs` was the slowest at 9 minutes, while build takes ~12 minutes, the other two less than 1 minute.

https://issues.apache.org/jira/browse/HDDS-12977

## How was this patch tested?

With 817df75327eddeaa9b1f63e80bea1914ead49a28:

```
[INFO] --- dependency:3.8.1:analyze-only (analyze) @ hdds-server-framework ---
[ERROR] Used undeclared dependencies found:
[ERROR]    org.apache.hadoop:hadoop-annotations:jar:3.4.1:compile
...
[INFO] BUILD FAILURE
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.8.1:analyze-only (analyze) on project hdds-server-framework: Dependency problems found
```

After a2cb3d023c6d8f02ea49200ea493816ef830deca:

```
[INFO] BUILD SUCCESS
```

https://github.com/adoroszlai/ozone/actions/runs/15487796231