### PR TITLE
HDDS-13489. Fix SCMBlockdeleting unnecessary iteration in corner case.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -451,11 +451,11 @@ public class DeletedBlockLogImpl
               Set<ContainerReplica> replicas = containerManager
                   .getContainerReplicas(
                       ContainerID.valueOf(txn.getContainerID()));
-              if (checkInadequateReplica(replicas, txn, dnList)) {
+              if (!checkInadequateReplica(replicas, txn, dnList)) {
+                getTransaction(txn, transactions, replicas, commandStatus);
+              } else {
                 metrics.incrSkippedTransaction();
-                continue;
               }
-              getTransaction(txn, transactions, replicas, commandStatus);
             } else if (txn.getCount() >= maxRetry || containerManager.getContainer(id).isOpen()) {
               metrics.incrSkippedTransaction();
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCMBlockDeletingService may do unnecessary iteration when there is inadequate replica in lastProcessedTransactionId and number of block deletion is less than the scm block deleting limit. We can break the iteration when we circled back the iteration once.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13489

## How was this patch tested?

https://github.com/ashishkumar50/ozone/actions/runs/16441608598/workflow
