### PR TITLE
HDDS-13581. Fix Intermittent failure in TestReplicationSupervisor#testReconcileContainerCommandDeduplication.

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -800,8 +800,10 @@ public class TestReplicationSupervisor {
       // Create reconcile commands with the same container ID but different peers
       ReconcileContainerCommand command1 = new ReconcileContainerCommand(containerID, Collections.singleton(
           MockDatanodeDetails.randomDatanodeDetails()));
+      command1.setTerm(1);
       ReconcileContainerCommand command2 = new ReconcileContainerCommand(containerID, Collections.singleton(
           MockDatanodeDetails.randomDatanodeDetails()));
+      command2.setTerm(1);
       assertEquals(command1, command2);
 
       // Create a controller that blocks the execution of reconciliation until the latch is counted down from the test.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -788,7 +789,7 @@ public class TestReplicationSupervisor {
   }
 
   @ContainerLayoutTestInfo.ContainerTest
-  public void testReconcileContainerCommandDeduplication() {
+  public void testReconcileContainerCommandDeduplication() throws Exception {
     ReplicationSupervisor supervisor = ReplicationSupervisor.newBuilder()
         .stateContext(context)
         .build();
@@ -802,11 +803,21 @@ public class TestReplicationSupervisor {
       ReconcileContainerCommand command2 = new ReconcileContainerCommand(containerID, Collections.singleton(
           MockDatanodeDetails.randomDatanodeDetails()));
       assertEquals(command1, command2);
+
+      // Create a controller that blocks the execution of reconciliation until the latch is counted down from the test.
+      ContainerController blockingController = mock(ContainerController.class);
+      CountDownLatch latch = new CountDownLatch(1);
+      doAnswer(arg -> {
+        latch.await();
+        return null;
+      }).when(blockingController).reconcileContainer(any(), anyLong(), any());
+
       ReconcileContainerTask task1 = new ReconcileContainerTask(
-          mock(ContainerController.class),
+          blockingController,
           mock(DNContainerOperationClient.class),
           command1);
       ReconcileContainerTask task2 = new ReconcileContainerTask(
+          // The second task should be discarded as a duplicate. It does not need to block.
           mock(ContainerController.class),
           mock(DNContainerOperationClient.class),
           command2);
@@ -820,6 +831,11 @@ public class TestReplicationSupervisor {
       supervisor.addTask(task2);
       assertEquals(1, supervisor.getTotalInFlightReplications());
       assertEquals(1, supervisor.getReplicationQueuedCount());
+
+      // Now the task has been unblocked. The supervisor should finish execution of the one blocked task.
+      latch.countDown();
+      GenericTestUtils.waitFor(() ->
+          supervisor.getTotalInFlightReplications() == 0 && supervisor.getReplicationQueuedCount() == 0, 500, 5000);
     } finally {
       supervisor.stop();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestReplicationSupervisor#testReconcileContainerCommandDeduplication` adds commands to the queue and then checks counters related to the queue's size. Events added to the queue are consumed in a different thread, so they may be removed before the test can check the queue counters. To fix this:
1. Add a term to the commands so they are [executed instead of dropped](https://github.com/apache/ozone/blob/1aef378d70f11ed7523c397903b3a26edf93c635/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java#L403) due the default term being 0.
2. Make the test block reconciliation execution while it checks the queue size. Note that [counters are not decremented until the currently processed task completes](https://github.com/apache/ozone/blob/1aef378d70f11ed7523c397903b3a26edf93c635/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java#L430).

## What is the link to the Apache JIRA

HDDS-13581

## How was this patch tested?

Change passed 100x [here](https://github.com/errose28/ozone/actions/runs/17105316933).