### PR TITLE
HDDS-13510. Add latency metrics for key creation operation

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -319,11 +319,11 @@ public class OMPerformanceMetrics {
     return createKeyAllocateBlockLatencyNs;
   }
 
-  public void setCreateKeyFailureLatencyNs(long latencyInNs) {
+  public void addCreateKeyFailureLatencyNs(long latencyInNs) {
     createKeyFailureLatencyNs.add(latencyInNs);
   }
 
-  public void setCreateKeySuccessLatencyNs(long latencyInNs) {
+  public void addCreateKeySuccessLatencyNs(long latencyInNs) {
     createKeySuccessLatencyNs.add(latencyInNs);
   }
     

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -148,6 +148,21 @@ public class OMPerformanceMetrics {
   @Metric(about = "Latency of each iteration of OpenKeyCleanupService in ms")
   private MutableGaugeLong openKeyCleanupServiceLatencyMs;
 
+  @Metric(about = "ResolveBucketLink and ACL check latency for createKey in nanoseconds")
+  private MutableRate createKeyResolveBucketAndAclCheckLatencyNs;
+  
+  @Metric(about = "check quota for createKey in nanoseconds")
+  private MutableRate createKeyQuotaCheckLatencyNs;
+
+  @Metric(about = "Block allocation latency for createKey in nanoseconds")
+  private MutableRate createKeyAllocateBlockLatencyNs;
+
+  @Metric(about = "createKeyFailure latency in nanoseconds")
+  private MutableRate createKeyFailureLatencyNs;
+
+  @Metric(about = "creteKeySuccess latency in nanoseconds")
+  private MutableRate createKeySuccessLatencyNs;
+
   public static OMPerformanceMetrics register() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     return ms.register(SOURCE_NAME,
@@ -290,6 +305,26 @@ public class OMPerformanceMetrics {
 
   public MutableRate getDeleteKeyResolveBucketAndAclCheckLatencyNs() {
     return deleteKeyResolveBucketAndAclCheckLatencyNs;
+  }
+
+  public MutableRate getCreateKeyResolveBucketAndAclCheckLatencyNs() {
+    return createKeyResolveBucketAndAclCheckLatencyNs;
+  }
+
+  public void addCreateKeyQuotaCheckLatencyNs(long latencyInNs) {
+    createKeyQuotaCheckLatencyNs.add(latencyInNs);
+  }
+
+  public MutableRate getCreateKeyAllocateBlockLatencyNs() {
+    return createKeyAllocateBlockLatencyNs;
+  }
+
+  public void setCreateKeyFailureLatencyNs(long latencyInNs) {
+    createKeyFailureLatencyNs.add(latencyInNs);
+  }
+
+  public void setCreateKeySuccessLatencyNs(long latencyInNs) {
+    createKeySuccessLatencyNs.add(latencyInNs);
   }
     
   public void addListKeysReadFromRocksDbLatencyNs(long latencyInNs) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -220,7 +220,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     List<OmKeyInfo> missingParentInfos = null;
     int numMissingParents = 0;
     final OMPerformanceMetrics perfMetrics = ozoneManager.getPerfMetrics();
-    long startNanos = Time.monotonicNowNanos();
+    long createKeyStartTime = Time.monotonicNowNanos();
     try {
 
       mergeOmLockDetails(
@@ -311,11 +311,11 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           * ozoneManager.getScmBlockSize()
           * replicationConfig.getRequiredNodes();
       // check bucket and volume quota
-      long startTime = Time.monotonicNowNanos();
+      long quotaCheckStartTime = Time.monotonicNowNanos();
       checkBucketQuotaInBytes(omMetadataManager, bucketInfo,
           preAllocatedSpace);
       checkBucketQuotaInNamespace(bucketInfo, numMissingParents + 1L);
-      perfMetrics.addCreateKeyQuotaCheckLatencyNs(Time.monotonicNowNanos() - startTime);
+      perfMetrics.addCreateKeyQuotaCheckLatencyNs(Time.monotonicNowNanos() - quotaCheckStartTime);
       bucketInfo.incrUsedNamespace(numMissingParents);
 
       if (numMissingParents > 0) {
@@ -344,7 +344,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
       result = Result.SUCCESS;
       long endNanosCreateKeySuccessLatencyNs = Time.monotonicNowNanos();
-      perfMetrics.setCreateKeySuccessLatencyNs(endNanosCreateKeySuccessLatencyNs - startNanos);
+      perfMetrics.addCreateKeySuccessLatencyNs(endNanosCreateKeySuccessLatencyNs - createKeyStartTime);
     } catch (IOException | InvalidPathException ex) {
       result = Result.FAILURE;
       exception = ex;
@@ -353,7 +353,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       omClientResponse = new OMKeyCreateResponse(
           createErrorOMResponse(omResponse, exception), getBucketLayout());
       long endNanosCreateKeyFailureLatencyNs = Time.monotonicNowNanos();
-      perfMetrics.setCreateKeyFailureLatencyNs(endNanosCreateKeyFailureLatencyNs - startNanos);
+      perfMetrics.addCreateKeyFailureLatencyNs(endNanosCreateKeyFailureLatencyNs - createKeyStartTime);
     } finally {
       if (acquireLock) {
         mergeOmLockDetails(ozoneLockStrategy

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
+import static org.apache.hadoop.ozone.util.MetricUtil.captureLatencyNs;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -38,6 +39,7 @@ import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
 import org.apache.hadoop.ozone.om.OzoneConfigUtil;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -88,6 +90,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     Preconditions.checkNotNull(createKeyRequest);
 
     KeyArgs keyArgs = createKeyRequest.getKeyArgs();
+
+    final OMPerformanceMetrics perfMetrics = ozoneManager.getPerfMetrics();
 
     if (keyArgs.hasExpectedDataGeneration()) {
       ozoneManager.checkFeatureEnabled(OzoneManagerVersion.ATOMIC_REWRITE_KEY);
@@ -141,15 +145,16 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       //  till leader is identified.
       UserInfo userInfo = getUserInfo();
       List<OmKeyLocationInfo> omKeyLocationInfoList =
-          allocateBlock(ozoneManager.getScmClient(),
-              ozoneManager.getBlockTokenSecretManager(), repConfig,
-              new ExcludeList(), requestedSize, scmBlockSize,
-              ozoneManager.getPreallocateBlocksMax(),
-              ozoneManager.isGrpcBlockTokenEnabled(),
-              ozoneManager.getOMServiceId(),
-              ozoneManager.getMetrics(),
-              keyArgs.getSortDatanodes(),
-              userInfo);
+          captureLatencyNs(perfMetrics.getCreateKeyAllocateBlockLatencyNs(),
+              () -> allocateBlock(ozoneManager.getScmClient(),
+                ozoneManager.getBlockTokenSecretManager(), repConfig,
+                new ExcludeList(), requestedSize, scmBlockSize,
+                ozoneManager.getPreallocateBlocksMax(),
+                ozoneManager.isGrpcBlockTokenEnabled(),
+                ozoneManager.getOMServiceId(),
+                ozoneManager.getMetrics(),
+                keyArgs.getSortDatanodes(),
+                userInfo));
 
       newKeyArgs = keyArgs.toBuilder().setModificationTime(Time.now())
               .setType(type).setFactor(factor)
@@ -171,9 +176,11 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       generateRequiredEncryptionInfo(keyArgs, newKeyArgs, ozoneManager);
     }
 
+    KeyArgs.Builder finalNewKeyArgs = newKeyArgs;
     KeyArgs resolvedKeyArgs =
-        resolveBucketAndCheckKeyAcls(newKeyArgs.build(), ozoneManager,
-            IAccessAuthorizer.ACLType.CREATE);
+        captureLatencyNs(perfMetrics.getCreateKeyResolveBucketAndAclCheckLatencyNs(), 
+            () -> resolveBucketAndCheckKeyAcls(finalNewKeyArgs.build(), ozoneManager,
+            IAccessAuthorizer.ACLType.CREATE));
     newCreateKeyRequest =
         createKeyRequest.toBuilder().setKeyArgs(resolvedKeyArgs)
             .setClientID(UniqueId.next());
@@ -212,6 +219,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     Result result = null;
     List<OmKeyInfo> missingParentInfos = null;
     int numMissingParents = 0;
+    final OMPerformanceMetrics perfMetrics = ozoneManager.getPerfMetrics();
+    long startNanos = Time.monotonicNowNanos();
     try {
 
       mergeOmLockDetails(
@@ -302,9 +311,11 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           * ozoneManager.getScmBlockSize()
           * replicationConfig.getRequiredNodes();
       // check bucket and volume quota
+      long startTime = Time.monotonicNowNanos();
       checkBucketQuotaInBytes(omMetadataManager, bucketInfo,
           preAllocatedSpace);
       checkBucketQuotaInNamespace(bucketInfo, numMissingParents + 1L);
+      perfMetrics.addCreateKeyQuotaCheckLatencyNs(Time.monotonicNowNanos() - startTime);
       bucketInfo.incrUsedNamespace(numMissingParents);
 
       if (numMissingParents > 0) {
@@ -332,6 +343,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           omKeyInfo, missingParentInfos, clientID, bucketInfo.copyObject());
 
       result = Result.SUCCESS;
+      long endNanosCreateKeySuccessLatencyNs = Time.monotonicNowNanos();
+      perfMetrics.setCreateKeySuccessLatencyNs(endNanosCreateKeySuccessLatencyNs - startNanos);
     } catch (IOException | InvalidPathException ex) {
       result = Result.FAILURE;
       exception = ex;
@@ -339,6 +352,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       omResponse.setCmdType(Type.CreateKey);
       omClientResponse = new OMKeyCreateResponse(
           createErrorOMResponse(omResponse, exception), getBucketLayout());
+      long endNanosCreateKeyFailureLatencyNs = Time.monotonicNowNanos();
+      perfMetrics.setCreateKeyFailureLatencyNs(endNanosCreateKeyFailureLatencyNs - startNanos);
     } finally {
       if (acquireLock) {
         mergeOmLockDetails(ozoneLockStrategy

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -98,6 +99,9 @@ public class TestCleanupTableInfo {
 
   @Mock
   private OMMetrics omMetrics;
+
+  @Mock
+  private OMPerformanceMetrics perfMetrics;
 
   @Mock
   private OzoneManager om;
@@ -184,6 +188,7 @@ public class TestCleanupTableInfo {
     when(om.getEnableFileSystemPaths()).thenReturn(true);
     when(om.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(false, false));
+    when(om.getPerfMetrics()).thenReturn(perfMetrics);
 
     Map<String, Integer> cacheItemCount = recordCacheItemCounts();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
As part of performance improvements, new metrics to capture latency for major sub-operation in key creation are introduced. This will help in understanding where more time is spent during key creation and make it easier to troubleshoot slowness.
## What is the link to the Apache JIRA

[HDDS-13510](https://issues.apache.org/jira/browse/HDDS-13510)

## How was this patch tested?

CI: https://github.com/sreejasahithi/ozone/actions/runs/16717200562

Sample outputs of the metrics over Prometheus for a total of 2000 keys created.

<img width="1692" height="623" alt="Screenshot 2025-08-04 at 10 44 23 AM" src="https://github.com/user-attachments/assets/7d69bed9-80d1-4d50-a32f-b01d4c69ce83" />

<img width="1684" height="622" alt="Screenshot 2025-08-04 at 10 43 45 AM" src="https://github.com/user-attachments/assets/f99f74a2-6255-4cdd-9318-23777d156837" />

<img width="1704" height="624" alt="Screenshot 2025-08-04 at 10 43 26 AM" src="https://github.com/user-attachments/assets/dbd3d5ce-81fe-4030-8477-a7a936df295d" />

<img width="1693" height="624" alt="Screenshot 2025-08-04 at 10 41 25 AM" src="https://github.com/user-attachments/assets/a701e95e-6396-4966-8796-0ea119f6dbca" />


