### PR TITLE
HDDS-13371. [Docs] Protect in-transit traffic

### DIFF
--- a/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
+++ b/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
@@ -52,3 +52,7 @@ Ozone traffic may also be transferred via gRPC (e.g., Ratis write pipeline or cl
 ## Ozone HTTP Web Console
 
 For information on securing the Ozone HTTP web console, please refer to the [Securing HTTP](https://ozone.apache.org/docs/latest/security/securing-http.html) documentation.
+
+## Further Reading
+
+For details on the specific network ports used by Ozone roles and the types of transport between them, refer to the [Network Ports](../concept/NetworkPorts.md) documentation.

--- a/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
+++ b/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
@@ -49,7 +49,7 @@ Ozone traffic may also be transferred via gRPC (e.g., Ratis write pipeline or cl
 
 ## Ozone HTTP Web Console
 
-For information on securing the Ozone HTTP web console, please refer to the [Securing HTTP](https://ozone.apache.org/docs/latest/security/securing-http.html) documentation.
+For information on securing the Ozone HTTP web console, please refer to the [Securing HTTP](SecuringOzoneHTTP.md) documentation.
 
 ## Further Reading
 

--- a/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
+++ b/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
@@ -1,0 +1,53 @@
+---
+title: Protect In-Transit Traffic
+name: Protect In-Transit Traffic
+parent: security
+menu: main
+weight: 6
+---
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+# Protecting In-Transit Traffic
+
+This document describes how to protect data in transit within Apache Ozone.
+
+## Hadoop RPC Encryption
+
+To encrypt client-OM (Ozone Manager) communication, configure `hadoop.rpc.protection` to `privacy` in your `core-site.xml`. This ensures that all data exchanged over Hadoop RPC is encrypted.
+
+```xml
+<property>
+  <name>hadoop.rpc.protection</name>
+  <value>privacy</value>
+</property>
+```
+
+## gRPC TLS Encryption
+
+To enable TLS for gRPC traffic, set `hdds.grpc.tls.enabled` to `true`. This encrypts communication between Ozone services that use gRPC.
+
+```xml
+<property>
+  <name>hdds.grpc.tls.enabled</name>
+  <value>true</value>
+</property>
+```
+
+## Ozone HTTP Web Console
+
+For information on securing the Ozone HTTP web console, please refer to the [Securing HTTP](https://ozone.apache.org/docs/latest/security/securing-http.html) documentation.

--- a/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
+++ b/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
@@ -1,8 +1,9 @@
 ---
 title: Protect In-Transit Traffic
 name: Protect In-Transit Traffic
-parent: security
-menu: main
+menu:
+  main:
+    parent: Security
 weight: 6
 ---
 <!---
@@ -24,11 +25,11 @@ weight: 6
 
 # Protecting In-Transit Traffic
 
-This document describes how to protect data in transit within Apache Ozone.
+This document describes how to protect data in transit within Apache Ozone, both between the cluster and clients, and internally within the cluster.
 
 ## Hadoop RPC Encryption
 
-To encrypt client-OM (Ozone Manager) communication, configure `hadoop.rpc.protection` to `privacy` in your `core-site.xml`. This ensures that all data exchanged over Hadoop RPC is encrypted.
+Ozone traffic, whether between the cluster and client, or internal inside the cluster, may be transferred via Hadoop RPC (e.g. client to Ozone Manager). To encrypt client-OM (Ozone Manager) communication, configure `hadoop.rpc.protection` to `privacy` in your `core-site.xml`. This ensures that all data exchanged over Hadoop RPC is encrypted.
 
 ```xml
 <property>
@@ -39,7 +40,7 @@ To encrypt client-OM (Ozone Manager) communication, configure `hadoop.rpc.protec
 
 ## gRPC TLS Encryption
 
-To enable TLS for gRPC traffic, set `hdds.grpc.tls.enabled` to `true`. This encrypts communication between Ozone services that use gRPC.
+Ozone traffic may also be transferred via gRPC (e.g., Ratis write pipeline or client reading blocks from DataNode). To enable TLS for gRPC traffic, set `hdds.grpc.tls.enabled` to `true`. This encrypts communication between Ozone services that use gRPC.
 
 ```xml
 <property>

--- a/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
+++ b/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
@@ -36,6 +36,10 @@ Ozone traffic, whether between the cluster and client, or internal inside the cl
 </property>
 ```
 
+### ozone.om.transport.class
+
+While the default is `org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory`, it is possible to specify a gRPC based transport using the `ozone.om.transport.class` configuration property: `org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory`. In this case, the Hadoop RPC configuration is not applicable.
+
 ## gRPC TLS Encryption
 
 Ozone traffic may also be transferred via gRPC (e.g., Ratis write pipeline or client reading blocks from DataNode). To enable TLS for gRPC traffic, set `hdds.grpc.tls.enabled` to `true`. This encrypts communication between Ozone services that use gRPC.

--- a/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
+++ b/hadoop-hdds/docs/content/security/protect-in-transit-traffic.md
@@ -23,8 +23,6 @@ weight: 6
     limitations under the License.
 -->
 
-# Protecting In-Transit Traffic
-
 This document describes how to protect data in transit within Apache Ozone, both between the cluster and clients, and internally within the cluster.
 
 ## Hadoop RPC Encryption


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13371. [Docs] Protect in-transit traffic

Please describe your PR in detail:
* Add a user doc page for protecting in-transit traffic under 'Security' page.
* Generated-by: Google Gemini Cli, Gemini 2.5 Flash; Prompt:

> Read the jira https://issues.apache.org/jira/browse/HDDS-13371 and implement it.

> Ozone traffic, whether between the cluster and client, or internal inside the cluster, may be transferred via Hadoop RPC (e.g. client to  Ozone Manager), via gRPC (Ratis write pipeline or client reading blocks from DataNode) or HTTP (web UI).

> Add a reference to "Network Ports" page so that interested reader can find out the type of transport used between roles.

Number of tokens used:

```
│  Input Tokens           399,316  │
│  Output Tokens            2,898  │
│  Thoughts Tokens          2,517  │
│  ──────────────────────────────  │
│  Total Tokens           404,731  │
│                                  │
│  Total duration (API)    1m 30s  │
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13371

## How was this patch tested?

Draft prepared by Gemini; Reviewed and updated manually.