### PR TITLE
HDDS-13346. Intermittent failure in TestCloseContainer#testContainerChecksumForClosedContainer

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCloseContainer.java
@@ -229,8 +229,8 @@ public class TestCloseContainer {
     // Checksum file exists after container close and matches the expected container
     // merkle tree for all the datanodes
     for (HddsDatanodeService hddsDatanode : hddsDatanodes) {
-      GenericTestUtils.waitFor(() -> checkContainerCloseInDatanode(hddsDatanode, containerInfo1), 100, 5000);
-      assertTrue(containerChecksumFileExists(hddsDatanode, containerInfo1.getContainerID()));
+      GenericTestUtils.waitFor(() -> checkContainerCloseInDatanode(hddsDatanode, containerInfo1) &&
+          containerChecksumFileExists(hddsDatanode, containerInfo1.getContainerID()), 100, 5000);
       OzoneContainer ozoneContainer = hddsDatanode.getDatanodeStateMachine().getContainer();
       Container<?> container1 = ozoneContainer.getController().getContainer(containerInfo1.getContainerID());
       ContainerProtos.ContainerChecksumInfo containerChecksumInfo = ContainerMerkleTreeTestUtils.readChecksumFile(
@@ -256,8 +256,8 @@ public class TestCloseContainer {
     // Checksum file exists after container close and matches the expected container
     // merkle tree for all the datanodes
     for (HddsDatanodeService hddsDatanode : hddsDatanodes) {
-      GenericTestUtils.waitFor(() -> checkContainerCloseInDatanode(hddsDatanode, containerInfo2), 100, 5000);
-      assertTrue(containerChecksumFileExists(hddsDatanode, containerInfo2.getContainerID()));
+      GenericTestUtils.waitFor(() -> checkContainerCloseInDatanode(hddsDatanode, containerInfo2) &&
+          containerChecksumFileExists(hddsDatanode, containerInfo2.getContainerID()), 100, 5000);
       OzoneContainer ozoneContainer = hddsDatanode.getDatanodeStateMachine().getContainer();
       Container<?> container2 = ozoneContainer.getController().getContainer(containerInfo2.getContainerID());
       ContainerProtos.ContainerChecksumInfo containerChecksumInfo = ContainerMerkleTreeTestUtils.readChecksumFile(
@@ -274,12 +274,12 @@ public class TestCloseContainer {
     assertNotEquals(prevExpectedChecksumInfo1.getContainerID(), prevExpectedChecksumInfo2.getContainerID());
     assertNotEquals(prevExpectedChecksumInfo1.getContainerMerkleTree().getDataChecksum(),
         prevExpectedChecksumInfo2.getContainerMerkleTree().getDataChecksum());
-    for (ContainerReplica replica : getContainerReplicas(containerInfo1)) {
-      assertNotEquals(0, replica.getDataChecksum());
-    }
-    for (ContainerReplica replica : getContainerReplicas(containerInfo2)) {
-      assertNotEquals(0, replica.getDataChecksum());
-    }
+
+    // Wait for SCM to receive container reports with non-zero checksums for all replicas
+    GenericTestUtils.waitFor(() -> getContainerReplicas(containerInfo1).stream()
+            .allMatch(r -> r.getDataChecksum() != 0), 200, 5000);
+    GenericTestUtils.waitFor(() -> getContainerReplicas(containerInfo2).stream()
+            .allMatch(r -> r.getDataChecksum() != 0), 200, 5000);
   }
 
   private boolean checkContainerCloseInDatanode(HddsDatanodeService hddsDatanode,


### PR DESCRIPTION
## What changes were proposed in this pull request?
The test was failing because we were not waiting for the ICR to be sent to SCM. The test now waits for the checksum to be reported to SCM through ICR.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13346

## How was this patch tested?

Ran the test 200 times 20 x 10
https://github.com/aswinshakil/ozone/actions/runs/16179046215
