### PR TITLE
HDDS-13393. Test Presigned HeadObject and HeadBucket support

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -543,26 +543,33 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
       PresignedHeadObjectRequest presignedRequest = presigner.presignHeadObject(presignRequest);
 
       URL presignedUrl = presignedRequest.url();
-      HttpURLConnection connection = (HttpURLConnection) presignedUrl.openConnection();
-      connection.setRequestMethod("HEAD");
+      HttpURLConnection connection = null;
+      try {
+        connection = (HttpURLConnection) presignedUrl.openConnection();
+        connection.setRequestMethod("HEAD");
 
-      int responseCode = connection.getResponseCode();
-      assertEquals(200, responseCode, "HeadObject presigned URL should return 200 OK");
+        int responseCode = connection.getResponseCode();
+        assertEquals(200, responseCode, "HeadObject presigned URL should return 200 OK");
 
-      // Use the AWS SDK for Java SdkHttpClient class to test the HEAD request
-      SdkHttpRequest request = SdkHttpRequest.builder()
-          .method(SdkHttpMethod.HEAD)
-          .uri(presignedUrl.toURI())
-          .build();
+        // Use the AWS SDK for Java SdkHttpClient class to test the HEAD request
+        SdkHttpRequest request = SdkHttpRequest.builder()
+            .method(SdkHttpMethod.HEAD)
+            .uri(presignedUrl.toURI())
+            .build();
 
-      HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
-          .request(request)
-          .build();
+        HttpExecuteRequest executeRequest = HttpExecuteRequest.builder()
+            .request(request)
+            .build();
 
-      try (SdkHttpClient sdkHttpClient = ApacheHttpClient.create()) {
-        HttpExecuteResponse response = sdkHttpClient.prepareRequest(executeRequest).call();
-        assertEquals(200, response.httpResponse().statusCode(),
-            "HeadObject presigned URL should return 200 OK via SdkHttpClient");
+        try (SdkHttpClient sdkHttpClient = ApacheHttpClient.create()) {
+          HttpExecuteResponse response = sdkHttpClient.prepareRequest(executeRequest).call();
+          assertEquals(200, response.httpResponse().statusCode(),
+              "HeadObject presigned URL should return 200 OK via SdkHttpClient");
+        }
+      } finally {
+        if (connection != null) {
+          connection.disconnect();
+        }
       }
 
       // Test HeadBucket presigned URL
@@ -578,26 +585,33 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
       PresignedHeadBucketRequest presignedBucketRequest = presigner.presignHeadBucket(headBucketPresignRequest);
 
       URL presignedBucketUrl = presignedBucketRequest.url();
-      HttpURLConnection bucketConnection = (HttpURLConnection) presignedBucketUrl.openConnection();
-      bucketConnection.setRequestMethod("HEAD");
+      HttpURLConnection bucketConnection = null;
+      try {
+        bucketConnection = (HttpURLConnection) presignedBucketUrl.openConnection();
+        bucketConnection.setRequestMethod("HEAD");
 
-      int bucketResponseCode = bucketConnection.getResponseCode();
-      assertEquals(200, bucketResponseCode, "HeadBucket presigned URL should return 200 OK");
+        int bucketResponseCode = bucketConnection.getResponseCode();
+        assertEquals(200, bucketResponseCode, "HeadBucket presigned URL should return 200 OK");
 
-      // Use the AWS SDK for Java SdkHttpClient class to test the HEAD request for bucket
-      SdkHttpRequest bucketSdkRequest = SdkHttpRequest.builder()
-          .method(SdkHttpMethod.HEAD)
-          .uri(presignedBucketUrl.toURI())
-          .build();
+        // Use the AWS SDK for Java SdkHttpClient class to test the HEAD request for bucket
+        SdkHttpRequest bucketSdkRequest = SdkHttpRequest.builder()
+            .method(SdkHttpMethod.HEAD)
+            .uri(presignedBucketUrl.toURI())
+            .build();
 
-      HttpExecuteRequest bucketExecuteRequest = HttpExecuteRequest.builder()
-          .request(bucketSdkRequest)
-          .build();
+        HttpExecuteRequest bucketExecuteRequest = HttpExecuteRequest.builder()
+            .request(bucketSdkRequest)
+            .build();
 
-      try (SdkHttpClient sdkHttpClient = ApacheHttpClient.create()) {
-        HttpExecuteResponse response = sdkHttpClient.prepareRequest(bucketExecuteRequest).call();
-        assertEquals(200, response.httpResponse().statusCode(),
-            "HeadBucket presigned URL should return 200 OK via SdkHttpClient");
+        try (SdkHttpClient sdkHttpClient = ApacheHttpClient.create()) {
+          HttpExecuteResponse response = sdkHttpClient.prepareRequest(bucketExecuteRequest).call();
+          assertEquals(200, response.httpResponse().statusCode(),
+              "HeadBucket presigned URL should return 200 OK via SdkHttpClient");
+        }
+      } finally {
+        if (bucketConnection != null) {
+          bucketConnection.disconnect();
+        }
       }
     }
   }

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -128,8 +128,10 @@ import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.HeadBucketPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.HeadObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadBucketRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedHeadObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
@@ -561,6 +563,41 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase {
         HttpExecuteResponse response = sdkHttpClient.prepareRequest(executeRequest).call();
         assertEquals(200, response.httpResponse().statusCode(),
             "HeadObject presigned URL should return 200 OK via SdkHttpClient");
+      }
+
+      // Test HeadBucket presigned URL
+      HeadBucketRequest bucketRequest = HeadBucketRequest.builder()
+          .bucket(bucketName)
+          .build();
+
+      HeadBucketPresignRequest headBucketPresignRequest = HeadBucketPresignRequest.builder()
+          .signatureDuration(Duration.ofMinutes(10))
+          .headBucketRequest(bucketRequest)
+          .build();
+
+      PresignedHeadBucketRequest presignedBucketRequest = presigner.presignHeadBucket(headBucketPresignRequest);
+
+      URL presignedBucketUrl = presignedBucketRequest.url();
+      HttpURLConnection bucketConnection = (HttpURLConnection) presignedBucketUrl.openConnection();
+      bucketConnection.setRequestMethod("HEAD");
+
+      int bucketResponseCode = bucketConnection.getResponseCode();
+      assertEquals(200, bucketResponseCode, "HeadBucket presigned URL should return 200 OK");
+
+      // Use the AWS SDK for Java SdkHttpClient class to test the HEAD request for bucket
+      SdkHttpRequest bucketSdkRequest = SdkHttpRequest.builder()
+          .method(SdkHttpMethod.HEAD)
+          .uri(presignedBucketUrl.toURI())
+          .build();
+
+      HttpExecuteRequest bucketExecuteRequest = HttpExecuteRequest.builder()
+          .request(bucketSdkRequest)
+          .build();
+
+      try (SdkHttpClient sdkHttpClient = ApacheHttpClient.create()) {
+        HttpExecuteResponse response = sdkHttpClient.prepareRequest(bucketExecuteRequest).call();
+        assertEquals(200, response.httpResponse().statusCode(),
+            "HeadBucket presigned URL should return 200 OK via SdkHttpClient");
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
AWS SDK Java SDK V2 v2.31.66 adds the ability to presign HeadObject and HeadBucket, we can test for this whether this is supported and add the support if it's not supported yet.

Please describe your PR in detail:
S3G already support head bucket/object in current version, so I add an integration test follow [testPresignedUrlGet](https://github.com/apache/ozone/blob/master/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java#L439) in ```AbstractS3SDKV2Tests```


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13393

## How was this patch tested?
https://github.com/hevinhsu/ozone/actions/runs/16364093333
