### PR TITLE
HDDS-13305. Create wrapper object for container checksums

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -362,7 +362,7 @@ abstract class AbstractContainerReportHandler {
         .setReplicaIndex(replicaProto.getReplicaIndex())
         .setBytesUsed(replicaProto.getUsed())
         .setEmpty(replicaProto.getIsEmpty())
-        .setDataChecksum(replicaProto.getDataChecksum())
+        .setChecksums(new ContainerChecksums(replicaProto.getDataChecksum()))
         .build();
 
     if (replica.getState().equals(State.DELETED)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerChecksums.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerChecksums.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container;
+
+import java.util.Objects;
+
+/**
+ * Wrapper for container checksums (data, metadata, etc.).
+ * Provides equality, hash, and hex string rendering.
+ */
+public class ContainerChecksums {
+  private final long dataChecksum;
+  private final Long metadataChecksum; // nullable for future use
+
+  public ContainerChecksums(long dataChecksum) {
+    this(dataChecksum, null);
+  }
+
+  public ContainerChecksums(long dataChecksum, Long metadataChecksum) {
+    this.dataChecksum = dataChecksum;
+    this.metadataChecksum = metadataChecksum;
+  }
+
+  public long getDataChecksum() {
+    return dataChecksum;
+  }
+
+  public Long getMetadataChecksum() {
+    return metadataChecksum;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof ContainerChecksums)) {
+      return false;
+    }
+    ContainerChecksums that = (ContainerChecksums) obj;
+    return dataChecksum == that.dataChecksum &&
+           Objects.equals(metadataChecksum, that.metadataChecksum);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dataChecksum, metadataChecksum);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("data=").append(Long.toHexString(dataChecksum));
+    if (metadataChecksum != null) {
+      sb.append(", metadata=").append(Long.toHexString(metadataChecksum));
+    }
+    return sb.toString();
+  }
+} 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -45,7 +45,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
   private final long keyCount;
   private final long bytesUsed;
   private final boolean isEmpty;
-  private final long dataChecksum;
+  private final ContainerChecksums checksums;
 
   private ContainerReplica(ContainerReplicaBuilder b) {
     this.containerID = Objects.requireNonNull(b.containerID, "containerID == null");
@@ -57,7 +57,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     this.replicaIndex = b.replicaIndex;
     this.isEmpty = b.isEmpty;
     this.sequenceId = b.sequenceId;
-    this.dataChecksum = b.dataChecksum;
+    this.checksums = Objects.requireNonNull(b.checksums, "checksums == null");
   }
 
   public ContainerID getContainerID() {
@@ -122,8 +122,8 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     return isEmpty;
   }
 
-  public long getDataChecksum() {
-    return dataChecksum;
+  public ContainerChecksums getChecksums() {
+    return checksums;
   }
 
   @Override
@@ -180,7 +180,8 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
         .setOriginNodeId(originDatanodeId)
         .setReplicaIndex(replicaIndex)
         .setSequenceId(sequenceId)
-        .setEmpty(isEmpty);
+        .setEmpty(isEmpty)
+        .setChecksums(checksums);
   }
 
   @Override
@@ -194,7 +195,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
         + ", keyCount=" + keyCount
         + ", bytesUsed=" + bytesUsed
         + ", " + (isEmpty ? "empty" : "non-empty")
-        + ", dataChecksum=" + dataChecksum
+        + ", checksums=" + checksums
         + '}';
   }
 
@@ -212,7 +213,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     private long keyCount;
     private int replicaIndex;
     private boolean isEmpty;
-    private long dataChecksum;
+    private ContainerChecksums checksums;
 
     /**
      * Set Container Id.
@@ -287,8 +288,8 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
       return this;
     }
 
-    public ContainerReplicaBuilder setDataChecksum(long dataChecksum) {
-      this.dataChecksum = dataChecksum;
+    public ContainerReplicaBuilder setChecksums(ContainerChecksums checksums) {
+      this.checksums = checksums;
       return this;
     }
 
@@ -298,6 +299,9 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
      * @return ContainerReplicaBuilder
      */
     public ContainerReplica build() {
+      if (this.checksums == null) {
+        this.checksums = new ContainerChecksums(0L);
+      }
       return new ContainerReplica(this);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -360,7 +360,7 @@ public class SCMClientProtocolServer implements
                 .setKeyCount(r.getKeyCount())
                 .setSequenceID(r.getSequenceId())
                 .setReplicaIndex(r.getReplicaIndex())
-                .setDataChecksum(r.getDataChecksum())
+                .setDataChecksum(r.getChecksums().getDataChecksum())
                 .build()
         );
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/ContainerChecksumsTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/ContainerChecksumsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ContainerChecksumsTest {
+  @Test
+  void testEqualsAndHashCode() {
+    ContainerChecksums c1 = new ContainerChecksums(123L);
+    ContainerChecksums c2 = new ContainerChecksums(123L);
+    ContainerChecksums c3 = new ContainerChecksums(456L);
+    ContainerChecksums c4 = new ContainerChecksums(123L, 789L);
+    ContainerChecksums c5 = new ContainerChecksums(123L, 789L);
+    ContainerChecksums c6 = new ContainerChecksums(123L, 790L);
+
+    assertEquals(c1, c2);
+    assertEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, c3);
+    assertNotEquals(c1, c4);
+    assertEquals(c4, c5);
+    assertNotEquals(c4, c6);
+  }
+
+  @Test
+  void testToString() {
+    ContainerChecksums c1 = new ContainerChecksums(0x1234ABCDL);
+    assertTrue(c1.toString().contains("data=1234abcd"));
+    assertFalse(c1.toString().contains("metadata="));
+
+    ContainerChecksums c2 = new ContainerChecksums(0x1234ABCDL, 0xDEADBEEFL);
+    assertTrue(c2.toString().contains("data=1234abcd"));
+    assertTrue(c2.toString().contains("metadata=deadbeef"));
+  }
+} 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -1205,7 +1205,7 @@ public class TestContainerReportHandler {
 
     // All replicas should start with an empty data checksum in SCM.
     boolean contOneDataChecksumsEmpty = containerManager.getContainerReplicas(contID).stream()
-        .allMatch(r -> r.getDataChecksum() == 0);
+        .allMatch(r -> r.getChecksums().getDataChecksum() == 0);
     assertTrue(contOneDataChecksumsEmpty, "Replicas of container one should not yet have any data checksums.");
 
     // Send a report to SCM from one datanode that still does not have a data checksum.
@@ -1222,7 +1222,7 @@ public class TestContainerReportHandler {
     // Regardless of which datanode sent the report, none of them have checksums, so all replica's data checksums
     // should remain empty.
     boolean containerDataChecksumEmpty = containerManager.getContainerReplicas(contID).stream()
-        .allMatch(r -> r.getDataChecksum() == 0);
+        .allMatch(r -> r.getChecksums().getDataChecksum() == 0);
     assertTrue(containerDataChecksumEmpty, "Replicas of the container should not have any data checksums.");
   }
 
@@ -1254,7 +1254,7 @@ public class TestContainerReportHandler {
 
     // All replicas should start with an empty data checksum in SCM.
     boolean dataChecksumsEmpty = containerManager.getContainerReplicas(contID).stream()
-        .allMatch(r -> r.getDataChecksum() == 0);
+        .allMatch(r -> r.getChecksums().getDataChecksum() == 0);
     assertTrue(dataChecksumsEmpty, "Replicas of container one should not yet have any data checksums.");
 
     // For each datanode, send a container report with a mismatched checksum.
@@ -1278,7 +1278,7 @@ public class TestContainerReportHandler {
     int numReplicasChecked = 0;
     for (ContainerReplica replica: containerManager.getContainerReplicas(contID)) {
       long expectedChecksum = createUniqueDataChecksumForReplica(contID, replica.getDatanodeDetails().getUuidString());
-      assertEquals(expectedChecksum, replica.getDataChecksum());
+      assertEquals(expectedChecksum, replica.getChecksums().getDataChecksum());
       numReplicasChecked++;
     }
     assertEquals(numNodes, numReplicasChecked);
@@ -1304,7 +1304,7 @@ public class TestContainerReportHandler {
     numReplicasChecked = 0;
     for (ContainerReplica replica: containerManager.getContainerReplicas(contID)) {
       long expectedChecksum = createMatchingDataChecksumForReplica(contID);
-      assertEquals(expectedChecksum, replica.getDataChecksum());
+      assertEquals(expectedChecksum, replica.getChecksums().getDataChecksum());
       numReplicasChecked++;
     }
     assertEquals(numNodes, numReplicasChecked);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -648,7 +648,7 @@ public class TestIncrementalContainerReportHandler {
 
     // All replicas should start with an empty data checksum in SCM.
     boolean contOneDataChecksumsEmpty = containerManager.getContainerReplicas(contID).stream()
-        .allMatch(r -> r.getDataChecksum() == 0);
+        .allMatch(r -> r.getChecksums().getDataChecksum() == 0);
     assertTrue(contOneDataChecksumsEmpty, "Replicas of container one should not yet have any data checksums.");
 
     // Send a report to SCM from one datanode that still does not have a data checksum.
@@ -663,7 +663,7 @@ public class TestIncrementalContainerReportHandler {
     // Regardless of which datanode sent the report, none of them have checksums, so all replica's data checksums
     // should remain empty.
     boolean containerDataChecksumEmpty = containerManager.getContainerReplicas(contID).stream()
-        .allMatch(r -> r.getDataChecksum() == 0);
+        .allMatch(r -> r.getChecksums().getDataChecksum() == 0);
     assertTrue(containerDataChecksumEmpty, "Replicas of the container should not have any data checksums.");
   }
 
@@ -695,7 +695,7 @@ public class TestIncrementalContainerReportHandler {
 
     // All replicas should start with a zero data checksum in SCM.
     boolean dataChecksumsEmpty = containerManager.getContainerReplicas(contID).stream()
-        .allMatch(r -> r.getDataChecksum() == 0);
+        .allMatch(r -> r.getChecksums().getDataChecksum() == 0);
     assertTrue(dataChecksumsEmpty, "Replicas of container one should not yet have any data checksums.");
 
     // For each datanode, send a container report with a mismatched checksum.
@@ -721,7 +721,7 @@ public class TestIncrementalContainerReportHandler {
     for (ContainerReplica replica: containerManager.getContainerReplicas(contID)) {
       long expectedChecksum = createUniqueDataChecksumForReplica(
           contID, replica.getDatanodeDetails().getUuidString());
-      assertEquals(expectedChecksum, replica.getDataChecksum());
+      assertEquals(expectedChecksum, replica.getChecksums().getDataChecksum());
       numReplicasChecked++;
     }
     assertEquals(numNodes, numReplicasChecked);
@@ -748,7 +748,7 @@ public class TestIncrementalContainerReportHandler {
     numReplicasChecked = 0;
     for (ContainerReplica replica: containerManager.getContainerReplicas(contID)) {
       long expectedChecksum = createMatchingDataChecksumForReplica(contID);
-      assertEquals(expectedChecksum, replica.getDataChecksum());
+      assertEquals(expectedChecksum, replica.getChecksums().getDataChecksum());
       numReplicasChecked++;
     }
     assertEquals(numNodes, numReplicasChecked);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestCloseContainer.java
@@ -159,7 +159,7 @@ public class TestCloseContainer {
     GenericTestUtils.waitFor(() ->
             getContainerReplicas(newContainer).size() == 3, 200, 30000);
     for (ContainerReplica replica : getContainerReplicas(newContainer)) {
-      assertNotEquals(0, replica.getDataChecksum());
+      assertNotEquals(0, replica.getChecksums().getDataChecksum());
     }
   }
 
@@ -201,7 +201,7 @@ public class TestCloseContainer {
     }
 
     for (ContainerReplica replica : getContainerReplicas(container)) {
-      assertNotEquals(0, replica.getDataChecksum());
+      assertNotEquals(0, replica.getChecksums().getDataChecksum());
     }
 
     assertThrows(IOException.class,
@@ -275,10 +275,10 @@ public class TestCloseContainer {
     assertNotEquals(prevExpectedChecksumInfo1.getContainerMerkleTree().getDataChecksum(),
         prevExpectedChecksumInfo2.getContainerMerkleTree().getDataChecksum());
     for (ContainerReplica replica : getContainerReplicas(containerInfo1)) {
-      assertNotEquals(0, replica.getDataChecksum());
+      assertNotEquals(0, replica.getChecksums().getDataChecksum());
     }
     for (ContainerReplica replica : getContainerReplicas(containerInfo2)) {
-      assertNotEquals(0, replica.getDataChecksum());
+      assertNotEquals(0, replica.getChecksums().getDataChecksum());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
@@ -85,7 +85,7 @@ class TestBackgroundContainerDataScannerIntegration
     assertTrue(containerChecksumFileExists(containerID));
 
     waitForScmToSeeReplicaState(containerID, CLOSED);
-    long initialReportedDataChecksum = getContainerReplica(containerID).getDataChecksum();
+    long initialReportedDataChecksum = getContainerReplica(containerID).getChecksums().getDataChecksum();
 
     corruption.applyTo(container);
 
@@ -98,7 +98,7 @@ class TestBackgroundContainerDataScannerIntegration
 
     // Wait for SCM to get a report of the unhealthy replica with a different checksum than before.
     waitForScmToSeeReplicaState(containerID, UNHEALTHY);
-    long newReportedDataChecksum = getContainerReplica(containerID).getDataChecksum();
+    long newReportedDataChecksum = getContainerReplica(containerID).getChecksums().getDataChecksum();
     if (corruption == TestContainerCorruptions.MISSING_METADATA_DIR ||
         corruption == TestContainerCorruptions.MISSING_CONTAINER_DIR) {
       // In these cases, the new tree will not be able to be written since it exists in the metadata directory.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
@@ -98,7 +98,7 @@ class TestBackgroundContainerMetadataScannerIntegration
     assertEquals(State.CLOSED, closedContainer.getContainerState());
     assertTrue(containerChecksumFileExists(closedContainerID));
     waitForScmToSeeReplicaState(closedContainerID, CLOSED);
-    long initialClosedChecksum = getContainerReplica(closedContainerID).getDataChecksum();
+    long initialClosedChecksum = getContainerReplica(closedContainerID).getChecksums().getDataChecksum();
     assertNotEquals(0, initialClosedChecksum);
 
     long openContainerID = writeDataToOpenContainer();
@@ -106,7 +106,7 @@ class TestBackgroundContainerMetadataScannerIntegration
     assertEquals(State.OPEN, openContainer.getContainerState());
     waitForScmToSeeReplicaState(openContainerID, OPEN);
     // Open containers should not yet have a checksum generated.
-    assertEquals(0, getContainerReplica(openContainerID).getDataChecksum());
+    assertEquals(0, getContainerReplica(openContainerID).getChecksums().getDataChecksum());
 
     // Corrupt both containers.
     corruption.applyTo(closedContainer);
@@ -124,17 +124,17 @@ class TestBackgroundContainerMetadataScannerIntegration
     // The metadata scanner does not generate data checksums and the other scanners have been turned off for this
     // test, so the data checksums should not change.
     waitForScmToSeeReplicaState(closedContainerID, UNHEALTHY);
-    assertEquals(initialClosedChecksum, getContainerReplica(closedContainerID).getDataChecksum());
+    assertEquals(initialClosedChecksum, getContainerReplica(closedContainerID).getChecksums().getDataChecksum());
     waitForScmToSeeReplicaState(openContainerID, UNHEALTHY);
     if (corruption == MISSING_METADATA_DIR || corruption == MISSING_CONTAINER_DIR) {
       // In these cases the tree cannot be generated when the container is marked unhealthy and the checksum should
       // remain at 0.
       // The tree is generated from metadata by the container changing to unhealthy, not by the metadata scanner.
-      assertEquals(0, getContainerReplica(openContainerID).getDataChecksum());
+      assertEquals(0, getContainerReplica(openContainerID).getChecksums().getDataChecksum());
     } else {
       // The checksum will be generated for the first time when the container is marked unhealthy.
       // The tree is generated from metadata by the container changing to unhealthy, not by the metadata scanner.
-      assertNotEquals(0, getContainerReplica(openContainerID).getDataChecksum());
+      assertNotEquals(0, getContainerReplica(openContainerID).getChecksums().getDataChecksum());
     }
 
     // Once the unhealthy replica is reported, the open container's lifecycle

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestOnDemandContainerDataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestOnDemandContainerDataScannerIntegration.java
@@ -105,7 +105,7 @@ class TestOnDemandContainerDataScannerIntegration
     assertTrue(containerChecksumFileExists(containerID));
 
     waitForScmToSeeReplicaState(containerID, CLOSED);
-    long initialReportedDataChecksum = getContainerReplica(containerID).getDataChecksum();
+    long initialReportedDataChecksum = getContainerReplica(containerID).getChecksums().getDataChecksum();
 
     // Corrupt the container.
     corruption.applyTo(container);
@@ -121,7 +121,7 @@ class TestOnDemandContainerDataScannerIntegration
     // Wait for SCM to get a report of the unhealthy replica.
     waitForScmToSeeReplicaState(containerID, UNHEALTHY);
     corruption.assertLogged(containerID, 1, logCapturer);
-    long newReportedDataChecksum = getContainerReplica(containerID).getDataChecksum();
+    long newReportedDataChecksum = getContainerReplica(containerID).getChecksums().getDataChecksum();
 
     if (corruption == TestContainerCorruptions.MISSING_METADATA_DIR ||
         corruption == TestContainerCorruptions.MISSING_CONTAINER_DIR) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaCount;
@@ -162,7 +163,8 @@ public class ContainerHealthStatus {
 
   public boolean isDataChecksumMismatched() {
     return !replicas.isEmpty() && replicas.stream()
-            .map(ContainerReplica::getDataChecksum)
+            .map(ContainerReplica::getChecksums)
+            .map(ContainerChecksums::getDataChecksum)
             .distinct()
             .count() != 1;
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistory.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.recon.scm;
 
 import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerReplicaHistoryProto;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 
 /**
  * A ContainerReplica timestamp class that tracks first and last seen time.
@@ -39,16 +40,16 @@ public class ContainerReplicaHistory {
 
   private long bcsId;
   private String state;
-  private long dataChecksum;
+  private ContainerChecksums checksums;
 
   public ContainerReplicaHistory(UUID id, Long firstSeenTime,
-      Long lastSeenTime, long bcsId, String state, long dataChecksum) {
+      Long lastSeenTime, long bcsId, String state, ContainerChecksums checksums) {
     this.uuid = id;
     this.firstSeenTime = firstSeenTime;
     this.lastSeenTime = lastSeenTime;
     this.bcsId = bcsId;
     this.state = state;
-    this.dataChecksum = dataChecksum;
+    this.checksums = checksums;
   }
 
   public long getBcsId() {
@@ -83,24 +84,26 @@ public class ContainerReplicaHistory {
     this.state = state;
   }
 
-  public long getDataChecksum() {
-    return dataChecksum;
+  public ContainerChecksums getChecksums() {
+    return checksums;
   }
 
-  public void setDataChecksum(long dataChecksum) {
-    this.dataChecksum = dataChecksum;
+  public void setChecksums(ContainerChecksums checksums) {
+    this.checksums = checksums;
   }
 
   public static ContainerReplicaHistory fromProto(
       ContainerReplicaHistoryProto proto) {
     return new ContainerReplicaHistory(UUID.fromString(proto.getUuid()),
         proto.getFirstSeenTime(), proto.getLastSeenTime(), proto.getBcsId(),
-        proto.getState(), proto.getDataChecksum());
+        proto.getState(), new ContainerChecksums(proto.getDataChecksum()));
   }
 
   public ContainerReplicaHistoryProto toProto() {
     return ContainerReplicaHistoryProto.newBuilder().setUuid(uuid.toString())
         .setFirstSeenTime(firstSeenTime).setLastSeenTime(lastSeenTime)
-        .setBcsId(bcsId).setState(state).setDataChecksum(dataChecksum).build();
+        .setBcsId(bcsId).setState(state)
+        .setDataChecksum(checksums != null ? checksums.getDataChecksum() : 0L)
+        .build();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
@@ -278,7 +279,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
     boolean flushToDB = false;
     long bcsId = replica.getSequenceId() != null ? replica.getSequenceId() : -1;
     String state = replica.getState().toString();
-    long dataChecksum = replica.getDataChecksum();
+    ContainerChecksums checksums = replica.getChecksums();
 
     // If replica doesn't exist in in-memory map, add to DB and add to map
     if (replicaLastSeenMap == null) {
@@ -286,7 +287,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
       replicaHistoryMap.putIfAbsent(id,
           new ConcurrentHashMap<UUID, ContainerReplicaHistory>() {{
             put(uuid, new ContainerReplicaHistory(uuid, currTime, currTime,
-                bcsId, state, dataChecksum));
+                bcsId, state, checksums));
           }});
       flushToDB = true;
     } else {
@@ -296,18 +297,19 @@ public class ReconContainerManager extends ContainerManagerImpl {
         // New Datanode
         replicaLastSeenMap.put(uuid,
             new ContainerReplicaHistory(uuid, currTime, currTime, bcsId,
-                state, dataChecksum));
+                state, checksums));
         flushToDB = true;
       } else {
         // if the object exists, only update the last seen time & bcsId fields
         ts.setLastSeenTime(currTime);
         ts.setBcsId(bcsId);
         ts.setState(state);
+        ts.setChecksums(checksums);
       }
     }
 
     if (flushToDB) {
-      upsertContainerHistory(id, uuid, currTime, bcsId, state, dataChecksum);
+      upsertContainerHistory(id, uuid, currTime, bcsId, state, checksums);
     }
   }
 
@@ -324,7 +326,6 @@ public class ReconContainerManager extends ContainerManagerImpl {
     final DatanodeDetails dnInfo = replica.getDatanodeDetails();
     final UUID uuid = dnInfo.getUuid();
     String state = replica.getState().toString();
-    long dataChecksum = replica.getDataChecksum();
 
     final Map<UUID, ContainerReplicaHistory> replicaLastSeenMap =
         replicaHistoryMap.get(id);
@@ -333,7 +334,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
       if (ts != null) {
         // Flush to DB, then remove from in-memory map
         upsertContainerHistory(id, uuid, ts.getLastSeenTime(), ts.getBcsId(),
-            state, dataChecksum);
+            state, ts.getChecksums());
         replicaLastSeenMap.remove(uuid);
       }
     }
@@ -392,7 +393,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
       final long lastSeenTime = entry.getValue().getLastSeenTime();
       long bcsId = entry.getValue().getBcsId();
       String state = entry.getValue().getState();
-      long dataChecksum = entry.getValue().getDataChecksum();
+      long dataChecksum = entry.getValue().getChecksums().getDataChecksum();
 
       resList.add(new ContainerHistory(containerID, uuid.toString(), hostname,
           firstSeenTime, lastSeenTime, bcsId, state, dataChecksum));
@@ -430,7 +431,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
   }
 
   public void upsertContainerHistory(long containerID, UUID uuid, long time,
-                                     long bcsId, String state, long dataChecksum) {
+                                     long bcsId, String state, ContainerChecksums checksums) {
     Map<UUID, ContainerReplicaHistory> tsMap;
     try {
       tsMap = cdbServiceProvider.getContainerReplicaHistory(containerID);
@@ -438,12 +439,12 @@ public class ReconContainerManager extends ContainerManagerImpl {
       if (ts == null) {
         // New entry
         tsMap.put(uuid, new ContainerReplicaHistory(uuid, time, time, bcsId,
-            state, dataChecksum));
+            state, checksums));
       } else {
         // Entry exists, update last seen time and put it back to DB.
         ts.setLastSeenTime(time);
         ts.setState(state);
-        ts.setDataChecksum(dataChecksum);
+        ts.setChecksums(checksums);
       }
       cdbServiceProvider.storeContainerReplicaHistory(containerID, tsMap);
     } catch (IOException e) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
@@ -1035,12 +1036,12 @@ public class TestContainerEndpoint {
     final UUID u2 = newDatanode("host2", "127.0.0.2");
     final UUID u3 = newDatanode("host3", "127.0.0.3");
     final UUID u4 = newDatanode("host4", "127.0.0.4");
-    reconContainerManager.upsertContainerHistory(1L, u1, 1L, 1L, "OPEN", 1234L);
-    reconContainerManager.upsertContainerHistory(1L, u2, 2L, 1L, "OPEN", 1234L);
-    reconContainerManager.upsertContainerHistory(1L, u3, 3L, 1L, "OPEN", 1234L);
-    reconContainerManager.upsertContainerHistory(1L, u4, 4L, 1L, "OPEN", 1234L);
+    reconContainerManager.upsertContainerHistory(1L, u1, 1L, 1L, "OPEN", new ContainerChecksums(1234L));
+    reconContainerManager.upsertContainerHistory(1L, u2, 2L, 1L, "OPEN", new ContainerChecksums(1234L));
+    reconContainerManager.upsertContainerHistory(1L, u3, 3L, 1L, "OPEN", new ContainerChecksums(1234L));
+    reconContainerManager.upsertContainerHistory(1L, u4, 4L, 1L, "OPEN", new ContainerChecksums(1234L));
 
-    reconContainerManager.upsertContainerHistory(1L, u1, 5L, 1L, "OPEN", 1234L);
+    reconContainerManager.upsertContainerHistory(1L, u1, 5L, 1L, "OPEN", new ContainerChecksums(1234L));
 
     Response response = containerEndpoint.getReplicaHistoryForContainer(1L);
     List<ContainerHistory> histories =
@@ -1150,13 +1151,13 @@ public class TestContainerEndpoint {
     long differentChecksum = dataChecksumMismatch ? 2345L : 1234L;
 
     reconContainerManager.upsertContainerHistory(cID, uuid1, 1L, 1L,
-        "UNHEALTHY", differentChecksum);
+        "UNHEALTHY", new ContainerChecksums(differentChecksum));
     reconContainerManager.upsertContainerHistory(cID, uuid2, 2L, 1L,
-        "UNHEALTHY", differentChecksum);
+        "UNHEALTHY", new ContainerChecksums(differentChecksum));
     reconContainerManager.upsertContainerHistory(cID, uuid3, 3L, 1L,
-        "UNHEALTHY", 1234L);
+        "UNHEALTHY", new ContainerChecksums(1234L));
     reconContainerManager.upsertContainerHistory(cID, uuid4, 4L, 1L,
-        "UNHEALTHY", 1234L);
+        "UNHEALTHY", new ContainerChecksums(1234L));
   }
 
   protected ContainerWithPipeline getTestContainer(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -416,7 +417,7 @@ public class TestContainerHealthStatus {
       replicas.add(new ContainerReplica.ContainerReplicaBuilder()
           .setContainerID(cont.containerID())
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
-          .setDataChecksum(1234L)
+          .setChecksums(new ContainerChecksums(1234L))
           .setContainerState(s)
           .build());
     }
@@ -432,7 +433,7 @@ public class TestContainerHealthStatus {
           .setContainerID(cont.containerID())
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
           .setContainerState(s)
-          .setDataChecksum(checksum)
+          .setChecksums(new ContainerChecksums(checksum))
           .build());
       checksum++;
     }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
@@ -690,7 +691,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
           .setContainerState(s)
           .setContainerID(ContainerID.valueOf(containerId))
           .setSequenceId(1)
-          .setDataChecksum(1234L)
+          .setChecksums(new ContainerChecksums(1234L))
           .build());
     }
     return replicas;
@@ -706,7 +707,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
           .setContainerState(s)
           .setContainerID(ContainerID.valueOf(containerId))
           .setSequenceId(1)
-          .setDataChecksum(checksum)
+          .setChecksums(new ContainerChecksums(checksum))
           .build());
       checksum++;
     }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -642,8 +643,8 @@ public class TestContainerHealthTaskRecordGenerator {
       replicas.add(new ContainerReplica.ContainerReplicaBuilder()
           .setContainerID(cont.containerID())
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+          .setChecksums(new ContainerChecksums(1234L))
           .setContainerState(s)
-          .setDataChecksum(1234L)
           .build());
     }
     return replicas;
@@ -658,7 +659,7 @@ public class TestContainerHealthTaskRecordGenerator {
           .setContainerID(cont.containerID())
           .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
           .setContainerState(s)
-          .setDataChecksum(checksum)
+          .setChecksums(new ContainerChecksums(checksum))
           .build());
       checksum++;
     }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
+import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -209,7 +210,8 @@ public class TestReconContainerManager
         .setUuid(uuid1).setHostName("host1").setIpAddress("127.0.0.1").build();
     ContainerReplica containerReplica1 = ContainerReplica.newBuilder()
         .setContainerID(containerID1).setContainerState(State.OPEN)
-        .setDatanodeDetails(datanodeDetails1).setSequenceId(1001L).setDataChecksum(1234L).build();
+        .setDatanodeDetails(datanodeDetails1).setSequenceId(1001L)
+        .setChecksums(new ContainerChecksums(1234L)).build();
 
     final ReconContainerManager containerManager = getContainerManager();
     final Map<Long, Map<UUID, ContainerReplicaHistory>> repHistMap =
@@ -237,7 +239,7 @@ public class TestReconContainerManager
     assertEquals(repHist1.getLastSeenTime(), repHist1.getFirstSeenTime());
     assertEquals(containerReplica1.getSequenceId().longValue(),
         repHist1.getBcsId());
-    assertEquals(containerReplica1.getDataChecksum(), repHist1.getDataChecksum());
+    assertEquals(containerReplica1.getChecksums().getDataChecksum(), repHist1.getChecksums().getDataChecksum());
 
     // Let's update the entry again
     containerReplica1 = ContainerReplica.newBuilder()
@@ -256,7 +258,8 @@ public class TestReconContainerManager
         .setUuid(uuid2).setHostName("host2").setIpAddress("127.0.0.2").build();
     final ContainerReplica containerReplica2 = ContainerReplica.newBuilder()
         .setContainerID(containerID1).setContainerState(State.OPEN)
-        .setDatanodeDetails(datanodeDetails2).setSequenceId(1051L).setDataChecksum(1234L).build();
+        .setDatanodeDetails(datanodeDetails2).setSequenceId(1051L)
+        .setChecksums(new ContainerChecksums(1234L)).build();
 
     // Add replica to DN02
     containerManager.updateContainerReplica(containerID1, containerReplica2);
@@ -270,7 +273,7 @@ public class TestReconContainerManager
     // Because this is a new entry, first seen time equals last seen time
     assertEquals(repHist2.getLastSeenTime(), repHist2.getFirstSeenTime());
     assertEquals(1051L, repHist2.getBcsId());
-    assertEquals(containerReplica2.getDataChecksum(), repHist2.getDataChecksum());
+    assertEquals(containerReplica2.getChecksums().getDataChecksum(), repHist2.getChecksums().getDataChecksum());
 
     // Remove replica from DN01
     containerManager.removeContainerReplica(containerID1, containerReplica1);


### PR DESCRIPTION
## What changes were proposed in this pull request?
As mentioned in the JIRA, this PR will
- create ContainerChecksums Wrapper to include `dataChecksum` and `metadataChecksum`
- provide further extension by `metadataChecksum`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13305

## How was this patch tested?

CI: https://github.com/echonesis/ozone/actions/runs/16216281749
