### PR TITLE
HDDS-13570. Reduce the code duplicate between Ratis and EC ContainerSafeModeRule.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRule.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.safemode;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer.NodeRegistrationContainerReport;
+import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.apache.hadoop.hdds.server.events.TypedEvent;
+
+/**
+ * Abstract class for Container Safe mode exit rule.
+ */
+public abstract class AbstractContainerSafeModeRule extends SafeModeExitRule<NodeRegistrationContainerReport> {
+
+  private final ContainerManager containerManager;
+  private final double safeModeCutoff;
+
+  public AbstractContainerSafeModeRule(ConfigurationSource conf,
+                                       SCMSafeModeManager safeModeManager,
+                                       ContainerManager containerManager,
+                                       String ruleName,
+                                       EventQueue eventQueue) {
+    super(safeModeManager, ruleName, eventQueue);
+    this.containerManager = containerManager;
+    this.safeModeCutoff = getSafeModeCutoff(conf);
+  }
+
+  protected abstract ReplicationType getContainerType();
+
+  protected abstract long getTotalNumberOfContainers();
+
+  protected abstract long getNumberOfContainersWithMinReplica();
+
+  protected abstract  Set<ContainerID> getSampleMissingContainers();
+
+  protected double getSafeModeCutoff() {
+    return safeModeCutoff;
+  }
+
+  @Override
+  protected TypedEvent<NodeRegistrationContainerReport> getEventType() {
+    return SCMEvents.CONTAINER_REGISTRATION_REPORT;
+  }
+
+  @Override
+  protected synchronized boolean validate() {
+    if (validateBasedOnReportProcessing()) {
+      return getCurrentContainerThreshold() >= getSafeModeCutoff();
+    }
+
+    final List<ContainerInfo> containers = containerManager.getContainers(getContainerType());
+    return containers.stream()
+        .filter(this::isClosed)
+        .map(ContainerInfo::containerID)
+        .noneMatch(this::isMissing);
+  }
+
+  @VisibleForTesting
+  public double getCurrentContainerThreshold() {
+    return getTotalNumberOfContainers() == 0 ? 1 :
+        ((double) getNumberOfContainersWithMinReplica() / getTotalNumberOfContainers());
+  }
+
+  /**
+   * Checks if the container has at least the minimum required number of replicas.
+   */
+  protected boolean isMissing(ContainerID id) {
+    try {
+      int minReplica = getMinReplica(id);
+      return containerManager.getContainerReplicas(id).size() < minReplica;
+    } catch (ContainerNotFoundException ex) {
+      /*
+       * This should never happen; in case this happens, the container somehow got removed from SCM.
+       * Safemode rule doesn't have to log/fix this. We will just exclude this
+       * from the rule validation.
+       */
+      return false;
+    }
+  }
+
+  protected boolean isClosed(ContainerInfo container) {
+    final LifeCycleState state = container.getState();
+    return state == LifeCycleState.QUASI_CLOSED || state == LifeCycleState.CLOSED;
+  }
+
+  protected int getMinReplica(ContainerID id) {
+    try {
+      final ContainerInfo container = containerManager.getContainer(id);
+      final ReplicationConfig replicationConfig = container.getReplicationConfig();
+      return replicationConfig.getMinimumNodes();
+    } catch (ContainerNotFoundException e) {
+      /*
+       * This should never happen; in case this happens, the container somehow got removed from SCM.
+       * Since the SCM is not tracking this Container anymore, the min replica required is 0.
+       */
+      return 0;
+    }
+  }
+
+  @Override
+  public String getStatusText() {
+    String status = String.format("%1.2f%% of [" + getContainerType() + "] " +
+            "Containers(%s / %s) with at least N reported replica (=%1.2f) >= " +
+            "safeModeCutoff (=%1.2f);",
+        getCurrentContainerThreshold() * 100,
+        getNumberOfContainersWithMinReplica(), getTotalNumberOfContainers(),
+        getCurrentContainerThreshold(), getSafeModeCutoff());
+
+    final Set<ContainerID> sampleContainers = getSampleMissingContainers();
+
+    if (!sampleContainers.isEmpty()) {
+      String sampleECContainerText = "Sample EC Containers not satisfying the criteria : " + sampleContainers + ";";
+      status = status.concat("\n").concat(sampleECContainerText);
+    }
+
+    return status;
+  }
+
+  private static double getSafeModeCutoff(ConfigurationSource conf) {
+    final double cutoff = conf.getDouble(HDDS_SCM_SAFEMODE_THRESHOLD_PCT,
+        HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT);
+    Preconditions.checkArgument((cutoff >= 0.0 && cutoff <= 1.0),
+        HDDS_SCM_SAFEMODE_THRESHOLD_PCT + " value should be >= 0.0 and <= 1.0");
+    return cutoff;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ECContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ECContainerSafeModeRule.java
@@ -17,58 +17,48 @@
 
 package org.apache.hadoop.hdds.scm.safemode;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
-import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer.NodeRegistrationContainerReport;
 import org.apache.hadoop.hdds.server.events.EventQueue;
-import org.apache.hadoop.hdds.server.events.TypedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Safe mode rule for EC containers.
+ * This rule validates that a configurable percentage of EC containers have a minimum
+ * number of replicas reported by the DataNodes. This rule is not satisfied until this
+ * condition is met.
  */
-public class ECContainerSafeModeRule extends SafeModeExitRule<NodeRegistrationContainerReport> {
+public class ECContainerSafeModeRule extends AbstractContainerSafeModeRule {
 
   private static final Logger LOG = LoggerFactory.getLogger(ECContainerSafeModeRule.class);
   private static final String NAME = "ECContainerSafeModeRule";
-  private static final int DEFAULT_MIN_REPLICA = 1;
 
   private final ContainerManager containerManager;
-  private final double safeModeCutoff;
-  private final Set<Long> ecContainers;
-  private final Map<Long, Set<UUID>> ecContainerDNsMap;
+  private final Set<ContainerID> ecContainers;
+  private final Map<ContainerID, Set<DatanodeID>> ecContainerDNsMap;
   private final AtomicLong ecContainerWithMinReplicas;
+
   private double ecMaxContainer;
 
   public ECContainerSafeModeRule(EventQueue eventQueue,
       ConfigurationSource conf,
       ContainerManager containerManager,
       SCMSafeModeManager manager) {
-    super(manager, NAME, eventQueue);
-    this.safeModeCutoff = getSafeModeCutoff(conf);
+    super(conf, manager, containerManager, NAME, eventQueue);
     this.containerManager = containerManager;
     this.ecContainers = new HashSet<>();
     this.ecContainerDNsMap = new ConcurrentHashMap<>();
@@ -76,88 +66,36 @@ public class ECContainerSafeModeRule extends SafeModeExitRule<NodeRegistrationCo
     initializeRule();
   }
 
-  private static double getSafeModeCutoff(ConfigurationSource conf) {
-    final double cutoff = conf.getDouble(HDDS_SCM_SAFEMODE_THRESHOLD_PCT,
-        HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT);
-    Preconditions.checkArgument((cutoff >= 0.0 && cutoff <= 1.0),
-        HDDS_SCM_SAFEMODE_THRESHOLD_PCT + " value should be >= 0.0 and <= 1.0");
-    return cutoff;
-  }
-
-  @Override
-  protected TypedEvent<NodeRegistrationContainerReport> getEventType() {
-    return SCMEvents.CONTAINER_REGISTRATION_REPORT;
-  }
-
-  @Override
-  protected synchronized boolean validate() {
-    if (validateBasedOnReportProcessing()) {
-      return getCurrentContainerThreshold() >= safeModeCutoff;
-    }
-
-    final List<ContainerInfo> containers = containerManager.getContainers(
-        ReplicationType.EC);
-
-    return containers.stream()
+  private void initializeRule() {
+    ecContainers.clear();
+    containerManager.getContainers(ReplicationType.EC).stream()
         .filter(this::isClosed)
+        .filter(c -> c.getNumberOfKeys() > 0)
         .map(ContainerInfo::containerID)
-        .noneMatch(this::isMissing);
+        .forEach(ecContainers::add);
+    ecMaxContainer = ecContainers.size();
+    long ecCutOff = (long) Math.ceil(ecMaxContainer * getSafeModeCutoff());
+    getSafeModeMetrics().setNumContainerWithECDataReplicaReportedThreshold(ecCutOff);
+
+    LOG.info("Refreshed Containers with ec n replica threshold count {}.", ecCutOff);
   }
 
-  /**
-   * Checks if the container has at least the minimum required number of replicas.
-   */
-  private boolean isMissing(ContainerID id) {
-    try {
-      int minReplica = getMinReplica(id.getId());
-      return containerManager.getContainerReplicas(id).size() < minReplica;
-    } catch (ContainerNotFoundException ex) {
-      /*
-       * This should never happen, in case this happens the container
-       * somehow got removed from SCM.
-       * Safemode rule doesn't have to log/fix this. We will just exclude this
-       * from the rule validation.
-       */
-      return false;
-    }
-  }
-
-  @VisibleForTesting
-  public double getCurrentContainerThreshold() {
-    return ecMaxContainer == 0 ? 1 : (ecContainerWithMinReplicas.doubleValue() / ecMaxContainer);
-  }
-
-  /**
-   * Get the minimum replica.
-   *
-   * @param pContainerID containerID
-   * @return MinReplica.
-   */
-  private int getMinReplica(long pContainerID) {
-    try {
-      ContainerID containerID = ContainerID.valueOf(pContainerID);
-      ContainerInfo container = containerManager.getContainer(containerID);
-      ReplicationConfig replicationConfig = container.getReplicationConfig();
-      return replicationConfig.getMinimumNodes();
-    } catch (Exception e) {
-      LOG.error("containerId = {} not found.", pContainerID, e);
-    }
-
-    return DEFAULT_MIN_REPLICA;
+  @Override
+  protected ReplicationType getContainerType() {
+    return ReplicationType.EC;
   }
 
   @Override
   protected void process(NodeRegistrationContainerReport report) {
-    DatanodeDetails datanodeDetails = report.getDatanodeDetails();
-    UUID datanodeUUID = datanodeDetails.getUuid();
+    final DatanodeID datanodeID = report.getDatanodeDetails().getID();
 
-    report.getReport().getReportsList().forEach(c -> {
-      long containerID = c.getContainerID();
-      if (ecContainers.contains(containerID)) {
-        putInContainerDNsMap(containerID, ecContainerDNsMap, datanodeUUID);
-        recordReportedContainer(containerID);
-      }
-    });
+    report.getReport().getReportsList().stream()
+        .map(c -> ContainerID.valueOf(c.getContainerID()))
+        .filter(ecContainers::contains)
+        .forEach(containerID -> {
+          putInContainerDNsMap(containerID, ecContainerDNsMap, datanodeID);
+          recordReportedContainer(containerID);
+        });
 
     if (scmInSafeMode()) {
       SCMSafeModeManager.getLogger().info(
@@ -166,10 +104,10 @@ public class ECContainerSafeModeRule extends SafeModeExitRule<NodeRegistrationCo
     }
   }
 
-  private void putInContainerDNsMap(long containerID,
-      Map<Long, Set<UUID>> containerDNsMap,
-      UUID datanodeUUID) {
-    containerDNsMap.computeIfAbsent(containerID, key -> Sets.newHashSet()).add(datanodeUUID);
+  private void putInContainerDNsMap(ContainerID containerID,
+      Map<ContainerID, Set<DatanodeID>> containerDNsMap,
+      DatanodeID datanodeID) {
+    containerDNsMap.computeIfAbsent(containerID, key -> Sets.newHashSet()).add(datanodeID);
   }
 
   /**
@@ -177,60 +115,32 @@ public class ECContainerSafeModeRule extends SafeModeExitRule<NodeRegistrationCo
    *
    * @param containerID containerID
    */
-  private void recordReportedContainer(long containerID) {
-
-    int uuids = 1;
-    if (ecContainerDNsMap.containsKey(containerID)) {
-      uuids = ecContainerDNsMap.get(containerID).size();
-    }
-
-    int minReplica = getMinReplica(containerID);
-    if (uuids >= minReplica) {
-      getSafeModeMetrics()
-          .incCurrentContainersWithECDataReplicaReportedCount();
+  private void recordReportedContainer(ContainerID containerID) {
+    final int minReplica = getMinReplica(containerID);
+    final int noOfDNs = ecContainerDNsMap.getOrDefault(containerID, Collections.emptySet()).size();
+    if (noOfDNs >= minReplica) {
+      getSafeModeMetrics().incCurrentContainersWithECDataReplicaReportedCount();
       ecContainerWithMinReplicas.getAndAdd(1);
     }
   }
 
-  private void initializeRule() {
-    ecContainers.clear();
-    containerManager.getContainers(ReplicationType.EC).stream()
-        .filter(this::isClosed).filter(c -> c.getNumberOfKeys() > 0)
-        .map(ContainerInfo::getContainerID).forEach(ecContainers::add);
-    ecMaxContainer = ecContainers.size();
-    long ecCutOff = (long) Math.ceil(ecMaxContainer * safeModeCutoff);
-    getSafeModeMetrics().setNumContainerWithECDataReplicaReportedThreshold(ecCutOff);
-
-    LOG.info("Refreshed Containers with ec n replica threshold count {}.", ecCutOff);
-  }
-
-  private boolean isClosed(ContainerInfo container) {
-    final LifeCycleState state = container.getState();
-    return state == LifeCycleState.QUASI_CLOSED || state == LifeCycleState.CLOSED;
+  @Override
+  protected long getTotalNumberOfContainers() {
+    return (long) ecMaxContainer;
   }
 
   @Override
-  public String getStatusText() {
-    String status = String.format(
-        "%1.2f%% of [EC] Containers(%s / %s) with at least N reported replica (=%1.2f) >= " +
-            "safeModeCutoff (=%1.2f);",
-        getCurrentContainerThreshold() * 100,
-        ecContainerWithMinReplicas, (long) ecMaxContainer,
-        getCurrentContainerThreshold(), this.safeModeCutoff);
+  protected long getNumberOfContainersWithMinReplica() {
+    return ecContainerWithMinReplicas.longValue();
+  }
 
-    Set<Long> sampleEcContainers = ecContainerDNsMap.entrySet().stream().filter(entry -> {
-      Long containerId = entry.getKey();
-      int minReplica = getMinReplica(containerId);
-      Set<UUID> allReplicas = entry.getValue();
-      return allReplicas.size() < minReplica;
-    }).map(Map.Entry::getKey).limit(SAMPLE_CONTAINER_DISPLAY_LIMIT).collect(Collectors.toSet());
-
-    if (!sampleEcContainers.isEmpty()) {
-      String sampleECContainerText = "Sample EC Containers not satisfying the criteria : " + sampleEcContainers + ";";
-      status = status.concat("\n").concat(sampleECContainerText);
-    }
-
-    return status;
+  @Override
+  protected Set<ContainerID> getSampleMissingContainers() {
+    return ecContainerDNsMap.entrySet().stream()
+        .filter(entry -> entry.getValue().size() < getMinReplica(entry.getKey()))
+        .map(Map.Entry::getKey)
+        .limit(SAMPLE_CONTAINER_DISPLAY_LIMIT)
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/RatisContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/RatisContainerSafeModeRule.java
@@ -17,118 +17,59 @@
 
 package org.apache.hadoop.hdds.scm.safemode;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
-import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer.NodeRegistrationContainerReport;
 import org.apache.hadoop.hdds.server.events.EventQueue;
-import org.apache.hadoop.hdds.server.events.TypedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Class defining Safe mode exit criteria for Ratis Containers.
+ * This rule validates that a configurable percentage of Ratis containers have a minimum
+ * number of replicas reported by the DataNodes. This rule is not satisfied until this
+ * condition is met.
  */
-public class RatisContainerSafeModeRule extends SafeModeExitRule<NodeRegistrationContainerReport> {
+public class RatisContainerSafeModeRule extends AbstractContainerSafeModeRule {
 
   private static final Logger LOG = LoggerFactory.getLogger(RatisContainerSafeModeRule.class);
   private static final String NAME = "RatisContainerSafeModeRule";
 
   private final ContainerManager containerManager;
-  // Required cutoff % for containers with at least 1 reported replica.
-  private final double safeModeCutoff;
-  // Containers read from scm db (excluding containers in ALLOCATED state).
-  private final Set<Long> ratisContainers;
+  private final Set<ContainerID> ratisContainers;
   private final AtomicLong ratisContainerWithMinReplicas;
+
   private double ratisMaxContainer;
 
   public RatisContainerSafeModeRule(EventQueue eventQueue,
       ConfigurationSource conf,
       ContainerManager containerManager,
       SCMSafeModeManager manager) {
-    super(manager, NAME, eventQueue);
-    this.safeModeCutoff = getSafeModeCutoff(conf);
+    super(conf, manager, containerManager, NAME, eventQueue);
     this.containerManager = containerManager;
     this.ratisContainers = new HashSet<>();
     this.ratisContainerWithMinReplicas = new AtomicLong(0);
     initializeRule();
   }
 
-  private static double getSafeModeCutoff(ConfigurationSource conf) {
-    final double cutoff = conf.getDouble(HDDS_SCM_SAFEMODE_THRESHOLD_PCT,
-        HDDS_SCM_SAFEMODE_THRESHOLD_PCT_DEFAULT);
-    Preconditions.checkArgument((cutoff >= 0.0 && cutoff <= 1.0),
-        HDDS_SCM_SAFEMODE_THRESHOLD_PCT + " value should be >= 0.0 and <= 1.0");
-    return cutoff;
-  }
-
   @Override
-  protected TypedEvent<NodeRegistrationContainerReport> getEventType() {
-    return SCMEvents.CONTAINER_REGISTRATION_REPORT;
-  }
-
-  @Override
-  protected synchronized boolean validate() {
-    if (validateBasedOnReportProcessing()) {
-      return (getCurrentContainerThreshold() >= safeModeCutoff);
-    }
-
-    final List<ContainerInfo> containers = containerManager.getContainers(
-        ReplicationType.RATIS);
-
-    return containers.stream()
-        .filter(this::isClosed)
-        .map(ContainerInfo::containerID)
-        .noneMatch(this::isMissing);
-  }
-
-  /**
-   * Checks if the container has any replica.
-   */
-  private boolean isMissing(ContainerID id) {
-    try {
-      return containerManager.getContainerReplicas(id).isEmpty();
-    } catch (ContainerNotFoundException ex) {
-      /*
-       * This should never happen, in case this happens the container
-       * somehow got removed from SCM.
-       * Safemode rule doesn't have to log/fix this. We will just exclude this
-       * from the rule validation.
-       */
-      return false;
-
-    }
-  }
-
-  @VisibleForTesting
-  public double getCurrentContainerThreshold() {
-    return ratisMaxContainer == 0 ? 1 : (ratisContainerWithMinReplicas.doubleValue() / ratisMaxContainer);
+  protected ReplicationType getContainerType() {
+    return ReplicationType.RATIS;
   }
 
   @Override
   protected void process(NodeRegistrationContainerReport report) {
-    report.getReport().getReportsList().forEach(c -> {
-      long containerID = c.getContainerID();
-      if (ratisContainers.contains(containerID)) {
-        recordReportedContainer(containerID);
-        ratisContainers.remove(containerID);
-      }
-    });
+    report.getReport().getReportsList().stream()
+        .map(c -> ContainerID.valueOf(c.getContainerID()))
+        .filter(ratisContainers::remove)
+        .forEach(c -> recordReportedContainer());
 
     if (scmInSafeMode()) {
       SCMSafeModeManager.getLogger().info(
@@ -137,53 +78,41 @@ public class RatisContainerSafeModeRule extends SafeModeExitRule<NodeRegistratio
     }
   }
 
-  /**
-   * Record the reported Container.
-   *
-   * @param containerID containerID
-   */
-  private void recordReportedContainer(long containerID) {
-    ratisContainerWithMinReplicas.getAndAdd(1);
-    getSafeModeMetrics()
-        .incCurrentContainersWithOneReplicaReportedCount();
+  /** Record the reported Container. */
+  private void recordReportedContainer() {
+    ratisContainerWithMinReplicas.incrementAndGet();
+    getSafeModeMetrics().incCurrentContainersWithOneReplicaReportedCount();
   }
 
   private void initializeRule() {
     ratisContainers.clear();
     containerManager.getContainers(ReplicationType.RATIS).stream()
-        .filter(this::isClosed).filter(c -> c.getNumberOfKeys() > 0)
-        .map(ContainerInfo::getContainerID).forEach(ratisContainers::add);
+        .filter(this::isClosed)
+        .filter(c -> c.getNumberOfKeys() > 0)
+        .map(ContainerInfo::containerID)
+        .forEach(ratisContainers::add);
     ratisMaxContainer = ratisContainers.size();
-    long ratisCutOff = (long) Math.ceil(ratisMaxContainer * safeModeCutoff);
+    long ratisCutOff = (long) Math.ceil(ratisMaxContainer * getSafeModeCutoff());
     getSafeModeMetrics().setNumContainerWithOneReplicaReportedThreshold(ratisCutOff);
 
     LOG.info("Refreshed Containers with one replica threshold count {}.", ratisCutOff);
   }
 
-  private boolean isClosed(ContainerInfo container) {
-    final LifeCycleState state = container.getState();
-    return state == LifeCycleState.QUASI_CLOSED || state == LifeCycleState.CLOSED;
+  @Override
+  protected long getNumberOfContainersWithMinReplica() {
+    return ratisContainerWithMinReplicas.longValue();
   }
 
   @Override
-  public String getStatusText() {
-    String status = String.format(
-        "%1.2f%% of [Ratis] Containers(%s / %s) with at least one reported replica (=%1.2f) >= " +
-            "safeModeCutoff (=%1.2f);",
-        getCurrentContainerThreshold() * 100,
-        ratisContainerWithMinReplicas, (long) ratisMaxContainer,
-        getCurrentContainerThreshold(), this.safeModeCutoff);
+  protected long getTotalNumberOfContainers() {
+    return (long) ratisMaxContainer;
+  }
 
-    Set<Long> sampleRatisContainers = ratisContainers.stream().limit(SAMPLE_CONTAINER_DISPLAY_LIMIT)
+  @Override
+  protected Set<ContainerID> getSampleMissingContainers() {
+    return ratisContainers.stream()
+        .limit(SAMPLE_CONTAINER_DISPLAY_LIMIT)
         .collect(Collectors.toSet());
-
-    if (!sampleRatisContainers.isEmpty()) {
-      String sampleContainerText = "Sample Ratis Containers not satisfying the criteria : " + sampleRatisContainers
-          + ";";
-      status = status.concat("\n").concat(sampleContainerText);
-    }
-
-    return status;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reduce the code duplicate between Ratis and EC ContainerSafeModeRule.

The initial idea was to make this change as part of [HDDS-13485](https://issues.apache.org/jira/browse/HDDS-13485), which tries to reduce the code duplicate between ContainerSafeModeRule tests. The size of the patch grew big, to make it easy for review the patch is split and ContainerSafeModeRule refactoring is done here and the test fixing/refactoring will be done as part of HDDS-13485.

## What is the link to the Apache JIRA
HDDS-13570

## How was this patch tested?
Unit test updated and verified.
