### PR TITLE
HDDS-13324. Optimize memory footprint for Recon listKeys API

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -274,15 +274,15 @@ public class ReconUtils {
       isDirectoryPresent = true;
     }
 
-    Collections.reverse(pathSegments);
     StringBuilder fullPath = new StringBuilder();
-
-    // Build the components in a list, then reverse and join once
     fullPath.append(volumeName).append(OM_KEY_PREFIX)
         .append(bucketName).append(OM_KEY_PREFIX);
-    for (String segment : pathSegments) {
-      fullPath.append(segment).append(OM_KEY_PREFIX);
+
+    // Build the components in a list, then reverse and join once
+    for (int i = pathSegments.size() - 1; i >= 0; i--) {
+      fullPath.append(pathSegments.get(i)).append(OM_KEY_PREFIX);
     }
+
     // TODO - why is this needed? It seems lke it should handle double slashes in the path name,
     //        but its not clear how they get there. This normalize call is quite expensive as it
     //        creates several objects (URI, PATH, back to string). There was a bug fixed above

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -245,10 +245,11 @@ public class ReconUtils {
   public static StringBuilder constructFullPathPrefix(long initialParentId, String volumeName,
       String bucketName, ReconNamespaceSummaryManager reconNamespaceSummaryManager,
       ReconOMMetadataManager omMetadataManager) throws IOException {
-    StringBuilder fullPath = new StringBuilder();
+
     long parentId = initialParentId;
     boolean isDirectoryPresent = false;
 
+    List<String> pathSegments = new ArrayList<>();
     while (parentId != 0) {
       NSSummary nsSummary = reconNamespaceSummaryManager.getNSSummary(parentId);
       if (nsSummary == null) {
@@ -265,7 +266,7 @@ public class ReconUtils {
       }
       // On the last pass, dir-name will be empty and parent will be zero, indicating the loop should end.
       if (!nsSummary.getDirName().isEmpty()) {
-        fullPath.insert(0, nsSummary.getDirName() + OM_KEY_PREFIX);
+        pathSegments.add(nsSummary.getDirName());
       }
 
       // Move to the parent ID of the current directory
@@ -273,8 +274,15 @@ public class ReconUtils {
       isDirectoryPresent = true;
     }
 
-    // Prepend the volume and bucket to the constructed path
-    fullPath.insert(0, volumeName + OM_KEY_PREFIX + bucketName + OM_KEY_PREFIX);
+    Collections.reverse(pathSegments);
+    StringBuilder fullPath = new StringBuilder();
+
+    // Build the components in a list, then reverse and join once
+    fullPath.append(volumeName).append(OM_KEY_PREFIX)
+        .append(bucketName).append(OM_KEY_PREFIX);
+    for (String segment : pathSegments) {
+      fullPath.append(segment).append(OM_KEY_PREFIX);
+    }
     // TODO - why is this needed? It seems lke it should handle double slashes in the path name,
     //        but its not clear how they get there. This normalize call is quite expensive as it
     //        creates several objects (URI, PATH, back to string). There was a bug fixed above
@@ -282,9 +290,11 @@ public class ReconUtils {
     //        bucket name, but with that fixed, it seems like this should not be needed. All tests
     //        pass without it for key listing.
     if (isDirectoryPresent) {
-      String path = fullPath.toString();
-      fullPath.setLength(0);
-      fullPath.append(OmUtils.normalizeKey(path, true));
+      if (fullPath.indexOf("//") >= 0) {
+        String path = fullPath.toString();
+        fullPath.setLength(0);
+        fullPath.append(OmUtils.normalizeKey(path, true));
+      }
     }
     return fullPath;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Optimize memory footprint for listKeys API.
While constructing full path prefix in constructFullPathPrefix method, below code can be expensive:

`fullPath.insert(0, nsSummary.getDirName() + OM_KEY_PREFIX);`
Inserting at position 0 in a StringBuilder has O(n) cost because it must shift the entire buffer every time.
For deeply nested paths (e.g., /a/b/c/d/e/f/g/...), this compounds quickly.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13324

## How was this patch tested?
Tested manually and with existing junit and integration test cases.
