### PR TITLE
HDDS-13109. Add database check for metadata volumes

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/SlidingWindow.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/SlidingWindow.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.utils;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A time-based sliding window implementation that tracks only failed test results within a specified time duration.
+ * It determines failure based on a configured tolerance threshold.
+ */
+public class SlidingWindow {
+  private final long windowDuration;
+  private final TimeUnit timeUnit;
+  private final int failureTolerance;
+  private final Deque<Long> failureTimestamps;
+
+  /**
+   * @param failureTolerance the number of failures that can be tolerated before the window is considered failed
+   * @param windowDuration   the duration of the sliding window
+   * @param timeUnit         the time unit of the window duration
+   */
+  public SlidingWindow(int failureTolerance, long windowDuration, TimeUnit timeUnit) {
+    this.windowDuration = windowDuration;
+    this.timeUnit = timeUnit;
+    this.failureTolerance = failureTolerance;
+    this.failureTimestamps = new ArrayDeque<>(Math.min(failureTolerance, 100));
+  }
+
+  public synchronized void add(boolean result) {
+    if (!result) {
+      if (failureTolerance > 0 && failureTimestamps.size() >= failureTolerance) {
+        failureTimestamps.remove();
+      }
+      long currentTime = System.currentTimeMillis();
+      failureTimestamps.addLast(currentTime);
+    }
+
+    removeExpiredFailures();
+  }
+
+  public synchronized boolean isFailed() {
+    removeExpiredFailures();
+    return failureTimestamps.size() >= failureTolerance;
+  }
+
+  private void removeExpiredFailures() {
+    long currentTime = System.currentTimeMillis();
+    long expirationThreshold = currentTime - timeUnit.toMillis(windowDuration);
+
+    while (!failureTimestamps.isEmpty() && failureTimestamps.peek() < expirationThreshold) {
+      failureTimestamps.remove();
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/SlidingWindow.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/SlidingWindow.java
@@ -26,6 +26,9 @@ import org.slf4j.LoggerFactory;
 /**
  * A time-based sliding window implementation that tracks only failed test results within a specified time duration.
  * It determines failure based on a configured tolerance threshold.
+ *
+ * The queue saves one failure more than the configured tolerance threshold,
+ * so that the window can be considered failed.
  */
 public class SlidingWindow {
   private static final Logger LOG = LoggerFactory.getLogger(SlidingWindow.class);
@@ -44,7 +47,8 @@ public class SlidingWindow {
     this.windowDuration = windowDuration;
     this.timeUnit = timeUnit;
     this.failureTolerance = failureTolerance;
-    this.failureTimestamps = new ArrayDeque<>(Math.min(failureTolerance, 100));
+    // If the failure tolerance is high, we limit the queue size to 100 as we want to control the memory usage
+    this.failureTimestamps = new ArrayDeque<>(Math.min(failureTolerance + 1, 100));
   }
 
   public synchronized void add(boolean result) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestSlidingWindow.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestSlidingWindow.java
@@ -51,7 +51,7 @@ public class TestSlidingWindow {
 
   @Test
   public void testAddFailedResult() {
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 3; i++) {
       slidingWindow.add(false);
       assertFalse(slidingWindow.isFailed());
     }
@@ -63,6 +63,7 @@ public class TestSlidingWindow {
 
   @Test
   public void testMixedResults() {
+    slidingWindow.add(false);
     slidingWindow.add(false);
     slidingWindow.add(false);
     assertFalse(slidingWindow.isFailed());
@@ -88,6 +89,7 @@ public class TestSlidingWindow {
     // Add failed results to reach failure threshold
     slidingWindow.add(false);
     slidingWindow.add(false);
+    slidingWindow.add(false);
     assertTrue(slidingWindow.isFailed());
 
     // Wait for failures to expire
@@ -104,6 +106,7 @@ public class TestSlidingWindow {
   public void testPartialExpiration() throws InterruptedException {
     slidingWindow = new SlidingWindow(3, 1, TimeUnit.SECONDS);
 
+    slidingWindow.add(false);
     slidingWindow.add(false);
     slidingWindow.add(false);
     slidingWindow.add(false);
@@ -132,7 +135,7 @@ public class TestSlidingWindow {
     SlidingWindow highToleranceWindow = new SlidingWindow(10, 5, TimeUnit.SECONDS);
 
     // Add failures less than tolerance
-    for (int i = 0; i < 9; i++) {
+    for (int i = 0; i < 10; i++) {
       highToleranceWindow.add(false);
       assertFalse(highToleranceWindow.isFailed());
     }
@@ -215,6 +218,8 @@ public class TestSlidingWindow {
   public void testEdgeCases() {
     // Test with minimum values
     SlidingWindow minWindow = new SlidingWindow(1, 1, TimeUnit.MILLISECONDS);
+    minWindow.add(false);
+    assertFalse(minWindow.isFailed());
     minWindow.add(false);
     assertTrue(minWindow.isFailed());
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestSlidingWindow.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestSlidingWindow.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests for {@link SlidingWindow} class.
+ */
+public class TestSlidingWindow {
+
+  private SlidingWindow slidingWindow;
+
+  @BeforeEach
+  public void setup() {
+    slidingWindow = new SlidingWindow(3, 5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testAddSuccessfulResult() {
+    for (int i = 0; i < 10; i++) {
+      slidingWindow.add(true);
+      assertFalse(slidingWindow.isFailed());
+    }
+  }
+
+  @Test
+  public void testAddFailedResult() {
+    for (int i = 0; i < 2; i++) {
+      slidingWindow.add(false);
+      assertFalse(slidingWindow.isFailed());
+    }
+
+    // Adding one more failed result should mark as failed
+    slidingWindow.add(false);
+    assertTrue(slidingWindow.isFailed());
+  }
+
+  @Test
+  public void testMixedResults() {
+    slidingWindow.add(false);
+    slidingWindow.add(false);
+    assertFalse(slidingWindow.isFailed());
+
+    // Add successful result - should not affect failure count
+    slidingWindow.add(true);
+    assertFalse(slidingWindow.isFailed());
+
+    // Add one more failed result - should mark as failed
+    slidingWindow.add(false);
+    assertTrue(slidingWindow.isFailed());
+
+    // Add more successful results - should not affect failure status
+    slidingWindow.add(true);
+    slidingWindow.add(true);
+    assertTrue(slidingWindow.isFailed());
+  }
+
+  @Test
+  public void testFailureExpiration() throws InterruptedException {
+    slidingWindow = new SlidingWindow(2, 500, TimeUnit.MILLISECONDS);
+
+    // Add failed results to reach failure threshold
+    slidingWindow.add(false);
+    slidingWindow.add(false);
+    assertTrue(slidingWindow.isFailed());
+
+    // Wait for failures to expire
+    Thread.sleep(600);
+
+    assertFalse(slidingWindow.isFailed());
+
+    // Add one more failure - should not be enough to mark as failed
+    slidingWindow.add(false);
+    assertFalse(slidingWindow.isFailed());
+  }
+
+  @Test
+  public void testPartialExpiration() throws InterruptedException {
+    slidingWindow = new SlidingWindow(3, 1, TimeUnit.SECONDS);
+
+    slidingWindow.add(false);
+    slidingWindow.add(false);
+    slidingWindow.add(false);
+    assertTrue(slidingWindow.isFailed());
+
+    Thread.sleep(600);
+    slidingWindow.add(false); // this will remove the oldest failure as the window is full
+
+    // Wait for the oldest failures to expire
+    Thread.sleep(500);
+    assertFalse(slidingWindow.isFailed());
+  }
+
+  @Test
+  public void testZeroFailureTolerance() {
+    // Window with zero failure tolerance
+    SlidingWindow zeroToleranceWindow = new SlidingWindow(0, 5, TimeUnit.SECONDS);
+
+    // Any failure should mark as failed
+    zeroToleranceWindow.add(false);
+    assertTrue(zeroToleranceWindow.isFailed());
+  }
+
+  @Test
+  public void testHighFailureTolerance() {
+    SlidingWindow highToleranceWindow = new SlidingWindow(10, 5, TimeUnit.SECONDS);
+
+    // Add failures less than tolerance
+    for (int i = 0; i < 9; i++) {
+      highToleranceWindow.add(false);
+      assertFalse(highToleranceWindow.isFailed());
+    }
+
+    // Add one more to reach tolerance
+    highToleranceWindow.add(false);
+    assertTrue(highToleranceWindow.isFailed());
+  }
+
+  @Test
+  public void testFailureQueueManagement() {
+    SlidingWindow window = new SlidingWindow(3, 5, TimeUnit.SECONDS);
+
+    // Add more failures than the tolerance
+    for (int i = 0; i < 10; i++) {
+      window.add(false);
+    }
+
+    // Should be failed
+    assertTrue(window.isFailed());
+
+    // Add successful results - should not affect failure status
+    for (int i = 0; i < 5; i++) {
+      window.add(true);
+    }
+
+    // Should still be failed
+    assertTrue(window.isFailed());
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testConcurrentAccess() throws InterruptedException {
+    // Create a sliding window with tolerance of 5
+    final SlidingWindow concurrentWindow = new SlidingWindow(5, 5, TimeUnit.SECONDS);
+    final int threadCount = 10;
+    final int operationsPerThread = 100;
+    final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final CountDownLatch finishLatch = new CountDownLatch(threadCount);
+    final AtomicBoolean hasError = new AtomicBoolean(false);
+
+    // Create and submit tasks
+    for (int i = 0; i < threadCount; i++) {
+      final int threadId = i;
+      executor.submit(() -> {
+        try {
+          startLatch.await(); // Wait for all threads to be ready
+          for (int j = 0; j < operationsPerThread; j++) {
+            // Alternate between adding success and failure based on thread ID and iteration
+            boolean result = (threadId + j) % 2 == 0;
+            concurrentWindow.add(result);
+            // Check failure status occasionally
+            if (j % 10 == 0) {
+              concurrentWindow.isFailed();
+            }
+          }
+        } catch (Exception e) {
+          hasError.set(true);
+          e.printStackTrace();
+        } finally {
+          finishLatch.countDown();
+        }
+      });
+    }
+
+    // Start all threads
+    startLatch.countDown();
+
+    // Wait for all threads to finish
+    finishLatch.await();
+    executor.shutdown();
+    executor.awaitTermination(5, TimeUnit.SECONDS);
+
+    // Verify no exceptions occurred
+    assertFalse(hasError.get(), "Concurrent operations caused errors");
+  }
+
+  @Test
+  public void testEdgeCases() {
+    // Test with minimum values
+    SlidingWindow minWindow = new SlidingWindow(1, 1, TimeUnit.MILLISECONDS);
+    minWindow.add(false);
+    assertTrue(minWindow.isFailed());
+
+    // Test with large values
+    SlidingWindow maxWindow = new SlidingWindow(Integer.MAX_VALUE - 1,
+        Long.MAX_VALUE / 1000, TimeUnit.SECONDS);
+    for (int i = 0; i < 100; i++) {
+      maxWindow.add(false);
+      assertFalse(maxWindow.isFailed());
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/package-info.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Tests for Common container utils. */
+package org.apache.hadoop.ozone.container.common.utils;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
@@ -160,6 +160,7 @@ public final class DatanodeTestUtils {
     for (File dir : dirs) {
       if (dir.exists()) {
         assertTrue(dir.setWritable(false, false));
+        assertTrue(dir.setReadable(false, false));
       }
     }
   }
@@ -173,6 +174,7 @@ public final class DatanodeTestUtils {
     for (File dir : dirs) {
       if (dir.exists()) {
         assertTrue(dir.setWritable(true, true));
+        assertTrue(dir.setReadable(true, true));
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/package-info.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for datanode.
+ */
+package org.apache.hadoop.ozone.dn;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -239,7 +239,7 @@ class TestDatanodeHddsVolumeFailureDetection {
 
   /**
    * {@link HddsVolume#check(Boolean)} will capture the failures injected by this test and not allow the
-   * test to reach the helper method {@link HddsVolume#checkDbHealth}.
+   * test to reach the helper method {@link StorageVolume#checkDbHealth}.
    * As a workaround, we test the helper method directly.
    * As we test the helper method directly, we cannot test for schemas older than V3.
    *

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeMetadataVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeMetadataVolumeFailureDetection.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.dn.volume;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+import static org.apache.hadoop.ozone.OzoneConsts.WITNESSED_CONTAINER_DB_NAME;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.time.Duration;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.dn.DatanodeTestUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * This class tests datanode can detect failed volumes.
+ */
+class TestDatanodeMetadataVolumeFailureDetection {
+
+  // witnessed db was introduced in schema V3 so we won't test for older schemas
+  @ParameterizedTest
+  @ValueSource(booleans = {true})
+  void corruptDbFile(boolean schemaV3) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(schemaV3)) {
+      try (OzoneClient client = cluster.newClient()) {
+        OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
+
+        HddsDatanodeService dn = cluster.getHddsDatanodes().get(0);
+        OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+
+        File dbDir = null;
+        if (schemaV3) {
+          dbDir = Paths.get(ServerUtils.getOzoneMetaDirPath(cluster.getConf()).getAbsolutePath(),
+                  "datanode-1", "meta", WITNESSED_CONTAINER_DB_NAME).toFile();
+        }
+
+        MutableVolumeSet metaVolumeSet = oc.getMetaVolumeSet();
+        StorageVolume vol0 = metaVolumeSet.getVolumesList().get(0);
+
+        try {
+          // simulate a problem by removing the read permission of the db dir
+          DatanodeTestUtils.injectContainerMetaDirFailure(dbDir);
+          if (schemaV3) {
+            // remove rocksDB from cache
+            DatanodeStoreCache.getInstance().removeDB(dbDir.getAbsolutePath());
+          }
+
+          metaVolumeSet.checkVolumeAsync(vol0);
+          DatanodeTestUtils.waitForCheckVolume(metaVolumeSet, 1L);
+          DatanodeTestUtils.waitForHandleFailedVolume(metaVolumeSet, 1);
+        } finally {
+          // restore all
+          DatanodeTestUtils.restoreContainerMetaDirFromFailure(dbDir);
+        }
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true})
+  void corruptDbFileWithoutDbHandleCacheInvalidation(boolean schemaV3) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(schemaV3)) {
+      try (OzoneClient client = cluster.newClient()) {
+        OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
+
+        HddsDatanodeService dn = cluster.getHddsDatanodes().get(0);
+        OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+
+        File dbDir = null;
+        if (schemaV3) {
+          dbDir = Paths.get(ServerUtils.getOzoneMetaDirPath(cluster.getConf()).getAbsolutePath(),
+              "datanode-1", "meta", WITNESSED_CONTAINER_DB_NAME).toFile();
+        }
+
+        MutableVolumeSet metaVolumeSet = oc.getMetaVolumeSet();
+        StorageVolume vol0 = metaVolumeSet.getVolumesList().get(0);
+
+        try {
+          // simulate a problem by removing the read permission of the db dir
+          DatanodeTestUtils.injectContainerMetaDirFailure(dbDir);
+
+          metaVolumeSet.checkVolumeAsync(vol0);
+          DatanodeTestUtils.waitForCheckVolume(metaVolumeSet, 1L);
+          DatanodeTestUtils.waitForHandleFailedVolume(metaVolumeSet, 1);
+        } finally {
+          // restore all
+          DatanodeTestUtils.restoreContainerMetaDirFromFailure(dbDir);
+        }
+      }
+    }
+  }
+
+  private static MiniOzoneCluster newCluster(boolean schemaV3)
+      throws Exception {
+    OzoneConfiguration ozoneConfig = new OzoneConfiguration();
+    ozoneConfig.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
+    ozoneConfig.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
+        0, StorageUnit.MB);
+    ozoneConfig.setInt(OZONE_REPLICATION, 1);
+    // keep the cache size = 1, so we could trigger io exception on
+    // reading on-disk db instance
+    ozoneConfig.setInt(OZONE_CONTAINER_CACHE_SIZE, 1);
+    if (!schemaV3) {
+      ContainerTestUtils.disableSchemaV3(ozoneConfig);
+    }
+    // set tolerated = 1
+    // shorten the gap between successive checks to ease tests
+    DatanodeConfiguration dnConf =
+        ozoneConfig.getObject(DatanodeConfiguration.class);
+    dnConf.setFailedDataVolumesTolerated(1);
+    // We are corrupting the metadb volume in the tests. If toleration is set to the default value of 1,
+    // the datanode will shut down and the test will exit without completing.
+    // To avoid this, we increase the tolerated volume failures.
+    dnConf.setFailedMetadataVolumesTolerated(10);
+    dnConf.setDiskCheckMinGap(Duration.ofSeconds(2));
+    ozoneConfig.setFromObject(dnConf);
+    MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
+        .setNumDatanodes(1)
+        .build();
+    cluster.waitForClusterToBeReady();
+    cluster.waitForPipelineTobeReady(ReplicationFactor.ONE, 30000);
+
+    return cluster;
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/package-info.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for volume related classes.
+ */
+package org.apache.hadoop.ozone.dn.volume;


### PR DESCRIPTION
Please describe your PR in detail:
This PR adds a check for the witnessed db in `MetadataVolume`. The check is similar to the one implemented for `StorageVolume`. 
This PR depends on https://github.com/apache/ozone/pull/8543 which should be merged before this PR. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13109

## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/15601904690