### PR TITLE
HDDS-13257. Remove separate split for shell integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2830,11 +2830,8 @@
               <excludes>
                 <exclude>org.apache.hadoop.ozone.client.**</exclude>
                 <exclude>org.apache.hadoop.ozone.container.**</exclude>
-                <exclude>org.apache.hadoop.ozone.debug.**</exclude>
-                <exclude>org.apache.hadoop.ozone.freon.**</exclude>
                 <exclude>org.apache.hadoop.ozone.om.**</exclude>
                 <exclude>org.apache.hadoop.ozone.recon.**</exclude>
-                <exclude>org.apache.hadoop.ozone.shell.**</exclude>
               </excludes>
               <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
@@ -2852,25 +2849,6 @@
             <configuration>
               <includes>
                 <include>org.apache.hadoop.ozone.recon.**</include>
-              </includes>
-              <excludedGroups>${unstable-test-groups}</excludedGroups>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>test-shell</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <includes>
-                <include>org.apache.hadoop.ozone.debug.**</include>
-                <include>org.apache.hadoop.ozone.freon.**</include>
-                <include>org.apache.hadoop.ozone.shell.**</include>
               </includes>
               <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Merge _integration (shell)_ (~12 minutes) into _integration (ozone)_ (~33 minutes) to reduce overhead of building the project.

https://issues.apache.org/jira/browse/HDDS-13257

## How was this patch tested?

Verified that tests from the old _integration (shell)_ split are now run in _integration (ozone)_, which finished in 40 minutes:

https://github.com/adoroszlai/ozone/actions/runs/15626723958/job/44022729282#step:13:5286