### PR TITLE
HDDS-13212. [DiskBalancer] Fix Inconsistent Health Check in DiskBalancer Status for Specific Hosts

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -111,9 +111,10 @@ public class DiskBalancerManager {
           useHostnames).stream()
           .filter(dn -> {
             try {
-              if (nodeManager.getNodeStatus(dn) != NodeStatus.inServiceHealthy()) {
+              NodeStatus nodeStatus = nodeManager.getNodeStatus(dn);
+              if (nodeStatus != NodeStatus.inServiceHealthy()) {
                 LOG.warn("Datanode {} is not in optimal state for disk balancing." +
-                    " Operational state: {}", dn.getHostName(), nodeManager.getNodeStatus(dn).getOperationalState());
+                    " NodeStatus: {}", dn.getHostName(), nodeStatus);
                 return false;
               }
               return true;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -34,7 +34,7 @@ import picocli.CommandLine.Option;
  */
 @Command(
     name = "status",
-    description = "Get Datanode DiskBalancer Status",
+    description = "Get Datanode DiskBalancer Status for inServiceHealthy DNs",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class DiskBalancerStatusSubcommand extends ScmSubcommand {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The DiskBalancerManager#getDiskBalancerStatus() method filters only healthy datanodes when querying all nodes, but returns all specified hosts regardless of their health. This inconsistency can lead to confusion or inaccurate monitoring.
This JIRA proposes applying the same IN_SERVICE and HEALTHY filters for specific hosts to ensure consistent behavior.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13212

## How was this patch tested?

Tested manually on docker cluster.
```
bash-5.1$ ozone admin datanode diskbalancer status -d ozone-ha-datanode-2 -d ozone-ha-datanode-3 -d  ozone-ha-datanode-1
Status result:
Datanode                            Status          Threshold(%)    BandwidthInMB   Threads      SuccessMove  FailureMove  BytesMoved(MB)  EstBytesToMove(MB) EstTimeLeft(min)
ozone-ha-datanode-1.ozone-ha_default STOPPED         10.0000         10              5            0            0            0               0               0              

Note: Estimated time left is calculated based on the estimated bytes to move and the configured disk bandwidth.
```
related logs 
```
2025-06-12 10:55:11 2025-06-12 05:25:11,553 [IPC Server handler 14 on default port 9860] WARN node.DiskBalancerManager: Datanode ozone-ha-datanode-2.ozone-ha_default is not in optimal state for disk balancing. NodeStatus: ENTERING_MAINTENANCE(expiry: 1749816487s)-HEALTHY
2025-06-12 10:55:11 2025-06-12 05:25:11,553 [IPC Server handler 14 on default port 9860] WARN node.DiskBalancerManager: Datanode ozone-ha-datanode-3.ozone-ha_default is not in optimal state for disk balancing. NodeStatus: DECOMMISSIONING(no expiry)-HEALTHY
```