### PR TITLE
HDDS-13278. [DiskBalancer] Incorrect tracking of DiskBalancer inProgressTask and balancedByteMap initialisation

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -90,7 +90,7 @@ public class DiskBalancerService extends BackgroundService {
   private AtomicLong balancedBytesInLastWindow = new AtomicLong(0L);
   private AtomicLong nextAvailableTime = new AtomicLong(Time.monotonicNow());
 
-  private Map<DiskBalancerTask, Integer> inProgressTasks;
+  private Set<DiskBalancerTask> inProgressTasks;
   private Set<Long> inProgressContainers;
 
   /**
@@ -124,7 +124,7 @@ public class DiskBalancerService extends BackgroundService {
     Preconditions.checkNotNull(diskBalancerInfoPath);
     diskBalancerInfoFile = new File(diskBalancerInfoPath);
 
-    inProgressTasks = new ConcurrentHashMap<>();
+    inProgressTasks = ConcurrentHashMap.newKeySet();
     inProgressContainers = ConcurrentHashMap.newKeySet();
     deltaSizes = new ConcurrentHashMap<>();
     volumeSet = ozoneContainer.getVolumeSet();
@@ -351,8 +351,10 @@ public class DiskBalancerService extends BackgroundService {
       ContainerData toBalanceContainer = containerChoosingPolicy
           .chooseContainer(ozoneContainer, sourceVolume, inProgressContainers);
       if (toBalanceContainer != null) {
-        queue.add(new DiskBalancerTask(toBalanceContainer, sourceVolume,
-            destVolume));
+        DiskBalancerTask task = new DiskBalancerTask(toBalanceContainer, sourceVolume,
+            destVolume);
+        queue.add(task);
+        inProgressTasks.add(task);
         inProgressContainers.add(toBalanceContainer.getContainerID());
         deltaSizes.put(sourceVolume, deltaSizes.getOrDefault(sourceVolume, 0L)
             - toBalanceContainer.getBytesUsed());
@@ -527,6 +529,7 @@ public class DiskBalancerService extends BackgroundService {
     }
 
     private void postCall() {
+      inProgressTasks.remove(this);
       inProgressContainers.remove(containerData.getContainerID());
       deltaSizes.put(sourceVolume, deltaSizes.get(sourceVolume) +
           containerData.getBytesUsed());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -74,6 +74,7 @@ public class DiskBalancerManager {
     this.nodeManager = nodeManager;
     this.useHostnames = conf.getBoolean(HDDS_DATANODE_USE_DN_HOSTNAME, HDDS_DATANODE_USE_DN_HOSTNAME_DEFAULT);
     this.statusMap = new ConcurrentHashMap<>();
+    this.balancedBytesMap = new ConcurrentHashMap<>();
   }
 
   public List<HddsProtos.DatanodeDiskBalancerInfoProto> getDiskBalancerReport(


### PR DESCRIPTION
## What changes were proposed in this pull request?
This ticket addresses two related issues within the DiskBalancer logic:

Incorrect Task Tracking: The DiskBalancerService fails to track in-progress tasks, causing it to constantly over-schedule new balancing operations. This leads to an excessive task queue and flawed decision-making based on an inaccurate view of pending work.
Uninitialized State Map: In the DiskBalancerManager, the balancedBytesMap is never initialized. Consequently, it remains null, and any attempts to record the number of balanced bytes from datanode reports are silently ignored, preventing proper state tracking.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13278

## How was this patch tested?

Passed existing tests.