### PR TITLE
HDDS-13404. Improve persistent test data dir creation/cleanup

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -25,23 +25,13 @@ export COMPOSE_DIR
 
 export OZONE_VOLUME
 
-# Clean up saved internal state from each container's volume for the next run.
-rm -rf "${OZONE_VOLUME}"
-mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om1,om2,om3,scm}
-
-if [[ -n "${OZONE_VOLUME_OWNER}" ]]; then
-  current_user=$(whoami)
-  if [[ "${OZONE_VOLUME_OWNER}" != "${current_user}" ]]; then
-    chown -R "${OZONE_VOLUME_OWNER}" "${OZONE_VOLUME}" \
-      || sudo chown -R "${OZONE_VOLUME_OWNER}" "${OZONE_VOLUME}"
-  fi
-fi
-
 export OZONE_DIR=/opt/hadoop
 export OM_SERVICE_ID=omservice
 
 # shellcheck source=/dev/null
 source "${COMPOSE_DIR}/../testlib.sh"
+
+create_data_dirs dn{1..3} om{1..3} scm
 
 start_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-debug-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-debug-tools.sh
@@ -29,19 +29,14 @@ export OM=om1
 export COMPOSE_FILE=docker-compose.yaml:debug-tools.yaml
 export OZONE_DIR=/opt/hadoop
 
-: "${OZONE_VOLUME_OWNER:=}"
 : "${OZONE_VOLUME:="${COMPOSE_DIR}/data"}"
 
 export OZONE_VOLUME
 
-# Clean up saved internal state from each container's volume for the next run.
-rm -rf "${OZONE_VOLUME}"
-mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,dn4,dn5,om1,om2,om3,scm1,scm2,scm3,recon,s3g,kms}
-
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-fix_data_dir_permissions
+create_data_dirs dn{1..5} kms om{1..3} recon s3g scm{1..3}
 
 start_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
@@ -29,19 +29,14 @@ export OM=om1
 export COMPOSE_FILE=docker-compose.yaml:debug-tools.yaml
 export OZONE_DIR=/opt/hadoop
 
-: "${OZONE_VOLUME_OWNER:=}"
 : "${OZONE_VOLUME:="${COMPOSE_DIR}/data"}"
 
 export OZONE_VOLUME
 
-# Clean up saved internal state from each container's volume for the next run.
-rm -rf "${OZONE_VOLUME}"
-mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,dn4,dn5,om1,om2,om3,scm1,scm2,scm3,recon,s3g,kms}
-
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-fix_data_dir_permissions
+create_data_dirs dn{1..5} kms om{1..3} recon s3g scm{1..3}
 
 start_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/restart/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/restart/test.sh
@@ -28,8 +28,7 @@ export OZONE_VOLUME
 # shellcheck source=/dev/null
 source "${COMPOSE_DIR}/../testlib.sh"
 
-mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om,recon,s3g,scm}
-fix_data_dir_permissions
+create_data_dirs dn{1..3} om recon s3g scm
 
 # prepare pre-upgrade cluster
 start_docker_env

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/load.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/load.sh
@@ -26,6 +26,7 @@ source "$TEST_DIR/testlib.sh"
 export COMPOSE_FILE="$TEST_DIR/compose/ha/docker-compose.yaml"
 export OM_SERVICE_ID=omservice
 export SECURITY_ENABLED="true"
-create_data_dirs "${OZONE_VOLUME}"/{om1,om2,om3,dn1,dn2,dn3,dn4,dn5,kms,recon,s3g,scm1,scm2,scm3}
+
+create_data_dirs dn{1..5} kms om{1..3} recon s3g scm{1..3}
 
 echo "Using docker cluster defined in $COMPOSE_FILE"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/load.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/load.sh
@@ -25,6 +25,7 @@ source "$TEST_DIR/testlib.sh"
 
 export COMPOSE_FILE="$TEST_DIR/compose/non-ha/docker-compose.yaml"
 export SECURITY_ENABLED=false
-create_data_dirs "${OZONE_VOLUME}"/{om,dn1,dn2,dn3,dn4,dn5,recon,s3g,scm}
+
+create_data_dirs dn{1..5} om recon s3g scm
 
 echo "Using docker cluster defined in $COMPOSE_FILE"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -23,27 +23,12 @@ _upgrade_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # 0 if all passed, 1 if any failed.
 : "${RESULT:=0}"
 : "${OZONE_REPLICATION_FACTOR:=3}"
-: "${OZONE_VOLUME_OWNER:=}"
 : "${ALL_RESULT_DIR:="$_upgrade_dir"/result}"
 
 # export for docker-compose
 export OZONE_REPLICATION_FACTOR
 
 source "${_upgrade_dir}/../testlib.sh"
-
-## @description Create the directory tree required for persisting data between
-##   compose cluster restarts
-create_data_dirs() {
-  local dirs_to_create="$@"
-
-  if [[ -z "${OZONE_VOLUME}" ]]; then
-    return 1
-  fi
-
-  rm -fr "${OZONE_VOLUME}" 2> /dev/null || sudo rm -fr "${OZONE_VOLUME}"
-  mkdir -p $dirs_to_create
-  fix_data_dir_permissions
-}
 
 ## @description Prepares to run an image with `start_docker_env`.
 ## @param the version of Ozone to be run.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some acceptance tests use data directories mounted from the host to keep data between restarts. The goal of this change is to:

- reduce code duplication around directory creation and cleanup
- attempt clean with `sudo` if necessary
- suppress errors during cleanup

Most of this can be done by reusing `create_data_dirs` from `upgrade/testlib.sh`.

https://issues.apache.org/jira/browse/HDDS-13404

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/16144325513