### PR TITLE
Update default value of ozone.scm.ha.dbtransactionbuffer.flush.interval.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -617,7 +617,7 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL =
       "ozone.scm.ha.dbtransactionbuffer.flush.interval";
   public static final long
-      OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL_DEFAULT = 600 * 1000L;
+      OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL_DEFAULT = 60 * 1000L;
 
   public static final String NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY =
       "net.topology.node.switch.mapping.impl";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3976,7 +3976,7 @@
   </property>
   <property>
     <name>ozone.scm.ha.dbtransactionbuffer.flush.interval</name>
-    <value>600s</value>
+    <value>60s</value>
     <tag>SCM, OZONE</tag>
     <description>Wait duration for flush of buffered transaction.</description>
   </property>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If there are less transactions in system, buffer flush delays for 10 min. We can do buffer flush every minute which is deletion interval in SCM. Updating default value for ozone.scm.ha.dbtransactionbuffer.flush.interval to 1 min.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13468

## How was this patch tested?

Existing test
https://github.com/ashishkumar50/ozone/actions/runs/16369751185/workflow
