### PR TITLE
HDDS-13429. Custom metadata headers with uppercase characters are not supported

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -297,8 +297,8 @@ public abstract class EndpointBase implements Auditor {
 
     Set<String> customMetadataKeys = requestHeaders.keySet().stream()
             .filter(k -> {
-              if (k.startsWith(CUSTOM_METADATA_HEADER_PREFIX) &&
-                      !excludeMetadataFields.contains(
+              if (k.toLowerCase().startsWith(CUSTOM_METADATA_HEADER_PREFIX) &&
+                  !excludeMetadataFields.contains(
                         k.substring(
                           CUSTOM_METADATA_HEADER_PREFIX.length()))) {
                 return true;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -94,6 +95,23 @@ public class TestEndpointBase {
         "getCustomMetadataFromHeaders should fail." +
             " Expected OS3Exception not thrown");
     assertThat(e.getCode()).contains("MetadataTooLarge");
+  }
+
+  @Test
+  public void testCustomMetadataHeadersWithUpperCaseHeaders() throws OS3Exception {
+    MultivaluedMap<String, String> s3requestHeaders = new MultivaluedHashMap<>();
+    String key = "CUSTOM-KEY";
+    String value = "custom-value1";
+    s3requestHeaders.add(CUSTOM_METADATA_HEADER_PREFIX.toUpperCase(Locale.ROOT) + key, value);
+
+    EndpointBase endpointBase = new EndpointBase() {
+      @Override
+      public void init() { }
+    };
+
+    Map<String, String> customMetadata = endpointBase.getCustomMetadataFromHeaders(s3requestHeaders);
+
+    assertEquals(value, customMetadata.get(key));
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The current [code block in EndpointBase.java](https://github.com/apache/ozone/blob/master/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java#L298-L308) does not correctly handle custom metadata headers when the header names contain uppercase characters.
This may lead to unexpected behavior when clients send headers with capital letters.

Please describe your PR in detail:
* Normalize custom metadata header keys to lowercase at the beginning of processing.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13429

## How was this patch tested?
https://github.com/hevinhsu/ozone/actions/runs/16282548652
