### PR TITLE
HDDS-13379. Document SCM Safe Mode and its configuration properties.

### DIFF
--- a/hadoop-hdds/docs/content/concept/StorageContainerManager.md
+++ b/hadoop-hdds/docs/content/concept/StorageContainerManager.md
@@ -87,6 +87,27 @@ The following data is persisted in Storage Container Manager side in a specific 
  * Valid cert
   * Used by the internal Certificate Authority to authorize other Ozone services
 
+## Safe Mode
+
+SCM (Storage Container Manager) enters safe mode on startup. This is a protective state that allows the system to become stable before it becomes fully operational. During safe mode, certain operations like block allocation are restricted.
+
+### How to Exit Safe Mode
+
+There are two ways to exit safe mode:
+
+1.  **Automatic Exit:** SCM will automatically exit safe mode when a set of predefined `SafeModeExitRule`s are satisfied. These rules ensure that the cluster is in a healthy state. The primary rules are:
+    *   **`DataNodeSafeModeRule`**: Checks if a minimum number of DataNodes have registered with the SCM. This is configured by `hdds.scm.safemode.min.datanode` (default: `3`).
+    *   **`RatisContainerSafeModeRule`**: Checks if a certain percentage of containers with at least one replica reported are available. This is configured by `hdds.scm.safemode.threshold.pct` (default: `0.99`).
+    *   **`HealthyPipelineSafeModeRule`**: Checks if a certain percentage of pipelines are healthy. This is configured by `hdds.scm.safemode.healthy.pipeline.pct` (default: `0.10`).
+    *   **`OneReplicaPipelineSafeModeRule`**: Checks if a certain percentage of pipelines have at least one replica reported. This is configured by `hdds.scm.safemode.atleast.one.node.reported.pipeline.pct` (default: `0.90`).
+    *   **`ECContainerSafeModeRule`**: Checks if a certain percentage of erasure coded block groups are healthy. This is also configured by `hdds.scm.safemode.threshold.pct` (default: `0.99`).
+
+2.  **Manual Exit:** You can force SCM to exit safe mode using the `ozone admin safemode --force-exit` command.
+
+### Safe Mode Pre-Check
+
+There's also a "pre-check" phase. SCM will not exit safe mode until all pre-check rules are satisfied. The `DataNodeSafeModeRule` is a pre-check rule. This means that SCM will wait for a minimum number of DataNodes to be available before it even considers the other conditions for exiting safe mode.
+
 ## Notable configurations
 
 key | default | description 


### PR DESCRIPTION
This commit adds a new section to the SCM user documentation explaining what Safe Mode is, how it works, and the conditions for exiting it. It also includes the default values for the relevant configuration properties.

## What changes were proposed in this pull request?
HDDS-13379: Document SCM Safe Mode and its configuration properties.

Please describe your PR in detail:
* Generate explanations for "Safe Mode"
* Generated-by: Google Gemini 2.5 Pro/Flash, + Gemini Cli. Prompt:

> Is there any user doc that details what safe mode is and what conditions must be satisfied to get over the safe mode?
> Good. Looks like existing user doc does not explain it. Add this description to the "Storage Container Manager" user doc.
> Add the default value for the configuration properties mentioned.
> Looks good. Commit the current update.

Tokens used:

```
│  Input Tokens         9,494,237  │
│  Output Tokens            4,728  │
│  Thoughts Tokens          2,767  │
│  ──────────────────────────────  │
│  Total Tokens         9,501,732  │
│                                  │
│  Total duration (API)    6m 13s  │
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13379

## How was this patch tested?

Draft prepared by Gemini; Reviewed and cross referenced the source code manually.
