### PR TITLE
HDDS-13566. Fix incorrect authorizer class in ACL documentation

### DIFF
--- a/hadoop-hdds/docs/content/security/SecurityAcls.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.md
@@ -32,7 +32,7 @@ Add the following properties to the ozone-site.xml to enable native ACLs.
 Property|Value
 --------|------------------------------------------------------------
 ozone.acl.enabled         | true
-ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.OzoneNativeAuthorizer
+ozone.acl.authorizer.class| org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer
 
 Ozone ACLs are a super set of Posix and S3 ACLs.
 

--- a/hadoop-hdds/docs/content/security/SecurityAcls.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.zh.md
@@ -30,7 +30,7 @@ Ozone 既支持类似 Ranger 这样的 ACL 插件，也支持原生的 ACL。如
 Property|Value
 --------|------------------------------------------------------------
 ozone.acl.enabled         | true
-ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.OzoneNativeAuthorizer
+ozone.acl.authorizer.class| org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer
 
 Ozone 的 ACL 是 Posix ACL 和 S3 ACL 的超集。
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix incorrect authorizer class in ACL documentation

Updated the authorizer class in both English and Chinese docs to use `org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer` instead of the incorrect `org.apache.ranger.authorization.ozone.authorizer.OzoneNativeAuthorizer`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13566
