### PR TITLE
HDDS-13252. Use RocksDB deleteRange to cleanup AOS on snapshot creation

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -73,6 +73,11 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public void deleteRangeWithBatch(BatchOperation batch, KEY beginKey, KEY endKey) throws CodecException {
+    table.deleteRangeWithBatch(batch, beginKey, endKey);
+  }
+
+  @Override
   public final KeyValueIterator<KEY, VALUE> iterator(KEY prefix, KeyValueIterator.Type type) {
     throw new UnsupportedOperationException("Iterating tables directly is not" +
         " supported for datanode containers due to differing schema " +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneDeletedBlocksTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneDeletedBlocksTable.java
@@ -78,6 +78,11 @@ public class SchemaOneDeletedBlocksTable extends DatanodeTable<String,
   }
 
   @Override
+  public void deleteRangeWithBatch(BatchOperation batch, String beginKey, String endKey) throws CodecException {
+    super.deleteRangeWithBatch(batch, prefix(beginKey), prefix(endKey));
+  }
+
+  @Override
   public boolean isExist(String key) throws RocksDatabaseException, CodecException {
     return super.isExist(prefix(key));
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
@@ -140,7 +140,7 @@ public class RDBBatchOperation implements BatchOperation {
       private final ColumnFamily family;
       /**
        * A (dbKey -> dbValue) map, where the dbKey type is {@link Bytes}
-       * and the dbValue type is {@link Object}.
+       * and the dbValue type is a {@link Pair} of {@link Op} and {@link Object}.
        * When dbValue is a byte[]/{@link ByteBuffer}, it represents a put-op.
        * Otherwise, it represents a delete-op (dbValue is {@link Op#DELETE}).
        * Order of the operations is preserved.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -205,6 +205,15 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
+  public void deleteRangeWithBatch(BatchOperation batch, byte[] beginKey, byte[] endKey) throws CodecException {
+    if (batch instanceof RDBBatchOperation) {
+      ((RDBBatchOperation) batch).deleteRange(family, beginKey, endKey);
+    } else {
+      throw new IllegalArgumentException("batch should be RDBBatchOperation");
+    }
+  }
+
+  @Override
   public KeyValueIterator<byte[], byte[]> iterator(byte[] prefix, KeyValueIterator.Type type)
       throws RocksDatabaseException {
     return new RDBStoreByteArrayIterator(db.newIterator(family, false), this,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -302,6 +302,16 @@ public final class RocksDatabase implements Closeable {
       }
     }
 
+    public void batchDeleteRange(ManagedWriteBatch writeBatch, byte[] startKey, byte[] endKey)
+        throws RocksDatabaseException {
+      try (UncheckedAutoCloseable ignored = acquire()) {
+        writeBatch.deleteRange(getHandle(), startKey, endKey);
+      } catch (RocksDBException e) {
+        throw toRocksDatabaseException(this, "batchDeleteRange startKey: " + bytes2String(startKey)
+            + " endKey: " + bytes2String(endKey), e);
+      }
+    }
+
     public void batchPut(ManagedWriteBatch writeBatch, byte[] key, byte[] value)
         throws RocksDatabaseException {
       if (LOG.isDebugEnabled()) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -142,6 +142,15 @@ public interface Table<KEY, VALUE> {
    */
   void deleteRange(KEY beginKey, KEY endKey) throws RocksDatabaseException, CodecException;
 
+  /**
+   * Deletes a range of keys from the metadata store as part of a batch operation.
+   *
+   * @param batch the batch operation
+   * @param beginKey start metadata key
+   * @param endKey end metadata key
+   */
+  void deleteRangeWithBatch(BatchOperation batch, KEY beginKey, KEY endKey) throws  CodecException;
+
   /** The same as iterator(null, KEY_AND_VALUE). */
   default KeyValueIterator<KEY, VALUE> iterator() throws RocksDatabaseException, CodecException {
     return iterator(null, KeyValueIterator.Type.KEY_AND_VALUE);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -386,6 +386,11 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public void deleteRangeWithBatch(BatchOperation batch, KEY beginKey, KEY endKey) throws CodecException {
+    rawTable.deleteRangeWithBatch(batch, encodeKey(beginKey), encodeKey(endKey));
+  }
+
+  @Override
   public KeyValueIterator<KEY, VALUE> iterator(KEY prefix, KeyValueIterator.Type type)
       throws RocksDatabaseException, CodecException {
     if (supportCodecBuffer) {
@@ -594,7 +599,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
     /**
      * Covert the given {@link Table.KeyValue}
-     * from ({@link RAW}, {@link RAW}) to ({@link KEY}, {@link VALUE}).
+     * from ({@link RAW}, {@link RAW}) to ({@link KEY}, {@@link VALUE}).
      */
     abstract KeyValue<KEY, VALUE> convert(KeyValue<RAW, RAW> raw) throws CodecException;
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/InMemoryTestTable.java
@@ -85,6 +85,11 @@ public final class InMemoryTestTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public void deleteRangeWithBatch(BatchOperation batch, KEY beginKey, KEY endKey) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public KeyValueIterator<KEY, VALUE> iterator(KEY prefix, KeyValueIterator.Type type) {
     throw new UnsupportedOperationException();
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -17,8 +17,8 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
+import static org.apache.hadoop.hdds.StringUtils.bytes2String;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.stream;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -300,7 +300,6 @@ public class TestRDBTableStore {
     }
   }
 
-  // Add test here for deleteRange with batch operation.
   @Test
   public void batchDeleteWithRange() throws Exception {
     final Table<byte[], byte[]> testTable = rdbStore.getTable("Fifth");
@@ -335,7 +334,7 @@ public class TestRDBTableStore {
     }
   }
 
-  // Add test to check for order of operations in batch.
+  @Test
   public void orderOfBatchOperations() throws Exception {
     final Table<byte[], byte[]> testTable = rdbStore.getTable("Fifth");
     try (BatchOperation batch = rdbStore.initBatchOperation()) {
@@ -345,12 +344,9 @@ public class TestRDBTableStore {
       byte[] startKey = ("1-" + keyStr).getBytes(StandardCharsets.UTF_8);
       byte[] keyInRange1 = ("2-" + keyStr).getBytes(StandardCharsets.UTF_8);
       byte[] endKey = ("3-" + keyStr).getBytes(StandardCharsets.UTF_8);
-      byte[] value1 =
-          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-      byte[] value2 =
-          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
-      byte[] value3 =
-          RandomStringUtils.secure().next(10).getBytes(StandardCharsets.UTF_8);
+      byte[] value1 = ("value1-" + RandomStringUtils.secure().next(10)).getBytes(StandardCharsets.UTF_8);
+      byte[] value2 = ("value2-" + RandomStringUtils.secure().next(10)).getBytes(StandardCharsets.UTF_8);
+      byte[] value3 = ("value3-" + RandomStringUtils.secure().next(10)).getBytes(StandardCharsets.UTF_8);
 
       //when
       testTable.putWithBatch(batch, startKey, value1);
@@ -371,11 +367,9 @@ public class TestRDBTableStore {
       rdbStore.commitBatchOperation(batch);
 
       //then
-      assertNotNull(testTable.get(startKey));
-      assertEquals(value3, testTable.get(startKey));
+      assertEquals(bytes2String(value3), bytes2String(testTable.get(startKey)));
       assertNull(testTable.get(keyInRange1));
-      assertNotNull(testTable.get(endKey));
-      assertEquals(value2, testTable.get(endKey));
+      assertEquals(bytes2String(value2), bytes2String(testTable.get(endKey)));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -542,34 +542,6 @@ public final class OmSnapshotManager implements AutoCloseable {
   }
 
   /**
-   * Helper method to perform operation on keys with a given iterator.
-   * @param keyIter TableIterator
-   * @param operationFunction operation to be performed for each key.
-   */
-  private static void performOperationOnKeys(
-      TableIterator<String, ? extends Table.KeyValue<String, ?>> keyIter,
-      CheckedFunction<Table.KeyValue<String, ?>,
-      Void, IOException> operationFunction) throws IOException {
-    // Continue only when there are entries of snapshot (bucket) scope
-    // in deletedTable in the first place
-    // Loop until prefix matches.
-    // Start performance tracking timer
-    long startTime = System.nanoTime();
-    while (keyIter.hasNext()) {
-      Table.KeyValue<String, ?> entry = keyIter.next();
-      operationFunction.apply(entry);
-    }
-    // Time took for the iterator to finish (in ns)
-    long timeElapsed = System.nanoTime() - startTime;
-    if (timeElapsed >= DB_TABLE_ITER_LOOP_THRESHOLD_NS) {
-      // Print time elapsed
-      LOG.warn("Took {} ns to find endKey. Caller is {}", timeElapsed,
-          new Throwable().fillInStackTrace().getStackTrace()[1]
-              .getMethodName());
-    }
-  }
-
-  /**
    * Helper method to delete DB keys in the snapshot scope (bucket)
    * from active DB's deletedTable.
    * @param omMetadataManager OMMetadataManager instance

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -82,8 +82,6 @@ import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
@@ -101,7 +99,6 @@ import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
-import org.apache.ratis.util.function.CheckedFunction;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -116,9 +113,6 @@ public final class OmSnapshotManager implements AutoCloseable {
   public static final String OM_HARDLINK_FILE = "hardLinkFile";
   private static final Logger LOG =
       LoggerFactory.getLogger(OmSnapshotManager.class);
-
-  // Threshold for the table iterator loop in nanoseconds.
-  private static final long DB_TABLE_ITER_LOOP_THRESHOLD_NS = 100000;
 
   private final OzoneManager ozoneManager;
   private final SnapshotDiffManager snapshotDiffManager;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -230,7 +230,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
       omMetrics.incNumSnapshotCreateFails();
       LOG.error("Failed to create snapshot '{}' with snapshotId: '{}' under " +
               "path '{}'",
-          snapshotName, snapshotInfo.getSnapshotId(), snapshotPath);
+          snapshotName, snapshotInfo.getSnapshotId(), snapshotPath, exception);
     }
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -25,8 +25,6 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.SNAPSHOT_RENAMED_T
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -84,11 +82,10 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
     final String startKey = omMetadataManager.getBucketKey(
         snapshotInfo.getVolumeName(), snapshotInfo.getBucketName())
         + OM_KEY_PREFIX;
+    // endKey is the smallest key that is lexicographically larger than the startKey. (exclusive)
+    final String endKey = startKey.substring(0, startKey.length() - 1) +
+        (char)(startKey.charAt(startKey.length() - 1) + 1);
 
-    // Range delete end key (exclusive) - next possible ASCII char after bucket key
-    // Creates the smallest key that is lexicographically larger than the startKey.
-    final String endKey = startKey + Character.MAX_VALUE;
-
-    omMetadataManager.getSnapshotRenamedTable().deleteRange(startKey, endKey);
+    omMetadataManager.getSnapshotRenamedTable().deleteRangeWithBatch(batchOperation, startKey, endKey);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On snapshot create we move deleted keys, directories and renamed keys from AOS to the snapshot by iterating the deletedTable, deletedDirectoryTable and snapshotRenamedTable, filtering keys that belong to the snapshotted bucket prefix and removing them from the AOS delete space.
Proposed optimization will use the deleteRange API removing keys with the bucket prefix. Starting key is the bucket prefix and the ending key is the smallest key that is lexicographically higher than the starting key. Ending key is exclusive.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13252


## How was this patch tested?

Unit Tests.
