### PR TITLE
HDDS-13322. Remove module auto-detection from flaky-test-check

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -65,7 +65,6 @@ env:
   RATIS_REPO: ${{ github.event.inputs.ratis-repo }}
   RATIS_VERSION: ${{ github.event.inputs.ratis-ref }}
   JAVA_VERSION: ${{ github.event.inputs.java-version }}
-  OUTPUT_DIR: flaky-test-check-ci-results
   # Surefire 3.0.0-M4 is used because newer versions do not reliably kill the fork on timeout
   # SUREFIRE-1722, SUREFIRE-1815
   SUREFIRE_VERSION: 3.0.0-M4
@@ -132,8 +131,8 @@ jobs:
       - name: Find modules
         id: modules
         run: |
-          grep --text -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' ${{ env.OUTPUT_DIR }}/output.log | grep --text -B1 'Running org.apache'
-          modules=$(grep --text -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' ${{ env.OUTPUT_DIR }}/output.log | grep --text -B1 'Running org.apache' \
+          grep --text -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' target/unit/output.log | grep --text -B1 'Running org.apache'
+          modules=$(grep --text -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' target/unit/output.log | grep --text -B1 'Running org.apache' \
               | grep --text surefire | cut -f2 -d'@' | awk '{ print $1 }' | sed 's/^/:/' | xargs | sed -e 's/ /,/g')
           echo "modules=$modules" >> $GITHUB_OUTPUT
         if: ${{ !cancelled() }}
@@ -276,14 +275,14 @@ jobs:
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Summary of failures
-        run: hadoop-ozone/dev-support/checks/_summary.sh ${{ env.OUTPUT_DIR }}/summary.txt
+        run: hadoop-ozone/dev-support/checks/_summary.sh target/unit/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: result-${{ github.run_number }}-${{ github.run_id }}-split-${{ matrix.split }}
-          path: ${{ env.OUTPUT_DIR }}
+          path: target/unit
   count-failures:
     if: ${{ failure() }}
     needs: run-test

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -30,7 +30,7 @@ on:
         required: false
       submodule:
         description: Submodule
-        default: 'AUTO'
+        default: 'ozone-integration-test'
         required: true
       iterations:
         description: Number of Iterations per split
@@ -94,54 +94,11 @@ jobs:
     with:
       repo: ${{ github.event.inputs.ratis-repo || format('{0}/ratis', github.repository_owner) }}
       ref: ${{ github.event.inputs.ratis-ref }}
-  find-tests:
-    if: ${{ always() && github.event.inputs.submodule == 'AUTO' }}
-    needs:
-      - prepare-job
-    runs-on: ubuntu-24.04
-    outputs:
-      modules: ${{ steps.modules.outputs.modules }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - name: Cache for maven dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.m2/repository/*/*/*
-            !~/.m2/repository/org/apache/ozone
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-repo-
-      - name: Setup java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ github.event.inputs.java-version }}
-      - name: Find tests
-        run: |
-          # find tests to be run in splits by running them with very short timeout
-          hadoop-ozone/dev-support/checks/junit.sh -DexcludedGroups="native|slow|unhealthy" -DskipShade \
-              -Dtest="$TEST_CLASS,Abstract*Test*\$*" \
-              -Dsurefire.fork.timeout=1 -Dmaven-surefire-plugin.version=${{ env.SUREFIRE_VERSION }} \
-              || true # ignore errors
-        env:
-          ITERATIONS: 1
-      - name: Find modules
-        id: modules
-        run: |
-          grep --text -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' target/unit/output.log | grep --text -B1 'Running org.apache'
-          modules=$(grep --text -e 'surefire:${{ env.SUREFIRE_VERSION }}:test' -e 'Running org.apache' target/unit/output.log | grep --text -B1 'Running org.apache' \
-              | grep --text surefire | cut -f2 -d'@' | awk '{ print $1 }' | sed 's/^/:/' | xargs | sed -e 's/ /,/g')
-          echo "modules=$modules" >> $GITHUB_OUTPUT
-        if: ${{ !cancelled() }}
   build:
     if: ${{ always() }}
     needs:
       - prepare-job
       - ratis
-      - find-tests
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -181,11 +138,7 @@ jobs:
             args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
           fi
 
-          if [[ "${{ github.event.inputs.submodule }}" != "AUTO" ]]; then
-            args="$args -am -pl :${{ github.event.inputs.submodule }}"
-          elif [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
-            args="$args -am -pl ${{ needs.find-tests.outputs.modules }}"
-          fi
+          args="$args -am -pl :${{ github.event.inputs.submodule }}"
 
           hadoop-ozone/dev-support/checks/build.sh $args
       - name: Store Maven repo for tests
@@ -201,7 +154,6 @@ jobs:
       - prepare-job
       - ratis
       - build
-      - find-tests
     name: Run-Split
     runs-on: ubuntu-24.04
     strategy:
@@ -256,11 +208,7 @@ jobs:
             args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
           fi
 
-          if [[ "${{ github.event.inputs.submodule }}" != "AUTO" ]]; then
-            args="$args -pl :${{ github.event.inputs.submodule }}"
-          elif [[ -n "${{ needs.find-tests.outputs.modules }}" ]]; then
-            args="$args -pl ${{ needs.find-tests.outputs.modules }}"
-          fi
+          args="$args -pl :${{ github.event.inputs.submodule }}"
 
           if [ "$TEST_METHOD" = "ALL" ]; then
             echo "Running all tests from $TEST_CLASS"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove automatic module detection from `flaky-test-check`.

1. It cannot detect some test classes, e.g. `TestOzoneIntegrationNonHA`.  This is due to having to use old Surefire plugin, because new version cannot reliably kill the fork.
2. With undetected module it has to build all modules.  `hdds-docs` runs `docs.sh` as part of the build, which truncates `output.log`.  This causes only the last iteration's result being kept in `OUTPUT_DIR`.
3. Manually setting the submodule is faster in all cases.

Thus I think it's best to remove `AUTO` as an option and make this input mandatory.

https://issues.apache.org/jira/browse/HDDS-13322

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/15821433077