### PR TITLE
HDDS-13481. Fix success latency metric in SCM panels of deletion grafana dashboard

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/dashboards/Ozone - DeleteKey Metrics.json
@@ -2498,7 +2498,7 @@
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "om_performance_metrics_delete_key_success_latency_ns_avg_time",
+              "expr": "scm_performance_metrics_delete_key_success_latency_ns_avg_time",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{hostname}}",


### PR DESCRIPTION
## What changes were proposed in this pull request?

The "Delete Key Success Latency (avg. time)" under "SCM Summary" wrongfully pointed to OM latency metrics. This is corrected to point to the latency metric from SCM performance metrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13481

## How was this patch tested?

Manually checked in docker with grafana:
<img width="1420" height="309" alt="Screenshot 2025-07-21 at 12 44 14 PM" src="https://github.com/user-attachments/assets/a6a7246b-a9c7-4bfb-bdb1-fd855c617f67" />
