### PR TITLE
HDDS-13296. Integration check always passes due to missing output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       integration-suites: ${{ steps.integration-suites.outputs.suites }}
       needs-basic-check: ${{ steps.categorize-basic-checks.outputs.needs-basic-check }}
       basic-checks: ${{ steps.categorize-basic-checks.outputs.basic-checks }}
-      needs-build: ${{ steps.selective-checks.outputs.needs-build }}
+      needs-build: ${{ steps.selective-checks.outputs.needs-build || steps.selective-checks.outputs.needs-integration-tests }}
       needs-compile: ${{ steps.selective-checks.outputs.needs-compile }}
       needs-compose-tests: ${{ steps.selective-checks.outputs.needs-compose-tests }}
       needs-integration-tests: ${{ steps.selective-checks.outputs.needs-integration-tests }}

--- a/hadoop-ozone/dev-support/checks/_post_process.sh
+++ b/hadoop-ozone/dev-support/checks/_post_process.sh
@@ -26,10 +26,18 @@
 # - $REPORT_FILE should be defined
 # - Maven output should be saved in $REPORT_DIR/output.log
 
+if [[ ! -d "${REPORT_DIR}" ]]; then
+  mkdir -p "${REPORT_DIR}"
+fi
+
 if [[ ! -s "${REPORT_FILE}" ]]; then
   # check if there are errors in the log
   if [[ -n "${ERROR_PATTERN:-}" ]]; then
-    grep -m25 "${ERROR_PATTERN}" "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
+    if [[ -e "${REPORT_DIR}/output.log" ]]; then
+      grep -m25 "${ERROR_PATTERN}" "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
+    else
+      echo "Unknown failure, output.log missing" > "${REPORT_FILE}"
+    fi
   fi
   # script failed, but report file is empty (does not reflect failure)
   if [[ ${rc} -ne 0 ]] && [[ ! -s "${REPORT_FILE}" ]]; then

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -107,5 +107,5 @@ if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
   mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec -Dscan=false
 fi
 
-ERROR_PATTERN="BUILD FAILURE"
+ERROR_PATTERN="\[ERROR\]"
 source "${DIR}/_post_process.sh"

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -68,7 +68,7 @@ for i in $(seq 1 ${ITERATIONS}); do
     mkdir -p "${REPORT_DIR}"
   fi
 
-  mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" clean verify \
+  mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" verify \
       | tee "${REPORT_DIR}/output.log"
   irc=$?
 

--- a/hadoop-ozone/dev-support/checks/rat.sh
+++ b/hadoop-ozone/dev-support/checks/rat.sh
@@ -24,7 +24,8 @@ mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-mvn -B --no-transfer-progress -fn org.apache.rat:apache-rat-plugin:check "$@"
+mvn -B --no-transfer-progress -fn org.apache.rat:apache-rat-plugin:check "$@" \
+    | tee "${REPORT_DIR}/output.log"
 
 grep -r --include=rat.txt "!????" $dirs | tee "$REPORT_FILE"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fail checks if `output.log` is missing.
   - Save `output.log` for `rat` check to prevent unintended failure.
2. Remove `clean` from test execution, since it removes `$REPORT_DIR` including `output.log`.  It is no longer necessary after HDDS-13179.
3. Fix the error pattern, `BUILD FAILURE` cannot happen due to `--fail-never` (HDDS-12500)

https://issues.apache.org/jira/browse/HDDS-13296

## How was this patch tested?

Verified (1) with only a58a717014:

```bash
$ ./hadoop-ozone/dev-support/checks/integration.sh -Dtest='TestConfigFileAppender' -am -pl :hdds-config
...
[INFO] BUILD SUCCESS
...

$ echo $?
1

$ cat target/integration/summary.txt 
Unknown failure, output.log missing
```

CI correctly reports integration test failures:
https://github.com/adoroszlai/ozone/actions/runs/15752841577