### PR TITLE
HDDS-13198. Avoid warning due to wrong min.free.space.percent default value

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -294,7 +294,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   private long minFreeSpace = getDefaultFreeSpace();
 
   @Config(key = "hdds.datanode.volume.min.free.space.percent",
-      defaultValue = "0.001", // changed from "-1" to a valid value, which is listed in Datanodes.md
+      defaultValue = "0.001", // match HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT_DEFAULT
       type = ConfigType.FLOAT,
       tags = { OZONE, CONTAINER, STORAGE, MANAGEMENT },
       description = "This determines the free space percent to be used for closing containers" +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -294,7 +294,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   private long minFreeSpace = getDefaultFreeSpace();
 
   @Config(key = "hdds.datanode.volume.min.free.space.percent",
-      defaultValue = "-1",
+      defaultValue = "0.001", // changed from "-1" to a valid value, which is listed in Datanodes.md
       type = ConfigType.FLOAT,
       tags = { OZONE, CONTAINER, STORAGE, MANAGEMENT },
       description = "This determines the free space percent to be used for closing containers" +

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -32,6 +32,7 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
@@ -48,7 +49,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for {@link DatanodeConfiguration}.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -42,13 +42,13 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 
 /**
  * Test for {@link DatanodeConfiguration}.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -274,4 +274,12 @@ public class TestDatanodeConfiguration {
     assertEquals(expected, t,
         RaftServerConfigKeys.Log.Appender.WAIT_TIME_MIN_KEY);
   }
+
+  @Test
+  public void defaultMinFreeSpacePercentIsValid() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.unset(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT); // ensure default
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+    assertEquals(0.001f, subject.getMinFreeSpaceRatio(), 1e-6);
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -193,12 +193,7 @@ public class TestDatanodeConfiguration {
 
     // Verify that no warnings were logged when using default values
     String logOutput = logCapturer.getOutput();
-    assertThat(logOutput).doesNotContain("must be greater than zero");
-    assertThat(logOutput).doesNotContain("must be greater than -1");
-    assertThat(logOutput).doesNotContain("must be >= 0");
-    assertThat(logOutput).doesNotContain("must be at least");
-    assertThat(logOutput).doesNotContain("Defaulting to");
-    assertThat(logOutput).doesNotContain("invalid, should be between");
+    assertThat(logOutput).doesNotContain("is invalid, should be between 0 and 1");
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -283,12 +283,4 @@ public class TestDatanodeConfiguration {
     assertEquals(expected, t,
         RaftServerConfigKeys.Log.Appender.WAIT_TIME_MIN_KEY);
   }
-
-  @Test
-  public void defaultMinFreeSpacePercentIsValid() {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    conf.unset(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT); // ensure default
-    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
-    assertEquals(0.001f, subject.getMinFreeSpaceRatio(), 1e-6);
-  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -47,6 +47,8 @@ import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for {@link DatanodeConfiguration}.
@@ -157,6 +159,9 @@ public class TestDatanodeConfiguration {
     // unset over-ridding configuration from ozone-site.xml defined for the test module
     conf.unset(DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE); // set in ozone-site.xml
 
+    // Capture logs to verify no warnings are generated
+    LogCapturer logCapturer = LogCapturer.captureLogs(DatanodeConfiguration.class);
+
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
 
@@ -185,6 +190,15 @@ public class TestDatanodeConfiguration {
     // capacity is large, consider min_free_space_percent, max(min_free_space, min_free_space_percent * capacity)ß
     assertEquals(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT_DEFAULT * oneGB * oneGB,
         subject.getMinFreeSpace(oneGB * oneGB));
+
+    // Verify that no warnings were logged when using default values
+    String logOutput = logCapturer.getOutput();
+    assertThat(logOutput).doesNotContain("must be greater than zero");
+    assertThat(logOutput).doesNotContain("must be greater than -1");
+    assertThat(logOutput).doesNotContain("must be >= 0");
+    assertThat(logOutput).doesNotContain("must be at least");
+    assertThat(logOutput).doesNotContain("Defaulting to");
+    assertThat(logOutput).doesNotContain("invalid, should be between");
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
As mentioned in the issue, this PR will
- modify the default value of `hdds.datanode.volume.min.free.space.percent` based on `Datanodes.md`
- add Test for the default value checking

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13198

## How was this patch tested?

CI: https://github.com/echonesis/ozone/actions/runs/16096530965