### PR TITLE
HDDS-13519. Reconciliation should continue if a peer datanode is unreachable

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1611,23 +1611,23 @@ public class KeyValueHandler extends Handler {
 
         // Handle missing blocks
         for (ContainerProtos.BlockMerkleTree missingBlock : diffReport.getMissingBlocks()) {
-          long localID = missingBlock.getBlockID();
-          BlockID blockID = new BlockID(containerID, localID);
-          if (getBlockManager().blockExists(container, blockID)) {
-            LOG.warn("Cannot reconcile block {} in container {} which was previously reported missing but is now " +
-                "present. Our container merkle tree is stale.", localID, containerID);
-          } else {
-            try {
+          try {
+            long localID = missingBlock.getBlockID();
+            BlockID blockID = new BlockID(containerID, localID);
+            if (getBlockManager().blockExists(container, blockID)) {
+              LOG.warn("Cannot reconcile block {} in container {} which was previously reported missing but is now " +
+                  "present. Our container merkle tree is stale.", localID, containerID);
+            } else {
               long chunksInBlockRetrieved = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, localID,
                   missingBlock.getChunkMerkleTreeList(), updatedTreeWriter, chunkByteBuffer);
               if (chunksInBlockRetrieved != 0) {
                 allBlocksUpdated.add(localID);
                 numMissingBlocksRepaired++;
               }
-            } catch (IOException e) {
-              LOG.error("Error while reconciling missing block for block {} in container {}", missingBlock.getBlockID(),
-                  containerID, e);
             }
+          } catch (IOException e) {
+            LOG.error("Error while reconciling missing block for block {} in container {}", missingBlock.getBlockID(),
+                  containerID, e);
           }
         }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1586,10 +1586,6 @@ public class KeyValueHandler extends Handler {
         long numMissingBlocksRepaired = 0;
         long numCorruptChunksRepaired = 0;
         long numMissingChunksRepaired = 0;
-        // This will be updated as we do repairs with this peer, then used to write the updated tree for the diff with
-        // the next peer.
-        ContainerMerkleTreeWriter updatedTreeWriter =
-            new ContainerMerkleTreeWriter(latestChecksumInfo.getContainerMerkleTree());
 
         LOG.info("Beginning reconciliation for container {} with peer {}. Current data checksum is {}",
             containerID, peer, checksumToString(ContainerChecksumTreeManager.getDataChecksum(latestChecksumInfo)));
@@ -1606,6 +1602,10 @@ public class KeyValueHandler extends Handler {
           continue;
         }
 
+        // This will be updated as we do repairs with this peer, then used to write the updated tree for the diff with
+        // the next peer.
+        ContainerMerkleTreeWriter updatedTreeWriter =
+            new ContainerMerkleTreeWriter(latestChecksumInfo.getContainerMerkleTree());
         ContainerDiffReport diffReport = checksumManager.diff(latestChecksumInfo, peerChecksumInfo);
         Pipeline pipeline = createSingleNodePipeline(peer);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1582,21 +1582,22 @@ public class KeyValueHandler extends Handler {
     ByteBuffer chunkByteBuffer = ByteBuffer.allocate(chunkSize);
 
     for (DatanodeDetails peer : peers) {
-      long numMissingBlocksRepaired = 0;
-      long numCorruptChunksRepaired = 0;
-      long numMissingChunksRepaired = 0;
-      // This will be updated as we do repairs with this peer, then used to write the updated tree for the diff with the
-      // next peer.
-      ContainerMerkleTreeWriter updatedTreeWriter =
-          new ContainerMerkleTreeWriter(latestChecksumInfo.getContainerMerkleTree());
-
-      LOG.info("Beginning reconciliation for container {} with peer {}. Current data checksum is {}",
-          containerID, peer, checksumToString(ContainerChecksumTreeManager.getDataChecksum(latestChecksumInfo)));
-      // Data checksum updated after each peer reconciles.
-      long start = Instant.now().toEpochMilli();
-      ContainerProtos.ContainerChecksumInfo peerChecksumInfo;
-      
       try {
+        long numMissingBlocksRepaired = 0;
+        long numCorruptChunksRepaired = 0;
+        long numMissingChunksRepaired = 0;
+        // This will be updated as we do repairs with this peer, then used to write the updated tree for the diff with
+        // the next peer.
+        ContainerMerkleTreeWriter updatedTreeWriter =
+            new ContainerMerkleTreeWriter(latestChecksumInfo.getContainerMerkleTree());
+
+        LOG.info("Beginning reconciliation for container {} with peer {}. Current data checksum is {}",
+            containerID, peer, checksumToString(ContainerChecksumTreeManager.getDataChecksum(latestChecksumInfo)));
+        // Data checksum updated after each peer reconciles.
+        long start = Instant.now().toEpochMilli();
+        ContainerProtos.ContainerChecksumInfo peerChecksumInfo;
+
+
         // Data checksum updated after each peer reconciles.
         peerChecksumInfo = dnClient.getContainerChecksumInfo(containerID, peer);
         if (peerChecksumInfo == null) {
@@ -1604,100 +1605,99 @@ public class KeyValueHandler extends Handler {
               containerID, peer);
           continue;
         }
-      } catch (Exception e) {
-        LOG.error("Failed to connect to peer {} for container {} reconciliation. Skipping to next peer.",
-            peer, containerID, e);
-        continue;
-      }
 
-      ContainerDiffReport diffReport = checksumManager.diff(latestChecksumInfo, peerChecksumInfo);
-      Pipeline pipeline = createSingleNodePipeline(peer);
+        ContainerDiffReport diffReport = checksumManager.diff(latestChecksumInfo, peerChecksumInfo);
+        Pipeline pipeline = createSingleNodePipeline(peer);
 
-      // Handle missing blocks
-      for (ContainerProtos.BlockMerkleTree missingBlock : diffReport.getMissingBlocks()) {
-        long localID = missingBlock.getBlockID();
-        BlockID blockID = new BlockID(containerID, localID);
-        if (getBlockManager().blockExists(container, blockID)) {
-          LOG.warn("Cannot reconcile block {} in container {} which was previously reported missing but is now " +
-              "present. Our container merkle tree is stale.", localID, containerID);
-        } else {
+        // Handle missing blocks
+        for (ContainerProtos.BlockMerkleTree missingBlock : diffReport.getMissingBlocks()) {
+          long localID = missingBlock.getBlockID();
+          BlockID blockID = new BlockID(containerID, localID);
+          if (getBlockManager().blockExists(container, blockID)) {
+            LOG.warn("Cannot reconcile block {} in container {} which was previously reported missing but is now " +
+                "present. Our container merkle tree is stale.", localID, containerID);
+          } else {
+            try {
+              long chunksInBlockRetrieved = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, localID,
+                  missingBlock.getChunkMerkleTreeList(), updatedTreeWriter, chunkByteBuffer);
+              if (chunksInBlockRetrieved != 0) {
+                allBlocksUpdated.add(localID);
+                numMissingBlocksRepaired++;
+              }
+            } catch (IOException e) {
+              LOG.error("Error while reconciling missing block for block {} in container {}", missingBlock.getBlockID(),
+                  containerID, e);
+            }
+          }
+        }
+
+        // Handle missing chunks
+        for (Map.Entry<Long, List<ContainerProtos.ChunkMerkleTree>> entry : diffReport.getMissingChunks().entrySet()) {
+          long localID = entry.getKey();
           try {
-            long chunksInBlockRetrieved = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, localID,
-                missingBlock.getChunkMerkleTreeList(), updatedTreeWriter, chunkByteBuffer);
-            if (chunksInBlockRetrieved != 0) {
+            long missingChunksRepaired = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, entry.getKey(),
+                entry.getValue(), updatedTreeWriter, chunkByteBuffer);
+            if (missingChunksRepaired != 0) {
               allBlocksUpdated.add(localID);
-              numMissingBlocksRepaired++;
+              numMissingChunksRepaired += missingChunksRepaired;
             }
           } catch (IOException e) {
-            LOG.error("Error while reconciling missing block for block {} in container {}", missingBlock.getBlockID(),
+            LOG.error("Error while reconciling missing chunk for block {} in container {}", entry.getKey(),
                 containerID, e);
           }
         }
-      }
 
-      // Handle missing chunks
-      for (Map.Entry<Long, List<ContainerProtos.ChunkMerkleTree>> entry : diffReport.getMissingChunks().entrySet()) {
-        long localID = entry.getKey();
-        try {
-          long missingChunksRepaired = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, entry.getKey(),
-              entry.getValue(), updatedTreeWriter, chunkByteBuffer);
-          if (missingChunksRepaired != 0) {
-            allBlocksUpdated.add(localID);
-            numMissingChunksRepaired += missingChunksRepaired;
+        // Handle corrupt chunks
+        for (Map.Entry<Long, List<ContainerProtos.ChunkMerkleTree>> entry : diffReport.getCorruptChunks().entrySet()) {
+          long localID = entry.getKey();
+          try {
+            long corruptChunksRepaired = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, entry.getKey(),
+                entry.getValue(), updatedTreeWriter, chunkByteBuffer);
+            if (corruptChunksRepaired != 0) {
+              allBlocksUpdated.add(localID);
+              numCorruptChunksRepaired += corruptChunksRepaired;
+            }
+          } catch (IOException e) {
+            LOG.error("Error while reconciling corrupt chunk for block {} in container {}", entry.getKey(),
+                containerID, e);
           }
-        } catch (IOException e) {
-          LOG.error("Error while reconciling missing chunk for block {} in container {}", entry.getKey(),
-              containerID, e);
         }
-      }
 
-      // Handle corrupt chunks
-      for (Map.Entry<Long, List<ContainerProtos.ChunkMerkleTree>> entry : diffReport.getCorruptChunks().entrySet()) {
-        long localID = entry.getKey();
-        try {
-          long corruptChunksRepaired = reconcileChunksPerBlock(kvContainer, pipeline, dnClient, entry.getKey(),
-              entry.getValue(), updatedTreeWriter, chunkByteBuffer);
-          if (corruptChunksRepaired != 0) {
-            allBlocksUpdated.add(localID);
-            numCorruptChunksRepaired += corruptChunksRepaired;
+        // Based on repaired done with this peer, write the updated merkle tree to the container.
+        // This updated tree will be used when we reconcile with the next peer.
+        ContainerProtos.ContainerChecksumInfo previousChecksumInfo = latestChecksumInfo;
+        latestChecksumInfo = updateAndGetContainerChecksum(container, updatedTreeWriter, false);
+
+        // Log the results of reconciliation with this peer.
+        long duration = Instant.now().toEpochMilli() - start;
+        long previousDataChecksum = ContainerChecksumTreeManager.getDataChecksum(previousChecksumInfo);
+        long latestDataChecksum = ContainerChecksumTreeManager.getDataChecksum(latestChecksumInfo);
+        if (previousDataChecksum == latestDataChecksum) {
+          if (numCorruptChunksRepaired != 0 || numMissingBlocksRepaired != 0 || numMissingChunksRepaired != 0) {
+            // This condition should never happen.
+            LOG.error("Checksum of container was not updated but blocks were repaired.");
           }
-        } catch (IOException e) {
-          LOG.error("Error while reconciling corrupt chunk for block {} in container {}", entry.getKey(),
-              containerID, e);
+          LOG.info("Container {} reconciled with peer {}. Data checksum {} was not updated. Time taken: {} ms",
+              containerID, peer, checksumToString(previousDataChecksum), duration);
+        } else {
+          LOG.warn("Container {} reconciled with peer {}. Data checksum updated from {} to {}" +
+                  ".\nMissing blocks repaired: {}/{}\n" +
+                  "Missing chunks repaired: {}/{}\n" +
+                  "Corrupt chunks repaired:  {}/{}\n" +
+                  "Time taken: {} ms",
+              containerID, peer, checksumToString(previousDataChecksum), checksumToString(latestDataChecksum),
+              numMissingBlocksRepaired, diffReport.getMissingBlocks().size(),
+              numMissingChunksRepaired, diffReport.getMissingChunks().size(),
+              numCorruptChunksRepaired, diffReport.getCorruptChunks().size(),
+              duration);
         }
+
+        ContainerLogger.logReconciled(container.getContainerData(), previousDataChecksum, peer);
+        successfulPeerCount++;
+      } catch (Exception e) {
+        LOG.error("Failed to reconcile with peer {} for container #{}. Skipping to next peer.",
+            peer, containerID, e);
       }
-
-      // Based on repaired done with this peer, write the updated merkle tree to the container.
-      // This updated tree will be used when we reconcile with the next peer.
-      ContainerProtos.ContainerChecksumInfo previousChecksumInfo = latestChecksumInfo;
-      latestChecksumInfo = updateAndGetContainerChecksum(container, updatedTreeWriter, false);
-
-      // Log the results of reconciliation with this peer.
-      long duration = Instant.now().toEpochMilli() - start;
-      long previousDataChecksum = ContainerChecksumTreeManager.getDataChecksum(previousChecksumInfo);
-      long latestDataChecksum = ContainerChecksumTreeManager.getDataChecksum(latestChecksumInfo);
-      if (previousDataChecksum == latestDataChecksum) {
-        if (numCorruptChunksRepaired != 0 || numMissingBlocksRepaired != 0 || numMissingChunksRepaired != 0) {
-          // This condition should never happen.
-          LOG.error("Checksum of container was not updated but blocks were repaired.");
-        }
-        LOG.info("Container {} reconciled with peer {}. Data checksum {} was not updated. Time taken: {} ms",
-            containerID, peer, checksumToString(previousDataChecksum), duration);
-      } else {
-        LOG.warn("Container {} reconciled with peer {}. Data checksum updated from {} to {}" +
-                ".\nMissing blocks repaired: {}/{}\n" +
-                "Missing chunks repaired: {}/{}\n" +
-                "Corrupt chunks repaired:  {}/{}\n" +
-                "Time taken: {} ms",
-            containerID, peer, checksumToString(previousDataChecksum), checksumToString(latestDataChecksum),
-            numMissingBlocksRepaired, diffReport.getMissingBlocks().size(),
-            numMissingChunksRepaired, diffReport.getMissingChunks().size(),
-            numCorruptChunksRepaired, diffReport.getCorruptChunks().size(),
-            duration);
-      }
-
-      ContainerLogger.logReconciled(container.getContainerData(), previousDataChecksum, peer);
-      successfulPeerCount++;
     }
 
     // Log a summary after reconciling with all peers.
@@ -1717,8 +1717,7 @@ public class KeyValueHandler extends Handler {
     }
 
     // Trigger on demand scanner, which will build the merkle tree based on the newly ingested data.
-    containerSet.scanContainerWithoutGap(containerID,
-        "Container reconciliation");
+    containerSet.scanContainerWithoutGap(containerID, "Container reconciliation");
     sendICR(container);
   }
 
@@ -1831,6 +1830,10 @@ public class KeyValueHandler extends Handler {
           chunkInfo.addMetadata(OzoneConsts.CHUNK_OVERWRITE, "true");
           writeChunkForClosedContainer(chunkInfo, blockID, chunkBuffer, container);
           localOffset2Chunk.put(chunkOffset, chunkInfoProto);
+          // Update the treeWriter to reflect the current state of blocks and chunks on disk after successful
+          // chunk writes. If putBlockForClosedContainer fails, the container scanner will later update the
+          // Merkle tree to resolve any discrepancies.
+          treeWriter.addChunks(localID, true, chunkInfoProto);
           if (LOG.isDebugEnabled()) {
             LOG.debug("Successfully ingested chunk at offset {} into block {} of container {} from peer {}",
                 chunkOffset, localID, containerID, peer);
@@ -1854,7 +1857,6 @@ public class KeyValueHandler extends Handler {
         List<ContainerProtos.ChunkInfo> allChunks = new ArrayList<>(localOffset2Chunk.values());
         localBlockData.setChunks(allChunks);
         putBlockForClosedContainer(container, localBlockData, maxBcsId, allChunksSuccessful);
-        treeWriter.addChunks(localID, true, allChunks);
         // Invalidate the file handle cache, so new read requests get the new file if one was created.
         chunkManager.finishWriteChunks(container, localBlockData);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1694,9 +1694,9 @@ public class KeyValueHandler extends Handler {
 
         ContainerLogger.logReconciled(container.getContainerData(), previousDataChecksum, peer);
         successfulPeerCount++;
-      } catch (Exception e) {
+      } catch (IOException ex) {
         LOG.error("Failed to reconcile with peer {} for container #{}. Skipping to next peer.",
-            peer, containerID, e);
+            peer, containerID, ex);
       }
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1594,11 +1594,19 @@ public class KeyValueHandler extends Handler {
           containerID, peer, checksumToString(ContainerChecksumTreeManager.getDataChecksum(latestChecksumInfo)));
       // Data checksum updated after each peer reconciles.
       long start = Instant.now().toEpochMilli();
-      ContainerProtos.ContainerChecksumInfo peerChecksumInfo = dnClient.getContainerChecksumInfo(
-          containerID, peer);
-      if (peerChecksumInfo == null) {
-        LOG.warn("Cannot reconcile container {} with peer {} which has not yet generated a checksum",
-            containerID, peer);
+      ContainerProtos.ContainerChecksumInfo peerChecksumInfo;
+      
+      try {
+        // Data checksum updated after each peer reconciles.
+        peerChecksumInfo = dnClient.getContainerChecksumInfo(containerID, peer);
+        if (peerChecksumInfo == null) {
+          LOG.warn("Cannot reconcile container {} with peer {} which has not yet generated a checksum",
+              containerID, peer);
+          continue;
+        }
+      } catch (Exception e) {
+        LOG.error("Failed to connect to peer {} for container {} reconciliation. Skipping to next peer.",
+            peer, containerID, e);
         continue;
       }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
@@ -268,7 +268,6 @@ public class TestContainerReconciliationWithMockDatanodes {
     MockDatanode corruptedNode = datanodes.get(0);
     MockDatanode healthyNode1 = datanodes.get(1);
     MockDatanode healthyNode2 = datanodes.get(2);
-    healthyDataChecksum = healthyNode1.checkAndGetDataChecksum(CONTAINER_ID);
     corruptedNode.introduceCorruption(CONTAINER_ID, 1, 1, false);
     
     // Use synchronous on-demand scans to re-build the merkle trees after corruption.


### PR DESCRIPTION
## What changes were proposed in this pull request?
When reconciling a container with all peers, we should continue on to the next peer if we cannot reach one peer, instead of failing reconciliation.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13519

## How was this patch tested?
Added UT
