### PR TITLE
HDDS-13430. Avoid using new OzoneConfiguration in OMSnapshotCreateRequest

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -188,7 +187,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
       // because it is a design goal of CreateSnapshot to be an O(1) operation.
       // TODO: [SNAPSHOT] Assign actual data size once we have the
       //  pre-replicated key size counter in OmBucketInfo.
-      snapshotInfo.setReferencedSize(estimateBucketDataSize(omBucketInfo));
+      snapshotInfo.setReferencedSize(estimateBucketDataSize(omBucketInfo, ozoneManager.getDefaultReplicationConfig()));
 
       addSnapshotInfoToSnapshotChainAndCache(ozoneManager, omMetadataManager, context.getIndex());
 
@@ -335,12 +334,12 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
    * bucket used size (w/ replication) by the replication factor of the bucket.
    * @param bucketInfo OmBucketInfo
    */
-  private long estimateBucketDataSize(OmBucketInfo bucketInfo) {
+  private long estimateBucketDataSize(OmBucketInfo bucketInfo, ReplicationConfig defaultReplicationConfig) {
     DefaultReplicationConfig defRC = bucketInfo.getDefaultReplicationConfig();
     final ReplicationConfig rc;
     if (defRC == null) {
       //  Fall back to config default.
-      rc = ReplicationConfig.getDefault(new OzoneConfiguration());
+      rc = defaultReplicationConfig;
     } else {
       rc = defRC.getReplicationConfig();
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -34,15 +34,12 @@ import java.util.Random;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.ClientVersion;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -206,12 +203,8 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
   @ParameterizedTest
   @CsvSource(value = {"false,false", "false,true", "true,false", "true,true"})
   public void testDirectoryPurge(boolean fromSnapshot, boolean purgeDirectory) throws Exception {
-    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
-        ReplicationConfig.fromTypeAndFactor(
-            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
-            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
-        )
-    );
+    when(ozoneManager.getDefaultReplicationConfig())
+        .thenReturn(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     Random random = new Random();
     String bucket = "bucket" + random.nextInt();
     // Add volume, bucket and key entries to OM DB.
@@ -337,12 +330,8 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
 
   @Test
   public void testValidateAndUpdateCacheSnapshotLastTransactionInfoUpdated() throws Exception {
-    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
-        ReplicationConfig.fromTypeAndFactor(
-            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
-            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
-        )
-    );
+    when(ozoneManager.getDefaultReplicationConfig())
+        .thenReturn(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     // Create and Delete keys. The keys should be moved to DeletedKeys table
     List<OmKeyInfo> deletedKeyInfos = createAndDeleteKeys(1, null);
     // The keys should be present in the DeletedKeys table before purging

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
@@ -33,11 +34,15 @@ import java.util.Random;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -201,6 +206,12 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
   @ParameterizedTest
   @CsvSource(value = {"false,false", "false,true", "true,false", "true,true"})
   public void testDirectoryPurge(boolean fromSnapshot, boolean purgeDirectory) throws Exception {
+    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
+        ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
+            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
+        )
+    );
     Random random = new Random();
     String bucket = "bucket" + random.nextInt();
     // Add volume, bucket and key entries to OM DB.
@@ -326,6 +337,12 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
 
   @Test
   public void testValidateAndUpdateCacheSnapshotLastTransactionInfoUpdated() throws Exception {
+    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
+        ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
+            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
+        )
+    );
     // Create and Delete keys. The keys should be moved to DeletedKeys table
     List<OmKeyInfo> deletedKeyInfos = createAndDeleteKeys(1, null);
     // The keys should be present in the DeletedKeys table before purging

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -28,12 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -183,12 +181,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
   @Test
   public void testKeyPurgeInSnapshot() throws Exception {
-    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
-        ReplicationConfig.fromTypeAndFactor(
-            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
-            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
-        )
-    );
+    when(ozoneManager.getDefaultReplicationConfig())
+        .thenReturn(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     // Create and Delete keys. The keys should be moved to DeletedKeys table
     Pair<List<String>, List<String>> deleteKeysAndRenamedEntry = createAndDeleteKeysAndRenamedEntry(1, null);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -21,14 +21,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -178,6 +183,12 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
   @Test
   public void testKeyPurgeInSnapshot() throws Exception {
+    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
+        ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
+            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
+        )
+    );
     // Create and Delete keys. The keys should be moved to DeletedKeys table
     Pair<List<String>, List<String>> deleteKeysAndRenamedEntry = createAndDeleteKeysAndRenamedEntry(1, null);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotRequestAndResponse.java
@@ -38,10 +38,10 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -175,12 +175,8 @@ public class TestSnapshotRequestAndResponse {
     bucketName = UUID.randomUUID().toString();
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
-    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
-        ReplicationConfig.fromTypeAndFactor(
-            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
-            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
-        )
-    );
+    when(ozoneManager.getDefaultReplicationConfig())
+        .thenReturn(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     omSnapshotManager = new OmSnapshotManager(ozoneManager);
     when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotRequestAndResponse.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
@@ -173,6 +175,12 @@ public class TestSnapshotRequestAndResponse {
     bucketName = UUID.randomUUID().toString();
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
+    when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
+        ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT.toUpperCase()),
+            ReplicationFactor.valueOf(OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT.toUpperCase())
+        )
+    );
     omSnapshotManager = new OmSnapshotManager(ozoneManager);
     when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`OMSnapshotCreateRequest` creates new `OzoneConfiguration `for getting the cluster-level default replication setting when the default replication config for the bucket is not set. But it can get the same information from `ozoneManager.getDefaultReplicationConfig()` to avoid instantiation and config loading.

## What is the link to the Apache JIRA

[HDDS-13430](https://issues.apache.org/jira/browse/HDDS-13430)

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/16269659671

unit tests
