### PR TITLE
HDDS-12955. Remove getCurrentContainerThreshold from SCMSafeModeManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -237,12 +237,6 @@ public class SCMSafeModeManager implements SafeModeManager {
     return LOG;
   }
 
-  // TODO: This will be removed by HDDS-12955
-  public double getCurrentContainerThreshold() {
-    return ((RatisContainerSafeModeRule) exitRules.get("RatisContainerSafeModeRule"))
-        .getCurrentContainerThreshold();
-  }
-
   /**
    * Class used during SafeMode status event.
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -138,7 +138,9 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManagerImpl;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineReportHandler;
 import org.apache.hadoop.hdds.scm.pipeline.WritableContainerFactory;
 import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.PipelineChoosePolicyFactory;
+import org.apache.hadoop.hdds.scm.safemode.RatisContainerSafeModeRule;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeRuleFactory;
 import org.apache.hadoop.hdds.scm.security.RootCARotationManager;
 import org.apache.hadoop.hdds.scm.security.SecretKeyManagerService;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReport;
@@ -1977,7 +1979,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   @VisibleForTesting
   public double getCurrentContainerThreshold() {
-    return scmSafeModeManager.getCurrentContainerThreshold();
+    RatisContainerSafeModeRule rule = SafeModeRuleFactory.getInstance()
+        .getSafeModeRule(RatisContainerSafeModeRule.class);
+    return rule != null ? rule.getCurrentContainerThreshold() : 1.0;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed getCurrentContainerThreshold from SCMSafeModeManager and updated its usage in StorageContainerManager.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12955

## How was this patch tested?
Pass all existing tests
https://github.com/erichung9060/ozone/actions/runs/16085692295
