### PR TITLE
HDDS-13279. Skip verifying Apache Ranger binaries in CI

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-ranger.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-ranger.sh
@@ -31,8 +31,10 @@ export OM_SERVICE_ID="omservice"
 export SCM=scm1.org
 export SECURITY_ENABLED=true
 
-curl -LO https://downloads.apache.org/ranger/KEYS
-gpg --import KEYS
+if [[ "${SKIP_APACHE_VERIFY_DOWNLOAD}" != "true" ]]; then
+  curl -LO https://downloads.apache.org/ranger/KEYS
+  gpg --import KEYS
+fi
 
 download_and_verify_apache_release "ranger/${RANGER_VERSION}/apache-ranger-${RANGER_VERSION}.tar.gz"
 tar -C "${DOWNLOAD_DIR}" -x -z -f "${DOWNLOAD_DIR}/apache-ranger-${RANGER_VERSION}.tar.gz"

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -30,6 +30,7 @@ source "${_testlib_dir}/../smoketest/testlib.sh"
 : ${OZONE_COMPOSE_RUNNING:=false}
 : ${SECURITY_ENABLED:=false}
 : ${SCM:=scm}
+: ${SKIP_APACHE_VERIFY_DOWNLOAD:=${CI:-false}}
 
 # Check if running from output of Maven build or from source
 _is_build() {
@@ -631,6 +632,8 @@ download_and_verify_apache_release() {
   local download_dir="${DOWNLOAD_DIR:-/tmp}"
 
   download_if_not_exists "${base_url}${remote_path}" "${download_dir}/${f}"
-  download_if_not_exists "${checksum_base_url}${remote_path}.asc"  "${download_dir}/${f}.asc"
-  gpg --verify "${download_dir}/${f}.asc" "${download_dir}/${f}" || exit 1
+  if [[ "${SKIP_APACHE_VERIFY_DOWNLOAD}" != "true" ]]; then
+    download_if_not_exists "${checksum_base_url}${remote_path}.asc"  "${download_dir}/${f}.asc"
+    gpg --verify "${download_dir}/${f}.asc" "${download_dir}/${f}" || exit 1
+  fi
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Downloading Apache Ranger keys and signatures from `downloads.apache.org` may fail due to infra ban:

```
curl: (28) Failed to connect to downloads.apache.org port 443 after 271591 ms: Couldn't connect to server
```

Hence, skip signature verification in CI.

https://issues.apache.org/jira/browse/HDDS-13279

## How was this patch tested?

Tested both regular and CI-like env:

```
$ cd hadoop-ozone/dist/target/ozone-2.1.0-SNAPSHOT/compose/ozonesecure-ha
$ ./test-ranger.sh
/tmp/apache-ranger-2.6.0.tar.gz already downloaded
/tmp/apache-ranger-2.6.0.tar.gz.asc already downloaded
...
gpg: Good signature from "Abhishek Kumar (Apache Ranger RC Signing) <abhi@apache.org>" [unknown]
...
Port 6080 is available on ranger
...

$ CI=true ./test-ranger.sh
/tmp/apache-ranger-2.6.0.tar.gz already downloaded
...
Port 6080 is available on ranger
...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/15673969771/job/44150748008#step:13:1019