### PR TITLE
HDDS-11797. Remove cyclic dependency between SCMSafeModeManager and SafeModeRules

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -90,10 +90,10 @@ public class SCMSafeModeManager implements SafeModeManager {
     this.scmContext = scmContext;
     this.safeModeMetrics = SafeModeMetrics.create();
 
-    // TODO: Remove the cyclic ("this") dependency (HDDS-11797)
-    SafeModeRuleFactory.initialize(conf, scmContext, eventQueue, this,
+    SafeModeRuleFactory.initialize(conf, scmContext, eventQueue,
         pipelineManager, containerManager, nodeManager);
     SafeModeRuleFactory factory = SafeModeRuleFactory.getInstance();
+    factory.addSafeModeManager(this);
     factory.getSafeModeRules().forEach(rule -> exitRules.put(rule.getRuleName(), rule));
     factory.getPreCheckRules().forEach(rule -> preCheckRules.add(rule.getRuleName()));
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeRuleFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeRuleFactory.java
@@ -35,8 +35,6 @@ public final class SafeModeRuleFactory {
   private final SCMContext scmContext;
   private final EventQueue eventQueue;
 
-  // TODO: Remove dependency on safeModeManager (HDDS-11797)
-  private final SCMSafeModeManager safeModeManager;
   private final PipelineManager pipelineManager;
   private final ContainerManager containerManager;
   private final NodeManager nodeManager;
@@ -49,23 +47,24 @@ public final class SafeModeRuleFactory {
   private SafeModeRuleFactory(final ConfigurationSource config,
                               final SCMContext scmContext,
                               final EventQueue eventQueue,
-                              final SCMSafeModeManager safeModeManager,
                               final PipelineManager pipelineManager,
                               final ContainerManager containerManager,
                               final NodeManager nodeManager) {
     this.config = config;
     this.scmContext = scmContext;
     this.eventQueue = eventQueue;
-    this.safeModeManager = safeModeManager;
     this.pipelineManager = pipelineManager;
     this.containerManager = containerManager;
     this.nodeManager = nodeManager;
     this.safeModeRules = new ArrayList<>();
     this.preCheckRules = new ArrayList<>();
-    loadRules();
   }
 
-  private void loadRules() {
+  public void addSafeModeManager(SCMSafeModeManager safeModeManager) {
+    loadRules(safeModeManager);
+  }
+
+  private void loadRules(SCMSafeModeManager safeModeManager) {
     // TODO: Use annotation to load the rules. (HDDS-11730)
     SafeModeExitRule<?> ratisContainerRule = new RatisContainerSafeModeRule(eventQueue,
         config, containerManager, safeModeManager);
@@ -102,12 +101,11 @@ public final class SafeModeRuleFactory {
       final ConfigurationSource config,
       final SCMContext scmContext,
       final EventQueue eventQueue,
-      final SCMSafeModeManager safeModeManager,
       final PipelineManager pipelineManager,
       final ContainerManager containerManager,
       final NodeManager nodeManager) {
     instance = new SafeModeRuleFactory(config, scmContext, eventQueue,
-          safeModeManager, pipelineManager, containerManager, nodeManager);
+          pipelineManager, containerManager, nodeManager);
   }
 
   public List<SafeModeExitRule<?>> getSafeModeRules() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeRuleFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeRuleFactory.java
@@ -48,8 +48,9 @@ class TestSafeModeRuleFactory {
 
   @Test
   public void testLoadedSafeModeRules() {
-    initializeSafeModeRuleFactory();
+    SCMSafeModeManager safeModeManager = initializeSafeModeRuleFactory();
     final SafeModeRuleFactory factory = SafeModeRuleFactory.getInstance();
+    factory.addSafeModeManager(safeModeManager);
 
     // Currently we assert the total count against hardcoded value
     // as the rules are hardcoded in SafeModeRuleFactory.
@@ -62,8 +63,9 @@ class TestSafeModeRuleFactory {
 
   @Test
   public void testLoadedPreCheckRules() {
-    initializeSafeModeRuleFactory();
+    SCMSafeModeManager safeModeManager = initializeSafeModeRuleFactory();
     final SafeModeRuleFactory factory = SafeModeRuleFactory.getInstance();
+    factory.addSafeModeManager(safeModeManager);
 
     // Currently we assert the total count against hardcoded value
     // as the rules are hardcoded in SafeModeRuleFactory.
@@ -74,13 +76,14 @@ class TestSafeModeRuleFactory {
 
   }
 
-  private void initializeSafeModeRuleFactory() {
+  private SCMSafeModeManager initializeSafeModeRuleFactory() {
     final SCMSafeModeManager safeModeManager = mock(SCMSafeModeManager.class);
     when(safeModeManager.getSafeModeMetrics()).thenReturn(mock(SafeModeMetrics.class));
     SafeModeRuleFactory.initialize(new OzoneConfiguration(),
-        SCMContext.emptyContext(), new EventQueue(), safeModeManager, mock(
+        SCMContext.emptyContext(), new EventQueue(), mock(
             PipelineManager.class),
         mock(ContainerManager.class), mock(NodeManager.class));
+    return safeModeManager;
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this PR, a cyclic dependency between SCMSafeModeManager and SafeModeRuleFactory has been removed.

## What is the link to the Apache JIRA
[HDDS-11797](https://issues.apache.org/jira/browse/HDDS-11797)

## How was this patch tested?
https://github.com/kostacie/ozone/actions/runs/16191411263
