### PR TITLE
HDDS-13256. Updated OM Snapshot Grafana Dashboard to reflect metric updates from HDDS-13181.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - OM Snapshot.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - OM Snapshot.json
@@ -305,7 +305,7 @@
         "x": 0,
         "y": 19
       },
-      "id": 4,
+      "id": 1,
       "options": {
         "legend": {
           "calcs": [],
@@ -324,14 +324,15 @@
             "type": "prometheus"
           },
           "editorMode": "code",
-          "expr": "om_metrics_num_snapshot_purges{instance=~\".*9874\"}",
+          "exemplar": false,
+          "expr": "om_metrics_num_snapshot_deleted{instance=~\".*:9874\"}",
           "instant": false,
           "legendFormat": "OM {{instance}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "NumSnapshotPurges",
+      "title": "NumSnapshotDeleted",
       "type": "timeseries"
     },
     {
@@ -491,7 +492,7 @@
         "x": 0,
         "y": 27
       },
-      "id": 1,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -510,15 +511,293 @@
             "type": "prometheus"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "om_metrics_num_snapshot_deleted{instance=~\".*:9874\"}",
+          "expr": "om_snapshot_internal_metrics_num_snapshot_purges{instance=~\".*9874\"}",
           "instant": false,
           "legendFormat": "OM {{instance}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "NumSnapshotDeleted",
+      "title": "NumSnapshotPurges",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "om_snapshot_internal_metrics_num_snapshot_purge_fails{instance=~\".*9874\"}",
+          "instant": false,
+          "legendFormat": "OM {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NumSnapshotPurgeFailures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "om_snapshot_internal_metrics_num_snapshot_move_table_keys{instance=~\".*9874\"}",
+          "instant": false,
+          "legendFormat": "OM {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NumSnapshotMoveTableKeys",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "om_snapshot_internal_metrics_num_snapshot_move_table_keys_fails{instance=~\".*9874\"}",
+          "instant": false,
+          "legendFormat": "OM {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NumSnapshotMoveTableKeyFailures",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since, `NumSnapshotPurges` metric was moved from `OMMetrics` to `OmSnapshotInternalMetrics` in HDDS-13256, updated the metric name in the OM Snapshot Grafana Dashboard. 
Added, `NumSnapshotPurgeFailures` , `NumMoveTableKeys` , `NumMoveTableKeyFailures` to the dashboard as well. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13256

## How was this patch tested?

Tested using docker.
<img width="1724" alt="Screenshot 2025-06-16 at 2 31 25 PM" src="https://github.com/user-attachments/assets/cc526fbd-5c86-4ae1-be53-b90a6e98d97f" />

