### PR TITLE
HDDS-13287. Upgrade commons-beanutils to 1.11.0 due to CVE-2025-48734

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <classpath.skip>true</classpath.skip>
     <codahale-metrics.version>3.0.2</codahale-metrics.version>
     <com.nimbusds.nimbus-jose-jwt.version>9.40</com.nimbusds.nimbus-jose-jwt.version>
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
+    <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-cli.version>1.8.0</commons-cli.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade Commons BeanUtils to 1.11.0 due to CVE-2025-48734

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13287

## How was this patch tested?
https://github.com/rohit-kb/ozone/actions/runs/15702273193
