### PR TITLE
HDDS-13533. Show the summary of replicas verify checks

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-keywords.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-keywords.robot
@@ -36,7 +36,8 @@ Execute replicas verify container state debug tool
 
 Parse replicas verify JSON output
     [Arguments]    ${output}
-    ${json} =      Evaluate    json.loads('''${output}''')    json
+    ${json_split} =  Evaluate  '''${output}'''.split('***')[0].strip()
+    ${json} =      Evaluate  json.loads('''${json_split}''')  json
     [Return]       ${json}
 
 Check to Verify Replicas


### PR DESCRIPTION
## What changes were proposed in this pull request?
A replica verification summary is now printed at the end of the command to provide a quick overview of replica health, eliminating the need to manually parse the full JSON output.

## What is the link to the Apache JIRA
[HDDS-13533](https://issues.apache.org/jira/browse/HDDS-13533)

## How was this patch tested?
Tested on a docker cluster.

Sample output:
When all key checks are passed - 
```
bash-5.1$ ozone debug replicas verify --checksums --block-existence --container-state /
{
  "keys" : [ ],
  "pass" : true
}

***************************************************
REPLICA VERIFICATION SUMMARY
***************************************************
Status: Success
Verification Scope: All Volumes
Verification Types: checksum, blockExistence, containerState
URI: /

Number of Volumes processed: 3
Number of Buckets processed: 4
Number of Keys processed: 20

Keys passed verification: 20
Keys failed verification: 0

Total Execution time: 00:00:01,119
***************************************************
```

If a check fails for a particular key - 
```
bash-5.1$ ozone debug replicas verify --checksums --block-existence --container-state /
{
  "keys" : [ {
    "volumeName" : "vol-1-66790",
    "bucketName" : "bucket-1-95566",
    "name" : "key-4-27187",
    "blocks" : [ {
      "containerID" : 1,
      "blockID" : 115816896921600018,
      "replicas" : [ {
        "datanode" : {
          "uuid" : "2779b09e-e6e0-45ab-b92b-044ff8f1d1e5",
          "hostname" : "ozone-datanode-1.ozone_default"
        },
        "checks" : [ {
          "type" : "checksum",
          "completed" : true,
          "pass" : false,
          "failures" : [ {
            "message" : "Checksum mismatched: this.checksums(0) != that.checksums(0), thisStartIndex=0, this=ChecksumData{CRC32, bytesPerChecksum=16384, checksums=[E9 0B B7 A4]}, that=ChecksumData{CRC32, bytesPerChecksum=16384, checksums=[E6 0E 0A DC]}"
          } ]
        }, {
          "type" : "blockExistence",
          "completed" : true,
          "pass" : true,
          "failures" : [ ]
        }, {
          "type" : "containerState",
          "completed" : true,
          "pass" : true,
          "failures" : [ ]
        } ],
        "replicaIndex" : 0
      } ]
    } ],
    "pass" : false
  } ],
  "pass" : false
}

***************************************************
REPLICA VERIFICATION SUMMARY
***************************************************
Status: Completed with failures
Verification Scope: All Volumes
Verification Types: checksum, blockExistence, containerState
URI: /

Number of Volumes processed: 3
Number of Buckets processed: 4
Number of Keys processed: 20

Keys passed verification: 19
Keys failed verification: 1

Keys failed checksum verification: 1
Note: A key may fail multiple verification types, so total may exceed overall failures.

Total Execution time: 00:00:03,061
***************************************************
```

Suppose the command is aborted midway, a partial summary is printed with stats based on the completed verifications.
```
bash-5.1$ ozone debug replicas verify --checksums --block-existence --container-state /
^C
***************************************************
REPLICA VERIFICATION SUMMARY
***************************************************
Status: Success
Verification Scope: All Volumes
Verification Types: checksum, blockExistence, containerState
URI: /

Number of Volumes processed: 2
Number of Buckets processed: 1
Number of Keys processed: 5

Keys passed verification: 5
Keys failed verification: 0

Total Execution time: 00:00:00,775
***************************************************
```

Ran checksum verifier on the specified key -
```
bash-5.1$ ozone debug replicas verify --checksums vol-1-66790/bucket-1-95566/key-4-27187
{
  "keys" : [ {
    "volumeName" : "vol-1-66790",
    "bucketName" : "bucket-1-95566",
    "name" : "key-4-27187",
    "blocks" : [ {
      "containerID" : 1,
      "blockID" : 115816896921600018,
      "replicas" : [ {
        "datanode" : {
          "uuid" : "2779b09e-e6e0-45ab-b92b-044ff8f1d1e5",
          "hostname" : "ozone-datanode-1.ozone_default"
        },
        "checks" : [ {
          "type" : "checksum",
          "completed" : true,
          "pass" : false,
          "failures" : [ {
            "message" : "Checksum mismatched: this.checksums(0) != that.checksums(0), thisStartIndex=0, this=ChecksumData{CRC32, bytesPerChecksum=16384, checksums=[E9 0B B7 A4]}, that=ChecksumData{CRC32, bytesPerChecksum=16384, checksums=[E6 0E 0A DC]}"
          } ]
        } ],
        "replicaIndex" : 0
      } ]
    } ],
    "pass" : false
  } ],
  "pass" : false
}

***************************************************
REPLICA VERIFICATION SUMMARY
***************************************************
Status: Completed with failures
Verification Scope: Key
Verification Types: checksum
URI: vol-1-66790/bucket-1-95566/key-4-27187

Number of Volumes processed: 0
Number of Buckets processed: 0
Number of Keys processed: 1

Keys passed verification: 0
Keys failed verification: 1

Keys failed checksum verification: 1
Note: A key may fail multiple verification types, so total may exceed overall failures.

Total Execution time: 00:00:02,762
***************************************************
```