### PR TITLE
HDDS-13342. Replace DatatypeConverter.printHexBinary with Hex.encodeHexString

### DIFF
--- a/hadoop-ozone/cli-shell/pom.xml
+++ b/hadoop-ozone/cli-shell/pom.xml
@@ -56,10 +56,6 @@
       <artifactId>picocli-shell-jline3</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/ChecksumKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/ChecksumKeyHandler.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.client.OzoneClientUtils.getFileChecksumWit
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import java.io.IOException;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -91,8 +92,8 @@ public class ChecksumKeyHandler extends KeyHandler {
           name, dataSize, client.getObjectStore().getClientProxy());
 
       this.algorithm = fileChecksum.getAlgorithmName();
-      this.checksum = javax.xml.bind.DatatypeConverter.printHexBinary(
-          fileChecksum.getBytes());
+      this.checksum = Hex.encodeHexString(
+          fileChecksum.getBytes()).toUpperCase();
     }
   }
 }

--- a/hadoop-ozone/cli-shell/src/test/java/org/apache/hadoop/ozone/shell/keys/TestChecksumKeyHandler.java
+++ b/hadoop-ozone/cli-shell/src/test/java/org/apache/hadoop/ozone/shell/keys/TestChecksumKeyHandler.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -110,8 +111,8 @@ public class TestChecksumKeyHandler {
     assertEquals(keySize, json.get("dataSize").asLong());
     assertEquals("COMPOSITE-CRC32", json.get("algorithm").asText());
 
-    String expectedChecksum = javax.xml.bind.DatatypeConverter.printHexBinary(
-        CrcUtil.intToBytes(Integer.valueOf(CHECKSUM)));
+    String expectedChecksum = Hex.encodeHexString(
+        CrcUtil.intToBytes(Integer.valueOf(CHECKSUM))).toUpperCase();
     assertEquals(expectedChecksum, json.get("checksum").asText());
   }
 

--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -37,6 +37,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -94,7 +94,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -1176,8 +1176,8 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
         UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
         PartETag partETag = uploadResult.getPartETag();
         assertEquals(i, partETag.getPartNumber());
-        assertEquals(DatatypeConverter.printHexBinary(
-            calculateDigest(fileInputStream, 0, (int) partSize)).toLowerCase(), partETag.getETag());
+        assertEquals(Hex.encodeHexString(
+            calculateDigest(fileInputStream, 0, (int) partSize)), partETag.getETag());
         partETags.add(partETag);
 
         filePosition += partSize;

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -48,7 +48,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
@@ -622,8 +622,8 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
             uploadPartRequest,
             RequestBody.fromByteBuffer(bb));
 
-        assertEquals(DatatypeConverter.printHexBinary(
-            calculateDigest(fileInputStream, 0, partSize)).toLowerCase(), partResponse.eTag());
+        assertEquals(Hex.encodeHexString(
+            calculateDigest(fileInputStream, 0, partSize)), partResponse.eTag());
 
         CompletedPart part = CompletedPart.builder()
             .partNumber(partNumber)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -41,7 +41,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -283,8 +283,8 @@ public abstract class TestOzoneFSWithObjectStoreCreate implements NonHATests.Tes
     // This should succeed, as we check during creation of part or during
     // complete MPU.
     ozoneOutputStream.getMetadata().put(ETAG,
-        DatatypeConverter.printHexBinary(MessageDigest.getInstance(MD5_HASH)
-            .digest(b)).toLowerCase());
+        Hex.encodeHexString(MessageDigest.getInstance(MD5_HASH)
+            .digest(b)));
     ozoneOutputStream.close();
 
     Map<Integer, String> partsMap = new HashMap<>();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -96,7 +96,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -3649,8 +3649,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
     ozoneOutputStream.getMetadata().put(ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
@@ -3660,8 +3659,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     ozoneOutputStream = bucket.createMultipartKey(keyName,
         data.length, 2, omMultipartInfo.getUploadID());
     ozoneOutputStream.getMetadata().put(ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.write(data, 0, data.length);
 
     Map<Integer, String> partsMap = new LinkedHashMap<>();
@@ -4315,8 +4313,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     ozoneOutputStream.write(data, 0,
         data.length);
     ozoneOutputStream.getMetadata().put(ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
@@ -4911,8 +4908,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     ozoneStreamOutput.write(ByteBuffer.wrap(sampleData), 0,
         valueLength);
     ozoneStreamOutput.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(MessageDigest.getInstance(OzoneConsts.MD5_HASH)
-            .digest(sampleData)).toLowerCase());
+        Hex.encodeHexString(MessageDigest.getInstance(OzoneConsts.MD5_HASH)
+            .digest(sampleData)));
     ozoneStreamOutput.close();
 
     OzoneMultipartUploadPartListParts parts =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -60,7 +60,7 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.BooleanSupplier;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.kms.KMSClientProvider;
@@ -740,8 +740,7 @@ class TestOzoneAtRestEncryption {
     ByteBuffer dataBuffer = ByteBuffer.wrap(data);
     multipartStreamKey.write(dataBuffer, 0, length);
     multipartStreamKey.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     multipartStreamKey.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
@@ -758,8 +757,7 @@ class TestOzoneAtRestEncryption {
         data.length, partNumber, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
     ozoneOutputStream.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -46,7 +46,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -447,8 +447,7 @@ public abstract class TestOzoneClientMultipartUploadWithFSO implements NonHATest
         data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
     ozoneOutputStream.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
@@ -458,8 +457,7 @@ public abstract class TestOzoneClientMultipartUploadWithFSO implements NonHATest
     ozoneOutputStream = bucket.createMultipartKey(keyName,
         data.length, 2, uploadID);
     ozoneOutputStream.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.write(data, 0, data.length);
 
     Map<Integer, String> partsMap = new LinkedHashMap<>();
@@ -1090,8 +1088,7 @@ public abstract class TestOzoneClientMultipartUploadWithFSO implements NonHATest
         data.length, partNumber, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
     ozoneOutputStream.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(eTagProvider.digest(data))
-            .toLowerCase());
+        Hex.encodeHexString(eTagProvider.digest(data)));
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -217,8 +217,8 @@ public abstract class TestObjectStoreWithLegacyFS implements NonHATests.TestCase
         data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
     ozoneOutputStream.getMetadata().put(OzoneConsts.ETAG,
-        DatatypeConverter.printHexBinary(MessageDigest.getInstance(OzoneConsts.MD5_HASH)
-            .digest(data)).toLowerCase());
+        Hex.encodeHexString(MessageDigest.getInstance(OzoneConsts.MD5_HASH)
+            .digest(data)));
     ozoneOutputStream.close();
 
     if (bucket.getBucketLayout() == BucketLayout.OBJECT_STORE) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
@@ -1083,13 +1083,13 @@ public final class OMRequestTestUtils {
         .addAllKeyLocations(new ArrayList<>())
         .addMetadata(KeyValue.newBuilder()
             .setKey(OzoneConsts.ETAG)
-            .setValue(DatatypeConverter.printHexBinary(
+            .setValue(Hex.encodeHexString(
                 new DigestInputStream(
                     new ByteArrayInputStream(
                         RandomStringUtils.secure().nextAlphanumeric((int) size)
                             .getBytes(StandardCharsets.UTF_8)),
                     eTagProvider)
-                    .getMessageDigest().digest()))
+                    .getMessageDigest().digest()).toUpperCase())
             .build());
     // Just adding dummy list. As this is for UT only.
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -102,8 +102,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
-import javax.xml.bind.DatatypeConverter;
 import net.jcip.annotations.Immutable;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -337,9 +337,8 @@ public class ObjectEndpoint extends EndpointBase {
           perf.appendMetaLatencyNanos(metadataLatencyNs);
           putLength = IOUtils.copyLarge(digestInputStream, output, 0, length,
               new byte[getIOBufferSize(length)]);
-          eTag = DatatypeConverter.printHexBinary(
-                  digestInputStream.getMessageDigest().digest())
-              .toLowerCase();
+          eTag = Hex.encodeHexString(
+                  digestInputStream.getMessageDigest().digest());
           output.getMetadata().put(ETAG, eTag);
         }
       }
@@ -1082,7 +1081,7 @@ public class ObjectEndpoint extends EndpointBase {
               new byte[getIOBufferSize(length)]);
           byte[] digest = digestInputStream.getMessageDigest().digest();
           ozoneOutputStream.getMetadata()
-              .put(ETAG, DatatypeConverter.printHexBinary(digest).toLowerCase());
+              .put(ETAG, Hex.encodeHexString(digest));
           outputStream = ozoneOutputStream;
         }
         getMetrics().incPutKeySuccessLength(putLength);
@@ -1234,7 +1233,7 @@ public class ObjectEndpoint extends EndpointBase {
             getMetrics().updateCopyKeyMetadataStats(startNanos);
         perf.appendMetaLatencyNanos(metadataLatencyNs);
         copyLength = IOUtils.copyLarge(src, dest, 0, srcKeyLen, new byte[getIOBufferSize(srcKeyLen)]);
-        String eTag = DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
+        String eTag = Hex.encodeHexString(src.getMessageDigest().digest());
         dest.getMetadata().put(ETAG, eTag);
       }
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.security.DigestInputStream;
 import java.util.Map;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -107,8 +107,7 @@ final class ObjectEndpointStreaming {
         length, replicationConfig, keyMetadata, tags)) {
       long metadataLatencyNs = METRICS.updatePutKeyMetadataStats(startNanos);
       writeLen = writeToStreamOutput(streamOutput, body, bufferSize, length);
-      eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
-          .toLowerCase();
+      eTag = Hex.encodeHexString(body.getMessageDigest().digest());
       perf.appendMetaLatencyNanos(metadataLatencyNs);
       ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);
     }
@@ -132,8 +131,7 @@ final class ObjectEndpointStreaming {
       long metadataLatencyNs =
           METRICS.updateCopyKeyMetadataStats(startNanos);
       writeLen = writeToStreamOutput(streamOutput, body, bufferSize, length);
-      String eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
-          .toLowerCase();
+      String eTag = Hex.encodeHexString(body.getMessageDigest().digest());
       perf.appendMetaLatencyNanos(metadataLatencyNs);
       ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);
     }
@@ -171,8 +169,8 @@ final class ObjectEndpointStreaming {
         long metadataLatencyNs = METRICS.updatePutKeyMetadataStats(startNanos);
         long putLength =
             writeToStreamOutput(streamOutput, body, chunkSize, length);
-        eTag = DatatypeConverter.printHexBinary(
-            body.getMessageDigest().digest()).toLowerCase();
+        eTag = Hex.encodeHexString(
+            body.getMessageDigest().digest());
         ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);
         METRICS.incPutKeySuccessLength(putLength);
         perf.appendMetaLatencyNanos(metadataLatencyNs);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -549,8 +549,8 @@ public final class OzoneBucketStub extends OzoneBucket {
           PartInfo partInfo = new PartInfo(partEntry.getKey(),
               partEntry.getValue().getPartName(),
               Time.now(), partEntry.getValue().getContent().length,
-              DatatypeConverter.printHexBinary(eTagProvider.digest(partEntry
-                  .getValue().getContent())).toLowerCase());
+              Hex.encodeHexString(eTagProvider.digest(partEntry
+                  .getValue().getContent())));
           partInfoList.add(partInfo);
           count++;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -2077,6 +2077,13 @@
                       <bannedImport>org.eclipse.jetty.util.StringUtil</bannedImport>
                     </bannedImports>
                   </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Use similar class from Apache Commons Codec</reason>
+                    <bannedImports>
+                      <bannedImport>javax.xml.bind.DatatypeConverter</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?
As mentioned in the issued JIRA, this PR will
- replace `javax.xml.bind.DatatypeConverter.printHexBinary` with `org.apache.commons.codec.binary.Hex`
- invert the `toUpperCase()` and `toLowerCase()` based on the mentioned methods

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13342

## How was this patch tested?

CI: https://github.com/echonesis/ozone/actions/runs/15922680115
Error for the bannedImports:
<img width="1071" alt="截圖 2025-06-27 下午4 35 57" src="https://github.com/user-attachments/assets/721bf5f3-1022-49ca-9a34-43cf7c8da6f0" />