### PR TITLE
HDDS-13422. Ozone tool should preserve previous RocksDB options

### DIFF
--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedConfigOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedConfigOptions.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db.managed;
+
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.track;
+
+import org.apache.ratis.util.UncheckedAutoCloseable;
+import org.rocksdb.ConfigOptions;
+
+/**
+ * Managed ConfigOptions.
+ */
+public class ManagedConfigOptions extends ConfigOptions {
+
+  private final UncheckedAutoCloseable leakTracker = track(this);
+
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      leakTracker.close();
+    }
+  }
+}

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
@@ -28,6 +28,7 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.DBOptions;
 import org.rocksdb.LiveFileMetaData;
+import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -82,6 +83,31 @@ public class ManagedRocksDB extends ManagedObject<RocksDB> {
     return new ManagedRocksDB(
         RocksDB.open(options, path,
             columnFamilyDescriptors, columnFamilyHandles)
+    );
+  }
+
+  /**
+   * Open a RocksDB option with the latest options. Other than {@link ManagedConfigOptions} and
+   * path, the other options and handles should be empty since it will be populated with
+   * loadLatestOptions. Nevertheless, the caller is still responsible in cleaning up / closing the resources.
+   * @param configOptions Config options.
+   * @param options DBOptions. This would be modified based on the latest options.
+   * @param path DB path.
+   * @param columnFamilyDescriptors Column family descriptors. These would be modified based on the latest options.
+   * @param columnFamilyHandles Column family handles. The underlying column family
+   * @return A RocksDB instance.
+   * @throws RocksDBException exception if thrown when opening a RocksDB instance.
+   */
+  public static ManagedRocksDB openWithLatestOptions(
+      final ManagedConfigOptions configOptions,
+      final DBOptions options, final String path,
+      final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
+      final List<ColumnFamilyHandle> columnFamilyHandles)
+      throws RocksDBException {
+    // Preserve all the previous DB options
+    OptionsUtil.loadLatestOptions(configOptions, path, options, columnFamilyDescriptors);
+    return new ManagedRocksDB(
+        RocksDB.open(options, path, columnFamilyDescriptors, columnFamilyHandles)
     );
   }
 

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
@@ -85,16 +85,6 @@ public class ManagedRocksDB extends ManagedObject<RocksDB> {
     );
   }
 
-  public static ManagedRocksDB open(
-      final String path,
-      final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
-      final List<ColumnFamilyHandle> columnFamilyHandles)
-      throws RocksDBException {
-    return new ManagedRocksDB(
-        RocksDB.open(path, columnFamilyDescriptors, columnFamilyHandles)
-    );
-  }
-
   /**
    * Delete liveMetaDataFile from rocks db using RocksDB#deleteFile Api.
    * This function makes the RocksDB#deleteFile Api synchronized by waiting

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
@@ -94,9 +94,9 @@ public class ManagedRocksDB extends ManagedObject<RocksDB> {
    * @param options DBOptions. This would be modified based on the latest options.
    * @param path DB path.
    * @param columnFamilyDescriptors Column family descriptors. These would be modified based on the latest options.
-   * @param columnFamilyHandles Column family handles. The underlying column family
+   * @param columnFamilyHandles Column family handles of the underlying column family
    * @return A RocksDB instance.
-   * @throws RocksDBException exception if thrown when opening a RocksDB instance.
+   * @throws RocksDBException thrown if error happens in underlying native library.
    */
   public static ManagedRocksDB openWithLatestOptions(
       final ManagedConfigOptions configOptions,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/TransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/TransactionInfoRepair.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.debug.RocksDBUtils;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
 
@@ -74,10 +73,8 @@ public class TransactionInfoRepair extends RepairTool {
     List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
     String columnFamilyName = getColumnFamily(serviceToBeOffline()).getName();
 
-    // Preserve all the previous DB options
-    OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescList);
-
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath, cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.openWithLatestOptions(
+        configOptions, dbOptions, dbPath, cfDescList, cfHandleList)) {
       ColumnFamilyHandle transactionInfoCfh = RocksDBUtils.getColumnFamilyHandle(columnFamilyName, cfHandleList);
       if (transactionInfoCfh == null) {
         throw new IllegalArgumentException(columnFamilyName +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/TransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/TransactionInfoRepair.java
@@ -77,7 +77,7 @@ public class TransactionInfoRepair extends RepairTool {
     // Preserve all the previous DB options
     OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescList);
 
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbPath, cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath, cfDescList, cfHandleList)) {
       ColumnFamilyHandle transactionInfoCfh = RocksDBUtils.getColumnFamilyHandle(columnFamilyName, cfHandleList);
       if (transactionInfoCfh == null) {
         throw new IllegalArgumentException(columnFamilyName +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
@@ -68,7 +68,7 @@ public class RocksDBManualCompaction extends RepairTool {
     // Preserve all the previous DB options
     OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescList);
 
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbPath, cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath, cfDescList, cfHandleList)) {
       ColumnFamilyHandle cfh = RocksDBUtils.getColumnFamilyHandle(columnFamilyName, cfHandleList);
       if (cfh == null) {
         throw new IllegalArgumentException(columnFamilyName +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.repair.RepairTool;
 import org.apache.hadoop.util.Time;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
 
@@ -65,10 +64,8 @@ public class RocksDBManualCompaction extends RepairTool {
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
     List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
 
-    // Preserve all the previous DB options
-    OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescList);
-
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath, cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.openWithLatestOptions(
+        configOptions, dbOptions, dbPath, cfDescList, cfHandleList)) {
       ColumnFamilyHandle cfh = RocksDBUtils.getColumnFamilyHandle(columnFamilyName, cfHandleList);
       if (cfh == null) {
         throw new IllegalArgumentException(columnFamilyName +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.ozone.repair.RepairTool;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,12 +88,10 @@ public class SnapshotChainRepair extends RepairTool {
     ManagedConfigOptions configOptions = new ManagedConfigOptions();
     ManagedDBOptions dbOptions = new ManagedDBOptions();
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
-    List<ColumnFamilyDescriptor> cfDescList = RocksDBUtils.getColumnFamilyDescriptors(dbPath);
+    List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
 
-    // Preserve all the previous DB options
-    OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescList);
-
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath, cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.openWithLatestOptions(
+        configOptions, dbOptions, dbPath, cfDescList, cfHandleList)) {
       ColumnFamilyHandle snapshotInfoCfh = RocksDBUtils.getColumnFamilyHandle(SNAPSHOT_INFO_TABLE, cfHandleList);
       if (snapshotInfoCfh == null) {
         error("%s is not in a column family in DB for the given path.", SNAPSHOT_INFO_TABLE);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/SnapshotChainRepair.java
@@ -94,7 +94,7 @@ public class SnapshotChainRepair extends RepairTool {
     // Preserve all the previous DB options
     OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescList);
 
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbPath, cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath, cfDescList, cfHandleList)) {
       ColumnFamilyHandle snapshotInfoCfh = RocksDBUtils.getColumnFamilyHandle(SNAPSHOT_INFO_TABLE, cfHandleList);
       if (snapshotInfoCfh == null) {
         error("%s is not in a column family in DB for the given path.", SNAPSHOT_INFO_TABLE);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestTransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestTransactionInfoRepair.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mockStatic;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedConfigOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.debug.RocksDBUtils;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
@@ -114,7 +115,8 @@ public class TestTransactionInfoRepair {
     try (MockedStatic<ManagedRocksDB> mocked = mockStatic(ManagedRocksDB.class);
          MockedStatic<RocksDBUtils> mockUtil = mockStatic(RocksDBUtils.class);
          MockedStatic<OptionsUtil> mockOptionsUtil = mockStatic(OptionsUtil.class)) {
-      mocked.when(() -> ManagedRocksDB.open(any(DBOptions.class), anyString(), anyList(), anyList())).thenReturn(mdb);
+      mocked.when(() -> ManagedRocksDB.openWithLatestOptions(any(ManagedConfigOptions.class), any(DBOptions.class),
+          anyString(), anyList(), anyList())).thenReturn(mdb);
       mockUtil.when(() -> RocksDBUtils.getColumnFamilyHandle(eq(expectedColumnFamilyName), anyList()))
           .thenReturn(columnFamilyHandle);
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestTransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestTransactionInfoRepair.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
@@ -111,7 +112,7 @@ public class TestTransactionInfoRepair {
     final String expectedColumnFamilyName = getColumnFamilyName(component);
     try (MockedStatic<ManagedRocksDB> mocked = mockStatic(ManagedRocksDB.class);
          MockedStatic<RocksDBUtils> mockUtil = mockStatic(RocksDBUtils.class)) {
-      mocked.when(() -> ManagedRocksDB.open(anyString(), anyList(), anyList())).thenReturn(mdb);
+      mocked.when(() -> ManagedRocksDB.open(any(DBOptions.class), anyString(), anyList(), anyList())).thenReturn(mdb);
       mockUtil.when(() -> RocksDBUtils.getColumnFamilyHandle(eq(expectedColumnFamilyName), anyList()))
           .thenReturn(columnFamilyHandle);
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestTransactionInfoRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestTransactionInfoRepair.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
@@ -111,7 +112,8 @@ public class TestTransactionInfoRepair {
   private void testCommand(String component, ManagedRocksDB mdb, ColumnFamilyHandle columnFamilyHandle) {
     final String expectedColumnFamilyName = getColumnFamilyName(component);
     try (MockedStatic<ManagedRocksDB> mocked = mockStatic(ManagedRocksDB.class);
-         MockedStatic<RocksDBUtils> mockUtil = mockStatic(RocksDBUtils.class)) {
+         MockedStatic<RocksDBUtils> mockUtil = mockStatic(RocksDBUtils.class);
+         MockedStatic<OptionsUtil> mockOptionsUtil = mockStatic(OptionsUtil.class)) {
       mocked.when(() -> ManagedRocksDB.open(any(DBOptions.class), anyString(), anyList(), anyList())).thenReturn(mdb);
       mockUtil.when(() -> RocksDBUtils.getColumnFamilyHandle(eq(expectedColumnFamilyName), anyList()))
           .thenReturn(columnFamilyHandle);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
@@ -262,7 +262,6 @@ public class TestLdbRepair {
       assertEquals(this.walTTL, other.walTTL);
       assertEquals(this.walSizeLimit, other.walSizeLimit);
 
-
       assertEquals(this.bytesPerSync, other.bytesPerSync);
       assertEquals(this.writeBufferSize, other.writeBufferSize);
       assertEquals(this.blockSize, other.blockSize);
@@ -284,9 +283,6 @@ public class TestLdbRepair {
       // BlockBasedTableConfig
       private long blockSize;
       private boolean pinL0FilterAndIndexBlocksInCache;
-
-      Builder() {
-      }
 
       public Builder setMaxBackgroundCompactions(int maxBackgroundCompactions) {
         this.maxBackgroundCompactions = maxBackgroundCompactions;

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
-import org.rocksdb.OptionsUtil;
 import picocli.CommandLine;
 
 /**
@@ -181,8 +180,8 @@ public class TestLdbRepair {
     List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
 
     try {
-      OptionsUtil.loadLatestOptions(configOptions, dbPath.toString(), dbOptions, cfDescList);
-      try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath.toString(), cfDescList, cfHandleList)) {
+      try (ManagedRocksDB db = ManagedRocksDB.openWithLatestOptions(
+          configOptions, dbOptions, dbPath.toString(), cfDescList, cfHandleList)) {
         DatabaseOptions.Builder builder = new DatabaseOptions.Builder();
         builder.setMaxBackgroundCompactions(dbOptions.maxBackgroundCompactions())
             .setMaxBackgroundFlushes(dbOptions.maxBackgroundFlushes())

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
@@ -19,24 +19,37 @@ package org.apache.hadoop.ozone.repair.ldb;
 
 import static org.apache.ozone.test.IntLambda.withTextFromSystemIn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.CodecBuffer;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableConfig;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedBlockBasedTableConfig;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedConfigOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.OptionsUtil;
 import picocli.CommandLine;
 
 /**
@@ -106,6 +119,8 @@ public class TestLdbRepair {
     long size2 = calculateSstFileSize(dbPath);
     rdbStore.close();
 
+    DatabaseOptions optionsBeforeCompaction = readDatabaseOptions();
+    // FIXME: After this a new RocksDB OPTIONS was created
     // Trigger compaction of the table
     RocksDBManualCompaction compactionTool = new RocksDBManualCompaction();
     CommandLine cmd = new CommandLine(compactionTool);
@@ -129,6 +144,10 @@ public class TestLdbRepair {
     // size3 < size1 as compaction should reduce size below original
     assertTrue(size3 < size1,
         String.format("Expected size3 (%d) < size1 (%d), but size3 >= size1", size3, size1));
+
+    DatabaseOptions optionsAfterCompaction = readDatabaseOptions();
+
+    optionsBeforeCompaction.assertEqualOptions(optionsAfterCompaction);
   }
 
   private long calculateSstFileSize(Path db) throws IOException {
@@ -148,6 +167,171 @@ public class TestLdbRepair {
             }
           })
           .sum();
+    }
+  }
+
+  /**
+   * Helper method to read the latest RocksDB options from a database and test column family.
+   */
+  private DatabaseOptions readDatabaseOptions() throws Exception {
+    assertNotNull(dbPath);
+    ManagedConfigOptions configOptions = new ManagedConfigOptions();
+    ManagedDBOptions dbOptions = new ManagedDBOptions();
+    List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
+    List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
+
+    try {
+      OptionsUtil.loadLatestOptions(configOptions, dbPath.toString(), dbOptions, cfDescList);
+      try (ManagedRocksDB db = ManagedRocksDB.open(dbOptions, dbPath.toString(), cfDescList, cfHandleList)) {
+        DatabaseOptions.Builder builder = new DatabaseOptions.Builder();
+        builder.setMaxBackgroundCompactions(dbOptions.maxBackgroundCompactions())
+            .setMaxBackgroundFlushes(dbOptions.maxBackgroundFlushes())
+            .setBytesPerSync(dbOptions.bytesPerSync())
+            .setMaxLogFileSize(dbOptions.maxLogFileSize())
+            .setKeepLogFileNum(dbOptions.keepLogFileNum())
+            .setWalTTL(dbOptions.walTtlSeconds())
+            .setWalSizeLimit(dbOptions.walSizeLimitMB());
+
+        Optional<ColumnFamilyDescriptor> testCfDesc = cfDescList.stream().filter(cfDesc ->
+            TableConfig.toName(cfDesc.getName()).equals(TEST_CF_NAME)).findFirst();
+        if (testCfDesc.isPresent()) {
+          ColumnFamilyOptions cfOptions = testCfDesc.get().getOptions();
+          builder.setWriteBufferSize(cfOptions.writeBufferSize());
+          if (cfOptions.tableFormatConfig() instanceof ManagedBlockBasedTableConfig) {
+            ManagedBlockBasedTableConfig tableConfig = (ManagedBlockBasedTableConfig) cfOptions.tableFormatConfig();
+            builder.setBlockSize(tableConfig.blockSize());
+            builder.setPinL0FilterAndIndexBlocksInCache(tableConfig.pinL0FilterAndIndexBlocksInCache());
+          }
+        }
+        return builder.build();
+      }
+    } finally {
+      configOptions.close();
+      dbOptions.close();
+      IOUtils.closeQuietly(cfHandleList);
+    }
+  }
+
+  /**
+   * Simple data class to hold database options for comparison.
+   * This consist of sampled options from the options set in {@link org.apache.hadoop.hdds.utils.db.DBProfile}.
+   */
+  private static final class DatabaseOptions {
+    // DBOptions
+    private final int maxBackgroundCompactions;
+    private final int maxBackgroundFlushes;
+    private final long bytesPerSync;
+    private final long maxLogFileSize;
+    private final long keepLogFileNum;
+    private final long walTTL;
+    private final long walSizeLimit;
+
+    // ColumnFamilyOptions
+    private final long writeBufferSize;
+    // BlockBasedTableConfig
+    private final long blockSize;
+    private final boolean pinL0FilterAndIndexBlocksInCache;
+
+    private DatabaseOptions(Builder b) {
+      this.maxBackgroundCompactions = b.maxBackgroundCompactions;
+      this.maxBackgroundFlushes = b.maxBackgroundFlushes;
+      this.bytesPerSync = b.bytesPerSync;
+      this.maxLogFileSize = b.maxLogFileSize;
+      this.keepLogFileNum = b.keepLogFileNum;
+      this.walTTL = b.walTTL;
+      this.walSizeLimit = b.walSizeLimit;
+      this.writeBufferSize = b.writeBufferSize;
+      this.blockSize = b.blockSize;
+      this.pinL0FilterAndIndexBlocksInCache = b.pinL0FilterAndIndexBlocksInCache;
+    }
+
+    public void assertEqualOptions(DatabaseOptions other) {
+      assertEquals(this.maxBackgroundCompactions, other.maxBackgroundCompactions);
+      assertEquals(this.maxBackgroundFlushes, other.maxBackgroundFlushes);
+      assertEquals(this.maxLogFileSize, other.maxLogFileSize);
+      assertEquals(this.keepLogFileNum, other.keepLogFileNum);
+      assertEquals(this.walTTL, other.walTTL);
+      assertEquals(this.walSizeLimit, other.walSizeLimit);
+
+
+      assertEquals(this.bytesPerSync, other.bytesPerSync);
+      assertEquals(this.writeBufferSize, other.writeBufferSize);
+      assertEquals(this.blockSize, other.blockSize);
+      assertEquals(this.pinL0FilterAndIndexBlocksInCache, other.pinL0FilterAndIndexBlocksInCache);
+    }
+
+    private static class Builder {
+      // DBOptions
+      private int maxBackgroundCompactions;
+      private int maxBackgroundFlushes;
+      private long bytesPerSync;
+      private long maxLogFileSize;
+      private long keepLogFileNum;
+      private long walTTL;
+      private long walSizeLimit;
+
+      // ColumnFamilyOptions
+      private long writeBufferSize;
+      // BlockBasedTableConfig
+      private long blockSize;
+      private boolean pinL0FilterAndIndexBlocksInCache;
+
+      Builder() {
+      }
+
+      public Builder setMaxBackgroundCompactions(int maxBackgroundCompactions) {
+        this.maxBackgroundCompactions = maxBackgroundCompactions;
+        return this;
+      }
+
+      public Builder setMaxBackgroundFlushes(int maxBackgroundFlushes) {
+        this.maxBackgroundFlushes = maxBackgroundFlushes;
+        return this;
+      }
+
+      public Builder setBytesPerSync(long bytesPerSync) {
+        this.bytesPerSync = bytesPerSync;
+        return this;
+      }
+
+      public Builder setMaxLogFileSize(long maxLogFileSize) {
+        this.maxLogFileSize = maxLogFileSize;
+        return this;
+      }
+
+      public Builder setKeepLogFileNum(long keepLogFileNum) {
+        this.keepLogFileNum = keepLogFileNum;
+        return this;
+      }
+
+      public Builder setWalTTL(long walTTL) {
+        this.walTTL = walTTL;
+        return this;
+      }
+
+      public Builder setWalSizeLimit(long walSizeLimit) {
+        this.walSizeLimit = walSizeLimit;
+        return this;
+      }
+
+      public Builder setWriteBufferSize(long writeBufferSize) {
+        this.writeBufferSize = writeBufferSize;
+        return this;
+      }
+
+      public Builder setBlockSize(long blockSize) {
+        this.blockSize = blockSize;
+        return this;
+      }
+
+      public Builder setPinL0FilterAndIndexBlocksInCache(boolean pinL0FilterAndIndexBlocksInCache) {
+        this.pinL0FilterAndIndexBlocksInCache = pinL0FilterAndIndexBlocksInCache;
+        return this;
+      }
+
+      public DatabaseOptions build() {
+        return new DatabaseOptions(this);
+      }
     }
   }
 }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
@@ -120,7 +120,6 @@ public class TestLdbRepair {
     rdbStore.close();
 
     DatabaseOptions optionsBeforeCompaction = readDatabaseOptions();
-    // FIXME: After this a new RocksDB OPTIONS was created
     // Trigger compaction of the table
     RocksDBManualCompaction compactionTool = new RocksDBManualCompaction();
     CommandLine cmd = new CommandLine(compactionTool);
@@ -147,7 +146,7 @@ public class TestLdbRepair {
     // check all tombstones were removed
     List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
     List<ColumnFamilyDescriptor> cfDescList = RocksDBUtils.getColumnFamilyDescriptors(dbPath.toString());
-    try (ManagedRocksDB db = ManagedRocksDB.open(dbPath.toString(), cfDescList, cfHandleList)) {
+    try (ManagedRocksDB db = ManagedRocksDB.openReadOnly(dbPath.toString(), cfDescList, cfHandleList)) {
       List<LiveFileMetaData> liveFileMetaDataList = RdbUtil
           .getLiveSSTFilesForCFs(db, Collections.singletonList(TEST_CF_NAME));
       for (LiveFileMetaData liveMetadata : liveFileMetaDataList) {
@@ -157,7 +156,6 @@ public class TestLdbRepair {
     }
 
     DatabaseOptions optionsAfterCompaction = readDatabaseOptions();
-
     optionsBeforeCompaction.assertEqualOptions(optionsAfterCompaction);
   }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.repair.ldb;
+
+import static org.apache.ozone.test.IntLambda.withTextFromSystemIn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.CodecBuffer;
+import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+/**
+ * Tests for RocksDB LDB repair tools.
+ */
+public class TestLdbRepair {
+
+  private static final String TEST_CF_NAME = "testColumnFamily";
+  private static final int NUM_KEYS = 100;
+
+  @TempDir
+  private Path tempDir;
+  private Path dbPath;
+  private RDBStore rdbStore;
+  private ManagedDBOptions options;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    CodecBuffer.enableLeakDetection();
+
+    dbPath = tempDir.resolve("test.db");
+    options = new ManagedDBOptions();
+    options.setCreateIfMissing(true)
+        .setCreateMissingColumnFamilies(true);
+    rdbStore = DBStoreBuilder.newBuilder(new OzoneConfiguration())
+        .setName(dbPath.toFile().getName())
+        .setPath(dbPath.getParent())
+        .addTable(TEST_CF_NAME)
+        .build();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (rdbStore != null && !rdbStore.isClosed()) {
+      rdbStore.close();
+    }
+    if (options != null) {
+      options.close();
+    }
+    CodecBuffer.assertNoLeaks();
+  }
+
+  /**
+   * Test manual compaction of RocksDB.
+   * This test creates a large number of keys, deletes them, and then triggers compaction.
+   * The sizes after each step is compared to ensure that compaction reduces the size of the database.
+   */
+  @Test
+  public void testRocksDBManualCompaction() throws Exception {
+    Table<byte[], byte[]> testTable = rdbStore.getTable(TEST_CF_NAME);
+
+    // Create many keys
+    for (int i = 0; i < NUM_KEYS; i++) {
+      String key = "key" + i;
+      String value = RandomStringUtils.secure().nextAlphanumeric(100);
+      testTable.put(key.getBytes(StandardCharsets.UTF_8), value.getBytes(StandardCharsets.UTF_8));
+    }
+    rdbStore.flushDB();
+    long size1 = calculateSstFileSize(dbPath);
+
+    // Delete all keys
+    for (int i = 0; i < NUM_KEYS; i++) {
+      String key = "key" + i;
+      testTable.delete(key.getBytes(StandardCharsets.UTF_8));
+    }
+    rdbStore.flushDB();
+    long size2 = calculateSstFileSize(dbPath);
+    rdbStore.close();
+
+    // Trigger compaction of the table
+    RocksDBManualCompaction compactionTool = new RocksDBManualCompaction();
+    CommandLine cmd = new CommandLine(compactionTool);
+    String[] args = {
+        "--db", dbPath.toString(),
+        "--column-family", TEST_CF_NAME
+    };
+    int exitCode = withTextFromSystemIn("y")
+        .execute(() -> cmd.execute(args));
+    assertEquals(0, exitCode, "Compaction command should execute successfully");
+    long size3 = calculateSstFileSize(dbPath);
+
+    System.out.println("Size after adding keys (size1): " + size1);
+    System.out.println("Size after deleting keys (size2): " + size2);
+    System.out.println("Size after compaction (size3): " + size3);
+
+    // size1 < size2 as deletes increase size due to tombstones
+    assertTrue(size1 < size2,
+        String.format("Expected size1 (%d) < size2 (%d), but size1 >= size2", size1, size2));
+
+    // size3 < size1 as compaction should reduce size below original
+    assertTrue(size3 < size1,
+        String.format("Expected size3 (%d) < size1 (%d), but size3 >= size1", size3, size1));
+  }
+
+  private long calculateSstFileSize(Path db) throws IOException {
+    if (!Files.exists(db)) {
+      return 0;
+    }
+
+    try (Stream<Path> paths = Files.walk(db)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .filter(path -> path.toString().endsWith(".sst"))
+          .mapToLong(path -> {
+            try {
+              return Files.size(path);
+            } catch (IOException e) {
+              return 0;
+            }
+          })
+          .sum();
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedConfigOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.debug.RocksDBUtils;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -107,11 +108,9 @@ public class TestSnapshotChainRepair {
     List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
     cfDescList.add(new ColumnFamilyDescriptor(new byte[] {1}));
 
-    mockedUtils.when(() -> RocksDBUtils.getColumnFamilyDescriptors(eq(DB_PATH)))
-        .thenReturn(cfDescList);
-
     // Mock DB open
-    mockedDB.when(() -> ManagedRocksDB.open(any(DBOptions.class), eq(DB_PATH), eq(cfDescList), eq(new ArrayList<>())))
+    mockedDB.when(() -> ManagedRocksDB.openWithLatestOptions(any(ManagedConfigOptions.class),
+            any(DBOptions.class), eq(DB_PATH), eq(new ArrayList<>()), eq(new ArrayList<>())))
         .thenReturn(managedRocksDB);
 
     // Mock column family handle

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.repair.om;
 import static org.apache.hadoop.ozone.OzoneConsts.SNAPSHOT_INFO_TABLE;
 import static org.apache.ozone.test.IntLambda.withTextFromSystemIn;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,6 +51,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -106,7 +108,7 @@ public class TestSnapshotChainRepair {
         .thenReturn(cfDescList);
 
     // Mock DB open
-    mockedDB.when(() -> ManagedRocksDB.open(eq(DB_PATH), eq(cfDescList), eq(new ArrayList<>())))
+    mockedDB.when(() -> ManagedRocksDB.open(any(DBOptions.class), eq(DB_PATH), eq(cfDescList), eq(new ArrayList<>())))
         .thenReturn(managedRocksDB);
 
     // Mock column family handle

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
-import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.DBOptions;
 import org.rocksdb.OptionsUtil;
@@ -103,10 +102,6 @@ public class TestSnapshotChainRepair {
     columnFamilyHandle = mock(ColumnFamilyHandle.class);
 
     when(managedRocksDB.get()).thenReturn(rocksDB);
-
-    // Mock column family descriptors
-    List<ColumnFamilyDescriptor> cfDescList = new ArrayList<>();
-    cfDescList.add(new ColumnFamilyDescriptor(new byte[] {1}));
 
     // Mock DB open
     mockedDB.when(() -> ManagedRocksDB.openWithLatestOptions(any(ManagedConfigOptions.class),

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/om/TestSnapshotChainRepair.java
@@ -52,6 +52,7 @@ import org.mockito.MockedStatic;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.OptionsUtil;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -72,6 +73,7 @@ public class TestSnapshotChainRepair {
 
   private MockedStatic<ManagedRocksDB> mockedDB;
   private MockedStatic<RocksDBUtils> mockedUtils;
+  private MockedStatic<OptionsUtil> mockedOptionsUtil;
 
   private GenericTestUtils.PrintStreamCapturer out;
   private GenericTestUtils.PrintStreamCapturer err;
@@ -84,11 +86,12 @@ public class TestSnapshotChainRepair {
     // Initialize static mocks
     mockedDB = mockStatic(ManagedRocksDB.class);
     mockedUtils = mockStatic(RocksDBUtils.class);
+    mockedOptionsUtil = mockStatic(OptionsUtil.class);
   }
 
   @AfterEach
   public void tearDown() {
-    IOUtils.closeQuietly(out, err, mockedDB, mockedUtils);
+    IOUtils.closeQuietly(out, err, mockedDB, mockedUtils, mockedOptionsUtil);
   }
 
   private void setupMockDB(SnapshotInfo snapshotInfo,


### PR DESCRIPTION
## What changes were proposed in this pull request?

We tried to use the offline RocksDB compaction tool to delete all the tombstones from the keyTable in OM DB. We used RdbUtil#getLiveSSTFilesForCFs to check for the LiveFileMetadata for the SST files on keyTable and confirmed that the numDeletions are all zero, meaning that all tombstones have been compacted away.

However, we saw that the compacted OM DB result in larger number of SST files (14332 -> 16111) and larger size (800GB -> 1.1T). We found out that the OPTIONS files before compaction and after the compaction are different. Notably the block_size is reduced from 16KB to 4KB. This might explain why there are larger number of SST files (due to file splitting) and the size increase (due to lower compression ratio on the smaller blocks).

One suspect is that RocksDB#open will simply reinitialize the RocksDB options to the default options (block_size is 4KB by default). We should use RDBStore instead that will use the correct RocksDB configuration in DBProfile (DBProfile#getBlockBasedTableConfig). If this is correct, then this might affect other CLI as well (TransactionInfoRepair, SnapshotChainRepair).

Update: From https://github.com/facebook/rocksdb/wiki/RocksDB-Options-File, we can use OptionUtil#loadLatestOptions and pass it during RocksDB open to use the latest options (i.e keep the options unchanged).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13422

## How was this patch tested?

Extended `TestLdbRepair` in https://github.com/apache/ozone/pull/8815 to check for RocksDB options preservation. Will rebase on master once the https://github.com/apache/ozone/pull/8815 is merged.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/16373116655

See https://github.com/ivandika3/ozone/actions/runs/16335656824/job/46147806784#step:13:4603 for the test failure without the fix.

