### PR TITLE
HDDS-13294. Remove the Table.close() method.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -139,9 +139,4 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
   public void loadFromFile(File externalFile) throws RocksDatabaseException {
     table.loadFromFile(externalFile);
   }
-
-  @Override
-  public void close() throws Exception {
-    table.close();
-  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -223,11 +223,6 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
-  public void close() {
-    // Nothing do for a Column Family.
-  }
-
-  @Override
   public long getEstimatedKeyCount() throws RocksDatabaseException {
     return db.estimateNumKeys(family);
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
  * different kind of tables.
  */
 @InterfaceStability.Evolving
-public interface Table<KEY, VALUE> extends AutoCloseable {
+public interface Table<KEY, VALUE> {
 
   /**
    * Puts a key-value pair into the store.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -423,12 +423,6 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public void close() {
-    rawTable.close();
-
-  }
-
-  @Override
   public void addCacheEntry(CacheKey<KEY> cacheKey,
       CacheValue<VALUE> cacheValue) {
     // This will override the entry if there is already entry for this key.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -221,18 +221,12 @@ public class TestRDBSnapshotProvider {
 
   public void insertRandomData(RDBStore dbStore, int familyIndex)
       throws IOException {
-    try (Table<byte[], byte[]> firstTable = dbStore.getTable(families.
-        get(familyIndex))) {
-      assertNotNull(firstTable, "Table cannot be null");
-      for (int x = 0; x < 100; x++) {
-        byte[] key =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        byte[] value =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        firstTable.put(key, value);
-      }
-    } catch (Exception e) {
-      throw new IOException(e);
+    Table<byte[], byte[]> firstTable = dbStore.getTable(families.get(familyIndex));
+    assertNotNull(firstTable, "Table cannot be null");
+    for (int x = 0; x < 100; x++) {
+      byte[] key = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      byte[] value = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      firstTable.put(key, value);
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
@@ -40,10 +40,6 @@ public final class InMemoryTestTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public void close() {
-  }
-
-  @Override
   public void put(KEY key, VALUE value) {
     map.put(key, value);
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -96,15 +96,12 @@ public class TestDBStoreBuilder {
         .build();
     // Building should succeed without error.
 
-    try (Table<byte[], byte[]> firstTable = dbStore.getTable("FIRST")) {
-      byte[] key =
-          RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
-      byte[] value =
-          RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
-      firstTable.put(key, value);
-      byte[] temp = firstTable.get(key);
-      assertArrayEquals(value, temp);
-    }
+    final Table<byte[], byte[]> firstTable = dbStore.getTable("FIRST");
+    byte[] key = RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
+    byte[] value = RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
+    firstTable.put(key, value);
+    byte[] temp = firstTable.get(key);
+    assertArrayEquals(value, temp);
 
     dbStore.close();
   }
@@ -118,19 +115,16 @@ public class TestDBStoreBuilder {
         .addTable("First")
         .addTable("Second")
         .build()) {
-      try (Table<byte[], byte[]> firstTable = dbStore.getTable("First")) {
-        byte[] key =
-            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
-        byte[] value =
-            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
-        firstTable.put(key, value);
-        byte[] temp = firstTable.get(key);
-        assertArrayEquals(value, temp);
-      }
+      final Table<byte[], byte[]> firstTable = dbStore.getTable("First");
+      byte[] key = RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
+      byte[] value = RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
+      firstTable.put(key, value);
+      byte[] temp = firstTable.get(key);
+      assertArrayEquals(value, temp);
 
-      try (Table secondTable = dbStore.getTable("Second")) {
-        assertTrue(secondTable.isEmpty());
-      }
+
+      final Table<byte[], byte[]> secondTable = dbStore.getTable("Second");
+      assertTrue(secondTable.isEmpty());
     }
   }
 
@@ -145,19 +139,15 @@ public class TestDBStoreBuilder {
         .addTable("Second")
         .setProfile(DBProfile.DISK)
         .build()) {
-      try (Table<byte[], byte[]> firstTable = dbStore.getTable("First")) {
-        byte[] key =
-            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
-        byte[] value =
-            RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
-        firstTable.put(key, value);
-        byte[] temp = firstTable.get(key);
-        assertArrayEquals(value, temp);
-      }
+      Table<byte[], byte[]> firstTable = dbStore.getTable("First");
+      byte[] key = RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
+      byte[] value = RandomStringUtils.secure().next(9).getBytes(StandardCharsets.UTF_8);
+      firstTable.put(key, value);
+      byte[] temp = firstTable.get(key);
+      assertArrayEquals(value, temp);
 
-      try (Table secondTable = dbStore.getTable("Second")) {
-        assertTrue(secondTable.isEmpty());
-      }
+      Table<byte[], byte[]> secondTable = dbStore.getTable("Second");
+      assertTrue(secondTable.isEmpty());
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -117,18 +117,14 @@ public class TestRDBStore {
 
   public void insertRandomData(RDBStore dbStore, int familyIndex)
       throws IOException {
-    try (Table<byte[], byte[]> firstTable = dbStore.getTable(families.
-        get(familyIndex))) {
-      assertNotNull(firstTable, "Table cannot be null");
-      for (int x = 0; x < 100; x++) {
-        byte[] key =
+    Table<byte[], byte[]> firstTable = dbStore.getTable(families.get(familyIndex));
+    assertNotNull(firstTable, "Table cannot be null");
+    for (int x = 0; x < 100; x++) {
+      byte[] key =
           RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        byte[] value =
+      byte[] value =
           RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        firstTable.put(key, value);
-      }
-    } catch (Exception e) {
-      throw new IOException(e);
+      firstTable.put(key, value);
     }
   }
 
@@ -191,20 +187,17 @@ public class TestRDBStore {
     byte[] value =
         RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
 
-    try (Table firstTable = rdbStore.getTable(families.get(1))) {
-      firstTable.put(key, value);
-      try (Table<byte[], byte[]> secondTable = rdbStore
-          .getTable(families.get(2))) {
-        rdbStore.move(key, firstTable, secondTable);
-        byte[] newvalue = secondTable.get(key);
-        // Make sure we have value in the second table
-        assertNotNull(newvalue);
-        //and it is same as what we wrote to the FirstTable
-        assertArrayEquals(value, newvalue);
-      }
-      // After move this key must not exist in the first table.
-      assertNull(firstTable.get(key));
-    }
+    final Table<byte[], byte[]> firstTable = rdbStore.getTable(families.get(1));
+    firstTable.put(key, value);
+    final Table<byte[], byte[]> secondTable = rdbStore.getTable(families.get(2));
+    rdbStore.move(key, firstTable, secondTable);
+    byte[] newvalue = secondTable.get(key);
+    // Make sure we have value in the second table
+    assertNotNull(newvalue);
+    //and it is same as what we wrote to the FirstTable
+    assertArrayEquals(value, newvalue);
+    // After move this key must not exist in the first table.
+    assertNull(firstTable.get(key));
   }
 
   @Test
@@ -216,20 +209,16 @@ public class TestRDBStore {
 
     byte[] nextValue =
         RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-    try (Table firstTable = rdbStore.getTable(families.get(1))) {
-      firstTable.put(key, value);
-      try (Table<byte[], byte[]> secondTable = rdbStore
-          .getTable(families.get(2))) {
-        rdbStore.move(key, nextValue, firstTable, secondTable);
-        byte[] newvalue = secondTable.get(key);
-        // Make sure we have value in the second table
-        assertNotNull(newvalue);
-        //and it is not same as what we wrote to the FirstTable, and equals
-        // the new value.
-        assertArrayEquals(nextValue, newvalue);
-      }
-    }
-
+    Table<byte[], byte[]> firstTable = rdbStore.getTable(families.get(1));
+    firstTable.put(key, value);
+    Table<byte[], byte[]> secondTable = rdbStore.getTable(families.get(2));
+    rdbStore.move(key, nextValue, firstTable, secondTable);
+    byte[] newvalue = secondTable.get(key);
+    // Make sure we have value in the second table
+    assertNotNull(newvalue);
+    //and it is not same as what we wrote to the FirstTable, and equals
+    // the new value.
+    assertArrayEquals(nextValue, newvalue);
   }
 
   @Test
@@ -250,9 +239,8 @@ public class TestRDBStore {
   @Test
   public void getTable() throws Exception {
     for (String tableName : families) {
-      try (Table table = rdbStore.getTable(tableName)) {
-        assertNotNull(table, tableName + "is null");
-      }
+      Table<byte[], byte[]> table = rdbStore.getTable(tableName);
+      assertNotNull(table, tableName + "is null");
     }
     assertThrows(IOException.class,
         () -> rdbStore.getTable("ATableWithNoName"));
@@ -315,48 +303,42 @@ public class TestRDBStore {
 
   @Test
   public void testGetDBUpdatesSince() throws Exception {
-
-    try (Table firstTable = rdbStore.getTable(families.get(1))) {
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key1"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value1"));
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key2"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value2"));
-    }
+    final Table<byte[], byte[]> firstTable = rdbStore.getTable(families.get(1));
+    firstTable.put(
+        getBytesUtf16("Key1"),
+        getBytesUtf16("Value1"));
+    firstTable.put(
+        getBytesUtf16("Key2"),
+        getBytesUtf16("Value2"));
     assertEquals(2, rdbStore.getDb().getLatestSequenceNumber());
 
     DBUpdatesWrapper dbUpdatesSince = rdbStore.getUpdatesSince(0);
     assertEquals(2, dbUpdatesSince.getData().size());
   }
 
+  static byte[] getBytesUtf16(String s) {
+    return s.getBytes(StandardCharsets.UTF_16);
+  }
+
   @Test
   public void testGetDBUpdatesSinceWithLimitCount() throws Exception {
 
-    try (Table firstTable = rdbStore.getTable(families.get(1))) {
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key1"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value1"));
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key2"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value2"));
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key3"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value3"));
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key4"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value4"));
-      firstTable.put(
-          org.apache.commons.codec.binary.StringUtils.getBytesUtf16("Key5"),
-          org.apache.commons.codec.binary.StringUtils
-              .getBytesUtf16("Value5"));
-    }
+    final Table<byte[], byte[]> firstTable = rdbStore.getTable(families.get(1));
+    firstTable.put(
+        getBytesUtf16("Key1"),
+        getBytesUtf16("Value1"));
+    firstTable.put(
+        getBytesUtf16("Key2"),
+        getBytesUtf16("Value2"));
+    firstTable.put(
+        getBytesUtf16("Key3"),
+        getBytesUtf16("Value3"));
+    firstTable.put(
+        getBytesUtf16("Key4"),
+        getBytesUtf16("Value4"));
+    firstTable.put(
+        getBytesUtf16("Key5"),
+        getBytesUtf16("Value5"));
     assertEquals(5, rdbStore.getDb().getLatestSequenceNumber());
 
     DBUpdatesWrapper dbUpdatesSince = rdbStore.getUpdatesSince(0, 5);
@@ -370,12 +352,10 @@ public class TestRDBStore {
     // Write data to current DB which has 6 column families at the time of
     // writing this test.
     for (String family : families) {
-      try (Table table = rdbStore.getTable(family)) {
-        byte[] key = family.getBytes(StandardCharsets.UTF_8);
-        byte[] value =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        table.put(key, value);
-      }
+      final Table<byte[], byte[]> table = rdbStore.getTable(family);
+      byte[] key = family.getBytes(StandardCharsets.UTF_8);
+      byte[] value = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      table.put(key, value);
     }
     // Close current DB.
     rdbStore.close();
@@ -394,21 +374,19 @@ public class TestRDBStore {
     rdbStore = newRDBStore(rdbStore.getDbLocation(), options, configSet,
         MAX_DB_UPDATES_SIZE_THRESHOLD);
     for (String family : familiesMinusOne) {
-      try (Table table = rdbStore.getTable(family)) {
-        assertNotNull(table, family + "is null");
-        Object val = table.get(family.getBytes(StandardCharsets.UTF_8));
-        assertNotNull(val);
-      }
+      final Table<byte[], byte[]> table = rdbStore.getTable(family);
+      assertNotNull(table, family + "is null");
+      Object val = table.get(family.getBytes(StandardCharsets.UTF_8));
+      assertNotNull(val);
     }
 
     // Technically the extra column family should also be open, even though
     // we do not use it.
     String extraFamily = families.get(families.size() - 1);
-    try (Table table = rdbStore.getTable(extraFamily)) {
-      assertNotNull(table, extraFamily + "is null");
-      Object val = table.get(extraFamily.getBytes(StandardCharsets.UTF_8));
-      assertNotNull(val);
-    }
+    final Table<byte[], byte[]> table = rdbStore.getTable(extraFamily);
+    assertNotNull(table, extraFamily + "is null");
+    Object val = table.get(extraFamily.getBytes(StandardCharsets.UTF_8));
+    assertNotNull(val);
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -94,7 +94,7 @@ public class TestRDBTableStore {
     }
   }
 
-  private static boolean consume(Table.KeyValue keyValue)  {
+  private static boolean consume(Table.KeyValue<byte[], byte[]> keyValue)  {
     count++;
     assertNotNull(assertDoesNotThrow(keyValue::getKey));
     return true;
@@ -140,27 +140,22 @@ public class TestRDBTableStore {
 
   @Test
   public void getHandle() throws Exception {
-    try (Table testTable = rdbStore.getTable("First")) {
-      assertNotNull(testTable);
-      assertNotNull(((RDBTable) testTable).getColumnFamily());
-    }
+    final RDBTable testTable = rdbStore.getTable("First");
+    assertNotNull(testTable);
+    assertNotNull(testTable.getColumnFamily());
   }
 
   @Test
   public void putGetAndEmpty() throws Exception {
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("First")) {
-      byte[] key =
-          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-      byte[] value =
-          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-      testTable.put(key, value);
-      assertFalse(testTable.isEmpty());
-      byte[] readValue = testTable.get(key);
-      assertArrayEquals(value, readValue);
-    }
-    try (Table secondTable = rdbStore.getTable("Second")) {
-      assertTrue(secondTable.isEmpty());
-    }
+    Table<byte[], byte[]> testTable = rdbStore.getTable("First");
+    byte[] key = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+    byte[] value = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+    testTable.put(key, value);
+    assertFalse(testTable.isEmpty());
+    byte[] readValue = testTable.get(key);
+    assertArrayEquals(value, readValue);
+    Table<byte[], byte[]> secondTable = rdbStore.getTable("Second");
+    assertTrue(secondTable.isEmpty());
   }
 
   @Test
@@ -181,23 +176,22 @@ public class TestRDBTableStore {
 
     // Write all the keys and delete the keys scheduled for delete.
     // Assert we find only expected keys in the Table.
-    try (Table testTable = rdbStore.getTable("Fourth")) {
-      for (byte[] bytes : deletedKeys) {
-        testTable.put(bytes, value);
-        testTable.delete(bytes);
-      }
+    final Table<byte[], byte[]> testTable = rdbStore.getTable("Fourth");
+    for (byte[] bytes : deletedKeys) {
+      testTable.put(bytes, value);
+      testTable.delete(bytes);
+    }
 
-      for (byte[] key : validKeys) {
-        testTable.put(key, value);
-      }
+    for (byte[] key : validKeys) {
+      testTable.put(key, value);
+    }
 
-      for (byte[] validKey : validKeys) {
-        assertNotNull(testTable.get(validKey));
-      }
+    for (byte[] validKey : validKeys) {
+      assertNotNull(testTable.get(validKey));
+    }
 
-      for (byte[] deletedKey : deletedKeys) {
-        assertNull(testTable.get(deletedKey));
-      }
+    for (byte[] deletedKey : deletedKeys) {
+      assertNull(testTable.get(deletedKey));
     }
   }
 
@@ -214,60 +208,58 @@ public class TestRDBTableStore {
     // Some random value
     byte[] val = RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
 
-    try (Table testTable = rdbStore.getTable("Ninth")) {
+    final Table<byte[], byte[]> testTable = rdbStore.getTable("Ninth");
 
-      // Write keys to the table
-      for (byte[] key : keys) {
-        testTable.put(key, val);
-      }
-
-      // All keys should exist at this point
-      for (byte[] key : keys) {
-        assertNotNull(testTable.get(key));
-      }
-
-      // Delete a range of keys: [10th, 20th), zero-indexed
-      final int deleteRangeBegin = 10, deleteRangeEnd = 20;
-      byte[] dRangeBeginKey = keys.get(deleteRangeBegin);
-      byte[] dRangeEndKey = keys.get(deleteRangeEnd);
-
-      testTable.deleteRange(dRangeBeginKey, dRangeEndKey);
-
-      // Keys [10th, 20th) should be gone now
-      for (int x = deleteRangeBegin; x < deleteRangeEnd; x++) {
-        assertNull(testTable.get(keys.get(x)));
-      }
-
-      // While the rest of the keys should be untouched
-      for (int x = 0; x < deleteRangeBegin; x++) {
-        assertNotNull(testTable.get(keys.get(x)));
-      }
-      for (int x = deleteRangeEnd; x < 100; x++) {
-        assertNotNull(testTable.get(keys.get(x)));
-      }
-
-      // Delete the rest of the keys
-      testTable.deleteRange(keys.get(0), keys.get(100 - 1));
-
-      // Confirm key deletion
-      for (int x = 0; x < 100 - 1; x++) {
-        assertNull(testTable.get(keys.get(x)));
-      }
-      // The last key is still there because
-      // deleteRange() excludes the endKey by design
-      assertNotNull(testTable.get(keys.get(100 - 1)));
-
-      // Delete the last key
-      testTable.delete(keys.get(100 - 1));
-      assertNull(testTable.get(keys.get(100 - 1)));
+    // Write keys to the table
+    for (byte[] key : keys) {
+      testTable.put(key, val);
     }
 
+    // All keys should exist at this point
+    for (byte[] key : keys) {
+      assertNotNull(testTable.get(key));
+    }
+
+    // Delete a range of keys: [10th, 20th), zero-indexed
+    final int deleteRangeBegin = 10, deleteRangeEnd = 20;
+    byte[] dRangeBeginKey = keys.get(deleteRangeBegin);
+    byte[] dRangeEndKey = keys.get(deleteRangeEnd);
+
+    testTable.deleteRange(dRangeBeginKey, dRangeEndKey);
+
+    // Keys [10th, 20th) should be gone now
+    for (int x = deleteRangeBegin; x < deleteRangeEnd; x++) {
+      assertNull(testTable.get(keys.get(x)));
+    }
+
+    // While the rest of the keys should be untouched
+    for (int x = 0; x < deleteRangeBegin; x++) {
+      assertNotNull(testTable.get(keys.get(x)));
+    }
+    for (int x = deleteRangeEnd; x < 100; x++) {
+      assertNotNull(testTable.get(keys.get(x)));
+    }
+
+    // Delete the rest of the keys
+    testTable.deleteRange(keys.get(0), keys.get(100 - 1));
+
+    // Confirm key deletion
+    for (int x = 0; x < 100 - 1; x++) {
+      assertNull(testTable.get(keys.get(x)));
+    }
+    // The last key is still there because
+    // deleteRange() excludes the endKey by design
+    assertNotNull(testTable.get(keys.get(100 - 1)));
+
+    // Delete the last key
+    testTable.delete(keys.get(100 - 1));
+    assertNull(testTable.get(keys.get(100 - 1)));
   }
 
   @Test
   public void batchPut() throws Exception {
-    try (Table testTable = rdbStore.getTable("Fifth");
-        BatchOperation batch = rdbStore.initBatchOperation()) {
+    final Table<byte[], byte[]> testTable = rdbStore.getTable("Fifth");
+    try (BatchOperation batch = rdbStore.initBatchOperation()) {
       //given
       byte[] key =
           RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
@@ -286,8 +278,8 @@ public class TestRDBTableStore {
 
   @Test
   public void batchDelete() throws Exception {
-    try (Table testTable = rdbStore.getTable("Fifth");
-        BatchOperation batch = rdbStore.initBatchOperation()) {
+    final Table<byte[], byte[]> testTable = rdbStore.getTable("Fifth");
+    try (BatchOperation batch = rdbStore.initBatchOperation()) {
 
       //given
       byte[] key =
@@ -309,41 +301,38 @@ public class TestRDBTableStore {
 
   @Test
   public void putGetTypedTableCodec() throws Exception {
-    try (Table<String, String> testTable = rdbStore.getTable("Ten", StringCodec.get(), StringCodec.get())) {
-      testTable.put("test1", "123");
-      assertFalse(testTable.isEmpty());
-      assertEquals("123", testTable.get("test1"));
-    }
-    try (Table<String, ByteString> testTable = rdbStore.getTable("Ten",
-        StringCodec.get(), ByteStringCodec.get(), CacheType.NO_CACHE)) {
-      assertEquals("123", testTable.get("test1").toStringUtf8());
-    }
+    Table<String, String> testTable = rdbStore.getTable("Ten", StringCodec.get(), StringCodec.get());
+    testTable.put("test1", "123");
+    assertFalse(testTable.isEmpty());
+    assertEquals("123", testTable.get("test1"));
+    Table<String, ByteString> testTable2 = rdbStore.getTable("Ten",
+        StringCodec.get(), ByteStringCodec.get(), CacheType.NO_CACHE);
+    assertEquals("123", testTable2.get("test1").toStringUtf8());
   }
 
   @Test
   public void forEachAndIterator() throws Exception {
     final int iterCount = 100;
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("Sixth")) {
-      for (int x = 0; x < iterCount; x++) {
-        byte[] key =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        byte[] value =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        testTable.put(key, value);
+    final Table<byte[], byte[]> testTable = rdbStore.getTable("Sixth");
+    for (int x = 0; x < iterCount; x++) {
+      byte[] key =
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      byte[] value =
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      testTable.put(key, value);
+    }
+    int localCount = 0;
+    try (Table.KeyValueIterator<byte[], byte[]> iter = testTable.iterator()) {
+      while (iter.hasNext()) {
+        iter.next();
+        localCount++;
       }
-      int localCount = 0;
-      try (Table.KeyValueIterator<byte[], byte[]> iter = testTable.iterator()) {
-        while (iter.hasNext()) {
-          iter.next();
-          localCount++;
-        }
 
-        assertEquals(iterCount, localCount);
-        iter.seekToFirst();
-        iter.forEachRemaining(TestRDBTableStore::consume);
-        assertEquals(iterCount, count);
+      assertEquals(iterCount, localCount);
+      iter.seekToFirst();
+      iter.forEachRemaining(TestRDBTableStore::consume);
+      assertEquals(iterCount, count);
 
-      }
     }
   }
 
@@ -357,71 +346,68 @@ public class TestRDBTableStore {
     final byte[] zeroSizeValue = {};
 
     final String tableName = families.get(0);
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable(tableName)) {
-      testTable.put(key, value);
+    Table<byte[], byte[]> testTable = rdbStore.getTable(tableName);
+    testTable.put(key, value);
 
-      // Test if isExist returns true for a key that definitely exists.
-      assertTrue(testTable.isExist(key));
+    // Test if isExist returns true for a key that definitely exists.
+    assertTrue(testTable.isExist(key));
 
-      // Test if isExist returns false for a key that has been deleted.
-      testTable.delete(key);
-      assertFalse(testTable.isExist(key));
+    // Test if isExist returns false for a key that has been deleted.
+    testTable.delete(key);
+    assertFalse(testTable.isExist(key));
 
-      // Test a key with zero size value.
-      assertNull(testTable.get(zeroSizeKey));
-      testTable.put(zeroSizeKey, zeroSizeValue);
-      assertEquals(0, testTable.get(zeroSizeKey).length);
+    // Test a key with zero size value.
+    assertNull(testTable.get(zeroSizeKey));
+    testTable.put(zeroSizeKey, zeroSizeValue);
+    assertEquals(0, testTable.get(zeroSizeKey).length);
 
-      byte[] invalidKey =
-          RandomStringUtils.secure().next(5).getBytes(StandardCharsets.UTF_8);
-      // Test if isExist returns false for a key that is definitely not present.
-      assertFalse(testTable.isExist(invalidKey));
+    byte[] invalidKey =
+        RandomStringUtils.secure().next(5).getBytes(StandardCharsets.UTF_8);
+    // Test if isExist returns false for a key that is definitely not present.
+    assertFalse(testTable.isExist(invalidKey));
 
-      RDBMetrics rdbMetrics = rdbStore.getMetrics();
-      assertEquals(3, rdbMetrics.getNumDBKeyMayExistChecks());
-      assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
-      assertEquals(2, rdbMetrics.getNumDBKeyGets());
+    RDBMetrics rdbMetrics = rdbStore.getMetrics();
+    assertEquals(3, rdbMetrics.getNumDBKeyMayExistChecks());
+    assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
+    assertEquals(2, rdbMetrics.getNumDBKeyGets());
 
-      // Reinsert key for further testing.
-      testTable.put(key, value);
-    }
+    // Reinsert key for further testing.
+    testTable.put(key, value);
 
     rdbStore.close();
     setUp();
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable(tableName)) {
-      // Verify isExist works with key not in block cache.
-      assertTrue(testTable.isExist(key));
-      assertEquals(0, testTable.get(zeroSizeKey).length);
-      assertTrue(testTable.isExist(zeroSizeKey));
+    Table<byte[], byte[]> testTable2 = rdbStore.getTable(tableName);
+    // Verify isExist works with key not in block cache.
+    assertTrue(testTable2.isExist(key));
+    assertEquals(0, testTable2.get(zeroSizeKey).length);
+    assertTrue(testTable2.isExist(zeroSizeKey));
 
-      RDBMetrics rdbMetrics = rdbStore.getMetrics();
-      assertEquals(2, rdbMetrics.getNumDBKeyMayExistChecks());
-      assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
-      assertEquals(2, rdbMetrics.getNumDBKeyGets());
-    }
+    RDBMetrics rdbMetrics2 = rdbStore.getMetrics();
+    assertEquals(2, rdbMetrics2.getNumDBKeyMayExistChecks());
+    assertEquals(0, rdbMetrics2.getNumDBKeyMayExistMisses());
+    assertEquals(2, rdbMetrics2.getNumDBKeyGets());
   }
 
   @Test
   public void testGetByteBuffer() throws Exception {
     final StringCodec codec = StringCodec.get();
     final String tableName = families.get(0);
-    try (RDBTable testTable = rdbStore.getTable(tableName)) {
-      final TypedTable<String, String> typedTable = new TypedTable<>(
-          testTable, StringCodec.get(), StringCodec.get(), CacheType.PARTIAL_CACHE);
+    RDBTable testTable = rdbStore.getTable(tableName);
+    final TypedTable<String, String> typedTable = new TypedTable<>(
+        testTable, StringCodec.get(), StringCodec.get(), CacheType.PARTIAL_CACHE);
 
-      for (int i = 0; i < 20; i++) {
-        final int valueSize = TypedTable.BUFFER_SIZE_DEFAULT * i / 4;
-        final String key = "key" + i;
-        final byte[] keyBytes = codec.toPersistedFormat(key);
-        final String value = RandomStringUtils.secure().next(valueSize, true, false);
-        final byte[] valueBytes = codec.toPersistedFormat(value);
+    for (int i = 0; i < 20; i++) {
+      final int valueSize = TypedTable.BUFFER_SIZE_DEFAULT * i / 4;
+      final String key = "key" + i;
+      final byte[] keyBytes = codec.toPersistedFormat(key);
+      final String value = RandomStringUtils.secure().next(valueSize, true, false);
+      final byte[] valueBytes = codec.toPersistedFormat(value);
 
-        testTable.put(keyBytes, valueBytes);
-        final byte[] got = testTable.get(keyBytes);
-        assertArrayEquals(valueBytes, got);
-        assertEquals(value, codec.fromPersistedFormat(got));
-        assertEquals(value, typedTable.get(key));
-      }
+      testTable.put(keyBytes, valueBytes);
+      final byte[] got = testTable.get(keyBytes);
+      assertArrayEquals(valueBytes, got);
+      assertEquals(value, codec.fromPersistedFormat(got));
+      assertEquals(value, typedTable.get(key));
     }
   }
 
@@ -433,115 +419,108 @@ public class TestRDBTableStore {
         .getBytes(StandardCharsets.UTF_8);
 
     final String tableName = families.get(0);
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable(tableName)) {
-      testTable.put(key, value);
+    Table<byte[], byte[]> testTable = rdbStore.getTable(tableName);
+    testTable.put(key, value);
 
-      // Test if isExist returns value for a key that definitely exists.
-      assertNotNull(testTable.getIfExist(key));
+    // Test if isExist returns value for a key that definitely exists.
+    assertNotNull(testTable.getIfExist(key));
 
-      // Test if isExist returns null for a key that has been deleted.
-      testTable.delete(key);
-      assertNull(testTable.getIfExist(key));
+    // Test if isExist returns null for a key that has been deleted.
+    testTable.delete(key);
+    assertNull(testTable.getIfExist(key));
 
-      byte[] invalidKey =
-          RandomStringUtils.secure().next(5).getBytes(StandardCharsets.UTF_8);
-      // Test if isExist returns null for a key that is definitely not present.
-      assertNull(testTable.getIfExist(invalidKey));
+    byte[] invalidKey =
+        RandomStringUtils.secure().next(5).getBytes(StandardCharsets.UTF_8);
+    // Test if isExist returns null for a key that is definitely not present.
+    assertNull(testTable.getIfExist(invalidKey));
 
-      RDBMetrics rdbMetrics = rdbStore.getMetrics();
-      assertEquals(3, rdbMetrics.getNumDBKeyGetIfExistChecks());
+    RDBMetrics rdbMetrics = rdbStore.getMetrics();
+    assertEquals(3, rdbMetrics.getNumDBKeyGetIfExistChecks());
 
-      assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistMisses());
+    assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistMisses());
 
-      assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistGets());
+    assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistGets());
 
-      // Reinsert key for further testing.
-      testTable.put(key, value);
-    }
+    // Reinsert key for further testing.
+    testTable.put(key, value);
 
     rdbStore.close();
     setUp();
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable(tableName)) {
-      // Verify getIfExists works with key not in block cache.
-      assertNotNull(testTable.getIfExist(key));
-    }
+    Table<byte[], byte[]> testTable2 = rdbStore.getTable(tableName);
+    // Verify getIfExists works with key not in block cache.
+    assertNotNull(testTable2.getIfExist(key));
   }
 
   @Test
   public void testCountEstimatedRowsInTable() throws Exception {
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("Eighth")) {
-      // Add a few keys
-      final int numKeys = 12345;
-      for (int i = 0; i < numKeys; i++) {
-        byte[] key =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        byte[] value =
-            RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-        testTable.put(key, value);
-      }
-      long keyCount = testTable.getEstimatedKeyCount();
-      // The result should be larger than zero but not exceed(?) numKeys
-      assertThat(keyCount).isGreaterThan(0).isLessThanOrEqualTo(numKeys);
+    Table<byte[], byte[]> testTable = rdbStore.getTable("Eighth");
+    // Add a few keys
+    final int numKeys = 12345;
+    for (int i = 0; i < numKeys; i++) {
+      byte[] key =
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      byte[] value =
+          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      testTable.put(key, value);
     }
+    long keyCount = testTable.getEstimatedKeyCount();
+    // The result should be larger than zero but not exceed(?) numKeys
+    assertThat(keyCount).isGreaterThan(0).isLessThanOrEqualTo(numKeys);
   }
 
   @Test
   public void testIteratorRemoveFromDB() throws Exception {
 
     // Remove without next removes first entry.
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("Fifth")) {
-      writeToTable(testTable, 3);
-      try (Table.KeyValueIterator<?, ?> iterator =
-          testTable.iterator()) {
-        iterator.removeFromDB();
-      }
-      assertNull(testTable.get(bytesOf[1]));
-      assertNotNull(testTable.get(bytesOf[2]));
-      assertNotNull(testTable.get(bytesOf[3]));
+    Table<byte[], byte[]> testTable = rdbStore.getTable("Fifth");
+    writeToTable(testTable, 3);
+    try (Table.KeyValueIterator<?, ?> iterator =
+             testTable.iterator()) {
+      iterator.removeFromDB();
     }
+    assertNull(testTable.get(bytesOf[1]));
+    assertNotNull(testTable.get(bytesOf[2]));
+    assertNotNull(testTable.get(bytesOf[3]));
 
     // Remove after seekToLast removes lastEntry
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("Sixth")) {
-      writeToTable(testTable, 3);
-      try (Table.KeyValueIterator<?, ?> iterator =
-               testTable.iterator()) {
-        iterator.seekToLast();
-        iterator.removeFromDB();
-      }
-      assertNotNull(testTable.get(bytesOf[1]));
-      assertNotNull(testTable.get(bytesOf[2]));
-      assertNull(testTable.get(bytesOf[3]));
+    Table<byte[], byte[]> testTable2 = rdbStore.getTable("Sixth");
+    writeToTable(testTable2, 3);
+    try (Table.KeyValueIterator<?, ?> iterator =
+             testTable2.iterator()) {
+      iterator.seekToLast();
+      iterator.removeFromDB();
     }
+    assertNotNull(testTable2.get(bytesOf[1]));
+    assertNotNull(testTable2.get(bytesOf[2]));
+    assertNull(testTable2.get(bytesOf[3]));
 
     // Remove after seek deletes that entry.
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("Sixth")) {
-      writeToTable(testTable, 3);
-      try (Table.KeyValueIterator<byte[], byte[]> iterator =
-               testTable.iterator()) {
-        iterator.seek(bytesOf[3]);
-        iterator.removeFromDB();
-      }
-      assertNotNull(testTable.get(bytesOf[1]));
-      assertNotNull(testTable.get(bytesOf[2]));
-      assertNull(testTable.get(bytesOf[3]));
+    Table<byte[], byte[]> testTable3 = rdbStore.getTable("Sixth");
+    writeToTable(testTable3, 3);
+    try (Table.KeyValueIterator<byte[], byte[]> iterator =
+             testTable3.iterator()) {
+      iterator.seek(bytesOf[3]);
+      iterator.removeFromDB();
     }
+    assertNotNull(testTable3.get(bytesOf[1]));
+    assertNotNull(testTable3.get(bytesOf[2]));
+    assertNull(testTable3.get(bytesOf[3]));
 
     // Remove after next() deletes entry that was returned by next.
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("Sixth")) {
-      writeToTable(testTable, 3);
-      try (Table.KeyValueIterator<byte[], byte[]> iterator =
-          testTable.iterator()) {
-        iterator.seek(bytesOf[2]);
-        iterator.next();
-        iterator.removeFromDB();
-      }
-      assertNotNull(testTable.get(bytesOf[1]));
-      assertNull(testTable.get(bytesOf[2]));
-      assertNotNull(testTable.get(bytesOf[3]));
+    Table<byte[], byte[]> testTable4 = rdbStore.getTable("Sixth");
+    writeToTable(testTable4, 3);
+    try (Table.KeyValueIterator<byte[], byte[]> iterator =
+             testTable4.iterator()) {
+      iterator.seek(bytesOf[2]);
+      iterator.next();
+      iterator.removeFromDB();
     }
+    assertNotNull(testTable4.get(bytesOf[1]));
+    assertNull(testTable4.get(bytesOf[2]));
+    assertNotNull(testTable4.get(bytesOf[3]));
   }
 
-  private void writeToTable(Table testTable, int num) throws IOException {
+  private void writeToTable(Table<byte[], byte[]> testTable, int num) throws IOException {
     for (int i = 1; i <= num; i++) {
       byte[] key = bytesOf[i];
       byte[] value =
@@ -557,30 +536,29 @@ public class TestRDBTableStore {
     List<String> testPrefixes = generatePrefixes(containerCount);
     List<Map<String, String>> testData = generateKVs(testPrefixes, blockCount);
 
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("PrefixFirst")) {
-      // write data
-      populatePrefixedTable(testTable, testData);
+    Table<byte[], byte[]> testTable = rdbStore.getTable("PrefixFirst");
+    // write data
+    populatePrefixedTable(testTable, testData);
 
-      // iterator should seek to right pos in the middle
-      byte[] samplePrefix = testPrefixes.get(2).getBytes(
-          StandardCharsets.UTF_8);
-      try (Table.KeyValueIterator<byte[], byte[]> iter = testTable.iterator(
-              samplePrefix)) {
-        int keyCount = 0;
-        while (iter.hasNext()) {
-          // iterator should only meet keys with samplePrefix
-          assertArrayEquals(samplePrefix, Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH));
-          keyCount++;
-        }
-
-        // iterator should end at right pos
-        assertEquals(blockCount, keyCount);
-
-        // iterator should be able to seekToFirst
-        iter.seekToFirst();
-        assertTrue(iter.hasNext());
+    // iterator should seek to right pos in the middle
+    byte[] samplePrefix = testPrefixes.get(2).getBytes(
+        StandardCharsets.UTF_8);
+    try (Table.KeyValueIterator<byte[], byte[]> iter = testTable.iterator(
+        samplePrefix)) {
+      int keyCount = 0;
+      while (iter.hasNext()) {
+        // iterator should only meet keys with samplePrefix
         assertArrayEquals(samplePrefix, Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH));
+        keyCount++;
       }
+
+      // iterator should end at right pos
+      assertEquals(blockCount, keyCount);
+
+      // iterator should be able to seekToFirst
+      iter.seekToFirst();
+      assertTrue(iter.hasNext());
+      assertArrayEquals(samplePrefix, Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH));
     }
   }
 
@@ -591,17 +569,15 @@ public class TestRDBTableStore {
     final List<String> prefixes = generatePrefixes(prefixCount);
     final List<Map<String, String>> data = generateKVs(prefixes, keyCount);
 
-    try (TypedTable<String, String> table = rdbStore.getTable(
-        "PrefixFirst", StringCodec.get(), StringCodec.get())) {
-      populateTable(table, data);
-      for (String prefix : prefixes) {
-        assertIterator(keyCount, prefix, table);
-      }
-
-      final String nonExistingPrefix = RandomStringUtils.secure().next(
-          PREFIX_LENGTH + 2, false, false);
-      assertIterator(0, nonExistingPrefix, table);
+    TypedTable<String, String> table = rdbStore.getTable("PrefixFirst", StringCodec.get(), StringCodec.get());
+    populateTable(table, data);
+    for (String prefix : prefixes) {
+      assertIterator(keyCount, prefix, table);
     }
+
+    final String nonExistingPrefix = RandomStringUtils.secure().next(
+        PREFIX_LENGTH + 2, false, false);
+    assertIterator(0, nonExistingPrefix, table);
   }
 
   static void assertIterator(int expectedCount, String prefix,
@@ -630,12 +606,10 @@ public class TestRDBTableStore {
 
   @Test
   public void testStringPrefixedIteratorCloseDb() throws Exception {
-    try (Table<String, String> testTable = rdbStore.getTable(
-        "PrefixFirst", StringCodec.get(), StringCodec.get())) {
-      // iterator should seek to right pos in the middle
-      rdbStore.close();
-      assertThrows(IOException.class, () -> testTable.iterator("abc"));
-    }
+    Table<String, String> testTable = rdbStore.getTable("PrefixFirst", StringCodec.get(), StringCodec.get());
+    // iterator should seek to right pos in the middle
+    rdbStore.close();
+    assertThrows(IOException.class, () -> testTable.iterator("abc"));
   }
 
   @Test
@@ -645,42 +619,41 @@ public class TestRDBTableStore {
     List<String> testPrefixes = generatePrefixes(containerCount);
     List<Map<String, String>> testData = generateKVs(testPrefixes, blockCount);
 
-    try (Table<byte[], byte[]> testTable = rdbStore.getTable("PrefixFirst")) {
+    Table<byte[], byte[]> testTable = rdbStore.getTable("PrefixFirst");
 
-      // write data
-      populatePrefixedTable(testTable, testData);
+    // write data
+    populatePrefixedTable(testTable, testData);
 
-      byte[] samplePrefix = testPrefixes.get(2).getBytes(
-          StandardCharsets.UTF_8);
+    byte[] samplePrefix = testPrefixes.get(2).getBytes(
+        StandardCharsets.UTF_8);
 
-      // test start at first
-      byte[] startKey = samplePrefix;
-      List<Table.KeyValue<byte[], byte[]>> rangeKVs = testTable
-          .getRangeKVs(startKey, 3, samplePrefix);
-      assertEquals(3, rangeKVs.size());
+    // test start at first
+    byte[] startKey = samplePrefix;
+    List<Table.KeyValue<byte[], byte[]>> rangeKVs = testTable
+        .getRangeKVs(startKey, 3, samplePrefix);
+    assertEquals(3, rangeKVs.size());
 
-      // test start with a middle key
-      startKey = StringUtils.string2Bytes(
-          StringUtils.bytes2String(samplePrefix) + "3");
-      rangeKVs = testTable.getRangeKVs(startKey, blockCount, samplePrefix);
-      assertEquals(2, rangeKVs.size());
+    // test start with a middle key
+    startKey = StringUtils.string2Bytes(
+        StringUtils.bytes2String(samplePrefix) + "3");
+    rangeKVs = testTable.getRangeKVs(startKey, blockCount, samplePrefix);
+    assertEquals(2, rangeKVs.size());
 
-      // test with a filter
-      MetadataKeyFilters.KeyPrefixFilter filter1 = new MetadataKeyFilters
-          .KeyPrefixFilter()
-          .addFilter(StringUtils.bytes2String(samplePrefix) + "1");
-      startKey = StringUtils.string2Bytes(
-          StringUtils.bytes2String(samplePrefix));
-      rangeKVs = testTable.getRangeKVs(startKey, blockCount,
-          samplePrefix, filter1);
-      assertEquals(1, rangeKVs.size());
+    // test with a filter
+    MetadataKeyFilters.KeyPrefixFilter filter1 = new MetadataKeyFilters
+        .KeyPrefixFilter()
+        .addFilter(StringUtils.bytes2String(samplePrefix) + "1");
+    startKey = StringUtils.string2Bytes(
+        StringUtils.bytes2String(samplePrefix));
+    rangeKVs = testTable.getRangeKVs(startKey, blockCount,
+        samplePrefix, filter1);
+    assertEquals(1, rangeKVs.size());
 
-      // test start with a non-exist key
-      startKey = StringUtils.string2Bytes(
-          StringUtils.bytes2String(samplePrefix) + 123);
-      rangeKVs = testTable.getRangeKVs(startKey, 10, samplePrefix);
-      assertEquals(0, rangeKVs.size());
-    }
+    // test start with a non-exist key
+    startKey = StringUtils.string2Bytes(
+        StringUtils.bytes2String(samplePrefix) + 123);
+    rangeKVs = testTable.getRangeKVs(startKey, 10, samplePrefix);
+    assertEquals(0, rangeKVs.size());
   }
 
   @Test
@@ -692,35 +665,33 @@ public class TestRDBTableStore {
     File dumpFile = new File(tempDir, "PrefixTwo.dump");
     byte[] samplePrefix = testPrefixes.get(2).getBytes(StandardCharsets.UTF_8);
 
-    try (Table<byte[], byte[]> testTable1 = rdbStore.getTable("PrefixTwo")) {
-      // write data
-      populatePrefixedTable(testTable1, testData);
+    Table<byte[], byte[]> testTable1 = rdbStore.getTable("PrefixTwo");
+    // write data
+    populatePrefixedTable(testTable1, testData);
 
-      // dump to external file
-      testTable1.dumpToFileWithPrefix(dumpFile, samplePrefix);
+    // dump to external file
+    testTable1.dumpToFileWithPrefix(dumpFile, samplePrefix);
 
-      // check dump file exist
-      assertTrue(dumpFile.exists());
-      assertNotEquals(0, dumpFile.length());
-    }
+    // check dump file exist
+    assertTrue(dumpFile.exists());
+    assertNotEquals(0, dumpFile.length());
 
     // load dump file into another table
-    try (Table<byte[], byte[]> testTable2 = rdbStore.getTable("PrefixThree")) {
-      testTable2.loadFromFile(dumpFile);
+    Table<byte[], byte[]> testTable2 = rdbStore.getTable("PrefixThree");
+    testTable2.loadFromFile(dumpFile);
 
-      // check loaded keys
-      try (Table.KeyValueIterator<byte[], byte[]> iter = testTable2.iterator(
-          samplePrefix)) {
-        int keyCount = 0;
-        while (iter.hasNext()) {
-          // check prefix
-          assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
-          keyCount++;
-        }
-
-        // check block count
-        assertEquals(blockCount, keyCount);
+    // check loaded keys
+    try (Table.KeyValueIterator<byte[], byte[]> iter = testTable2.iterator(
+        samplePrefix)) {
+      int keyCount = 0;
+      while (iter.hasNext()) {
+        // check prefix
+        assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
+        keyCount++;
       }
+
+      // check block count
+      assertEquals(blockCount, keyCount);
     }
   }
 
@@ -732,35 +703,33 @@ public class TestRDBTableStore {
     File dumpFile = new File(tempDir, "PrefixFour.dump");
     byte[] samplePrefix = testPrefixes.get(2).getBytes(StandardCharsets.UTF_8);
 
-    try (Table<byte[], byte[]> testTable1 = rdbStore.getTable("PrefixFour")) {
-      // no data
+    Table<byte[], byte[]> testTable1 = rdbStore.getTable("PrefixFour");
+    // no data
 
-      // dump to external file
-      testTable1.dumpToFileWithPrefix(dumpFile, samplePrefix);
+    // dump to external file
+    testTable1.dumpToFileWithPrefix(dumpFile, samplePrefix);
 
-      // check dump file exist
-      assertTrue(dumpFile.exists());
-      // empty dump file
-      assertEquals(0, dumpFile.length());
-    }
+    // check dump file exist
+    assertTrue(dumpFile.exists());
+    // empty dump file
+    assertEquals(0, dumpFile.length());
 
     // load dump file into another table
-    try (Table<byte[], byte[]> testTable2 = rdbStore.getTable("PrefixFifth")) {
-      testTable2.loadFromFile(dumpFile);
+    Table<byte[], byte[]> testTable2 = rdbStore.getTable("PrefixFifth");
+    testTable2.loadFromFile(dumpFile);
 
-      // check loaded keys
-      try (Table.KeyValueIterator<byte[], byte[]> iter = testTable2.iterator(
-          samplePrefix)) {
-        int keyCount = 0;
-        while (iter.hasNext()) {
-          // check prefix
-          assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
-          keyCount++;
-        }
-
-        // check block count
-        assertEquals(0, keyCount);
+    // check loaded keys
+    try (Table.KeyValueIterator<byte[], byte[]> iter = testTable2.iterator(
+        samplePrefix)) {
+      int keyCount = 0;
+      while (iter.hasNext()) {
+        // check prefix
+        assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
+        keyCount++;
       }
+
+      // check block count
+      assertEquals(0, keyCount);
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -102,19 +102,17 @@ public class TestTypedRDBTableStore {
 
   @Test
   public void putGetAndEmpty() throws Exception {
-    try (Table<String, String> testTable = createTypedTable(
-        "First")) {
-      String key =
-          RandomStringUtils.secure().next(10);
-      String value = RandomStringUtils.secure().next(10);
-      testTable.put(key, value);
-      assertFalse(testTable.isEmpty());
-      String readValue = testTable.get(key);
-      assertEquals(value, readValue);
-    }
-    try (Table secondTable = rdbStore.getTable("Second")) {
-      assertTrue(secondTable.isEmpty());
-    }
+    final Table<String, String> testTable = createTypedTable("First");
+    String key =
+        RandomStringUtils.secure().next(10);
+    String value = RandomStringUtils.secure().next(10);
+    testTable.put(key, value);
+    assertFalse(testTable.isEmpty());
+    String readValue = testTable.get(key);
+    assertEquals(value, readValue);
+
+    final Table<byte[], byte[]> secondTable = rdbStore.getTable("Second");
+    assertTrue(secondTable.isEmpty());
   }
 
   private Table<String, String> createTypedTable(String name)
@@ -142,33 +140,29 @@ public class TestTypedRDBTableStore {
 
     // Write all the keys and delete the keys scheduled for delete.
     //Assert we find only expected keys in the Table.
-    try (Table<String, String> testTable = createTypedTable(
-        "Fourth")) {
-      for (String deletedKey : deletedKeys) {
-        testTable.put(deletedKey, value);
-        testTable.delete(deletedKey);
-      }
+    final Table<String, String> testTable = createTypedTable("Fourth");
+    for (String deletedKey : deletedKeys) {
+      testTable.put(deletedKey, value);
+      testTable.delete(deletedKey);
+    }
 
-      for (String validKey : validKeys) {
-        testTable.put(validKey, value);
-      }
+    for (String validKey : validKeys) {
+      testTable.put(validKey, value);
+    }
 
-      for (String validKey : validKeys) {
-        assertNotNull(testTable.get(validKey));
-      }
+    for (String validKey : validKeys) {
+      assertNotNull(testTable.get(validKey));
+    }
 
-      for (String deletedKey : deletedKeys) {
-        assertNull(testTable.get(deletedKey));
-      }
+    for (String deletedKey : deletedKeys) {
+      assertNull(testTable.get(deletedKey));
     }
   }
 
   @Test
   public void batchPut() throws Exception {
-
-    try (Table<String, String> testTable = createTypedTable(
-        "Fourth");
-        BatchOperation batch = rdbStore.initBatchOperation()) {
+    final Table<String, String> testTable = createTypedTable("Fourth");
+    try (BatchOperation batch = rdbStore.initBatchOperation()) {
       //given
       String key =
           RandomStringUtils.secure().next(10);
@@ -186,9 +180,8 @@ public class TestTypedRDBTableStore {
 
   @Test
   public void batchDelete() throws Exception {
-    try (Table<String, String> testTable = createTypedTable(
-        "Fourth");
-        BatchOperation batch = rdbStore.initBatchOperation()) {
+    final Table<String, String> testTable = createTypedTable("Fourth");
+    try (BatchOperation batch = rdbStore.initBatchOperation()) {
 
       //given
       String key =
@@ -215,30 +208,25 @@ public class TestTypedRDBTableStore {
   @Test
   public void forEachAndIterator() throws Exception {
     final int iterCount = 100;
-    try (Table<String, String> testTable = createTypedTable(
-        "Sixth")) {
-      for (int x = 0; x < iterCount; x++) {
-        String key =
-            RandomStringUtils.secure().next(10);
-        String value =
-            RandomStringUtils.secure().next(10);
-        testTable.put(key, value);
+    final Table<String, String> testTable = createTypedTable("Sixth");
+    for (int x = 0; x < iterCount; x++) {
+      String key = RandomStringUtils.secure().next(10);
+      String value = RandomStringUtils.secure().next(10);
+      testTable.put(key, value);
+    }
+    int localCount = 0;
+
+    try (Table.KeyValueIterator<String, String> iter = testTable.iterator()) {
+      while (iter.hasNext()) {
+        iter.next();
+        localCount++;
       }
-      int localCount = 0;
 
-      try (Table.KeyValueIterator<String, String> iter =
-          testTable.iterator()) {
-        while (iter.hasNext()) {
-          Table.KeyValue keyValue = iter.next();
-          localCount++;
-        }
+      assertEquals(iterCount, localCount);
+      iter.seekToFirst();
+      iter.forEachRemaining(TestTypedRDBTableStore::consume);
+      assertEquals(iterCount, count);
 
-        assertEquals(iterCount, localCount);
-        iter.seekToFirst();
-        iter.forEachRemaining(TestTypedRDBTableStore::consume);
-        assertEquals(iterCount, count);
-
-      }
     }
   }
 
@@ -247,32 +235,28 @@ public class TestTypedRDBTableStore {
     RDBTable rdbTable = mock(RDBTable.class);
     when(rdbTable.iterator((CodecBuffer) null, Table.KeyValueIterator.Type.KEY_AND_VALUE))
         .thenThrow(new IOException());
-    try (Table<String, String> testTable = new TypedTable<>(rdbTable,
-        StringCodec.get(), StringCodec.get(), CacheType.PARTIAL_CACHE)) {
-      assertThrows(IOException.class, testTable::iterator);
-    }
+    final Table<String, String> testTable = new TypedTable<>(rdbTable,
+        StringCodec.get(), StringCodec.get(), CacheType.PARTIAL_CACHE);
+    assertThrows(IOException.class, testTable::iterator);
   }
 
   @Test
   public void testTypedTableWithCache() throws Exception {
     int iterCount = 10;
-    try (Table<String, String> testTable = createTypedTable(
-        "Seven")) {
+    final Table<String, String> testTable = createTypedTable("Seven");
 
-      for (int x = 0; x < iterCount; x++) {
-        String key = Integer.toString(x);
-        String value = Integer.toString(x);
-        testTable.addCacheEntry(new CacheKey<>(key),
-            CacheValue.get(x, value));
-      }
+    for (int x = 0; x < iterCount; x++) {
+      String key = Integer.toString(x);
+      String value = Integer.toString(x);
+      testTable.addCacheEntry(new CacheKey<>(key),
+          CacheValue.get(x, value));
+    }
 
-      // As we have added to cache, so get should return value even if it
-      // does not exist in DB.
-      for (int x = 0; x < iterCount; x++) {
-        assertEquals(Integer.toString(1),
-            testTable.get(Integer.toString(1)));
-      }
-
+    // As we have added to cache, so get should return value even if it
+    // does not exist in DB.
+    for (int x = 0; x < iterCount; x++) {
+      assertEquals(Integer.toString(1),
+          testTable.get(Integer.toString(1)));
     }
   }
 
@@ -280,142 +264,123 @@ public class TestTypedRDBTableStore {
   public void testTypedTableWithCacheWithFewDeletedOperationType()
       throws Exception {
     int iterCount = 10;
-    try (Table<String, String> testTable = createTypedTable(
-        "Seven")) {
+    final Table<String, String> testTable = createTypedTable("Seven");
 
-      for (int x = 0; x < iterCount; x++) {
-        String key = Integer.toString(x);
-        String value = Integer.toString(x);
-        if (x % 2 == 0) {
-          testTable.addCacheEntry(new CacheKey<>(key),
-              CacheValue.get(x, value));
-        } else {
-          testTable.addCacheEntry(new CacheKey<>(key),
-              CacheValue.get(x));
-        }
+    for (int x = 0; x < iterCount; x++) {
+      String key = Integer.toString(x);
+      String value = Integer.toString(x);
+      if (x % 2 == 0) {
+        testTable.addCacheEntry(new CacheKey<>(key),
+            CacheValue.get(x, value));
+      } else {
+        testTable.addCacheEntry(new CacheKey<>(key),
+            CacheValue.get(x));
       }
+    }
 
-      // As we have added to cache, so get should return value even if it
-      // does not exist in DB.
-      for (int x = 0; x < iterCount; x++) {
-        if (x % 2 == 0) {
-          assertEquals(Integer.toString(x),
-              testTable.get(Integer.toString(x)));
-        } else {
-          assertNull(testTable.get(Integer.toString(x)));
-        }
+    // As we have added to cache, so get should return value even if it
+    // does not exist in DB.
+    for (int x = 0; x < iterCount; x++) {
+      if (x % 2 == 0) {
+        assertEquals(Integer.toString(x),
+            testTable.get(Integer.toString(x)));
+      } else {
+        assertNull(testTable.get(Integer.toString(x)));
       }
+    }
 
-      ArrayList<Long> epochs = new ArrayList<>();
-      for (long i = 0; i <= 5L; i++) {
-        epochs.add(i);
+    ArrayList<Long> epochs = new ArrayList<>();
+    for (long i = 0; i <= 5L; i++) {
+      epochs.add(i);
+    }
+    testTable.cleanupCache(epochs);
+
+    GenericTestUtils.waitFor(() ->
+            ((TypedTable<String, String>) testTable).getCache().size() == 4,
+        100, 5000);
+
+
+    //Check remaining values
+    for (int x = 6; x < iterCount; x++) {
+      if (x % 2 == 0) {
+        assertEquals(Integer.toString(x),
+            testTable.get(Integer.toString(x)));
+      } else {
+        assertNull(testTable.get(Integer.toString(x)));
       }
-      testTable.cleanupCache(epochs);
-
-      GenericTestUtils.waitFor(() ->
-          ((TypedTable<String, String>) testTable).getCache().size() == 4,
-          100, 5000);
-
-
-      //Check remaining values
-      for (int x = 6; x < iterCount; x++) {
-        if (x % 2 == 0) {
-          assertEquals(Integer.toString(x),
-              testTable.get(Integer.toString(x)));
-        } else {
-          assertNull(testTable.get(Integer.toString(x)));
-        }
-      }
-
-
     }
   }
 
   @Test
   public void testIsExist() throws Exception {
-    try (Table<String, String> testTable = createTypedTable(
-        "Eighth")) {
-      String key =
-          RandomStringUtils.secure().next(10);
-      String value = RandomStringUtils.secure().next(10);
-      testTable.put(key, value);
-      assertTrue(testTable.isExist(key));
+    final Table<String, String> testTable = createTypedTable("Eighth");
+    String key = RandomStringUtils.secure().next(10);
+    String value = RandomStringUtils.secure().next(10);
+    testTable.put(key, value);
+    assertTrue(testTable.isExist(key));
 
-      String invalidKey = key + RandomStringUtils.secure().next(1);
-      assertFalse(testTable.isExist(invalidKey));
+    String invalidKey = key + RandomStringUtils.secure().next(1);
+    assertFalse(testTable.isExist(invalidKey));
 
-      testTable.delete(key);
-      assertFalse(testTable.isExist(key));
-    }
+    testTable.delete(key);
+    assertFalse(testTable.isExist(key));
   }
 
   @Test
   public void testGetIfExist() throws Exception {
-    try (Table<String, String> testTable = createTypedTable(
-        "Eighth")) {
-      String key =
-          RandomStringUtils.secure().next(10);
-      String value = RandomStringUtils.secure().next(10);
-      testTable.put(key, value);
-      assertNotNull(testTable.getIfExist(key));
+    final Table<String, String> testTable = createTypedTable("Eighth");
+    String key = RandomStringUtils.secure().next(10);
+    String value = RandomStringUtils.secure().next(10);
+    testTable.put(key, value);
+    assertNotNull(testTable.getIfExist(key));
 
-      String invalidKey = key + RandomStringUtils.secure().next(1);
-      assertNull(testTable.getIfExist(invalidKey));
+    String invalidKey = key + RandomStringUtils.secure().next(1);
+    assertNull(testTable.getIfExist(invalidKey));
 
-      testTable.delete(key);
-      assertNull(testTable.getIfExist(key));
-    }
+    testTable.delete(key);
+    assertNull(testTable.getIfExist(key));
   }
 
   @Test
   public void testIsExistCache() throws Exception {
-    try (Table<String, String> testTable = createTypedTable(
-        "Eighth")) {
-      String key =
-          RandomStringUtils.secure().next(10);
-      String value = RandomStringUtils.secure().next(10);
-      testTable.addCacheEntry(new CacheKey<>(key),
-          CacheValue.get(1L, value));
-      assertTrue(testTable.isExist(key));
+    final Table<String, String> testTable = createTypedTable("Eighth");
+    String key = RandomStringUtils.secure().next(10);
+    String value = RandomStringUtils.secure().next(10);
+    testTable.addCacheEntry(new CacheKey<>(key), CacheValue.get(1L, value));
+    assertTrue(testTable.isExist(key));
 
-      testTable.addCacheEntry(new CacheKey<>(key),
-          CacheValue.get(1L));
-      assertFalse(testTable.isExist(key));
-    }
+    testTable.addCacheEntry(new CacheKey<>(key),
+        CacheValue.get(1L));
+    assertFalse(testTable.isExist(key));
   }
 
   @Test
   public void testCountEstimatedRowsInTable() throws Exception {
-    try (Table<String, String> testTable = createTypedTable(
-        "Ninth")) {
-      // Add a few keys
-      final int numKeys = 12345;
-      for (int i = 0; i < numKeys; i++) {
-        String key =
-            RandomStringUtils.secure().next(10);
-        String value = RandomStringUtils.secure().next(10);
-        testTable.put(key, value);
-      }
-      long keyCount = testTable.getEstimatedKeyCount();
-      // The result should be larger than zero but not exceed(?) numKeys
-      assertThat(keyCount).isGreaterThan(0).isLessThanOrEqualTo(numKeys);
+    final Table<String, String> testTable = createTypedTable("Ninth");
+    // Add a few keys
+    final int numKeys = 12345;
+    for (int i = 0; i < numKeys; i++) {
+      String key =
+          RandomStringUtils.secure().next(10);
+      String value = RandomStringUtils.secure().next(10);
+      testTable.put(key, value);
     }
+    long keyCount = testTable.getEstimatedKeyCount();
+    // The result should be larger than zero but not exceed(?) numKeys
+    assertThat(keyCount).isGreaterThan(0).isLessThanOrEqualTo(numKeys);
   }
 
   @Test
   public void testByteArrayTypedTable() throws Exception {
-    try (Table<byte[], byte[]> testTable = new TypedTable<>(
-            rdbStore.getTable("Ten"),
-            ByteArrayCodec.get(), ByteArrayCodec.get(), CacheType.PARTIAL_CACHE)) {
-      byte[] key = new byte[] {1, 2, 3};
-      byte[] value = new byte[] {4, 5, 6};
-      testTable.put(key, value);
-      byte[] actualValue = testTable.get(key);
-      assertArrayEquals(value, testTable.get(key));
-      assertNotSame(value, actualValue);
-      testTable.addCacheEntry(new CacheKey<>(key),
-              CacheValue.get(1L, value));
-      assertSame(value, testTable.get(key));
-    }
+    final Table<byte[], byte[]> testTable = new TypedTable<>(rdbStore.getTable("Ten"),
+        ByteArrayCodec.get(), ByteArrayCodec.get(), CacheType.PARTIAL_CACHE);
+    byte[] key = new byte[]{1, 2, 3};
+    byte[] value = new byte[]{4, 5, 6};
+    testTable.put(key, value);
+    byte[] actualValue = testTable.get(key);
+    assertArrayEquals(value, testTable.get(key));
+    assertNotSame(value, actualValue);
+    testTable.addCacheEntry(new CacheKey<>(key), CacheValue.get(1L, value));
+    assertSame(value, testTable.get(key));
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedTable.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedTable.java
@@ -117,68 +117,60 @@ public class TestTypedTable {
 
     // Table 1: ContainerID -> String
     // Table 2: Long -> String
-    try (TypedTable<ContainerID, String> idTable = newTypedTable(
-        1, ContainerID.getCodec(), StringCodec.get());
-         TypedTable<Long, String> longTable = newTypedTable(
-             2, LongCodec.get(), StringCodec.get())) {
+    final TypedTable<ContainerID, String> idTable = newTypedTable(1, ContainerID.getCodec(), StringCodec.get());
+    final TypedTable<Long, String> longTable = newTypedTable(2, LongCodec.get(), StringCodec.get());
 
-      for (Map.Entry<Long, ContainerID> e : keys.entrySet()) {
-        final long n = e.getKey();
-        final ContainerID id = e.getValue();
-        final String value = id.toString();
-        // put the same value to both tables
-        idTable.put(id, value);
-        longTable.put(n, value);
-      }
+    for (Map.Entry<Long, ContainerID> e : keys.entrySet()) {
+      final long n = e.getKey();
+      final ContainerID id = e.getValue();
+      final String value = id.toString();
+      // put the same value to both tables
+      idTable.put(id, value);
+      longTable.put(n, value);
     }
 
     // Reopen tables with different key types
 
     // Table 1: Long -> String
     // Table 2: ContainerID -> String
-    try (TypedTable<ContainerID, String> idTable = newTypedTable(
-        2, ContainerID.getCodec(), StringCodec.get());
-         TypedTable<Long, String> longTable = newTypedTable(
-             1, LongCodec.get(), StringCodec.get())) {
+    final TypedTable<ContainerID, String> idTable2 = newTypedTable(2, ContainerID.getCodec(), StringCodec.get());
+    final TypedTable<Long, String> longTable2 = newTypedTable(1, LongCodec.get(), StringCodec.get());
 
-      for (Map.Entry<Long, ContainerID> e : keys.entrySet()) {
-        final long n = e.getKey();
-        final ContainerID id = e.getValue();
-        final String expected = id.toString();
-        // Read the value using a different key type
-        final String idValue = idTable.get(id);
-        assertEquals(expected, idValue);
-        final String longValue = longTable.get(n);
-        assertEquals(expected, longValue);
-      }
+    for (Map.Entry<Long, ContainerID> e : keys.entrySet()) {
+      final long n = e.getKey();
+      final ContainerID id = e.getValue();
+      final String expected = id.toString();
+      // Read the value using a different key type
+      final String idValue = idTable2.get(id);
+      assertEquals(expected, idValue);
+      final String longValue = longTable2.get(n);
+      assertEquals(expected, longValue);
     }
 
     // test iterator type
-    try (TypedTable<Long, String> longTable = newTypedTable(
-        1, LongCodec.get(), StringCodec.get());
-         Table.KeyValueIterator<Long, String> neither = longTable.iterator(NEITHER);
-         Table.KeyValueIterator<Long, String> keyOnly = longTable.iterator(KEY_ONLY);
-         Table.KeyValueIterator<Long, String> valueOnly = longTable.iterator(VALUE_ONLY);
-         Table.KeyValueIterator<Long, String> keyAndValue = longTable.iterator(KEY_AND_VALUE)) {
-      while (keyAndValue.hasNext()) {
-        final Table.KeyValue<Long, String> keyValue = keyAndValue.next();
-        final Long expectedKey = Objects.requireNonNull(keyValue.getKey());
+    final TypedTable<Long, String> longTable3 = newTypedTable(1, LongCodec.get(), StringCodec.get());
+    final Table.KeyValueIterator<Long, String> neither = longTable3.iterator(NEITHER);
+    final Table.KeyValueIterator<Long, String> keyOnly = longTable3.iterator(KEY_ONLY);
+    final Table.KeyValueIterator<Long, String> valueOnly = longTable3.iterator(VALUE_ONLY);
+    final Table.KeyValueIterator<Long, String> keyAndValue = longTable3.iterator(KEY_AND_VALUE);
+    while (keyAndValue.hasNext()) {
+      final Table.KeyValue<Long, String> keyValue = keyAndValue.next();
+      final Long expectedKey = Objects.requireNonNull(keyValue.getKey());
 
-        final String expectedValue = Objects.requireNonNull(keyValue.getValue());
-        assertEquals(keys.get(expectedKey).toString(), expectedValue);
+      final String expectedValue = Objects.requireNonNull(keyValue.getValue());
+      assertEquals(keys.get(expectedKey).toString(), expectedValue);
 
-        final int expectedValueSize = keyValue.getValueByteSize();
-        assertEquals(expectedValue.length(), expectedValueSize);
+      final int expectedValueSize = keyValue.getValueByteSize();
+      assertEquals(expectedValue.length(), expectedValueSize);
 
-        assertKeyValue(expectedKey, null, 0, keyOnly);
-        assertKeyValue(null, expectedValue, expectedValueSize, valueOnly);
-        assertKeyValue(null, null, 0, neither);
-      }
-
-      assertFalse(keyOnly.hasNext());
-      assertFalse(valueOnly.hasNext());
-      assertFalse(neither.hasNext());
+      assertKeyValue(expectedKey, null, 0, keyOnly);
+      assertKeyValue(null, expectedValue, expectedValueSize, valueOnly);
+      assertKeyValue(null, null, 0, neither);
     }
+
+    assertFalse(keyOnly.hasNext());
+    assertFalse(valueOnly.hasNext());
+    assertFalse(neither.hasNext());
   }
 
   static <K, V> void assertKeyValue(K expectedKey, V expectedValue, int expectedValueSize,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.container;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -35,8 +34,7 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
  * ContainerManager is responsible for keeping track of all Containers and
  * managing all containers operations like creating, deleting etc.
  */
-public interface ContainerManager extends Closeable {
-
+public interface ContainerManager {
   /**
    * Reinitialize the containerManager with the updated container store.
    * @param containerStore Container Table

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -443,11 +443,6 @@ public class ContainerManagerImpl implements ContainerManager {
     return containerStateManager.contains(id);
   }
 
-  @Override
-  public void close() throws IOException {
-    containerStateManager.close();
-  }
-
   // Remove this after fixing Recon
   @Override
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -207,9 +207,4 @@ public interface ContainerStateManager {
    */
   void reinitialize(Table<ContainerID, ContainerInfo> containerStore)
       throws IOException;
-
-  /**
-   *
-   */
-  void close() throws IOException;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -532,20 +532,10 @@ public final class ContainerStateManagerImpl
   public void reinitialize(
       Table<ContainerID, ContainerInfo> store) throws IOException {
     try (AutoCloseableLock ignored = writeLock()) {
-      close();
       this.containerStore = store;
       this.containers = new ContainerStateMap();
       this.lastUsedMap = new ConcurrentHashMap<>();
       initialize();
-    }
-  }
-
-  @Override
-  public void close() throws IOException {
-    try {
-      containerStore.close();
-    } catch (Exception e) {
-      throw new IOException(e);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
@@ -111,7 +111,7 @@ public interface PipelineStateManager {
   void removeContainerFromPipeline(PipelineID pipelineID,
                                    ContainerID containerID) throws IOException;
 
-  void close() throws Exception;
+  void close();
 
   void reinitialize(Table<PipelineID, Pipeline> pipelineStore)
       throws IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -303,14 +303,10 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     lock.writeLock().lock();
     try {
-      if (pipelineStore != null) {
-        pipelineStore = null;
-      }
-    } catch (Exception ex) {
-      LOG.error("Pipeline store close failed", ex);
+      pipelineStore = null;
     } finally {
       lock.writeLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -307,7 +307,6 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
     lock.writeLock().lock();
     try {
       if (pipelineStore != null) {
-        pipelineStore.close();
         pipelineStore = null;
       }
     } catch (Exception ex) {
@@ -322,7 +321,6 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
       throws IOException {
     lock.writeLock().lock();
     try {
-      pipelineStore.close();
       this.pipelineStateMap = new PipelineStateMap();
       this.pipelineStore = store;
       initialize();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1707,7 +1707,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       SCMHAMetrics.unRegister();
     }
 
-    IOUtils.cleanupWithLogger(LOG, containerManager);
     IOUtils.cleanupWithLogger(LOG, pipelineManager);
 
     if (ms != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManagerImpl.java
@@ -228,7 +228,6 @@ public class FinalizationStateManagerImpl implements FinalizationStateManager {
       throws IOException {
     checkpointLock.writeLock().lock();
     try {
-      this.finalizationStore.close();
       this.finalizationStore = newFinalizationStore;
       initialize();
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -104,10 +104,6 @@ public class TestContainerManagerImpl {
 
   @AfterEach
   public void cleanup() throws Exception {
-    if (containerManager != null) {
-      containerManager.close();
-    }
-
     if (dbStore != null) {
       dbStore.close();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -162,7 +162,6 @@ public class TestContainerReportHandler {
 
   @AfterEach
   public void tearDown() throws Exception {
-    containerStateManager.close();
     if (dbStore != null) {
       dbStore.close();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -100,7 +100,6 @@ public class TestContainerStateManager {
 
   @AfterEach
   public void tearDown() throws Exception {
-    containerStateManager.close();
     if (dbStore != null) {
       dbStore.close();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -185,7 +185,6 @@ public class TestIncrementalContainerReportHandler {
 
   @AfterEach
   public void tearDown() throws Exception {
-    containerStateManager.close();
     nodeManager.close();
     if (dbStore != null) {
       dbStore.close();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
@@ -36,13 +36,9 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
-import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
-import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
-import org.apache.hadoop.hdds.scm.pipeline.MockPipelineManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -62,13 +58,10 @@ public class TestUnknownContainerReport {
 
   private NodeManager nodeManager;
   private ContainerManager containerManager;
-  private ContainerStateManager containerStateManager;
   private EventPublisher publisher;
-  private PipelineManager pipelineManager;
   @TempDir
   private File testDir;
   private DBStore dbStore;
-  private SCMHAManager scmhaManager;
 
   @BeforeEach
   public void setup() throws IOException {
@@ -76,16 +69,6 @@ public class TestUnknownContainerReport {
     this.nodeManager = new MockNodeManager(true, 10);
     this.containerManager = mock(ContainerManager.class);
     dbStore = DBStoreBuilder.createDBStore(conf, SCMDBDefinition.get());
-    scmhaManager = SCMHAManagerStub.getInstance(true);
-    pipelineManager =
-        new MockPipelineManager(dbStore, scmhaManager, nodeManager);
-    containerStateManager = ContainerStateManagerImpl.newBuilder()
-        .setConfiguration(conf)
-        .setPipelineManager(pipelineManager)
-        .setRatisServer(scmhaManager.getRatisServer())
-        .setContainerStore(SCMDBDefinition.CONTAINERS.getTable(dbStore))
-        .setSCMDBTransactionBuffer(scmhaManager.getDBTransactionBuffer())
-        .build();
     this.publisher = mock(EventPublisher.class);
 
     when(containerManager.getContainer(any(ContainerID.class)))
@@ -94,7 +77,6 @@ public class TestUnknownContainerReport {
 
   @AfterEach
   public void tearDown() throws Exception {
-    containerStateManager.close();
     if (dbStore != null) {
       dbStore.close();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -242,7 +242,6 @@ public class TestContainerPlacement {
     } catch (NodeNotFoundException e) {
       throw new RuntimeException(e);
     } finally {
-      IOUtils.closeQuietly(containerManager);
       IOUtils.closeQuietly(scmNodeManager);
       if (xceiverClientManager != null) {
         xceiverClientManager.close();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -603,9 +603,6 @@ public class OzoneDelegationTokenSecretManager
   public void stop() throws IOException {
     super.stop();
     stopThreads();
-    if (this.store != null) {
-      this.store.close();
-    }
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneSecretStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneSecretStore.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.security;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,22 +30,11 @@ import org.slf4j.LoggerFactory;
 /**
  * SecretStore for Ozone Master.
  */
-public class OzoneSecretStore implements Closeable {
+public class OzoneSecretStore {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(OzoneSecretStore.class);
   private OMMetadataManager omMetadataManager;
-
-  @Override
-  public void close() throws IOException {
-    if (omMetadataManager != null) {
-      try {
-        omMetadataManager.getDelegationTokenTable().close();
-      } catch (Exception e) {
-        throw new IOException("Error while closing OzoneSecretStore.", e);
-      }
-    }
-  }
 
   /**
    * Support class to maintain state of OzoneSecretStore.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -464,7 +464,6 @@ public class ReconStorageContainerManagerFacade
       LOG.error("SCM Event Queue stop failed", ex);
     }
     IOUtils.cleanupWithLogger(LOG, nodeManager);
-    IOUtils.cleanupWithLogger(LOG, containerManager);
     IOUtils.cleanupWithLogger(LOG, pipelineManager);
     LOG.info("Flushing container replica history to DB.");
     containerManager.flushReplicaHistoryMapToDB(true);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
@@ -126,7 +126,6 @@ public class AbstractReconContainerManagerTest {
 
   @AfterEach
   public void tearDown() throws Exception {
-    containerManager.close();
     pipelineManager.close();
     store.close();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

All the implementations of the Table.close() method are noop.  We should remove it.

The patch of this PR is quite big due to the try-with-resource change for auto-closing Table.

## What is the link to the Apache JIRA

HDDS-13294

## How was this patch tested?

By existing tests.