### PR TITLE
HDDS-13192. Adding pending delete bytes info in storage report of DN

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -40,6 +40,7 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
   private final long remaining;
   private final long committed;
   private final long freeSpaceToSpare;
+  private final long pendingDeletions;
   private final StorageType storageType;
   private final String storageLocation;
 
@@ -53,6 +54,7 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
     this.freeSpaceToSpare = builder.freeSpaceToSpare;
     this.storageType = builder.storageType;
     this.storageLocation = builder.storageLocation;
+    this.pendingDeletions = builder.pendingDeletions;
   }
 
   public long getUsableSpace() {
@@ -92,6 +94,11 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
   @Override
   public long getFreeSpaceToSpare() {
     return freeSpaceToSpare;
+  }
+
+  @Override
+  public long getPendingDeletions() {
+    return pendingDeletions;
   }
 
   @Override
@@ -179,6 +186,7 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
         .setStorageLocation(getStorageLocation())
         .setFailed(isFailed())
         .setFreeSpaceToSpare(getFreeSpaceToSpare())
+        .setPendingDeletions(getPendingDeletions())
         .build();
   }
 
@@ -226,6 +234,10 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
       builder.setRemaining(report.getRemaining());
     }
 
+    if (report.hasPendingDeletions()) {
+      builder.setPendingDeletions(report.getPendingDeletions());
+    }
+
     if (report.hasFailed()) {
       builder.setFailed(report.getFailed());
     }
@@ -247,6 +259,7 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
           .append(" used=").append(scmUsed)
           .append(" available=").append(remaining)
           .append(" minFree=").append(freeSpaceToSpare)
+          .append(" pendingDeletions=").append(pendingDeletions)
           .append(" committed=").append(committed);
     }
 
@@ -273,6 +286,7 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
     private long remaining;
     private long committed;
     private long freeSpaceToSpare;
+    private long pendingDeletions;
     private StorageType storageType;
     private String storageLocation;
 
@@ -370,6 +384,16 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
      */
     public Builder setFreeSpaceToSpare(long freeSpaceToSpare) {
       this.freeSpaceToSpare = freeSpaceToSpare;
+      return this;
+    }
+
+    /**
+     * Sets the pending deletion bytes.
+     * @param pendingDeletions the size in bytes that is pending deletion.
+     * @return StorageLocationReport.Builder
+     */
+    public Builder setPendingDeletions(long pendingDeletions) {
+      this.pendingDeletions = pendingDeletions;
       return this;
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/StorageLocationReportMXBean.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/StorageLocationReportMXBean.java
@@ -36,6 +36,8 @@ public interface StorageLocationReportMXBean {
 
   long getFreeSpaceToSpare();
 
+  long getPendingDeletions();
+
   String getStorageLocation();
 
   String getStorageTypeName();

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -215,6 +215,7 @@ message DatanodeUsageInfoProto {
     optional int64 committed = 6;
     optional int64 freeSpaceToSpare = 7;
     optional int64 pipelineCount = 8;
+    optional int64 pendingDeletions = 9;
 }
 
 /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -182,6 +182,7 @@ message StorageReportProto {
   optional bool failed = 7 [default = false];
   optional uint64 committed = 8 [default = 0];
   optional uint64 freeSpaceToSpare = 9 [default = 0];
+  optional uint64 pendingDeletions = 10 [default = 0];
 }
 
 message MetadataStorageReportProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -1066,7 +1066,7 @@ public class ContainerBalancerTask implements Runnable {
       return 0;
     }
     SCMNodeStat aggregatedStats = new SCMNodeStat(
-        0, 0, 0, 0, 0);
+        0, 0, 0, 0, 0, 0);
     for (DatanodeUsageInfo node : nodes) {
       aggregatedStats.add(node.getScmNodeStat());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/NodeStat.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/NodeStat.java
@@ -53,6 +53,8 @@ interface NodeStat {
    */
   LongMetric getFreeSpaceToSpare();
 
+  LongMetric getPendingDeletions();
+
   /**
    * Set the total/used/remaining space.
    * @param capacity - total space.
@@ -61,7 +63,7 @@ interface NodeStat {
    */
   @VisibleForTesting
   void set(long capacity, long used, long remain, long committed,
-           long freeSpaceToSpare);
+           long freeSpaceToSpare, long pendingDeletions);
 
   /**
    * Adding of the stat.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeMetric.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeMetric.java
@@ -46,9 +46,9 @@ public class SCMNodeMetric implements DatanodeMetric<SCMNodeStat, Long>,
    */
   @VisibleForTesting
   public SCMNodeMetric(long capacity, long used, long remaining,
-                       long committed, long freeSpaceToSpare) {
+                       long committed, long freeSpaceToSpare, long pendingDeletions) {
     this.stat = new SCMNodeStat();
-    this.stat.set(capacity, used, remaining, committed, freeSpaceToSpare);
+    this.stat.set(capacity, used, remaining, committed, freeSpaceToSpare, pendingDeletions);
   }
 
   /**
@@ -160,7 +160,7 @@ public class SCMNodeMetric implements DatanodeMetric<SCMNodeStat, Long>,
   public void set(SCMNodeStat value) {
     stat.set(value.getCapacity().get(), value.getScmUsed().get(),
         value.getRemaining().get(), value.getCommitted().get(),
-        value.getFreeSpaceToSpare().get());
+        value.getFreeSpaceToSpare().get(), value.getPendingDeletions().get());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
@@ -29,29 +29,33 @@ public class SCMNodeStat implements NodeStat {
   private LongMetric remaining;
   private LongMetric committed;
   private LongMetric freeSpaceToSpare;
+  private LongMetric pendingDeletions;
 
   public SCMNodeStat() {
-    this(0L, 0L, 0L, 0L, 0L);
+    this(0L, 0L, 0L, 0L, 0L, 0L);
   }
 
   public SCMNodeStat(SCMNodeStat other) {
     this(other.capacity.get(), other.scmUsed.get(), other.remaining.get(),
-        other.committed.get(), other.freeSpaceToSpare.get());
+        other.committed.get(), other.freeSpaceToSpare.get(), other.pendingDeletions.get());
   }
 
   public SCMNodeStat(long capacity, long used, long remaining, long committed,
-                     long freeSpaceToSpare) {
+                     long freeSpaceToSpare, long pendingDeletions) {
     Preconditions.checkArgument(capacity >= 0, "Capacity cannot be " +
         "negative.");
     Preconditions.checkArgument(used >= 0, "used space cannot be " +
         "negative.");
     Preconditions.checkArgument(remaining >= 0, "remaining cannot be " +
         "negative");
+    Preconditions.checkArgument(pendingDeletions >= 0, "pendingDeletions cannot be " +
+        "negative");
     this.capacity = new LongMetric(capacity);
     this.scmUsed = new LongMetric(used);
     this.remaining = new LongMetric(remaining);
     this.committed = new LongMetric(committed);
     this.freeSpaceToSpare = new LongMetric(freeSpaceToSpare);
+    this.pendingDeletions = new LongMetric(pendingDeletions);
   }
 
   /**
@@ -96,6 +100,11 @@ public class SCMNodeStat implements NodeStat {
     return freeSpaceToSpare;
   }
 
+  @Override
+  public LongMetric getPendingDeletions() {
+    return pendingDeletions;
+  }
+
   /**
    * Set the capacity, used and remaining space on a datanode.
    *
@@ -106,7 +115,7 @@ public class SCMNodeStat implements NodeStat {
   @Override
   @VisibleForTesting
   public void set(long newCapacity, long newUsed, long newRemaining,
-                  long newCommitted, long newFreeSpaceToSpare) {
+                  long newCommitted, long newFreeSpaceToSpare, long newPendingDeletions) {
     Preconditions.checkArgument(newCapacity >= 0, "Capacity cannot be " +
         "negative.");
     Preconditions.checkArgument(newUsed >= 0, "used space cannot be " +
@@ -119,6 +128,7 @@ public class SCMNodeStat implements NodeStat {
     this.remaining = new LongMetric(newRemaining);
     this.committed = new LongMetric(newCommitted);
     this.freeSpaceToSpare = new LongMetric(newFreeSpaceToSpare);
+    this.pendingDeletions = new LongMetric(newPendingDeletions);
   }
 
   /**
@@ -135,6 +145,7 @@ public class SCMNodeStat implements NodeStat {
     this.committed.set(this.getCommitted().get() + stat.getCommitted().get());
     this.freeSpaceToSpare.set(this.freeSpaceToSpare.get() +
         stat.getFreeSpaceToSpare().get());
+    this.pendingDeletions.set(this.pendingDeletions.get() + stat.getPendingDeletions().get());
     return this;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -220,6 +220,7 @@ public class DatanodeUsageInfo {
       builder.setRemaining(scmNodeStat.getRemaining().get());
       builder.setCommitted(scmNodeStat.getCommitted().get());
       builder.setFreeSpaceToSpare(scmNodeStat.getFreeSpaceToSpare().get());
+      builder.setPendingDeletions(scmNodeStat.getPendingDeletions().get());
     }
 
     builder.setContainerCount(containerCount);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -933,6 +933,7 @@ public class SCMNodeManager implements NodeManager {
     long remaining = 0L;
     long committed = 0L;
     long freeSpaceToSpare = 0L;
+    long pendingDeletions = 0L;
 
     for (SCMNodeStat stat : getNodeStats().values()) {
       capacity += stat.getCapacity().get();
@@ -940,9 +941,11 @@ public class SCMNodeManager implements NodeManager {
       remaining += stat.getRemaining().get();
       committed += stat.getCommitted().get();
       freeSpaceToSpare += stat.getFreeSpaceToSpare().get();
+      pendingDeletions += stat.getPendingDeletions().get();
+
     }
     return new SCMNodeStat(capacity, used, remaining, committed,
-        freeSpaceToSpare);
+        freeSpaceToSpare, pendingDeletions);
   }
 
   /**
@@ -1049,6 +1052,7 @@ public class SCMNodeManager implements NodeManager {
       long remaining = 0L;
       long committed = 0L;
       long freeSpaceToSpare = 0L;
+      long pendingDeletions = 0L;
 
       final DatanodeInfo datanodeInfo = nodeStateManager
           .getNode(datanodeDetails);
@@ -1060,9 +1064,10 @@ public class SCMNodeManager implements NodeManager {
         remaining += reportProto.getRemaining();
         committed += reportProto.getCommitted();
         freeSpaceToSpare += reportProto.getFreeSpaceToSpare();
+        pendingDeletions += reportProto.getPendingDeletions();
       }
       return new SCMNodeStat(capacity, used, remaining, committed,
-          freeSpaceToSpare);
+          freeSpaceToSpare, pendingDeletions);
     } catch (NodeNotFoundException e) {
       LOG.warn("Cannot generate NodeStat, datanode {} not found.", datanodeDetails);
       return null;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -220,7 +220,7 @@ public class MockNodeManager implements NodeManager {
         NODES[x % NODES.length].capacity - NODES[x % NODES.length].used;
     newStat.set(
         (NODES[x % NODES.length].capacity),
-        (NODES[x % NODES.length].used), remaining, 0, 100000);
+        (NODES[x % NODES.length].used), remaining, 0, 100000, 0);
     this.nodeMetricMap.put(datanodeDetails, newStat);
     aggregateStat.add(newStat);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -468,7 +468,7 @@ public class TestContainerBalancerTask {
       }
       SCMNodeStat stat = new SCMNodeStat(datanodeCapacity, datanodeUsedSpace,
           datanodeCapacity - datanodeUsedSpace, 0,
-          datanodeCapacity - datanodeUsedSpace - 1);
+          datanodeCapacity - datanodeUsedSpace - 1, 0);
       nodesInCluster.get(i).setScmNodeStat(stat);
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
@@ -53,11 +53,11 @@ public class TestFindTargetStrategy {
 
     //create three datanodes with different usageinfo
     DatanodeUsageInfo dui1 = new DatanodeUsageInfo(MockDatanodeDetails
-        .randomDatanodeDetails(), new SCMNodeStat(100, 0, 40, 0, 30));
+        .randomDatanodeDetails(), new SCMNodeStat(100, 0, 40, 0, 30, 0));
     DatanodeUsageInfo dui2 = new DatanodeUsageInfo(MockDatanodeDetails
-        .randomDatanodeDetails(), new SCMNodeStat(100, 0, 60, 0, 30));
+        .randomDatanodeDetails(), new SCMNodeStat(100, 0, 60, 0, 30, 0));
     DatanodeUsageInfo dui3 = new DatanodeUsageInfo(MockDatanodeDetails
-        .randomDatanodeDetails(), new SCMNodeStat(100, 0, 80, 0, 30));
+        .randomDatanodeDetails(), new SCMNodeStat(100, 0, 80, 0, 30, 0));
 
     //insert in ascending order
     overUtilizedDatanodes.add(dui1);
@@ -92,11 +92,11 @@ public class TestFindTargetStrategy {
   public void testResetPotentialTargets() {
     // create three datanodes with different usage infos
     DatanodeUsageInfo dui1 = new DatanodeUsageInfo(MockDatanodeDetails
-        .randomDatanodeDetails(), new SCMNodeStat(100, 30, 70, 0, 50));
+        .randomDatanodeDetails(), new SCMNodeStat(100, 30, 70, 0, 50, 0));
     DatanodeUsageInfo dui2 = new DatanodeUsageInfo(MockDatanodeDetails
-        .randomDatanodeDetails(), new SCMNodeStat(100, 20, 80, 0, 60));
+        .randomDatanodeDetails(), new SCMNodeStat(100, 20, 80, 0, 60, 0));
     DatanodeUsageInfo dui3 = new DatanodeUsageInfo(MockDatanodeDetails
-        .randomDatanodeDetails(), new SCMNodeStat(100, 10, 90, 0, 70));
+        .randomDatanodeDetails(), new SCMNodeStat(100, 10, 90, 0, 70, 0));
 
     List<DatanodeUsageInfo> potentialTargets = new ArrayList<>();
     potentialTargets.add(dui1);
@@ -171,18 +171,18 @@ public class TestFindTargetStrategy {
     List<DatanodeUsageInfo> overUtilizedDatanodes = new ArrayList<>();
     //set the farthest target with the lowest usage info
     overUtilizedDatanodes.add(
-        new DatanodeUsageInfo(target5, new SCMNodeStat(100, 0, 90, 0, 80)));
+        new DatanodeUsageInfo(target5, new SCMNodeStat(100, 0, 90, 0, 80, 0)));
     //set the tree targets, which have the same network topology distance
     //to source , with different usage info
     overUtilizedDatanodes.add(
-        new DatanodeUsageInfo(target2, new SCMNodeStat(100, 0, 20, 0, 10)));
+        new DatanodeUsageInfo(target2, new SCMNodeStat(100, 0, 20, 0, 10, 0)));
     overUtilizedDatanodes.add(
-        new DatanodeUsageInfo(target3, new SCMNodeStat(100, 0, 40, 0, 30)));
+        new DatanodeUsageInfo(target3, new SCMNodeStat(100, 0, 40, 0, 30, 0)));
     overUtilizedDatanodes.add(
-        new DatanodeUsageInfo(target4, new SCMNodeStat(100, 0, 60, 0, 50)));
+        new DatanodeUsageInfo(target4, new SCMNodeStat(100, 0, 60, 0, 50, 0)));
     //set the nearest target with the highest usage info
     overUtilizedDatanodes.add(
-        new DatanodeUsageInfo(target1, new SCMNodeStat(100, 0, 10, 0, 5)));
+        new DatanodeUsageInfo(target1, new SCMNodeStat(100, 0, 10, 0, 5, 0)));
 
 
     FindTargetGreedyByNetworkTopology findTargetGreedyByNetworkTopology =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
@@ -80,7 +80,7 @@ public final class TestableCluster {
 
       SCMNodeStat stat = new SCMNodeStat(datanodeCapacity, datanodeUsedSpace,
           datanodeCapacity - datanodeUsedSpace, 0,
-          datanodeCapacity - datanodeUsedSpace - 1);
+          datanodeCapacity - datanodeUsedSpace - 1, 0);
       nodesInCluster[i].setScmNodeStat(stat);
       clusterUsedSpace += datanodeUsedSpace;
       clusterCapacity += datanodeCapacity;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -105,13 +105,13 @@ public class TestSCMContainerPlacementCapacity {
         .thenReturn(new ArrayList<>(datanodes));
 
     when(mockNodeManager.getNodeStat(any()))
-        .thenReturn(new SCMNodeMetric(100L, 0L, 100L, 0, 90));
+        .thenReturn(new SCMNodeMetric(100L, 0L, 100L, 0, 90, 0));
     when(mockNodeManager.getNodeStat(datanodes.get(2)))
-        .thenReturn(new SCMNodeMetric(100L, 90L, 10L, 0, 9));
+        .thenReturn(new SCMNodeMetric(100L, 90L, 10L, 0, 9, 0));
     when(mockNodeManager.getNodeStat(datanodes.get(3)))
-        .thenReturn(new SCMNodeMetric(100L, 80L, 20L, 0, 19));
+        .thenReturn(new SCMNodeMetric(100L, 80L, 20L, 0, 19, 0));
     when(mockNodeManager.getNodeStat(datanodes.get(4)))
-        .thenReturn(new SCMNodeMetric(100L, 70L, 30L, 0, 20));
+        .thenReturn(new SCMNodeMetric(100L, 70L, 30L, 0, 20, 0));
     when(mockNodeManager.getNode(any(DatanodeID.class))).thenAnswer(
             invocation -> datanodes.stream()
                 .filter(dn -> dn.getID().equals(invocation.getArgument(0)))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestCapacityPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestCapacityPipelineChoosePolicy.java
@@ -53,13 +53,13 @@ public class TestCapacityPipelineChoosePolicy {
     // used       0   10    20    30
     NodeManager mockNodeManager = mock(NodeManager.class);
     when(mockNodeManager.getNodeStat(datanodes.get(0)))
-        .thenReturn(new SCMNodeMetric(100L, 0, 100L, 0, 0));
+        .thenReturn(new SCMNodeMetric(100L, 0, 100L, 0, 0, 0));
     when(mockNodeManager.getNodeStat(datanodes.get(1)))
-        .thenReturn(new SCMNodeMetric(100L, 10L, 90L, 0, 0));
+        .thenReturn(new SCMNodeMetric(100L, 10L, 90L, 0, 0, 0));
     when(mockNodeManager.getNodeStat(datanodes.get(2)))
-        .thenReturn(new SCMNodeMetric(100L, 20L, 80L, 0, 0));
+        .thenReturn(new SCMNodeMetric(100L, 20L, 80L, 0, 0, 0));
     when(mockNodeManager.getNodeStat(datanodes.get(3)))
-        .thenReturn(new SCMNodeMetric(100L, 30L, 70L, 0, 0));
+        .thenReturn(new SCMNodeMetric(100L, 30L, 70L, 0, 0, 0));
 
     PipelineChoosePolicy policy = new CapacityPipelineChoosePolicy().init(mockNodeManager);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestDatanodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestDatanodeMetrics.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.Test;
 public class TestDatanodeMetrics {
   @Test
   public void testSCMNodeMetric() {
-    SCMNodeStat stat = new SCMNodeStat(100L, 10L, 90L, 0, 80);
+    SCMNodeStat stat = new SCMNodeStat(100L, 10L, 90L, 0, 80, 0);
     assertEquals((long) stat.getCapacity().get(), 100L);
     assertEquals(10L, (long) stat.getScmUsed().get());
     assertEquals(90L, (long) stat.getRemaining().get());
     SCMNodeMetric metric = new SCMNodeMetric(stat);
 
-    SCMNodeStat newStat = new SCMNodeStat(100L, 10L, 90L, 0, 80);
+    SCMNodeStat newStat = new SCMNodeStat(100L, 10L, 90L, 0, 80, 0);
     assertEquals(100L, (long) stat.getCapacity().get());
     assertEquals(10L, (long) stat.getScmUsed().get());
     assertEquals(90L, (long) stat.getRemaining().get());
@@ -52,8 +52,8 @@ public class TestDatanodeMetrics {
     assertTrue(metric.isGreater(zeroMetric.get()));
 
     // Another case when nodes have similar weight
-    SCMNodeStat stat1 = new SCMNodeStat(10000000L, 50L, 9999950L, 0, 100000);
-    SCMNodeStat stat2 = new SCMNodeStat(10000000L, 51L, 9999949L, 0, 100000);
+    SCMNodeStat stat1 = new SCMNodeStat(10000000L, 50L, 9999950L, 0, 100000, 0);
+    SCMNodeStat stat2 = new SCMNodeStat(10000000L, 51L, 9999949L, 0, 100000, 0);
     assertTrue(new SCMNodeMetric(stat2).isGreater(stat1));
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -1404,6 +1404,6 @@ public class TestNSSummaryEndpointWithFSO {
 
   private static SCMNodeStat getMockSCMRootStat() {
     return new SCMNodeStat(ROOT_QUOTA, ROOT_DATA_SIZE,
-        ROOT_QUOTA - ROOT_DATA_SIZE, 0, ROOT_QUOTA - ROOT_DATA_SIZE - 1);
+        ROOT_QUOTA - ROOT_DATA_SIZE, 0, ROOT_QUOTA - ROOT_DATA_SIZE - 1, 0);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -1330,6 +1330,6 @@ public class TestNSSummaryEndpointWithLegacy {
 
   private static SCMNodeStat getMockSCMRootStat() {
     return new SCMNodeStat(ROOT_QUOTA, ROOT_DATA_SIZE, 
-        ROOT_QUOTA - ROOT_DATA_SIZE, 0, ROOT_QUOTA - ROOT_DATA_SIZE - 1);
+        ROOT_QUOTA - ROOT_DATA_SIZE, 0, ROOT_QUOTA - ROOT_DATA_SIZE - 1, 0);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithOBSAndLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithOBSAndLegacy.java
@@ -1450,7 +1450,7 @@ public class TestNSSummaryEndpointWithOBSAndLegacy {
 
   private static SCMNodeStat getMockSCMRootStat() {
     return new SCMNodeStat(ROOT_QUOTA, ROOT_DATA_SIZE,
-        ROOT_QUOTA - ROOT_DATA_SIZE, 0L, 0L);
+        ROOT_QUOTA - ROOT_DATA_SIZE, 0L, 0L, 0);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Accurate accounting of pending-delete bytes per container
- Added `incrPendingDeletions(long)` and `decrPendingDeletions(long)` to `ContainerData` with a new `pendingDeletionBytes` field that is persisted in container metadata.
- Integrated the counter with `DeleteBlocksCommandHandler`:
  - Introduced helper method `incrPendingDeletionBytes()` which sums the sizes of blocks in each `DeletedBlocksTransaction` and updates the container’s counter when blocks are logically marked for deletion.
  - When blocks are physically removed in `deleteViaTransactionStore()`, the counter is decremented accordingly.

### Datanode-level aggregation & reporting
- `StorageReport` now includes an aggregated `pendingDeletionBytes` value (sum across all containers).
- Introduced a short-lived in-memory cache (default TTL: 10 minutes) for the aggregated value to avoid recomputing on every heartbeat, reducing CPU overhead.

### Metrics & API exposure
- Exposed `pendingDeletionBytes` as a Datanode metric.
- Extended:
  - Datanode-to-SCM heartbeat protobuf to include the new metric.
  - Recon REST API (`/datanode`) to surface the pending deletion bytes.

### Upgrade path for existing clusters
- For containers created before the upgrade:
  - During open, if `pendingDeletionBytes` is missing, it is computed using `KeyValueContainerUtil.populateContainerMetadata()` by scanning the block table.
  - A background task reprocesses existing delete transactions and block metadata to compute accurate pending delete sizes.
- Mixed-version compatibility:
  - Older DNs/SCMs gracefully ignore unknown fields.
  - Recon detects support and falls back to legacy logic if needed.

## What is the link to the Apache JIRA

[HDDS-13192](https://issues.apache.org/jira/browse/HDDS-13192)


## How was this patch tested?

### Unit Tests
- Verified counter updates via unit tests in `ContainerData`.
- Added unit tests for `DeleteBlocksCommandHandler` flows that mark and delete blocks.

### Integration Testing
- Pending

### Upgrade & Backward Compatibility
- No impacts

### Performance Testing
- Pending
