### PR TITLE
HDDS-13306. Intermittent failure in testDirectoryDeletingServiceIntervalReconfiguration

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.conf.ReconfigurationException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurableBase;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.TestInstance;
 public abstract class TestReconfigShell implements NonHATests.TestCase {
 
   private OzoneAdmin ozoneAdmin;
-  private OzoneConfiguration conf;
   private ReconfigurationHandler reconfigurationHandler;
   private GenericTestUtils.PrintStreamCapturer out;
   private GenericTestUtils.PrintStreamCapturer err;
@@ -64,7 +63,6 @@ public abstract class TestReconfigShell implements NonHATests.TestCase {
     out = GenericTestUtils.captureOut();
     err = GenericTestUtils.captureErr();
     ozoneAdmin = new OzoneAdmin();
-    conf = new OzoneConfiguration();
     reconfigurationHandler = cluster().getOzoneManager().getReconfigurationHandler();
   }
 
@@ -89,10 +87,12 @@ public abstract class TestReconfigShell implements NonHATests.TestCase {
   }
 
   @Test
-  void testDirectoryDeletingServiceIntervalReconfiguration() throws ReconfigurationException {
+  void testDirectoryDeletingServiceIntervalReconfiguration() throws ReconfigurationException,
+      InterruptedException, TimeoutException {
     OzoneManager om = cluster().getOzoneManager();
     InetSocketAddress socket = om.getOmRpcServerAddr();
-    LogCapturer logCapturer = LogCapturer.captureLogs(DirectoryDeletingService.class);
+    LogCapturer dirDeletingServiceLog = LogCapturer.captureLogs(DirectoryDeletingService.class);
+    LogCapturer reconfigHandlerLog = LogCapturer.captureLogs(ReconfigurationHandler.class);
 
     String initialInterval = "1m";
     String intervalFromXML = "2m"; //config value set in ozone-site.xml
@@ -103,18 +103,20 @@ public abstract class TestReconfigShell implements NonHATests.TestCase {
 
     //Start the reconfiguration task
     executeAndAssertStart("OM", socket);
-    //If config value is set in ozone-site.xml then it is picked up during reconfiguration
-    assertThat(conf.get(OZONE_DIR_DELETING_SERVICE_INTERVAL)).isEqualTo(intervalFromXML);
-
-    executeAndAssertStatus("OM", socket);
-    assertThat(reconfigurationHandler.getConf().get(OZONE_DIR_DELETING_SERVICE_INTERVAL)).isEqualTo(intervalFromXML);
-    assertThat(out.get()).contains(
-        String.format("SUCCESS: Changed property %s", OZONE_DIR_DELETING_SERVICE_INTERVAL)
-    );
-    assertThat(logCapturer.getOutput()).contains(
+    GenericTestUtils.waitFor(() -> reconfigHandlerLog.getOutput().contains("Reconfiguration completed"),
+        1000, 20000);
+    assertThat(dirDeletingServiceLog.getOutput()).contains(
         String.format("Updating and restarting DirectoryDeletingService with interval %d %s",
-            intervalFromXMLInSeconds, TimeUnit.SECONDS.name().toLowerCase())
-    );
+            intervalFromXMLInSeconds, TimeUnit.SECONDS.name().toLowerCase()));
+    assertThat(reconfigurationHandler.getConf().get(OZONE_DIR_DELETING_SERVICE_INTERVAL)).isEqualTo(intervalFromXML);
+
+    String address = socket.getHostString() + ":" + socket.getPort();
+    GenericTestUtils.waitFor(() -> {
+      ozoneAdmin.getCmd().execute("reconfig", "--service", "OM", "--address", address, "status");
+      String output = out.get();
+      return output.contains("finished") &&
+          output.contains(String.format("SUCCESS: Changed property %s", OZONE_DIR_DELETING_SERVICE_INTERVAL));
+    }, 1000, 20000);
   }
 
   @Test
@@ -175,12 +177,6 @@ public abstract class TestReconfigShell implements NonHATests.TestCase {
     String address = socket.getHostString() + ":" + socket.getPort();
     ozoneAdmin.getCmd().execute("reconfig", "--service", service, "--address", address, "start");
     assertThat(out.get()).contains(service + ": Started reconfiguration task on node [" + address + "]");
-  }
-
-  private void executeAndAssertStatus(String service, InetSocketAddress socket) {
-    String address = socket.getHostString() + ":" + socket.getPort();
-    ozoneAdmin.getCmd().execute("reconfig", "--service", service, "--address", address, "status");
-    assertThat(out.get()).contains(service + ": Reconfiguring status for node [" + address + "]: started");
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
```
org.apache.ozone.test.NonHATests$ReconfigShell.testDirectoryDeletingServiceIntervalReconfiguration -- Time elapsed: 0.138 s <<< FAILURE!

java.lang.AssertionError: 

Expecting actual:
  "OM: Started reconfiguration task on node [localhost:15006].
OM: Reconfiguring status for node [localhost:15006]: started at Fri Jun 20 06:16:46 UTC 2025 and is still running.
"
to contain:
  "SUCCESS: Changed property ozone.directory.deleting.service.interval" 
	at org.apache.hadoop.ozone.shell.TestReconfigShell.testDirectoryDeletingServiceIntervalReconfiguration(TestReconfigShell.java:111)
```
The test failure occurs because the assertion is executed before the reconfiguration status has completed. As a result, the expected success message ("SUCCESS: Changed property ozone.directory.deleting.service.interval") is not yet present in the status command output.

To fix this, we now wait for the reconfiguration status to complete before asserting the status command output.

## What is the link to the Apache JIRA
[HDDS-13306](https://issues.apache.org/jira/browse/HDDS-13306)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/15828149542

flaky-test-check: https://github.com/sarvekshayr/ozone/actions/runs/15829604475/job/44618830714
(failures in the test are not related to ReconfigShell)