### PR TITLE
HDDS-13611. [DiskBalancer] Inconsistent VolumeDataDensity calculations between SCM and DN and incorrect EstBytesToMove

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -49,7 +49,11 @@ import org.apache.hadoop.ozone.container.common.helpers.DeletedContainerBlocksSu
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerInfo;
+import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerService;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ClosePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
@@ -258,9 +262,26 @@ public class HeartbeatEndpointTask
   }
 
   private void addDiskBalancerReport(SCMHeartbeatRequestProto.Builder requestBuilder) {
-    DiskBalancerInfo info = context.getParent().getContainer().getDiskBalancerInfo();
+    OzoneContainer ozoneContainer = context.getParent().getContainer();
+    DiskBalancerInfo info = ozoneContainer.getDiskBalancerInfo();
     if (info != null) {
-      requestBuilder.setDiskBalancerReport(info.toDiskBalancerReportProto());
+      // Get volumeSet and deltaMap for accurate VolumeDataDensity calculation
+      try {
+        MutableVolumeSet volumeSet = ozoneContainer.getVolumeSet();
+        Map<HddsVolume, Long> deltaMap = null;
+        
+        // Get deltaMap from DiskBalancerService if available
+        DiskBalancerService diskBalancerService = ozoneContainer.getDiskBalancerService();
+        if (diskBalancerService != null) {
+          deltaMap = diskBalancerService.getDeltaSizes();
+        }
+        
+        requestBuilder.setDiskBalancerReport(info.toDiskBalancerReportProto(volumeSet, deltaMap));
+      } catch (Exception e) {
+        // Fallback to basic report if there are any issues
+        LOG.warn("Falling back to basic DiskBalancerReportProto due to: ", e);
+        requestBuilder.setDiskBalancerReport(info.toDiskBalancerReportProto());
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -642,37 +643,38 @@ public class DiskBalancerService extends BackgroundService {
   }
 
   public long calculateBytesToMove(MutableVolumeSet inputVolumeSet) {
-    long bytesPendingToMove = 0;
-    long totalFreeSpace = 0;
-    long totalCapacity = 0;
-
-    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(inputVolumeSet.getVolumesList())) {
-      totalFreeSpace += volume.getCurrentUsage().getAvailable();
-      totalCapacity += volume.getCurrentUsage().getCapacity();
-    }
-
-    if (totalCapacity == 0) {
+    // If there are no available volumes, return 0 bytes to move
+    if (inputVolumeSet.getVolumesList().isEmpty()) {
       return 0;
     }
 
-    double datanodeUtilization = ((double) (totalCapacity - totalFreeSpace)) / totalCapacity;
+    double idealUsage = inputVolumeSet.getIdealUsage();
+    double normalizedThreshold = threshold / 100.0;
 
-    double thresholdFraction = threshold / 100.0;
-    double upperLimit = datanodeUtilization + thresholdFraction;
+    long totalBytesToMove = 0;
 
     // Calculate excess data in overused volumes
     for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(inputVolumeSet.getVolumesList())) {
-      long freeSpace = volume.getCurrentUsage().getAvailable();
-      long capacity = volume.getCurrentUsage().getCapacity();
-      double volumeUtilization = ((double) (capacity - freeSpace)) / capacity;
+      SpaceUsageSource usage = volume.getCurrentUsage();
 
-      // Consider only volumes exceeding the upper threshold
-      if (volumeUtilization > upperLimit) {
-        long excessData = (capacity - freeSpace) - (long) (upperLimit * capacity);
-        bytesPendingToMove += excessData;
+      if (usage.getCapacity() == 0) {
+        continue;
+      }
+
+      long deltaSize = deltaSizes.getOrDefault(volume, 0L);
+      double currentUsage = (double)((usage.getCapacity() - usage.getAvailable())
+          + deltaSize + volume.getCommittedBytes()) / usage.getCapacity();
+
+      double volumeUtilisation = currentUsage - idealUsage;
+
+      // Only consider volumes that exceed the threshold (source volumes)
+      if (volumeUtilisation >= normalizedThreshold) {
+        // Calculate excess bytes that need to be moved from this volume
+        long excessBytes = (long) ((volumeUtilisation - normalizedThreshold) * usage.getCapacity());
+        totalBytesToMove += Math.max(0, excessBytes);
       }
     }
-    return bytesPendingToMove;
+    return totalBytesToMove;
   }
 
   private Path getDiskBalancerTmpDir(HddsVolume hddsVolume) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/VolumeDataDensityCalculation.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/VolumeDataDensityCalculation.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.diskbalancer;
+
+import com.google.common.base.Preconditions;
+import java.util.Map;
+import org.apache.hadoop.hdds.fs.SpaceUsageSource;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Standalone utility class for calculating VolumeDataDensity.
+ * This class uses the same logic as DefaultVolumeChoosingPolicy to ensure
+ * consistency between operational balancing decisions and reporting.
+ * 
+ * This calculation is independent and can be used by any component that needs
+ * to calculate volume density without depending on DiskBalancerService.
+ */
+public final class VolumeDataDensityCalculation {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(VolumeDataDensityCalculation.class);
+  
+  private VolumeDataDensityCalculation() {
+  }
+  
+  /**
+   * Calculate VolumeDataDensity using the same logic as DefaultVolumeChoosingPolicy.
+   * This ensures consistency between operational balancing decisions and reporting.
+   * 
+   * @param volumeSet The MutableVolumeSet containing all volumes
+   * @param deltaMap Map of volume to delta sizes (ongoing operations), can be null
+   * @return VolumeDataDensity sum across all volumes
+   */
+  public static double calculate(MutableVolumeSet volumeSet, Map<HddsVolume, Long> deltaMap) {
+    if (volumeSet == null) {
+      LOG.warn("VolumeSet is null, returning 0.0 for VolumeDataDensity");
+      return 0.0;
+    }
+    
+    try {
+      double volumeDensitySum = 0.0;
+
+      // Get ideal usage
+      double idealUsage = volumeSet.getIdealUsage();
+      
+      // Calculate density for each volume
+      for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList())) {
+        SpaceUsageSource usage = volume.getCurrentUsage();
+        Preconditions.checkArgument(usage.getCapacity() != 0);
+
+        long deltaSize = (deltaMap != null) ? deltaMap.getOrDefault(volume, 0L) : 0L;
+        double currentUsage = (double)((usage.getCapacity() - usage.getAvailable())
+            + deltaSize + volume.getCommittedBytes()) / usage.getCapacity();
+        
+        // Calculate density as absolute difference from ideal usage
+        double volumeDensity = Math.abs(currentUsage - idealUsage);
+        volumeDensitySum += volumeDensity;
+      }
+      return volumeDensitySum;
+    } catch (Exception e) {
+      LOG.error("Error calculating VolumeDataDensity", e);
+      return 0.0;
+    }
+  }
+}

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -495,6 +495,7 @@ message DiskBalancerReportProto {
   optional uint64 successMoveCount = 4;
   optional uint64 failureMoveCount = 5;
   optional uint64 bytesToMove = 6;
+  optional double volumeDataDensity = 7;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_USE_DN_HOSTNAM
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +33,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerRunningStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -84,10 +82,9 @@ public class DiskBalancerManager {
 
     for (DatanodeDetails datanodeDetails: nodeManager.getNodes(IN_SERVICE,
         HddsProtos.NodeState.HEALTHY)) {
-      double volumeDensitySum =
-          getVolumeDataDensitySumForDatanodeDetails(datanodeDetails);
+      DiskBalancerStatus status = getStatus(datanodeDetails);
       reportList.add(HddsProtos.DatanodeDiskBalancerInfoProto.newBuilder()
-          .setCurrentVolumeDensitySum(volumeDensitySum)
+          .setCurrentVolumeDensitySum(status.getVolumeDataDensity())
           .setNode(datanodeDetails.toProto(clientVersion))
           .build());
     }
@@ -267,14 +264,12 @@ public class DiskBalancerManager {
 
   private HddsProtos.DatanodeDiskBalancerInfoProto getInfoProto(
       DatanodeInfo dn, int clientVersion) {
-    double volumeDensitySum =
-        getVolumeDataDensitySumForDatanodeDetails(dn);
     DiskBalancerStatus status = getStatus(dn);
 
     HddsProtos.DatanodeDiskBalancerInfoProto.Builder builder =
         HddsProtos.DatanodeDiskBalancerInfoProto.newBuilder()
             .setNode(dn.toProto(clientVersion))
-            .setCurrentVolumeDensitySum(volumeDensitySum)
+            .setCurrentVolumeDensitySum(status.getVolumeDataDensity())
             .setRunningStatus(status.getRunningStatus())
             .setSuccessMoveCount(status.getSuccessMoveCount())
             .setFailureMoveCount(status.getFailureMoveCount())
@@ -287,45 +282,16 @@ public class DiskBalancerManager {
     return builder.build();
   }
 
-  /**
-   * Get volume density for a specific DatanodeDetails node.
-   *
-   * @param datanodeDetails DatanodeDetails
-   * @return DiskBalancer report.
-   */
-  private double getVolumeDataDensitySumForDatanodeDetails(
-      DatanodeDetails datanodeDetails) {
-    Preconditions.checkArgument(datanodeDetails instanceof DatanodeInfo);
-
-    DatanodeInfo datanodeInfo = (DatanodeInfo) datanodeDetails;
-
-    double totalCapacity = 0d, totalFree = 0d;
-    for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
-      totalCapacity += reportProto.getCapacity();
-      totalFree += reportProto.getRemaining();
-    }
-
-    Preconditions.checkArgument(totalCapacity != 0);
-    double idealUsage = (totalCapacity - totalFree) / totalCapacity;
-
-    double volumeDensitySum = datanodeInfo.getStorageReports().stream()
-        .map(report ->
-            Math.abs(((double) (report.getCapacity() - report.getRemaining())) / report.getCapacity()
-                - idealUsage))
-        .mapToDouble(Double::valueOf).sum();
-
-    return volumeDensitySum;
-  }
-
   public DiskBalancerStatus getStatus(DatanodeDetails datanodeDetails) {
     return statusMap.computeIfAbsent(datanodeDetails,
-        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN, new DiskBalancerConfiguration(), 0, 0, 0, 0));
+        dn -> new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN, new DiskBalancerConfiguration(),
+            0, 0, 0, 0, Double.NaN));
   }
 
   @VisibleForTesting
   public void addRunningDatanode(DatanodeDetails datanodeDetails) {
     statusMap.put(datanodeDetails, new DiskBalancerStatus(DiskBalancerRunningStatus.RUNNING,
-        new DiskBalancerConfiguration(), 0, 0, 0, 0));
+        new DiskBalancerConfiguration(), 0, 0, 0, 0, 0.0));
   }
 
   public void processDiskBalancerReport(DiskBalancerReportProto reportProto,
@@ -340,9 +306,14 @@ public class DiskBalancerManager {
     long failureMoveCount = reportProto.getFailureMoveCount();
     long bytesToMove = reportProto.getBytesToMove();
     long balancedBytes = reportProto.getBalancedBytes();
+    // Use NaN if volumeDataDensity is not available (for backward compatibility with older DNs)
+    double volumeDataDensity = reportProto.hasVolumeDataDensity() ? 
+        reportProto.getVolumeDataDensity() : Double.NaN;
+
     statusMap.put(dn, new DiskBalancerStatus(
         isRunning ? DiskBalancerRunningStatus.RUNNING : DiskBalancerRunningStatus.STOPPED,
-        diskBalancerConfiguration, successMoveCount, failureMoveCount, bytesToMove, balancedBytes));
+        diskBalancerConfiguration, successMoveCount, failureMoveCount, bytesToMove, balancedBytes,
+        volumeDataDensity));
     if (reportProto.hasBalancedBytes() && balancedBytesMap != null) {
       balancedBytesMap.put(dn, reportProto.getBalancedBytes());
     }
@@ -353,7 +324,7 @@ public class DiskBalancerManager {
     if (currentStatus != null &&
         currentStatus.getRunningStatus() != DiskBalancerRunningStatus.UNKNOWN) {
       DiskBalancerStatus unknownStatus = new DiskBalancerStatus(DiskBalancerRunningStatus.UNKNOWN,
-          new DiskBalancerConfiguration(), 0, 0, 0, 0);
+          new DiskBalancerConfiguration(), 0, 0, 0, 0, Double.NaN);
       statusMap.put(dn, unknownStatus);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerStatus.java
@@ -35,15 +35,18 @@ public class DiskBalancerStatus {
   private long failureMoveCount;
   private long bytesToMove;
   private long balancedBytes;
+  private double volumeDataDensity;
 
   public DiskBalancerStatus(DiskBalancerRunningStatus isRunning, DiskBalancerConfiguration conf,
-      long successMoveCount, long failureMoveCount, long bytesToMove, long balancedBytes) {
+      long successMoveCount, long failureMoveCount, long bytesToMove, long balancedBytes, 
+      double volumeDataDensity) {
     this.isRunning = isRunning;
     this.diskBalancerConfiguration = conf;
     this.successMoveCount = successMoveCount;
     this.failureMoveCount = failureMoveCount;
     this.bytesToMove = bytesToMove;
     this.balancedBytes = balancedBytes;
+    this.volumeDataDensity = volumeDataDensity;
   }
 
   public DiskBalancerRunningStatus getRunningStatus() {
@@ -68,5 +71,9 @@ public class DiskBalancerStatus {
 
   public long getBalancedBytes() {
     return balancedBytes;
+  }
+
+  public double getVolumeDataDensity() {
+    return volumeDataDensity;
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -60,7 +60,14 @@ public class DiskBalancerReportSubcommand extends ScmSubcommand {
     for (HddsProtos.DatanodeDiskBalancerInfoProto proto: protos) {
       formatBuilder.append("%-50s %s%n");
       contentList.add(proto.getNode().getHostName());
-      contentList.add(String.valueOf(proto.getCurrentVolumeDensitySum()));
+      
+      // Display "N/A" for dead/down datanodes, otherwise show the actual value
+      double volumeDensity = proto.getCurrentVolumeDensitySum();
+      if (Double.isNaN(volumeDensity)) {
+        contentList.add("N/A");
+      } else {
+        contentList.add(String.valueOf(volumeDensity));
+      }
     }
 
     return String.format(formatBuilder.toString(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
This ticket fixes inconsistencies in **VolumeDataDensity calculations** between SCM and DN causing misleading reports.

Although **volumeDataDensity for the datanode is 0.0** still it is started and showing containers moved.
**Estimated bytes moved** and **estimated time left is 0** although it is moving containers. 
**Proposed Solution:**

VolumeDataDensity calculation (on SCM side in DiskBalancerManager ), EstimatedBytesToMove calculation should be aligned with DefaultVolumeChoosingPolicy calculation.{}

VolumeDataDensity calculation should be done on the DN side so that it considers all the ongoing operations and then correctly report it to the SCM.
And this VolumeDataDensity calculation should be standAlone utility on datanode side that can calculate VolumeDataDensity regardless of diskbalancer state (stopped or running) .

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13611

## How was this patch tested?

passed existing test.
