### PR TITLE
HDDS-13494. DirectoryDeletingService incorrectly waits for all the deleted directories processing

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -335,7 +335,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
       IOUtils.closeQuietly(deleteTableIterator);
     }
   }
@@ -521,7 +521,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
      * @param currentSnapshotInfo if null, deleted directories in AOS should be processed.
      * @param keyManager KeyManager of the underlying store.
      */
-    private void processDeletedDirsForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
+    void processDeletedDirsForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
         long remainingBufLimit, long rnCnt) throws IOException, ExecutionException, InterruptedException {
       String volume, bucket; String snapshotTableKey;
       if (currentSnapshotInfo != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -320,7 +320,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   }
 
   private static final class DeletedDirSupplier implements Closeable {
-    private TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
+    private final TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
         deleteTableIterator;
 
     private DeletedDirSupplier(TableIterator<String, ? extends KeyValue<String, OmKeyInfo>> deleteTableIterator) {
@@ -521,6 +521,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
      * @param currentSnapshotInfo if null, deleted directories in AOS should be processed.
      * @param keyManager KeyManager of the underlying store.
      */
+    @VisibleForTesting
     void processDeletedDirsForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
         long remainingBufLimit, long rnCnt) throws IOException, ExecutionException, InterruptedException {
       String volume, bucket; String snapshotTableKey;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -528,7 +528,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
               return false;
             }
           }, deletionThreadPool);
-          processedAllDeletedDirs = future.thenCombine(future, (a, b) -> a && b);
+          processedAllDeletedDirs = processedAllDeletedDirs.thenCombine(future, (a, b) -> a && b);
         }
         // If AOS or all directories have been processed for snapshot, update snapshot size delta and deep clean flag
         // if it is a snapshot.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -60,11 +60,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test Directory Deleting Service.
  */
 public class TestDirectoryDeletingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestDirectoryDeletingService.class);
+
   @TempDir
   private Path folder;
   private OzoneManagerProtocol writeClient;
@@ -188,7 +193,7 @@ public class TestDirectoryDeletingService {
           try {
             Thread.sleep(100);
           } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.error("Error while sleeping", e);
           }
         }
         for (int i = futureList.size() - 1; i >= 0; i--) {
@@ -199,7 +204,7 @@ public class TestDirectoryDeletingService {
           try {
             Thread.sleep(500);
           } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOG.error("Error while sleeping", e);
           }
         }
       });

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -19,13 +19,22 @@ package org.apache.hadoop.ozone.om.service;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -49,6 +58,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Test Directory Deleting Service.
@@ -66,7 +77,7 @@ public class TestDirectoryDeletingService {
     ExitUtils.disableSystemExit();
   }
 
-  private OzoneConfiguration createConfAndInitValues() throws IOException {
+  private OzoneConfiguration createConfAndInitValues(int threadCount) throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
     File newFolder = folder.toFile();
     if (!newFolder.exists()) {
@@ -76,6 +87,7 @@ public class TestDirectoryDeletingService {
     ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
     conf.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 3000,
         TimeUnit.MILLISECONDS);
+    conf.setInt(OZONE_THREAD_NUMBER_DIR_DELETION, threadCount);
     conf.set(OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT, "4MB");
     conf.setQuietMode(false);
 
@@ -87,12 +99,14 @@ public class TestDirectoryDeletingService {
 
   @AfterEach
   public void cleanup() throws Exception {
-    om.stop();
+    if (om != null) {
+      om.stop();
+    }
   }
 
   @Test
   public void testDeleteDirectoryCrossingSizeLimit() throws Exception {
-    OzoneConfiguration conf = createConfAndInitValues();
+    OzoneConfiguration conf = createConfAndInitValues(10);
     OmTestManagers omTestManagers
         = new OmTestManagers(conf);
     KeyManager keyManager = omTestManagers.getKeyManager();
@@ -157,5 +171,60 @@ public class TestDirectoryDeletingService {
             && dirDeletingService.getMovedFilesCount() <= 2000,
         500, 60000);
     assertThat(dirDeletingService.getRunCount().get()).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void testMultithreadedDirectoryDeletion() throws Exception {
+    int threadCount = 10;
+    OzoneConfiguration conf = createConfAndInitValues(threadCount);
+    OmTestManagers omTestManagers
+        = new OmTestManagers(conf);
+    OzoneManager ozoneManager = omTestManagers.getOzoneManager();
+    AtomicBoolean isRunning = new AtomicBoolean(true);
+    try (MockedStatic mockedStatic = Mockito.mockStatic(CompletableFuture.class, CALLS_REAL_METHODS)) {
+      List<Pair<Supplier, CompletableFuture>> futureList = new ArrayList<>();
+      Thread deletionThread = new Thread(() -> {
+        while (futureList.size() < threadCount) {
+          try {
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+        }
+        for (int i = futureList.size() - 1; i >= 0; i--) {
+          Pair<Supplier, CompletableFuture> pair = futureList.get(i);
+          pair.getLeft().get();
+          assertTrue(isRunning.get());
+          pair.getRight().complete(false);
+          try {
+            Thread.sleep(500);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+        }
+      });
+      deletionThread.start();
+
+      mockedStatic
+          .when(() -> CompletableFuture.supplyAsync(any(), any()))
+          .thenAnswer(invocation -> {
+            Supplier<Boolean> supplier = invocation.getArgument(0);
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            futureList.add(Pair.of(supplier, future));
+            return future;
+          });
+      ozoneManager.getKeyManager().getDirDeletingService().suspend();
+      DirectoryDeletingService.DirDeletingTask dirDeletingTask =
+          ozoneManager.getKeyManager().getDirDeletingService().new DirDeletingTask(null);
+
+      dirDeletingTask.processDeletedDirsForStore(null, ozoneManager.getKeyManager(), Long.MAX_VALUE, 1);
+      assertThat(futureList).hasSize(threadCount);
+      for (Pair<Supplier, CompletableFuture> pair : futureList) {
+        assertTrue(pair.getRight().isDone());
+      }
+      isRunning.set(false);
+    } finally {
+      ozoneManager.stop();
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently while parallely processing deleted directory table, the main thread doesn't wait for all the threads to finish it's set of deleted directory which could lead to main thread prematurely rocksdb iterator and also leading to incorrectly marking the deep cleaned directories.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13494

## How was this patch tested?
Added unit tests for the same.