### PR TITLE
HDDS-13245. Container scanner needs to account for deleted blocks when building the merkle tree.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1602,7 +1602,8 @@ public class KeyValueHandler extends Handler {
         continue;
       }
 
-      ContainerDiffReport diffReport = checksumManager.diff(latestChecksumInfo, peerChecksumInfo);
+      ContainerDiffReport diffReport = checksumManager.diff(latestChecksumInfo, peerChecksumInfo, 
+          kvContainer.getContainerData());
       Pipeline pipeline = createSingleNodePipeline(peer);
 
       // Handle missing blocks

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/ContainerMerkleTreeTestUtils.java
@@ -28,7 +28,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -160,7 +162,7 @@ public final class ContainerMerkleTreeTestUtils {
       buildTestTreeWithMismatches(ContainerMerkleTreeWriter originalTree, int numMissingBlocks, int numMissingChunks,
                                   int numCorruptChunks) {
 
-    ContainerProtos.ContainerMerkleTree.Builder treeBuilder = originalTree.toProto().toBuilder();
+    ContainerProtos.ContainerMerkleTree.Builder treeBuilder = originalTree.toProto(Collections.emptyList()).toBuilder();
     ContainerDiffReport diff = new ContainerDiffReport(1);
 
     introduceMissingBlocks(treeBuilder, numMissingBlocks, diff);
@@ -345,5 +347,15 @@ public final class ContainerMerkleTreeTestUtils {
           + data.getContainerID(), ex);
     }
     data.setDataChecksum(checksumInfo.getContainerMerkleTree().getDataChecksum());
+  }
+
+  public static List<ContainerProtos.BlockMerkleTree> createBlockMerkleTreesFromIds(List<Long> blockIDs) {
+    List<ContainerProtos.BlockMerkleTree> blockMerkleTrees = new ArrayList<>();
+    for (Long blockID : blockIDs) {
+      ContainerProtos.BlockMerkleTree blockMerkleTree = ContainerProtos.BlockMerkleTree.newBuilder().setBlockID(blockID)
+          .setDataChecksum(0).build();
+      blockMerkleTrees.add(blockMerkleTree);
+    }
+    return blockMerkleTrees;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestContainerMerkleTreeWriter.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestContainerMerkleTreeWriter.java
@@ -51,7 +51,7 @@ class TestContainerMerkleTreeWriter {
   @Test
   public void testBuildEmptyTree() {
     ContainerMerkleTreeWriter tree = new ContainerMerkleTreeWriter();
-    ContainerProtos.ContainerMerkleTree treeProto = tree.toProto();
+    ContainerProtos.ContainerMerkleTree treeProto = tree.toProto(Collections.emptyList());
     assertEquals(0, treeProto.getDataChecksum());
     assertEquals(0, treeProto.getBlockMerkleTreeCount());
   }
@@ -73,7 +73,7 @@ class TestContainerMerkleTreeWriter {
     actualTree.addChunks(blockID, true, chunk);
 
     // Ensure the trees match.
-    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto();
+    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto(Collections.emptyList());
     assertTreesSortedAndMatch(expectedTree, actualTreeProto);
 
     // Do some manual verification of the generated tree as well.
@@ -109,7 +109,7 @@ class TestContainerMerkleTreeWriter {
     actualTree.addChunks(blockID, true, chunk1, chunk3);
 
     // Ensure the trees match.
-    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto();
+    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto(Collections.emptyList());
     assertTreesSortedAndMatch(expectedTree, actualTreeProto);
   }
 
@@ -129,8 +129,8 @@ class TestContainerMerkleTreeWriter {
     ContainerMerkleTreeWriter tree2 = new ContainerMerkleTreeWriter();
     tree2.addChunks(blockID2, true, chunk1, chunk2);
 
-    ContainerProtos.ContainerMerkleTree tree1Proto = tree1.toProto();
-    ContainerProtos.ContainerMerkleTree tree2Proto = tree2.toProto();
+    ContainerProtos.ContainerMerkleTree tree1Proto = tree1.toProto(Collections.emptyList());
+    ContainerProtos.ContainerMerkleTree tree2Proto = tree2.toProto(Collections.emptyList());
 
     // Even though the chunks are identical, the block checksums should be different
     // because the block IDs are different
@@ -162,8 +162,8 @@ class TestContainerMerkleTreeWriter {
     ContainerMerkleTreeWriter tree2 = new ContainerMerkleTreeWriter();
     tree2.addChunks(blockID, true, chunk1, chunk2);
 
-    ContainerProtos.ContainerMerkleTree tree1Proto = tree1.toProto();
-    ContainerProtos.ContainerMerkleTree tree2Proto = tree2.toProto();
+    ContainerProtos.ContainerMerkleTree tree1Proto = tree1.toProto(Collections.emptyList());
+    ContainerProtos.ContainerMerkleTree tree2Proto = tree2.toProto(Collections.emptyList());
 
     // Blocks with same ID and identical chunks should have same checksums
     ContainerProtos.BlockMerkleTree block1 = tree1Proto.getBlockMerkleTree(0);
@@ -200,8 +200,8 @@ class TestContainerMerkleTreeWriter {
     replica2.addChunks(3, true, chunk1, chunk2);
     replica2.addChunks(4, true, chunk1, chunk2);
     
-    ContainerProtos.ContainerMerkleTree replica1Proto = replica1.toProto();
-    ContainerProtos.ContainerMerkleTree replica2Proto = replica2.toProto();
+    ContainerProtos.ContainerMerkleTree replica1Proto = replica1.toProto(Collections.emptyList());
+    ContainerProtos.ContainerMerkleTree replica2Proto = replica2.toProto(Collections.emptyList());
     assertNotEquals(replica1Proto.getDataChecksum(), replica2Proto.getDataChecksum(),
         "Container replicas with identical blocks but different missing blocks should have different checksums");
     
@@ -221,7 +221,7 @@ class TestContainerMerkleTreeWriter {
     actualTree.addBlock(blockID);
 
     // Ensure the trees match.
-    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto();
+    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto(Collections.emptyList());
     assertTreesSortedAndMatch(expectedTree, actualTreeProto);
   }
 
@@ -242,7 +242,7 @@ class TestContainerMerkleTreeWriter {
     actualTree.addBlock(blockID);
 
     // Ensure the trees match.
-    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto();
+    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto(Collections.emptyList());
     assertTreesSortedAndMatch(expectedTree, actualTreeProto);
   }
 
@@ -274,7 +274,7 @@ class TestContainerMerkleTreeWriter {
     actualTree.addChunks(blockID1, true, b1c1, b1c2);
 
     // Ensure the trees match.
-    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto();
+    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto(Collections.emptyList());
     assertTreesSortedAndMatch(expectedTree, actualTreeProto);
   }
 
@@ -315,7 +315,7 @@ class TestContainerMerkleTreeWriter {
     actualTree.addChunks(blockID3, true, b3c2);
 
     // Ensure the trees match.
-    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto();
+    ContainerProtos.ContainerMerkleTree actualTreeProto = actualTree.toProto(Collections.emptyList());
     assertTreesSortedAndMatch(expectedTree, actualTreeProto);
   }
 
@@ -344,7 +344,7 @@ class TestContainerMerkleTreeWriter {
         Arrays.asList(blockTree1, blockTree2, blockTree3));
 
     ContainerMerkleTreeWriter treeWriter = new ContainerMerkleTreeWriter(expectedTree);
-    assertTreesSortedAndMatch(expectedTree, treeWriter.toProto());
+    assertTreesSortedAndMatch(expectedTree, treeWriter.toProto(Collections.emptyList()));
 
     // Modifying the tree writer created from the proto should also succeed.
     ContainerProtos.ChunkInfo b3c1 = buildChunk(config, 0, ByteBuffer.wrap(new byte[]{1}));
@@ -356,7 +356,7 @@ class TestContainerMerkleTreeWriter {
     ContainerProtos.ContainerMerkleTree expectedUpdatedTree = buildExpectedContainerTree(
         Arrays.asList(blockTree1, blockTree2, blockTree3, blockTree4));
 
-    assertTreesSortedAndMatch(expectedUpdatedTree, treeWriter.toProto());
+    assertTreesSortedAndMatch(expectedUpdatedTree, treeWriter.toProto(Collections.emptyList()));
   }
 
   private ContainerProtos.ContainerMerkleTree buildExpectedContainerTree(List<ContainerProtos.BlockMerkleTree> blocks) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -161,7 +162,7 @@ public class TestKeyValueContainerCheck
     // result here.
     ContainerProtos.ContainerChecksumInfo healthyChecksumInfo = ContainerProtos.ContainerChecksumInfo.newBuilder()
         .setContainerID(containerID)
-        .setContainerMerkleTree(result.getDataTree().toProto())
+        .setContainerMerkleTree(result.getDataTree().toProto(Collections.emptyList()))
         .build();
 
     // Put different types of block failures in the middle of the container.
@@ -200,7 +201,8 @@ public class TestKeyValueContainerCheck
     // This will read the corrupted tree from the disk, which represents the current state of the container, and
     // compare it against the original healthy tree. The diff we get back should match the failures we injected.
     ContainerProtos.ContainerChecksumInfo generatedChecksumInfo = checksumManager.read(container.getContainerData());
-    ContainerDiffReport diffReport = checksumManager.diff(generatedChecksumInfo, healthyChecksumInfo);
+    ContainerDiffReport diffReport = checksumManager.diff(generatedChecksumInfo, healthyChecksumInfo,
+        containerData);
 
     LOG.info("Diff of healthy container with actual container {}", diffReport);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -662,7 +662,7 @@ public class TestKeyValueHandler {
     // Allows checking the invocation count of the lambda.
     AtomicInteger icrCount = new AtomicInteger(0);
     ContainerMerkleTreeWriter treeWriter = buildTestTree(conf);
-    final long updatedDataChecksum = treeWriter.toProto().getDataChecksum();
+    final long updatedDataChecksum = treeWriter.toProto(Collections.emptyList()).getDataChecksum();
     IncrementalReportSender<Container> icrSender = c -> {
       // Check that the ICR contains expected info about the container.
       ContainerReplicaProto report = c.getContainerReport();
@@ -692,7 +692,7 @@ public class TestKeyValueHandler {
     assertEquals(updatedDataChecksum, containerData.getDataChecksum());
     // Check disk content.
     ContainerProtos.ContainerChecksumInfo checksumInfo = checksumManager.read(containerData);
-    assertTreesSortedAndMatch(treeWriter.toProto(), checksumInfo.getContainerMerkleTree());
+    assertTreesSortedAndMatch(treeWriter.toProto(Collections.emptyList()), checksumInfo.getContainerMerkleTree());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestDataScanResult.java
@@ -56,7 +56,7 @@ class TestDataScanResult {
     assertEquals(1, result.getErrors().size());
     assertTrue(result.toString().contains("1 error"));
     // Tree should be empty if the metadata scan failed, since the data scan could not proceed.
-    assertEquals(0, result.getDataTree().toProto().getBlockMerkleTreeCount());
+    assertEquals(0, result.getDataTree().toProto(Collections.emptyList()).getBlockMerkleTreeCount());
   }
 
   @Test
@@ -78,6 +78,6 @@ class TestDataScanResult {
     assertTrue(result.getErrors().isEmpty());
     assertTrue(result.toString().contains("deleted"));
     // Tree should be empty if the container was deleted.
-    assertEquals(0, result.getDataTree().toProto().getBlockMerkleTreeCount());
+    assertEquals(0, result.getDataTree().toProto(Collections.emptyList()).getBlockMerkleTreeCount());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -67,6 +67,7 @@ import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -342,7 +343,7 @@ public class TestContainerCommandReconciliation {
     for (DatanodeDetails dn: datanodeDetails) {
       ContainerProtos.ContainerChecksumInfo containerChecksumInfo =
           dnClient.getContainerChecksumInfo(containerID, dn);
-      assertTreesSortedAndMatch(tree.toProto(), containerChecksumInfo.getContainerMerkleTree());
+      assertTreesSortedAndMatch(tree.toProto(Collections.emptyList()), containerChecksumInfo.getContainerMerkleTree());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the container scanner rebuilds the merkle tree based only on what it sees on disk. This will cause the data checksum to change when blocks are deleted, which is not desirable. The scanner should also consult the list of deleted blocks already stored in the checksum file and add those to the tree it generates.

Also when reconciling, if a peer has marked a block as deleted and we have not, but we also don't have the block, we need to add that block and its checksum to our deleted block list.

- This allows checksums to converge for containers that had blocks deleted before upgrading to reconciliation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13245

## How was this patch tested?

Added UT and Integration tests. 
