### PR TITLE
HDDS-13493. [Docs] Ozone 2.0 supports distcp between encrypted Ozone clusters

### DIFF
--- a/hadoop-hdds/docs/content/integration/DistCp.md
+++ b/hadoop-hdds/docs/content/integration/DistCp.md
@@ -86,7 +86,7 @@ By specifying the appropriate checksum configuration or skipping the validation,
 
 When data resides in an HDFS encryption zone or Ozone encrypted buckets, the file checksum will not match. This is because the underlying block data differs due to the use of a new EDEK (Encryption Data Encryption Key) at the destination. In such cases, specify the `-skipcrccheck` parameter to avoid job failures.
 
-Note that `distcp` is supported between encrypted Ozone clusters in Ozone 2.0.
+Note that `distcp` is supported between encrypted Ozone clusters starting with Ozone 2.0.
 
 For more information about using Hadoop DistCp, consult the [DistCp Guide](https://hadoop.apache.org/docs/current/hadoop-distcp/DistCp.html).
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13493. [Docs] Ozone 2.0 supports distcp between encrypted Ozone clusters

Please describe your PR in detail:
* Add a single line in the doc to note the users that Ozone 2.0 supports distcp between encrypted Ozone clusters.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13493

## How was this patch tested?

Doc only.