### PR TITLE
HDDS-13221. Remove Flush future from OMClientResponse

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.om.response;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -34,7 +33,6 @@ public abstract class OMClientResponse {
 
   private final OMResponse omResponse;
   /** Used only for non-Ratis. */
-  private CompletableFuture<Void> flushFuture = null;
   private OMLockDetails omLockDetails;
 
   public OMClientResponse(OMResponse omResponse) {
@@ -78,14 +76,6 @@ public abstract class OMClientResponse {
    */
   public OMResponse getOMResponse() {
     return omResponse;
-  }
-
-  public void setFlushFuture(CompletableFuture<Void> flushFuture) {
-    this.flushFuture = flushFuture;
-  }
-
-  public CompletableFuture<Void> getFlushFuture() {
-    return flushFuture;
   }
 
   public OMLockDetails getOmLockDetails() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 public abstract class OMClientResponse {
 
   private final OMResponse omResponse;
-  /** Used only for non-Ratis. */
   private OMLockDetails omLockDetails;
 
   public OMClientResponse(OMResponse omResponse) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the drop of non-ratis support ([HDDS-11754](https://issues.apache.org/jira/browse/HDDS-11754)), we can remove OMClientResponse flushFuture which was only used for non-ratis case.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13221

## How was this patch tested?
removed unsued code , ran unit tests 
