### PR TITLE
Feature/hdds 13502 quasi closed block deletion

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -134,6 +134,7 @@ public class TestContainerDeletionChoosingPolicy {
     fail("Chosen container results were same 100 times");
 
   }
+
   @ContainerLayoutTestInfo.ContainerTest
   public void testBlockDeletionAllowedAndDisallowedStates(ContainerLayoutVersion layout)
       throws IOException {
@@ -197,7 +198,6 @@ public class TestContainerDeletionChoosingPolicy {
     assertThat(containerSet.getContainerMapCopy()).containsKey(containerId);
     return data;
   }
-
 
   @ContainerLayoutTestInfo.ContainerTest
   public void testTopNOrderedChoosingPolicy(ContainerLayoutVersion layout)


### PR DESCRIPTION
## What changes were proposed in this pull request?
hdds-13502 : Allow block deletion for QUASI_CLOSED containers and add comprehensive tests.

Please describe your PR in detail:
## What changed
- Updated BlockDeletingService to allow block deletion for QUASI_CLOSED containers in addition to CLOSED containers.
- Added detailed logging for container state checks during block deletion.
- Introduced a new test (testBlockDeletionAllowedAndDisallowedStates) in TestContainerDeletionChoosingPolicy to verify:
  - CLOSED and QUASI_CLOSED containers are included.
  - OPEN and CLOSING containers are excluded.
- Refactored test code to avoid duplication using helper method createContainerWithState().

## Why this change
Currently, QUASI_CLOSED containers are ignored during block deletion, leaving pending blocks unprocessed until full closure. This change ensures better cleanup efficiency while maintaining safety.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13502

## How was this patch tested?
- Added unit tests to cover both allowed and disallowed container states.
- Verified test results using `mvn clean install -DskipTests=false` on a local MiniOzoneCluster.