### PR TITLE
HDDS-13213. KeyDeletingService should batch keys based on Ratis buffer size instead of keyLimitPerTask.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -154,11 +155,10 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * underlying metadataManager.
    * @throws IOException
    */
-  List<Table.KeyValue<String, String>> getRenamesKeyEntries(
+  Pair<Integer, List<Table.KeyValue<String, String>>> getRenamesKeyEntries(
       String volume, String bucket, String startKey,
       CheckedFunction<Table.KeyValue<String, String>, Boolean, IOException> filter, int count)
       throws IOException;
-
 
   /**
    * Returns the previous snapshot's ozone directorInfo corresponding for the object.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -722,6 +722,7 @@ public class KeyManagerImpl implements KeyManager {
       int count) throws IOException {
     List<BlockGroup> keyBlocksList = Lists.newArrayList();
     Map<String, RepeatedOmKeyInfo> keysToModify = new HashMap<>();
+    int consumedSize = 0;
     // Bucket prefix would be empty if volume is empty i.e. either null or "".
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
     try (TableIterator<String, ? extends KeyValue<String, RepeatedOmKeyInfo>>
@@ -733,8 +734,7 @@ public class KeyManagerImpl implements KeyManager {
       if (startKey != null) {
         delKeyIter.seek(startKey);
       }
-      int currentCount = 0;
-      while (delKeyIter.hasNext() && currentCount < count) {
+      while (delKeyIter.hasNext() && count > 0) {
         RepeatedOmKeyInfo notReclaimableKeyInfo = new RepeatedOmKeyInfo();
         KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
         if (kv != null) {
@@ -751,7 +751,9 @@ public class KeyManagerImpl implements KeyManager {
               BlockGroup keyBlocks = BlockGroup.newBuilder().setKeyName(kv.getKey())
                   .addAllBlockIDs(blockIDS).build();
               blockGroupList.add(keyBlocks);
-              currentCount++;
+              long serializedSize = keyBlocks.getProto().getSerializedSize();
+              count -= serializedSize;
+              consumedSize += serializedSize;
             } else {
               notReclaimableKeyInfo.addOmKeyInfo(info);
             }
@@ -768,15 +770,14 @@ public class KeyManagerImpl implements KeyManager {
         }
       }
     }
-    return new PendingKeysDeletion(keyBlocksList, keysToModify);
+    return new PendingKeysDeletion(keyBlocksList, keysToModify, consumedSize);
   }
 
-  private <V, R> List<KeyValue<String, R>> getTableEntries(String startKey,
-          TableIterator<String, ? extends KeyValue<String, V>> tableIterator,
-          Function<V, R> valueFunction,
-          CheckedFunction<KeyValue<String, V>, Boolean, IOException> filter,
-          int size) throws IOException {
+  private <V, R> Pair<Integer, List<KeyValue<String, R>>> getTableEntries(String startKey,
+      TableIterator<String, ? extends KeyValue<String, V>> tableIterator, Function<V, R> valueFunction,
+      CheckedFunction<KeyValue<String, V>, Boolean, IOException> filter, int size) throws IOException {
     List<KeyValue<String, R>> entries = new ArrayList<>();
+    int consumedSize = 0;
     /* Seek to the start key if it's not null. The next key in queue is ensured to start with the bucket
          prefix, {@link org.apache.hadoop.hdds.utils.db.Table#iterator(bucketPrefix)} would ensure this.
     */
@@ -785,15 +786,18 @@ public class KeyManagerImpl implements KeyManager {
     } else {
       tableIterator.seekToFirst();
     }
-    int currentCount = 0;
-    while (tableIterator.hasNext() && currentCount < size) {
+    while (tableIterator.hasNext() && size > 0) {
       KeyValue<String, V> kv = tableIterator.next();
       if (kv != null && filter.apply(kv)) {
-        entries.add(Table.newKeyValue(kv.getKey(), valueFunction.apply(kv.getValue())));
-        currentCount++;
+        R value = valueFunction.apply(kv.getValue());
+        KeyValue<String, R> newKV = Table.newKeyValue(kv.getKey(), value);
+        int valueSize = newKV.getValueByteSize();
+        entries.add(newKV);
+        consumedSize += valueSize;
+        size -= valueSize;
       }
     }
-    return entries;
+    return Pair.of(consumedSize, entries);
   }
 
   private Optional<String> getBucketPrefix(String volumeName, String bucketName, boolean isFSO) throws IOException {
@@ -809,7 +813,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<KeyValue<String, String>> getRenamesKeyEntries(
+  public Pair<Integer, List<Table.KeyValue<String, String>>> getRenamesKeyEntries(
       String volume, String bucket, String startKey,
       CheckedFunction<KeyValue<String, String>, Boolean, IOException> filter, int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
@@ -865,7 +869,7 @@ public class KeyManagerImpl implements KeyManager {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
     try (TableIterator<String, ? extends KeyValue<String, RepeatedOmKeyInfo>>
              delKeyIter = metadataManager.getDeletedTable().iterator(bucketPrefix.orElse(""))) {
-      return getTableEntries(startKey, delKeyIter, RepeatedOmKeyInfo::cloneOmKeyInfoList, filter, size);
+      return getTableEntries(startKey, delKeyIter, RepeatedOmKeyInfo::cloneOmKeyInfoList, filter, size).getValue();
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PendingKeysDeletion.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PendingKeysDeletion.java
@@ -37,11 +37,13 @@ public class PendingKeysDeletion {
 
   private Map<String, RepeatedOmKeyInfo> keysToModify;
   private List<BlockGroup> keyBlocksList;
+  private long consumedSize;
 
   public PendingKeysDeletion(List<BlockGroup> keyBlocksList,
-       Map<String, RepeatedOmKeyInfo> keysToModify) {
+       Map<String, RepeatedOmKeyInfo> keysToModify, long consumedSize) {
     this.keysToModify = keysToModify;
     this.keyBlocksList = keyBlocksList;
+    this.consumedSize = consumedSize;
   }
 
   public Map<String, RepeatedOmKeyInfo> getKeysToModify() {
@@ -50,5 +52,9 @@ public class PendingKeysDeletion {
 
   public List<BlockGroup> getKeyBlocksList() {
     return keyBlocksList;
+  }
+
+  public long getConsumedSize() {
+    return consumedSize;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
@@ -85,6 +86,7 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
   private final ScmBlockLocationProtocol scmClient;
 
   private int keyLimitPerTask;
+  private int ratisByteLimit;
   private final AtomicLong deletedKeyCount;
   private final boolean deepCleanSnapshots;
   private final SnapshotChainManager snapshotChainManager;
@@ -100,6 +102,11 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
         OZONE_KEY_DELETING_LIMIT_PER_TASK_DEFAULT);
     Preconditions.checkArgument(keyLimitPerTask >= 0,
         OZONE_KEY_DELETING_LIMIT_PER_TASK + " cannot be negative.");
+    int limit = (int) conf.getStorageSize(
+        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
+        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
+        StorageUnit.BYTES);
+    this.ratisByteLimit = (int) (limit * 0.9);
     this.deletedKeyCount = new AtomicLong(0);
     this.deepCleanSnapshots = deepCleanSnapshots;
     this.snapshotChainManager = ((OmMetadataManagerImpl)ozoneManager.getMetadataManager()).getSnapshotChainManager();
@@ -348,11 +355,12 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
              ReclaimableRenameEntryFilter renameEntryFilter = new ReclaimableRenameEntryFilter(
                  getOzoneManager(), omSnapshotManager, snapshotChainManager, currentSnapshotInfo,
                  keyManager, lock)) {
+          Pair<Integer, List<Table.KeyValue<String, String>>> renameEntriesPair =
+              keyManager.getRenamesKeyEntries(volume, bucket, null, renameEntryFilter, remainNum);
           List<String> renamedTableEntries =
-              keyManager.getRenamesKeyEntries(volume, bucket, null, renameEntryFilter, remainNum).stream()
-                  .map(Table.KeyValue::getKey)
-                  .collect(Collectors.toList());
-          remainNum -= renamedTableEntries.size();
+              renameEntriesPair.getValue().stream().map(Table.KeyValue::getKey).collect(Collectors.toList());
+          //remainNum -= renamedTableEntries.size();
+          remainNum -= renameEntriesPair.getKey();
 
           // Get pending keys that can be deleted
           PendingKeysDeletion pendingKeysDeletion = currentSnapshotInfo == null
@@ -366,7 +374,8 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
                 expectedPreviousSnapshotId);
             Pair<Integer, Boolean> purgeResult = processKeyDeletes(keyBlocksList, pendingKeysDeletion.getKeysToModify(),
                 renamedTableEntries, snapshotTableKey, expectedPreviousSnapshotId);
-            remainNum -= purgeResult.getKey();
+            //remainNum -= purgeResult.getKey();
+            remainNum -= pendingKeysDeletion.getConsumedSize();
             successStatus = purgeResult.getValue();
             getMetrics().incrNumKeysProcessed(keyBlocksList.size());
             getMetrics().incrNumKeysSentForPurge(purgeResult.getKey());
@@ -421,7 +430,7 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
         } else {
           LOG.debug("Running KeyDeletingService for snapshot : {}, {}", snapshotId, run);
         }
-        int remainNum = keyLimitPerTask;
+        int remainNum = ratisByteLimit;
         OmSnapshotManager omSnapshotManager = getOzoneManager().getOmSnapshotManager();
         SnapshotInfo snapInfo = null;
         try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -184,13 +185,14 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
                 snapInfo.getVolumeName(), snapInfo.getBucketName(), remaining - moveCount);
             moveCount += deletedDirEntries.size();
             // Get all entries from snapshotRenamedTable.
-            List<Table.KeyValue<String, String>> renameEntries = snapshotKeyManager.getRenamesKeyEntries(
-                snapInfo.getVolumeName(), snapInfo.getBucketName(), null, (kv) -> true, remaining - moveCount);
-            moveCount += renameEntries.size();
+            Pair<Integer, List<Table.KeyValue<String, String>>> renameEntries =
+                snapshotKeyManager.getRenamesKeyEntries(snapInfo.getVolumeName(), snapInfo.getBucketName(), null,
+                    (kv) -> true, remaining - moveCount);
+            moveCount += renameEntries.getValue().size();
             if (moveCount > 0) {
               List<SnapshotMoveKeyInfos> deletedKeys = new ArrayList<>(deletedKeyEntries.size());
               List<SnapshotMoveKeyInfos> deletedDirs = new ArrayList<>(deletedDirEntries.size());
-              List<HddsProtos.KeyValue> renameKeys = new ArrayList<>(renameEntries.size());
+              List<HddsProtos.KeyValue> renameKeys = new ArrayList<>(renameEntries.getValue().size());
 
               // Convert deletedKeyEntries to SnapshotMoveKeyInfos.
               for (Table.KeyValue<String, List<OmKeyInfo>> deletedEntry : deletedKeyEntries) {
@@ -207,7 +209,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
               }
 
               // Convert renamedEntries to KeyValue.
-              for (Table.KeyValue<String, String> renameEntry : renameEntries) {
+              for (Table.KeyValue<String, String> renameEntry : renameEntries.getValue()) {
                 renameKeys.add(HddsProtos.KeyValue.newBuilder().setKey(renameEntry.getKey())
                     .setValue(renameEntry.getValue()).build());
               }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of relying on a fixed keyLimitPerTask, keys should be fetched until the total size reaches the Ratis buffer limit (default: 32 MB).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13213

## How was this patch tested?

Tested Manually.
