### PR TITLE
HDDS-13470. Use partitioned filters for new SST files

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -150,6 +150,7 @@ public abstract class DatanodeDBProfile {
               StorageUnit.BYTES);
       blockBasedTableConfig.closeAndSetBlockCache(
           new ManagedLRUCache(cacheSize));
+      blockBasedTableConfig.setPartitionFilters(true);
       return blockBasedTableConfig;
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -88,7 +88,8 @@ public enum DBProfile {
       config.setBlockCache(new ManagedLRUCache(blockCacheSize))
             .setBlockSize(blockSize)
             .setPinL0FilterAndIndexBlocksInCache(true)
-            .setFilterPolicy(new ManagedBloomFilter());
+            .setFilterPolicy(new ManagedBloomFilter())
+            .setPartitionFilters(true);
       return config;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Warning: Testing only, for now. We would only want to enable this for big SSTs we are writing as in HDDS-13003 (Snapshot Compaction / Snapshot Defragmentation project).

This could benefit with cache hit ratio and reduced I/O. Thus potential performance improvement. For more, see: https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters#what-is-partitioned-indexfilters

Shouldn't have upgrade concerns as rocksdb v7.7.3 supports it already. But it could break things that operates on SST files directly (e.g. some fs snapshot impl).

It affects newly written SST files only.

https://javadoc.io/doc/org.rocksdb/rocksdbjni/7.7.3/org/rocksdb/BlockBasedTableConfig.html#setPartitionFilters-boolean-

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13470

## How was this patch tested?

- CI
- Upgrade concerns to be reevaluated
- FS snapshot impact to be evaluated