### PR TITLE
HDDS-13280. Smoketest Ozone with Ranger authorizer

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/init-kdc.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/init-kdc.sh
@@ -81,6 +81,11 @@ export_keytab rm/rm rm
 export_keytab nm/nm nm
 export_keytab jhs/jhs jhs
 
+# for Ranger
+for host in dn httpfs om recon s3g scm; do
+  export_keytab "hdfs/$host" hdfs
+done
+
 chmod 755 /etc/security/keytabs/*.keytab
 chown 1000. /etc/security/keytabs/*.keytab
 

--- a/hadoop-ozone/dist/src/main/compose/common/ranger.yaml
+++ b/hadoop-ozone/dist/src/main/compose/common/ranger.yaml
@@ -45,3 +45,7 @@ services:
     environment:
       RANGER_DB_TYPE: postgres
       RANGER_VERSION:
+    healthcheck:
+      test: 'grep "Successfully retrieved .*dev_ozone" /var/log/ranger/ranger-admin*log'
+      interval: 2s
+      retries: 60

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/ranger.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/ranger.yaml
@@ -25,8 +25,10 @@ x-om-ranger-config:
       OZONE-SITE.XML_ozone.om.ranger.https.admin.api.passwd: "rangerR0cks!"
       OZONE-SITE.XML_ozone.om.ranger.service: "dev_ozone"
       OZONE-SITE.XML_ozone.om.tenant.dev.skip.ranger: "false"
+      RANGER-OZONE-SECURITY.XML_ranger.plugin.ozone.forceNonKerberos: "true"
       RANGER-OZONE-SECURITY.XML_ranger.plugin.ozone.policy.rest.url: "http://ranger:6080"
-      RANGER-OZONE-SECURITY.XML_ranger.plugin.ozone.policyengine.option.disable.policy.refresher: "true"
+      RANGER-OZONE-SECURITY.XML_ranger.plugin.ozone.policy.rest.client.username: "hdfs"
+      RANGER-OZONE-SECURITY.XML_ranger.plugin.ozone.policy.rest.client.password: "hdfs"
       RANGER-OZONE-SECURITY.XML_ranger.plugin.ozone.service.name: "dev_ozone"
     volumes:
       - ../..:/opt/hadoop
@@ -40,10 +42,19 @@ x-om-ranger-config:
 services:
   om1:
     <<: *om-ranger-config
+    depends_on:
+      ranger:
+        condition: service_healthy
   om2:
     <<: *om-ranger-config
+    depends_on:
+      ranger:
+        condition: service_healthy
   om3:
     <<: *om-ranger-config
+    depends_on:
+      ranger:
+        condition: service_healthy
   ranger:
     networks:
       ozone_net:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-ranger.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-ranger.sh
@@ -58,4 +58,8 @@ perl -wpl -i \
 start_docker_env
 wait_for_port ranger 6080 120
 
+execute_robot_test s3g -v testuser:hdfs kinit.robot
+execute_robot_test s3g freon/generate.robot
+execute_robot_test s3g freon/validate.robot
+
 # execute_robot_test scm security/ozone-secure-tenant.robot


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `ozonesecure-ha/test-ranger.sh` just starts the cluster.  This change adds a basic Freon test, and tweaks the setup as necessary for the test to succeed.

- Enable policy sync.
- Ranger creates `dev_ozone` policy (among others) with some delay.  Start OMs only after that, to allow the first policy sync to succeed.
- Create keytabs for `hdfs`, which is granted access in Ranger's setup, and execute the test as this user.

https://issues.apache.org/jira/browse/HDDS-13280

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/15679980269/job/44169693339#step:13:925