### PR TITLE
HDDS-13341. Rename ScanResult.isHealthy() to hasErrors()

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ScanResult.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ScanResult.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScanError;
  * Encapsulates the result of a container scan.
  */
 public interface ScanResult {
-  boolean isHealthy();
+  boolean hasErrors();
 
   boolean isDeleted();
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -183,7 +183,7 @@ public class KeyValueContainerCheck {
     MetadataScanResult metadataResult = fastCheck();
     if (metadataResult.isDeleted()) {
       return DataScanResult.deleted();
-    } else if (!metadataResult.isHealthy()) {
+    } else if (!metadataResult.hasErrors()) {
       return DataScanResult.unhealthyMetadata(metadataResult);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -183,7 +183,7 @@ public class KeyValueContainerCheck {
     MetadataScanResult metadataResult = fastCheck();
     if (metadataResult.isDeleted()) {
       return DataScanResult.deleted();
-    } else if (!metadataResult.hasErrors()) {
+    } else if (metadataResult.hasErrors()) {
       return DataScanResult.unhealthyMetadata(metadataResult);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
@@ -65,7 +65,7 @@ public class BackgroundContainerMetadataScanner extends
       LOG.debug("Container [{}] has been deleted during the metadata scan.", containerID);
       return;
     }
-    if (!result.hasErrors()) {
+    if (result.hasErrors()) {
       scanHelper.handleUnhealthyScanResult(containerID, result);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
@@ -65,7 +65,7 @@ public class BackgroundContainerMetadataScanner extends
       LOG.debug("Container [{}] has been deleted during the metadata scan.", containerID);
       return;
     }
-    if (!result.isHealthy()) {
+    if (!result.hasErrors()) {
       scanHelper.handleUnhealthyScanResult(containerID, result);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
@@ -74,7 +74,7 @@ public final class ContainerScanHelper {
       } catch (IOException ex) {
         log.warn("Failed to update container checksum after scan of container {}", containerId, ex);
       }
-      if (!result.hasErrors()) {
+      if (result.hasErrors()) {
         handleUnhealthyScanResult(containerId, result);
       }
       metrics.incNumContainersScanned();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
@@ -74,7 +74,7 @@ public final class ContainerScanHelper {
       } catch (IOException ex) {
         log.warn("Failed to update container checksum after scan of container {}", containerId, ex);
       }
-      if (!result.isHealthy()) {
+      if (!result.hasErrors()) {
         handleUnhealthyScanResult(containerId, result);
       }
       metrics.incNumContainersScanned();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/DataScanResult.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/DataScanResult.java
@@ -45,7 +45,7 @@ public final class DataScanResult extends MetadataScanResult {
    * This data scan result will have an empty data tree with a zero checksum to indicate that no data was scanned.
    */
   public static DataScanResult unhealthyMetadata(MetadataScanResult result) {
-    Preconditions.checkArgument(!result.isHealthy());
+    Preconditions.checkArgument(!result.hasErrors());
     return new DataScanResult(result.getErrors(), new ContainerMerkleTreeWriter(), false);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/DataScanResult.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/DataScanResult.java
@@ -45,7 +45,7 @@ public final class DataScanResult extends MetadataScanResult {
    * This data scan result will have an empty data tree with a zero checksum to indicate that no data was scanned.
    */
   public static DataScanResult unhealthyMetadata(MetadataScanResult result) {
-    Preconditions.checkArgument(!result.hasErrors());
+    Preconditions.checkArgument(result.hasErrors());
     return new DataScanResult(result.getErrors(), new ContainerMerkleTreeWriter(), false);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/MetadataScanResult.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/MetadataScanResult.java
@@ -63,7 +63,7 @@ public class MetadataScanResult implements ScanResult {
   }
 
   @Override
-  public boolean isHealthy() {
+  public boolean hasErrors() {
     return errors.isEmpty();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/MetadataScanResult.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/MetadataScanResult.java
@@ -64,7 +64,7 @@ public class MetadataScanResult implements ScanResult {
 
   @Override
   public boolean hasErrors() {
-    return errors.isEmpty();
+    return !errors.isEmpty();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -121,7 +121,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     DataScanResult result = kvCheck.fullCheck(throttler, null);
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
 
     // Inject a metadata and a data error.
     metadataCorruption.applyTo(container);
@@ -131,7 +131,7 @@ public class TestKeyValueContainerCheck
     }
 
     result = kvCheck.fullCheck(throttler, null);
-    assertFalse(result.hasErrors());
+    assertFalse(!result.hasErrors());
     // Scan should have failed after the first metadata error and not made it to the data error.
     assertEquals(1, result.getErrors().size());
     assertEquals(metadataCorruption.getExpectedResult(), result.getErrors().get(0).getFailureType());
@@ -157,7 +157,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     DataScanResult result = kvCheck.fullCheck(throttler, null);
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     // The scanner would write the checksum file to disk. `KeyValueContainerCheck` does not, so we will create the
     // result here.
     ContainerProtos.ContainerChecksumInfo healthyChecksumInfo = ContainerProtos.ContainerChecksumInfo.newBuilder()
@@ -186,7 +186,7 @@ public class TestKeyValueContainerCheck
     result = kvCheck.fullCheck(throttler, null);
     result.getErrors().forEach(e -> LOG.info("Error detected: {}", e));
 
-    assertFalse(result.hasErrors());
+    assertFalse(!result.hasErrors());
     // Check that all data errors were detected in order.
     assertEquals(expectedErrors.size(), result.getErrors().size());
     List<FailureType> actualErrors = result.getErrors().stream()
@@ -246,13 +246,13 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     // first run checks on a Open Container
-    boolean valid = kvCheck.fastCheck().hasErrors();
+    boolean valid = !kvCheck.fastCheck().hasErrors();
     assertTrue(valid);
 
     container.close();
 
     // next run checks on a Closed Container
-    valid = kvCheck.fullCheck(new DataTransferThrottler(
+    valid = !kvCheck.fullCheck(new DataTransferThrottler(
         c.getBandwidthPerVolume()), null).hasErrors();
     assertTrue(valid);
   }
@@ -301,11 +301,11 @@ public class TestKeyValueContainerCheck
     }
 
     // metadata check should pass.
-    boolean valid = kvCheck.fastCheck().hasErrors();
+    boolean valid = !kvCheck.fastCheck().hasErrors();
     assertTrue(valid);
 
     // checksum validation should fail.
-    valid = kvCheck.fullCheck(new DataTransferThrottler(
+    valid = !kvCheck.fullCheck(new DataTransferThrottler(
             sc.getBandwidthPerVolume()), null).hasErrors();
     assertFalse(valid);
   }
@@ -320,7 +320,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(getConf(), container);
     // The full container should exist and pass a scan.
     ScanResult result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertFalse(result.isDeleted());
 
     // When a container is not marked for deletion and it has pieces missing, the scan should fail.
@@ -328,14 +328,14 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(metadataDir);
     assertFalse(metadataDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertFalse(result.hasErrors());
+    assertFalse(!result.hasErrors());
     assertFalse(result.isDeleted());
 
     // Once the container is marked for deletion, the scan should pass even if some of the internal pieces are missing.
     // Here the metadata directory has been deleted.
     container.markContainerForDelete();
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertTrue(result.isDeleted());
 
     // Now the data directory is deleted.
@@ -343,7 +343,7 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(chunksDir);
     assertFalse(chunksDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertTrue(result.isDeleted());
 
     // Now the whole container directory is gone.
@@ -351,7 +351,7 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(containerDir);
     assertFalse(containerDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertTrue(result.isDeleted());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -121,7 +121,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     DataScanResult result = kvCheck.fullCheck(throttler, null);
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
 
     // Inject a metadata and a data error.
     metadataCorruption.applyTo(container);
@@ -131,7 +131,7 @@ public class TestKeyValueContainerCheck
     }
 
     result = kvCheck.fullCheck(throttler, null);
-    assertFalse(result.isHealthy());
+    assertFalse(result.hasErrors());
     // Scan should have failed after the first metadata error and not made it to the data error.
     assertEquals(1, result.getErrors().size());
     assertEquals(metadataCorruption.getExpectedResult(), result.getErrors().get(0).getFailureType());
@@ -157,7 +157,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     DataScanResult result = kvCheck.fullCheck(throttler, null);
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     // The scanner would write the checksum file to disk. `KeyValueContainerCheck` does not, so we will create the
     // result here.
     ContainerProtos.ContainerChecksumInfo healthyChecksumInfo = ContainerProtos.ContainerChecksumInfo.newBuilder()
@@ -186,7 +186,7 @@ public class TestKeyValueContainerCheck
     result = kvCheck.fullCheck(throttler, null);
     result.getErrors().forEach(e -> LOG.info("Error detected: {}", e));
 
-    assertFalse(result.isHealthy());
+    assertFalse(result.hasErrors());
     // Check that all data errors were detected in order.
     assertEquals(expectedErrors.size(), result.getErrors().size());
     List<FailureType> actualErrors = result.getErrors().stream()
@@ -246,14 +246,14 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     // first run checks on a Open Container
-    boolean valid = kvCheck.fastCheck().isHealthy();
+    boolean valid = kvCheck.fastCheck().hasErrors();
     assertTrue(valid);
 
     container.close();
 
     // next run checks on a Closed Container
     valid = kvCheck.fullCheck(new DataTransferThrottler(
-        c.getBandwidthPerVolume()), null).isHealthy();
+        c.getBandwidthPerVolume()), null).hasErrors();
     assertTrue(valid);
   }
 
@@ -301,12 +301,12 @@ public class TestKeyValueContainerCheck
     }
 
     // metadata check should pass.
-    boolean valid = kvCheck.fastCheck().isHealthy();
+    boolean valid = kvCheck.fastCheck().hasErrors();
     assertTrue(valid);
 
     // checksum validation should fail.
     valid = kvCheck.fullCheck(new DataTransferThrottler(
-            sc.getBandwidthPerVolume()), null).isHealthy();
+            sc.getBandwidthPerVolume()), null).hasErrors();
     assertFalse(valid);
   }
 
@@ -320,7 +320,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(getConf(), container);
     // The full container should exist and pass a scan.
     ScanResult result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
 
     // When a container is not marked for deletion and it has pieces missing, the scan should fail.
@@ -328,14 +328,14 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(metadataDir);
     assertFalse(metadataDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertFalse(result.isHealthy());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
 
     // Once the container is marked for deletion, the scan should pass even if some of the internal pieces are missing.
     // Here the metadata directory has been deleted.
     container.markContainerForDelete();
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertTrue(result.isDeleted());
 
     // Now the data directory is deleted.
@@ -343,7 +343,7 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(chunksDir);
     assertFalse(chunksDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertTrue(result.isDeleted());
 
     // Now the whole container directory is gone.
@@ -351,7 +351,7 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(containerDir);
     assertFalse(containerDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertTrue(result.isDeleted());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -121,7 +121,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     DataScanResult result = kvCheck.fullCheck(throttler, null);
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
 
     // Inject a metadata and a data error.
     metadataCorruption.applyTo(container);
@@ -131,7 +131,7 @@ public class TestKeyValueContainerCheck
     }
 
     result = kvCheck.fullCheck(throttler, null);
-    assertFalse(!result.hasErrors());
+    assertTrue(result.hasErrors());
     // Scan should have failed after the first metadata error and not made it to the data error.
     assertEquals(1, result.getErrors().size());
     assertEquals(metadataCorruption.getExpectedResult(), result.getErrors().get(0).getFailureType());
@@ -157,7 +157,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(conf, container);
 
     DataScanResult result = kvCheck.fullCheck(throttler, null);
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     // The scanner would write the checksum file to disk. `KeyValueContainerCheck` does not, so we will create the
     // result here.
     ContainerProtos.ContainerChecksumInfo healthyChecksumInfo = ContainerProtos.ContainerChecksumInfo.newBuilder()
@@ -320,7 +320,7 @@ public class TestKeyValueContainerCheck
     KeyValueContainerCheck kvCheck = new KeyValueContainerCheck(getConf(), container);
     // The full container should exist and pass a scan.
     ScanResult result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
 
     // When a container is not marked for deletion and it has pieces missing, the scan should fail.
@@ -328,14 +328,14 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(metadataDir);
     assertFalse(metadataDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertFalse(!result.hasErrors());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
 
     // Once the container is marked for deletion, the scan should pass even if some of the internal pieces are missing.
     // Here the metadata directory has been deleted.
     container.markContainerForDelete();
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertTrue(result.isDeleted());
 
     // Now the data directory is deleted.
@@ -343,7 +343,7 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(chunksDir);
     assertFalse(chunksDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertTrue(result.isDeleted());
 
     // Now the whole container directory is gone.
@@ -351,7 +351,7 @@ public class TestKeyValueContainerCheck
     FileUtils.deleteDirectory(containerDir);
     assertFalse(containerDir.exists());
     result = kvCheck.fullCheck(mock(DataTransferThrottler.class), mock(Canceler.class));
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertTrue(result.isDeleted());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -186,7 +186,7 @@ public class TestKeyValueContainerCheck
     result = kvCheck.fullCheck(throttler, null);
     result.getErrors().forEach(e -> LOG.info("Error detected: {}", e));
 
-    assertFalse(!result.hasErrors());
+    assertTrue(result.hasErrors());
     // Check that all data errors were detected in order.
     assertEquals(expectedErrors.size(), result.getErrors().size());
     List<FailureType> actualErrors = result.getErrors().stream()

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
@@ -39,7 +39,7 @@ class TestDataScanResult {
   void testFromEmptyErrors() {
     // No errors means the scan result is healthy.
     DataScanResult result = DataScanResult.fromErrors(Collections.emptyList(), TREE);
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("0 errors"));
@@ -51,7 +51,7 @@ class TestDataScanResult {
     MetadataScanResult metadataResult =
         MetadataScanResult.fromErrors(Collections.singletonList(getMetadataScanError()));
     DataScanResult result = DataScanResult.unhealthyMetadata(metadataResult);
-    assertFalse(result.isHealthy());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(1, result.getErrors().size());
     assertTrue(result.toString().contains("1 error"));
@@ -62,7 +62,7 @@ class TestDataScanResult {
   @Test
   void testFromErrors() {
     DataScanResult result = DataScanResult.fromErrors(Arrays.asList(getDataScanError(), getDataScanError()), TREE);
-    assertFalse(result.isHealthy());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(2, result.getErrors().size());
     assertTrue(result.toString().contains("2 errors"));
@@ -73,7 +73,7 @@ class TestDataScanResult {
   @Test
   void testDeleted() {
     DataScanResult result = DataScanResult.deleted();
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertTrue(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
@@ -39,7 +39,7 @@ class TestDataScanResult {
   void testFromEmptyErrors() {
     // No errors means the scan result is healthy.
     DataScanResult result = DataScanResult.fromErrors(Collections.emptyList(), TREE);
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("0 errors"));
@@ -51,7 +51,7 @@ class TestDataScanResult {
     MetadataScanResult metadataResult =
         MetadataScanResult.fromErrors(Collections.singletonList(getMetadataScanError()));
     DataScanResult result = DataScanResult.unhealthyMetadata(metadataResult);
-    assertFalse(!result.hasErrors());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(1, result.getErrors().size());
     assertTrue(result.toString().contains("1 error"));
@@ -62,7 +62,7 @@ class TestDataScanResult {
   @Test
   void testFromErrors() {
     DataScanResult result = DataScanResult.fromErrors(Arrays.asList(getDataScanError(), getDataScanError()), TREE);
-    assertFalse(!result.hasErrors());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(2, result.getErrors().size());
     assertTrue(result.toString().contains("2 errors"));
@@ -73,7 +73,7 @@ class TestDataScanResult {
   @Test
   void testDeleted() {
     DataScanResult result = DataScanResult.deleted();
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertTrue(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
@@ -39,7 +39,7 @@ class TestDataScanResult {
   void testFromEmptyErrors() {
     // No errors means the scan result is healthy.
     DataScanResult result = DataScanResult.fromErrors(Collections.emptyList(), TREE);
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertFalse(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("0 errors"));
@@ -51,7 +51,7 @@ class TestDataScanResult {
     MetadataScanResult metadataResult =
         MetadataScanResult.fromErrors(Collections.singletonList(getMetadataScanError()));
     DataScanResult result = DataScanResult.unhealthyMetadata(metadataResult);
-    assertFalse(result.hasErrors());
+    assertFalse(!result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(1, result.getErrors().size());
     assertTrue(result.toString().contains("1 error"));
@@ -62,7 +62,7 @@ class TestDataScanResult {
   @Test
   void testFromErrors() {
     DataScanResult result = DataScanResult.fromErrors(Arrays.asList(getDataScanError(), getDataScanError()), TREE);
-    assertFalse(result.hasErrors());
+    assertFalse(!result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(2, result.getErrors().size());
     assertTrue(result.toString().contains("2 errors"));
@@ -73,7 +73,7 @@ class TestDataScanResult {
   @Test
   void testDeleted() {
     DataScanResult result = DataScanResult.deleted();
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertTrue(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestMetadataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestMetadataScanResult.java
@@ -31,7 +31,7 @@ class TestMetadataScanResult {
   void testFromEmptyErrors() {
     // No errors means the scan result is healthy.
     MetadataScanResult result = MetadataScanResult.fromErrors(Collections.emptyList());
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("0 errors"));
@@ -41,7 +41,7 @@ class TestMetadataScanResult {
   void testFromErrors() {
     MetadataScanResult result =
         MetadataScanResult.fromErrors(Arrays.asList(getMetadataScanError(), getMetadataScanError()));
-    assertFalse(!result.hasErrors());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(2, result.getErrors().size());
     assertTrue(result.toString().contains("2 errors"));
@@ -50,7 +50,7 @@ class TestMetadataScanResult {
   @Test
   void testDeleted() {
     MetadataScanResult result = MetadataScanResult.deleted();
-    assertTrue(!result.hasErrors());
+    assertFalse(result.hasErrors());
     assertTrue(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestMetadataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestMetadataScanResult.java
@@ -31,7 +31,7 @@ class TestMetadataScanResult {
   void testFromEmptyErrors() {
     // No errors means the scan result is healthy.
     MetadataScanResult result = MetadataScanResult.fromErrors(Collections.emptyList());
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertFalse(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("0 errors"));
@@ -41,7 +41,7 @@ class TestMetadataScanResult {
   void testFromErrors() {
     MetadataScanResult result =
         MetadataScanResult.fromErrors(Arrays.asList(getMetadataScanError(), getMetadataScanError()));
-    assertFalse(result.hasErrors());
+    assertFalse(!result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(2, result.getErrors().size());
     assertTrue(result.toString().contains("2 errors"));
@@ -50,7 +50,7 @@ class TestMetadataScanResult {
   @Test
   void testDeleted() {
     MetadataScanResult result = MetadataScanResult.deleted();
-    assertTrue(result.hasErrors());
+    assertTrue(!result.hasErrors());
     assertTrue(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestMetadataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestMetadataScanResult.java
@@ -31,7 +31,7 @@ class TestMetadataScanResult {
   void testFromEmptyErrors() {
     // No errors means the scan result is healthy.
     MetadataScanResult result = MetadataScanResult.fromErrors(Collections.emptyList());
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertFalse(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("0 errors"));
@@ -41,7 +41,7 @@ class TestMetadataScanResult {
   void testFromErrors() {
     MetadataScanResult result =
         MetadataScanResult.fromErrors(Arrays.asList(getMetadataScanError(), getMetadataScanError()));
-    assertFalse(result.isHealthy());
+    assertFalse(result.hasErrors());
     assertFalse(result.isDeleted());
     assertEquals(2, result.getErrors().size());
     assertTrue(result.toString().contains("2 errors"));
@@ -50,7 +50,7 @@ class TestMetadataScanResult {
   @Test
   void testDeleted() {
     MetadataScanResult result = MetadataScanResult.deleted();
-    assertTrue(result.isHealthy());
+    assertTrue(result.hasErrors());
     assertTrue(result.isDeleted());
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Hdds-13341: Renamed the method ishealthy in ScanResult.java to hasErrors 

Please describe your PR in detail:
Renamed the method ishealthy in ScanResult.java to hasErrors 


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13341

## How was this patch tested?
Ran Unit tests
