### PR TITLE
HDDS-13523. Bump commons-fileupload to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-configuration2.version>2.12.0</commons-configuration2.version>
     <commons-daemon.version>1.4.0</commons-daemon.version>
-    <commons-fileupload.version>1.5</commons-fileupload.version>
+    <commons-fileupload.version>1.6.0</commons-fileupload.version>
     <commons-io.version>2.18.0</commons-io.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Apache Commons FileUpload from 1.5 to 1.6.0.

https://issues.apache.org/jira/browse/HDDS-13523

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/16624291576