### PR TITLE
HDDS-13423. Logging reason behind triggering onDemand scan on containers

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -140,11 +140,11 @@ public class ContainerSet implements Iterable<Container<?>> {
    * exist in the set.
    * @param containerID The container in this set to scan.
    */
-  public void scanContainer(long containerID) {
+  public void scanContainer(long containerID, String reasonForScan) {
     if (containerScanner != null) {
       Container<?> container = getContainer(containerID);
       if (container != null) {
-        containerScanner.scanContainer(container);
+        containerScanner.scanContainer(container, reasonForScan);
       } else {
         LOG.warn("Request to scan container {} which was not found in the container set", containerID);
       }
@@ -156,11 +156,11 @@ public class ContainerSet implements Iterable<Container<?>> {
    * This is a no-op if no scanner is registered or the container does not exist in the set.
    * @param containerID The container in this set to scan.
    */
-  public void scanContainerWithoutGap(long containerID) {
+  public void scanContainerWithoutGap(long containerID, String reasonForScan) {
     if (containerScanner != null) {
       Container<?> container = getContainer(containerID);
       if (container != null) {
-        containerScanner.scanContainerWithoutGap(container);
+        containerScanner.scanContainerWithoutGap(container, reasonForScan);
       } else {
         LOG.warn("Request to scan container {} which was not found in the container set", containerID);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -434,7 +434,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         // Create a specific exception that signals for on demand scanning
         // and move this general scan to where it is more appropriate.
         // Add integration tests to test the full functionality.
-        containerSet.scanContainer(containerID);
+        containerSet.scanContainer(containerID, result.name());
         audit(action, eventType, msg, dispatcherContext, AuditEventStatus.FAILURE,
             new Exception(responseProto.getMessage()));
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1715,7 +1715,8 @@ public class KeyValueHandler extends Handler {
     }
 
     // Trigger on demand scanner, which will build the merkle tree based on the newly ingested data.
-    containerSet.scanContainerWithoutGap(containerID);
+    containerSet.scanContainerWithoutGap(containerID,
+        "OnDemand container scan triggered due to container reconciliation.");
     sendICR(container);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1716,7 +1716,7 @@ public class KeyValueHandler extends Handler {
 
     // Trigger on demand scanner, which will build the merkle tree based on the newly ingested data.
     containerSet.scanContainerWithoutGap(containerID,
-        "OnDemand container scan triggered due to container reconciliation.");
+        "Container reconciliation");
     sendICR(container);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerScanner.java
@@ -80,9 +80,6 @@ public final class OnDemandContainerScanner {
 
   private Optional<Future<?>> scanContainer(Container<?> container, ContainerScanHelper helper, String reasonForScan) {
     if (!helper.shouldScanMetadata(container)) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Skipping on-demand scan for container {}.", container.getContainerData().getContainerID());
-      }
       return Optional.empty();
     }
 
@@ -95,7 +92,7 @@ public final class OnDemandContainerScanner {
       });
     } else {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Skipping on-demand scan for container {}.", containerId);
+        LOG.debug("Skipping OnDemandScan for Container {}, Reason: {}", containerId, "Already scheduled.");
       }
     }
     return Optional.ofNullable(resultFuture);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerScanner.java
@@ -65,8 +65,8 @@ public final class OnDemandContainerScanner {
    * @return An Optional containing a Future representing the pending scan task if the task is queued.
    *   The optional is empty if the task is not queued due to an ongoing scan.
    */
-  public Optional<Future<?>> scanContainer(Container<?> container) {
-    return scanContainer(container, scannerHelper);
+  public Optional<Future<?>> scanContainer(Container<?> container, String reasonForScan) {
+    return scanContainer(container, scannerHelper, reasonForScan);
   }
 
   /**
@@ -74,11 +74,14 @@ public final class OnDemandContainerScanner {
    * @return An Optional containing a Future representing the pending scan task if the task is queued.
    *   The optional is empty if the task is not queued due to an ongoing scan.
    */
-  public Optional<Future<?>> scanContainerWithoutGap(Container<?> container) {
-    return scanContainer(container, scannerHelperWithoutGap);
+  public Optional<Future<?>> scanContainerWithoutGap(Container<?> container, String reasonForScan) {
+    return scanContainer(container, scannerHelperWithoutGap, reasonForScan);
   }
 
-  private Optional<Future<?>> scanContainer(Container<?> container, ContainerScanHelper helper) {
+  private Optional<Future<?>> scanContainer(Container<?> container, ContainerScanHelper helper, String reasonForScan) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Container {}: {}", container.getContainerData().getContainerID(), reasonForScan);
+    }
     if (!helper.shouldScanMetadata(container)) {
       return Optional.empty();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerScanner.java
@@ -92,7 +92,8 @@ public final class OnDemandContainerScanner {
       });
     } else {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Skipping OnDemandScan for Container {}, Reason: {}", containerId, "Already scheduled.");
+        LOG.debug("Skipping OnDemandScan for Container {} triggered due to '{}'. Reason: Already scheduled.",
+            containerId, reasonForScan);
       }
     }
     return Optional.ofNullable(resultFuture);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -125,7 +125,7 @@ public class ContainerImporter {
         // After container import is successful, increase used space for the volume and schedule an OnDemand scan for it
         targetVolume.incrementUsedSpace(container.getContainerData().getBytesUsed());
         containerSet.addContainerByOverwriteMissingContainer(container);
-        containerSet.scanContainer(containerID);
+        containerSet.scanContainer(containerID, "OnDemand container scan triggered for imported container.");
       }
     } finally {
       importContainerProgress.remove(containerID);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -125,7 +125,7 @@ public class ContainerImporter {
         // After container import is successful, increase used space for the volume and schedule an OnDemand scan for it
         targetVolume.incrementUsedSpace(container.getContainerData().getBytesUsed());
         containerSet.addContainerByOverwriteMissingContainer(container);
-        containerSet.scanContainer(containerID, "OnDemand container scan triggered for imported container.");
+        containerSet.scanContainer(containerID, "Imported container");
       }
     } finally {
       importContainerProgress.remove(containerID);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -63,6 +63,8 @@ public class TestContainerSet {
 
   private ContainerLayoutVersion layoutVersion;
 
+  private static final String TEST_SCAN = "Test Scan";
+
   private void setLayoutVersion(ContainerLayoutVersion layoutVersion) {
     this.layoutVersion = layoutVersion;
   }
@@ -294,7 +296,7 @@ public class TestContainerSet {
     setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
     // Scan when no handler is registered should not throw an exception.
-    containerSet.scanContainer(FIRST_ID, "OnDemand container scan triggered when no handler is registered.");
+    containerSet.scanContainer(FIRST_ID, TEST_SCAN);
 
     AtomicLong invocationCount = new AtomicLong();
     OnDemandContainerScanner mockScanner = mock(OnDemandContainerScanner.class);
@@ -308,11 +310,11 @@ public class TestContainerSet {
     containerSet.registerOnDemandScanner(mockScanner);
 
     // Scan of an existing container when a handler is registered should trigger a scan.
-    containerSet.scanContainer(FIRST_ID, "OnDemand container scan triggered for existing container.");
+    containerSet.scanContainer(FIRST_ID, TEST_SCAN);
     assertEquals(1, invocationCount.get());
 
     // Scan of non-existent container should not throw exception or trigger an additional invocation.
-    containerSet.scanContainer(FIRST_ID - 1, "OnDemand container scan triggered for non-existing container.");
+    containerSet.scanContainer(FIRST_ID - 1, TEST_SCAN);
     assertEquals(1, invocationCount.get());
   }
 
@@ -321,7 +323,7 @@ public class TestContainerSet {
     setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
     // Scan when no handler is registered should not throw an exception.
-    containerSet.scanContainer(FIRST_ID, "OnDemand container scan triggered when no handler is registered.");
+    containerSet.scanContainer(FIRST_ID, TEST_SCAN);
 
     AtomicLong invocationCount = new AtomicLong();
     OnDemandContainerScanner mockScanner = mock(OnDemandContainerScanner.class);
@@ -335,11 +337,11 @@ public class TestContainerSet {
     containerSet.registerOnDemandScanner(mockScanner);
 
     // Scan of an existing container when a handler is registered should trigger a scan.
-    containerSet.scanContainerWithoutGap(FIRST_ID, "OnDemand container scan triggered for existing container.");
+    containerSet.scanContainerWithoutGap(FIRST_ID, TEST_SCAN);
     assertEquals(1, invocationCount.get());
 
     // Scan of non-existent container should not throw exception or trigger an additional invocation.
-    containerSet.scanContainerWithoutGap(FIRST_ID - 1, "OnDemand container scan triggered for non-existing container.");
+    containerSet.scanContainerWithoutGap(FIRST_ID - 1, TEST_SCAN);
     assertEquals(1, invocationCount.get());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -293,11 +294,11 @@ public class TestContainerSet {
     setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
     // Scan when no handler is registered should not throw an exception.
-    containerSet.scanContainer(FIRST_ID);
+    containerSet.scanContainer(FIRST_ID, "OnDemand container scan triggered when no handler is registered.");
 
     AtomicLong invocationCount = new AtomicLong();
     OnDemandContainerScanner mockScanner = mock(OnDemandContainerScanner.class);
-    when(mockScanner.scanContainer(any())).then(inv -> {
+    when(mockScanner.scanContainer(any(), anyString())).then(inv -> {
       KeyValueContainer c = inv.getArgument(0);
       // If the handler was incorrectly triggered for a non-existent container, this assert would fail.
       assertEquals(FIRST_ID, c.getContainerData().getContainerID());
@@ -307,11 +308,11 @@ public class TestContainerSet {
     containerSet.registerOnDemandScanner(mockScanner);
 
     // Scan of an existing container when a handler is registered should trigger a scan.
-    containerSet.scanContainer(FIRST_ID);
+    containerSet.scanContainer(FIRST_ID, "OnDemand container scan triggered for existing container.");
     assertEquals(1, invocationCount.get());
 
     // Scan of non-existent container should not throw exception or trigger an additional invocation.
-    containerSet.scanContainer(FIRST_ID - 1);
+    containerSet.scanContainer(FIRST_ID - 1, "OnDemand container scan triggered for non-existing container.");
     assertEquals(1, invocationCount.get());
   }
 
@@ -320,11 +321,11 @@ public class TestContainerSet {
     setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
     // Scan when no handler is registered should not throw an exception.
-    containerSet.scanContainer(FIRST_ID);
+    containerSet.scanContainer(FIRST_ID, "OnDemand container scan triggered when no handler is registered.");
 
     AtomicLong invocationCount = new AtomicLong();
     OnDemandContainerScanner mockScanner = mock(OnDemandContainerScanner.class);
-    when(mockScanner.scanContainerWithoutGap(any())).then(inv -> {
+    when(mockScanner.scanContainerWithoutGap(any(), anyString())).then(inv -> {
       KeyValueContainer c = inv.getArgument(0);
       // If the handler was incorrectly triggered for a non-existent container, this assert would fail.
       assertEquals(FIRST_ID, c.getContainerData().getContainerID());
@@ -334,11 +335,11 @@ public class TestContainerSet {
     containerSet.registerOnDemandScanner(mockScanner);
 
     // Scan of an existing container when a handler is registered should trigger a scan.
-    containerSet.scanContainerWithoutGap(FIRST_ID);
+    containerSet.scanContainerWithoutGap(FIRST_ID, "OnDemand container scan triggered for existing container.");
     assertEquals(1, invocationCount.get());
 
     // Scan of non-existent container should not throw exception or trigger an additional invocation.
-    containerSet.scanContainerWithoutGap(FIRST_ID - 1);
+    containerSet.scanContainerWithoutGap(FIRST_ID - 1, "OnDemand container scan triggered for non-existing container.");
     assertEquals(1, invocationCount.get());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
@@ -420,7 +420,8 @@ public class TestContainerReconciliationWithMockDatanodes {
      * Triggers a synchronous scan of the container. This method will block until the scan completes.
      */
     public void scanContainer(long containerID) {
-      Optional<Future<?>> scanFuture = onDemandScanner.scanContainerWithoutGap(containerSet.getContainer(containerID));
+      Optional<Future<?>> scanFuture = onDemandScanner.scanContainerWithoutGap(containerSet.getContainer(containerID),
+          "OnDemand container scan triggered.");
       assertTrue(scanFuture.isPresent());
 
       try {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
@@ -121,6 +121,8 @@ public class TestContainerReconciliationWithMockDatanodes {
   private static final int CHUNKS_PER_BLOCK = 4;
   private static final int NUM_DATANODES = 3;
 
+  private static final String TEST_SCAN = "Test Scan";
+
   /**
    * Number of corrupt blocks and chunks.
    *
@@ -421,7 +423,7 @@ public class TestContainerReconciliationWithMockDatanodes {
      */
     public void scanContainer(long containerID) {
       Optional<Future<?>> scanFuture = onDemandScanner.scanContainerWithoutGap(containerSet.getContainer(containerID),
-          "OnDemand container scan triggered.");
+          TEST_SCAN);
       assertTrue(scanFuture.isPresent());
 
       try {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
@@ -198,7 +198,8 @@ class TestContainerImporter {
     containerImporter.importContainer(containerId, tarFile.toPath(),
         targetVolume, NO_COMPRESSION);
 
-    verify(containerSet, atLeastOnce()).scanContainer(containerId);
+    verify(containerSet, atLeastOnce()).scanContainer(containerId,
+        "OnDemand container scan triggered for imported container.");
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
@@ -198,8 +198,7 @@ class TestContainerImporter {
     containerImporter.importContainer(containerId, tarFile.toPath(),
         targetVolume, NO_COMPRESSION);
 
-    verify(containerSet, atLeastOnce()).scanContainer(containerId,
-        "OnDemand container scan triggered for imported container.");
+    verify(containerSet, atLeastOnce()).scanContainer(containerId, "Imported container");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -389,7 +389,8 @@ public class TestContainerCommandReconciliation {
       db.getStore().flushDB();
     }
 
-    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID);
+    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID,
+        "OnDemand container scan triggered to detect missing blocks in container.");
     waitForDataChecksumsAtSCM(containerID, 2);
     ContainerProtos.ContainerChecksumInfo containerChecksumAfterBlockDelete =
         readChecksumFile(container.getContainerData());
@@ -438,7 +439,8 @@ public class TestContainerCommandReconciliation {
       TestContainerCorruptions.CORRUPT_BLOCK.applyTo(container, blockID);
     }
 
-    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID);
+    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID,
+        "OnDemand container scan triggered to detect block corruption in container.");
     waitForDataChecksumsAtSCM(containerID, 2);
     ContainerProtos.ContainerChecksumInfo containerChecksumAfterChunkCorruption =
         readChecksumFile(container.getContainerData());
@@ -509,7 +511,8 @@ public class TestContainerCommandReconciliation {
       db.getStore().flushDB();
     }
 
-    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID);
+    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID,
+        "OnDemand container scan triggered to detect missing blocks in container.");
     waitForDataChecksumsAtSCM(containerID, 2);
     ContainerProtos.ContainerChecksumInfo containerChecksumAfterBlockDelete =
         readChecksumFile(container.getContainerData());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -137,6 +137,7 @@ public class TestContainerCommandReconciliation {
   private static DNContainerOperationClient dnClient;
   private static final String KEY_NAME = "testkey";
   private static final Logger LOG = LoggerFactory.getLogger(TestContainerCommandReconciliation.class);
+  private static final String TEST_SCAN = "Test Scan";
 
   @TempDir
   private static File testDir;
@@ -389,8 +390,7 @@ public class TestContainerCommandReconciliation {
       db.getStore().flushDB();
     }
 
-    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID,
-        "OnDemand container scan triggered to detect missing blocks in container.");
+    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID, TEST_SCAN);
     waitForDataChecksumsAtSCM(containerID, 2);
     ContainerProtos.ContainerChecksumInfo containerChecksumAfterBlockDelete =
         readChecksumFile(container.getContainerData());
@@ -439,8 +439,7 @@ public class TestContainerCommandReconciliation {
       TestContainerCorruptions.CORRUPT_BLOCK.applyTo(container, blockID);
     }
 
-    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID,
-        "OnDemand container scan triggered to detect block corruption in container.");
+    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID, TEST_SCAN);
     waitForDataChecksumsAtSCM(containerID, 2);
     ContainerProtos.ContainerChecksumInfo containerChecksumAfterChunkCorruption =
         readChecksumFile(container.getContainerData());
@@ -511,8 +510,7 @@ public class TestContainerCommandReconciliation {
       db.getStore().flushDB();
     }
 
-    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID,
-        "OnDemand container scan triggered to detect missing blocks in container.");
+    datanodeStateMachine.getContainer().getContainerSet().scanContainerWithoutGap(containerID, TEST_SCAN);
     waitForDataChecksumsAtSCM(containerID, 2);
     ContainerProtos.ContainerChecksumInfo containerChecksumAfterBlockDelete =
         readChecksumFile(container.getContainerData());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently there are no logs present which tell why an on-demand container scan was triggered.
This PR adds the reason for on-demand container scan at the respective locations.

## What is the link to the Apache JIRA

[HDDS-13423](https://issues.apache.org/jira/browse/HDDS-13423)

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/16463299349
