### PR TITLE
HDDS-13112. [Docs] OM Bootstrap can also happen when follower falls behind too much.

### DIFF
--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -143,7 +143,7 @@ When a follower OM falls significantly behind and is unable to catch up with the
   This logic is implemented in the `OzoneManagerStateMachine.notifyInstallSnapshotFromLeader()` method. The install is triggered automatically by the consensus layer (Ratis) when it detects that a follower cannot catch up by log replay alone.
 
 - **What this means for administrators:**
-  - In most scenarios, stale OMs will recover automatically after coming back online, even if they have missed a large number of operations.
+  - In most scenarios, stale OMs—whether they were temporarily offline or simply fell too far behind the leader while remaining online—will recover automatically, even if they have missed a large number of operations.
   - Manual intervention (such as running `ozone om --bootstrap`) is only required when adding a new OM node to the cluster or when explicitly requested by support instructions.
 
 

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -143,6 +143,8 @@ This logic is implemented in the `OzoneManagerStateMachine.notifyInstallSnapshot
 see the [code](https://github.com/apache/ozone/blob/ozone-2.0.0/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L520-L531)
 in Release 2.0.0.
 
+Note that this `Raft Snapshot`, used for OM HA state synchronization, is distinct from `Ozone Snapshot`, which is used for data backup and recovery purposes.
+
 In most scenarios, stale OMs will recover automatically, even if they have missed a large number of operations.
 Manual intervention (such as running `ozone om --bootstrap`) is only required when adding a new OM node to the cluster.
 

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -144,8 +144,7 @@ see the [code](https://github.com/apache/ozone/blob/ozone-2.0.0/hadoop-ozone/ozo
 in Release 2.0.0.
 
 In most scenarios, stale OMs will recover automatically, even if they have missed a large number of operations.
-Manual intervention (such as running `ozone om --bootstrap`) is only required when adding a new OM node to the cluster
-or when explicitly requested by support instructions.
+Manual intervention (such as running `ozone om --bootstrap`) is only required when adding a new OM node to the cluster.
 
 **Important Note on Ozone Manager (OM) Disk Space for Snapshots**
 

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -127,21 +127,34 @@ Note that using the _force_ option during bootstrap could crash the OM process i
 
 ## Automatic Snapshot Installation for Stale Ozone Managers
 
-Sometimes an OM follower node may be offline or fall so far behind the leader OM's log that it cannot catch up by replaying individual log entries.  The OM HA implementation includes an automatic snapshot installation and recovery process for such cases.
+Sometimes an OM follower node may be offline or fall far behind the OM leader's raft log.
+Then, it cannot easily catch up by replaying individual log entries.
+The OM HA implementation includes an automatic snapshot installation
+and recovery process for such cases.
 
 How it works:
 
 1. Leader determines that the follower is too far behind.
-2. Leader notifies the follower to catch up via snapshot.
+2. Leader notifies the follower to install a snapshot.
 3. The follower downloads and installs the latest snapshot from the leader.
 4. After installing the snapshot, the follower OM resumes normal operation and log replication from the new state.
 
-This logic is implemented in the [`OzoneManagerStateMachine.notifyInstallSnapshotFromLeader()` method](https://github.com/apache/ozone/blob/931bc2d8a9e8e8595bb49034c03c14e2b15be865/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L521-L541).
+This logic is implemented in the `OzoneManagerStateMachine.notifyInstallSnapshotFromLeader()`;
+see the [code](https://github.com/apache/ozone/blob/ozone-2.0.0/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L520-L531)
+in Release 2.0.0.
 
-In most scenarios, stale OMs will recover automatically, even if they have missed a large number of operations.  Manual intervention (such as running `ozone om --bootstrap`) is only required when adding a new OM node to the cluster or when explicitly requested by support instructions.
+In most scenarios, stale OMs will recover automatically, even if they have missed a large number of operations.
+Manual intervention (such as running `ozone om --bootstrap`) is only required when adding a new OM node to the cluster
+or when explicitly requested by support instructions.
+
+**Important Note on Ozone Manager (OM) Disk Space for Snapshots**
+
+When an Ozone Manager (OM) acts as a follower in an HA setup, it downloads snapshot tarballs from the leader to its
+local metadata directory. Therefore, always ensure your OM disks have at least 2x the current OM database size to
+accommodate the existing data and incoming snapshots, preventing disk space issues and maintaining cluster stability.
 
 ## References
 
  * Check [this page]({{< ref "design/omha.md" >}}) for the links to the original design docs
  * Ozone distribution contains an example OM HA configuration, under the `compose/ozone-om-ha` directory which can be tested with the help of [docker-compose]({{< ref "start/RunningViaDocker.md" >}}).
-* [Apache Ratis State Machine API documentation](https://github.com/apache/ratis/blob/3612bcaf7d3e48a658935fc8b250e5d3b35df174/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java)
+* [Apache Ratis State Machine API documentation](https://github.com/apache/ratis/blob/ratis-3.1.3/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java)

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -132,7 +132,7 @@ In an Ozone Manager (OM) High Availability (HA) cluster, all OM nodes maintain a
 The OM HA implementation includes an **automatic snapshot installation and recovery process** for such cases:
 
 - **Snapshot Installation Trigger:**  
-  When a follower OM falls significantly behind and is unable to catch up with the leader OM through standard log replication, the leader OM will notify the follower to install a snapshot. This is handled internally by the OM state machine.
+When a follower OM falls significantly behind and is unable to catch up with the leader OM through standard log replication, the Ratis consensus layer on the leader OM may determine that a snapshot installation is necessary. The leader then notifies the follower, and the snapshot installation on the follower is handled by its `OzoneManagerStateMachine`.
 
 - **How it works:**
   - The follower OM receives a snapshot installation notification from the leader via the consensus protocol.

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -152,4 +152,4 @@ When a follower OM falls significantly behind and is unable to catch up with the
  * Check [this page]({{< ref "design/omha.md" >}}) for the links to the original design docs
  * Ozone distribution contains an example OM HA configuration, under the `compose/ozone-om-ha` directory which can be tested with the help of [docker-compose]({{< ref "start/RunningViaDocker.md" >}}).
 * [OzoneManagerStateMachine.notifyInstallSnapshotFromLeader source code](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L530)
-* [Apache Ratis State Machine API documentation](https://github.com/apache/ratis/blob/master/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java)
+* [Apache Ratis State Machine API documentation](https://github.com/apache/ratis/blob/3612bcaf7d3e48a658935fc8b250e5d3b35df174/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java)

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -151,5 +151,5 @@ When a follower OM falls significantly behind and is unable to catch up with the
 
  * Check [this page]({{< ref "design/omha.md" >}}) for the links to the original design docs
  * Ozone distribution contains an example OM HA configuration, under the `compose/ozone-om-ha` directory which can be tested with the help of [docker-compose]({{< ref "start/RunningViaDocker.md" >}}).
- * [OzoneManagerStateMachine.notifyInstallSnapshotFromLeader source code](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java)
+* [OzoneManagerStateMachine.notifyInstallSnapshotFromLeader source code](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L530)
 * [Apache Ratis State Machine API documentation](https://github.com/apache/ratis/blob/master/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java)

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -151,5 +151,4 @@ When a follower OM falls significantly behind and is unable to catch up with the
 
  * Check [this page]({{< ref "design/omha.md" >}}) for the links to the original design docs
  * Ozone distribution contains an example OM HA configuration, under the `compose/ozone-om-ha` directory which can be tested with the help of [docker-compose]({{< ref "start/RunningViaDocker.md" >}}).
-* [OzoneManagerStateMachine.notifyInstallSnapshotFromLeader source code](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L530)
 * [Apache Ratis State Machine API documentation](https://github.com/apache/ratis/blob/3612bcaf7d3e48a658935fc8b250e5d3b35df174/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java)


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13112. [Docs] Add a section "Automatic Snapshot Installation for Stale Ozone Managers" to OM HA doc

Please describe your PR in detail:
* Generated-by: ChatGPT, prompt:
```
https://ozone.apache.org/docs/edge/feature/om-ha.html

 

It is written in the user doc that OM bootstrap happens when adding a new OM. Ratis would trigger notifyInstallSnapshotFromLeader() if a follower OM falls behind the leader OM. We should update the doc to include this condition too.

https://github.com/apache/ratis/blob/c1da37cb455bbf94da267b3f2b9bf3884017e1ca/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java#L109

/**
 * Should this {@link LogAppender} send a snapshot to the follower?
 *
 * @return the snapshot if it should install a snapshot; otherwise, return null.
 */
default SnapshotInfo shouldInstallSnapshot() {
  // we should install snapshot if the follower needs to catch up and:
  // 1. there is no local log entry but there is snapshot
  // 2. or the follower's next index is smaller than the log start index
  // 3. or the follower is bootstrapping and has not installed any snapshot yet 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13112

## How was this patch tested?

User doc.