### PR TITLE
HDDS-13240. Add newly added metrics into grafana dashboard.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
@@ -1171,7 +1171,7 @@
               "useBackend": false
             }
           ],
-          "title": "KeyDeletingService: Keys purged from OM",
+          "title": "KeyDeletingService: No. of keys to be purged",
           "type": "timeseries"
         },
         {
@@ -1549,7 +1549,7 @@
               "useBackend": false
             }
           ],
-          "title": "PurgeRequests: Keys Purged",
+          "title": "PurgeRequests: No. of keys purged",
           "type": "timeseries"
         },
         {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
@@ -38,7 +38,7 @@ public final class DeletingServiceMetrics {
   /*
    * Total directory deletion metrics across all iterations of DirectoryDeletingService since last restart.
    */
-  @Metric("Total no. of directories deleted")
+  @Metric("Total no. of deleted directories sent for purge")
   private MutableGaugeLong numDirsSentForPurge;
   @Metric("Total no. of sub-directories sent for purge")
   private MutableGaugeLong numSubDirsSentForPurge;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the existing Grafana dashboard with the newly added metrics for 

1) Block count sent from SCM to DN (Both overall and DN specific)

2) Block count received from OM

3) Command timedout from SCM to DN

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13240

## How was this patch tested?

Tested Manually.
