### PR TITLE
HDDS-13486. Exclusivity Between Node Selection and Sorting Options in ListInfoSubcommand

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -66,17 +66,14 @@ public class ListInfoSubcommand extends ScmSubcommand {
   private boolean json;
 
   @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
-  private UsageSortingOptions usageSortingOptions;
+  private ExclusiveNodeOptions exclusiveNodeOptions;
 
   @CommandLine.Mixin
   private ListLimitOptions listLimitOptions;
 
-  @CommandLine.Mixin
-  private NodeSelectionMixin nodeSelectionMixin;
-
   private List<Pipeline> pipelines;
 
-  static class UsageSortingOptions {
+  static class ExclusiveNodeOptions extends NodeSelectionMixin {
     @CommandLine.Option(names = {"--most-used"},
         description = "Show datanodes sorted by Utilization (most to least).")
     private boolean mostUsed;
@@ -89,8 +86,8 @@ public class ListInfoSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     pipelines = scmClient.listPipelines();
-    if (!Strings.isNullOrEmpty(nodeSelectionMixin.getNodeId())) {
-      HddsProtos.Node node = scmClient.queryNode(UUID.fromString(nodeSelectionMixin.getNodeId()));
+    if (exclusiveNodeOptions != null && !Strings.isNullOrEmpty(exclusiveNodeOptions.getNodeId())) {
+      HddsProtos.Node node = scmClient.queryNode(UUID.fromString(exclusiveNodeOptions.getNodeId()));
       DatanodeWithAttributes dwa = new DatanodeWithAttributes(DatanodeDetails
           .getFromProtoBuf(node.getNodeID()),
           node.getNodeOperationalStates(0),
@@ -105,13 +102,13 @@ public class ListInfoSubcommand extends ScmSubcommand {
       return;
     }
     Stream<DatanodeWithAttributes> allNodes = getAllNodes(scmClient).stream();
-    if (!Strings.isNullOrEmpty(nodeSelectionMixin.getIp())) {
+    if (exclusiveNodeOptions != null && !Strings.isNullOrEmpty(exclusiveNodeOptions.getIp())) {
       allNodes = allNodes.filter(p -> p.getDatanodeDetails().getIpAddress()
-          .compareToIgnoreCase(nodeSelectionMixin.getIp()) == 0);
+          .compareToIgnoreCase(exclusiveNodeOptions.getIp()) == 0);
     }
-    if (!Strings.isNullOrEmpty(nodeSelectionMixin.getHostname())) {
+    if (exclusiveNodeOptions != null && !Strings.isNullOrEmpty(exclusiveNodeOptions.getHostname())) {
       allNodes = allNodes.filter(p -> p.getDatanodeDetails().getHostName()
-          .compareToIgnoreCase(nodeSelectionMixin.getHostname()) == 0);
+          .compareToIgnoreCase(exclusiveNodeOptions.getHostname()) == 0);
     }
     if (!Strings.isNullOrEmpty(nodeOperationalState)) {
       allNodes = allNodes.filter(p -> p.getOpState().toString()
@@ -140,8 +137,8 @@ public class ListInfoSubcommand extends ScmSubcommand {
       throws IOException {
 
     // If sorting is requested
-    if (usageSortingOptions != null && (usageSortingOptions.mostUsed || usageSortingOptions.leastUsed)) {
-      boolean sortByMostUsed = usageSortingOptions.mostUsed;
+    if (exclusiveNodeOptions != null && (exclusiveNodeOptions.mostUsed || exclusiveNodeOptions.leastUsed)) {
+      boolean sortByMostUsed = exclusiveNodeOptions.mostUsed;
       List<HddsProtos.DatanodeUsageInfoProto> usageInfos = scmClient.getDatanodeUsageInfo(sortByMostUsed, 
           Integer.MAX_VALUE);
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
@@ -276,6 +277,40 @@ public class TestListInfoSubcommand {
 
     String textOutput = outContent.toString(DEFAULT_ENCODING);
     validateOrderingFromTextOutput(textOutput, orderDirection);
+  }
+
+  @ParameterizedTest(name = "{0} and {1} should be mutually exclusive")
+  @CsvSource({
+      "--most-used, --node-id",
+      "--most-used, --ip",
+      "--most-used, --hostname",
+      "--least-used, --node-id",
+      "--least-used, --ip",
+      "--least-used, --hostname"
+  })
+  public void testNodeSelectionAndUsageSortingAreMutuallyExclusive(String sortingFlag, String selectionFlag) {
+    CommandLine c = new CommandLine(cmd);
+    
+    List<HddsProtos.Node> nodes = getNodeDetails();
+    String nodeSelectionValue;
+    if ("--node-id".equals(selectionFlag)) {
+      nodeSelectionValue = nodes.get(0).getNodeID().getUuid();
+    } else if ("--ip".equals(selectionFlag)) {
+      nodeSelectionValue = "192.168.1.100";
+    } else {
+      nodeSelectionValue = "host-one";
+    } 
+    
+    CommandLine.MutuallyExclusiveArgsException thrown = assertThrows(
+        CommandLine.MutuallyExclusiveArgsException.class,
+        () -> c.parseArgs(sortingFlag, selectionFlag, nodeSelectionValue),
+        () -> String.format("Expected MutuallyExclusiveArgsException when combining %s and %s",
+            sortingFlag, selectionFlag)
+    );
+    
+    String expectedErrorMessagePart = "mutually exclusive";
+    assertTrue(thrown.getMessage().contains(expectedErrorMessagePart),
+        "Exception message should contain '" + expectedErrorMessagePart + "' but was: " + thrown.getMessage());
   }
 
   private void validateOrdering(JsonNode root, String orderDirection) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the ozone admin datanode list command allows users to combine node selection options (e.g., --node-id, --ip, --hostname) with usage sorting options (e.g., --most-used, --least-used).
This combination leads to confusing command behaviour. For instance, 
`ozone admin datanode list --most-used=true --ip=<IP Address>`
will attempt to get all the nodes in increasing order of usage but then filter to a single node with the given IP. This provides a misleading output to the user since the user would expect all the Dns to be listed in an order based on their usage.
Hence we need to make node selection options and usage sorting options mutually exclusive for this command.

## What is the link to the Apache JIRA

[HDDS-13486](https://issues.apache.org/jira/browse/HDDS-13486)

## How was this patch tested?
https://github.com/sreejasahithi/ozone/actions/runs/16436557059
