### PR TITLE
HDDS-12998. Bring real container size in pb message when exporting/importing containers

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerDownloader.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.replication;
 import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 
 /**
@@ -32,8 +33,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
  */
 public interface ContainerDownloader extends Closeable {
 
-  Path getContainerDataFromReplicas(long containerId,
+  Pair<Path, Long> getContainerDataFromReplicas(long containerId,
       List<DatanodeDetails> sources, Path downloadDir,
       CopyContainerCompression compression);
-
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -60,7 +60,7 @@ public class ContainerImporter {
   private final ContainerController controller;
   private final MutableVolumeSet volumeSet;
   private final VolumeChoosingPolicy volumeChoosingPolicy;
-  private final long containerSize;
+  private final long defaultContainerSize;
 
   private final Set<Long> importContainerProgress
       = Collections.synchronizedSet(new HashSet<>());
@@ -76,7 +76,7 @@ public class ContainerImporter {
     this.controller = controller;
     this.volumeSet = volumeSet;
     this.volumeChoosingPolicy = volumeChoosingPolicy;
-    containerSize = (long) conf.getStorageSize(
+    defaultContainerSize = (long) conf.getStorageSize(
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
     this.conf = conf;
@@ -170,6 +170,16 @@ public class ContainerImporter {
   }
 
   public long getDefaultReplicationSpace() {
-    return HddsServerUtil.requiredReplicationSpace(containerSize);
+    return HddsServerUtil.requiredReplicationSpace(defaultContainerSize);
+  }
+
+  /**
+   * Calculate required replication space based on actual container size.
+   *
+   * @param actualContainerSize the actual size of the container in bytes
+   * @return required space for replication (2 * actualContainerSize)
+   */
+  public long getRequiredReplicationSpace(long actualContainerSize) {
+    return HddsServerUtil.requiredReplicationSpace(actualContainerSize);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerReplicationSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerReplicationSource.java
@@ -48,4 +48,17 @@ public interface ContainerReplicationSource {
       CopyContainerCompression compression)
       throws IOException;
 
+  /**
+   * Get the actual size of the container in bytes.
+   * This is used for space reservation during replication.
+   *
+   * @param containerId ID of the container
+   * @return actual container size in bytes, or null if size cannot be determined
+   * @throws IOException if container is not found or size cannot be retrieved
+   */
+  default Long getContainerSize(long containerId) throws IOException {
+    // Default implementation returns null for backward compatibility
+    return null;
+  }
+
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerUploader.java
@@ -27,6 +27,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
  */
 public interface ContainerUploader {
   OutputStream startUpload(long containerId, DatanodeDetails target,
-      CompletableFuture<Void> callback, CopyContainerCompression compression)
+      CompletableFuture<Void> callback, CopyContainerCompression compression, Long containerSize)
       throws IOException;
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -54,7 +54,7 @@ public class GrpcContainerUploader implements ContainerUploader {
 
   @Override
   public OutputStream startUpload(long containerId, DatanodeDetails target,
-      CompletableFuture<Void> callback, CopyContainerCompression compression)
+      CompletableFuture<Void> callback, CopyContainerCompression compression, Long containerSize)
       throws IOException {
     GrpcReplicationClient client = createReplicationClient(target, compression);
     try {
@@ -68,7 +68,7 @@ public class GrpcContainerUploader implements ContainerUploader {
               (CallStreamObserver<SendContainerRequest>) client.upload(
               responseObserver), responseObserver);
       return new SendContainerOutputStream(requestStream, containerId,
-          GrpcReplicationService.BUFFER_SIZE, compression) {
+          GrpcReplicationService.BUFFER_SIZE, compression, containerSize) {
         @Override
         public void close() throws IOException {
           try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -126,11 +126,19 @@ public class GrpcReplicationService extends
         "with compression {}", containerID, compression);
     OutputStream outputStream = null;
     try {
+      // Get container size before creating stream
+      Long containerSize = null;
+      try {
+        containerSize = source.getContainerSize(containerID);
+      } catch (Exception e) {
+        LOG.warn("Could not get container size for {}, proceeding without size info", containerID, e);
+      }
+
       outputStream = new CopyContainerResponseStream(
           // gRPC runtime always provides implementation of CallStreamObserver
           // that allows flow control.
           (CallStreamObserver<CopyContainerResponseProto>) responseObserver,
-          containerID, BUFFER_SIZE);
+          containerID, BUFFER_SIZE, containerSize);
       source.copyData(containerID, outputStream, compression);
     } catch (IOException e) {
       LOG.warn("Error streaming container {}", containerID, e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/OnDemandContainerReplicationSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/OnDemandContainerReplicationSource.java
@@ -61,4 +61,14 @@ public class OnDemandContainerReplicationSource
         container.getContainerType(), containerId, destination,
         new TarContainerPacker(compression));
   }
+
+  @Override
+  public Long getContainerSize(long containerId) throws IOException {
+    Container container = controller.getContainer(containerId);
+    if (container == null) {
+      throw new StorageContainerException("Container " + containerId +
+          " is not found.", CONTAINER_NOT_FOUND);
+    }
+    return container.getContainerData().getBytesUsed();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
@@ -56,12 +56,21 @@ public class PushReplicator implements ContainerReplicator {
     LOG.info("Starting replication of container {} to {} using {}",
         containerID, target, compression);
 
+    // Get container size before starting upload (same as pull replication)
+    Long containerSize = null;
+    try {
+      containerSize = source.getContainerSize(containerID);
+      LOG.info("Container {} actual size: {} bytes", containerID, containerSize);
+    } catch (Exception e) {
+      LOG.warn("Could not get container size for {}, proceeding without size info", containerID, e);
+    }
+
     source.prepare(containerID);
 
     CountingOutputStream output = null;
     try {
       output = new CountingOutputStream(
-          uploader.startUpload(containerID, target, fut, compression));
+          uploader.startUpload(containerID, target, fut, compression, containerSize));
       source.copyData(containerID, output, compression);
       fut.get();
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
@@ -56,7 +57,7 @@ public class SimpleContainerDownloader implements ContainerDownloader {
   }
 
   @Override
-  public Path getContainerDataFromReplicas(
+  public Pair<Path, Long> getContainerDataFromReplicas(
       long containerId, List<DatanodeDetails> sourceDatanodes,
       Path downloadDir, CopyContainerCompression compression) {
 
@@ -73,7 +74,7 @@ public class SimpleContainerDownloader implements ContainerDownloader {
       GrpcReplicationClient client = null;
       try {
         client = createReplicationClient(datanode, compression);
-        CompletableFuture<Path> result =
+        CompletableFuture<Pair<Path, Long>> result =
             downloadContainer(client, containerId, downloadDir);
         return result.get();
       } catch (InterruptedException e) {
@@ -127,7 +128,7 @@ public class SimpleContainerDownloader implements ContainerDownloader {
   }
 
   @VisibleForTesting
-  protected CompletableFuture<Path> downloadContainer(
+  protected CompletableFuture<Pair<Path, Long>> downloadContainer(
       GrpcReplicationClient client, long containerId, Path downloadDir) {
     return client.download(containerId, downloadDir);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
@@ -129,7 +129,7 @@ class TestGrpcContainerUploader {
   private static OutputStream startUpload(GrpcContainerUploader subject,
       CompletableFuture<Void> callback) throws IOException {
     DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
-    return subject.startUpload(1, target, callback, NO_COMPRESSION);
+    return subject.startUpload(1, target, callback, NO_COMPRESSION, null);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcReplicationService.java
@@ -173,7 +173,7 @@ class TestGrpcReplicationService {
     Path result = downloader.getContainerDataFromReplicas(
         CONTAINER_ID,
         Collections.singletonList(datanode), downloadDir,
-        CopyContainerCompression.NO_COMPRESSION);
+        CopyContainerCompression.NO_COMPRESSION).getLeft();
 
     assertTrue(result.toString().startsWith(downloadDir.toString()));
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
@@ -140,7 +140,7 @@ class TestPushReplicator {
 
     when(
         uploader.startUpload(eq(containerID), eq(target),
-            futureArgument.capture(), compressionArgument.capture()
+            futureArgument.capture(), compressionArgument.capture(), any(Long.class)
         ))
         .thenReturn(outputStream);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -72,6 +72,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -336,7 +337,7 @@ public class TestReplicationSupervisor {
     when(
         moc.getContainerDataFromReplicas(anyLong(), anyList(),
             any(Path.class), any()))
-        .thenReturn(res);
+        .thenReturn(Pair.of(res, null));
 
     final String testDir = tempFile.getPath();
     MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
@@ -406,7 +407,7 @@ public class TestReplicationSupervisor {
     when(
         moc.getContainerDataFromReplicas(anyLong(), anyList(),
             any(Path.class), any()))
-        .thenReturn(tarFile.toPath());
+        .thenReturn(Pair.of(tarFile.toPath(), null));
 
     ContainerImporter importer =
         new ContainerImporter(conf, set, controllerMock, volumeSet, volumeChoosingPolicy);
@@ -581,7 +582,7 @@ public class TestReplicationSupervisor {
       SimpleContainerDownloader moc = mock(SimpleContainerDownloader.class);
       Path res = Paths.get("file:/tmp/no-such-file");
       when(moc.getContainerDataFromReplicas(anyLong(), anyList(),
-          any(Path.class), any())).thenReturn(res);
+          any(Path.class), any())).thenReturn(Pair.of(res, null));
 
       final String testDir = tempFile.getPath();
       MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerOutputStream.java
@@ -40,14 +40,14 @@ class TestSendContainerOutputStream
   @Override
   protected OutputStream createSubject() {
     return new SendContainerOutputStream(getObserver(),
-        getContainerId(), getBufferSize(), NO_COMPRESSION);
+        getContainerId(), getBufferSize(), NO_COMPRESSION, null);
   }
 
   @ParameterizedTest
   @EnumSource
   void usesCompression(CopyContainerCompression compression) throws Exception {
     OutputStream subject = new SendContainerOutputStream(
-        getObserver(), getContainerId(), getBufferSize(), compression);
+        getObserver(), getContainerId(), getBufferSize(), compression, null);
 
     byte[] bytes = getRandomBytes(16);
     subject.write(bytes, 0, bytes.length);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -56,7 +57,7 @@ public class TestSimpleContainerDownloader {
 
     //WHEN
     Path result = downloader.getContainerDataFromReplicas(1L, datanodes,
-        tempDir, NO_COMPRESSION);
+        tempDir, NO_COMPRESSION).getLeft();
 
     //THEN
     assertEquals(datanodes.get(0).getUuidString(),
@@ -77,7 +78,7 @@ public class TestSimpleContainerDownloader {
     //WHEN
     final Path result =
         downloader.getContainerDataFromReplicas(1L, datanodes,
-            tempDir, NO_COMPRESSION);
+            tempDir, NO_COMPRESSION).getLeft();
 
     //THEN
     //first datanode is failed, second worked
@@ -98,7 +99,7 @@ public class TestSimpleContainerDownloader {
     //WHEN
     final Path result =
         downloader.getContainerDataFromReplicas(1L, datanodes,
-            tempDir, NO_COMPRESSION);
+            tempDir, NO_COMPRESSION).getLeft();
 
     //THEN
     //first datanode is failed, second worked
@@ -123,7 +124,7 @@ public class TestSimpleContainerDownloader {
     //returned.
     for (int i = 0; i < 10000; i++) {
       Path path = downloader.getContainerDataFromReplicas(1L, datanodes,
-          tempDir, NO_COMPRESSION);
+          tempDir, NO_COMPRESSION).getLeft();
       if (path.toString().equals(datanodes.get(1).getUuidString())) {
         return;
       }
@@ -206,7 +207,7 @@ public class TestSimpleContainerDownloader {
     }
 
     @Override
-    protected CompletableFuture<Path> downloadContainer(
+    protected CompletableFuture<Pair<Path, Long>> downloadContainer(
         GrpcReplicationClient client,
         long containerId, Path downloadPath) {
 
@@ -225,7 +226,7 @@ public class TestSimpleContainerDownloader {
 
         //path includes the dn id to make it possible to assert.
         return CompletableFuture.completedFuture(
-            Paths.get(datanode.getUuidString()));
+            Pair.of(Paths.get(datanode.getUuidString()), null));
       }
 
     }

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -541,6 +541,7 @@ message CopyContainerResponseProto {
   required bool eof = 4;
   required bytes data = 5;
   optional int64 checksum = 6;
+  optional uint64 actualContainerSize = 7;
 }
 
 message SendContainerRequest {
@@ -549,6 +550,7 @@ message SendContainerRequest {
   required bytes data = 3;
   optional int64 checksum = 4;
   optional CopyContainerCompressProto compression = 5;
+  optional int64 actualContainerSize = 6;
 }
 
 message SendContainerResponse {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -402,10 +403,10 @@ public class TestOzoneContainerWithTLS {
     LogCapturer logCapture = captureLogs(SimpleContainerDownloader.class);
     SimpleContainerDownloader downloader =
         new SimpleContainerDownloader(conf, caClient);
-    Path file = downloader.getContainerDataFromReplicas(containerId,
+    Pair<Path, Long> result = downloader.getContainerDataFromReplicas(containerId,
         sourceDatanodes, tempFolder.resolve("tmp"), NO_COMPRESSION);
     downloader.close();
-    assertNull(file);
+    assertNull(result);
     assertThat(logCapture.getOutput())
         .contains("java.security.cert.CertificateExpiredException");
   }
@@ -416,7 +417,7 @@ public class TestOzoneContainerWithTLS {
       SimpleContainerDownloader downloader =
           new SimpleContainerDownloader(conf, caClient);
       Path file = downloader.getContainerDataFromReplicas(cId, sourceDatanodes,
-          tempFolder.resolve("tmp"), NO_COMPRESSION);
+          tempFolder.resolve("tmp"), NO_COMPRESSION).getLeft();
       downloader.close();
       assertNotNull(file);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Generally, the tar zip file of container will have smaller size than it's real size, so reserve a 2* max container size is conservative enough in most cases. But there are container over-allocated case, where container size can be double or triple the max container size as [@siddhantsangwan](https://github.com/siddhantsangwan) saw in user's environment, have a accurate container size can handle this case welly, and that info could be brought in [proto message](https://github.com/apache/ozone/blob/f52069b7aa757d39e4819bae7d06b12955660576/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto#L529-L545).

For backward compatibility, if that field unset, fallback to get the container size from config.

comments:

https://github.com/apache/ozone/pull/8360#issuecomment-2850023149
https://github.com/apache/ozone/pull/8360#issuecomment-2857154196
https://github.com/apache/ozone/pull/8360#issuecomment-2857213750
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12998

## How was this patch tested?

Updated existing UT.
