### PR TITLE
HDDS-13407. Fix intermittent failure in TestOnDemandContainerDataScanner#testUnhealthyContainersDetected.

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerScanner.java
@@ -222,11 +222,6 @@ public class TestOnDemandContainerScanner extends
   @Test
   @Override
   public void testUnhealthyContainersDetected() throws Exception {
-    // Without initialization,
-    // there shouldn't be interaction with containerController
-    onDemandScanner.scanContainer(corruptData);
-    verifyNoInteractions(controller);
-
     scanContainer(healthy);
     verifyContainerMarkedUnhealthy(healthy, never());
     scanContainer(corruptData);


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12849 made the on-demand scanner non-static. This means we do not need to wait for it to be initialized before scanning, so the assert that was failing here was no longer valid. The failure shows up intermittently because on-demand scanning is async. In most cases the scan would not have completed by the time the assert ran, so there were still no interactions with the mock.

## What is the link to the Apache JIRA

HDDS-13407

## How was this patch tested?

Previously it was noted the test failed [about 1/10 times in CI](https://github.com/apache/ozone/actions/runs/16146253641/job/45566302619). 200 runs of this test are currently in-progress [here](https://github.com/errose28/ozone/actions/runs/16603273378). I will move this out of draft once they finish.
