### PR TITLE
HDDS-13442. Replace OMKeyInfo with light-weight ReconBasicOmKeyInfo under OmTableHandlers

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ReconBasicOmKeyInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ReconBasicOmKeyInfo.java
@@ -247,6 +247,30 @@ public final class ReconBasicOmKeyInfo extends WithParentObjectId {
     return builder.build();
   }
 
+  public static ReconBasicOmKeyInfo getFromProtobuf(OzoneManagerProtocolProtos.KeyInfo keyInfoProto) {
+    if (keyInfoProto == null) {
+      return null;
+    }
+
+    String keyName = keyInfoProto.getKeyName();
+
+    Builder builder = new Builder()
+        .setVolumeName(keyInfoProto.getVolumeName())
+        .setBucketName(keyInfoProto.getBucketName())
+        .setKeyName(keyName)
+        .setDataSize(keyInfoProto.getDataSize())
+        .setCreationTime(keyInfoProto.getCreationTime())
+        .setModificationTime(keyInfoProto.getModificationTime())
+        .setReplicationConfig(ReplicationConfig.fromProto(
+            keyInfoProto.getType(),
+            keyInfoProto.getFactor(),
+            keyInfoProto.getEcReplicationConfig()))
+        .setIsFile(!keyName.endsWith("/"))
+        .setParentId(keyInfoProto.getParentID());
+
+    return builder.build();
+  }
+
   public OzoneManagerProtocolProtos.KeyInfoProtoLight toProtobuf() {
     throw new UnsupportedOperationException("This method is not supported.");
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ReconBasicOmKeyInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ReconBasicOmKeyInfo.java
@@ -247,6 +247,14 @@ public final class ReconBasicOmKeyInfo extends WithParentObjectId {
     return builder.build();
   }
 
+  /**
+   * Converts a KeyInfo protobuf object into a ReconBasicOmKeyInfo instance.
+   * This method extracts only the essential fields required for Recon event handling, avoiding the overhead of
+   * deserializing unused metadata such as KeyLocationList or ACLs.
+   *
+   * @param keyInfoProto required for deserialization.
+   * @return the deserialized lightweight ReconBasicOmKeyInfo object.
+   */
   public static ReconBasicOmKeyInfo getFromProtobuf(OzoneManagerProtocolProtos.KeyInfo keyInfoProto) {
     if (keyInfoProto == null) {
       return null;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
@@ -21,9 +21,9 @@ import java.util.Map;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
+import org.apache.hadoop.ozone.recon.api.types.ReconBasicOmKeyInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
           (k, count) -> count + 1L);
 
       for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
         unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
             (k, size) -> size + omKeyInfo.getDataSize());
         replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
@@ -75,7 +75,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
           (k, count) -> count > 0 ? count - 1L : 0L);
 
       for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
         unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
             (k, size) -> {
               long newSize = size > omKeyInfo.getDataSize() ? size - omKeyInfo.getDataSize() : 0L;
@@ -121,7 +121,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
 
       // Calculate old sizes
       for (PartKeyInfo partKeyInfo : oldMultipartKeyInfo.getPartKeyInfoMap()) {
-        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
         unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
             (k, size) -> size - omKeyInfo.getDataSize());
         replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
@@ -130,7 +130,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
 
       // Calculate new sizes
       for (PartKeyInfo partKeyInfo : newMultipartKeyInfo.getPartKeyInfoMap()) {
-        OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
         unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
             (k, size) -> size + omKeyInfo.getDataSize());
         replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
@@ -160,7 +160,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
         if (kv != null && kv.getValue() != null) {
           OmMultipartKeyInfo multipartKeyInfo = (OmMultipartKeyInfo) kv.getValue();
           for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-            OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+            ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
             unReplicatedSize += omKeyInfo.getDataSize();
             replicatedSize += omKeyInfo.getReplicatedSize();
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon OmTableHandlers currently rely on the full KeyInfo proto for key metadata. However, most of the fields in OMKeyInfo, such as KeyLocationList, FileEncryptionInfoProto, OzoneAclInfo, and FileChecksumProto, are not required and contribute to unnecessary serialization and deserialization overhead.

This inefficiency becomes significant for larger keys or multipart upload (MPU) keys, where the KeyLocationList can be very large. As a result, this can cause performance degradation for clients querying this API.

To address this, OMKeyInfo objects should be replaced with a lighter weight ReconBasicOmKeyInfo object (based on the KeyInfoProtoLight proto) introduced in [PR #8699](https://github.com/apache/ozone/pull/8699). This lightweight version includes only the necessary fields required for event handling.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13442

## How was this patch tested?

- Existing MPU test-cases under TestOmTableInsightTask.
- Green Git CI/CD: https://github.com/apache/ozone/actions/runs/16287409178
