### PR TITLE
HDDS-13376. Add server-side limit note to ozone sh snapshot diff --page-size option

### DIFF
--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -61,7 +61,10 @@ public class SnapshotDiffHandler extends Handler {
   private String token;
 
   @CommandLine.Option(names = {"-p", "--page-size"},
-      description = "number of diff entries to be returned in the response",
+      description = "number of diff entries to be returned in the response. " +
+          "Note the effective page size will also be bound by " +
+          "the server-side page size limit, see config:\n" +
+          "  ozone.om.snapshot.diff.max.page.size",
       defaultValue = "1000",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a note to the page-size option of ozone sh snapshot diff that server-side config [`ozone.om.snapshot.diff.max.page.size`](https://github.com/apache/ozone/blob/8651aa4a76f84473b1e3d4ae8aee4601d6f4503b/hadoop-hdds/common/src/main/resources/ozone-default.xml#L4462-L4469) would also be a limiting factor.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13376

## How was this patch tested?

- Updated CLI help print:
```bash
bash-5.1$ ozone sh snapshot diff -h
Usage: ozone sh snapshot diff [-chV] [--json] [--verbose] [-p=<pageSize>]
                              [-t=<token>] <value> <fromSnapshot> <toSnapshot>
Get the differences between two snapshots
      <value>           URI of the bucket (format: volume/bucket).
...
  -p, --page-size=<pageSize>
                        number of diff entries to be returned in the response.
                          Note the effective page size will also be bound by
                          the server-side page size limit, see config:
                          ozone.om.snapshot.diff.max.page.size
                          Default: 1000
```