### PR TITLE
HDDS-13214. populate-cache fails due to unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2681,6 +2681,7 @@
       <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.shade.skip>true</maven.shade.skip>
+        <mdep.analyze.skip>true</mdep.analyze.skip>
         <skip.installnodenpm>true</skip.installnodenpm>
         <skip.npx>true</skip.npx>
         <skipDocs>true</skipDocs>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build [failure](https://github.com/apache/ozone/actions/runs/15530372634/job/43717857994#step:8:4649) in `populate-cache` workflow (which builds `ozonefs-hadoop*`, but skips `maven-shade-plugin` execution):

```
[INFO] --- dependency:3.8.1:analyze-only (analyze) @ ozone-filesystem-hadoop3-client ---
[ERROR] Unused declared dependencies found:
[ERROR]    org.apache.ozone:ozone-filesystem-hadoop3:jar:2.1.0-SNAPSHOT:compile
```

https://issues.apache.org/jira/browse/HDDS-13214

## How was this patch tested?

Will be tested after merge to `master`.