### PR TITLE
HDDS-13264. Fix OzoneTokenIdentifier to correctly handle missing omServiceId field

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -192,6 +192,9 @@ public class OzoneTokenIdentifier extends
 
     if (token.hasOmServiceId()) {
       setOmServiceId(token.getOmServiceId());
+    } else {
+      // Explicitly set to null if not present.
+      setOmServiceId(null);
     }
   }
 
@@ -225,7 +228,11 @@ public class OzoneTokenIdentifier extends
     if (token.hasSecretKeyId()) {
       identifier.setSecretKeyId(token.getSecretKeyId());
     }
-    identifier.setOmServiceId(token.getOmServiceId());
+    if (token.hasOmServiceId()) {
+      identifier.setOmServiceId(token.getOmServiceId());
+    } else {
+      identifier.setOmServiceId(null); // Explicitly set to null if not present.
+    }
     return identifier;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -192,9 +192,6 @@ public class OzoneTokenIdentifier extends
 
     if (token.hasOmServiceId()) {
       setOmServiceId(token.getOmServiceId());
-    } else {
-      // Explicitly set to null if not present.
-      setOmServiceId(null);
     }
   }
 
@@ -230,8 +227,6 @@ public class OzoneTokenIdentifier extends
     }
     if (token.hasOmServiceId()) {
       identifier.setOmServiceId(token.getOmServiceId());
-    } else {
-      identifier.setOmServiceId(null); // Explicitly set to null if not present.
     }
     return identifier;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -55,6 +55,8 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -282,10 +284,13 @@ public class TestOzoneTokenIdentifier {
     assertEquals(idEncode, idDecode);
   }
 
-  @Test
-  void testTokenPersistence() throws IOException {
+  @ParameterizedTest
+  @CsvSource({"true", "false"})
+  void testTokenPersistence(boolean isOMServiceIdGiven) throws IOException {
     OzoneTokenIdentifier idWrite = getIdentifierInst();
-    idWrite.setOmServiceId("defaultServiceId");
+    if (isOMServiceIdGiven) {
+      idWrite.setOmServiceId("defaultServiceId");
+    }
 
     byte[] oldIdBytes = idWrite.getBytes();
     Codec<OzoneTokenIdentifier> idCodec = TokenIdentifierCodec.get();


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR addresses an OzoneTokenIdentifier bug where a `null` omServiceId field i.e when omServiceId is not set it  incorrectly deserializes as an empty string. Potentially, the problem can be that you might think a delegation token has been removed from RocksDB, but due to this bug, the token actually remains in RocksDB.a corner case previously not covered by tests.

## What is the link to the Apache JIRA

[HDDS-13264](https://issues.apache.org/jira/browse/HDDS-13264)

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/16417716751
