### PR TITLE
HDDS-13041. Add basic snapshot diff report test for object tag, stream key, rewriteKey

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -3253,11 +3253,11 @@ public abstract class TestOmSnapshot {
       mixedStream.write(mixedPart);
     }
 
-    assertEquals(3,
+    assertEquals(1,
         bucket.listParts(regularPartsKey, regularMpuInfo.getUploadID(), 0, 100).getPartInfoList().size());
-    assertEquals(2,
+    assertEquals(1,
         bucket.listParts(streamPartsKey, streamMpuInfo.getUploadID(), 0, 100).getPartInfoList().size());
-    assertEquals(3,
+    assertEquals(1,
         bucket.listParts(mixedPartsKey, mixedMpuInfo.getUploadID(), 0, 100).getPartInfoList().size());
 
     String snap2 = "snap-after-parts-" + counter.incrementAndGet();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -3458,7 +3458,8 @@ public abstract class TestOmSnapshot {
     bucket.completeMultipartUpload(keyName, uploadId, partsMap);
   }
 
-  private void completeMultiplePartMPU(OzoneBucket bucket, String keyName, List<String> partDataList) throws IOException {
+  private void completeMultiplePartMPU(
+      OzoneBucket bucket, String keyName, List<String> partDataList) throws IOException {
     OmMultipartInfo mpuInfo = bucket.initiateMultipartUpload(keyName, getDefaultReplication());
     String uploadId = mpuInfo.getUploadID();
 
@@ -3472,7 +3473,8 @@ public abstract class TestOmSnapshot {
       }
     }
 
-    OzoneMultipartUploadPartListParts partsList = bucket.listParts(keyName, uploadId, 0, partDataList.size());
+    OzoneMultipartUploadPartListParts partsList = bucket.
+        listParts(keyName, uploadId, 0, partDataList.size());
     Map<Integer, String> partsMap = new HashMap<>();
 
     for (OzoneMultipartUploadPartListParts.PartInfo partInfo : partsList.getPartInfoList()) {
@@ -3482,7 +3484,8 @@ public abstract class TestOmSnapshot {
     bucket.completeMultipartUpload(keyName, uploadId, partsMap);
   }
 
-  private void completeMixedPartMPU(OzoneBucket bucket, String keyName, String regularData, String streamData) throws IOException {
+  private void completeMixedPartMPU(
+      OzoneBucket bucket, String keyName, String regularData, String streamData) throws IOException {
     OmMultipartInfo mpuInfo = bucket.initiateMultipartUpload(keyName, getDefaultReplication());
     String uploadId = mpuInfo.getUploadID();
 
@@ -3508,7 +3511,8 @@ public abstract class TestOmSnapshot {
     bucket.completeMultipartUpload(keyName, uploadId, partsMap);
   }
 
-  private void completeMPUWithReplication(OzoneBucket bucket, String keyName, ReplicationConfig replicationConfig) throws IOException {
+  private void completeMPUWithReplication(
+      OzoneBucket bucket, String keyName, ReplicationConfig replicationConfig) throws IOException {
     OmMultipartInfo mpuInfo;
     if (replicationConfig != null) {
       mpuInfo = bucket.initiateMultipartUpload(keyName, replicationConfig);
@@ -3655,7 +3659,7 @@ public abstract class TestOmSnapshot {
   }
 
   @Test
-  public void testSnapshotDiffMPU_CreateWithMetadataAndTags() throws Exception {
+  public void testSnapshotDiffMPUCreateWithMetadataAndTags() throws Exception {
     String testVolumeName = "vol-create-meta-" + counter.incrementAndGet();
     String testBucketName = "bucket-create-meta-" + counter.incrementAndGet();
 
@@ -3695,7 +3699,7 @@ public abstract class TestOmSnapshot {
   }
 
   @Test
-  public void testSnapshotDiffMPU_CreateWithDifferentReplication() throws Exception {
+  public void testSnapshotDiffMPUCreateWithDifferentReplication() throws Exception {
     String testVolumeName = "vol-create-repl-" + counter.incrementAndGet();
     String testBucketName = "bucket-create-repl-" + counter.incrementAndGet();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -139,7 +139,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
-import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add snapshot diff report with object tag, stream key, rewriteKey and S3 MPU operations: initiateMultipartUpload, createMultipartKey, createMultipartStreamKey, completeMultipartUpload, abortMultipartUpload

Please describe your PR in detail:
This PR extends snapshot diff reporting to properly handle modern Ozone object operations including object tagging, stream keys, key rewrites, and S3 Multipart Upload (MPU) operations. Added comprehensive tests comparing diff types across all operations to ensure correct snapshot behavior and proper cleanup of temporary artifacts.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13041

## How was this patch tested?
Patch is tested in local and automation.

