### PR TITLE
HDDS-13086. Block duplicate reconciliation requests for the same container and datanode within the datanode.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconcileContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconcileContainerCommand.java
@@ -94,12 +94,11 @@ public class ReconcileContainerCommand extends SCMCommand<ReconcileContainerComm
       return false;
     }
     ReconcileContainerCommand that = (ReconcileContainerCommand) o;
-    return getContainerID() == that.getContainerID() &&
-        Objects.equals(peerDatanodes, that.peerDatanodes);
+    return getContainerID() == that.getContainerID();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getContainerID(), peerDatanodes);
+    return Objects.hash(getContainerID());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestReconcileContainerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/checksum/TestReconcileContainerTask.java
@@ -88,8 +88,8 @@ class TestReconcileContainerTask {
 
     // Same container ID and peers.
     assertEquals(peerSet1Task, otherPeerSet1Task);
-    // Same container ID, different peers.
-    assertNotEquals(peerSet1Task, peerSet2Task);
+    // Same container ID, different peers - should still be equal now.
+    assertEquals(peerSet1Task, peerSet2Task);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use only container ID for equality in `ReconcileContainerCommand` so that we don't queue multiple reconciliations for the same container. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13086

## How was this patch tested?
Added unit test.
