### PR TITLE
HDDS-13362. Abstract OM response class should not be annotated with CleanupTableInfo

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -17,8 +17,6 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
-
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
@@ -30,14 +28,12 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
 /**
  * Base class for responses that need to move keys from an arbitrary table to
  * the deleted table.
  */
-@CleanupTableInfo(cleanupTables = {DELETED_TABLE})
 public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
 
   public AbstractOMKeyDeleteResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
@@ -17,12 +17,6 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
-
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
@@ -36,7 +30,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartAbortInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
@@ -45,8 +38,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKey
  * Base class for responses that need to move multipart info part keys to the
  * deleted table.
  */
-@CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, OPEN_FILE_TABLE,
-    DELETED_TABLE, MULTIPART_INFO_TABLE, BUCKET_TABLE})
 public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
 
   public AbstractS3MultipartAbortResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponseWithFSO.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
@@ -32,7 +33,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Response for Multipart Abort Request - prefix layout.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_FILE_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE})
+    MULTIPART_INFO_TABLE, BUCKET_TABLE})
 public class S3MultipartUploadAbortResponseWithFSO
     extends S3MultipartUploadAbortResponse {
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.om.response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -29,6 +31,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Iterators;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +62,6 @@ import org.apache.hadoop.ozone.om.request.file.OMFileCreateRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyCreateRequest;
 import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
-import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
 import org.apache.hadoop.ozone.om.response.util.OMEchoRPCWriteResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
@@ -130,23 +132,29 @@ public class TestCleanupTableInfo {
 
     Set<String> tables = omMetadataManager.listTableNames();
     Set<Class<? extends OMClientResponse>> subTypes = responseClasses();
-    // OmKeyResponse is an abstract class that does not need CleanupTable.
-    subTypes.remove(OmKeyResponse.class);
     // OMEchoRPCWriteResponse does not need CleanupTable.
     subTypes.remove(OMEchoRPCWriteResponse.class);
     subTypes.remove(DummyOMClientResponse.class);
     subTypes.forEach(aClass -> {
-      assertTrue(aClass.isAnnotationPresent(CleanupTableInfo.class),
-          aClass + " does not have annotation of" +
-              " CleanupTableInfo");
+      if (Modifier.isAbstract(aClass.getModifiers())) {
+        assertFalse(aClass.isAnnotationPresent(CleanupTableInfo.class),
+            aClass + " is an abstract class and should not contain CleanupTableInfo annotations");
+        return;
+      } else {
+        assertTrue(aClass.isAnnotationPresent(CleanupTableInfo.class),
+            aClass + " does not have annotation of" +
+                " CleanupTableInfo");
+      }
       CleanupTableInfo annotation =
           aClass.getAnnotation(CleanupTableInfo.class);
+      assertNotNull(annotation, "CleanupTableInfo is null for class " + aClass.getSimpleName());
       String[] cleanupTables = annotation.cleanupTables();
       boolean cleanupAll = annotation.cleanupAll();
       if (cleanupTables.length >= 1) {
         assertTrue(
             Arrays.stream(cleanupTables).allMatch(tables::contains)
         );
+
       } else {
         assertTrue(cleanupAll);
       }


### PR DESCRIPTION
We need to ensure that abstract OM response class should NOT have CleanupTableInfo annotation since the OM response subclass CleanupTableInfo annotation values will override the parent CleanupTableInfo. The abstract class @CleanupTableInfo will tempt contributors to exclude it in the CleanupTableInfo of the subclasses. It is also difficult to keep track the inheritance if we have more than one level of subclasses (e.g. OMKeyCreateResponseWithFSO extends OMFileCreateResponseWithFSO extends OMFileCreateResponse)

Currently we have these abstract classes:

- AbstractS3MultipartAbortResponse
- AbstractOMKeyDeleteResponse

We can push the CleanupTableInfo of these abstract classes to the all the sub concrete classes. After we need to validate by tests to prevent adding the annotation on abstract classes.

Alternatively, we can make OMClientResponse to have CleanupTableInfo with cleanupAll enabled to ensure that OM response without CleanupTableInfo will cleanup the cache entries. However, this might cause noticeable overhead since the OM response needs to traverse the class hierarchy to find the first parent with CleanupTableInfo interface as well as needing to check all the OM tables.

This also fixes the missing `BUCKET_TABLE` CleanupTable in `S3MultipartUploadAbortResponseWithFSO`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13362

## How was this patch tested?

Unit test in `TestCleanupTableInfo`.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/16040129826
