### PR TITLE
HDDS-13604: Add volume and bucket to checkpoint existence/creation logs.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -513,12 +513,18 @@ public final class OmSnapshotManager implements AutoCloseable {
         snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(), batchOperation);
 
     if (dbCheckpoint != null && snapshotDirExist) {
-      LOG.info("Checkpoint : {} for snapshot {} already exists.",
-          dbCheckpoint.getCheckpointLocation(), snapshotInfo.getName());
+      LOG.info("Checkpoint: {} for snapshot {} (volume: {}, bucket: {}) already exists.",
+          dbCheckpoint.getCheckpointLocation(),
+          snapshotInfo.getName(),
+          snapshotInfo.getVolumeName(),
+          snapshotInfo.getBucketName());
       return dbCheckpoint;
     } else if (dbCheckpoint != null) {
-      LOG.info("Created checkpoint : {} for snapshot {}",
-          dbCheckpoint.getCheckpointLocation(), snapshotInfo.getName());
+      LOG.info("Created checkpoint: {} for snapshot {} (volume: {}, bucket: {})",
+          dbCheckpoint.getCheckpointLocation(),
+          snapshotInfo.getName(),
+          snapshotInfo.getVolumeName(),
+          snapshotInfo.getBucketName());
     }
 
     return dbCheckpoint;


### PR DESCRIPTION
Currently OmSnapshotManager logs only the checkpoint path and snapshot name when a snapshot checkpoint is created or already exists. This patch adds the volume and bucket information from SnapshotInfo to both log branches, improving operational visibility and debugging of snapshot lifecycle events.

## What changes were proposed in this pull request?
HDDS-13604: Add volume and bucket to checkpoint existence/creation logs.

Please describe your PR in detail:
Currently OmSnapshotManager logs only the checkpoint path and snapshot name when a snapshot checkpoint is created or already exists. This patch adds the volume and bucket information from SnapshotInfo to both log branches, improving operational visibility and debugging of snapshot lifecycle events.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13604


## How was this patch tested?
Ran unit tests 
