### PR TITLE
HDDS-13451. Exception handling for unchecked exception for deleteBlock command from SCM

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -333,7 +333,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
                 "container={}, TXID={}", tx.getContainerID(), tx.getTxID(), e);
         Thread.currentThread().interrupt();
         txResultBuilder.setContainerID(containerId).setSuccess(false);
-      } catch (Throwable e) {
+      } catch (Exception e) {
         LOG.error("Unexpected exception while deleting blocks for " +
                 "container={}, TXID={}", tx.getContainerID(), tx.getTxID(), e);
         txResultBuilder.setContainerID(containerId).setSuccess(false);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -333,6 +333,10 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
                 "container={}, TXID={}", tx.getContainerID(), tx.getTxID(), e);
         Thread.currentThread().interrupt();
         txResultBuilder.setContainerID(containerId).setSuccess(false);
+      } catch (Throwable e) {
+        LOG.error("Unexpected exception while deleting blocks for " +
+                "container={}, TXID={}", tx.getContainerID(), tx.getTxID(), e);
+        txResultBuilder.setContainerID(containerId).setSuccess(false);
       }
       return new DeleteBlockTransactionExecutionResult(
           txResultBuilder.build(), lockAcquisitionFailed);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a safety net to catch unchecked exceptions thrown as a result of NPE (e.g. from HDDS-10061) and other unexpected exceptions.

Apache Jira description, originally added by @swamirishi :

> When an unchecked exception is thrown right now DN doesn't return a false value back to the SCM. This can lead to the SCM not knowing about the txn status. Another throwable catch block should be added to catch all the exceptions thrown.
https://github.com/apache/ozone/blob/ece9330d8d0324abb1696e3441cb1eb562117d32/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java#L327-L336

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13451

## How was this patch tested?

- n/a