### PR TITLE
HDDS-13499. Intermittent failure in OM DB Size Reduction After Compaction

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-repair-tools.sh
@@ -42,4 +42,12 @@ start_docker_env
 
 execute_robot_test ${OM} kinit.robot
 
+echo "Creating test keys to verify om compaction"
+om_container="ozonesecure-ha-om1-1"
+docker exec "${om_container}" ozone freon ockg -n 100000 -t 20 -s 0 > /dev/null 2>&1
+echo "Test keys created"
+
+echo "Restarting OM after key creation to flush and generate sst files"
+docker restart "${om_container}"
+
 execute_robot_test ${OM} repair/om-compact.robot

--- a/hadoop-ozone/dist/src/main/smoketest/repair/om-compact.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/repair/om-compact.robot
@@ -22,13 +22,8 @@ Test Timeout        10 minutes
 
 *** Variables ***
 ${OM_DB_PATH}       /data/metadata/om.db
-${KEY_COUNT}        200000
-${THREAD_COUNT}     20
 
 *** Keywords ***
-Create Test Keys
-    Execute    ozone freon ockg -n ${KEY_COUNT} -t ${THREAD_COUNT} -s 0
-
 Delete Test Keys
     Execute    ozone fs -rm -R -skipTrash ofs://${OM_SERVICE_ID}/vol1/bucket1
 
@@ -43,8 +38,7 @@ Compact OM DB Column Family
 
 *** Test Cases ***
 Testing OM DB Size Reduction After Compaction
-    [Setup]    Create Test Keys
-    
+    # Test keys are already created and flushed
     # Delete keys to create tombstones that need compaction
     Delete Test Keys
     


### PR DESCRIPTION
## What changes were proposed in this pull request?
The intermittent failure was caused by `sst` files not being generated immediately after creating a large number of keys. 

This is resolved by restarting the OM container after key creation, which forces a flush and triggers `sst` file generation. Additionally, reduced the number of keys to be created, as the OM restart ensures `sst` files are created even with fewer keys.

```
Testing OM DB Size Reduction After Compaction                         | FAIL |
'' cannot be converted to an integer: ValueError: invalid literal for int() with base 10: ''
```

## What is the link to the Apache JIRA
[HDDS-13499](https://issues.apache.org/jira/browse/HDDS-13499)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/16491234553/job/46627566391#step:13:467

repeat-acceptance-test CI: https://github.com/sarvekshayr/ozone/actions/runs/16496011518
