### PR TITLE
HDDS-13546. Exit code should be non-zero if balancer commands fail

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1298,6 +1298,7 @@ public class SCMClientProtocolServer implements
     } catch (IllegalContainerBalancerStateException e) {
       AUDIT.logWriteFailure(buildAuditMessageForFailure(
           SCMAction.STOP_CONTAINER_BALANCER, null, e));
+      throw new IOException(e.getMessage());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1298,7 +1298,7 @@ public class SCMClientProtocolServer implements
     } catch (IllegalContainerBalancerStateException e) {
       AUDIT.logWriteFailure(buildAuditMessageForFailure(
           SCMAction.STOP_CONTAINER_BALANCER, null, e));
-      throw new IOException(e.getMessage());
+      throw new IOException(e.getMessage(), e);
     }
   }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
@@ -131,12 +131,10 @@ public class ContainerBalancerStartSubcommand extends ScmSubcommand {
     if (response.getStart()) {
       System.out.println("Container Balancer started successfully.");
     } else {
-      String errMsg = "Failed to start Container Balancer.";
-      System.out.println(errMsg);
       if (response.hasMessage()) {
-        System.out.printf("Failure reason: %s", response.getMessage());
+        System.err.printf("Failure reason: %s%n", response.getMessage());
       }
-      throw new IOException(errMsg);
+      throw new IOException("Failed to start Container Balancer.");
     }
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
@@ -131,10 +131,11 @@ public class ContainerBalancerStartSubcommand extends ScmSubcommand {
     if (response.getStart()) {
       System.out.println("Container Balancer started successfully.");
     } else {
+      System.err.println("Failed to start Container Balancer.");
       if (response.hasMessage()) {
         System.err.printf("Failure reason: %s%n", response.getMessage());
       }
-      throw new IOException("Failed to start Container Balancer.");
+      throw new IOException(response.getMessage());
     }
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
@@ -131,10 +131,12 @@ public class ContainerBalancerStartSubcommand extends ScmSubcommand {
     if (response.getStart()) {
       System.out.println("Container Balancer started successfully.");
     } else {
-      System.out.println("Failed to start Container Balancer.");
+      String errMsg = "Failed to start Container Balancer.";
+      System.out.println(errMsg);
       if (response.hasMessage()) {
         System.out.printf("Failure reason: %s", response.getMessage());
       }
+      throw new IOException(errMsg);
     }
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStartSubcommand.java
@@ -131,11 +131,13 @@ public class ContainerBalancerStartSubcommand extends ScmSubcommand {
     if (response.getStart()) {
       System.out.println("Container Balancer started successfully.");
     } else {
+      String reason = "";
       System.err.println("Failed to start Container Balancer.");
       if (response.hasMessage()) {
-        System.err.printf("Failure reason: %s%n", response.getMessage());
+        reason = response.getMessage();
+        System.err.printf("Failure reason: %s%n", reason);
       }
-      throw new IOException(response.getMessage());
+      throw new IOException("Failed to start Container Balancer. " + reason);
     }
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
@@ -40,7 +40,7 @@ public class ContainerBalancerStopSubcommand extends ScmSubcommand {
     } catch (IOException e) {
       String msg = "Failed to stop Container Balancer";
       System.err.println(msg);
-      throw new IOException(msg, e);
+      throw e;
     }
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
@@ -39,7 +39,7 @@ public class ContainerBalancerStopSubcommand extends ScmSubcommand {
       System.out.println("Container Balancer stopped.");
     } catch (IOException e) {
       String msg = "Failed to stop Container Balancer";
-      System.out.println(msg);
+      System.err.println(msg);
       throw new IOException(msg, e);
     }
   }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
@@ -34,7 +34,13 @@ public class ContainerBalancerStopSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     System.out.println("Sending stop command. Waiting for Container Balancer to stop...");
-    scmClient.stopContainerBalancer();
-    System.out.println("Container Balancer stopped.");
+    try {
+      scmClient.stopContainerBalancer();
+      System.out.println("Container Balancer stopped.");
+    } catch (IOException e) {
+      String msg = "Failed to stop Container Balancer";
+      System.out.println(msg);
+      throw new IOException(msg, e);
+    }
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -472,8 +472,7 @@ class TestContainerBalancerSubCommand {
             .setStart(false)
             .setMessage("")
             .build());
-    Exception ex = assertThrows(IOException.class, () -> startCmd.execute(scmClient));
-    assertThat(ex.getMessage()).containsPattern(FAILED_TO_START);
+    assertThrows(IOException.class, () -> startCmd.execute(scmClient));
     assertThat(err.get()).containsPattern(FAILED_TO_START);
   }
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import static org.apache.hadoop.ozone.OzoneConsts.GB;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +65,7 @@ class TestContainerBalancerSubCommand {
   private static final Pattern WAITING_TO_STOP = Pattern.compile(
       "^Sending\\sstop\\scommand.\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
       "Container\\sBalancer\\sstopped.");
+  private static final Pattern STOP_FAILED = Pattern.compile("^Failed\\sto\\sstop\\sContainer\\sBalancer$");
 
   private static final String BALANCER_CONFIG_OUTPUT = "Container Balancer Configuration values:\n" +
       "Key                                                Value\n" +
@@ -434,6 +437,15 @@ class TestContainerBalancerSubCommand {
   }
 
   @Test
+  public void testContainerBalancerStopSubcommandInvalidState() throws IOException {
+    ScmClient scmClient = mock(ScmClient.class);
+    doThrow(IOException.class).when(scmClient).stopContainerBalancer();
+    Exception ex = assertThrows(IOException.class, () -> stopCmd.execute(scmClient));
+    assertThat(err.get()).containsPattern(STOP_FAILED);
+    assertThat(ex.getMessage()).containsPattern(STOP_FAILED);
+  }
+
+  @Test
   public void testContainerBalancerStartSubcommandWhenBalancerIsNotRunning()
       throws IOException {
     ScmClient scmClient = mock(ScmClient.class);
@@ -460,8 +472,8 @@ class TestContainerBalancerSubCommand {
             .setStart(false)
             .setMessage("")
             .build());
-    startCmd.execute(scmClient);
-
+    Exception ex = assertThrows(IOException.class, () -> startCmd.execute(scmClient));
+    assertThat(ex.getMessage()).containsPattern(FAILED_TO_START);
     assertThat(out.get()).containsPattern(FAILED_TO_START);
   }
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -474,7 +474,7 @@ class TestContainerBalancerSubCommand {
             .build());
     Exception ex = assertThrows(IOException.class, () -> startCmd.execute(scmClient));
     assertThat(ex.getMessage()).containsPattern(FAILED_TO_START);
-    assertThat(out.get()).containsPattern(FAILED_TO_START);
+    assertThat(err.get()).containsPattern(FAILED_TO_START);
   }
 
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -440,7 +440,7 @@ class TestContainerBalancerSubCommand {
   public void testContainerBalancerStopSubcommandInvalidState() throws IOException {
     ScmClient scmClient = mock(ScmClient.class);
     doThrow(IOException.class).when(scmClient).stopContainerBalancer();
-    Exception ex = assertThrows(IOException.class, () -> stopCmd.execute(scmClient));
+    assertThrows(IOException.class, () -> stopCmd.execute(scmClient));
     assertThat(err.get()).containsPattern(STOP_FAILED);
   }
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -442,7 +442,6 @@ class TestContainerBalancerSubCommand {
     doThrow(IOException.class).when(scmClient).stopContainerBalancer();
     Exception ex = assertThrows(IOException.class, () -> stopCmd.execute(scmClient));
     assertThat(err.get()).containsPattern(STOP_FAILED);
-    assertThat(ex.getMessage()).containsPattern(STOP_FAILED);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a container balancer start or stop command fails due to invalid states or options passed, although a suitable error message is printed, the exit code of the command was still 0 which is mis-leading. 
This PR changes the behaviour to throw an exception to client too, making the exit code non-zero

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13546

## How was this patch tested?

Added unit test coverage
