### PR TITLE
HDDS-13547. [DiskBalancer] Change VolumeChoosingPolicy to DiskBalancerVolumeChoosingPolicy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -55,7 +55,7 @@ import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.diskbalancer.policy.ContainerChoosingPolicy;
-import org.apache.hadoop.ozone.container.diskbalancer.policy.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.diskbalancer.policy.DiskBalancerVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
@@ -109,7 +109,7 @@ public class DiskBalancerService extends BackgroundService {
   private Map<HddsVolume, Long> deltaSizes;
   private MutableVolumeSet volumeSet;
 
-  private VolumeChoosingPolicy volumeChoosingPolicy;
+  private DiskBalancerVolumeChoosingPolicy volumeChoosingPolicy;
   private ContainerChoosingPolicy containerChoosingPolicy;
   private final File diskBalancerInfoFile;
 
@@ -158,7 +158,7 @@ public class DiskBalancerService extends BackgroundService {
     volumeSet = ozoneContainer.getVolumeSet();
 
     try {
-      volumeChoosingPolicy = (VolumeChoosingPolicy)
+      volumeChoosingPolicy = (DiskBalancerVolumeChoosingPolicy)
           conf.getObject(DiskBalancerConfiguration.class)
           .getVolumeChoosingPolicyClass().newInstance();
       containerChoosingPolicy = (ContainerChoosingPolicy)
@@ -686,7 +686,7 @@ public class DiskBalancerService extends BackgroundService {
     return containerChoosingPolicy;
   }
 
-  public VolumeChoosingPolicy getVolumeChoosingPolicy() {
+  public DiskBalancerVolumeChoosingPolicy getVolumeChoosingPolicy() {
     return volumeChoosingPolicy;
   }
 
@@ -700,7 +700,7 @@ public class DiskBalancerService extends BackgroundService {
   }
 
   @VisibleForTesting
-  public void setVolumeChoosingPolicy(VolumeChoosingPolicy volumeChoosingPolicy) {
+  public void setVolumeChoosingPolicy(DiskBalancerVolumeChoosingPolicy volumeChoosingPolicy) {
     this.volumeChoosingPolicy = volumeChoosingPolicy;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DiskBalancerVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DiskBalancerVolumeChoosingPolicy.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 /**
  * This interface specifies the policy for choosing volumes to balance.
  */
-public interface VolumeChoosingPolicy {
+public interface DiskBalancerVolumeChoosingPolicy {
   /**
    * Choose a pair of volumes for balancing.
    *

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -975,6 +975,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } catch (Exception e) {
       LOG.error("Got exception when copying container {} to {}",
           containerData.getContainerID(), destination, e);
+      throw e;
     } finally {
       if (lock.isWriteLockedByCurrentThread()) {
         writeUnlock();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -52,7 +52,7 @@ import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerService.DiskBa
 import org.apache.hadoop.ozone.container.diskbalancer.policy.ContainerChoosingPolicy;
 import org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultContainerChoosingPolicy;
 import org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultVolumeChoosingPolicy;
-import org.apache.hadoop.ozone.container.diskbalancer.policy.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.diskbalancer.policy.DiskBalancerVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
@@ -275,7 +275,7 @@ public class TestDiskBalancerService {
         false, DiskBalancerVersion.DEFAULT_VERSION);
     svc.refresh(info);
 
-    VolumeChoosingPolicy volumePolicy = mock(VolumeChoosingPolicy.class);
+    DiskBalancerVolumeChoosingPolicy volumePolicy = mock(DiskBalancerVolumeChoosingPolicy.class);
     ContainerChoosingPolicy containerPolicy = mock(ContainerChoosingPolicy.class);
     svc.setVolumeChoosingPolicy(volumePolicy);
     svc.setContainerChoosingPolicy(containerPolicy);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestVolumeChoosingPolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestVolumeChoosingPolicy.java
@@ -49,7 +49,7 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultVolumeChoosingPolicy;
-import org.apache.hadoop.ozone.container.diskbalancer.policy.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.diskbalancer.policy.DiskBalancerVolumeChoosingPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +64,7 @@ public class TestVolumeChoosingPolicy {
   private static final int NUM_VOLUMES = 20;
   private static final int NUM_THREADS = 10;
   private static final int NUM_ITERATIONS = 10000;
-  private static final double THRESHOLD = 0.1; // 10% threshold
+  private static final double THRESHOLD = 10; // 10% threshold
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
 
@@ -73,7 +73,7 @@ public class TestVolumeChoosingPolicy {
 
   private MutableVolumeSet volumeSet;
   private List<HddsVolume> hddsVolumes;
-  private VolumeChoosingPolicy volumeChoosingPolicy;
+  private DiskBalancerVolumeChoosingPolicy volumeChoosingPolicy;
   private ExecutorService executor;
 
   // delta sizes for source volumes
@@ -118,7 +118,7 @@ public class TestVolumeChoosingPolicy {
    * pairChosenCount: Number of successful volume pair choices from the policy.
    * FailureCount: Failures due to any exceptions thrown during volume choice or null return.
    */
-  private void testPolicyPerformance(String policyName, VolumeChoosingPolicy policy) throws Exception {
+  private void testPolicyPerformance(String policyName, DiskBalancerVolumeChoosingPolicy policy) throws Exception {
     CountDownLatch latch = new CountDownLatch(NUM_THREADS);
     AtomicInteger pairChosenCount = new AtomicInteger(0);
     AtomicInteger pairNotChosenCount = new AtomicInteger(0);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This ticket covers several key improvements to the Disk Balancer functionality, focusing on :

volumeChoosingPolicy,  ” threshold / 100 ” it should be normalized before using it in volumeChoosingPolicy
Rename VolumeChoosingPolicy to DiskBalancerVolumeChoosingPolicy
copyContainer failure should throw exception

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13547

## How was this patch tested?

Existing UT.