### PR TITLE
HDDS-13464. Make ozone.snapshot.filtering.service.interval reconfigurable

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -47,7 +47,6 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmConfig;
 import org.apache.hadoop.ozone.om.OzoneManager;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -93,7 +93,7 @@ class TestOzoneFsSnapshot {
     // Enable filesystem snapshot feature for the test regardless of the default
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
     conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
-    conf.setInt(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, KeyManagerImpl.DISABLE_VALUE);
+    conf.setInt(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, -1);
     conf.setInt(OmConfig.Keys.SERVER_LIST_MAX_SIZE, 20);
     conf.setInt(OZONE_FS_LISTING_PAGE_SIZE, 30);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -412,7 +412,7 @@ public class TestOMRatisSnapshots {
     SnapshotInfo snapshotInfo2 = createOzoneSnapshot(leaderOM, "snap100");
     followerOM.getConfiguration().setInt(
         OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
-        KeyManagerImpl.DISABLE_VALUE);
+        -1);
     // Start the inactive OM. Checkpoint installation will happen spontaneously.
     cluster.startInactiveOM(followerNodeId);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -227,7 +227,7 @@ public abstract class TestOmSnapshot {
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
     conf.setInt(OMStorage.TESTING_INIT_LAYOUT_VERSION_KEY, OMLayoutFeature.BUCKET_LAYOUT_SUPPORT.layoutVersion());
     conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
-    conf.setInt(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, KeyManagerImpl.DISABLE_VALUE);
+    conf.setInt(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, -1);
     if (!disableNativeDiff) {
       conf.setTimeDuration(OZONE_OM_SNAPSHOT_COMPACTION_DAG_PRUNE_DAEMON_RUN_INTERVAL, 0, TimeUnit.SECONDS);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
-import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OmConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -144,7 +143,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
         .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
             org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
             java.util.concurrent.TimeUnit.MILLISECONDS);
-    assertTrue(originalInterval > -1, "Original interval should be greater than -1");
+    assertTrue(originalInterval > 0, "Original interval should be greater than 0");
 
     // 1. Test reconfiguring to a different valid interval (30 seconds)
     // This should restart the SstFilteringService
@@ -165,7 +164,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
     assertEquals(30000, newInterval, "New interval should be 30 seconds (30000ms)");
 
     // 2. Service should stop when interval is reconfigured to -1
-    final String disableValue = String.valueOf(KeyManagerImpl.DISABLE_VALUE);
+    final String disableValue = String.valueOf(-1);
     getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, disableValue);
     assertEquals(disableValue, cluster().getOzoneManager().getConfiguration()
         .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.reconfig;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
@@ -24,7 +25,9 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_P
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,7 +39,9 @@ import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
+import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OmConfig;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -134,55 +139,52 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
   @Test
   void sstFilteringServiceInterval() throws ReconfigurationException {
     // Tests reconfiguration of SST filtering service interval
+    final OzoneManager om = cluster().getOzoneManager();
+    final KeyManagerImpl keyManagerImpl = (KeyManagerImpl) om.getKeyManager();
 
     // Get the original interval value
-    String originalValue = cluster().getOzoneManager().getConfiguration()
-        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL);
+    String originalValue = om.getConfiguration().get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL);
     // Verify the original value is valid (should be larger than -1)
-    long originalInterval = cluster().getOzoneManager().getConfiguration()
-        .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
-            org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
-            java.util.concurrent.TimeUnit.MILLISECONDS);
-    assertTrue(originalInterval > 0, "Original interval should be greater than 0");
+    long originalInterval = om.getConfiguration().getTimeDuration(
+        OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+        MILLISECONDS);
+    assertThat(originalInterval).isPositive();
 
     // 1. Test reconfiguring to a different valid interval (30 seconds)
     // This should restart the SstFilteringService
     final String newIntervalValue = "30s";
     getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, newIntervalValue);
-    assertEquals(newIntervalValue, cluster().getOzoneManager().getConfiguration()
+    assertEquals(newIntervalValue, om.getConfiguration()
         .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
     // Verify the service is still enabled with the new interval
-    assertTrue(((org.apache.hadoop.ozone.om.KeyManagerImpl) cluster().getOzoneManager().getKeyManager())
-        .isSstFilteringSvcEnabled(), "SstFilteringService should remain enabled with new interval");
-    assertNotNull(cluster().getOzoneManager().getKeyManager().getSnapshotSstFilteringService(),
+    assertTrue(keyManagerImpl.isSstFilteringSvcEnabled(),
+        "SstFilteringService should remain enabled with new interval");
+    assertNotNull(keyManagerImpl.getSnapshotSstFilteringService(),
         "SstFilteringService should not be null with new interval");
     // Verify the new interval is applied (30 seconds = 30000 milliseconds)
-    long newInterval = cluster().getOzoneManager().getConfiguration()
-        .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
-            org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
-            java.util.concurrent.TimeUnit.MILLISECONDS);
+    long newInterval = om.getConfiguration().getTimeDuration(
+        OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+        MILLISECONDS);
     assertEquals(30000, newInterval, "New interval should be 30 seconds (30000ms)");
 
     // 2. Service should stop when interval is reconfigured to -1
     final String disableValue = String.valueOf(-1);
     getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, disableValue);
-    assertEquals(disableValue, cluster().getOzoneManager().getConfiguration()
-        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
+    assertEquals(disableValue, om.getConfiguration().get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
     // Verify that the SstFilteringService is stopped
-    assertFalse(((org.apache.hadoop.ozone.om.KeyManagerImpl) cluster().getOzoneManager().getKeyManager())
-        .isSstFilteringSvcEnabled(), "SstFilteringService should be disabled when interval is -1");
-    assertNull(cluster().getOzoneManager().getKeyManager().getSnapshotSstFilteringService(),
+    assertFalse(keyManagerImpl.isSstFilteringSvcEnabled(),
+        "SstFilteringService should be disabled when interval is -1");
+    assertNull(keyManagerImpl.getSnapshotSstFilteringService(),
         "SstFilteringService should be null when disabled");
 
     // Set the interval back to the original value
     // Service should be started again when reconfigured to a valid value
     getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, originalValue);
-    assertEquals(originalValue, cluster().getOzoneManager().getConfiguration()
-        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
+    assertEquals(originalValue, om.getConfiguration().get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
     // Verify that the SstFilteringService is running again
-    assertTrue(((org.apache.hadoop.ozone.om.KeyManagerImpl) cluster().getOzoneManager().getKeyManager())
-        .isSstFilteringSvcEnabled(), "SstFilteringService should be enabled after restoring original interval");
-    assertNotNull(cluster().getOzoneManager().getKeyManager().getSnapshotSstFilteringService(),
+    assertTrue(keyManagerImpl.isSstFilteringSvcEnabled(),
+        "SstFilteringService should be enabled after restoring original interval");
+    assertNotNull(keyManagerImpl.getSnapshotSstFilteringService(),
         "SstFilteringService should not be null when enabled");
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestOmReconfiguration.java
@@ -23,14 +23,20 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
+import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OmConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -55,6 +61,7 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
         .add(OZONE_READONLY_ADMINISTRATORS)
         .add(OZONE_DIR_DELETING_SERVICE_INTERVAL)
         .add(OZONE_THREAD_NUMBER_DIR_DELETION)
+        .add(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL)
         .addAll(new OmConfig().reconfigurableProperties())
         .build();
 
@@ -123,6 +130,61 @@ public abstract class TestOmReconfiguration extends ReconfigurationTestBase {
     getSubject().reconfigurePropertyImpl(OZONE_OM_VOLUME_LISTALL_ALLOWED, newValue);
 
     assertEquals(OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT, cluster().getOzoneManager().getAllowListAllVolumes());
+  }
+
+  @Test
+  void sstFilteringServiceInterval() throws ReconfigurationException {
+    // Tests reconfiguration of SST filtering service interval
+
+    // Get the original interval value
+    String originalValue = cluster().getOzoneManager().getConfiguration()
+        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL);
+    // Verify the original value is valid (should be larger than -1)
+    long originalInterval = cluster().getOzoneManager().getConfiguration()
+        .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
+            org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+            java.util.concurrent.TimeUnit.MILLISECONDS);
+    assertTrue(originalInterval > -1, "Original interval should be greater than -1");
+
+    // 1. Test reconfiguring to a different valid interval (30 seconds)
+    // This should restart the SstFilteringService
+    final String newIntervalValue = "30s";
+    getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, newIntervalValue);
+    assertEquals(newIntervalValue, cluster().getOzoneManager().getConfiguration()
+        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
+    // Verify the service is still enabled with the new interval
+    assertTrue(((org.apache.hadoop.ozone.om.KeyManagerImpl) cluster().getOzoneManager().getKeyManager())
+        .isSstFilteringSvcEnabled(), "SstFilteringService should remain enabled with new interval");
+    assertNotNull(cluster().getOzoneManager().getKeyManager().getSnapshotSstFilteringService(),
+        "SstFilteringService should not be null with new interval");
+    // Verify the new interval is applied (30 seconds = 30000 milliseconds)
+    long newInterval = cluster().getOzoneManager().getConfiguration()
+        .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
+            org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+            java.util.concurrent.TimeUnit.MILLISECONDS);
+    assertEquals(30000, newInterval, "New interval should be 30 seconds (30000ms)");
+
+    // 2. Service should stop when interval is reconfigured to -1
+    final String disableValue = String.valueOf(KeyManagerImpl.DISABLE_VALUE);
+    getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, disableValue);
+    assertEquals(disableValue, cluster().getOzoneManager().getConfiguration()
+        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
+    // Verify that the SstFilteringService is stopped
+    assertFalse(((org.apache.hadoop.ozone.om.KeyManagerImpl) cluster().getOzoneManager().getKeyManager())
+        .isSstFilteringSvcEnabled(), "SstFilteringService should be disabled when interval is -1");
+    assertNull(cluster().getOzoneManager().getKeyManager().getSnapshotSstFilteringService(),
+        "SstFilteringService should be null when disabled");
+
+    // Set the interval back to the original value
+    // Service should be started again when reconfigured to a valid value
+    getSubject().reconfigurePropertyImpl(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, originalValue);
+    assertEquals(originalValue, cluster().getOzoneManager().getConfiguration()
+        .get(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL));
+    // Verify that the SstFilteringService is running again
+    assertTrue(((org.apache.hadoop.ozone.om.KeyManagerImpl) cluster().getOzoneManager().getKeyManager())
+        .isSstFilteringSvcEnabled(), "SstFilteringService should be enabled after restoring original interval");
+    assertNotNull(cluster().getOzoneManager().getKeyManager().getSnapshotSstFilteringService(),
+        "SstFilteringService should not be null when enabled");
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -376,7 +376,7 @@ public class KeyManagerImpl implements KeyManager {
               serviceTimeout, ozoneManager, conf);
       snapshotSstFilteringService.start();
     } else {
-      LOG.debug("Snapshot SST filtering service is disabled.");
+      LOG.info("SstFilteringService is disabled.");
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -380,11 +380,20 @@ public class KeyManagerImpl implements KeyManager {
     }
   }
 
-  public void restartSnapshotSstFilteringService(OzoneConfiguration conf) {
+  /**
+   * Stop the snapshot SST filtering service if it is running.
+   */
+  public void stopSnapshotSstFilteringService() {
     if (snapshotSstFilteringService != null) {
       snapshotSstFilteringService.shutdown();
       snapshotSstFilteringService = null;
+    } else {
+      LOG.info("SstFilteringService is already stopped or not started.");
     }
+  }
+
+  public void restartSnapshotSstFilteringService(OzoneConfiguration conf) {
+    stopSnapshotSstFilteringService();
     startSnapshotSstFilteringService(conf);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -213,7 +213,7 @@ public class KeyManagerImpl implements KeyManager {
 
   public KeyManagerImpl(OzoneManager om, ScmClient scmClient,
       OzoneConfiguration conf, OMPerformanceMetrics metrics) {
-    this (om, scmClient, om.getMetadataManager(), conf,
+    this(om, scmClient, om.getMetadataManager(), conf,
         om.getBlockTokenMgr(), om.getKmsProvider(), metrics);
   }
 
@@ -360,15 +360,16 @@ public class KeyManagerImpl implements KeyManager {
    * @param conf
    */
   public void startSnapshotSstFilteringService(OzoneConfiguration conf) {
-    long serviceInterval = conf.getTimeDuration(
-        OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
-        OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
-        TimeUnit.MILLISECONDS);
-    long serviceTimeout = conf.getTimeDuration(
-        OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT,
-        OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT,
-        TimeUnit.MILLISECONDS);
     if (isSstFilteringSvcEnabled()) {
+      long serviceInterval = conf.getTimeDuration(
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+          TimeUnit.MILLISECONDS);
+      long serviceTimeout = conf.getTimeDuration(
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT,
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT,
+          TimeUnit.MILLISECONDS);
+
       snapshotSstFilteringService =
           new SstFilteringService(serviceInterval, TimeUnit.MILLISECONDS,
               serviceTimeout, ozoneManager, conf);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -186,7 +186,6 @@ import org.slf4j.LoggerFactory;
 public class KeyManagerImpl implements KeyManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(KeyManagerImpl.class);
-  public static final int DISABLE_VALUE = -1;
 
   /**
    * A SCM block client, used to talk to SCM to allocate block during putKey.
@@ -306,7 +305,6 @@ public class KeyManagerImpl implements KeyManager {
 
     if (snapshotSstFilteringService == null &&
         ozoneManager.isFilesystemSnapshotEnabled()) {
-
       startSnapshotSstFilteringService(configuration);
     }
 
@@ -390,11 +388,6 @@ public class KeyManagerImpl implements KeyManager {
     } else {
       LOG.info("SstFilteringService is already stopped or not started.");
     }
-  }
-
-  public void restartSnapshotSstFilteringService(OzoneConfiguration conf) {
-    stopSnapshotSstFilteringService();
-    startSnapshotSstFilteringService(conf);
   }
 
   private void startCompactionService(OzoneConfiguration configuration,
@@ -990,7 +983,8 @@ public class KeyManagerImpl implements KeyManager {
         .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
             OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
             TimeUnit.MILLISECONDS);
-    return serviceInterval != DISABLE_VALUE;
+    // any interval <= 0 causes IllegalArgumentException from scheduleWithFixedDelay
+    return serviceInterval > 0;
   }
   
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -525,7 +525,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .register(OZONE_READONLY_ADMINISTRATORS,
                 this::reconfOzoneReadOnlyAdmins)
             .register(OZONE_OM_VOLUME_LISTALL_ALLOWED, this::reconfigureAllowListAllVolumes)
-            .register(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, this::reconfFSSnapshotSSTFilteringServiceInterval)
+            .register(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
+                this::reconfOzoneSnapshotSSTFilteringServiceInterval)
             .register(OZONE_KEY_DELETING_LIMIT_PER_TASK,
                 this::reconfOzoneKeyDeletingLimitPerTask)
             .register(OZONE_DIR_DELETING_SERVICE_INTERVAL, this::reconfOzoneDirDeletingServiceInterval)
@@ -5208,7 +5209,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     return newVal;
   }
 
-  private String reconfFSSnapshotSSTFilteringServiceInterval(String newVal) {
+  private String reconfOzoneSnapshotSSTFilteringServiceInterval(String newVal) {
     boolean wasSstFilteringSvcEnabled = ((KeyManagerImpl) keyManager).isSstFilteringSvcEnabled();
     getConfiguration().set(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, newVal);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -5214,19 +5214,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     if (this.isFilesystemSnapshotEnabled()) {
       if (wasSstFilteringSvcEnabled) {
-        LOG.info("Restarting SstFilteringService as {} is reconfigured to {}",
-            OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, newVal);
         // Sanity check
         Preconditions.checkNotNull(keyManager.getSnapshotSstFilteringService(),
             "sstFilteringService should not be null when SST filtering service is enabled.");
-
-        ((KeyManagerImpl) keyManager).restartSnapshotSstFilteringService(getConfiguration());
-      } else {
-        // Start SstFilteringService
-        LOG.info("Starting SstFilteringService as {} is reconfigured to {}",
-            OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, newVal);
-        ((KeyManagerImpl) keyManager).startSnapshotSstFilteringService(getConfiguration());
+        ((KeyManagerImpl) keyManager).stopSnapshotSstFilteringService();
       }
+      // Note startSnapshotSstFilteringService checks whether the config is set to a value that enables the service
+      ((KeyManagerImpl) keyManager).startSnapshotSstFilteringService(getConfiguration());
     } else {
       LOG.warn("Ozone filesystem snapshot is not enabled. {} is reconfigured but will not make any difference.",
           OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -525,11 +525,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .register(OZONE_READONLY_ADMINISTRATORS,
                 this::reconfOzoneReadOnlyAdmins)
             .register(OZONE_OM_VOLUME_LISTALL_ALLOWED, this::reconfigureAllowListAllVolumes)
+            .register(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, this::reconfFSSnapshotSSTFilteringServiceInterval)
             .register(OZONE_KEY_DELETING_LIMIT_PER_TASK,
                 this::reconfOzoneKeyDeletingLimitPerTask)
             .register(OZONE_DIR_DELETING_SERVICE_INTERVAL, this::reconfOzoneDirDeletingServiceInterval)
-            .register(OZONE_THREAD_NUMBER_DIR_DELETION, this::reconfOzoneThreadNumberDirDeletion)
-            .register(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, this::reconfFSSnapshotSSTFilteringServiceInterval);
+            .register(OZONE_THREAD_NUMBER_DIR_DELETION, this::reconfOzoneThreadNumberDirDeletion);
 
     reconfigurationHandler.setReconfigurationCompleteCallback(reconfigurationHandler.defaultLoggingCallback());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -257,7 +257,7 @@ public class SstFilteringService extends BackgroundService
 
   @Override
   public void shutdown() {
-    LOG.debug("Shutting down SstFilteringService");
+    LOG.info("Shutting down SstFilteringService");
     running.set(false);
     super.shutdown();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -257,6 +257,7 @@ public class SstFilteringService extends BackgroundService
 
   @Override
   public void shutdown() {
+    LOG.debug("Shutting down SstFilteringService");
     running.set(false);
     super.shutdown();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -257,7 +257,6 @@ public class SstFilteringService extends BackgroundService
 
   @Override
   public void shutdown() {
-    LOG.info("Shutting down SstFilteringService");
     running.set(false);
     super.shutdown();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch makes `ozone.snapshot.filtering.service.interval` reconfigurable to allow live enabling/disabling/restarting SST filtering service in addition to service interval reconfiguration.

A fix has also been included in this PR: any negative value (`<= 0`) for `ozone.snapshot.filtering.service.interval` would disable the `SstFilteringService` now. Otherwise it throws `IllegalArgumentException` from `scheduleWithFixedDelay`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13464

## How was this patch tested?

- Add reconfiguration test case. Example OM log output during reconfiguration:

```log4j
2025-07-21 19:28:38,278 [main] INFO  utils.BackgroundService (BackgroundService.java:shutdown(178)) - Shutting down service SstFilteringService
2025-07-21 19:28:38,278 [main] INFO  utils.BackgroundService (BackgroundService.java:start(118)) - Starting service SstFilteringService with interval 30000 milliseconds
2025-07-21 19:28:38,282 [main] INFO  utils.BackgroundService (BackgroundService.java:shutdown(178)) - Shutting down service SstFilteringService
2025-07-21 19:28:38,282 [main] INFO  om.KeyManagerImpl (KeyManagerImpl.java:startSnapshotSstFilteringService(377)) - SstFilteringService is disabled.
2025-07-21 19:28:38,282 [main] INFO  utils.BackgroundService (BackgroundService.java:start(118)) - Starting service SstFilteringService with interval 60000 milliseconds
```

- Also tested manually in Docker dev env

```bash
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 properties
OM: Node [om:9862] Reconfigurable properties:
ozone.administrators
ozone.directory.deleting.service.interval
ozone.key.deleting.limit.per.task
ozone.om.server.list.max.size
ozone.om.volume.listall.allowed
ozone.readonly.administrators
ozone.snapshot.filtering.service.interval
ozone.thread.number.dir.deletion
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: no task was found.
```

Stopping SstFilteringService:
```bash
bash-5.1$ sed -i '/<\/configuration>/i\
<property><name>ozone.snapshot.filtering.service.interval</name><value>-1</value></property>
' /etc/hadoop/ozone-site.xml
bash-5.1$ tail -3 /etc/hadoop/ozone-site.xml
<property><name>ozone.filesystem.snapshot.enabled</name><value>true</value></property>
  <property><name>ozone.snapshot.filtering.service.interval</name><value>-1</value></property>
</configuration>
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 start
OM: Started reconfiguration task on node [om:9862].
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: started at Tue Jul 22 01:55:58 UTC 2025 and finished at Tue Jul 22 01:55:58 UTC 2025.
SUCCESS: Changed property ozone.snapshot.filtering.service.interval
	From: "1m"
	To: "-1"
```

From OM logs:
```
...
2025-07-22 02:24:53,341 [Reconfiguration Task] INFO conf.ReconfigurableBase: Change property: ozone.snapshot.filtering.service.interval from "1m" to "-1".
2025-07-22 02:24:53,341 [Reconfiguration Task] INFO utils.BackgroundService: Shutting down service SstFilteringService
2025-07-22 02:24:53,342 [Reconfiguration Task] INFO om.KeyManagerImpl: SstFilteringService is disabled.
```

Starting SstFilteringService again:

```bash
bash-5.1$ sed -i '/<name>ozone\.snapshot\.filtering\.service\.interval<\/name>/{
  N; s|<value>.*</value>|<value>20s</value>|
}' /etc/hadoop/ozone-site.xml
bash-5.1$ tail -3 /etc/hadoop/ozone-site.xml
<property><name>ozone.filesystem.snapshot.enabled</name><value>true</value></property>
  <property><name>ozone.snapshot.filtering.service.interval</name><value>20s</value></property>
</configuration>
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 start
OM: Started reconfiguration task on node [om:9862].
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: started at Tue Jul 22 01:59:51 UTC 2025 and finished at Tue Jul 22 01:59:51 UTC 2025.
SUCCESS: Changed property ozone.snapshot.filtering.service.interval
	From: "-1"
	To: "20s"

```

OM logs this time:

```
2025-07-22 02:26:39,834 [Reconfiguration Task] INFO conf.ReconfigurableBase: Change property: ozone.snapshot.filtering.service.interval from "-1" to "20s".
2025-07-22 02:26:39,835 [Reconfiguration Task] INFO utils.BackgroundService: Starting service SstFilteringService with interval 20000 milliseconds
```

Note if the config is not changed, ReconfigurationHandler will not be triggered (thus SstFilteringService will not be restarted in this case):

```bash
bash-5.1$ tail -3 /etc/hadoop/ozone-site.xml
<property><name>ozone.filesystem.snapshot.enabled</name><value>true</value></property>
  <property><name>ozone.snapshot.filtering.service.interval</name><value>20s</value></property>
</configuration>
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 start
OM: Started reconfiguration task on node [om:9862].
bash-5.1$ ozone admin reconfig --service=OM --address=om:9862 status
OM: Reconfiguring status for node [om:9862]: started at Tue Jul 22 02:01:14 UTC 2025 and finished at Tue Jul 22 02:01:14 UTC 2025.
```

OM logs:

```
2025-07-22 02:01:14,455 [Reconfiguration Task] INFO conf.ReconfigurationHandler: Reconfiguration complete. No properties were changed.
```