### PR TITLE
HDDS-8565. Recon - memory leak in NSSummary in Recon.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
+import static org.apache.hadoop.hdds.utils.db.DBDefinition.LOG;
 import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.NAMESPACE_SUMMARY;
 import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTable;
 
@@ -65,6 +66,7 @@ public class ReconNamespaceSummaryManagerImpl
                                     long objectId, NSSummary nsSummary)
       throws IOException {
     nsSummaryTable.putWithBatch(batch, objectId, nsSummary);
+    LOG.info("put in NSSummaryTable with objectId: {}, nsSummary: {}", objectId, nsSummary);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -210,7 +210,7 @@ public class NSSummaryTask implements ReconOmTask {
           TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
 
       // Log performance metrics
-      LOG.debug("Task execution time: {} milliseconds", durationInMillis);
+      LOG.info("Task execution time: {} milliseconds", durationInMillis);
     }
 
     return buildTaskResult(true);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithFSO.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_DIR_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
 
@@ -60,9 +62,9 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
     this.nsSummaryFlushToDBMaxThreshold = nsSummaryFlushToDBMaxThreshold;
   }
 
-  // We only listen to updates from FSO-enabled KeyTable(FileTable) and DirTable
+  // We listen to updates from FSO-enabled FileTable, DirTable, DeletedTable and DeletedDirTable
   public Collection<String> getTaskTables() {
-    return Arrays.asList(FILE_TABLE, DIRECTORY_TABLE);
+    return Arrays.asList(FILE_TABLE, DIRECTORY_TABLE, DELETED_TABLE, DELETED_DIR_TABLE);
   }
 
   public Pair<Integer, Boolean> processWithFSO(OMUpdateEventBatch events,
@@ -83,9 +85,11 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
       OMDBUpdateEvent.OMDBUpdateAction action = omdbUpdateEvent.getAction();
       eventCounter++;
 
-      // we only process updates on OM's FileTable and Dirtable
+      // we process updates on OM's FileTable, DirTable, DeletedTable and DeletedDirTable
       String table = omdbUpdateEvent.getTable();
       boolean updateOnFileTable = table.equals(FILE_TABLE);
+      boolean updateOnDeletedTable = table.equals(DELETED_TABLE);
+      boolean updateOnDeletedDirTable = table.equals(DELETED_DIR_TABLE);
       if (!taskTables.contains(table)) {
         continue;
       }
@@ -94,68 +98,19 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
 
       try {
         if (updateOnFileTable) {
-          // key update on fileTable
-          OMDBUpdateEvent<String, OmKeyInfo> keyTableUpdateEvent =
-                  (OMDBUpdateEvent<String, OmKeyInfo>) omdbUpdateEvent;
-          OmKeyInfo updatedKeyInfo = keyTableUpdateEvent.getValue();
-          OmKeyInfo oldKeyInfo = keyTableUpdateEvent.getOldValue();
+          handleUpdateOnFileTable(omdbUpdateEvent, action, nsSummaryMap, updatedKey);
 
-          switch (action) {
-          case PUT:
-            handlePutKeyEvent(updatedKeyInfo, nsSummaryMap);
-            break;
+        } else if (updateOnDeletedTable) {
+          // Hard delete from deletedTable - cleanup memory leak for files
+          handleUpdateOnDeletedTable(omdbUpdateEvent, action, nsSummaryMap);
 
-          case DELETE:
-            handleDeleteKeyEvent(updatedKeyInfo, nsSummaryMap);
-            break;
-
-          case UPDATE:
-            if (oldKeyInfo != null) {
-              // delete first, then put
-              handleDeleteKeyEvent(oldKeyInfo, nsSummaryMap);
-            } else {
-              LOG.warn("Update event does not have the old keyInfo for {}.",
-                      updatedKey);
-            }
-            handlePutKeyEvent(updatedKeyInfo, nsSummaryMap);
-            break;
-
-          default:
-            LOG.debug("Skipping DB update event : {}",
-                    omdbUpdateEvent.getAction());
-          }
+        } else if (updateOnDeletedDirTable) {
+          // Hard delete from deletedDirectoryTable - cleanup memory leak for directories
+          handleUpdateOnDeletedDirTable((OMDBUpdateEvent<String, OmKeyInfo>) omdbUpdateEvent, action, nsSummaryMap);
 
         } else {
           // directory update on DirTable
-          OMDBUpdateEvent<String, OmDirectoryInfo> dirTableUpdateEvent =
-                  (OMDBUpdateEvent<String, OmDirectoryInfo>) omdbUpdateEvent;
-          OmDirectoryInfo updatedDirectoryInfo = dirTableUpdateEvent.getValue();
-          OmDirectoryInfo oldDirectoryInfo = dirTableUpdateEvent.getOldValue();
-
-          switch (action) {
-          case PUT:
-            handlePutDirEvent(updatedDirectoryInfo, nsSummaryMap);
-            break;
-
-          case DELETE:
-            handleDeleteDirEvent(updatedDirectoryInfo, nsSummaryMap);
-            break;
-
-          case UPDATE:
-            if (oldDirectoryInfo != null) {
-              // delete first, then put
-              handleDeleteDirEvent(oldDirectoryInfo, nsSummaryMap);
-            } else {
-              LOG.warn("Update event does not have the old dirInfo for {}.",
-                      updatedKey);
-            }
-            handlePutDirEvent(updatedDirectoryInfo, nsSummaryMap);
-            break;
-
-          default:
-            LOG.debug("Skipping DB update event : {}",
-                    omdbUpdateEvent.getAction());
-          }
+          handleUpdateOnDirTable(omdbUpdateEvent, action, nsSummaryMap, updatedKey);
         }
       } catch (IOException ioEx) {
         LOG.error("Unable to process Namespace Summary data in Recon DB. ",
@@ -177,6 +132,152 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
     }
     LOG.debug("Completed a process run of NSSummaryTaskWithFSO");
     return new ImmutablePair<>(seekPos, true);
+  }
+
+  private void handleUpdateOnDirTable(OMDBUpdateEvent<String, ? extends WithParentObjectId> omdbUpdateEvent,
+                         OMDBUpdateEvent.OMDBUpdateAction action, Map<Long, NSSummary> nsSummaryMap, String updatedKey)
+      throws IOException {
+    OMDBUpdateEvent<String, OmDirectoryInfo> dirTableUpdateEvent =
+            (OMDBUpdateEvent<String, OmDirectoryInfo>) omdbUpdateEvent;
+    OmDirectoryInfo updatedDirectoryInfo = dirTableUpdateEvent.getValue();
+    OmDirectoryInfo oldDirectoryInfo = dirTableUpdateEvent.getOldValue();
+
+    switch (action) {
+    case PUT:
+      handlePutDirEvent(updatedDirectoryInfo, nsSummaryMap);
+      break;
+
+    case DELETE:
+      handleDeleteDirEvent(updatedDirectoryInfo, nsSummaryMap);
+      break;
+
+    case UPDATE:
+      if (oldDirectoryInfo != null) {
+        // delete first, then put
+        handleDeleteDirEvent(oldDirectoryInfo, nsSummaryMap);
+      } else {
+        LOG.warn("Update event does not have the old dirInfo for {}.",
+            updatedKey);
+      }
+      handlePutDirEvent(updatedDirectoryInfo, nsSummaryMap);
+      break;
+
+    default:
+      LOG.debug("Skipping DB update event : {}",
+              omdbUpdateEvent.getAction());
+    }
+  }
+
+  private void handleUpdateOnDeletedDirTable(OMDBUpdateEvent<String, OmKeyInfo> omdbUpdateEvent,
+                                OMDBUpdateEvent.OMDBUpdateAction action, Map<Long, NSSummary> nsSummaryMap) {
+    OMDBUpdateEvent<String, OmKeyInfo> deletedDirTableUpdateEvent =
+        omdbUpdateEvent;
+    OmKeyInfo deletedKeyInfo = deletedDirTableUpdateEvent.getValue();
+
+    switch (action) {
+    case DELETE:
+      // When entry is removed from deletedDirTable, remove from nsSummaryMap to prevent memory leak
+      if (deletedKeyInfo != null) {
+        long objectId = deletedKeyInfo.getObjectID();
+        nsSummaryMap.remove(objectId);
+        LOG.info("Removed hard deleted directory with objectId {} from nsSummaryMap", objectId);
+        
+        // Also remove the parent directory's entry that references this deleted directory
+        long parentObjectId = deletedKeyInfo.getParentObjectID();
+        NSSummary parentSummary = nsSummaryMap.get(parentObjectId);
+        if (parentSummary != null) {
+          parentSummary.removeChildDir(objectId);
+          nsSummaryMap.put(parentObjectId, parentSummary);
+          LOG.info("Updated parent directory {} to remove child directory {}", parentObjectId, objectId);
+        }
+        
+        // Delete the NSSummary entry from the database to prevent memory leak
+        try {
+          getReconNamespaceSummaryManager().deleteNSSummary(objectId);
+          LOG.info("Deleted NSSummary entry for objectId {} from database", objectId);
+        } catch (Exception e) {
+          LOG.error("Failed to delete NSSummary entry for objectId {} from database", objectId, e);
+        }
+      }
+      break;
+
+    default:
+      LOG.info("Skipping DB update event on deletedDirTable: {}", action);
+    }
+  }
+
+  private void handleUpdateOnDeletedTable(OMDBUpdateEvent<String, ? extends WithParentObjectId> omdbUpdateEvent,
+                                OMDBUpdateEvent.OMDBUpdateAction action, Map<Long, NSSummary> nsSummaryMap) {
+    OMDBUpdateEvent<String, ?> deletedTableUpdateEvent = omdbUpdateEvent;
+    Object value = deletedTableUpdateEvent.getValue();
+
+    switch (action) {
+    case DELETE:
+      // When entry is removed from deletedTable, update parent directory in nsSummaryMap
+      if (value instanceof OmKeyInfo) {
+        OmKeyInfo deletedKeyInfo = (OmKeyInfo) value;
+        long parentObjectId = deletedKeyInfo.getParentObjectID();
+        
+        // Update the parent directory's NSSummary to reflect the hard deleted file
+        NSSummary parentSummary = nsSummaryMap.get(parentObjectId);
+        if (parentSummary != null) {
+          // Decrement file count and size
+          parentSummary.setNumOfFiles(parentSummary.getNumOfFiles() - 1);
+          parentSummary.setSizeOfFiles(parentSummary.getSizeOfFiles() - deletedKeyInfo.getDataSize());
+          
+          // Update file size bucket
+          int[] fileBucket = parentSummary.getFileSizeBucket();
+          int binIndex = org.apache.hadoop.ozone.recon.ReconUtils.getFileSizeBinIndex(deletedKeyInfo.getDataSize());
+          if (binIndex >= 0 && binIndex < fileBucket.length) {
+            fileBucket[binIndex] = Math.max(0, fileBucket[binIndex] - 1);
+          }
+          parentSummary.setFileSizeBucket(fileBucket);
+
+          nsSummaryMap.put(parentObjectId, parentSummary);
+          LOG.debug("Updated parent directory {} after hard deleted file with objectId {}", parentObjectId,
+              deletedKeyInfo.getObjectID());
+        }
+      }
+      break;
+
+    default:
+      LOG.info("Skipping DB update event on deletedTable: {}", action);
+    }
+  }
+
+  private void handleUpdateOnFileTable(OMDBUpdateEvent<String, ? extends WithParentObjectId> omdbUpdateEvent,
+                         OMDBUpdateEvent.OMDBUpdateAction action, Map<Long, NSSummary> nsSummaryMap, String updatedKey)
+      throws IOException {
+    // key update on fileTable
+    OMDBUpdateEvent<String, OmKeyInfo> keyTableUpdateEvent =
+            (OMDBUpdateEvent<String, OmKeyInfo>) omdbUpdateEvent;
+    OmKeyInfo updatedKeyInfo = keyTableUpdateEvent.getValue();
+    OmKeyInfo oldKeyInfo = keyTableUpdateEvent.getOldValue();
+
+    switch (action) {
+    case PUT:
+      handlePutKeyEvent(updatedKeyInfo, nsSummaryMap);
+      break;
+
+    case DELETE:
+      handleDeleteKeyEvent(updatedKeyInfo, nsSummaryMap);
+      break;
+
+    case UPDATE:
+      if (oldKeyInfo != null) {
+        // delete first, then put
+        handleDeleteKeyEvent(oldKeyInfo, nsSummaryMap);
+      } else {
+        LOG.warn("Update event does not have the old keyInfo for {}.",
+            updatedKey);
+      }
+      handlePutKeyEvent(updatedKeyInfo, nsSummaryMap);
+      break;
+
+    default:
+      LOG.debug("Skipping DB update event : {}",
+              omdbUpdateEvent.getAction());
+    }
   }
 
   public boolean reprocessWithFSO(OMMetadataManager omMetadataManager) {
@@ -225,9 +326,10 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
     }
     // flush and commit left out keys at end
     if (!flushAndCommitNSToDB(nsSummaryMap)) {
+      LOG.info("flushAndCommitNSToDB failed during reprocessWithFSO.");
       return false;
     }
-    LOG.debug("Completed a reprocess run of NSSummaryTaskWithFSO");
+    LOG.info("Completed a reprocess run of NSSummaryTaskWithFSO");
     return true;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -72,6 +74,11 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
     this.nsSummaryFlushToDBMaxThreshold = nsSummaryFlushToDBMaxThreshold;
   }
 
+  // Listen to Legacy KeyTable and DeletedTable for hard delete cleanup
+  public Collection<String> getTaskTables() {
+    return Arrays.asList(KEY_TABLE, DELETED_TABLE);
+  }
+
   public Pair<Integer, Boolean> processWithLegacy(OMUpdateEventBatch events,
                                                   int seekPos) {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
@@ -91,39 +98,62 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       OMDBUpdateEvent.OMDBUpdateAction action = omdbUpdateEvent.getAction();
       eventCounter++;
 
-      // we only process updates on OM's KeyTable
+      // we only process updates on OM's KeyTable and DeletedTable
       String table = omdbUpdateEvent.getTable();
+      boolean updateOnKeyTable = table.equals(KEY_TABLE);
+      boolean updateOnDeletedTable = table.equals(DELETED_TABLE);
 
-      if (!table.equals(KEY_TABLE)) {
+      if (!updateOnKeyTable && !updateOnDeletedTable) {
         continue;
       }
 
       String updatedKey = omdbUpdateEvent.getKey();
 
       try {
-        OMDBUpdateEvent<String, ?> keyTableUpdateEvent = omdbUpdateEvent;
-        Object value = keyTableUpdateEvent.getValue();
-        Object oldValue = keyTableUpdateEvent.getOldValue();
-
-        if (!(value instanceof OmKeyInfo)) {
-          LOG.warn("Unexpected value type {} for key {}. Skipping processing.",
-              value.getClass().getName(), updatedKey);
-          continue;
-        }
-
-        OmKeyInfo updatedKeyInfo = (OmKeyInfo) value;
-        OmKeyInfo oldKeyInfo = (OmKeyInfo) oldValue;
-
-        if (!isBucketLayoutValid(metadataManager, updatedKeyInfo)) {
-          continue;
-        }
-
-        if (enableFileSystemPaths) {
-          processWithFileSystemLayout(updatedKeyInfo, oldKeyInfo, action,
-              nsSummaryMap);
+        if (updateOnDeletedTable) {
+          // Hard delete from deletedTable - cleanup memory leak
+          OMDBUpdateEvent<String, ?> deletedTableUpdateEvent = omdbUpdateEvent;
+          Object value = deletedTableUpdateEvent.getValue();
+          
+          switch (action) {
+          case DELETE:
+            // When entry is removed from deletedTable, remove from nsSummaryMap to prevent memory leak
+            if (value instanceof OmKeyInfo) {
+              OmKeyInfo deletedKeyInfo = (OmKeyInfo) value;
+              long objectId = deletedKeyInfo.getObjectID();
+              nsSummaryMap.remove(objectId);
+            }
+            break;
+            
+          default:
+            LOG.debug("Skipping DB update event on deletedTable: {}", action);
+          }
         } else {
-          processWithObjectStoreLayout(updatedKeyInfo, oldKeyInfo, action,
-              nsSummaryMap);
+          // Handle keyTable events
+          OMDBUpdateEvent<String, ?> keyTableUpdateEvent = omdbUpdateEvent;
+          Object value = keyTableUpdateEvent.getValue();
+          Object oldValue = keyTableUpdateEvent.getOldValue();
+
+          if (!(value instanceof OmKeyInfo)) {
+            LOG.warn("Unexpected value type {} for key {}. Skipping processing.",
+                value.getClass().getName(), updatedKey);
+            continue;
+          }
+
+          OmKeyInfo updatedKeyInfo = (OmKeyInfo) value;
+          OmKeyInfo oldKeyInfo = (OmKeyInfo) oldValue;
+
+          if (!isBucketLayoutValid(metadataManager, updatedKeyInfo)) {
+            continue;
+          }
+
+          if (enableFileSystemPaths) {
+            processWithFileSystemLayout(updatedKeyInfo, oldKeyInfo, action,
+                nsSummaryMap);
+          } else {
+            processWithObjectStoreLayout(updatedKeyInfo, oldKeyInfo, action,
+                nsSummaryMap);
+          }
         }
       } catch (IOException ioEx) {
         LOG.error("Unable to process Namespace Summary data in Recon DB. ",


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to address the issue of memory leak in NSSummary map when lot of files and directories gets deleted and some orphan dir links gets unlinked from NSSummary tree, then they can lie in map for ever. So once the directories and files are completely deleted from Ozone including `deletedTable` and `deletedDirTable`, then we should cleanup the entries from NSSummary map as well as NSSummary table.

**Key Changes Made:**

  1. `NSSummaryTaskWithFSO.java:`
    - Extended `getTaskTables()` to include DELETED_TABLE and DELETED_DIR_TABLE for monitoring hard delete operations
    - Added `handleUpdateOnDeletedTable()` method to properly handle DELETE operations on `deletedTable`
    - Added `handleUpdateOnDeletedDirTable()` method to properly handle DELETE operations on `deletedDirTable`
    - Both methods now remove corresponding entries from `nsSummaryMap` and delete them from the database to prevent memory leaks
  2. Memory Leak Fix Logic:
    - For files: When entries are removed from `deletedTable` (hard delete), we update the parent directory's NSSummary to decrement file count, size, and file size
   buckets
    - For directories: When entries are removed from `deletedDirTable` (hard delete), we remove the directory's NSSummary entry and update the parent directory to
  remove the child directory reference
    - Database cleanup: Added calls to `deleteNSSummary()` to ensure entries are properly removed from the database, not just from the in-memory map
  3. Test Implementation:
    - Fixed the OmKeyInfo.Builder NPE by adding all required fields (setFileName, setCreationTime, setModificationTime, etc.)
    - Created a comprehensive test that simulates the soft delete → hard delete flow
    - The test validates that NSSummary objects are properly cleaned up during hard delete operations

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8565

(Please replace this section with the link to the Apache JIRA)
Tested by running docker and existing integration and unit tests.
