### PR TITLE
HDDS-13541. Bump sonar-maven-plugin to 5.1.0.4751

### DIFF
--- a/hadoop-ozone/dev-support/checks/sonar.sh
+++ b/hadoop-ozone/dev-support/checks/sonar.sh
@@ -23,7 +23,8 @@ if [ ! "$SONAR_TOKEN" ]; then
   exit 1
 fi
 
+: "${SONAR_MAVEN_PLUGIN_VERSION:=5.1.0.4751}"
 
 mvn -V -B -DskipShade -DskipTests -DskipRecon --no-transfer-progress \
   -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
-  verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar
+  verify "org.sonarsource.scanner.maven:sonar-maven-plugin:${SONAR_MAVEN_PLUGIN_VERSION}:sonar"

--- a/hadoop-ozone/dev-support/checks/sonar.sh
+++ b/hadoop-ozone/dev-support/checks/sonar.sh
@@ -27,4 +27,4 @@ fi
 mvn -V -B -DskipShade -DskipTests -DskipRecon --no-transfer-progress \
   -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
   -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone \
-  verify org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar
+  verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar

--- a/hadoop-ozone/dev-support/checks/sonar.sh
+++ b/hadoop-ozone/dev-support/checks/sonar.sh
@@ -26,5 +26,4 @@ fi
 
 mvn -V -B -DskipShade -DskipTests -DskipRecon --no-transfer-progress \
   -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
-  -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone \
   verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.1.0.4751:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,10 @@
     <slf4j.version>2.0.17</slf4j.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <snappy-java.version>1.1.10.8</snappy-java.version>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
+    <sonar.organization>apache</sonar.organization>
+    <sonar.projectKey>hadoop-ozone</sonar.projectKey>
     <sortpom-maven-plugin.version>3.0.1</sortpom-maven-plugin.version>
     <spotbugs.version>3.1.12.2</spotbugs.version>
     <spring.version>5.3.39</spring.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bump Sonar Scanner for Maven plugin to the latest version.
- Set SonarQube properties (address and project ID) to allow overriding (for internal builds).
- Also allow overriding the plugin version via environment variable.  (Not as property in `pom.xml`, to minimize CI workflow for future PRs bumping the version, since coverage check is skipped in pull requests.)

https://issues.apache.org/jira/browse/HDDS-13541

## How was this patch tested?

https://github.com/apache/ozone/actions/runs/16770890224/job/47490032778