### PR TITLE
HDDS-13248. Remove `ozone debug replicas verify` option --output-dir

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -37,7 +37,7 @@ Write keys
 
 *** Test Cases ***
 Test ozone debug replicas verify checksums
-    ${output} =    Execute   ozone debug replicas verify --checksums --block-existence --container-state o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE} --output-dir ${TEMP_DIR}
+    ${output} =    Execute   ozone debug replicas verify --checksums --block-existence --container-state o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE}
     ${json} =      Evaluate  json.loads('''${output}''')      json
 
     # 'keys' array should be empty if all keys and their replicas passed checksum verification

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -23,7 +23,7 @@ ${OM_SERVICE_ID}                    %{OM_SERVICE_ID}
 
 *** Keywords ***
 Execute replicas verify checksums CLI tool
-    Execute                         ozone debug -Dozone.network.topology.aware.read=true replicas verify --checksums --output-dir ${TEMP_DIR} o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE}
+    Execute                         ozone debug -Dozone.network.topology.aware.read=true replicas verify --checksums o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE}
     ${directory} =                  Execute     ls -d ${TEMP_DIR}/${VOLUME}_${BUCKET}_${TESTFILE}_*/ | tail -n 1
     Directory Should Exist          ${directory}
     File Should Exist               ${directory}/${TESTFILE}_manifest

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -104,7 +104,7 @@ public abstract class TestOzoneDebugShell implements NonHATests.TestCase {
         getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY),
         getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY),
         "replicas", "verify", "--checksums", "--block-existence", "--container-state", fullKeyPath,
-        "--output-dir", "/"//, "--all-results"
+        //, "--all-results"
     };
 
     int exitCode = ozoneDebugShell.execute(args);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -55,12 +55,6 @@ public class ReplicasVerify extends Handler {
       description = Shell.OZONE_URI_DESCRIPTION)
   private String uri;
 
-  @CommandLine.Option(names = {"-o", "--output-dir"},
-      description = "Destination directory to save the generated output. " +
-          "If not specified, the output is printed to the console. " +
-          "Note: This option is currently not supported") // TODO: HDDS-13063
-  private String outputDir;
-
   @CommandLine.Option(names = {"--all-results"},
       description = "Print results for all passing and failing keys")
   private boolean allResults;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -56,8 +56,9 @@ public class ReplicasVerify extends Handler {
   private String uri;
 
   @CommandLine.Option(names = {"-o", "--output-dir"},
-      description = "Destination directory to save the generated output.",
-      required = true)
+      description = "Destination directory to save the generated output. " +
+          "If not specified, the output is printed to the console. " +
+          "Note: This option is currently not supported") // TODO: HDDS-13063
   private String outputDir;
 
   @CommandLine.Option(names = {"--all-results"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the output directory option isn't being used for the replicas verify command. In future, the support for writing the output into a file might be added (through [HDDS-13063](https://issues.apache.org/jira/browse/HDDS-13063)), but right now it isn't present.
So the option can be removed, added later if needed

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13248

## How was this patch tested?

Updated unit and robot test
