### PR TITLE
HDDS-13200. OM RocksDB Grafana Dashbroad shows no data on all panels

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - OMComittedIndexMetrics.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - OMComittedIndexMetrics.json
@@ -55,7 +55,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -134,7 +134,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "editorMode": "code",
           "exemplar": false,

--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - Ozone Manager RocksDB.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - Ozone Manager RocksDB.json
@@ -88,7 +88,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -142,7 +142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -165,7 +165,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -219,7 +219,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -238,7 +238,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -292,7 +292,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -311,7 +311,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -365,7 +365,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -384,7 +384,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -438,7 +438,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -457,7 +457,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -511,7 +511,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -530,7 +530,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -584,7 +584,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -616,7 +616,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -670,7 +670,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -689,7 +689,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -743,7 +743,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -775,7 +775,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -829,7 +829,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -861,7 +861,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "gridPos": {
         "h": 3,
@@ -899,7 +899,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -979,7 +979,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -998,7 +998,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1077,7 +1077,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1096,7 +1096,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1175,7 +1175,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1194,7 +1194,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1273,7 +1273,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1292,7 +1292,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1372,7 +1372,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1391,7 +1391,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1471,7 +1471,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1490,7 +1490,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1569,7 +1569,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1601,7 +1601,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1681,7 +1681,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1700,7 +1700,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1780,7 +1780,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1799,7 +1799,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1879,7 +1879,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1898,7 +1898,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -1978,7 +1978,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1997,7 +1997,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2077,7 +2077,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2096,7 +2096,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2176,7 +2176,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2208,7 +2208,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "description": "",
       "fieldConfig": {
@@ -2289,7 +2289,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2308,7 +2308,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2388,7 +2388,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2407,7 +2407,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "description": "",
       "fieldConfig": {
@@ -2488,7 +2488,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2507,7 +2507,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2587,7 +2587,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2619,7 +2619,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2699,7 +2699,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2718,7 +2718,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2798,7 +2798,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2817,7 +2817,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2897,7 +2897,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2916,7 +2916,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "-- Grafana --"
       },
       "fieldConfig": {
         "defaults": {
@@ -2996,7 +2996,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "-- Grafana --"
           },
           "disableTextWrap": false,
           "editorMode": "builder",


### PR DESCRIPTION
## What changes were proposed in this pull request?

The OM RocksDB shows no data in each panel even I have enable the rocksdb statistics.

I have to click into each chart and click refresh so they could show data.
![image](https://github.com/user-attachments/assets/bb8303b3-a46f-482c-bea4-62069537fdaa)
![image](https://github.com/user-attachments/assets/c9723e87-1f09-4c15-8b17-423fcc0893fb)
![image](https://github.com/user-attachments/assets/8c30f76a-9bed-49f1-88b8-5665bfe9033b)
![image](https://github.com/user-attachments/assets/94175eba-d1d6-423f-8f54-910cb4b8c028)

I found the cause is the error in frontend:
![image](https://github.com/user-attachments/assets/fa41dc94-8064-4cc4-b2e5-f882e55d5608)


Then the dashbroad become good after I replace the ${DS_PROMETHEUS} with "-- Grafana ---".
![image](https://github.com/user-attachments/assets/9f409dab-e176-4c48-ba5a-8233b1ec0f8d)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13200

## How was this patch tested?

No test needed.