### PR TITLE
HDDS-13325. Introduce OZONE_SERVER_OPTS for common options for server processes

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/compatibility/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/docker-config
@@ -37,5 +37,6 @@ HADOOP_OPTS="-Dhadoop.opts=test"
 HDFS_STORAGECONTAINERMANAGER_OPTS="-Dhdfs.scm.opts=test"
 HDFS_OM_OPTS="-Dhdfs.om.opts=test"
 HDDS_DN_OPTS="-Dhdds.dn.opts=test"
+OZONE_SERVER_OPTS="-Dserver.opt=test"
 
 no_proxy=om,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/dn.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/dn.robot
@@ -25,3 +25,4 @@ Picks up command line options
     ${processes} =    List All Processes
     Should Contain    ${processes}   %{HDDS_DN_OPTS}
     Should Contain    ${processes}   %{HADOOP_OPTS}
+    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/dn.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/dn.robot
@@ -15,14 +15,12 @@
 
 *** Settings ***
 Documentation       Test datanode compatibility
-Library             BuiltIn
-Resource            ../lib/os.robot
+Resource            lib.resource
 Test Timeout        5 minutes
 
 *** Test Cases ***
 Picks up command line options
     Pass Execution If    '%{HDDS_DN_OPTS}' == ''    Command-line option required for process check
-    ${processes} =    List All Processes
+    ${processes} =    Wait for server command-line options
     Should Contain    ${processes}   %{HDDS_DN_OPTS}
-    Should Contain    ${processes}   %{HADOOP_OPTS}
-    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}
+    Check client command-line options

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/lib.resource
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/lib.resource
@@ -14,18 +14,22 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Test om compatibility
-Resource            lib.resource
-Test Timeout        5 minutes
+Library             BuiltIn
+Library             OperatingSystem
+Resource            ../lib/os.robot
 
-*** Test Cases ***
-Picks up command line options
-    Pass Execution If    '%{HDFS_OM_OPTS}' == ''    Command-line option required for process check
-    ${processes} =    Wait for server command-line options
-    Should Contain    ${processes}   %{HDFS_OM_OPTS}
-    Check client command-line options
+*** Keywords ***
+Check server command-line options
+    ${processes} =    List All Processes
+    Should Contain    ${processes}   %{HADOOP_OPTS}
+    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}
+    RETURN    ${processes}
 
-Rejects Atomic Key Rewrite
-    Execute           ozone freon ockg -n1 -t1 -p rewrite
-    ${output} =       Execute and check rc    ozone sh key rewrite -t EC -r rs-3-2-1024k /vol1/bucket1/rewrite/0    255
-    Should Contain    ${output}    Feature disabled: ATOMIC_REWRITE_KEY
+Wait for server command-line options
+    ${processes} =     Wait Until Keyword Succeeds    3min    2sec    Check server command-line options
+    RETURN    ${processes}
+
+Check client command-line options
+    Set Environment Variable    OZONE_SHELL_SCRIPT_DEBUG    true
+    ${output} =    Execute    ozone sh --help
+    Should Not Contain    ${output}    %{OZONE_SERVER_OPTS}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/om.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/om.robot
@@ -24,6 +24,7 @@ Check command-line options
     ${processes} =    List All Processes
     Should Contain    ${processes}   %{HDFS_OM_OPTS}
     Should Contain    ${processes}   %{HADOOP_OPTS}
+    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}
 
 *** Test Cases ***
 Picks up command line options

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/recon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/recon.robot
@@ -15,17 +15,11 @@
 
 *** Settings ***
 Documentation       Test recon compatibility
-Library             BuiltIn
-Resource            ../lib/os.robot
+Resource            lib.resource
 Test Timeout        5 minutes
-
-*** Keywords ***
-Check command-line options
-    ${processes} =    List All Processes
-    Should Contain    ${processes}   %{HADOOP_OPTS}
-    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}
 
 *** Test Cases ***
 Picks up command line options
     Pass Execution If    '%{HADOOP_OPTS}' == ''    Command-line option required for process check
-    Wait Until Keyword Succeeds    3min    2sec    Check command-line options
+    Wait for server command-line options
+    Check client command-line options

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/recon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/recon.robot
@@ -23,6 +23,7 @@ Test Timeout        5 minutes
 Check command-line options
     ${processes} =    List All Processes
     Should Contain    ${processes}   %{HADOOP_OPTS}
+    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}
 
 *** Test Cases ***
 Picks up command line options

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/scm.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/scm.robot
@@ -25,3 +25,4 @@ Picks up command line options
     ${processes} =    List All Processes
     Should Contain    ${processes}   %{HDFS_STORAGECONTAINERMANAGER_OPTS}
     Should Contain    ${processes}   %{HADOOP_OPTS}
+    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/scm.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/scm.robot
@@ -15,14 +15,12 @@
 
 *** Settings ***
 Documentation       Test scm compatibility
-Library             BuiltIn
-Resource            ../lib/os.robot
+Resource            lib.resource
 Test Timeout        5 minutes
 
 *** Test Cases ***
 Picks up command line options
     Pass Execution If    '%{HDFS_STORAGECONTAINERMANAGER_OPTS}' == ''    Command-line option required for process check
-    ${processes} =    List All Processes
+    ${processes} =    Wait for server command-line options
     Should Contain    ${processes}   %{HDFS_STORAGECONTAINERMANAGER_OPTS}
-    Should Contain    ${processes}   %{HADOOP_OPTS}
-    Should Contain    ${processes}   %{OZONE_SERVER_OPTS}
+    Check client command-line options

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -337,6 +337,7 @@ ozone_suppress_shell_log
 ozone_assemble_classpath
 
 ozone_add_client_opts
+ozone_add_server_opts
 
 if [[ ${OZONE_WORKER_MODE} = true ]]; then
   ozone_worker_mode_execute "${OZONE_HOME}/bin/ozone" "${OZONE_USER_PARAMS[@]}"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1563,6 +1563,18 @@ function ozone_add_client_opts
   fi
 }
 
+## @description  Adds the OZONE_SERVER_OPTS variable to OZONE_OPTS if OZONE_SUBCMD_SUPPORTDAEMONIZATION is true
+## @audience     public
+## @stability    stable
+## @replaceable  yes
+function ozone_add_server_opts
+{
+  if [[ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == "true" ]] && [[ -n "${OZONE_SERVER_OPTS:-}" ]]; then
+    ozone_debug "Appending OZONE_SERVER_OPTS onto OZONE_OPTS"
+    OZONE_OPTS="${OZONE_OPTS} ${OZONE_SERVER_OPTS}"
+  fi
+}
+
 ## @description  Finish configuring Hadoop specific system properties
 ## @description  prior to executing Java
 ## @audience     private


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. `OZONE_OPTS` applies to all `ozone` commands
2. each command (e.g. `ozone om` and `ozone sh`) has its own `OZONE_<component>_OPTS`

Currently setting options only for server processes needs to be done via (2).  Non-server commands also accept additional options via `OZONE_CLIENT_OPTS`.  This change introduces a similar new variable `OZONE_SERVER_OPTS` that will be applied to all server processes, but not to other commands.

https://issues.apache.org/jira/browse/HDDS-13325

## How was this patch tested?

Added assertion in existing test cases.

https://github.com/adoroszlai/ozone/actions/runs/15844757365/job/44665086087