### PR TITLE
HDDS-13142. Correct SCMPerformanceMetrics for delete operation.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -270,7 +270,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
           .addGauge(DatanodeCommandDetails.COMMANDS_TIMEOUT_BY_DN,
               e.getValue().getCommandsTimeout())
           .addGauge(DatanodeCommandDetails.BLOCKS_SENT_TO_DN_COMMAND,
-          e.getValue().getCommandsTimeout());
+          e.getValue().getBlocksSent());
     }
     recordBuilder.endRecord();
   }
@@ -345,6 +345,10 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     
     public long getCommandsTimeout() {
       return commandsTimeout;
+    }
+
+    public long getBlocksSent() {
+      return blocksSent;
     }
 
     @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -43,7 +43,7 @@ public final class SCMPerformanceMetrics implements MetricsSource {
   private MetricsRegistry registry;
   private static SCMPerformanceMetrics instance;
 
-  @Metric(about = "Number of failed deleteKey operations")
+  @Metric(about = "Number of failed deleteKeys")
   private MutableCounterLong deleteKeyFailure;
   @Metric(about = "Number of successful deleteKey operations")
   private MutableCounterLong deleteKeySuccess;
@@ -56,9 +56,9 @@ public final class SCMPerformanceMetrics implements MetricsSource {
   @Metric(about = "Latency for a failed allocateBlock call in nanoseconds")
   private MutableRate allocateBlockFailureLatencyNs;
   @Metric(about = "Total blocks taken in each key delete cycle.")
-  private MutableCounterLong deleteKeyBlocksInKeyDeleteCycle;
+  private MutableCounterLong deleteKeyBlocksSuccess;
   @Metric(about = "Total blocks taken in each key delete cycle failure.")
-  private MutableCounterLong deleteKeyBlocksInKeyDeleteCycleFailure;
+  private MutableCounterLong deleteKeyBlocksFailure;
 
   public SCMPerformanceMetrics() {
     this.registry = new MetricsRegistry(SOURCE_NAME);
@@ -88,8 +88,8 @@ public final class SCMPerformanceMetrics implements MetricsSource {
     deleteKeyFailureLatencyNs.snapshot(recordBuilder, true);
     allocateBlockSuccessLatencyNs.snapshot(recordBuilder, true);
     allocateBlockFailureLatencyNs.snapshot(recordBuilder, true);
-    deleteKeyBlocksInKeyDeleteCycle.snapshot(recordBuilder, true);
-    deleteKeyBlocksInKeyDeleteCycleFailure.snapshot(recordBuilder, true);
+    deleteKeyBlocksSuccess.snapshot(recordBuilder, true);
+    deleteKeyBlocksFailure.snapshot(recordBuilder, true);
   }
 
   public void updateAllocateBlockSuccessLatencyNs(long startNanos) {
@@ -110,12 +110,12 @@ public final class SCMPerformanceMetrics implements MetricsSource {
     deleteKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
   }
 
-  public void updateDeleteKeySuccessBlocksInKeyDeleteCycle(long keys) {
-    deleteKeyBlocksInKeyDeleteCycle.incr(keys);
+  public void updateDeleteKeySuccessBlocks(long keys) {
+    deleteKeyBlocksSuccess.incr(keys);
   }
 
-  public void updateDeleteKeyFailedBlocksInKeyDeleteCycle(long keys) {
-    deleteKeyBlocksInKeyDeleteCycleFailure.incr(keys);
+  public void updateDeleteKeyFailedBlocks(long keys) {
+    deleteKeyBlocksFailure.incr(keys);
   }
 }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -45,7 +45,7 @@ public final class SCMPerformanceMetrics implements MetricsSource {
 
   @Metric(about = "Number of failed deleteKeys")
   private MutableCounterLong deleteKeyFailure;
-  @Metric(about = "Number of successful deleteKey operations")
+  @Metric(about = "Number of success deleteKeys")
   private MutableCounterLong deleteKeySuccess;
   @Metric(about = "Latency for deleteKey failure in nanoseconds")
   private MutableRate deleteKeyFailureLatencyNs;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -55,6 +55,10 @@ public final class SCMPerformanceMetrics implements MetricsSource {
   private MutableRate allocateBlockSuccessLatencyNs;
   @Metric(about = "Latency for a failed allocateBlock call in nanoseconds")
   private MutableRate allocateBlockFailureLatencyNs;
+  @Metric(about = "Total blocks taken in each key delete cycle.")
+  private MutableCounterLong deleteKeyBlocksInKeyDeleteCycle;
+  @Metric(about = "Total blocks taken in each key delete cycle failure.")
+  private MutableCounterLong deleteKeyBlocksInKeyDeleteCycleFailure;
 
   public SCMPerformanceMetrics() {
     this.registry = new MetricsRegistry(SOURCE_NAME);
@@ -84,6 +88,8 @@ public final class SCMPerformanceMetrics implements MetricsSource {
     deleteKeyFailureLatencyNs.snapshot(recordBuilder, true);
     allocateBlockSuccessLatencyNs.snapshot(recordBuilder, true);
     allocateBlockFailureLatencyNs.snapshot(recordBuilder, true);
+    deleteKeyBlocksInKeyDeleteCycle.snapshot(recordBuilder, true);
+    deleteKeyBlocksInKeyDeleteCycleFailure.snapshot(recordBuilder, true);
   }
 
   public void updateAllocateBlockSuccessLatencyNs(long startNanos) {
@@ -94,14 +100,22 @@ public final class SCMPerformanceMetrics implements MetricsSource {
     allocateBlockFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
   }
 
-  public void updateDeleteKeySuccessStats(long startNanos) {
-    deleteKeySuccess.incr();
+  public void updateDeleteKeySuccessStats(long keys, long startNanos) {
+    deleteKeySuccess.incr(keys);
     deleteKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
   }
 
-  public void updateDeleteKeyFailureStats(long startNanos) {
-    deleteKeyFailure.incr();
+  public void updateDeleteKeyFailureStats(long keys, long startNanos) {
+    deleteKeyFailure.incr(keys);
     deleteKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updateDeleteKeyBlocksInKeyDeleteCycle(long keys) {
+    deleteKeyBlocksInKeyDeleteCycle.incr(keys);
+  }
+
+  public void updateDeleteKeyFailedBlocksInKeyDeleteCycle(long keys) {
+    deleteKeyBlocksInKeyDeleteCycleFailure.incr(keys);
   }
 }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -110,7 +110,7 @@ public final class SCMPerformanceMetrics implements MetricsSource {
     deleteKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
   }
 
-  public void updateDeleteKeyBlocksInKeyDeleteCycle(long keys) {
+  public void updateDeleteKeySuccessBlocksInKeyDeleteCycle(long keys) {
     deleteKeyBlocksInKeyDeleteCycle.incr(keys);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -281,7 +281,7 @@ public class SCMBlockProtocolServer implements
     long startNanos = Time.monotonicNowNanos();
     try {
       scm.getScmBlockManager().deleteBlocks(keyBlocksInfoList);
-      perfMetrics.updateDeleteKeySuccessBlocksInKeyDeleteCycle(totalBlocks);
+      perfMetrics.updateDeleteKeySuccessBlocks(totalBlocks);
       perfMetrics.updateDeleteKeySuccessStats(keyBlocksInfoList.size(), startNanos);
       resultCode = ScmBlockLocationProtocolProtos.
           DeleteScmBlockResult.Result.success;
@@ -290,7 +290,7 @@ public class SCMBlockProtocolServer implements
       }
     } catch (IOException ioe) {
       e = ioe;
-      perfMetrics.updateDeleteKeyFailedBlocksInKeyDeleteCycle(totalBlocks);
+      perfMetrics.updateDeleteKeyFailedBlocks(totalBlocks);
       perfMetrics.updateDeleteKeyFailureStats(keyBlocksInfoList.size(), startNanos);
       LOG.warn("Fail to delete {} keys", keyBlocksInfoList.size(), ioe);
       switch (ioe instanceof SCMException ? ((SCMException) ioe).getResult() :


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SCMPerformanceMetrics, deleteKeySuccess and deleteKeyFailure are not updated at the key level but at the request level from OM. These metrics should be updated at the key level to know the actual key count received from OM to SCM for deletion.

Also, we should add block count metrics(Number of blocks received from OM to SCM for deletion).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13142

## How was this patch tested?

Tested Manually.
