### PR TITLE
HDDS-13187. Extend Recon events handling to MultipartInfoTable

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages records in the MultipartInfo Table, updating counts and sizes of
+ * multipart upload keys in the backend.
+ */
+public class MultipartInfoInsightHandler implements OmTableHandler {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MultipartInfoInsightHandler.class);
+
+  /**
+   * Invoked by the process method to add information on those keys that have
+   * been initiated for multipart upload in the backend.
+   */
+  @Override
+  public void handlePutEvent(OMDBUpdateEvent<String, Object> event,
+                             String tableName,
+                             Map<String, Long> objectCountMap,
+                             Map<String, Long> unReplicatedSizeMap,
+                             Map<String, Long> replicatedSizeMap) {
+
+    if (event.getValue() != null) {
+      OmMultipartKeyInfo multipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
+          (k, count) -> count + 1L);
+
+      for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size + omKeyInfo.getDataSize());
+        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size + omKeyInfo.getReplicatedSize());
+      }
+    } else {
+      LOG.warn("Put event does not have the Multipart Key Info for {}.", event.getKey());
+    }
+  }
+
+  /**
+   * Invoked by the process method to delete information on those multipart uploads that
+   * have been completed or aborted in the backend.
+   */
+  @Override
+  public void handleDeleteEvent(OMDBUpdateEvent<String, Object> event,
+                                String tableName,
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
+
+    if (event.getValue() != null) {
+      OmMultipartKeyInfo multipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
+          (k, count) -> count > 0 ? count - 1L : 0L);
+
+      for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size > omKeyInfo.getDataSize() ?
+                size - omKeyInfo.getDataSize() : 0L);
+        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size > omKeyInfo.getReplicatedSize() ?
+                size - omKeyInfo.getReplicatedSize() : 0L);
+      }
+    } else {
+      LOG.warn("Delete event does not have the Multipart Key Info for {}.", event.getKey());
+    }
+  }
+
+  /**
+   * Invoked by the process method to update information on those multipart uploads that
+   * have been updated in the backend.
+   */
+  @Override
+  public void handleUpdateEvent(OMDBUpdateEvent<String, Object> event,
+                                String tableName,
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
+
+    if (event.getValue() != null) {
+      if (event.getOldValue() == null) {
+        LOG.warn("Update event does not have the old Multipart Key Info for {}.", event.getKey());
+        return;
+      }
+
+      // In Update event the count for the multipart info table will not change. So we
+      // don't need to update the count.
+      OmMultipartKeyInfo oldMultipartKeyInfo = (OmMultipartKeyInfo) event.getOldValue();
+      OmMultipartKeyInfo newMultipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
+
+      // Calculate old sizes
+      for (PartKeyInfo partKeyInfo : oldMultipartKeyInfo.getPartKeyInfoMap()) {
+        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size - omKeyInfo.getDataSize());
+        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size - omKeyInfo.getReplicatedSize());
+      }
+
+      // Calculate new sizes
+      for (PartKeyInfo partKeyInfo : newMultipartKeyInfo.getPartKeyInfoMap()) {
+        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size + omKeyInfo.getDataSize());
+        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+            (k, size) -> size + omKeyInfo.getReplicatedSize());
+      }
+    } else {
+      LOG.warn("Update event does not have the Multipart Key Info for {}.", event.getKey());
+    }
+  }
+
+  /**
+   * This method is called by the reprocess method. It calculates the record
+   * counts for the multipart info table. Additionally, it computes the sizes
+   * of both replicated and unreplicated parts that are currently in multipart
+   * uploads in the backend.
+   */
+  @Override
+  public Triple<Long, Long, Long> getTableSizeAndCount(
+      TableIterator<String, ? extends Table.KeyValue<String, ?>> iterator)
+      throws IOException {
+    long count = 0;
+    long unReplicatedSize = 0;
+    long replicatedSize = 0;
+
+    if (iterator != null) {
+      while (iterator.hasNext()) {
+        Table.KeyValue<String, ?> kv = iterator.next();
+        if (kv != null && kv.getValue() != null) {
+          OmMultipartKeyInfo multipartKeyInfo = (OmMultipartKeyInfo) kv.getValue();
+          for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+            OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+            unReplicatedSize += omKeyInfo.getDataSize();
+            replicatedSize += omKeyInfo.getReplicatedSize();
+          }
+          count++;
+        }
+      }
+    }
+    return Triple.of(count, unReplicatedSize, replicatedSize);
+  }
+} 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import static org.jooq.impl.DSL.currentTimestamp;
@@ -78,6 +79,7 @@ public class OmTableInsightTask implements ReconOmTask {
     tableHandlers.put(OPEN_KEY_TABLE, new OpenKeysInsightHandler());
     tableHandlers.put(OPEN_FILE_TABLE, new OpenKeysInsightHandler());
     tableHandlers.put(DELETED_TABLE, new DeletedKeysInsightHandler());
+    tableHandlers.put(MULTIPART_INFO_TABLE, new MultipartInfoInsightHandler());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Space held by keys or files that are uncommitted or still in progress. Some of this information is already shown as of today on the Recon Overview Page - Open Keys Summary Tile, but this does not include the MPU open key / file size information.
- The total open (uncommitted) keys / files size can be derived from the entries of `OpenKeyTable`, `OpenFileTable` and `MultipartInfoTable`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13187

## How was this patch tested?

Pending - Tests to be added.
