### PR TITLE
HDDS-13307. integration (flaky) fails with all tests passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       integration-suites: ${{ steps.integration-suites.outputs.suites }}
       needs-basic-check: ${{ steps.categorize-basic-checks.outputs.needs-basic-check }}
       basic-checks: ${{ steps.categorize-basic-checks.outputs.basic-checks }}
-      needs-build: ${{ steps.selective-checks.outputs.needs-build || steps.selective-checks.outputs.needs-integration-tests }}
+      needs-build: ${{ steps.selective-checks.outputs.needs-build }}
       needs-compile: ${{ steps.selective-checks.outputs.needs-compile }}
       needs-compose-tests: ${{ steps.selective-checks.outputs.needs-compose-tests }}
       needs-integration-tests: ${{ steps.selective-checks.outputs.needs-integration-tests }}
@@ -111,7 +111,7 @@ jobs:
   build:
     needs:
       - build-info
-    if: needs.build-info.outputs.needs-build == 'true'
+    if: needs.build-info.outputs.needs-build == 'true' || needs.build-info.outputs.needs-integration-tests == 'true'
     uses: ./.github/workflows/check.yml
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}

--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -16,10 +16,13 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CHECK=integration
+ERROR_PATTERN="\[ERROR\]"
 
 args=""
 if [[ "$@" =~ "-Ptest-flaky" ]]; then
   args="$args -Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600"
+  # tests may pass on re-run, so we cannot rely on output for status
+  ERROR_PATTERN=""
 fi
 if [[ "$@" =~ "-Ptest-" ]] && [[ ! "$@" =~ "-Ptest-filesystem" ]]; then
   args="$args -DskipShade"

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -107,5 +107,4 @@ if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
   mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec -Dscan=false
 fi
 
-ERROR_PATTERN="\[ERROR\]"
 source "${DIR}/_post_process.sh"


### PR DESCRIPTION
## What changes were proposed in this pull request?

_integration (flaky)_ re-runs a few times, if necessary, until they pass, but `[ERROR]` appears in the log for each failure.  Example:

```
[WARNING] Flakes: 
[WARNING] org.apache.hadoop.fs.ozone.TestLeaseRecovery.testGetCommittedBlockLengthTimeout(boolean)[1]
[ERROR]   Run 1: TestLeaseRecovery.testGetCommittedBlockLengthTimeout:400->closeIgnoringOMException:123 expected: <KEY_UNDER_LEASE_RECOVERY> but was: <KEY_NOT_FOUND>
[INFO]   Run 2: PASS
[INFO] 
[WARNING] org.apache.hadoop.fs.ozone.TestLeaseRecovery.testGetCommittedBlockLengthTimeout(boolean)[2]
[ERROR]   Run 1: TestLeaseRecovery.testGetCommittedBlockLengthTimeout:390 expected: <3> but was: <0>
[INFO]   Run 2: PASS
[INFO] 
[INFO] 
[WARNING] Tests run: 103, Failures: 0, Errors: 0, Skipped: 0, Flakes: 2
```

This was flagged by `_post_process.sh` as a problem, failing _integration (flaky)_ in the end.

Therefore, use only test results to determine its status.

https://issues.apache.org/jira/browse/HDDS-13307

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/15773378890

Flaky test check (to verify status is reported correctly):
- passing: https://github.com/adoroszlai/ozone/actions/runs/15773833469
- failing: https://github.com/adoroszlai/ozone/actions/runs/15773861827