### PR TITLE
HDDS-13484. Replace goofys in Ozone CSI

### DIFF
--- a/hadoop-hdds/docs/content/interface/CSI.md
+++ b/hadoop-hdds/docs/content/interface/CSI.md
@@ -26,7 +26,7 @@ summary: Ozone supports Container Storage Interface(CSI) protocol. You can use O
 
 <div class="alert alert-warning" role="alert">
 
-Ozone CSI support is still in alpha phase and buckets can be mounted only via 3rd party S3 compatible Fuse implementation (like Goofys). Fuse over S3 can provide only limited performance compared to a native Fuse file system. Long-term Ozone may support a custom solution to mount buckets which provides better user experience (with fuse or NFS or any other solution). Until that CSI is recommended to use only if you can live with this limitation and your use case is tested carefully.
+Ozone CSI support is still in alpha phase and buckets can be mounted only via 3rd party S3 compatible Fuse implementation (like mountpoint-s3). Fuse over S3 can provide only limited performance compared to a native Fuse file system. Long-term Ozone may support a custom solution to mount buckets which provides better user experience (with fuse or NFS or any other solution). Until that CSI is recommended to use only if you can live with this limitation and your use case is tested carefully.
 </div>
 
 `Container Storage Interface` (CSI) will enable storage vendors (SP) to develop a plugin once and have it work across a number of container orchestration (CO) systems like Kubernetes or Yarn.
@@ -37,7 +37,7 @@ CSI defined a simple GRPC interface with 3 interfaces (Identity, Controller, Nod
 
 ![CSI](CSI.png)
 
-By default Ozone CSI service uses a S3 fuse driver ([goofys](https://github.com/kahing/goofys)) to mount the created Ozone bucket. Implementation of other mounting options such as a dedicated NFS server or native Fuse driver is work in progress.
+By default Ozone CSI service uses a S3 fuse driver ([mountpoint-s3](https://github.com/awslabs/mountpoint-s3)) to mount the created Ozone bucket. Implementation of other mounting options such as a dedicated NFS server or native Fuse driver is work in progress.
 
 
 
@@ -47,7 +47,7 @@ Ozone CSI is an implementation of CSI, it can make possible of using Ozone as a 
 
 First of all, we need an Ozone cluster with s3gateway, and its OM rpc port and s3gateway port must be visible to CSI pod,
 because CSIServer will access OM to create or delete a bucket, also, CSIServer will publish volume by creating a mount point to s3g
-through goofys. 
+through mountpoint-s3. 
 
 If you don't have an Ozone cluster on kubernetes, you can reference [Kubernetes]({{< ref "start/Kubernetes.md" >}}) to create one. Use the resources from `kubernetes/examples/ozone` where you can find all the required Kubernetes resources to run cluster together with the dedicated Ozone CSI daemon (check `kubernetes/examples/ozone/csi`)   
 

--- a/hadoop-hdds/docs/content/interface/CSI.zh.md
+++ b/hadoop-hdds/docs/content/interface/CSI.zh.md
@@ -34,7 +34,7 @@ CSI 定义了一个简单的，包含3个接口（Identity， Controller， Node
 
 ![CSI](CSI.png)
 
-默认情况下，Ozone CSI 服务使用 S3 FUSE 驱动程序（[goofys](https://github.com/kahing/goofys)）挂载 Ozone 桶。
+默认情况下，Ozone CSI 服务使用 S3 FUSE 驱动程序（[mountpoint-s3](https://github.com/awslabs/mountpoint-s3)）挂载 Ozone 桶。
 其他挂载方式（如专用 NFS 服务或本机FUSE驱动程序）的实现正在进行中。
 
 
@@ -44,7 +44,7 @@ Ozone CSI 是 CSI 的一种实现，它可以将 Ozone 用作容器的存储卷�
 ## 入门
 
 首先，我们需要一个带有 s3gateway 的 Ozone 集群，并且它的 OM 和 s3gateway 的端口都可以对 CSI pod 可见，
-因为 CSIServer 将会访问 OM 来创建或者删除桶，同时 CSIServer 通过 goofys 创建一个可以访问 s3g 的挂载点来发布卷。 
+因为 CSIServer 将会访问 OM 来创建或者删除桶，同时 CSIServer 通过 mountpoint-s3 创建一个可以访问 s3g 的挂载点来发布卷。 
 
 如果你没有一个运行在 Kubernetes 上的 Ozone 集群，你可以参考[Kubernetes]({{< ref "start/Kubernetes.zh.md" >}}) 来创建一个。
 使用来自 `kubernetes/examples/ozone`的资源，你可以找到所有需要的 Kubernetes 资源来和指定的 CSI 运行在一起

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -83,6 +83,10 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Once the latest ozone docker runner release has the mountpoint-s3 binaries, we can replace goofys in Ozone CSI service:

https://github.com/peterxcli/ozone/blob/7481fe9aeafb85f6023d62a6e023035b9cb34605/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java#L133

We also need to update the user doc to reflect the change: https://github.com/peterxcli/ozone/blob/cb0a402bea59da76fe51c51cd61ab4bfe99417cb/hadoop-hdds/docs/content/interface/CSI.md#L29

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13484

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
