### PR TITLE
HDDS-13168. Fix error response format in CheckUploadContentTypeFilter

### DIFF
--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
@@ -53,6 +53,7 @@ public class CheckUploadContentTypeFilter implements Filter {
    * This implementation is a NOP.
    *
    * @param config filter configuration.
+   *
    * @throws ServletException thrown if the filter could not be initialized.
    */
   @Override
@@ -63,10 +64,11 @@ public class CheckUploadContentTypeFilter implements Filter {
    * Enforces the content-type to be application/octet-stream for
    * POST and PUT requests.
    *
-   * @param request  servlet request.
+   * @param request servlet request.
    * @param response servlet response.
-   * @param chain    filter chain.
-   * @throws IOException      thrown if an IO error occurs.
+   * @param chain filter chain.
+   *
+   * @throws IOException thrown if an IO error occurs.
    * @throws ServletException thrown if a servlet error occurs.
    */
   @Override

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
@@ -18,6 +18,7 @@
 package org.apache.ozone.fs.http.server;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
 import javax.servlet.Filter;
@@ -52,7 +53,6 @@ public class CheckUploadContentTypeFilter implements Filter {
    * This implementation is a NOP.
    *
    * @param config filter configuration.
-   *
    * @throws ServletException thrown if the filter could not be initialized.
    */
   @Override
@@ -63,11 +63,10 @@ public class CheckUploadContentTypeFilter implements Filter {
    * Enforces the content-type to be application/octet-stream for
    * POST and PUT requests.
    *
-   * @param request servlet request.
+   * @param request  servlet request.
    * @param response servlet response.
-   * @param chain filter chain.
-   *
-   * @throws IOException thrown if an IO error occurs.
+   * @param chain    filter chain.
+   * @throws IOException      thrown if an IO error occurs.
    * @throws ServletException thrown if a servlet error occurs.
    */
   @Override
@@ -93,10 +92,20 @@ public class CheckUploadContentTypeFilter implements Filter {
     if (contentTypeOK) {
       chain.doFilter(httpReq, httpRes);
     } else {
-      httpRes.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                        "Data upload requests must have content-type set to '" +
-                            HttpFSConstants.UPLOAD_CONTENT_TYPE + "'");
+      httpRes.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      httpRes.setContentType("application/json");
+      httpRes.setCharacterEncoding("UTF-8");
 
+      String errorMessage = "Data upload requests must have content-type set to '" +
+          HttpFSConstants.UPLOAD_CONTENT_TYPE + "'";
+
+      // Create JSON response
+      String jsonResponse = "{\"error\":\"" + errorMessage + "\"}";
+
+      PrintWriter writer = httpRes.getWriter();
+      writer.write(jsonResponse);
+      writer.flush();
+      writer.close();
     }
   }
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
@@ -19,7 +19,9 @@ package org.apache.ozone.fs.http.server;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -101,8 +103,10 @@ public class CheckUploadContentTypeFilter implements Filter {
       String errorMessage = "Data upload requests must have content-type set to '" +
           HttpFSConstants.UPLOAD_CONTENT_TYPE + "'";
 
-      // Create JSON response
-      String jsonResponse = "{\"error\":\"" + errorMessage + "\"}";
+      Map<String, String> errorMap = new HashMap<>();
+      errorMap.put("error", errorMessage);
+
+      String jsonResponse = JsonUtil.toJsonString(errorMap);
 
       PrintWriter writer = httpRes.getWriter();
       writer.write(jsonResponse);


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-13168. Fix content type error response format in `CheckUploadContentTypeFilter.java`

The `CheckUploadContentTypeFilter` was modified to return properly formatted JSON error responses instead of using the generic sendError() method. When a data upload request lacks the required `application/octet-stream` content-type, the filter now returns a consistent JSON error response with the correct `application/json` content-type header.

This change ensures API consistency across all WebHDFS endpoints and makes error responses easier for clients to parse programmatically. Previously, error responses from this filter were not properly formatted as JSON, creating inconsistency with other API responses.

The specific changes include:
- Replaced the sendError() call with a proper JSON response construction
- Set appropriate HTTP status code (400 Bad Request)
- Ensured the response content-type is `application/json;charset=utf-8`
- Maintained the same error message content for backward compatibility.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13168

## How was this patch tested?

1. Build distribution

```shell
mvn clean package -DskipTests=true
```

2. Run docker compose

```shell
cd ./hadoop-ozone/dist/target/ozone-2.1.0-SNAPSHOT/compose/ozone
OZONE_DATANODES=3 ./run.sh -d
```

3. Create a file called `test.txt` in the local directory

```shell
echo 'hello world' > export.txt
```

4. Send request without content-type

```shell

curl -v -X PUT -T ./export.txt "http://localhost:14000/webhdfs/v1/exports/text/export.txt?op=CREATE&data=true&user.name=hadoop"
```

5. Verify that response code is Bad Request (400), and the error message is:

and the response will be:

```shell
curl -v -X PUT -T ./test.txt  "http://localhost:14000/webhdfs/v1/exports/text/export.txt?op=CREATE&data=true&user.name=hadoop"
Note: Unnecessary use of -X or --request, PUT is already inferred.
* Host localhost:14000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:14000...
* Connected to localhost (::1) port 14000
> PUT /webhdfs/v1/exports/text/export.txt?op=CREATE&data=true&user.name=hadoop HTTP/1.1
> Host: localhost:14000
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Length: 12
> 
* upload completely sent off: 12 bytes
< HTTP/1.1 400 Bad Request
< Date: Thu, 12 Jun 2025 15:33:13 GMT
< Cache-Control: no-cache
< Expires: Thu, 12 Jun 2025 15:33:13 GMT
< Pragma: no-cache
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Set-Cookie: hadoop.auth="u=hadoop&p=hadoop&t=simple-dt&e=1749778393435&s=qrnNFoyNNWT+lE4tzPx6ke2XMpGUUH4Eb7W13zdodYQ="; Path=/; HttpOnly
< Content-Type: application/json;charset=utf-8
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
{"error":"Data upload requests must have content-type set to 'application/octet-stream'"}
```

Which has status code Bad Request (400) and JSON response will be:

```json
{"error":"Data upload requests must have content-type set to 'application/octet-stream'"}
```

6. Now, send request with content-type set to `application/octet-stream` 

```shell
curl -v -X PUT -T ./export.txt -H"Content-Type: application/octet-stream" "http://localhost:14000/webhdfs/v1/exports/text/export.txt?op=CREATE&data=true&user.name=hadoop"
```

and the response code will be `201`

```shell
Note: Unnecessary use of -X or --request, PUT is already inferred.
* Host localhost:14000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:14000...
* Connected to localhost (::1) port 14000
> PUT /webhdfs/v1/exports/text/export.txt?op=CREATE&data=true&user.name=hadoop HTTP/1.1
> Host: localhost:14000
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/octet-stream
> Content-Length: 12
> 
* upload completely sent off: 12 bytes
< HTTP/1.1 201 Created
< Date: Thu, 12 Jun 2025 15:30:48 GMT
< Cache-Control: no-cache
< Expires: Thu, 12 Jun 2025 15:30:48 GMT
< Pragma: no-cache
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Set-Cookie: hadoop.auth="u=hadoop&p=hadoop&t=simple-dt&e=1749778248717&s=m66Bktyw7AXq6xuDt64EdpF9llvWFGAt7tx0K64Fmd8="; Path=/; HttpOnly
< Location: http://localhost:14000/webhdfs/v1/exports/text/export.txt
< Content-Type: application/json
< Content-Length: 72
< 
* Connection #0 to host localhost left intact
{"Location":"http://localhost:14000/webhdfs/v1/exports/text/export.txt"}
```

Which has status code Created (201) and JSON response will be:

```json
{"Location":"http://localhost:14000/webhdfs/v1/exports/text/export.txt"}
```

