### PR TITLE
HDDS-13473. Amend validation for OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -217,8 +217,8 @@ public final class OmSnapshotManager implements AutoCloseable {
         OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES,
         OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT
     );
-    Preconditions.checkArgument(this.maxOpenSstFilesInSnapshotDb > 0,
-        OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES + " must be positive.");
+    Preconditions.checkArgument(this.maxOpenSstFilesInSnapshotDb >= -1,
+        OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES + " value should be larger than or equal to -1.");
 
     ColumnFamilyHandle snapDiffJobCf;
     ColumnFamilyHandle snapDiffReportCf;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Context: https://github.com/apache/ozone/pull/8787#discussion_r2212829117

`-1` is a valid value for max_open_files option, along with `0`

> max_open_files – RocksDB keeps all file descriptors in a table cache. If number of file descriptors exceeds max_open_files, some files are evicted from table cache and their file descriptors closed. This means that every read must go through the table cache to lookup the file needed. Set max_open_files to -1 to always keep all files open, which avoids expensive table cache calls.

https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#tuning-other-options

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13473

## How was this patch tested?

- Existing tests