### PR TITLE
HDDS-13301. Fix TestSchemaOneBackwardsCompatibility.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
@@ -38,7 +38,8 @@ import org.apache.ratis.thirdparty.com.google.protobuf.TextFormat;
  */
 public class BlockData {
   private static final Codec<BlockData> CODEC = new DelegatedCodec<>(
-      Proto3Codec.get(ContainerProtos.BlockData.getDefaultInstance()),
+      // allow InvalidProtocolBufferException for backward compatibility with Schema One
+      Proto3Codec.get(ContainerProtos.BlockData.getDefaultInstance(), true),
       BlockData::getFromProtoBuf,
       BlockData::getProtoBufMessage,
       BlockData.class);
@@ -96,6 +97,9 @@ public class BlockData {
    * @return - BlockData
    */
   public static BlockData getFromProtoBuf(ContainerProtos.BlockData data) throws CodecException {
+    if (data == null) {
+      return null;
+    }
     BlockData blockData = new BlockData(
         BlockID.getFromProtobuf(data.getBlockID()));
     for (int x = 0; x < data.getMetadataCount(); x++) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneChunkInfoListCodec.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneChunkInfoListCodec.java
@@ -17,11 +17,14 @@
 
 package org.apache.hadoop.ozone.container.metadata;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.CodecException;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Codec for parsing {@link org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfoList}
@@ -44,6 +47,8 @@ import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferExce
  * always be present.
  */
 public final class SchemaOneChunkInfoListCodec implements Codec<ChunkInfoList> {
+  public static final Logger LOG = LoggerFactory.getLogger(SchemaOneChunkInfoListCodec.class);
+  private static final AtomicBoolean LOGGED = new AtomicBoolean(false);
 
   private static final Codec<ChunkInfoList> INSTANCE =
       new SchemaOneChunkInfoListCodec();
@@ -72,9 +77,12 @@ public final class SchemaOneChunkInfoListCodec implements Codec<ChunkInfoList> {
       return ChunkInfoList.getFromProtoBuf(
               ContainerProtos.ChunkInfoList.parseFrom(rawData));
     } catch (InvalidProtocolBufferException ex) {
-      throw new CodecException("Invalid chunk information. " +
+      if (LOGGED.compareAndSet(false, true)) {
+        LOG.warn("Invalid chunk information. " +
               "This data may have been written using datanode " +
               "schema version one, which did not save chunk information.", ex);
+      }
+      return null;
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -366,8 +366,7 @@ public class TestSchemaOneBackwardsCompatibility {
 
       for (Table.KeyValue<String, ChunkInfoList> chunkListKV: deletedBlocks) {
         preUpgradeBlocks.add(chunkListKV.getKey());
-        assertThrows(IOException.class, () -> chunkListKV.getValue(),
-            "No exception thrown when trying to retrieve old deleted blocks values as chunk lists.");
+        assertNull(chunkListKV.getValue());
       }
 
       assertEquals(TestDB.NUM_DELETED_BLOCKS, preUpgradeBlocks.size());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -625,7 +625,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       try {
         return convert(rawIterator.next());
       } catch (CodecException e) {
-        throw new IllegalStateException("Failed next()", e);
+        throw new IllegalStateException("Failed next() in " + TypedTable.this, e);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before [HDDS-13235](https://issues.apache.org/jira/browse/HDDS-13235), KayValue.getValue() deserializes the byte data when it is invoked.  TestSchemaOneBackwardsCompatibility expects it will throw an exception since Schema One does not store the values.

[HDDS-13235](https://issues.apache.org/jira/browse/HDDS-13235) has changed it to deserialize the byte data before creating an KayValue object.  As a result, it will fail earlier.  

In the pull request, we change the codec to return null instead of throwing an exception for maintaining backward compatibility.

## What is the link to the Apache JIRA

[HDDS-13301](https://issues.apache.org/jira/browse/HDDS-13301)

## How was this patch tested?

By existing tests