### PR TITLE
HDDS-13387. OMSnapshotCreateRequest logs invalid warning about DefaultReplicationConfig

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -339,8 +339,6 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
     DefaultReplicationConfig defRC = bucketInfo.getDefaultReplicationConfig();
     final ReplicationConfig rc;
     if (defRC == null) {
-      // Note: A lot of tests are not setting bucket DefaultReplicationConfig,
-      //  sometimes intentionally.
       //  Fall back to config default.
       rc = ReplicationConfig.getDefault(new OzoneConfiguration());
     } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -341,12 +341,8 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
     if (defRC == null) {
       // Note: A lot of tests are not setting bucket DefaultReplicationConfig,
       //  sometimes intentionally.
-      //  Fall back to config default and print warning level log.
+      //  Fall back to config default.
       rc = ReplicationConfig.getDefault(new OzoneConfiguration());
-      LOG.warn("DefaultReplicationConfig is not correctly set in " +
-          "OmBucketInfo for volume '{}' bucket '{}'. " +
-          "Falling back to config default '{}'",
-          bucketInfo.getVolumeName(), bucketInfo.getBucketName(), rc);
     } else {
       rc = defRC.getReplicationConfig();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
It is normal for a bucket to not have replication config, in this case the default config would be used. So this need not be logged as a warning message.

## What is the link to the Apache JIRA

[HDDS-13387](https://issues.apache.org/jira/browse/HDDS-13387)

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/16110023140
