### PR TITLE
HDDS-11514. Set optimal default values for delete configurations based on live cluster testing.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -104,7 +104,7 @@ public class ScmConfig extends ReconfigurableConfig {
 
   @Config(key = "hdds.scm.block.deletion.per-interval.max",
       type = ConfigType.INT,
-      defaultValue = "100000",
+      defaultValue = "500000",
       reconfigurable = true,
       tags = { ConfigTag.SCM, ConfigTag.DELETION},
       description =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -467,7 +467,7 @@
   </property>
   <property>
     <name>ozone.key.deleting.limit.per.task</name>
-    <value>20000</value>
+    <value>50000</value>
     <tag>OM, PERFORMANCE</tag>
     <description>
       A maximum number of keys to be scanned by key deleting service

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -258,13 +258,13 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   private long blockDeleteMaxLockWaitTimeoutMs = Duration.ofMillis(100).toMillis();
 
   @Config(key = "block.deleting.limit.per.interval",
-      defaultValue = "5000",
+      defaultValue = "20000",
       reconfigurable = true,
       type = ConfigType.INT,
-      tags = { ConfigTag.SCM, ConfigTag.DELETION },
+      tags = { ConfigTag.SCM, ConfigTag.DELETION, DATANODE },
       description = "Number of blocks to be deleted in an interval."
   )
-  private int blockLimitPerInterval = 5000;
+  private int blockLimitPerInterval = 20000;
 
   @Config(key = "block.deleting.max.lock.holding.time",
       defaultValue = "1s",

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -106,7 +106,7 @@ public final class OMConfigKeys {
 
   public static final String OZONE_KEY_DELETING_LIMIT_PER_TASK =
       "ozone.key.deleting.limit.per.task";
-  public static final int OZONE_KEY_DELETING_LIMIT_PER_TASK_DEFAULT = 20000;
+  public static final int OZONE_KEY_DELETING_LIMIT_PER_TASK_DEFAULT = 50000;
   public static final String OZONE_SNAPSHOT_KEY_DELETING_LIMIT_PER_TASK =
       "ozone.snapshot.key.deleting.limit.per.task";
   public static final int OZONE_SNAPSHOT_KEY_DELETING_LIMIT_PER_TASK_DEFAULT


### PR DESCRIPTION
## What changes were proposed in this pull request?

Background deletion configurations were initially chosen based on educated guesses and lacked validation on real-world workloads. I have now tested large-scale deletions involving millions of files and directories, on a real cluster. Based on the results, I'm updating the relevant property values to better reflect practical performance and scalability.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11514

## How was this patch tested?

Tested Manually.
