### PR TITLE
HDDS-13123. Add testing for the `ozone repair om skip-ratis-transaction` command

### DIFF
--- a/dev-support/byteman/fail-create-bucket.btm
+++ b/dev-support/byteman/fail-create-bucket.btm
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This script instruments ozone manager to fail a CreateBucket request for a specific name
+#
+
+RULE Crash OM with CreateBucket
+CLASS org.apache.hadoop.ozone.om.request.bucket.OMBucketCreateRequest
+METHOD validateAndUpdateCache
+BIND result = $bucketName
+AT LINE 177
+IF (result.equals("bucket-crash-1"))
+DO
+  traceln("--> crashing CreateBucket request");
+  THROW new RuntimeException("Byteman crashes OM");
+ENDRULE

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
@@ -59,7 +59,7 @@ repair_and_restart_om() {
   done
   echo "Container '${om_container}' has stopped."
 
-  LOG_PATH="$(find "$OZONE_VOLUME/$om_id/metadata/ratis" -type f -name 'log_inprogress_0' 2>/dev/null | head -n 1)"
+  LOG_PATH="$(find / -type f -name 'log_inprogress_0' 2>/dev/null | head -n 1)"
   echo "Log path: ${LOG_PATH}"
   newpath=$(echo "${LOG_PATH}" | sed 's|.*/compose/|/opt/hadoop/compose/|')
   echo "New path: ${newpath}"

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
@@ -59,12 +59,14 @@ repair_and_restart_om() {
   done
   echo "Container '${om_container}' has stopped."
 
-  LOG_PATH="$(find / -type f -name 'log_inprogress_0' 2>/dev/null | head -n 1)"
-  echo "Log path: ${LOG_PATH}"
-  newpath=$(echo "${LOG_PATH}" | sed 's|.*/compose/|/opt/hadoop/compose/|')
-  echo "New path: ${newpath}"
+  # LOG_PATH="$(find / -type f -name 'log_inprogress_0' 2>/dev/null | head -n 1)"
+  # echo "Log path: ${LOG_PATH}"
+  # newpath=$(echo "${LOG_PATH}" | sed 's|.*/compose/|/opt/hadoop/compose/|')
+  # echo "New path: ${newpath}"
+  logpath=$(execute_command_in_container ${SCM} bash -c find / -type f -path "/*/$om_id/*/log_inprogress_0" 2>/dev/null | head -n 1)
+  echo "logpath: ${logpath}"
 
-  execute_command_in_container ${SCM} bash -c "ozone repair om srt -b=/opt/hadoop/compose/ozonesecure-ha/data/$om_id/backup1 --index=3 -s=${newpath}"
+  execute_command_in_container ${SCM} bash -c "ozone repair om srt -b=/opt/hadoop/compose/ozonesecure-ha/data/$om_id/backup1 --index=3 -s=${logpath}"
   echo "Repair command executed for ${om_id}."
   docker start "${om_container}"
   echo "Container '${om_container}' started again."

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
@@ -63,7 +63,7 @@ repair_and_restart_om() {
   # echo "Log path: ${LOG_PATH}"
   # newpath=$(echo "${LOG_PATH}" | sed 's|.*/compose/|/opt/hadoop/compose/|')
   # echo "New path: ${newpath}"
-  logpath=$(execute_command_in_container ${SCM} bash -c find / -type f -path "/*/$om_id/*/log_inprogress_0" 2>/dev/null | head -n 1)
+  logpath=$(execute_command_in_container ${SCM} bash -c "find / -type f -path '/*/$om_id/*/log_inprogress_0' 2>/dev/null | head -n 1")
   echo "logpath: ${logpath}"
 
   execute_command_in_container ${SCM} bash -c "ozone repair om srt -b=/opt/hadoop/compose/ozonesecure-ha/data/$om_id/backup1 --index=3 -s=${logpath}"

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
@@ -40,6 +40,48 @@ create_data_dirs dn{1..5} kms om{1..3} recon s3g scm{1..3}
 
 start_docker_env
 
+repair_and_restart_om() {
+  local om_container="$1"
+  local om_id="$2"
+  echo "Waiting for container '${om_container}' to stop..."
+  # Loop until the container is not running
+  timeout=60  # seconds
+  start_time=$(date +%s)
+  while [ "$(docker inspect -f '{{.State.Running}}' "${om_container}" 2>/dev/null)" == "true" ]; do
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [ "$elapsed" -ge "$timeout" ]; then
+      echo "Timeout: Container '${om_container}' did not stop within ${timeout} seconds."
+      exit 1
+    fi
+    sleep 1
+  done
+  echo "Container '${om_container}' has stopped."
+
+  LOG_PATH="$(find "$OZONE_VOLUME/$om_id/metadata/ratis" -type f -name 'log_inprogress_0' 2>/dev/null | head -n 1)"
+  newpath=$(echo "${LOG_PATH}" | sed 's|.*/compose/|/opt/hadoop/compose/|')
+
+  execute_command_in_container ${SCM} bash -c "ozone repair om srt -b=/opt/hadoop/compose/ozonesecure-ha/data/$om_id/backup1 --index=3 -s=${newpath}"
+  docker start "${om_container}"
+  echo "Container '${om_container}' started again."
+  bucketTable=$(execute_command_in_container ${SCM} bash -c "ozone debug ldb --db=/opt/hadoop/compose/ozonesecure-ha/data/$om_id/metadata/om.db scan --cf=bucketTable")
+  if echo "$bucketTable" | grep -q "bucket-crash-1"; then
+    echo "bucket 'bucket-crash-1' should not have been created, but it is present in the bucketTable of $om_id"
+    exit 1
+  fi
+}
+
+execute_robot_test ${SCM} kinit.robot
+execute_robot_test ${SCM} repair/transaction-repair.robot
+repair_and_restart_om "ozonesecure-ha-om1-1" "om1"
+repair_and_restart_om "ozonesecure-ha-om2-1" "om2"
+repair_and_restart_om "ozonesecure-ha-om3-1" "om3"
+if ! execute_command_in_container scm1.org timeout 15s ozone sh volume list; then
+  echo "Command timed out or failed => OMs are not running as expected. Test for repairing ratis transaction failed."
+  exit 1
+fi
+
 execute_robot_test ${OM} kinit.robot
 
 execute_robot_test ${OM} repair/om-compact.robot

--- a/hadoop-ozone/dist/src/main/smoketest/repair/transaction-repair.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/repair/transaction-repair.robot
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test recovering from OM crash due to transaction failure
+Library             OperatingSystem
+Library             BuiltIn
+Library             Process
+Resource            ../lib/os.robot
+Resource            ../ozone-fi/BytemanKeywords.robot
+
+*** Variables ***
+${VOLUME}               test-txn-vol
+${GOOD_BUCKET}          bucket-good-1
+${BAD_BUCKET}           bucket-crash-1
+${CRASH_RULE}           /opt/hadoop/share/ozone/byteman/fail-create-bucket.btm
+${TIMEOUT}              10 seconds
+
+*** Test Cases ***
+Verify OM crash at bucket create
+    Inject Fault Into OMs Only      ${CRASH_RULE}
+    Execute         ozone sh volume create o3://${OM_SERVICE_ID}/${VOLUME}
+    Execute         ozone sh bucket create o3://${OM_SERVICE_ID}/${VOLUME}/${GOOD_BUCKET}
+    Run Process     ozone sh bucket create o3://${OM_SERVICE_ID}/${VOLUME}/${BAD_BUCKET}    timeout=${TIMEOUT}    shell=True


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds a robot test to check the `skip-ratis-transaction` command.
Using byteman rule to crash the OMs when a request is executed, the test proceeds to run the repair command on all the OMs and the restart them. Then by running a simple ozone command, we check if the cluster is functioning as normal.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13123

## How was this patch tested?

Green CI: https://github.com/Tejaskriya/ozone/actions/runs/16286588585/job/45987367157
Also tested locally by running the test script `./test-repair-tools.sh`
