### PR TITLE
HDDS-10490. Intermittent NPE in TestSnapshotDiffManager#testLoadJobsOnStartUp

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -730,10 +730,10 @@ public class SnapshotDiffManager implements AutoCloseable {
     // If executor cannot take any more job, remove the job form DB and return
     // the Rejected Job status with wait time.
     try {
+      updateJobStatus(jobKey, QUEUED, IN_PROGRESS);
       snapDiffExecutor.execute(() -> generateSnapshotDiffReport(jobKey, jobId,
           volumeName, bucketName, fromSnapshotName, toSnapshotName,
           forceFullDiff, disableNativeDiff));
-      updateJobStatus(jobKey, QUEUED, IN_PROGRESS);
       return new SnapshotDiffResponse(
           new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName,
               bucketName, fromSnapshotName, toSnapshotName, new ArrayList<>(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
Error message:
```
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.423 s <<< FAILURE! -- in org.apache.hadoop.ozone.om.snapshot.TestSnapshotDiffManager
Error:  org.apache.hadoop.ozone.om.snapshot.TestSnapshotDiffManager.testGetSnapshotDiffReportJob -- Time elapsed: 3.040 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <IN_PROGRESS> but was: <FAILED>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.apache.hadoop.ozone.om.snapshot.TestSnapshotDiffManager.testGetSnapshotDiffReportJob(TestSnapshotDiffManager.java:1649)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

The root cause is that the job status should be transfered from IN_PROGRESS to QUEUED after submission. However, since the snapshotdiff job execution is asynchronous, it's logically possible for the job to complete quickly and reach DONE before the Transition. This lead to throwing an IllegalStateException. In this PR, I make the transition before submitting the job.

This patch also fix [HDDS-12361](https://issues.apache.org/jira/browse/HDDS-12361).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10490

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/15546591504

Passed 10x100 after change:
https://github.com/chungen0126/ozone/actions/runs/15546601439
https://github.com/chungen0126/ozone/actions/runs/15547934999

