### PR TITLE
HDDS-13410. Control block deletion for each DN from SCM.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -456,6 +456,11 @@ public final class ScmConfigKeys {
       "ozone.scm.block.deletion.max.retry";
   public static final int OZONE_SCM_BLOCK_DELETION_MAX_RETRY_DEFAULT = 4096;
 
+  public static final String OZONE_SCM_BLOCK_DELETION_MAX_BLOCKS_PER_DN =
+      "ozone.scm.block.deletion.max.blocks.per.dn";
+
+  public static final int OZONE_SCM_BLOCK_DELETION_MAX_BLOCKS_PER_DN_DEFAULT = 100000;
+
   public static final String OZONE_SCM_SEQUENCE_ID_BATCH_SIZE =
       "ozone.scm.sequence.id.batch.size";
   public static final int OZONE_SCM_SEQUENCE_ID_BATCH_SIZE_DEFAULT = 1000;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -779,6 +779,14 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.block.deletion.max.blocks.per.dn</name>
+    <value>100000</value>
+    <tag>OZONE, SCM</tag>
+    <description>
+      Maximum number of delete blocks SCM can send to each datanode in every interval.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.block.size</name>
     <value>256MB</value>
     <tag>OZONE, SCM</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
@@ -68,6 +68,14 @@ class DatanodeDeletedBlockTransactions {
         .collect(Collectors.toList());
   }
 
+  public int getNumberOfBlocksForDatanode(DatanodeID dnId) {
+    return Optional.ofNullable(transactions.get(dnId))
+        .orElse(new LinkedList<>())
+        .stream()
+        .mapToInt(DeletedBlocksTransaction::getLocalIDCount)
+        .sum();
+  }
+
   boolean isEmpty() {
     return transactions.isEmpty();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Control number of delete blocks request per DN in a cycle, we can safely increase total delete block request in SCM in each cycle, as it can distribute requests to more DN. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13410

## How was this patch tested?

New unit test
