### PR TITLE
HDDS-13107. ozone admin datanode list should support limiting list output

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -119,7 +119,7 @@ public class ListInfoSubcommand extends ScmSubcommand {
           .compareToIgnoreCase(nodeState) == 0);
     }
 
-    if(!listLimitOptions.isAll()){
+    if (!listLimitOptions.isAll()) {
       allNodes = allNodes.limit(listLimitOptions.getLimit());
     }
     


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds support for limiting the number of datanodes returned by the `ozone admin datanode list` command using the ListLimitOption mixin. The limit is applied after all user-specified filters, allowing targeted queries like showing the first N dead or stale nodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13107

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/15532324953