### PR TITLE
HDDS-13144. Fix mvn javadoc:aggregate goal.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -232,13 +232,6 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           OZONE_WITH_COVERAGE: ${{ inputs.with-coverage }}
 
-      - name: 'Debug: List target directory contents'
-        if: always() && inputs.script == 'javadoc'
-        run: |
-          echo "--- Listing contents of target directory ---"
-          ls -lR target
-          echo "--- End of target directory listing ---"
-
       - name: Execute post-failure steps
         if: ${{ failure() && inputs.post-failure }}
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -232,6 +232,13 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           OZONE_WITH_COVERAGE: ${{ inputs.with-coverage }}
 
+      - name: 'Debug: List target directory contents'
+        if: always() && inputs.script == 'javadoc'
+        run: |
+          echo "--- Listing contents of target directory ---"
+          ls -lR target
+          echo "--- End of target directory listing ---"
+
       - name: Execute post-failure steps
         if: ${{ failure() && inputs.post-failure }}
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -258,7 +258,6 @@ jobs:
           path: |
             target/${{ inputs.script }}
             target/reports/apidocs
-            target/site/apidocs
         continue-on-error: true
 
       # The following steps are hard-coded to be run only for 'build' check,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -255,7 +255,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ (inputs.split && format('{0}-{1}', inputs.script, inputs.split)) || inputs.script }}
-          path: target/${{ inputs.script }}
+          path: |
+            target/${{ inputs.script }}
+            target/site/apidocs
         continue-on-error: true
 
       # The following steps are hard-coded to be run only for 'build' check,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -264,6 +264,7 @@ jobs:
           name: ${{ (inputs.split && format('{0}-{1}', inputs.script, inputs.split)) || inputs.script }}
           path: |
             target/${{ inputs.script }}
+            target/reports/apidocs
             target/site/apidocs
         continue-on-error: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,19 @@ jobs:
       sha: ${{ needs.build-info.outputs.sha }}
       timeout-minutes: 15
 
+  javadoc:
+    needs:
+      - build-info
+      - build
+    uses: ./.github/workflows/check.yml
+    secrets: inherit
+    with:
+      java-version: ${{ needs.build-info.outputs.java-version }}
+      needs-ozone-repo: true
+      script: javadoc
+      sha: ${{ needs.build-info.outputs.sha }}
+      timeout-minutes: 30
+
   repro:
     needs:
       - build-info

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -27,6 +27,7 @@
 
   <properties>
     <classpath.skip>false</classpath.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <!-- no tests in this module so far -->
     <maven.test.skip>true</maven.test.skip>
   </properties>

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR/../../.." || exit 1
+
+export MAVEN_OPTS="\
+-Dmaven.wagon.http.pool=false \
+-Dmaven.wagon.http.retryHandler.class=standard \
+-Dmaven.wagon.http.retryHandler.count=3"
+
+mvn javadoc:aggregate

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -22,6 +22,8 @@ cd "$DIR/../../.." || exit 1
 export MAVEN_OPTS="\
 -Dmaven.wagon.http.pool=false \
 -Dmaven.wagon.http.retryHandler.class=standard \
--Dmaven.wagon.http.retryHandler.count=3"
+-Dmaven.wagon.http.retryHandler.count=3 \
+-DreportOutputDirectory=target \
+-DdestDir=javadoc"
 
 mvn javadoc:aggregate

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -19,4 +19,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
-mvn javadoc:aggregate -DreportOutputDirectory=target/javadoc
+mvn javadoc:aggregate -DreportOutputDirectory=target/javadoc -X

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -19,11 +19,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
-export MAVEN_OPTS="\
--Dmaven.wagon.http.pool=false \
--Dmaven.wagon.http.retryHandler.class=standard \
--Dmaven.wagon.http.retryHandler.count=3 \
--DreportOutputDirectory=target \
--DdestDir=javadoc"
-
-mvn javadoc:aggregate
+mvn javadoc:aggregate -DreportOutputDirectory=target/javadoc

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -19,4 +19,11 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
+export MAVEN_OPTS="\
+-Dmaven.wagon.http.pool=false \
+-Dmaven.wagon.http.retryHandler.class=standard \
+-Dmaven.wagon.http.retryHandler.count=3 \
+-DreportOutputDirectory=target \
+-DdestDir=javadoc"
+
 mvn javadoc:aggregate

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -19,11 +19,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
-export MAVEN_OPTS="\
--Dmaven.wagon.http.pool=false \
--Dmaven.wagon.http.retryHandler.class=standard \
--Dmaven.wagon.http.retryHandler.count=3 \
--DreportOutputDirectory=target \
--DdestDir=javadoc"
-
 mvn javadoc:aggregate

--- a/hadoop-ozone/dev-support/checks/javadoc.sh
+++ b/hadoop-ozone/dev-support/checks/javadoc.sh
@@ -19,4 +19,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
-mvn javadoc:aggregate -DreportOutputDirectory=target/javadoc -X
+mvn javadoc:aggregate

--- a/hadoop-ozone/mini-cluster/pom.xml
+++ b/hadoop-ozone/mini-cluster/pom.xml
@@ -25,6 +25,10 @@
   <name>Apache Ozone Mini Cluster</name>
   <description>Apache Ozone Mini Cluster for Integration Tests</description>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1818,9 +1818,19 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
+            <sourceFileExcludes>
+              <exclude>**/package-info.java</exclude>
+            </sourceFileExcludes>
             <doclint>none</doclint>
             <notimestamp>true</notimestamp>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.google.protobuf</groupId>
+              <artifactId>protobuf-java</artifactId>
+              <version>${grpc.protobuf-compile.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1824,13 +1824,6 @@
             <doclint>none</doclint>
             <notimestamp>true</notimestamp>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>com.google.protobuf</groupId>
-              <artifactId>protobuf-java</artifactId>
-              <version>${grpc.protobuf-compile.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1818,8 +1818,10 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
+            <excludePackageNames>org.apache.hadoop.hdds.protocol.datanode.proto:org.apache.hadoop.hdds.protocol.proto:org.apache.hadoop.hdds.protocol.proto3:org.apache.hadoop.hdds.protocol.scm.proto:org.apache.hadoop.ozone.protocol.proto:org.apache.hadoop.ozone.protocol.proto3:org.apache.hadoop.ozone.security.proto:org.apache.hadoop.ozone.security.proto3:org.apache.hadoop.ozone.storage.proto:org.apache.ozone.recon.schema.generated:org.apache.ozone.recon.schema.generated.tables</excludePackageNames>
             <sourceFileExcludes>
               <exclude>**/package-info.java</exclude>
+              <exclude>**/org/apache/ozone/recon/schema/generated/tables/**/*.java</exclude>
             </sourceFileExcludes>
             <doclint>none</doclint>
             <notimestamp>true</notimestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -2504,6 +2504,16 @@
                 </goals>
                 <phase>package</phase>
               </execution>
+              <execution>
+                <id>aggregate</id>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2504,16 +2504,6 @@
                 </goals>
                 <phase>package</phase>
               </execution>
-              <execution>
-                <id>aggregate</id>
-                <goals>
-                  <goal>aggregate</goal>
-                </goals>
-                <phase>package</phase>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
           <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Javadoc aggregation build failures

Please describe your PR in detail:
* Skip Javadoc for problematic modules: The build failed with cannot find symbol: class OneofDescriptor errors when processing Protobuf-generated sources in the hadoop-ozone/csi module. Instead of attempting complex global source exclusions, **this fix disables Javadoc generation entirely for the csi module**. The same property is also applied to the **mini-cluster module** to avoid issues where its main sources depend on test utilities.
* Excluding all 'package-info.java' files from the aggregation to prevent 'package has already been annotated' errors from conflicting definitions.

## What is the link to the Apache JIRA

[HDDS-13143](https://issues.apache.org/jira/browse/HDDS-13143)

## How was this patch tested?

[CI Pass](https://github.com/Jimmyweng006/ozone/actions/runs/16860070232)

The patch was verified by running **mvn javadoc:aggregate** from the project root. 

The command completed successfully, and the generated Javadoc is available and renders correctly at target/reports/apidocs/index.html.

<img width="2529" height="1283" alt="image" src="https://github.com/user-attachments/assets/5f56c63d-a313-41e9-be10-efc2e2a01726" />

