### PR TITLE
HDDS-13514. Intermittent failure in TestNSSummaryMemoryLeak

### DIFF
--- a/hadoop-ozone/integration-test-recon/pom.xml
+++ b/hadoop-ozone/integration-test-recon/pom.xml
@@ -189,6 +189,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestNSSummaryMemoryLeak.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestNSSummaryMemoryLeak.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +46,7 @@ import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.RaftTestUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -309,15 +311,14 @@ public class TestNSSummaryMemoryLeak {
     
     simulateHardDelete(omMetadataManager);
     syncDataFromOM();
+    
+    // Force garbage collection
+    RaftTestUtil.gc();
 
-    GenericTestUtils.waitFor(() -> {
-      System.gc();
-
-      // Verify memory cleanup
-      long memoryAfter = runtime.totalMemory() - runtime.freeMemory();
-      LOG.info("Memory usage - Before: {} bytes, After: {} bytes", memoryBefore, memoryAfter);
-      return memoryAfter <= memoryBefore;
-    }, 100, 30_000);
+    // Verify memory cleanup
+    long memoryAfter = runtime.totalMemory() - runtime.freeMemory();
+    LOG.info("Memory usage - Before: {} bytes, After: {} bytes", memoryBefore, memoryAfter);
+    assertThat(memoryAfter).isLessThanOrEqualTo(memoryBefore);
 
     // Verify NSSummary cleanup
     ReconNamespaceSummaryManager namespaceSummaryManager = 

--- a/pom.xml
+++ b/pom.xml
@@ -1311,6 +1311,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-server</artifactId>
+        <version>${ratis.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
         <artifactId>ratis-server-api</artifactId>
         <version>${ratis.version}</version>
       </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestNSSummaryMemoryLeak`:

```
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 50.48 s <<< FAILURE! -- in org.apache.hadoop.ozone.recon.TestNSSummaryMemoryLeak
org.apache.hadoop.ozone.recon.TestNSSummaryMemoryLeak.testMemoryLeakWithLargeStructure -- Time elapsed: 14.14 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
...
  at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
  at org.apache.hadoop.ozone.recon.TestNSSummaryMemoryLeak.testMemoryLeakWithLargeStructure(TestNSSummaryMemoryLeak.java:321)
```

https://issues.apache.org/jira/browse/HDDS-13514

## How was this patch tested?

Before: 6/100 runs failed
https://github.com/adoroszlai/ozone/actions/runs/16676152386

After: 100/100 runs passed
~https://github.com/adoroszlai/ozone/actions/runs/16676072218~
https://github.com/adoroszlai/ozone/actions/runs/16679377827