### PR TITLE
HDDS-13582. Fix checknative tool for rocks-tools

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CheckNative.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CheckNative.java
@@ -56,6 +56,7 @@ public class CheckNative extends AbstractSubcommand implements Callable<Void>, D
     ));
 
     // Ozone
+    ManagedRocksObjectUtils.loadRocksDBLibrary();
     NativeLibraryLoader.getInstance().loadLibrary(
         ROCKS_TOOLS_NATIVE_LIBRARY_NAME,
         Collections.singletonList(ManagedRocksObjectUtils.getRocksDBLibFileName()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

I was using `ozone debug checknative` to check if the rocks-tools lib is properly loaded but it always gives me `false`.

I later found that it was because RocksDB library wasn't loaded before attempting to load rocks-tools lib (ozone_rocksdb_tools). ozone_rocksdb_tools has a dependency on RocksDB library. A symptom is that it throws UnsatisfiedLinkError when debugging TestCheckNative. (Interestingly running the CLI in dist doesn't give any detail, could be because of the log level.)

The solution is to load RocksDB lib before loading rocks-tools lib, just like what [`ManagedRawSSTFileReader#loadLibrary`](https://github.com/apache/ozone/blob/cd308eaa85b0a75f2e263c313da320f33fd227ff/hadoop-hdds/rocks-native/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRawSSTFileReader.java#L50-L51) does.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13582

## How was this patch tested?

- Existing test `TestCheckNative` should cover this when it is run.