### PR TITLE
HDDS-13291. [DiskBalancer] Add Performance Test for VolumeChoosingPolicy in DiskBalancer

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestVolumeChoosingPolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestVolumeChoosingPolicy.java
@@ -157,10 +157,9 @@ public class TestVolumeChoosingPolicy {
               destVolume.incCommittedBytes(containerSize);
             }
 
+            long threadStart = System.nanoTime();
             try {
-              long threadStart = System.nanoTime();
               Pair<HddsVolume, HddsVolume> pair = policy.chooseVolume(volumeSet, THRESHOLD, deltaSizes);
-              totalTimeNanos.addAndGet(System.nanoTime() - threadStart);
 
               if (pair == null) {
                 volumeNotChosen++;
@@ -177,6 +176,8 @@ public class TestVolumeChoosingPolicy {
               }
             } catch (Exception e) {
               failures++;
+            } finally {
+              totalTimeNanos.addAndGet(System.nanoTime() - threadStart);
             }
           }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This JIRA tracks the addition of a **micro-benchmark tes**t to evaluate the performance and efficiency of volume selection logic in DiskBalancer.

**Test Scenario**: Test the volume choosing efficiency in diskbalancer.

**SetUp**:
Set up a cluster with one DN with 20 volume.
Distribute data across these volumes such that:
•A subset of volumes (e.g., 5 volumes) are significantly over-utilized (e.g., > 80% full).
•Another subset of volumes (e.g., 5 volumes) are significantly under-utilized (e.g., < 20% full).
•The remaining volumes (e.g., 10 volumes) have usage around the ideal average utilization for the DN.

**Expected Behaviour**: 
Picks pairs of volume efficiently such that one is most utilised while the other is least utilised.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13291
## How was this patch tested?

Added `TestVolumeChoosingPolicy`.