### PR TITLE
HDDS-13560. Convert redundant fields to local var in hdds-container-service module

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
@@ -70,7 +70,6 @@ public class TestDatanodeStateMachine {
   // Changing it to 1, as current code checks for multiple scm directories,
   // and fail if exists
   private static final int SCM_SERVER_COUNT = 1;
-  private List<String> serverAddresses;
   private List<RPC.Server> scmServers;
   private List<ScmTestMock> mockServers;
   private ExecutorService executorService;
@@ -89,7 +88,7 @@ public class TestDatanodeStateMachine {
         true);
     conf.setBoolean(
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATASTREAM_RANDOM_PORT, true);
-    serverAddresses = new ArrayList<>();
+    List<String> serverAddresses = new ArrayList<>();
     scmServers = new ArrayList<>();
     mockServers = new ArrayList<>();
     for (int x = 0; x < SCM_SERVER_COUNT; x++) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -42,12 +42,11 @@ public class TestKeyValueContainerData {
   private static final long MAXSIZE = (long) StorageUnit.GB.toBytes(5);
 
   private ContainerLayoutVersion layout;
-  private String schemaVersion;
   private OzoneConfiguration conf;
 
   private void initVersionInfo(ContainerTestVersionInfo versionInfo) {
     this.layout = versionInfo.getLayout();
-    this.schemaVersion = versionInfo.getSchemaVersion();
+    String schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
@@ -102,7 +102,6 @@ public class TestSchemaTwoBackwardsCompatibility {
   private BlockManager blockManager;
   private ChunkManager chunkManager;
   private ContainerSet containerSet;
-  private KeyValueHandler keyValueHandler;
   private OzoneContainer ozoneContainer;
 
   private static final int BLOCKS_PER_CONTAINER = 6;
@@ -132,7 +131,8 @@ public class TestSchemaTwoBackwardsCompatibility {
     chunkManager = new FilePerBlockStrategy(true, blockManager);
 
     containerSet = newContainerSet();
-    keyValueHandler = ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet);
+    KeyValueHandler keyValueHandler =
+        ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet);
     ozoneContainer = mock(OzoneContainer.class);
     when(ozoneContainer.getContainerSet()).thenReturn(containerSet);
     when(ozoneContainer.getWriteChannel()).thenReturn(null);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -71,10 +71,8 @@ public class TestStaleRecoveringContainerScrubbingService {
   private Path tempDir;
   private String datanodeUuid;
   private OzoneConfiguration conf;
-  private HddsVolume hddsVolume;
 
   private ContainerLayoutVersion layout;
-  private String schemaVersion;
   private String clusterID;
   private int containerIdNum = 0;
   private MutableVolumeSet volumeSet;
@@ -85,7 +83,7 @@ public class TestStaleRecoveringContainerScrubbingService {
   private void initVersionInfo(ContainerTestVersionInfo versionInfo)
       throws IOException {
     this.layout = versionInfo.getLayout();
-    this.schemaVersion = versionInfo.getSchemaVersion();
+    String schemaVersion = versionInfo.getSchemaVersion();
     conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
     init();
@@ -98,8 +96,8 @@ public class TestStaleRecoveringContainerScrubbingService {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, volumeDir.getAbsolutePath());
     datanodeUuid = UUID.randomUUID().toString();
     clusterID = UUID.randomUUID().toString();
-    hddsVolume = new HddsVolume.Builder(volumeDir.getAbsolutePath())
-        .conf(conf).datanodeUuid(datanodeUuid).clusterID(clusterID).build();
+    HddsVolume hddsVolume = new HddsVolume.Builder(volumeDir.getAbsolutePath())
+                                .conf(conf).datanodeUuid(datanodeUuid).clusterID(clusterID).build();
     hddsVolume.format(clusterID);
     hddsVolume.createWorkingDir(clusterID, null);
     volumeSet = mock(MutableVolumeSet.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeVersionFile.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeVersionFile.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestDatanodeVersionFile {
 
   private File versionFile;
-  private DatanodeVersionFile dnVersionFile;
   private Properties properties;
 
   private String storageID;
@@ -64,12 +63,12 @@ public class TestDatanodeVersionFile {
     cTime = Time.now();
     lv = HDDSVolumeLayoutVersion.getLatestVersion().getVersion();
 
-    dnVersionFile = new DatanodeVersionFile(
+    DatanodeVersionFile dnVersionFile = new DatanodeVersionFile(
         storageID, clusterID, datanodeUUID, cTime, lv);
 
     dnVersionFile.createVersionFile(versionFile);
 
-    properties = dnVersionFile.readFrom(versionFile);
+    properties = DatanodeVersionFile.readFrom(versionFile);
   }
 
   @Test
@@ -101,10 +100,10 @@ public class TestDatanodeVersionFile {
   @Test
   public void testVerifyCTime() throws IOException {
     long invalidCTime = -10;
-    dnVersionFile = new DatanodeVersionFile(
+    DatanodeVersionFile dnVersionFile = new DatanodeVersionFile(
         storageID, clusterID, datanodeUUID, invalidCTime, lv);
     dnVersionFile.createVersionFile(versionFile);
-    properties = dnVersionFile.readFrom(versionFile);
+    properties = DatanodeVersionFile.readFrom(versionFile);
 
     InconsistentStorageStateException exception = assertThrows(InconsistentStorageStateException.class,
         () -> StorageVolumeUtil.getCreationTime(properties, versionFile));
@@ -114,10 +113,10 @@ public class TestDatanodeVersionFile {
   @Test
   public void testVerifyLayOut() throws IOException {
     int invalidLayOutVersion = 100;
-    dnVersionFile = new DatanodeVersionFile(
+    DatanodeVersionFile dnVersionFile = new DatanodeVersionFile(
         storageID, clusterID, datanodeUUID, cTime, invalidLayOutVersion);
     dnVersionFile.createVersionFile(versionFile);
-    Properties props = dnVersionFile.readFrom(versionFile);
+    Properties props = DatanodeVersionFile.readFrom(versionFile);
     InconsistentStorageStateException exception = assertThrows(InconsistentStorageStateException.class,
         () -> StorageVolumeUtil.getLayOutVersion(props, versionFile));
     assertThat(exception).hasMessageContaining("Invalid layOutVersion.");

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -60,10 +60,8 @@ public class TestContainerDeletionChoosingPolicy {
   @TempDir
   private File tempFile;
   private String path;
-  private OzoneContainer ozoneContainer;
   private ContainerSet containerSet;
   private OzoneConfiguration conf;
-  private BlockDeletingService blockDeletingService;
   // the service timeout
   private static final int SERVICE_TIMEOUT_IN_MILLISECONDS = 0;
   private static final int SERVICE_INTERVAL_IN_MILLISECONDS = 1000;
@@ -102,7 +100,7 @@ public class TestContainerDeletionChoosingPolicy {
           containerSet.getContainerMapCopy())
               .containsKey(data.getContainerID());
     }
-    blockDeletingService = getBlockDeletingService();
+    BlockDeletingService blockDeletingService = getBlockDeletingService();
 
     int blockLimitPerInterval = 5;
     ContainerDeletionChoosingPolicy deletionPolicy =
@@ -159,7 +157,7 @@ public class TestContainerDeletionChoosingPolicy {
     KeyValueContainerData closingData = createContainerWithState(layout,
         ContainerProtos.ContainerDataProto.State.CLOSING);
 
-    blockDeletingService = getBlockDeletingService();
+    BlockDeletingService blockDeletingService = getBlockDeletingService();
     ContainerDeletionChoosingPolicy deletionPolicy =
         new TopNOrderedContainerDeletionChoosingPolicy();
 
@@ -239,7 +237,7 @@ public class TestContainerDeletionChoosingPolicy {
     }
     numberOfBlocks.sort(Collections.reverseOrder());
     int blockLimitPerInterval = 5;
-    blockDeletingService = getBlockDeletingService();
+    BlockDeletingService blockDeletingService = getBlockDeletingService();
     ContainerDeletionChoosingPolicy deletionPolicy =
         new TopNOrderedContainerDeletionChoosingPolicy();
     List<ContainerBlockInfo> result0 = blockDeletingService
@@ -281,10 +279,10 @@ public class TestContainerDeletionChoosingPolicy {
   }
 
   private BlockDeletingService getBlockDeletingService() {
-    ozoneContainer = mock(OzoneContainer.class);
+    OzoneContainer ozoneContainer = mock(OzoneContainer.class);
     when(ozoneContainer.getContainerSet()).thenReturn(containerSet);
     when(ozoneContainer.getWriteChannel()).thenReturn(null);
-    blockDeletingService = new BlockDeletingService(ozoneContainer,
+    BlockDeletingService blockDeletingService = new BlockDeletingService(ozoneContainer,
         SERVICE_INTERVAL_IN_MILLISECONDS, SERVICE_TIMEOUT_IN_MILLISECONDS,
         TimeUnit.MILLISECONDS, 10, conf, new ContainerChecksumTreeManager(conf));
     return blockDeletingService;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/interfaces/TestHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/interfaces/TestHandler.java
@@ -46,16 +46,13 @@ import org.junit.jupiter.api.Test;
  */
 public class TestHandler {
 
-  private OzoneConfiguration conf;
   private HddsDispatcher dispatcher;
-  private ContainerSet containerSet;
-  private VolumeSet volumeSet;
 
   @BeforeEach
   public void setup() throws Exception {
-    this.conf = new OzoneConfiguration();
-    this.containerSet = mock(ContainerSet.class);
-    this.volumeSet = mock(MutableVolumeSet.class);
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ContainerSet containerSet = mock(ContainerSet.class);
+    VolumeSet volumeSet = mock(MutableVolumeSet.class);
     VolumeChoosingPolicy volumeChoosingPolicy = VolumeChoosingPolicyFactory.getPolicy(conf);
     DatanodeDetails datanodeDetails = mock(DatanodeDetails.class);
     StateContext context = ContainerTestUtils.getMockContext(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestClosePipelineCommandHandler.java
@@ -59,7 +59,6 @@ import org.junit.jupiter.api.Test;
 public class TestClosePipelineCommandHandler {
 
   private OzoneContainer ozoneContainer;
-  private StateContext stateContext;
   private SCMConnectionManager connectionManager;
   private RaftClient raftClient;
   private GroupManagementApi raftClientGroupManager;
@@ -83,7 +82,7 @@ public class TestClosePipelineCommandHandler {
     final PipelineID pipelineID = PipelineID.randomId();
     final SCMCommand<ClosePipelineCommandProto> command =
         new ClosePipelineCommand(pipelineID);
-    stateContext = ContainerTestUtils.getMockContext(currentDatanode, conf);
+    StateContext stateContext = ContainerTestUtils.getMockContext(currentDatanode, conf);
 
     final boolean shouldDeleteRatisLogDirectory = true;
     XceiverServerRatis writeChannel = mock(XceiverServerRatis.class);
@@ -115,7 +114,7 @@ public class TestClosePipelineCommandHandler {
     final PipelineID pipelineID = PipelineID.randomId();
     final SCMCommand<ClosePipelineCommandProto> command =
         new ClosePipelineCommand(pipelineID);
-    stateContext = ContainerTestUtils.getMockContext(currentDatanode, conf);
+    StateContext stateContext = ContainerTestUtils.getMockContext(currentDatanode, conf);
 
     XceiverServerRatis writeChannel = mock(XceiverServerRatis.class);
     when(ozoneContainer.getWriteChannel()).thenReturn(writeChannel);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
@@ -61,7 +61,6 @@ import org.mockito.quality.Strictness;
 public class TestCreatePipelineCommandHandler {
 
   private OzoneContainer ozoneContainer;
-  private StateContext stateContext;
   private SCMConnectionManager connectionManager;
   private RaftClient raftClient;
   private GroupManagementApi raftClientGroupManager;
@@ -86,7 +85,7 @@ public class TestCreatePipelineCommandHandler {
     final SCMCommand<CreatePipelineCommandProto> command =
         new CreatePipelineCommand(pipelineID, HddsProtos.ReplicationType.RATIS,
             HddsProtos.ReplicationFactor.THREE, datanodes);
-    stateContext = ContainerTestUtils.getMockContext(datanodes.get(0), conf);
+    StateContext stateContext = ContainerTestUtils.getMockContext(datanodes.get(0), conf);
 
     final XceiverServerSpi writeChanel = mock(XceiverServerSpi.class);
     when(ozoneContainer.getWriteChannel()).thenReturn(writeChanel);
@@ -118,7 +117,7 @@ public class TestCreatePipelineCommandHandler {
             HddsProtos.ReplicationFactor.THREE, datanodes);
 
     final XceiverServerSpi writeChanel = mock(XceiverServerSpi.class);
-    stateContext = ContainerTestUtils.getMockContext(datanodes.get(0), conf);
+    StateContext stateContext = ContainerTestUtils.getMockContext(datanodes.get(0), conf);
     when(ozoneContainer.getWriteChannel()).thenReturn(writeChanel);
     when(writeChanel.isExist(pipelineID.getProtobuf()))
         .thenReturn(true);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -90,9 +90,6 @@ import org.mockito.stubbing.Answer;
 public class TestDeleteBlocksCommandHandler {
   @TempDir
   private Path folder;
-  private OzoneConfiguration conf;
-  private ContainerLayoutVersion layout;
-  private OzoneContainer ozoneContainer;
   private ContainerSet containerSet;
   private DeleteBlocksCommandHandler handler;
   private String schemaVersion;
@@ -101,17 +98,16 @@ public class TestDeleteBlocksCommandHandler {
 
   private void prepareTest(ContainerTestVersionInfo versionInfo)
       throws Exception {
-    this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
-    conf = new OzoneConfiguration();
+    OzoneConfiguration conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
     setup();
   }
 
   private void setup() throws Exception {
-    conf = new OzoneConfiguration();
-    layout = ContainerLayoutVersion.FILE_PER_BLOCK;
-    ozoneContainer = mock(OzoneContainer.class);
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ContainerLayoutVersion layout = ContainerLayoutVersion.FILE_PER_BLOCK;
+    OzoneContainer ozoneContainer = mock(OzoneContainer.class);
     containerSet = newContainerSet();
     volume1 = mock(HddsVolume.class);
     when(volume1.getStorageID()).thenReturn("uuid-1");

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -65,7 +65,6 @@ public class TestKeyValueBlockIterator {
 
   private static final long CONTAINER_ID = 105L;
 
-  private KeyValueContainer container;
   private KeyValueContainerData containerData;
   private MutableVolumeSet volumeSet;
   private OzoneConfiguration conf;
@@ -73,14 +72,13 @@ public class TestKeyValueBlockIterator {
   private File testRoot;
   private DBHandle db;
   private ContainerLayoutVersion layout;
-  private String schemaVersion;
   private String datanodeID = UUID.randomUUID().toString();
   private String clusterID = UUID.randomUUID().toString();
 
   private void initTest(ContainerTestVersionInfo versionInfo,
       String keySeparator) throws Exception {
     this.layout = versionInfo.getLayout();
-    this.schemaVersion = versionInfo.getSchemaVersion();
+    String schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
     DatanodeConfiguration dc = conf.getObject(DatanodeConfiguration.class);
@@ -116,7 +114,7 @@ public class TestKeyValueBlockIterator {
         (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
         UUID.randomUUID().toString());
     // Init the container.
-    container = new KeyValueContainer(containerData, conf);
+    KeyValueContainer container = new KeyValueContainer(containerData, conf);
     container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
         clusterID);
     db = BlockUtils.getDB(containerData, conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -52,13 +52,11 @@ public class TestKeyValueContainerMarkUnhealthy {
   @TempDir
   private Path folder;
 
-  private OzoneConfiguration conf;
   private String scmId = UUID.randomUUID().toString();
   private VolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
   private KeyValueContainerData keyValueContainerData;
   private KeyValueContainer keyValueContainer;
-  private UUID datanodeId;
 
   private ContainerLayoutVersion layout;
 
@@ -68,8 +66,8 @@ public class TestKeyValueContainerMarkUnhealthy {
   }
 
   public void setup() throws Exception {
-    conf = new OzoneConfiguration();
-    datanodeId = UUID.randomUUID();
+    OzoneConfiguration conf = new OzoneConfiguration();
+    UUID datanodeId = UUID.randomUUID();
     String dataDir = Files.createDirectory(
         folder.resolve("data")).toAbsolutePath().toString();
     HddsVolume hddsVolume = new HddsVolume.Builder(dataDir)

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -66,15 +66,10 @@ public class TestBlockManagerImpl {
   private Path folder;
   private OzoneConfiguration config;
   private String scmId = UUID.randomUUID().toString();
-  private VolumeSet volumeSet;
-  private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
-  private KeyValueContainerData keyValueContainerData;
   private KeyValueContainer keyValueContainer;
   private BlockData blockData;
   private BlockData blockData1;
   private BlockManagerImpl blockManager;
-  private BlockID blockID;
-  private BlockID blockID1;
 
   private ContainerLayoutVersion layout;
   private String schemaVersion;
@@ -97,13 +92,13 @@ public class TestBlockManagerImpl {
     StorageVolumeUtil.checkVolume(hddsVolume, scmId, scmId, config,
         null, null);
 
-    volumeSet = mock(MutableVolumeSet.class);
+    VolumeSet volumeSet = mock(MutableVolumeSet.class);
 
-    volumeChoosingPolicy = mock(RoundRobinVolumeChoosingPolicy.class);
+    RoundRobinVolumeChoosingPolicy volumeChoosingPolicy = mock(RoundRobinVolumeChoosingPolicy.class);
     when(volumeChoosingPolicy.chooseVolume(anyList(), anyLong()))
         .thenReturn(hddsVolume);
 
-    keyValueContainerData = new KeyValueContainerData(1L,
+    KeyValueContainerData keyValueContainerData = new KeyValueContainerData(1L,
         layout,
         (long) StorageUnit.GB.toBytes(5), UUID.randomUUID().toString(),
         datanodeId.toString());
@@ -114,7 +109,7 @@ public class TestBlockManagerImpl {
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
 
     // Creating BlockData
-    blockID = new BlockID(1L, 1L);
+    BlockID blockID = new BlockID(1L, 1L);
     blockData = new BlockData(blockID);
     blockData.addMetadata(OzoneConsts.VOLUME, OzoneConsts.OZONE);
     blockData.addMetadata(OzoneConsts.OWNER,
@@ -126,13 +121,13 @@ public class TestBlockManagerImpl {
     blockData.setChunks(chunkList);
 
     // Creating BlockData
-    blockID1 = new BlockID(1L, 2L);
-    blockData1 = new BlockData(blockID1);
+    blockID = new BlockID(1L, 2L);
+    blockData1 = new BlockData(blockID);
     blockData1.addMetadata(OzoneConsts.VOLUME, OzoneConsts.OZONE);
     blockData1.addMetadata(OzoneConsts.OWNER,
         OzoneConsts.OZONE_SIMPLE_HDFS_USER);
     List<ContainerProtos.ChunkInfo> chunkList1 = new ArrayList<>();
-    ChunkInfo info1 = new ChunkInfo(String.format("%d.data.%d", blockID1
+    ChunkInfo info1 = new ChunkInfo(String.format("%d.data.%d", blockID
         .getLocalID(), 0), 0, 1024);
     chunkList1.add(info1.getProtoBufMessage());
     blockData1.setChunks(chunkList1);
@@ -278,7 +273,7 @@ public class TestBlockManagerImpl {
     assertEquals(1, listBlockData.size());
 
     for (long i = 2; i <= 10; i++) {
-      blockID = new BlockID(1L, i);
+      BlockID blockID = new BlockID(1L, i);
       blockData = new BlockData(blockID);
       blockData.addMetadata(OzoneConsts.VOLUME, OzoneConsts.OZONE);
       blockData.addMetadata(OzoneConsts.OWNER,
@@ -300,10 +295,10 @@ public class TestBlockManagerImpl {
   private BlockData createBlockData(long containerID, long blockNo,
       int chunkID, long offset, long len, long bcsID)
       throws IOException {
-    blockID1 = new BlockID(containerID, blockNo);
-    blockData = new BlockData(blockID1);
+    BlockID blockID = new BlockID(containerID, blockNo);
+    blockData = new BlockData(blockID);
     List<ContainerProtos.ChunkInfo> chunkList1 = new ArrayList<>();
-    ChunkInfo info1 = new ChunkInfo(String.format("%d_chunk_%d", blockID1
+    ChunkInfo info1 = new ChunkInfo(String.format("%d_chunk_%d", blockID
         .getLocalID(), chunkID), offset, len);
     chunkList1.add(info1.getProtoBufMessage());
     blockData.setChunks(chunkList1);
@@ -316,14 +311,14 @@ public class TestBlockManagerImpl {
   private BlockData createBlockDataWithOneFullChunk(long containerID,
       long blockNo, int chunkID, long offset, long len, long bcsID)
       throws IOException {
-    blockID1 = new BlockID(containerID, blockNo);
-    blockData = new BlockData(blockID1);
+    BlockID blockID = new BlockID(containerID, blockNo);
+    blockData = new BlockData(blockID);
     List<ContainerProtos.ChunkInfo> chunkList1 = new ArrayList<>();
-    ChunkInfo info1 = new ChunkInfo(String.format("%d_chunk_%d", blockID1
+    ChunkInfo info1 = new ChunkInfo(String.format("%d_chunk_%d", blockID
         .getLocalID(), 1), 0, 4 * 1024 * 1024);
     info1.addMetadata(FULL_CHUNK, "");
 
-    ChunkInfo info2 = new ChunkInfo(String.format("%d_chunk_%d", blockID1
+    ChunkInfo info2 = new ChunkInfo(String.format("%d_chunk_%d", blockID
         .getLocalID(), chunkID), offset, len);
     chunkList1.add(info1.getProtoBufMessage());
     chunkList1.add(info2.getProtoBufMessage());
@@ -336,13 +331,13 @@ public class TestBlockManagerImpl {
 
   private BlockData createBlockDataWithThreeFullChunks(long containerID,
       long blockNo, long bcsID) throws IOException {
-    blockID1 = new BlockID(containerID, blockNo);
-    blockData = new BlockData(blockID1);
+    BlockID blockID = new BlockID(containerID, blockNo);
+    blockData = new BlockData(blockID);
     List<ContainerProtos.ChunkInfo> chunkList1 = new ArrayList<>();
     long chunkLimit = 4 * 1024 * 1024;
     for (int i = 1; i < 4; i++) {
       ChunkInfo info1 = new ChunkInfo(
-          String.format("%d_chunk_%d", blockID1.getLocalID(), i),
+          String.format("%d_chunk_%d", blockID.getLocalID(), i),
           chunkLimit * i, chunkLimit);
       info1.addMetadata(FULL_CHUNK, "");
       chunkList1.add(info1.getProtoBufMessage());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -105,7 +105,6 @@ public class TestContainerReader {
   private long blockLen = 1024;
 
   private ContainerLayoutVersion layout;
-  private String schemaVersion;
   private KeyValueHandler keyValueHandler;
 
   @TempDir
@@ -843,7 +842,7 @@ public class TestContainerReader {
   private void setLayoutAndSchemaVersion(
       ContainerTestVersionInfo versionInfo) {
     layout = versionInfo.getLayout();
-    schemaVersion = versionInfo.getSchemaVersion();
+    String schemaVersion = versionInfo.getSchemaVersion();
     conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -74,17 +74,15 @@ public class TestOzoneContainer {
   private String clusterId = UUID.randomUUID().toString();
   private MutableVolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
-  private KeyValueContainerData keyValueContainerData;
   private KeyValueContainer keyValueContainer;
   private final DatanodeDetails datanodeDetails = createDatanodeDetails();
   private HashMap<String, Long> commitSpaceMap; //RootDir -> committed space
 
   private ContainerLayoutVersion layout;
-  private String schemaVersion;
 
   private void initTest(ContainerTestVersionInfo versionInfo) throws Exception {
     this.layout = versionInfo.getLayout();
-    this.schemaVersion = versionInfo.getSchemaVersion();
+    String schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
     setup();
@@ -133,7 +131,7 @@ public class TestOzoneContainer {
 
       HddsVolume myVolume;
 
-      keyValueContainerData = new KeyValueContainerData(i,
+      KeyValueContainerData keyValueContainerData = new KeyValueContainerData(i,
           layout,
           maxCap, UUID.randomUUID().toString(),
           datanodeDetails.getUuidString());
@@ -238,7 +236,7 @@ public class TestOzoneContainer {
       // eat up 10 bytes more, now available space is less than 1 container
       volume.incCommittedBytes(10);
     }
-    keyValueContainerData = new KeyValueContainerData(99,
+    KeyValueContainerData keyValueContainerData = new KeyValueContainerData(99,
         layout, containerSize,
         UUID.randomUUID().toString(), datanodeDetails.getUuidString());
     keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestDownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestDownloadAndImportReplicator.java
@@ -56,24 +56,20 @@ public class TestDownloadAndImportReplicator {
   @TempDir
   private File tempDir;
 
-  private OzoneConfiguration conf;
-  private VolumeChoosingPolicy volumeChoosingPolicy;
-  private ContainerSet containerSet;
   private MutableVolumeSet volumeSet;
-  private ContainerImporter importer;
   private SimpleContainerDownloader downloader;
   private DownloadAndImportReplicator replicator;
   private long containerMaxSize;
 
   @BeforeEach
   void setup() throws IOException {
-    conf = new OzoneConfiguration();
+    OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, tempDir.getAbsolutePath());
-    volumeChoosingPolicy = VolumeChoosingPolicyFactory.getPolicy(conf);
-    containerSet = newContainerSet(0);
+    VolumeChoosingPolicy volumeChoosingPolicy = VolumeChoosingPolicyFactory.getPolicy(conf);
+    ContainerSet containerSet = newContainerSet(0);
     volumeSet = new MutableVolumeSet("test", conf, null,
         StorageVolume.VolumeType.DATA_VOLUME, null);
-    importer = new ContainerImporter(conf, containerSet,
+    ContainerImporter importer = new ContainerImporter(conf, containerSet,
         mock(ContainerController.class), volumeSet, volumeChoosingPolicy);
     downloader = mock(SimpleContainerDownloader.class);
     replicator = new DownloadAndImportReplicator(conf, containerSet, importer,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerRequestHandler.java
@@ -62,8 +62,6 @@ public class TestSendContainerRequestHandler {
 
   private OzoneConfiguration conf;
 
-  private VolumeChoosingPolicy volumeChoosingPolicy;
-
   private ContainerSet containerSet;
   private MutableVolumeSet volumeSet;
   private ContainerImporter importer;
@@ -75,7 +73,7 @@ public class TestSendContainerRequestHandler {
   void setup() throws IOException {
     conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, tempDir.getAbsolutePath());
-    volumeChoosingPolicy = VolumeChoosingPolicyFactory.getPolicy(conf);
+    VolumeChoosingPolicy volumeChoosingPolicy = VolumeChoosingPolicyFactory.getPolicy(conf);
     containerSet = newContainerSet(0);
     volumeSet = new MutableVolumeSet("test", conf, null,
         StorageVolume.VolumeType.DATA_VOLUME, null);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToContainerIdsTable.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToContainerIdsTable.java
@@ -55,7 +55,6 @@ public class TestDatanodeUpgradeToContainerIdsTable {
   private Path tempFolder;
 
   private DatanodeStateMachine dsm;
-  private ContainerDispatcher dispatcher;
   private OzoneConfiguration conf;
   private static final String CLUSTER_ID = "clusterID";
 
@@ -93,7 +92,7 @@ public class TestDatanodeUpgradeToContainerIdsTable {
     UpgradeTestHelper.addHddsVolume(conf, tempFolder);
     dsm = UpgradeTestHelper.startPreFinalizedDatanode(conf, tempFolder, dsm, address,
         HDDSLayoutFeature.HBASE_SUPPORT.layoutVersion());
-    dispatcher = dsm.getContainer().getDispatcher();
+    ContainerDispatcher dispatcher = dsm.getContainer().getDispatcher();
     final Pipeline pipeline = MockPipeline.createPipeline(Collections.singletonList(dsm.getDatanodeDetails()));
 
     // add a container
@@ -129,7 +128,7 @@ public class TestDatanodeUpgradeToContainerIdsTable {
     UpgradeTestHelper.addHddsVolume(conf, tempFolder);
     dsm = UpgradeTestHelper.startPreFinalizedDatanode(conf, tempFolder, dsm, address,
         HDDSLayoutFeature.HBASE_SUPPORT.layoutVersion());
-    dispatcher = dsm.getContainer().getDispatcher();
+    ContainerDispatcher dispatcher = dsm.getContainer().getDispatcher();
     final Pipeline pipeline = MockPipeline.createPipeline(Collections.singletonList(dsm.getDatanodeDetails()));
 
     // add a container

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToHBaseSupport.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToHBaseSupport.java
@@ -49,7 +49,6 @@ public class TestDatanodeUpgradeToHBaseSupport {
   private Path tempFolder;
 
   private DatanodeStateMachine dsm;
-  private ContainerDispatcher dispatcher;
   private OzoneConfiguration conf;
   private static final String CLUSTER_ID = "clusterID";
 
@@ -91,7 +90,7 @@ public class TestDatanodeUpgradeToHBaseSupport {
     UpgradeTestHelper.addHddsVolume(conf, tempFolder);
     dsm = UpgradeTestHelper.startPreFinalizedDatanode(conf, tempFolder, dsm, address,
         HDDSLayoutFeature.HADOOP_PRC_PORTS_IN_DATANODEDETAILS.layoutVersion());
-    dispatcher = dsm.getContainer().getDispatcher();
+    ContainerDispatcher dispatcher = dsm.getContainer().getDispatcher();
     final Pipeline pipeline = MockPipeline.createPipeline(
         Collections.singletonList(dsm.getDatanodeDetails()));
 
@@ -126,7 +125,7 @@ public class TestDatanodeUpgradeToHBaseSupport {
     UpgradeTestHelper.addHddsVolume(conf, tempFolder);
     dsm = UpgradeTestHelper.startPreFinalizedDatanode(conf, tempFolder, dsm, address,
         HDDSLayoutFeature.HADOOP_PRC_PORTS_IN_DATANODEDETAILS.layoutVersion());
-    dispatcher = dsm.getContainer().getDispatcher();
+    ContainerDispatcher dispatcher = dsm.getContainer().getDispatcher();
     final Pipeline pipeline = MockPipeline.createPipeline(
         Collections.singletonList(dsm.getDatanodeDetails()));
 


### PR DESCRIPTION
Cleared test code in hdds-container-service from fields which could be converted to local variables.

Please describe your PR in detail:
The production codebase has been updated to comply with the PMD SingularField rule. Instances where compliance was not feasible have been suppressed. In more complex cases, TODO comments were added with corresponding Jira tickets to refactor those sections when converting the field to a local variable is not straightforward.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13560

## How was this patch tested?

Patch is tested using existing automation. New tests are not required.