### PR TITLE
HDDS-13265. Simplify the page Access Ozone using HTTPFS REST API

### DIFF
--- a/hadoop-hdds/docs/content/recipe/PythonRequestsOzoneHttpFS.md
+++ b/hadoop-hdds/docs/content/recipe/PythonRequestsOzoneHttpFS.md
@@ -33,31 +33,9 @@ This tutorial demonstrates how to access Apache Ozone using the HTTPFS REST API 
 
 ### 1️⃣ Start Ozone in Docker
 
-Download the latest Docker Compose configuration file:
-
+Download the latest Docker Compose file for Ozone and start the cluster with 3 DataNodes:
 ```bash
 curl -O https://raw.githubusercontent.com/apache/ozone-docker/refs/heads/latest/docker-compose.yaml
-```
-
-Add httpfs container configurations and environment variable overrides at the bottom of `docker-compose.yaml`:
-
-```yaml
-   httpfs:
-     <<: *image
-     ports:
-       - 14000:14000
-     environment:
-       CORE-SITE.XML_fs.defaultFS: "ofs://om"
-       CORE-SITE.XML_hadoop.proxyuser.hadoop.hosts: "*"
-       CORE-SITE.XML_hadoop.proxyuser.hadoop.groups: "*"
-       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-       <<: *common-config
-     command: [ "ozone","httpfs" ]
-```
-
-Start the cluster:
-
-```bash
 docker compose up -d --scale datanode=3
 ```
 

--- a/hadoop-hdds/docs/content/recipe/PythonRequestsOzoneHttpFS.md
+++ b/hadoop-hdds/docs/content/recipe/PythonRequestsOzoneHttpFS.md
@@ -35,7 +35,7 @@ This tutorial demonstrates how to access Apache Ozone using the HTTPFS REST API 
 
 Download the latest Docker Compose file for Ozone and start the cluster with 3 DataNodes:
 ```bash
-curl -O https://raw.githubusercontent.com/apache/ozone-docker/refs/heads/latest/docker-compose.yaml
+curl -O https://raw.githubusercontent.com/apache/ozone-docker/latest/docker-compose.yaml
 docker compose up -d --scale datanode=3
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13265. Simplify the page Access Ozone using HTTPFS REST API (Docker + Python Requests).

Please describe your PR in detail:
* The docker compose file is updated to include httpfs so the instructions can be simplified.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13265

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
