### PR TITLE
HDDS-13414. Build a basic deb package for Ozone

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -247,6 +247,7 @@
         <version>1.14</version>
         <executions>
           <execution>
+            <phase>none</phase>
             <goals>
               <goal>jdeb</goal>
             </goals>
@@ -259,15 +260,8 @@
               <data>
                 <dataSet>
                   <data>
-                    <src>${project.build.directory}/ozone-${project.version}</src>
-                    <includes>
-                      <include>etc/**</include>
-                      <include>libexec/**</include>
-                      <include>log</include>
-                      <include>share/**</include>
-                      <include>bin/**</include>
-                      <include>sbin/**</include>
-                    </includes>
+                    <src>${project.build.directory}/ozone-${project.version}.tar.gz</src>
+                    <type>archive</type>
                     <mapper>
                       <type>perm</type>
                       <user>root</user>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -241,38 +241,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-        <version>1.14</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>jdeb</goal>
-            </goals>
-            <phase>none</phase>
-            <configuration>
-              <controlDir>${basedir}/src/main/package/deb/control</controlDir>
-              <deb>${project.build.directory}/ozone-${project.version}.deb</deb>
-              <skip>false</skip>
-              <skipPOMs>false</skipPOMs>
-              <data>
-                <dataSet>
-                  <data>
-                    <src>${project.build.directory}/ozone-${project.version}.tar.gz</src>
-                    <type>archive</type>
-                    <mapper>
-                      <type>perm</type>
-                      <user>root</user>
-                      <group>root</group>
-                    </mapper>
-                  </data>
-                </dataSet>
-              </data>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -464,6 +432,91 @@
                     <argument>${project.build.directory}</argument>
                   </arguments>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>deb</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.vafer</groupId>
+            <artifactId>jdeb</artifactId>
+            <version>1.14</version>
+            <configuration>
+              <controlDir>${basedir}/src/main/package/deb/control</controlDir>
+              <deb>${project.build.directory}/ozone-${project.version}.deb</deb>
+              <skip>false</skip>
+              <skipPOMs>false</skipPOMs>
+              <dataSet>
+                <data>
+                  <src>${project.build.directory}/ozone-${project.version}/bin/ozone</src>
+                  <type>file</type>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/opt/ozone/bin</prefix>
+                    <user>root</user>
+                    <group>root</group>
+                    <filemode>755</filemode>
+                  </mapper>
+                </data>
+
+                <data>
+                  <src>${project.build.directory}/ozone-${project.version}/sbin</src>
+                  <type>directory</type>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/opt/ozone/sbin</prefix>
+                    <user>root</user>
+                    <group>root</group>
+                  </mapper>
+                </data>
+
+                <data>
+                  <src>${project.build.directory}/ozone-${project.version}/etc</src>
+                  <type>directory</type>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/opt/ozone/etc</prefix>
+                    <user>root</user>
+                    <group>root</group>
+                  </mapper>
+                </data>
+
+                <data>
+                  <src>${project.build.directory}/ozone-${project.version}/libexec</src>
+                  <dst>/opt/ozone/libexec</dst>
+                  <type>directory</type>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/opt/ozone/libexec</prefix>
+                    <user>root</user>
+                    <group>root</group>
+                  </mapper>
+                </data>
+
+                <data>
+                  <src>${project.build.directory}/ozone-${project.version}/share</src>
+                  <dst>/opt/ozone/share</dst>
+                  <type>directory</type>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/opt/ozone/share</prefix>
+                    <user>root</user>
+                    <group>root</group>
+                  </mapper>
+                </data>
+              </dataSet>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>jdeb</goal>
+                </goals>
+                <phase>package</phase>
               </execution>
             </executions>
           </plugin>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -241,6 +241,44 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.vafer</groupId>
+        <artifactId>jdeb</artifactId>
+        <version>1.14</version> <executions>
+        <execution>
+          <phase>package</phase>
+          <goals>
+            <goal>deb</goal>
+          </goals>
+          <configuration>
+            <controlDir>${basedir}/src/main/package/deb/control</controlDir>
+            <deb>${project.build.directory}/ozone-${project.version}.deb</deb>
+            <skip>false</skip>
+            <skipPOMs>false</skipPOMs>
+            <data>
+              <dataSet>
+                <data>
+                  <src>${project.build.directory}/ozone-${project.version}</src>
+                  <includes>
+                    <include>etc/**</include>
+                    <include>libexec/**</include>
+                    <include>log</include>
+                    <include>share/**</include>
+                    <include>bin/**</include>
+                    <include>sbin/**</include>
+                  </includes>
+                  <mapper>
+                    <type>perm</type>
+                    <user>root</user>
+                    <group>root</group>
+                  </mapper>
+                </data>
+              </dataSet>
+            </data>
+          </configuration>
+        </execution>
+      </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -247,11 +247,10 @@
         <version>1.14</version>
         <executions>
           <execution>
-            <phase>none</phase>
             <goals>
               <goal>jdeb</goal>
             </goals>
-            <phase>package</phase>
+            <phase>none</phase>
             <configuration>
               <controlDir>${basedir}/src/main/package/deb/control</controlDir>
               <deb>${project.build.directory}/ozone-${project.version}.deb</deb>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -244,40 +244,41 @@
       <plugin>
         <groupId>org.vafer</groupId>
         <artifactId>jdeb</artifactId>
-        <version>1.14</version> <executions>
-        <execution>
-          <phase>package</phase>
-          <goals>
-            <goal>deb</goal>
-          </goals>
-          <configuration>
-            <controlDir>${basedir}/src/main/package/deb/control</controlDir>
-            <deb>${project.build.directory}/ozone-${project.version}.deb</deb>
-            <skip>false</skip>
-            <skipPOMs>false</skipPOMs>
-            <data>
-              <dataSet>
-                <data>
-                  <src>${project.build.directory}/ozone-${project.version}</src>
-                  <includes>
-                    <include>etc/**</include>
-                    <include>libexec/**</include>
-                    <include>log</include>
-                    <include>share/**</include>
-                    <include>bin/**</include>
-                    <include>sbin/**</include>
-                  </includes>
-                  <mapper>
-                    <type>perm</type>
-                    <user>root</user>
-                    <group>root</group>
-                  </mapper>
-                </data>
-              </dataSet>
-            </data>
-          </configuration>
-        </execution>
-      </executions>
+        <version>1.14</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jdeb</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <controlDir>${basedir}/src/main/package/deb/control</controlDir>
+              <deb>${project.build.directory}/ozone-${project.version}.deb</deb>
+              <skip>false</skip>
+              <skipPOMs>false</skipPOMs>
+              <data>
+                <dataSet>
+                  <data>
+                    <src>${project.build.directory}/ozone-${project.version}</src>
+                    <includes>
+                      <include>etc/**</include>
+                      <include>libexec/**</include>
+                      <include>log</include>
+                      <include>share/**</include>
+                      <include>bin/**</include>
+                      <include>sbin/**</include>
+                    </includes>
+                    <mapper>
+                      <type>perm</type>
+                      <user>root</user>
+                      <group>root</group>
+                    </mapper>
+                  </data>
+                </dataSet>
+              </data>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/hadoop-ozone/dist/src/main/package/deb/control/control
+++ b/hadoop-ozone/dist/src/main/package/deb/control/control
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+Package: [[artifactId]]
+Version: [[project.version]]
+Section: net
+Priority: extra
+Depends: jdk (>= 8), maven (>= 3.6)
+Architecture: all
+Description: A scalable, redundant, and distributed object store for Big Data.
+Maintainer: chungen0126 <chungen@apache.org>

--- a/hadoop-ozone/dist/src/main/package/deb/control/control
+++ b/hadoop-ozone/dist/src/main/package/deb/control/control
@@ -16,7 +16,7 @@ Package: [[artifactId]]
 Version: [[project.version]]
 Section: net
 Priority: extra
-Depends: jdk (>= 8), maven (>= 3.6)
+Depends: openjdk-8-jre | openjdk-11-jre | openjdk-17-jre | openjdk-21-jre
 Architecture: all
 Description: A scalable, redundant, and distributed object store for Big Data.
 Maintainer: chungen0126 <chungen@apache.org>

--- a/hadoop-ozone/dist/src/main/package/deb/control/control
+++ b/hadoop-ozone/dist/src/main/package/deb/control/control
@@ -16,7 +16,7 @@ Package: [[artifactId]]
 Version: [[project.version]]
 Section: net
 Priority: extra
-Depends: openjdk-8-jre | openjdk-11-jre | openjdk-17-jre | openjdk-21-jre
+Depends: openjdk-8-jdk | openjdk-11-jdk | openjdk-17-jdk | openjdk-21-jdk
 Architecture: all
 Description: A scalable, redundant, and distributed object store for Big Data.
 Maintainer: chungen0126 <chungen@apache.org>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Build a basic deb package for Ozone

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13414

## How was this patch tested?

I successfully built the Debian package locally using the command by running `mvn clean package -DskipTests -Pdeb` and manual tested on a clean Ubuntu 22.04 Docker container
