### PR TITLE
HDDS-13295. Remove jackson1 exclusions in ozone-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,22 +842,6 @@
             <artifactId>zookeeper</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>*</artifactId>
           </exclusion>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR removes jackson1 exclusions in ozone-common, which reflects the root POM.
- groupId: `org.codehaus.jackson`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13295

## How was this patch tested?

CI: https://github.com/echonesis/ozone/actions/runs/15847246951
