### PR TITLE
HDDS-13186. Track replicated sizes of committed keys in OM via Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1353,13 +1353,6 @@ public class OMDBInsightEndpoint {
         OmTableInsightTask.getTableCountKeyFromTable(DELETED_DIR_TABLE)));
     // Calculate the total number of deleted directories
     dirSummary.put("totalDeletedDirectories", deletedDirCount);
-
-    // Get all deleted directories without pagination
-    KeyInsightInfoResponse deletedDirInsightInfo = new KeyInsightInfoResponse();
-    getPendingForDeletionDirInfo(Integer.MAX_VALUE, "", deletedDirInsightInfo);
-    // Calculate the total replicated and unreplicated data size for deleted directories
-    dirSummary.put("totalReplicatedDataSize", deletedDirInsightInfo.getReplicatedDataSize());
-    dirSummary.put("totalUnreplicatedDataSize", deletedDirInsightInfo.getUnreplicatedDataSize());
   }
 
   private boolean validateStartPrefix(String startPrefix) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1305,6 +1305,13 @@ public class OMDBInsightEndpoint {
         OmTableInsightTask.getTableCountKeyFromTable(DELETED_DIR_TABLE)));
     // Calculate the total number of deleted directories
     dirSummary.put("totalDeletedDirectories", deletedDirCount);
+
+    // Get all deleted directories without pagination
+    KeyInsightInfoResponse deletedDirInsightInfo = new KeyInsightInfoResponse();
+    getPendingForDeletionDirInfo(Integer.MAX_VALUE, "", deletedDirInsightInfo);
+    // Calculate the total replicated and unreplicated data size for deleted directories
+    dirSummary.put("totalReplicatedDataSize", deletedDirInsightInfo.getReplicatedDataSize());
+    dirSummary.put("totalUnreplicatedDataSize", deletedDirInsightInfo.getUnreplicatedDataSize());
   }
 
   private boolean validateStartPrefix(String startPrefix) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/CommittedKeysInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/CommittedKeysInsightHandler.java
@@ -27,15 +27,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handler for committed keys in both FILE_TABLE and KEY_TABLE.
+ * Manages records in the key table and file table - updating counts, both replicated and unreplicated sizes of
+ * committed keys in the backend.
  */
 public class CommittedKeysInsightHandler implements OmTableHandler {
   private static final Logger LOG =
       LoggerFactory.getLogger(CommittedKeysInsightHandler.class);
 
   /**
-   * Invoked by the process method to add information on those keys that have
-   * been committed  in the OM DB.
+   * Invoked by the process method to add information on those keys that have been committed in the OM DB.
    */
   @Override
   public void handlePutEvent(OMDBUpdateEvent<String, Object> event,
@@ -58,7 +58,7 @@ public class CommittedKeysInsightHandler implements OmTableHandler {
   }
 
   /**
-   * Invoked by the process method to delete information on those keys that are no longer closed in the OM DB.
+   * Invoked by the process method to delete information on those keys that are no longer present in the OM DB.
    */
   @Override
   public void handleDeleteEvent(OMDBUpdateEvent<String, Object> event,
@@ -100,8 +100,8 @@ public class CommittedKeysInsightHandler implements OmTableHandler {
         return;
       }
 
-      // In Update event the count for the key table and file table will not change. So we don't need to update the
-      // count.
+      // During an UPDATE event the count for the key table and file table will not change. So we don't have to
+      // update the count.
       OmKeyInfo oldKeyInfo = (OmKeyInfo) event.getOldValue();
       OmKeyInfo newKeyInfo = (OmKeyInfo) event.getValue();
       unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
@@ -118,8 +118,8 @@ public class CommittedKeysInsightHandler implements OmTableHandler {
 
   /**
    * This method is called by the reprocess method. It calculates the record counts for both the key table and the
-   * file table. Additionally, it computes the sizes of both replicated and unreplicated keys
-   * that are currently committed in the OM DB.
+   * file table. Additionally, it computes both replicated and unreplicated sizes of keys that are currently
+   * committed in the OM DB.
    */
   @Override
   public Triple<Long, Long, Long> getTableSizeAndCount(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/CommittedKeysInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/CommittedKeysInsightHandler.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler for committed keys in both FILE_TABLE and KEY_TABLE.
+ */
+public class CommittedKeysInsightHandler implements OmTableHandler {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CommittedKeysInsightHandler.class);
+
+  /**
+   * Invoked by the process method to add information on those keys that have
+   * been committed  in the OM DB.
+   */
+  @Override
+  public void handlePutEvent(OMDBUpdateEvent<String, Object> event,
+                             String tableName,
+                             Map<String, Long> objectCountMap,
+                             Map<String, Long> unReplicatedSizeMap,
+                             Map<String, Long> replicatedSizeMap) {
+
+    if (event.getValue() != null) {
+      OmKeyInfo omKeyInfo = (OmKeyInfo) event.getValue();
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName), (k, count) -> count + 1L);
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+          (k, size) -> size + omKeyInfo.getDataSize());
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+          (k, size) -> size + omKeyInfo.getReplicatedSize());
+    } else {
+      LOG.warn("Put event does not have the Key Info for {}.",
+          event.getKey());
+    }
+  }
+
+  /**
+   * Invoked by the process method to delete information on those keys that are no longer closed in the OM DB.
+   */
+  @Override
+  public void handleDeleteEvent(OMDBUpdateEvent<String, Object> event,
+                                String tableName,
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
+
+    if (event.getValue() != null) {
+      OmKeyInfo omKeyInfo = (OmKeyInfo) event.getValue();
+      objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
+          (k, count) -> count > 0 ? count - 1L : 0L);
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+          (k, size) -> size > omKeyInfo.getDataSize() ?
+              size - omKeyInfo.getDataSize() : 0L);
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+          (k, size) -> size > omKeyInfo.getReplicatedSize() ?
+              size - omKeyInfo.getReplicatedSize() : 0L);
+    } else {
+      LOG.warn("Delete event does not have the Key Info for {}.",
+          event.getKey());
+    }
+  }
+
+  /**
+   * Invoked by the process method to update information on those keys and files that have been updated in the OM DB.
+   */
+  @Override
+  public void handleUpdateEvent(OMDBUpdateEvent<String, Object> event,
+                                String tableName,
+                                Map<String, Long> objectCountMap,
+                                Map<String, Long> unReplicatedSizeMap,
+                                Map<String, Long> replicatedSizeMap) {
+
+    if (event.getValue() != null) {
+      if (event.getOldValue() == null) {
+        LOG.warn("Update event does not have the old Key Info for {}.",
+            event.getKey());
+        return;
+      }
+
+      // In Update event the count for the key table and file table will not change. So we don't need to update the
+      // count.
+      OmKeyInfo oldKeyInfo = (OmKeyInfo) event.getOldValue();
+      OmKeyInfo newKeyInfo = (OmKeyInfo) event.getValue();
+      unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+          (k, size) -> size - oldKeyInfo.getDataSize() +
+              newKeyInfo.getDataSize());
+      replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+          (k, size) -> size - oldKeyInfo.getReplicatedSize() +
+              newKeyInfo.getReplicatedSize());
+    } else {
+      LOG.warn("Update event does not have the Key Info for {}.",
+          event.getKey());
+    }
+  }
+
+  /**
+   * This method is called by the reprocess method. It calculates the record counts for both the key table and the
+   * file table. Additionally, it computes the sizes of both replicated and unreplicated keys
+   * that are currently committed in the OM DB.
+   */
+  @Override
+  public Triple<Long, Long, Long> getTableSizeAndCount(
+      TableIterator<String, ? extends Table.KeyValue<String, ?>> iterator)
+      throws IOException {
+    long count = 0;
+    long unReplicatedSize = 0;
+    long replicatedSize = 0;
+
+    if (iterator != null) {
+      while (iterator.hasNext()) {
+        Table.KeyValue<String, ?> kv = iterator.next();
+        if (kv != null && kv.getValue() != null) {
+          OmKeyInfo omKeyInfo = (OmKeyInfo) kv.getValue();
+          unReplicatedSize += omKeyInfo.getDataSize();
+          replicatedSize += omKeyInfo.getReplicatedSize();
+          count++;
+        }
+      }
+    }
+    return Triple.of(count, unReplicatedSize, replicatedSize);
+  }
+
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import static org.jooq.impl.DSL.currentTimestamp;
@@ -78,6 +80,8 @@ public class OmTableInsightTask implements ReconOmTask {
     tableHandlers.put(OPEN_KEY_TABLE, new OpenKeysInsightHandler());
     tableHandlers.put(OPEN_FILE_TABLE, new OpenKeysInsightHandler());
     tableHandlers.put(DELETED_TABLE, new DeletedKeysInsightHandler());
+    tableHandlers.put(KEY_TABLE, new CommittedKeysInsightHandler());
+    tableHandlers.put(FILE_TABLE, new CommittedKeysInsightHandler());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Created a new `CommittedKeysInsightHandler` to track committed keys in both `FILE_TABLE` and `KEY_TABLE`. Modified `OmTableInsightTask` to use the new handler for both tables. Implemented tracking of:
  - Total count of committed keys
  - Total unreplicated data size
  - Total replicated data size

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13186

## How was this patch tested?

Tested the changes manually