### PR TITLE
HDDS-13361. Attempt to delete non-empty tenant fails after revoke

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/UpdateRangerSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/UpdateRangerSubcommand.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.admin.om;
 
 import java.util.concurrent.Callable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import picocli.CommandLine;
@@ -65,12 +64,6 @@ public class UpdateRangerSubcommand implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-
-    if (StringUtils.isEmpty(omServiceId) && StringUtils.isEmpty(omHost)) {
-      System.err.println("Error: Please specify -id or -host");
-      return null;
-    }
-
     boolean forceHA = false;
     try (OzoneManagerProtocol client = parent.createOmClient(
         omServiceId, omHost, forceHA)) {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/UpdateRangerSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/UpdateRangerSubcommand.java
@@ -65,6 +65,7 @@ public class UpdateRangerSubcommand implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
+
     if (StringUtils.isEmpty(omServiceId) && StringUtils.isEmpty(omHost)) {
       System.err.println("Error: Please specify -id or -host");
       return null;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/UpdateRangerSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/UpdateRangerSubcommand.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.admin.om;
 
 import java.util.concurrent.Callable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import picocli.CommandLine;
@@ -64,6 +65,11 @@ public class UpdateRangerSubcommand implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
+    if (StringUtils.isEmpty(omServiceId) && StringUtils.isEmpty(omHost)) {
+      System.err.println("Error: Please specify -id or -host");
+      return null;
+    }
+
     boolean forceHA = false;
     try (OzoneManagerProtocol client = parent.createOmClient(
         omServiceId, omHost, forceHA)) {

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -164,6 +164,8 @@ OZONE_LOG_DIR=/var/log/hadoop
 
 no_proxy=om,scm,recon,s3g,kdc,localhost,127.0.0.1
 
+OM_SERVICE_ID=omservice
+
 # Explicitly enable filesystem snapshot feature for this Docker compose cluster
 OZONE-SITE.XML_ozone.filesystem.snapshot.enabled=true
 

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/lib.resource
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/lib.resource
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Library             OperatingSystem
+
+*** Keywords ***
+Get OM Service ID
+    ${service_id} =     Get Environment Variable    OM_SERVICE_ID    ${EMPTY}
+    RETURN    ${service_id}
+
+
+Get OM Service Param
+    ${service_id} =     Get OM Service ID
+
+    IF    '${service_id}' == ''
+        RETURN    --service-host om
+    ELSE
+        RETURN    --service-id '${service_id}'
+    END

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -112,10 +112,9 @@ Delete Tenant Failure Tenant Not Empty
     ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant delete ${TENANT}
                         Should contain   ${output}         TENANT_NOT_EMPTY Tenant '${TENANT}' is not empty. All accessIds associated to this tenant must be revoked before the tenant can be deleted. See `ozone tenant user revoke`
 
-#failing as ${OM_HA_PARAM} is empty thus host is missing
-#Trigger and wait for background Sync to recover Policies and Roles in Authorizer
-#    ${rc}  ${output} =  Run And Return Rc And Output  ozone admin om updateranger ${OM_HA_PARAM}
-#                       Should contain   ${output}         Operation completed successfully
+Trigger and wait for background Sync to recover Policies and Roles in Authorizer
+   ${rc}  ${output} =  Run And Return Rc And Output  ozone admin om updateranger ${OM_HA_PARAM}
+                       Should contain   ${output}         Operation completed successfully
 
 Create Tenant Failure with Regular User
     Run Keyword         Kinit test user     testuser2    testuser2.keytab

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -108,14 +108,14 @@ Delete Bucket 1 Success With Newly Set SecretKey via S3 API
                         Execute          aws configure set aws_secret_access_key 'somesecret1'
     ${output} =         Execute          aws s3api --endpoint-url ${S3G_ENDPOINT_URL} delete-bucket --bucket bucket-test1
 
-# see HDDS-13361
-#Delete Tenant Failure Tenant Not Empty
-#    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant delete ${TENANT}
-#                        Should contain   ${output}         TENANT_NOT_EMPTY Tenant '${TENANT}' is not empty. All accessIds associated to this tenant must be revoked before the tenant can be deleted. See `ozone tenant user revoke`
-#
+Delete Tenant Failure Tenant Not Empty
+    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant delete ${TENANT}
+                        Should contain   ${output}         TENANT_NOT_EMPTY Tenant '${TENANT}' is not empty. All accessIds associated to this tenant must be revoked before the tenant can be deleted. See `ozone tenant user revoke`
+
+#failing as ${OM_HA_PARAM} is empty thus host is missing
 #Trigger and wait for background Sync to recover Policies and Roles in Authorizer
 #    ${rc}  ${output} =  Run And Return Rc And Output  ozone admin om updateranger ${OM_HA_PARAM}
-#                        Should contain   ${output}         Operation completed successfully
+#                       Should contain   ${output}         Operation completed successfully
 
 Create Tenant Failure with Regular User
     Run Keyword         Kinit test user     testuser2    testuser2.keytab

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -20,6 +20,7 @@ Library             String
 Library             BuiltIn
 Resource            ../commonlib.robot
 Resource            ../s3/commonawslib.robot
+Resource            ../admincli/lib.resource
 Test Timeout        5 minutes
 
 *** Variables ***
@@ -113,7 +114,8 @@ Delete Tenant Failure Tenant Not Empty
                         Should contain   ${output}         TENANT_NOT_EMPTY Tenant '${TENANT}' is not empty. All accessIds associated to this tenant must be revoked before the tenant can be deleted. See `ozone tenant user revoke`
 
 Trigger and wait for background Sync to recover Policies and Roles in Authorizer
-   ${rc}  ${output} =  Run And Return Rc And Output  ozone admin om updateranger ${OM_HA_PARAM}
+   ${om_param}=        Get OM Service Param
+   ${rc}  ${output} =  Run And Return Rc And Output  ozone admin om updateranger ${om_param}
                        Should contain   ${output}         Operation completed successfully
 
 Create Tenant Failure with Regular User

--- a/hadoop-ozone/dist/src/main/smoketest/upgrade/lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/upgrade/lib.robot
@@ -17,23 +17,9 @@
 Documentation       Keywords for Upgrade Tests
 Library             OperatingSystem
 Resource            ../lib/os.robot
+Resource            ../admincli/lib.resource
 
 *** Keywords ***
-Get OM Service ID
-    ${service_id} =     Get Environment Variable    OM_SERVICE_ID    ${EMPTY}
-    RETURN    ${service_id}
-
-
-Get OM Service Param
-    ${service_id} =     Get OM Service ID
-
-    IF    '${service_id}' == ''
-        RETURN    --service-host om
-    ELSE
-        RETURN    --service-id '${service_id}'
-    END
-
-
 OM Finalization Status
     ${param} =     Get OM Service Param
     ${result} =    Execute      ozone admin om finalizationstatus ${param}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -82,6 +82,17 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
     final String tenantId = omRequest.getDeleteTenantRequest().getTenantId();
     Preconditions.checkNotNull(tenantId);
 
+    // Check if there are any accessIds in the tenant.
+    // This must be done before we attempt to delete policies from Ranger.
+    if (!multiTenantManager.isTenantEmpty(tenantId)) {
+      LOG.warn("tenant: '{}' is not empty. Unable to delete the tenant",
+          tenantId);
+      throw new OMException("Tenant '" + tenantId + "' is not empty. " +
+          "All accessIds associated to this tenant must be revoked before " +
+          "the tenant can be deleted. See `ozone tenant user revoke`",
+          TENANT_NOT_EMPTY);
+    }
+
     // Get tenant object by tenant name
     final Tenant tenantObj = multiTenantManager.getTenantFromDBById(tenantId);
 
@@ -148,16 +159,6 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
       mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
           VOLUME_LOCK, volumeName));
       acquiredVolumeLock = getOmLockDetails().isLockAcquired();
-
-      // Check if there are any accessIds in the tenant
-      if (!ozoneManager.getMultiTenantManager().isTenantEmpty(tenantId)) {
-        LOG.warn("tenant: '{}' is not empty. Unable to delete the tenant",
-            tenantId);
-        throw new OMException("Tenant '" + tenantId + "' is not empty. " +
-            "All accessIds associated to this tenant must be revoked before " +
-            "the tenant can be deleted. See `ozone tenant user revoke`",
-            TENANT_NOT_EMPTY);
-      }
 
       // Invalidate cache entry
       omMetadataManager.getTenantStateTable().addCacheEntry(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- ozone tenant delete fails with TENANT_NOT_EMPTY if user is assigned to the tenant, but OM deletes associated policies from Ranger first.
- Thus, after ozone tenant user revoke, the tenant is empty, but ozone tenant delete still fails, now due to 404 Not Found error from Ranger, when OM tries to delete policies.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13361

## How was this patch tested?

Passed Existing Acceptance Test.
