### PR TITLE
HDDS-12990. Generate tree from metadata when it doesn't exist during getContainerChecksumInfo call

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -409,7 +408,7 @@ public class ContainerChecksumTreeManager {
   public ByteString getContainerChecksumInfo(KeyValueContainerData data) throws IOException {
     File checksumFile = getContainerChecksumFile(data);
     if (!checksumFile.exists()) {
-      throw new NoSuchFileException("Checksum file does not exist for container #" + data.getContainerID());
+      throw new FileNotFoundException("Checksum file does not exist for container #" + data.getContainerID());
     }
 
     try (InputStream inStream = Files.newInputStream(checksumFile.toPath())) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -764,7 +764,7 @@ public class KeyValueHandler extends Handler {
       // Only build from metadata if the file doesn't exist
       if (ex instanceof FileNotFoundException) {
         try {
-          LOG.info("Checksum tree file not found for container {}. Building from merkle tree from metadata.",
+          LOG.info("Checksum tree file not found for container {}. Building merkle tree from container metadata.",
               containerData.getContainerID());
           ContainerProtos.ContainerChecksumInfo checksumInfo = updateAndGetContainerChecksumFromMetadata(kvContainer);
           checksumTree = checksumInfo.toByteString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPA
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -101,6 +102,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.TestHelper;
+import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
 import org.apache.hadoop.ozone.container.checksum.ContainerMerkleTreeWriter;
 import org.apache.hadoop.ozone.container.checksum.DNContainerOperationClient;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
@@ -230,11 +232,10 @@ public class TestContainerCommandReconciliation {
   }
 
   /**
-   * Tests reading the container checksum info file from a datanode where the container exists, but the file has not
-   * yet been created.
+   * Tests container checksum file creation if it doesn't exist during getContainerChecksumInfo call.
    */
   @Test
-  public void testGetChecksumInfoNonexistentFile() throws Exception {
+  public void testMerkleTreeCreationDuringGetChecksumInfo() throws Exception {
     String volume = UUID.randomUUID().toString();
     String bucket = UUID.randomUUID().toString();
     long containerID = writeDataAndGetContainer(true, volume, bucket);
@@ -244,14 +245,39 @@ public class TestContainerCommandReconciliation {
         .getContainerSet().getContainer(containerID);
     File treeFile = getContainerChecksumFile(container.getContainerData());
     // Closing the container should have generated the tree file.
+    ContainerProtos.ContainerChecksumInfo srcChecksumInfo = ContainerChecksumTreeManager.readChecksumInfo(
+        container.getContainerData()).get();
     assertTrue(treeFile.exists());
     assertTrue(treeFile.delete());
+
+    ContainerProtos.ContainerChecksumInfo destChecksumInfo = dnClient.getContainerChecksumInfo(
+        containerID, targetDN.getDatanodeDetails());
+    assertNotNull(destChecksumInfo);
+    assertTreesSortedAndMatch(srcChecksumInfo.getContainerMerkleTree(), destChecksumInfo.getContainerMerkleTree());
+  }
+
+  /**
+   * Tests reading the container checksum info file from a datanode where there's an IO error 
+   * that's not related to file not found (e.g., permission error). Such errors should not 
+   * trigger fallback to building from metadata.
+   */
+  @Test
+  public void testGetChecksumInfoIOError() throws Exception {
+    String volume = UUID.randomUUID().toString();
+    String bucket = UUID.randomUUID().toString();
+    long containerID = writeDataAndGetContainer(true, volume, bucket);
+    // Pick a datanode and make its checksum file unreadable to simulate permission error.
+    HddsDatanodeService targetDN = cluster.getHddsDatanodes().get(0);
+    Container<?> container = targetDN.getDatanodeStateMachine().getContainer()
+        .getContainerSet().getContainer(containerID);
+    File treeFile = getContainerChecksumFile(container.getContainerData());
+    assertTrue(treeFile.exists());
+    // Make the server unable to read the file (permission error, not file not found).
+    assertTrue(treeFile.setReadable(false));
 
     StorageContainerException ex = assertThrows(StorageContainerException.class, () ->
         dnClient.getContainerChecksumInfo(containerID, targetDN.getDatanodeDetails()));
     assertEquals(ContainerProtos.Result.IO_EXCEPTION, ex.getResult());
-    assertTrue(ex.getMessage().contains("Checksum file does not exist"), ex.getMessage() +
-        " did not contain the expected string");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the client will get an [IO_EXCEPTION](https://github.com/apache/ozone/blob/229e5c94eaf1f16b9dcfdb19d7cc5451d104a6dd/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java#L794) result code when [requesting](https://github.com/apache/ozone/blob/8768d048160a6b3761ddc2938d7287f9cd609e04/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java#L366) the merkle tree of a peer that has not been generated yet. If the container is not open, have the peer build the merkle tree from metadata and return this instead. This change builds merkle tree if it's not available.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12990

## How was this patch tested?

Existing tests.
