### PR TITLE
HDDS-2647. Describe Ratis properties loaded with hdds.ratis prefixed Ozone configurations properties.

### DIFF
--- a/hadoop-hdds/docs/content/feature/multi-raft-support.md
+++ b/hadoop-hdds/docs/content/feature/multi-raft-support.md
@@ -105,6 +105,22 @@ Ratis handles concurrent logs per node.
   The Ratis pipelines will be distributed accordingly.
   - Be cautious with very high pipeline counts due to memory/CPU overhead.
 
+## Advanced Ratis Configuration
+
+For more fine-grained control, Ozone allows you to pass Ratis-specific settings directly from your `ozone-site.xml` configuration. This is useful for administrators and applications that need to tune Ratis performance.
+
+Ozone uses the prefix `hdds.ratis.` for all Ratis-related properties. When Ozone encounters a property with this prefix, it forwards the setting to the appropriate Ratis component (server or client) after removing the prefix.
+
+For example, setting `hdds.ratis.raft.grpc.message.size.max` in `ozone-site.xml` configures the Ratis property `raft.grpc.message.size.max`, which controls the maximum allowed gRPC message size.
+
+### Server-Side Configuration
+The Ozone Manager (OM), Storage Container Manager (SCM), and Datanodes automatically load any Ratis server properties defined in `ozone-site.xml` with the `hdds.ratis.` prefix. These are typically properties that do not start with `raft.client`, `raft.client.data-stream`, or `raft.netty.dataStream`.
+
+### Client-Side Configuration
+Similarly, Ozone clients and applications load all Ratis client properties prefixed with `hdds.ratis.`. These are generally properties that begin with `raft.client`, `raft.client.data-stream`, or `raft.netty.dataStream`.
+
+For a complete list of Ratis properties, see the official [Apache Ratis documentation](https://github.com/apache/ratis/blob/master/ratis-docs/src/site/markdown/configurations.md).
+
 ## Limitations
 - Global configuration: cannot set per-node limits
 - Requires restart after changing storage dirs


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-2647. Describe Ratis properties loaded with hdds.ratis prefixed Ozone configurations properties.

Please describe your PR in detail:
* HDDS-2647 is an ancient jira. Looking at it, it is no longer an issue. However, I can't find any user doc mentioning the use of hdds.ratis prefix Ozone configuraiton properties. I don't think it should stay undocumented.
* Generated-by: Google Gemini 2.5 Pro + Gemini Cli

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2647

## How was this patch tested?

User doc. See RatisHelper.createRaftClientProperties, RatisHelper.createRaftServerProperties, and TestRatisHelper.