### PR TITLE
HDDS-13483. Nested tests are run twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2731,6 +2731,8 @@
               </includes>
               <excludes>
                 <exclude>org.apache.hadoop.ozone.om.snapshot.**</exclude>
+                <!-- default excludes -->
+                <exclude>**/*$*</exclude>
               </excludes>
               <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
@@ -2785,6 +2787,8 @@
               </includes>
               <excludes>
                 <exclude>org.apache.hadoop.hdds.scm.container.**</exclude>
+                <!-- default excludes -->
+                <exclude>**/*$*</exclude>
               </excludes>
               <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
@@ -2809,6 +2813,8 @@
                 <exclude>org.apache.hadoop.ozone.container.**</exclude>
                 <exclude>org.apache.hadoop.ozone.om.**</exclude>
                 <exclude>org.apache.hadoop.ozone.recon.**</exclude>
+                <!-- default excludes -->
+                <exclude>**/*$*</exclude>
               </excludes>
               <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Nested tests are run twice in some splits due to custom [`excludes`](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes) settings, which overrides the default one.

Example: https://github.com/apache/ozone/actions/runs/16407594620/job/46356454414#step:13:3688

```
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Failing
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.03 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Failing
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.12 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Normal
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.23 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Normal
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.32 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService
...
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Failing
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.23 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Failing
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Normal
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.96 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Normal
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 53.29 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService
```

https://issues.apache.org/jira/browse/HDDS-13483

## How was this patch tested?

CI: https://github.com/adoroszlai/ozone/actions/runs/16418999121/job/46393344269#step:13:3694

```
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Failing
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.77 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Failing
[INFO] Running org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Normal
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.72 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService$Normal
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 52.58 s -- in org.apache.hadoop.ozone.om.service.TestKeyDeletingService
```