### PR TITLE
HDDS-13327. Improve log and error handling while starting Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -180,12 +180,8 @@ public class ReconServer extends GenericCli implements Callable<Void> {
       isStarted = true;
       LOG.info("Recon server initialized successfully!");
     } catch (Exception e) {
-      ReconStorageContainerManagerFacade reconStorageContainerManagerFacade =
-          (ReconStorageContainerManagerFacade) this.getReconStorageContainerManager();
-      ReconContext reconContext = reconStorageContainerManagerFacade.getReconContext();
-      reconContext.updateHealthStatus(new AtomicBoolean(false));
-      reconContext.getErrors().add(ReconContext.ErrorCode.INTERNAL_ERROR);
       LOG.error("Error during initializing Recon server.", e);
+      updateAndLogReconHealthStatus();
     }
 
     ShutdownHookManager.get().addShutdownHook(() -> {
@@ -197,6 +193,44 @@ public class ReconServer extends GenericCli implements Callable<Void> {
       }
     }, DEFAULT_SHUTDOWN_HOOK_PRIORITY);
     return null;
+  }
+
+  private void updateAndLogReconHealthStatus() {
+    ReconContext reconContext = injector.getInstance(ReconContext.class);
+
+    checkComponentAndLog(
+        this.getReconStorageContainerManager(),
+        "ReconStorageContainerManagerFacade is not initialized properly.",
+        reconContext
+    );
+
+    checkComponentAndLog(
+        this.getReconNamespaceSummaryManager(),
+        "ReconNamespaceSummaryManager is not initialized properly.",
+        reconContext
+    );
+
+    checkComponentAndLog(
+        this.getOzoneManagerServiceProvider(),
+        "OzoneManagerServiceProvider is not initialized properly.",
+        reconContext
+    );
+
+    checkComponentAndLog(
+        this.getReconContainerMetadataManager(),
+        "ReconContainerMetadataManager is not initialized properly.",
+        reconContext
+    );
+  }
+
+  private void checkComponentAndLog(Object component, String errorMessage, ReconContext context) {
+    // Updating health status and adding error code in ReconContext will help to expose the information to user
+    // via /recon/health endpoint.
+    if (component == null) {
+      LOG.error("{} Setting health status to false and adding error code.", errorMessage);
+      context.updateHealthStatus(new AtomicBoolean(false));
+      context.getErrors().add(ReconContext.ErrorCode.INTERNAL_ERROR);
+    }
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.ozone.recon.api.types.FeatureProvider;
 import org.apache.hadoop.ozone.recon.metrics.ReconTaskStatusMetrics;
 import org.apache.hadoop.ozone.recon.scm.ReconSafeModeManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageConfig;
-import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.security.ReconCertificateClient;
 import org.apache.hadoop.ozone.recon.spi.OzoneManagerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -196,6 +196,7 @@ public class ReconServer extends GenericCli implements Callable<Void> {
 
   private void updateAndLogReconHealthStatus() {
     ReconContext reconContext = injector.getInstance(ReconContext.class);
+    assert reconContext != null;
 
     checkComponentAndLog(
         this.getReconStorageContainerManager(),

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconSafeModeMgrTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconSafeModeMgrTask.java
@@ -85,7 +85,7 @@ public class ReconSafeModeMgrTask {
         safeModeManager.setInSafeMode(false);
       }
     } catch (Throwable t) {
-      LOG.error("Exception in Missing Container task Thread.", t);
+      LOG.error("Exception in ReconSafeModeMgrTask Thread.", t);
       if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconSafeModeMgrTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconSafeModeMgrTask.java
@@ -82,7 +82,11 @@ public class ReconSafeModeMgrTask {
       }
       // Exceeded safe mode grace period. Exit safe mode
       if (safeModeManager.getInSafeMode()) {
+        LOG.warn("Recon could not exit safe mode after {} ms. Exiting safe mode anyway. " +
+            "Please check for any unexpected startup issues", timeElapsed);
         safeModeManager.setInSafeMode(false);
+      } else {
+        LOG.info("Recon exited safe mode after {} ms.", timeElapsed);
       }
     } catch (Throwable t) {
       LOG.error("Exception in ReconSafeModeMgrTask Thread.", t);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -435,6 +435,7 @@ public class ReconStorageContainerManagerFacade
     if (!this.safeModeManager.getInSafeMode()) {
       this.reconScmTasks.forEach(ReconScmTask::start);
     }
+    LOG.info("Successfully started Recon Storage Container Manager.");
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -510,6 +510,8 @@ public class ReconStorageContainerManagerFacade
       }
     } catch (IOException e) {
       LOG.error("Exception encountered while getting SCM DB.");
+      reconContext.updateHealthStatus(new AtomicBoolean(false));
+      reconContext.updateErrors(ReconContext.ErrorCode.INTERNAL_ERROR);
     } finally {
       isSyncDataFromSCMRunning.compareAndSet(true, false);
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -309,6 +309,7 @@ public class OzoneManagerServiceProviderImpl
     }
     reconTaskController.reInitializeTasks(omMetadataManager, reconOmTaskMap);
     startSyncDataFromOM(initialDelay);
+    LOG.info("Ozone Manager Service Provider is started.");
   }
 
   private void startSyncDataFromOM(long initialDelay) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -247,6 +247,8 @@ public class OzoneManagerServiceProviderImpl
       omMetadataManager.start(configuration);
     } catch (IOException ioEx) {
       LOG.error("Error starting Recon OM Metadata Manager.", ioEx);
+      reconContext.updateHealthStatus(new AtomicBoolean(false));
+      reconContext.updateErrors(ReconContext.ErrorCode.INTERNAL_ERROR);
     } catch (RuntimeException runtimeException) {
       LOG.warn("Unexpected runtime error starting Recon OM Metadata Manager.", runtimeException);
       LOG.warn("Trying to delete existing recon OM snapshot DB and fetch new one.");


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to update the health status of ReconContext to false and add an error code to indicate internal error if any component's dependencies failed to initialize properly. This will be used by ReconHealthCheckService to report the health status of Recon. Also improved logging for all components initialization. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13327

## How was this patch tested?
This patch is tested with existing junit and integration tests and manually using docker container cluster setup locally.
