### PR TITLE
HDDS-13447. [S3G] ListObjectsV2 should accept maxKeys=0

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectlist.robot
@@ -41,9 +41,9 @@ List objects with negative max-keys should fail
     ${result} =    Execute AWSS3APICli and checkrc    list-objects-v2 --bucket ${BUCKET} --max-keys -1    255
     Should Contain    ${result}    InvalidArgument
 
-List objects with zero max-keys should fail
-    ${result} =    Execute AWSS3APICli and checkrc    list-objects-v2 --bucket ${BUCKET} --max-keys 0    255
-    Should Contain    ${result}    InvalidArgument
+List objects with zero max-keys should not fail
+    ${result} =    Execute AWSS3APICli and checkrc    list-objects-v2 --bucket ${BUCKET} --max-keys 0    0
+    Should not Contain    ${result}    InvalidArgument
 
 List objects with max-keys exceeding config limit should not return more than limit
     Prepare Many Objects In Bucket    1100

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -225,7 +225,7 @@ public class BucketEndpoint extends EndpointBase {
     }
     String lastKey = null;
     int count = 0;
-    if (maxKeys > 0 ) {
+    if (maxKeys > 0) {
       while (ozoneKeyIterator != null && ozoneKeyIterator.hasNext()) {
         OzoneKey next = ozoneKeyIterator.next();
         if (bucket != null && bucket.getBucketLayout().isFileSystemOptimized() &&

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -281,7 +281,7 @@ public class BucketEndpoint extends EndpointBase {
 
     if (count < maxKeys) {
       response.setTruncated(false);
-    } else if (ozoneKeyIterator.hasNext()) {
+    } else if (ozoneKeyIterator.hasNext() && lastKey != null) {
       response.setTruncated(true);
       ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
       response.setNextToken(nextToken.encodeToString());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -538,11 +538,8 @@ public class TestBucketList {
     assertEquals(S3ErrorTable.INVALID_ARGUMENT.getCode(), e1.getCode());
 
     // maxKeys == 0
-    OS3Exception e2 = assertThrows(OS3Exception.class, () ->
-        bucketEndpoint.get("bucket", null, null, null, 0, null,
-            null, null, null, null, null, null, 1000)
-    );
-    assertEquals(S3ErrorTable.INVALID_ARGUMENT.getCode(), e2.getCode());
+    bucketEndpoint.get("bucket", null, null, null, 0, null,
+        null, null, null, null, null, null, 1000);
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -524,7 +524,7 @@ public class TestBucketList {
 
   @Test
   public void testListObjectsWithNegativeMaxKeys() throws Exception {
-    OzoneClient client = createClientWithKeys("file1");
+    OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket("bucket");
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
@@ -540,7 +540,7 @@ public class TestBucketList {
 
   @Test
   public void testListObjectsWithZeroMaxKeys() throws Exception {
-    OzoneClient client = createClientWithKeys("file1");
+    OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket("bucket");
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
@@ -553,6 +553,27 @@ public class TestBucketList {
 
     assertEquals(0, response.getContents().size());
     assertFalse(response.isTruncated());
+  }
+
+  @Test
+  public void testListObjectsWithZeroMaxKeysInNonEmptyBucket() throws Exception {
+    OzoneClient client = createClientWithKeys("file1", "file2", "file3", "file4", "file5");
+    BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    ListObjectResponse response = (ListObjectResponse) bucketEndpoint.get(
+        "b1", null, null, null, 0, null,
+        null, null, null, null, null, null, 1000).getEntity();
+
+    // Should return empty list and not throw.
+    assertEquals(0, response.getContents().size());
+    assertFalse(response.isTruncated());
+
+    ListObjectResponse fullResponse = (ListObjectResponse) bucketEndpoint.get(
+        "b1", null, null, null, 1000, null,
+        null, null, null, null, null, null, 1000).getEntity();
+    assertEquals(5, fullResponse.getContents().size());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
[S3G] ListObjectsV2 should accept maxKeys=0

Please describe your PR in detail:

- Optimized Key Processing: In BucketEndpoint.java, a check if (maxKeys > 0) is introduced to wrap the key processing loop. This avoids unnecessary iteration and immediately returns an empty result, improving efficiency for this specific use case.
- Corrected Validation: The validation logic is adjusted to only reject negative values for max-keys, while correctly permitting 0.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13447

## How was this patch tested?

[CI Pass](https://github.com/Jimmyweng006/ozone/actions/runs/16396222335)
