### PR TITLE
HDDS-13243. copy-rename-maven-plugin version is missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1719,6 +1719,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.coderplus.maven.plugins</groupId>
+          <artifactId>copy-rename-maven-plugin</artifactId>
+          <version>${copy-rename-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
           <version>${sortpom-maven-plugin.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restore definition of `copy-rename-plugin` with version, accidentally removed in HDDS-13179.

```
[WARNING] Some problems were encountered while building the effective model for org.apache.ozone:ozone-filesystem-shaded:jar:2.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for com.coderplus.maven.plugins:copy-rename-maven-plugin is missing. @ line 331, column 15
```

https://issues.apache.org/jira/browse/HDDS-13243

## How was this patch tested?

No warning about missing version in build:
https://github.com/adoroszlai/ozone/actions/runs/15588817819/job/43902182649