### PR TITLE
HDDS-13364. Use properties for Java/Maven version enforcement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,13 +80,8 @@
     <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
     <download-maven-plugin.version>1.9.0</download-maven-plugin.version>
     <dropwizard-metrics.version>3.2.6</dropwizard-metrics.version>
-    <!-- The java version enforced by the maven enforcer -->
-    <!-- more complex patterns can be used here, such as
-       [${javac.version})
-    for an open-ended enforcement
-    -->
     <enforced.java.version>[${javac.version},)</enforced.java.version>
-    <enforced.maven.version>[3.3.0,)</enforced.maven.version>
+    <enforced.maven.version>[3.6.3,)</enforced.maven.version>
     <errorprone-annotations.version>2.29.2</errorprone-annotations.version>
     <!-- test groups excluded by default (without any manual profile activation) -->
     <excluded-test-groups>unhealthy</excluded-test-groups>
@@ -1889,10 +1884,10 @@
           <configuration>
             <rules>
               <requireMavenVersion>
-                <version>[3.0.2,)</version>
+                <version>${enforced.maven.version}</version>
               </requireMavenVersion>
               <requireJavaVersion>
-                <version>[1.8,)</version>
+                <version>${enforced.java.version}</version>
               </requireJavaVersion>
             </rules>
           </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

POM properties `enforced.java.version` and `enforced.maven.version` are currently unused, enforcer plugin is configured with hard-coded values.  This change is to start using the properties.

Also bump minimum Maven version to 3.6.3, since it is required by the enforcer plugin anyway.

https://issues.apache.org/jira/browse/HDDS-13364

## How was this patch tested?

Enforcer passes with software matching the default enforced versions:

```bash
$ java -version
openjdk version "1.8.0_452"
...

$ mvn -v
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
...

$ mvn -N validate
...
[INFO] --- maven-enforcer-plugin:3.5.0:enforce (enforce-property) @ ozone-main ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.property.RequireProperty passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
...
[INFO] BUILD SUCCESS
```

Using newer software with default enforced versions:

```bash
$ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn -N validate
...
[INFO] BUILD SUCCESS

$ ~/lib/apache-maven-3.9.9/bin/mvn -V -N validate
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
...
[INFO] BUILD SUCCESS
```

Also with newer software using custom enforced versions:

```bash
$ JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 mvn -N validate -Djavac.version=11
...
[INFO] BUILD SUCCESS

$ ~/lib/apache-maven-3.9.10/bin/mvn -V -N validate -Denforced.maven.version=3.9.9
Apache Maven 3.9.10 (5f519b97e944483d878815739f519b2eade0a91d)
...
[INFO] BUILD SUCCESS
```

But fails with older ones:

```bash
$ mvn -N validate -Denforced.maven.version=3.9.10
...
[ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireMavenVersion failed with message:
[ERROR] Detected Maven Version: 3.6.3 is not in the allowed range [3.9.10,).

$ mvn -N validate -Djavac.version=11
...
[ERROR] Rule 2: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK version 1.8.0-452 (JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre) is not in the allowed range [11,).

$ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn -N validate -Djavac.version=21
...
[ERROR] Rule 2: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK version 11.0.27 (JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64) is not in the allowed range [21,).

$ ~/lib/apache-maven-3.3.9/bin/mvn -V -N validate
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T17:41:47+01:00)
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-property) on project ozone-main: The plugin org.apache.maven.plugins:maven-enforcer-plugin:3.5.0 requires Maven version 3.6.3
...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/16018602189