### PR TITLE
HDDS-13290. Correct the pagination semantic of listMultipartUploads

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -97,4 +97,17 @@ public final class StringUtils {
   public static byte[] string2Bytes(String str) {
     return str.getBytes(UTF8);
   }
+
+  /**
+   * Get the upper bound of a key. Eg. "a" -> "b", "a/b" -> "a/c", "a/b/c" -> "a/b/d".
+   * Usually used to get the upper bound of a key for pagination.
+   * @param key The key to get the upper bound of.
+   * @return The upper bound of the key.
+   */
+  public static String getKeyUpperBound(String key) {
+    if (key.isEmpty()) {
+      return key;
+    }
+    return key.substring(0, key.length() - 1) + (char)(key.charAt(key.length() - 1) + 1);
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -99,10 +99,14 @@ public final class StringUtils {
   }
 
   /**
-   * Get the upper bound of a key. Eg. "a" -> "b", "a/b" -> "a/c", "a/b/c" -> "a/b/d".
-   * Usually used to get the upper bound of a key for pagination.
-   * @param key The key to get the upper bound of.
-   * @return The upper bound of the key.
+   * Returns the exclusive upper bound string for the given key, suitable for
+   * range scans and pagination.
+   * <p>
+   * Examples: {@code "a" -> "b"}, {@code "a/b" -> "a/c"}, {@code "a/b/c" -> "a/b/d"}.
+   * </p>
+   *
+   * @param key the key to get the upper bound of (non-null); if empty, returns an empty string
+   * @return the upper bound of the key (exclusive)
    */
   public static String getKeyUpperBound(String key) {
     if (key.isEmpty()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -986,14 +986,12 @@ public class KeyManagerImpl implements KeyManager {
       OmMultipartUploadList.Builder resultBuilder = OmMultipartUploadList.newBuilder();
 
       if (withPagination && multipartUploadKeys.size() == maxUploads + 1) {
-        int lastIndex = multipartUploadKeys.size() - 1;
-        OmMultipartUpload lastUpload = multipartUploadKeys.get(lastIndex);
-        resultBuilder.setNextKeyMarker(lastUpload.getKeyName())
-            .setNextUploadIdMarker(lastUpload.getUploadId())
+        // Per spec, next markers should be the last element of the returned list, not the lookahead.
+        multipartUploadKeys.remove(multipartUploadKeys.size() - 1);
+        OmMultipartUpload lastReturned = multipartUploadKeys.get(multipartUploadKeys.size() - 1);
+        resultBuilder.setNextKeyMarker(lastReturned.getKeyName())
+            .setNextUploadIdMarker(lastReturned.getUploadId())
             .setIsTruncated(true);
-
-        // remove next upload from the list
-        multipartUploadKeys.remove(lastIndex);
       }
 
       return resultBuilder

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.ozone.om;
 
-import static org.apache.hadoop.hdds.StringUtils.getKeyUpperBound;
+import static org.apache.hadoop.hdds.StringUtils.getLexicographicallyHigherString;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
@@ -1532,7 +1532,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       // - If upload-id-marker is specified,
       // any multipart uploads for a key equal to the key-marker might also be included,
       // provided those multipart uploads have upload IDs lexicographically greater than the specified upload-id-marker.
-      prefix = getKeyUpperBound(prefix);
+      prefix = getLexicographicallyHigherString(prefix);
     }
     String seekKey = OmMultipartUpload.getDbKey(volumeName, bucketName, prefix);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Enforce spec-correct key-marker behavior:
  - When upload-id-marker is absent, list keys strictly greater than key-marker.
  - When upload-id-marker is present, include same-key uploads only if uploadId > upload-id-marker.
- Set nextKeyMarker/nextUploadIdMarker to the last element actually returned, not the lookahead.
- Use `getLexicographicallyHigherString()` to compute an exclusive seek start for marker handling in RocksDB scans.
- Align DB iteration bounds with page size (avoid over-fetch in the iterator) while still supporting truncation detection.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13290

## How was this patch tested?

Add one corner cases test into s3 sdk v1 test