### PR TITLE
HDDS-13098. Create PicoCLI mixin to standardize datanode selection options

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/NodeSelectionMixin.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/NodeSelectionMixin.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import com.google.common.base.Strings;
+import picocli.CommandLine;
+
+/**
+ * Picocli mixin providing standardized datanode selection options for consistent CLI usage across commands.
+ */
+public class NodeSelectionMixin {
+
+  @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+  private Selection selection = new Selection();
+
+  public String getNodeId() {
+    return selection.getEffectiveNodeId();
+  }
+
+  public String getHostname() {
+    return selection.hostname;
+  }
+
+  public String getIp() {
+    return selection.ip;
+  }
+
+  static class Selection {
+
+    @CommandLine.Option(names = "--node-id", description = "Show info by datanode UUID.", defaultValue = "")
+    private String nodeId;
+
+    @Deprecated
+    @CommandLine.Option(names = "--id", description = "Show info by datanode UUID.", defaultValue = "", hidden = true)
+    private String id;
+
+    @Deprecated
+    @CommandLine.Option(names = "--uuid", description = "Show info by datanode UUID.", defaultValue = "", hidden = true)
+    private String uuid;
+
+    @CommandLine.Option(names = "--hostname", description = "Hostname of the datanode", defaultValue = "")
+    private String hostname;
+
+    @CommandLine.Option(names = "--ip", description = "IP address of the datanode", defaultValue = "")
+    private String ip;
+
+    //Falling back to deprecated --id or --uuid for backward compatibility
+    String getEffectiveNodeId() {
+      return !Strings.isNullOrEmpty(nodeId) ? nodeId :
+          !Strings.isNullOrEmpty(id) ? id :
+              !Strings.isNullOrEmpty(uuid) ? uuid : "";
+    }
+  }
+}

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
@@ -72,16 +72,21 @@ public class UsageInfoSubcommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
+    String hostnameOrIp =
+        !Strings.isNullOrEmpty(exclusiveArguments.getIp()) ? exclusiveArguments.getIp()
+            : !Strings.isNullOrEmpty(exclusiveArguments.getHostname()) ? exclusiveArguments.getHostname()
+            : exclusiveArguments.address; //Fallback to deprecated --address for backward compatibility with older CLI.
+    
     List<HddsProtos.DatanodeUsageInfoProto> infoList;
     if (count < 1) {
       throw new IOException("Count must be an integer greater than 0.");
     }
 
     // fetch info by ip or hostname or uuid
-    if (!Strings.isNullOrEmpty(exclusiveArguments.address) ||
-        !Strings.isNullOrEmpty(exclusiveArguments.uuid)) {
-      infoList = scmClient.getDatanodeUsageInfo(exclusiveArguments.address,
-          exclusiveArguments.uuid);
+    if (!Strings.isNullOrEmpty(hostnameOrIp) ||
+        !Strings.isNullOrEmpty(exclusiveArguments.getNodeId())) {
+      infoList = scmClient.getDatanodeUsageInfo(hostnameOrIp,
+          exclusiveArguments.getNodeId());
     } else { // get info of most used or least used nodes
       infoList = scmClient.getDatanodeUsageInfo(exclusiveArguments.mostUsed,
           count);
@@ -268,15 +273,13 @@ public class UsageInfoSubcommand extends ScmSubcommand {
     }
   }
 
-  private static class ExclusiveArguments {
+  private static class ExclusiveArguments extends NodeSelectionMixin {
+    @Deprecated
     @CommandLine.Option(names = {"--address"}, paramLabel = "ADDRESS",
         description = "Show info by datanode ip or hostname address.",
-        defaultValue = "")
+        defaultValue = "",
+        hidden = true)
     private String address;
-
-    @CommandLine.Option(names = {"--uuid"}, paramLabel = "UUID", description =
-        "Show info by datanode UUID.", defaultValue = "")
-    private String uuid;
 
     @CommandLine.Option(names = {"-m", "--most-used"},
         description = "Show the most used datanodes.",

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionStatusSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionStatusSubCommand.java
@@ -81,6 +81,8 @@ public class TestDecommissionStatusSubCommand {
     when(scmClient.getContainersOnDecomNode(any())).thenReturn(containerOnDecom);
     when(scmClient.getMetrics(any())).thenReturn(metrics.get(1));
 
+    CommandLine cmdLine = new CommandLine(cmd);
+    cmdLine.parseArgs();
     cmd.execute(scmClient);
     Pattern p = Pattern.compile("Decommission\\sStatus:\\s" +
             "DECOMMISSIONING\\s-\\s2\\snode\\(s\\)\n");
@@ -112,6 +114,8 @@ public class TestDecommissionStatusSubCommand {
         .thenReturn(new ArrayList<>());
     when(scmClient.getContainersOnDecomNode(any())).thenReturn(new HashMap<>());
     when(scmClient.getMetrics(any())).thenReturn(metrics.get(0));
+    CommandLine cmdLine = new CommandLine(cmd);
+    cmdLine.parseArgs();
     cmd.execute(scmClient);
 
     Pattern p = Pattern.compile("Decommission\\sStatus:\\s" +

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -41,7 +41,7 @@ List datanodes
 
 Filter list by UUID
     ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
-    ${output} =         Execute      ozone admin datanode list --id "${uuid}"
+    ${output} =         Execute      ozone admin datanode list --node-id "${uuid}"
     Assert Output       ${output}    1    ${uuid}
 
 Filter list by Ip address
@@ -70,22 +70,22 @@ Filter list by NodeState
 
 Get usage info by UUID
     ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
-    ${output} =         Execute      ozone admin datanode usageinfo --uuid "${uuid}"
+    ${output} =         Execute      ozone admin datanode usageinfo --node-id "${uuid}"
     Should contain      ${output}    Usage Information (1 Datanodes)
 
 Get usage info by Ip address
     ${ip} =             Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$3 }'
-    ${output} =         Execute      ozone admin datanode usageinfo --address "${ip}"
+    ${output} =         Execute      ozone admin datanode usageinfo --ip "${ip}"
     Should contain      ${output}    Usage Information (1 Datanodes)
 
 Get usage info by Hostname
     ${hostname} =       Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$4 }'
-    ${output} =         Execute      ozone admin datanode usageinfo --address "${hostname}"
+    ${output} =         Execute      ozone admin datanode usageinfo --hostname "${hostname}"
     Should contain      ${output}    Usage Information (1 Datanodes)
 
 Get usage info with invalid address
     ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
-    ${output} =         Execute      ozone admin datanode usageinfo --address "${uuid}"
+    ${output} =         Execute      ozone admin datanode usageinfo --ip "${uuid}"
     Should contain      ${output}    Usage Information (0 Datanodes)
 
 Incomplete command


### PR DESCRIPTION
## What changes were proposed in this pull request?
Introduced a reusable PicoCLI mixin (NodeSelectionMixin) to standardize datanode selection flags across commands. This includes:

> --node-id for datanode UUID
> 
> --hostname for datanode host name
> 
> --ip for datanode IP address

Deprecated older/ambiguous flags like --id, --uuid, and --address for clarity and consistency, while retaining them in hidden mode to preserve backward compatibility.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13098

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/15778605382
