### PR TITLE
HDDS-8903. Add validation for ozone.om.snapshot.db.max.open.files.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -217,10 +217,8 @@ public final class OmSnapshotManager implements AutoCloseable {
         OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES,
         OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT
     );
-    if (this.maxOpenSstFilesInSnapshotDb <= 0) {
-      throw new IllegalArgumentException(
-          OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES + " must be positive.");
-    }
+    Preconditions.checkArgument(this.maxOpenSstFilesInSnapshotDb > 0,
+        OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES + " must be positive.");
 
     ColumnFamilyHandle snapDiffJobCf;
     ColumnFamilyHandle snapDiffReportCf;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -217,6 +217,11 @@ public final class OmSnapshotManager implements AutoCloseable {
         OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES,
         OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT
     );
+    if (this.maxOpenSstFilesInSnapshotDb <= 0) {
+      throw new IllegalArgumentException(
+          OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES + " must be positive.");
+    }
+
     ColumnFamilyHandle snapDiffJobCf;
     ColumnFamilyHandle snapDiffReportCf;
     ColumnFamilyHandle snapDiffPurgedJobCf;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -754,7 +754,7 @@ class TestOmSnapshotManager {
   void testNegativeMaxOpenFiles(@TempDir File tempDir) throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, tempDir.getAbsolutePath());
-    conf.setInt(OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES, -2);
+    conf.setInt(OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES, 0);
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
 
     assertThrows(IllegalArgumentException.class, () -> new OmTestManagers(conf));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -749,4 +749,14 @@ class TestOmSnapshotManager {
         UUID.randomUUID(),
         Time.now());
   }
+
+  @Test
+  void testNegativeMaxOpenFiles(@TempDir File tempDir) throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, tempDir.getAbsolutePath());
+    conf.setInt(OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES, -2);
+    conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
+
+    assertThrows(IllegalArgumentException.class, () -> new OmTestManagers(conf));
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-8903. Add validation for ozone.om.snapshot.db.max.open.files.

Please describe your PR in detail:
* Add value validation for the config property. Not clear what a valid check is, so verify for non-negative number.
* Generated-by: Google Gemini 2.5 Pro + Gemini Cli. Prompt:

> Read jira https://issues.apache.org/jira/browse/HDDS-8903 and tell me what this is about?


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8903

## How was this patch tested?

mvn test -pl hadoop-ozone/ozone-manager -Dtest=TestOmSnapshotManager