### PR TITLE
HDDS-13571. Add upgrade action for NSSummary aggregated totals Improvement.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconGuiceServletContextListener.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconGuiceServletContextListener.java
@@ -36,4 +36,11 @@ public class ReconGuiceServletContextListener
   static void setInjector(Injector inj) {
     injector = inj;
   }
+
+  /**
+   * Expose injector for internal upgrade actions that run outside Jersey.
+   */
+  public static Injector getGlobalInjector() {
+    return injector;
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/NSSummaryAggregatedTotalsUpgrade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/NSSummaryAggregatedTotalsUpgrade.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.upgrade;
+
+import static org.apache.hadoop.ozone.recon.upgrade.ReconUpgradeAction.UpgradeActionType.FINALIZE;
+
+import javax.sql.DataSource;
+import com.google.inject.Injector;
+import org.apache.hadoop.ozone.recon.ReconGuiceServletContextListener;
+import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Upgrade action that triggers a rebuild of the NSSummary tree to
+ * populate materialized totals upon upgrade to the feature version.
+ *
+ * This runs at FINALIZE and schedules the rebuild asynchronously so
+ * Recon startup is not blocked. During rebuild, APIs that depend on
+ * the tree may return initializing responses as designed.
+ */
+@UpgradeActionRecon(feature = ReconLayoutFeature.NSSUMMARY_AGGREGATED_TOTALS, type = FINALIZE)
+public class NSSummaryAggregatedTotalsUpgrade implements ReconUpgradeAction {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NSSummaryAggregatedTotalsUpgrade.class);
+
+  @Override
+  public void execute(DataSource source) throws Exception {
+    // Resolve required services from Guice
+    Injector injector = ReconGuiceServletContextListener.getGlobalInjector();
+    if (injector == null) {
+      // Should not happen since ReconServer sets the injector before finalize call
+      LOG.warn("Guice injector not initialized yet; skipping NSSummary rebuild at upgrade.");
+      return;
+    }
+
+    ReconNamespaceSummaryManager nsMgr = injector.getInstance(ReconNamespaceSummaryManager.class);
+    ReconOMMetadataManager omMgr = injector.getInstance(ReconOMMetadataManager.class);
+
+    // Fire and forget: unified control using ReconUtils -> NSSummaryTask
+    LOG.info("Triggering asynchronous NSSummary tree rebuild for materialized totals (upgrade action).");
+    ReconUtils.triggerAsyncNSSummaryRebuild(nsMgr, omMgr);
+  }
+
+  @Override
+  public UpgradeActionType getType() {
+    return FINALIZE;
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutFeature.java
@@ -31,7 +31,10 @@ public enum ReconLayoutFeature {
   // Represents the starting point for Recon's layout versioning system.
   INITIAL_VERSION(0, "Recon Layout Versioning Introduction"),
   TASK_STATUS_STATISTICS(1, "Recon Task Status Statistics Tracking Introduced"),
-  UNHEALTHY_CONTAINER_REPLICA_MISMATCH(2, "Adding replica mismatch state to the unhealthy container table");
+  UNHEALTHY_CONTAINER_REPLICA_MISMATCH(2, "Adding replica mismatch state to the unhealthy container table"),
+
+  // HDDS-13432: Materialize NSSummary totals and rebuild tree on upgrade
+  NSSUMMARY_AGGREGATED_TOTALS(4, "Aggregated totals for NSSummary and auto-rebuild on upgrade");
 
   private final int version;
   private final String description;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add upgrade action that triggers asynchronous NSSummary tree rebuild during Recon layout feature finalization. This ensures the NSSummary tree is rebuilt when upgrading to support materialized totals, without blocking Recon startup.

**What this PR includes:**

- NSSummaryAggregatedTotalsUpgrade class implementing ReconUpgradeAction
- Feature version 3 in ReconLayoutFeature enum

Its an upgrade action for the Improvement - https://github.com/apache/ozone/pull/8797 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13571

## How was this patch tested?
Tested manually 
