### PR TITLE
HDDS-13554. Clean up snapshot local YAML file on Snapshot purge.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.CodecException;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -180,6 +181,7 @@ public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAn
     // Check if all the checkpoints are cleared.
     for (Path checkpoint : checkpointPaths) {
       assertFalse(Files.exists(checkpoint));
+      assertFalse(OmSnapshotManager.getSnapshotLocalPropertyYamlPath(checkpoint));
     }
     assertEquals(initialSnapshotPurgeCount + 1, getOmSnapshotIntMetrics().getNumSnapshotPurges());
     assertEquals(initialSnapshotPurgeFailCount, getOmSnapshotIntMetrics().getNumSnapshotPurgeFails());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -32,6 +32,7 @@ import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -158,6 +159,14 @@ public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAn
 
     List<String> snapshotDbKeysToPurge = createSnapshots(10);
     assertFalse(getOmMetadataManager().getSnapshotInfoTable().isEmpty());
+
+    // Check if all the checkpoints are created.
+    for (Path checkpoint : checkpointPaths) {
+      assertTrue(Files.exists(checkpoint));
+      assertTrue(Files.exists(Paths.get(
+          OmSnapshotManager.getSnapshotLocalPropertyYamlPath(checkpoint))));
+    }
+
     OMRequest snapshotPurgeRequest = createPurgeKeysRequest(
         snapshotDbKeysToPurge);
 
@@ -181,7 +190,8 @@ public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAn
     // Check if all the checkpoints are cleared.
     for (Path checkpoint : checkpointPaths) {
       assertFalse(Files.exists(checkpoint));
-      assertFalse(OmSnapshotManager.getSnapshotLocalPropertyYamlPath(checkpoint));
+      assertFalse(Files.exists(Paths.get(
+          OmSnapshotManager.getSnapshotLocalPropertyYamlPath(checkpoint))));
     }
     assertEquals(initialSnapshotPurgeCount + 1, getOmSnapshotIntMetrics().getNumSnapshotPurges());
     assertEquals(initialSnapshotPurgeFailCount, getOmSnapshotIntMetrics().getNumSnapshotPurgeFails());


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-13253](https://issues.apache.org/jira/browse/HDDS-13253) Creates a local data file (YAML) on snapshot create or every snapshot to track snapshot compaction metadata.  
This PR ensures that the local data file is removed along with the snapshot checkpoint on snapshot purge.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13554

## How was this patch tested?

Updated existing Unit test.
