### PR TITLE
HDDS-13512. Set the Vite base URL for Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/vite.config.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/vite.config.ts
@@ -29,6 +29,9 @@ function pathResolve(dir: string) {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // This "base" path determines the import locations for other files. By default it is '/' which causes all files to be
+  // fetched from a root URL. However in case of proxy we need to get this value relative to a base, hence it is set to empty string
+  base: "",
   plugins: [
     react({
       devTarget: "es2015" //SWC by default bypasses the build target, set dev target explicitly


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13512. Set the Vite base URL for Recon

Please describe your PR in detail:
* Currently when Recon V2 UI is integrated with a reverse proxy like Knox the resources are not properly rerouted.
* This is caused as Vite has a configuration "base" which determines the location relative to which other files will be imported.
* By default this is set to the root, hence reroutes do not work properly as the imports might point to root location which is not accessible via the proxy.
* This should be fixed by letting Vite set relative paths instead for the resources/imports

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13512

## How was this patch tested?
Patch was tested manually and in a cluster by accessing Recon via Knox