### PR TITLE
HDDS-13266. ozone debug checknative command to add openssl lib check.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CheckNative.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CheckNative.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdds.utils.NativeConstants.ROCKS_TOOLS_NATIVE_LI
 
 import java.util.Collections;
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.utils.NativeLibraryLoader;
@@ -37,27 +38,59 @@ import picocli.CommandLine;
 @MetaInfServices(DebugSubcommand.class)
 public class CheckNative extends AbstractSubcommand implements Callable<Void>, DebugSubcommand {
 
+  private static class LibraryCheckResult {
+    final boolean loaded;
+    final String detail;
+
+    LibraryCheckResult(boolean loaded, String detail) {
+      this.loaded = loaded;
+      this.detail = detail;
+    }
+  }
+
+  private LibraryCheckResult getLibraryStatus(
+      Supplier<String> failureReasonSupplier,
+      Supplier<String> libraryNameSupplier) {
+    String failureReason = failureReasonSupplier.get();
+    if (failureReason != null) {
+      return new LibraryCheckResult(false, failureReason);
+    } else {
+      return new LibraryCheckResult(true, libraryNameSupplier.get());
+    }
+  }
+
   @Override
   public Void call() throws Exception {
     boolean nativeHadoopLoaded = org.apache.hadoop.util.NativeCodeLoader.isNativeCodeLoaded();
     String hadoopLibraryName = "";
     String isalDetail = "";
     boolean isalLoaded = false;
+    String opensslDetail = "";
+    boolean opensslLoaded = false;
+
     if (nativeHadoopLoaded) {
       hadoopLibraryName = org.apache.hadoop.util.NativeCodeLoader.getLibraryName();
 
-      isalDetail = ErasureCodeNative.getLoadingFailureReason();
-      if (isalDetail != null) {
-        isalLoaded = false;
-      } else {
-        isalDetail = ErasureCodeNative.getLibraryName();
-        isalLoaded = true;
-      }
+      LibraryCheckResult isalStatus = getLibraryStatus(
+          ErasureCodeNative::getLoadingFailureReason,
+          ErasureCodeNative::getLibraryName
+      );
+      isalLoaded = isalStatus.loaded;
+      isalDetail = isalStatus.detail;
+
+      // Check OpenSSL status
+      LibraryCheckResult opensslStatus = getLibraryStatus(
+          org.apache.hadoop.crypto.OpensslCipher::getLoadingFailureReason,
+          org.apache.hadoop.crypto.OpensslCipher::getLibraryName
+      );
+      opensslLoaded = opensslStatus.loaded;
+      opensslDetail = opensslStatus.detail;
     }
     out().println("Native library checking:");
     out().printf("hadoop:  %b %s%n", nativeHadoopLoaded,
         hadoopLibraryName);
     out().printf("ISA-L:   %b %s%n", isalLoaded, isalDetail);
+    out().printf("OpenSSL: %b %s%n", opensslLoaded, opensslDetail);
 
     // Attempt to load the rocks-tools lib
     boolean nativeRocksToolsLoaded = NativeLibraryLoader.getInstance().loadLibrary(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CheckNative.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CheckNative.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.utils.NativeConstants.ROCKS_TOOLS_NATIVE_LI
 import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import org.apache.hadoop.crypto.OpensslCipher;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.DebugSubcommand;
 import org.apache.hadoop.hdds.utils.NativeLibraryLoader;
@@ -39,12 +40,20 @@ import picocli.CommandLine;
 public class CheckNative extends AbstractSubcommand implements Callable<Void>, DebugSubcommand {
 
   private static class LibraryCheckResult {
-    final boolean loaded;
-    final String detail;
+    private final boolean loaded;
+    private final String detail;
 
     LibraryCheckResult(boolean loaded, String detail) {
       this.loaded = loaded;
       this.detail = detail;
+    }
+
+    public boolean isLoaded() {
+      return loaded;
+    }
+
+    public String getDetail() {
+      return detail;
     }
   }
 
@@ -75,16 +84,16 @@ public class CheckNative extends AbstractSubcommand implements Callable<Void>, D
           ErasureCodeNative::getLoadingFailureReason,
           ErasureCodeNative::getLibraryName
       );
-      isalLoaded = isalStatus.loaded;
-      isalDetail = isalStatus.detail;
+      isalLoaded = isalStatus.isLoaded();
+      isalDetail = isalStatus.getDetail();
 
       // Check OpenSSL status
       LibraryCheckResult opensslStatus = getLibraryStatus(
-          org.apache.hadoop.crypto.OpensslCipher::getLoadingFailureReason,
-          org.apache.hadoop.crypto.OpensslCipher::getLibraryName
+          OpensslCipher::getLoadingFailureReason,
+          OpensslCipher::getLibraryName
       );
-      opensslLoaded = opensslStatus.loaded;
-      opensslDetail = opensslStatus.detail;
+      opensslLoaded = opensslStatus.isLoaded();
+      opensslDetail = opensslStatus.getDetail();
     }
     out().println("Native library checking:");
     out().printf("hadoop:  %b %s%n", nativeHadoopLoaded,

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestCheckNative.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestCheckNative.java
@@ -62,6 +62,7 @@ class TestCheckNative {
         .contains("Native library checking:")
         .contains("hadoop: false")
         .contains("ISA-L: false")
+        .contains("OpenSSL: false")
         .contains("rocks-tools: " + expectedRocksNative);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13266. ozone debug checknative command to add openssl lib check.

Please describe your PR in detail:
* Added openssl library check in 'ozone debug checknative' command output.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13266

## How was this patch tested?

The following is the output of 'ozone debug checknative' in debug log level, running in ozone-docker-runner:


```
  curl -L "https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-3.4.0/hadoop-3.4.0-aarch64.tar.gz" | tar -xz --wildcards 'hadoop-3.4.0/lib/native/libhadoop.*'
  export LD_LIBRARY_PATH=$PWD/hadoop-3.4.0/lib/native/:$LD_LIBRARY_PATH
  ozone --debug --loglevel DEBUG debug checknative

  2025-06-14 02:58:18,567 [main] WARN erasurecode.ErasureCodeNative: ISA-L support is not available in your platform... using builtin-java codec where applicable
2025-06-14 02:58:18,569 [main] WARN crypto.OpensslCipher: Failed to load OpenSSL Cipher.
java.lang.UnsatisfiedLinkError: Cannot load libcrypto.so (libcrypto.so: cannot open shared object file: No such file or directory)!
        at org.apache.hadoop.crypto.OpensslCipher.initIDs(Native Method)
        at org.apache.hadoop.crypto.OpensslCipher.<clinit>(OpensslCipher.java:90)
        at org.apache.hadoop.ozone.debug.CheckNative.getLibraryStatus(CheckNative.java:54)
        at org.apache.hadoop.ozone.debug.CheckNative.call(CheckNative.java:82)
        at org.apache.hadoop.ozone.debug.CheckNative.call(CheckNative.java:36)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2031)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
        at org.apache.hadoop.ozone.shell.Shell.lambda$execute$0(Shell.java:95)
        at org.apache.hadoop.hdds.tracing.TracingUtil.executeInSpan(TracingUtil.java:167)
        at org.apache.hadoop.hdds.tracing.TracingUtil.executeInNewSpan(TracingUtil.java:157)
        at org.apache.hadoop.ozone.shell.Shell.execute(Shell.java:95)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:89)
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:80)
        at org.apache.hadoop.ozone.debug.OzoneDebug.main(OzoneDebug.java:36)
Native library checking:
hadoop:  true /opt/hadoop/hadoop-3.4.0/lib/native/libhadoop.so.1.0.0
ISA-L:   false libhadoop was built without ISA-L support
OpenSSL: false Cannot load libcrypto.so (libcrypto.so: cannot open shared object file: No such file or directory)!
2025-06-14 02:58:18,571 [main] DEBUG utils.LeakDetector: Starting leak detector thread ManagedRocksObject0.
2025-06-14 02:58:18,588 [main] INFO utils.NativeLibraryLoader: Loading Library: ozone_rocksdb_tools
rocks-tools: false 
```