### PR TITLE
HDDS-13620. Explicitly install pnpm and avoid npx usage in builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,12 +45,6 @@ on:
         default: ''
         required: false
 
-      pnpm-version:
-        type: string
-        description: "pnpm version to use for builds (default: none)"
-        default: ''
-        required: false
-
       needs-maven-cache:
         type: boolean
         description: "Whether to restore Maven cache before run (default: yes)"
@@ -173,7 +167,6 @@ jobs:
         with:
           path: |
             ~/.pnpm-store
-            **/node_modules
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
@@ -225,12 +218,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java-version }}
-
-      - name: Setup pnpm version ${{ inputs.pnpm-version }}
-        if: ${{ inputs.pnpm-version }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ inputs.pnpm-version }}
 
       - name: Execute pre-test steps
         if: ${{ inputs.pre-script }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -220,6 +220,12 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ inputs.java-version }}
 
+      - name: Setup pnpm version ${{ inputs.pnpm-version }}
+        if: ${{ inputs.pnpm-version }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ inputs.pnpm-version }}
+
       - name: Execute pre-test steps
         if: ${{ inputs.pre-script }}
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,12 @@ on:
         default: ''
         required: false
 
+      pnpm-version:
+        type: string
+        description: "pnpm version to use for builds (default: none)"
+        default: ''
+        required: false
+
       needs-maven-cache:
         type: boolean
         description: "Whether to restore Maven cache before run (default: yes)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ env:
   BUILD_ARGS: "-Pdist -Psrc -Dmaven.javadoc.skip=true -Drocks_tools_native"
   # Minimum required Java version for running Ozone is defined in pom.xml (javac.version).
   TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
-  PNPM_VERSION: 8.15.7 # This is defined in the pom.xml file with pnpm.version, should be updated accordingly
   # MAVEN_ARGS and MAVEN_OPTS are duplicated in check.yml, please keep in sync
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
@@ -55,7 +54,6 @@ jobs:
       # `env` context cannot be used when calling reusable workflow, so we need to convert these to `outputs`
       build-args: ${{ env.BUILD_ARGS }}
       java-version: ${{ env.TEST_JAVA_VERSION }}
-      pnpm-version: ${{ env.PNPM_VERSION }}
       with-coverage: ${{ env.OZONE_WITH_COVERAGE }}
     steps:
       - name: "Checkout ${{ github.ref }} / ${{ github.sha }} (push)"
@@ -116,7 +114,6 @@ jobs:
     if: needs.build-info.outputs.needs-build == 'true' || needs.build-info.outputs.needs-integration-tests == 'true'
     uses: ./.github/workflows/check.yml
     with:
-      pnpm-version: ${{ needs.build-info.outputs.pnpm-version }}
       java-version: ${{ needs.build-info.outputs.java-version }}
       needs-npm-cache: true
       ratis-args: ${{ inputs.ratis_args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ env:
   BUILD_ARGS: "-Pdist -Psrc -Dmaven.javadoc.skip=true -Drocks_tools_native"
   # Minimum required Java version for running Ozone is defined in pom.xml (javac.version).
   TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
+  PNPM_VERSION: 8.15.7 # This is defined in the pom.xml file with pnpm.version, should be updated accordingly
   # MAVEN_ARGS and MAVEN_OPTS are duplicated in check.yml, please keep in sync
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
@@ -54,6 +55,7 @@ jobs:
       # `env` context cannot be used when calling reusable workflow, so we need to convert these to `outputs`
       build-args: ${{ env.BUILD_ARGS }}
       java-version: ${{ env.TEST_JAVA_VERSION }}
+      pnpm-version: ${{ env.PNPM_VERSION }}
       with-coverage: ${{ env.OZONE_WITH_COVERAGE }}
     steps:
       - name: "Checkout ${{ github.ref }} / ${{ github.sha }} (push)"
@@ -114,6 +116,7 @@ jobs:
     if: needs.build-info.outputs.needs-build == 'true' || needs.build-info.outputs.needs-integration-tests == 'true'
     uses: ./.github/workflows/check.yml
     with:
+      pnpm-version: ${{ needs.build-info.outputs.pnpm-version }}
       java-version: ${{ needs.build-info.outputs.java-version }}
       needs-npm-cache: true
       ratis-args: ${{ inputs.ratis_args }}

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -429,28 +429,28 @@
           <execution>
             <id>set pnpm@${pnpm.version} store path</id>
             <goals>
-              <goal>npx</goal>
+              <goal>pnpm</goal>
             </goals>
             <configuration>
-              <arguments>pnpm@${pnpm.version} config set store-dir ~/.pnpm-store</arguments>
+              <arguments>config set store-dir ~/.pnpm-store</arguments>
             </configuration>
           </execution>
           <execution>
             <id>install frontend dependencies</id>
             <goals>
-              <goal>npx</goal>
+              <goal>pnpm</goal>
             </goals>
             <configuration>
-              <arguments>pnpm@${pnpm.version} install --frozen-lockfile</arguments>
+              <arguments>install --frozen-lockfile</arguments>
             </configuration>
           </execution>
           <execution>
             <id>Build frontend</id>
             <goals>
-              <goal>npx</goal>
+              <goal>pnpm</goal>
             </goals>
             <configuration>
-              <arguments>pnpm@${pnpm.version} run build</arguments>
+              <arguments>run build</arguments>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -415,16 +415,15 @@
           <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
           <installDirectory>target</installDirectory>
           <workingDirectory>${basedir}/src/main/resources/webapps/recon/ozone-recon-web</workingDirectory>
+          <nodeVersion>v${nodejs.version}</nodeVersion>
+          <pnpmVersion>${pnpm.version}</pnpmVersion>
         </configuration>
         <executions>
           <execution>
             <id>Install node and npm locally to the project</id>
             <goals>
-              <goal>install-node-and-npm</goal>
+              <goal>install-node-and-pnpm</goal>
             </goals>
-            <configuration>
-              <nodeVersion>v${nodejs.version}</nodeVersion>
-            </configuration>
           </execution>
           <execution>
             <id>set pnpm@${pnpm.version} store path</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Explicitly install pnpm as part of build step and avoid npx

Please describe your PR in detail:
Ozone builds are failing as npx is not connecting to the npmjs registry.
Initial inspection points towards IP blacklisting. As a part of this PR we make the following changes:

- We directly install pnpm as part of the Recon builds using the frontend-maven-plugin
- Replace usage of `npx pnpm@<version>` with direct `pnpm ...` to avoid calls to npmjs registry
- We also remove node_modules from the cache as adding the pnpm store will ensure the next run can properly access the node modules via the centralized store reducing unnecessary caching

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13620

## How was this patch tested?
Patch was tested manually via the CI that runs on local fork
https://github.com/devabhishekpal/ozone/actions/runs/17243111558