### PR TITLE
HDDS-13358. Refactor SafeModeStatus to an enum

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationCheckpoint;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -278,8 +277,6 @@ public final class SCMContext {
     private boolean isLeader = false;
     private long term = INVALID_TERM;
     private SafeModeStatus safeModeStatus = SafeModeStatus.OUT_OF_SAFE_MODE;
-    private boolean isInSafeMode = false;
-    private boolean isPreCheckComplete = true;
     private OzoneStorageContainerManager scm = null;
     private FinalizationCheckpoint finalizationCheckpoint = FinalizationCheckpoint.FINALIZATION_COMPLETE;
     private String threadNamePrefix = "";
@@ -296,16 +293,6 @@ public final class SCMContext {
 
     public Builder setSafeModeStatus(SafeModeStatus status) {
       this.safeModeStatus = status;
-      return this;
-    }
-
-    public Builder setIsInSafeMode(boolean inSafeMode) {
-      this.isInSafeMode = inSafeMode;
-      return this;
-    }
-
-    public Builder setIsPreCheckComplete(boolean preCheckComplete) {
-      this.isPreCheckComplete = preCheckComplete;
       return this;
     }
 
@@ -328,7 +315,6 @@ public final class SCMContext {
 
     public SCMContext build() {
       Objects.requireNonNull(scm, "scm == null");
-      Preconditions.assertSame(SafeModeStatus.of(isInSafeMode, isPreCheckComplete), safeModeStatus, "safeModeStatus");
       return buildMaybeInvalid();
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -244,20 +244,29 @@ public class SCMSafeModeManager implements SafeModeManager {
   }
 
   /**
-   * Class used during SafeMode status event.
+   * Possible states of SCM SafeMode.
    */
-  public static final class SafeModeStatus {
+  public enum SafeModeStatus {
+
+    INITIAL(true, false),
+    PRE_CHECKS_PASSED(true, true),
+    OUT_OF_SAFE_MODE(false, true);
 
     private final boolean safeModeStatus;
     private final boolean preCheckPassed;
 
-    private SafeModeStatus(boolean safeModeState, boolean preCheckPassed) {
+    SafeModeStatus(boolean safeModeState, boolean preCheckPassed) {
       this.safeModeStatus = safeModeState;
       this.preCheckPassed = preCheckPassed;
     }
 
     public static SafeModeStatus of(boolean safeMode, boolean preCheck) {
-      return new SafeModeStatus(safeMode, preCheck);
+      for (SafeModeStatus status : values()) {
+        if (status.safeModeStatus == safeMode && status.preCheckPassed == preCheck) {
+          return status;
+        }
+      }
+      throw new IllegalArgumentException("Invalid " + toString(safeMode, preCheck));
     }
 
     public boolean isInSafeMode() {
@@ -270,6 +279,10 @@ public class SCMSafeModeManager implements SafeModeManager {
 
     @Override
     public String toString() {
+      return toString(safeModeStatus, preCheckPassed);
+    }
+
+    private static String toString(boolean safeModeStatus, boolean preCheckPassed) {
       return "SafeModeStatus{" +
           "safeModeStatus=" + safeModeStatus +
           ", preCheckPassed=" + preCheckPassed +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -242,15 +242,6 @@ public class SCMSafeModeManager implements SafeModeManager {
       this.preCheckPassed = preCheckPassed;
     }
 
-    public static SafeModeStatus of(boolean safeMode, boolean preCheck) {
-      for (SafeModeStatus status : values()) {
-        if (status.safeModeStatus == safeMode && status.preCheckPassed == preCheck) {
-          return status;
-        }
-      }
-      throw new IllegalArgumentException("Invalid " + toString(safeMode, preCheck));
-    }
-
     public boolean isInSafeMode() {
       return safeModeStatus;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -252,10 +252,6 @@ public class SCMSafeModeManager implements SafeModeManager {
 
     @Override
     public String toString() {
-      return toString(safeModeStatus, preCheckPassed);
-    }
-
-    private static String toString(boolean safeModeStatus, boolean preCheckPassed) {
       return "SafeModeStatus{" +
           "safeModeStatus=" + safeModeStatus +
           ", preCheckPassed=" + preCheckPassed +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -712,6 +712,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           .setTerm(0)
           .setIsInSafeMode(true)
           .setIsPreCheckComplete(false)
+          .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.INITIAL)
           .setSCM(this)
           .setThreadNamePrefix(threadNamePrefix)
           .setFinalizationCheckpoint(finalizationManager.getCheckpoint())

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -710,8 +710,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       scmContext = new SCMContext.Builder()
           .setLeader(false)
           .setTerm(0)
-          .setIsInSafeMode(true)
-          .setIsPreCheckComplete(false)
           .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.INITIAL)
           .setSCM(this)
           .setThreadNamePrefix(threadNamePrefix)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -186,7 +186,7 @@ public class TestBlockManager {
     replicationConfig = RatisReplicationConfig
         .getInstance(ReplicationFactor.THREE);
 
-    scm.getScmContext().updateSafeModeStatus(SafeModeStatus.of(false, true));
+    scm.getScmContext().updateSafeModeStatus(SafeModeStatus.OUT_OF_SAFE_MODE);
   }
 
   @AfterEach
@@ -450,8 +450,7 @@ public class TestBlockManager {
 
   @Test
   public void testAllocateBlockFailureInSafeMode() {
-    scm.getScmContext().updateSafeModeStatus(
-        SCMSafeModeManager.SafeModeStatus.of(true, true));
+    scm.getScmContext().updateSafeModeStatus(SafeModeStatus.PRE_CHECKS_PASSED);
     // Test1: In safe mode expect an SCMException.
     Throwable t = assertThrows(IOException.class, () ->
         blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestBackgroundSCMService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestBackgroundSCMService.java
@@ -29,7 +29,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
-import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,8 +91,7 @@ public class TestBackgroundSCMService {
     assertTrue(backgroundSCMService.shouldRun());
 
     // go into safe mode, RUNNING -> PAUSING
-    scmContext.updateSafeModeStatus(
-        SCMSafeModeManager.SafeModeStatus.of(true, true));
+    scmContext.updateSafeModeStatus(SafeModeStatus.PRE_CHECKS_PASSED);
     backgroundSCMService.notifyStatusChanged();
     assertFalse(backgroundSCMService.shouldRun());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
@@ -55,8 +55,6 @@ public class TestSCMContext {
     // in safe mode
     SCMContext scmContext = new SCMContext.Builder()
         .setSafeModeStatus(SafeModeStatus.INITIAL)
-        .setIsInSafeMode(true)
-        .setIsPreCheckComplete(false)
         .buildMaybeInvalid();
 
     assertTrue(scmContext.isInSafeMode());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
@@ -54,6 +54,7 @@ public class TestSCMContext {
   public void testSafeModeOperations() {
     // in safe mode
     SCMContext scmContext = new SCMContext.Builder()
+        .setSafeModeStatus(SafeModeStatus.INITIAL)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
         .buildMaybeInvalid();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
@@ -63,12 +63,12 @@ public class TestSCMContext {
     assertFalse(scmContext.isPreCheckComplete());
 
     // in safe mode, pass preCheck
-    scmContext.updateSafeModeStatus(SafeModeStatus.of(true, true));
+    scmContext.updateSafeModeStatus(SafeModeStatus.PRE_CHECKS_PASSED);
     assertTrue(scmContext.isInSafeMode());
     assertTrue(scmContext.isPreCheckComplete());
 
     // out of safe mode
-    scmContext.updateSafeModeStatus(SafeModeStatus.of(false, true));
+    scmContext.updateSafeModeStatus(SafeModeStatus.OUT_OF_SAFE_MODE);
     assertFalse(scmContext.isInSafeMode());
     assertTrue(scmContext.isPreCheckComplete());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
@@ -33,8 +33,6 @@ public class TestSCMServiceManager {
         .setLeader(false)
         .setTerm(1)
         .setSafeModeStatus(SafeModeStatus.INITIAL)
-        .setIsInSafeMode(true)
-        .setIsPreCheckComplete(false)
         .buildMaybeInvalid();
 
     // A service runs when it is leader.
@@ -102,8 +100,6 @@ public class TestSCMServiceManager {
         .setLeader(false)
         .setTerm(1)
         .setSafeModeStatus(SafeModeStatus.INITIAL)
-        .setIsInSafeMode(true)
-        .setIsPreCheckComplete(false)
         .buildMaybeInvalid();
 
     // A service runs when it is leader and out of safe mode.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hdds.scm.ha;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,7 +32,7 @@ public class TestSCMServiceManager {
     SCMContext scmContext = new SCMContext.Builder()
         .setLeader(false)
         .setTerm(1)
-        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.INITIAL)
+        .setSafeModeStatus(SafeModeStatus.INITIAL)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
         .buildMaybeInvalid();
@@ -76,8 +76,7 @@ public class TestSCMServiceManager {
     assertFalse(serviceRunWhenLeader.shouldRun());
 
     // PAUSING when out of safe mode.
-    scmContext.updateSafeModeStatus(
-        SCMSafeModeManager.SafeModeStatus.of(false, true));
+    scmContext.updateSafeModeStatus(SafeModeStatus.OUT_OF_SAFE_MODE);
     serviceManager.notifyStatusChanged();
     assertFalse(serviceRunWhenLeader.shouldRun());
 
@@ -87,8 +86,7 @@ public class TestSCMServiceManager {
     assertTrue(serviceRunWhenLeader.shouldRun());
 
     // RUNNING when in safe mode.
-    scmContext.updateSafeModeStatus(
-        SCMSafeModeManager.SafeModeStatus.of(true, false));
+    scmContext.updateSafeModeStatus(SafeModeStatus.INITIAL);
     serviceManager.notifyStatusChanged();
     assertTrue(serviceRunWhenLeader.shouldRun());
 
@@ -103,7 +101,7 @@ public class TestSCMServiceManager {
     SCMContext scmContext = new SCMContext.Builder()
         .setLeader(false)
         .setTerm(1)
-        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.INITIAL)
+        .setSafeModeStatus(SafeModeStatus.INITIAL)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
         .buildMaybeInvalid();
@@ -147,8 +145,7 @@ public class TestSCMServiceManager {
     assertFalse(serviceRunWhenLeaderAndOutOfSafeMode.shouldRun());
 
     // PAUSING when out of safe mode.
-    scmContext.updateSafeModeStatus(
-        SCMSafeModeManager.SafeModeStatus.of(false, true));
+    scmContext.updateSafeModeStatus(SafeModeStatus.OUT_OF_SAFE_MODE);
     serviceManager.notifyStatusChanged();
     assertFalse(serviceRunWhenLeaderAndOutOfSafeMode.shouldRun());
 
@@ -158,8 +155,7 @@ public class TestSCMServiceManager {
     assertTrue(serviceRunWhenLeaderAndOutOfSafeMode.shouldRun());
 
     // PAUSING when in safe mode.
-    scmContext.updateSafeModeStatus(
-        SCMSafeModeManager.SafeModeStatus.of(true, false));
+    scmContext.updateSafeModeStatus(SafeModeStatus.INITIAL);
     serviceManager.notifyStatusChanged();
     assertFalse(serviceRunWhenLeaderAndOutOfSafeMode.shouldRun());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
@@ -32,6 +32,7 @@ public class TestSCMServiceManager {
     SCMContext scmContext = new SCMContext.Builder()
         .setLeader(false)
         .setTerm(1)
+        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.INITIAL)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
         .buildMaybeInvalid();
@@ -102,6 +103,7 @@ public class TestSCMServiceManager {
     SCMContext scmContext = new SCMContext.Builder()
         .setLeader(false)
         .setTerm(1)
+        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.INITIAL)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
         .buildMaybeInvalid();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -103,9 +103,9 @@ public class TestDeadNodeHandler {
     eventQueue = new EventQueue();
     scm = HddsTestUtils.getScm(conf);
     nodeManager = (SCMNodeManager) scm.getScmNodeManager();
-    scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+    scmContext = new SCMContext.Builder()
         .setSafeModeStatus(SafeModeStatus.PRE_CHECKS_PASSED)
-        .setLeader(true).setIsPreCheckComplete(true)
+        .setLeader(true)
         .setSCM(scm).build();
     pipelineManager =
         (PipelineManagerImpl)scm.getPipelineManager();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManagerImpl;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -103,6 +104,7 @@ public class TestDeadNodeHandler {
     scm = HddsTestUtils.getScm(conf);
     nodeManager = (SCMNodeManager) scm.getScmNodeManager();
     scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+        .setSafeModeStatus(SafeModeStatus.PRE_CHECKS_PASSED)
         .setLeader(true).setIsPreCheckComplete(true)
         .setSCM(scm).build();
     pipelineManager =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -197,9 +197,9 @@ public class TestSCMNodeManager {
   SCMNodeManager createNodeManager(OzoneConfiguration config)
       throws IOException, AuthenticationException {
     scm = HddsTestUtils.getScm(config);
-    scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+    scmContext = new SCMContext.Builder()
         .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.PRE_CHECKS_PASSED)
-        .setLeader(true).setIsPreCheckComplete(true)
+        .setLeader(true)
         .setSCM(scm).build();
     PipelineManagerImpl pipelineManager =
         (PipelineManagerImpl) scm.getPipelineManager();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -95,6 +95,7 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManagerImpl;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.NodeReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -197,6 +198,7 @@ public class TestSCMNodeManager {
       throws IOException, AuthenticationException {
     scm = HddsTestUtils.getScm(config);
     scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.PRE_CHECKS_PASSED)
         .setLeader(true).setIsPreCheckComplete(true)
         .setSCM(scm).build();
     PipelineManagerImpl pipelineManager =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -150,9 +150,9 @@ public class TestPipelineManagerImpl {
         conf.getInt(OZONE_DATANODE_PIPELINE_LIMIT,
             OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT) /
         HddsProtos.ReplicationFactor.THREE.getNumber();
-    scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+    scmContext = new SCMContext.Builder()
         .setSafeModeStatus(SafeModeStatus.PRE_CHECKS_PASSED)
-        .setLeader(true).setIsPreCheckComplete(true)
+        .setLeader(true)
         .setSCM(scm).build();
     serviceManager = new SCMServiceManager();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -150,6 +150,7 @@ public class TestPipelineManagerImpl {
             OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT) /
         HddsProtos.ReplicationFactor.THREE.getNumber();
     scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.PRE_CHECKS_PASSED)
         .setLeader(true).setIsPreCheckComplete(true)
         .setSCM(scm).build();
     serviceManager = new SCMServiceManager();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -197,7 +197,6 @@ public class ReconStorageContainerManagerFacade
     this.reconContext = reconContext;
     this.scmContext = new SCMContext.Builder()
         .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.OUT_OF_SAFE_MODE)
-        .setIsPreCheckComplete(true)
         .setSCM(this)
         .build();
     this.ozoneConfiguration = getReconScmConfiguration(conf);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -94,6 +94,7 @@ import org.apache.hadoop.hdds.scm.node.StaleNodeHandler;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineActionHandler;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReport;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
@@ -195,6 +196,7 @@ public class ReconStorageContainerManagerFacade
     eventQueue.setSilent(true);
     this.reconContext = reconContext;
     this.scmContext = new SCMContext.Builder()
+        .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.OUT_OF_SAFE_MODE)
         .setIsPreCheckComplete(true)
         .setSCM(this)
         .build();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -149,9 +149,9 @@ public class TestReconPipelineManager {
       StorageContainerManager mock = mock(StorageContainerManager.class);
       when(mock.getScmNodeDetails())
           .thenReturn(mock(SCMNodeDetails.class));
-      scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+      scmContext = new SCMContext.Builder()
               .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.PRE_CHECKS_PASSED)
-              .setLeader(true).setIsPreCheckComplete(true)
+              .setLeader(true)
               .setSCM(mock).build();
       reconPipelineManager.setScmContext(scmContext);
       reconPipelineManager.addPipeline(validPipeline);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineFactory;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -149,6 +150,7 @@ public class TestReconPipelineManager {
       when(mock.getScmNodeDetails())
           .thenReturn(mock(SCMNodeDetails.class));
       scmContext = new SCMContext.Builder().setIsInSafeMode(true)
+              .setSafeModeStatus(SCMSafeModeManager.SafeModeStatus.PRE_CHECKS_PASSED)
               .setLeader(true).setIsPreCheckComplete(true)
               .setSCM(mock).build();
       reconPipelineManager.setScmContext(scmContext);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Convert `SafeModeStatus` to an enum, with 3 constants (combination of `safeMode=false`, `preCheckPassed=false` is invalid)
- Replace separate boolean fields in `SCMContext.Builder` and `SCMSafeModeManager` with instance of the new enum
- Check current state before state transition for non-force exit.

https://issues.apache.org/jira/browse/HDDS-13358

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/16000960427