### PR TITLE
HDDS-13375. Add Ozone logo to the Github README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<div align="center">
+  <a href="https://ozone.apache.org">
+    <img src="https://www.apache.org/logos/res/ozone/default.png" alt="Apache Ozone Logo" />
+  </a>
+</div>
+
+[![License](https://img.shields.io/:license-Apache%202-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.txt)
+[![Docker Pulls](https://img.shields.io/docker/pulls/apache/ozone.svg)](https://hub.docker.com/r/apache/ozone)
+[![Docker Stars](https://img.shields.io/docker/stars/apache/ozone.svg)](https://hub.docker.com/r/apache/ozone)
+[![Contributors](https://img.shields.io/github/contributors/apache/ozone)](https://github.com/apache/ozone/graphs/contributors)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/apache/ozone)](https://github.com/apache/ozone/commits/master)
+[![OSSRank](https://shields.io/endpoint?url=https://ossrank.com/shield/3018)](https://ossrank.com/p/3018-apache-ozone)
+
 Apache Ozone
 ===
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
As mentioned in the JIRA, this PR will
- add Apache Ozone logo on top of the README page
- provide a direct link to Apache Ozone official site while clicking the logo
- add some badges with community contribution statistics

The proposed REAME.md page would be:
![截圖 2025-07-04 上午10 09 31](https://github.com/user-attachments/assets/f14ef895-48b3-4bf4-a900-1b42643c29ef)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13375

## How was this patch tested?

CI: https://github.com/echonesis/ozone/actions/runs/16064042816
This PR includes the README.md modifications only.
