### PR TITLE
HDDS-13188. Track total pending deletion size for FSO directories in OM via Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -684,6 +684,7 @@ public class OMDBInsightEndpoint {
         OmKeyInfo omKeyInfo = kv.getValue();
         if (omKeyInfo != null) {
           totalUnreplicatedSize += fetchSizeForDeletedDirectory(omKeyInfo.getObjectID());
+          // TODO: Based on HDDS-13180 merge, update totalReplicatedSize calculation using fetchSizeForDeletedDirectory.
           totalReplicatedSize += omKeyInfo.getReplicatedSize();
         }
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -686,10 +686,9 @@ public class OMDBInsightEndpoint {
         Table.KeyValue<String, OmKeyInfo> kv = iterator.next();
         OmKeyInfo omKeyInfo = kv.getValue();
         if (omKeyInfo != null) {
-          totalDataSize += fetchSizeForDeletedDirectory(omKeyInfo.getObjectID());
-          // TODO: Based on HDDS-13180 merge, update totalReplicatedDataSize calculation using
-          //  fetchSizeForDeletedDirectory.
-          totalReplicatedDataSize += omKeyInfo.getReplicatedSize();
+          Pair<Long, Long> sizeInfo = fetchSizeForDeletedDirectory(omKeyInfo.getObjectID());
+          totalDataSize += sizeInfo.getLeft();
+          totalReplicatedDataSize += sizeInfo.getRight();
         }
       }
     } catch (IOException ex) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1352,6 +1352,13 @@ public class OMDBInsightEndpoint {
         OmTableInsightTask.getTableCountKeyFromTable(DELETED_DIR_TABLE)));
     // Calculate the total number of deleted directories
     dirSummary.put("totalDeletedDirectories", deletedDirCount);
+
+    // Get all deleted directories without pagination
+    KeyInsightInfoResponse deletedDirInsightInfo = new KeyInsightInfoResponse();
+    getPendingForDeletionDirInfo(Integer.MAX_VALUE, "", deletedDirInsightInfo);
+    // Calculate the total replicated and unreplicated data size for deleted directories
+    dirSummary.put("totalReplicatedDataSize", deletedDirInsightInfo.getReplicatedDataSize());
+    dirSummary.put("totalUnreplicatedDataSize", deletedDirInsightInfo.getUnreplicatedDataSize());
   }
 
   private boolean validateStartPrefix(String startPrefix) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR introduces a `GET` `/api/v1/keys/deletePending/dirs/size-summary` endpoint to include `totalUnreplicatedDataSize` and `totalReplicatedDataSize` fields for tracking the total pending deletion size for FSO directories in OM.

  - `totalReplicatedDataSize`: Total size of directories pending deletion with expected replicated size.
  - `totalUnreplicatedDataSize`: Total raw size of directories pending deletion without replicated size.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13188

## How was this patch tested?

Manual Testing:

```
bash-5.1$ ozone sh volume create vol1
bash-5.1$ ozone sh bucket create vol1/buck1 --layout=FILE_SYSTEM_OPTIMIZED
bash-5.1$ ozone fs -mkdir -p ofs://om/vol1/buck1/dir1/dir2/dir3

# Create 1 MB file:
bash-5.1$ dd if=/dev/zero of=test.txt bs=1M count=1
bash-5.1$ ozone fs -put test.txt ofs://om/vol1/buck1/dir1/file1
bash-5.1$ ozone fs -put test.txt ofs://om/vol1/buck1/dir1/dir2/file2
bash-5.1$ ozone fs -put test.txt ofs://om/vol1/buck1/dir1/dir2/dir3/file3

Directory structure:

dir1/
    ├── file1 (1 MB)
    └── dir2/
        ├── file2 (1 MB)
        └── dir3/
            └── file3 (1 MB)

# Recursively delete top-level directory:
bash-5.1$ ozone fs -rm -r ofs://om/vol1/buck1/dir1

GET /api/v1/keys/deletePending/dirs/size-summary:

Before https://github.com/apache/ozone/pull/8568:

{
  "totalDeletedDirectories": 1,
  "totalReplicatedDataSize": 0,
  "totalUnreplicatedDataSize": 3145728
}

After https://github.com/apache/ozone/pull/8568:

{
  "totalDeletedDirectories": 1,
  "totalReplicatedDataSize": 9437184,
  "totalUnreplicatedDataSize": 3145728
}
```
