### PR TITLE
HDDS-13537. Client skip send request to listener OM

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -381,16 +381,32 @@ public final class OmUtils {
     return nodeIds;
   }
 
+  /**
+   * Returns a collection of OM node IDs configured as listeners
+   * for the given OM service ID. The result aggregates IDs from both
+   * the service-specific and global listener configuration keys.
+   *
+   * @param conf        Configuration source to read OM node settings.
+   * @param omServiceId The OM service ID to scope the search.
+   * @return A collection of OM node IDs configured as listeners.
+   */
   public static Collection<String> getListenerOMNodeIds(
       ConfigurationSource conf, String omServiceId) {
-    String listenerNodesKeyWithServiceIdSuffix =
-        ConfUtils.addKeySuffixes(OZONE_OM_LISTENER_NODES_KEY, omServiceId);
+    String listenerNodesKeyWithServiceIdSuffix = ConfUtils.addKeySuffixes(OZONE_OM_LISTENER_NODES_KEY, omServiceId);
     HashSet<String> listenerNodeIds = new HashSet<>(
         conf.getTrimmedStringCollection(listenerNodesKeyWithServiceIdSuffix));
     listenerNodeIds.addAll(conf.getTrimmedStringCollection(OZONE_OM_LISTENER_NODES_KEY));
     return listenerNodeIds;
   }
 
+  /**
+   * Returns active OM node IDs that are not listener nodes for the given service
+   * ID.
+   *
+   * @param conf        Configuration source
+   * @param omServiceId OM service ID
+   * @return Collection of active non-listener node IDs
+   */
   public static Collection<String> getActiveNonListenerOMNodeIds(
       ConfigurationSource conf, String omServiceId) {
     HashSet<String> nodeIds = new HashSet<>(

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -378,19 +378,24 @@ public final class OmUtils {
         getDecommissionedNodeIds(conf, decommissionNodesKeyWithServiceIdSuffix);
     nodeIds.removeAll(decommissionedNodeIds);
 
-    // Exclude listener nodes if configured.
+    return nodeIds;
+  }
+
+  public static Collection<String> getListenerOMNodeIds(
+      ConfigurationSource conf, String omServiceId) {
     String listenerNodesKeyWithServiceIdSuffix =
         ConfUtils.addKeySuffixes(OZONE_OM_LISTENER_NODES_KEY, omServiceId);
-    HashSet<String> serviceIds = new HashSet<>(
-        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
-    Collection<String> listenerNodeIds =
-        conf.getTrimmedStringCollection(listenerNodesKeyWithServiceIdSuffix);
-    if (listenerNodeIds.isEmpty() && serviceIds.size() == 1) {
-      listenerNodeIds = conf.getTrimmedStringCollection(
-          OZONE_OM_LISTENER_NODES_KEY);
-    }
-    nodeIds.removeAll(listenerNodeIds);
+    HashSet<String> listenerNodeIds = new HashSet<>(
+        conf.getTrimmedStringCollection(listenerNodesKeyWithServiceIdSuffix));
+    listenerNodeIds.addAll(conf.getTrimmedStringCollection(OZONE_OM_LISTENER_NODES_KEY));
+    return listenerNodeIds;
+  }
 
+  public static Collection<String> getActiveNonListenerOMNodeIds(
+      ConfigurationSource conf, String omServiceId) {
+    HashSet<String> nodeIds = new HashSet<>(
+        getActiveOMNodeIds(conf, omServiceId));
+    nodeIds.removeAll(getListenerOMNodeIds(conf, omServiceId));
     return nodeIds;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -391,9 +391,9 @@ public final class OmUtils {
    */
   public static Collection<String> getActiveNonListenerOMNodeIds(
       ConfigurationSource conf, String omServiceId) {
-    HashSet<String> nodeIds = new HashSet<>(
-        getActiveOMNodeIds(conf, omServiceId));
-    nodeIds.removeAll(getListenerOMNodeIds(conf, omServiceId));
+    Collection<String> nodeIds = getActiveOMNodeIds(conf, omServiceId);
+    Collection<String> listenerNodeIds = getListenerOMNodeIds(conf, omServiceId);
+    nodeIds.removeAll(listenerNodeIds);
     return nodeIds;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -438,19 +438,6 @@ public final class OmUtils {
   }
 
   /**
-   * Get a collection of listener omNodeIds for the given omServiceId.
-   */
-  public static Collection<String> getListenerOMNodeIds(ConfigurationSource conf,
-      String omServiceId) {
-    String listenerNodesKey = ConfUtils.addKeySuffixes(
-        OZONE_OM_LISTENER_NODES_KEY, omServiceId);
-    Collection<String> listenerNodeIds = conf.getTrimmedStringCollection(
-        listenerNodesKey);
-
-    return listenerNodeIds;
-  }
-
-  /**
    * Get a collection of all omNodeIds (active and decommissioned) for a
    * gived omServiceId.
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -395,7 +395,6 @@ public final class OmUtils {
     String listenerNodesKeyWithServiceIdSuffix = ConfUtils.addKeySuffixes(OZONE_OM_LISTENER_NODES_KEY, omServiceId);
     HashSet<String> listenerNodeIds = new HashSet<>(
         conf.getTrimmedStringCollection(listenerNodesKeyWithServiceIdSuffix));
-    listenerNodeIds.addAll(conf.getTrimmedStringCollection(OZONE_OM_LISTENER_NODES_KEY));
     return listenerNodeIds;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -378,6 +378,19 @@ public final class OmUtils {
         getDecommissionedNodeIds(conf, decommissionNodesKeyWithServiceIdSuffix);
     nodeIds.removeAll(decommissionedNodeIds);
 
+    // Exclude listener nodes if configured.
+    String listenerNodesKeyWithServiceIdSuffix =
+        ConfUtils.addKeySuffixes(OZONE_OM_LISTENER_NODES_KEY, omServiceId);
+    HashSet<String> serviceIds = new HashSet<>(
+        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+    Collection<String> listenerNodeIds =
+        conf.getTrimmedStringCollection(listenerNodesKeyWithServiceIdSuffix);
+    if (listenerNodeIds.isEmpty() && serviceIds.size() == 1) {
+      listenerNodeIds = conf.getTrimmedStringCollection(
+          OZONE_OM_LISTENER_NODES_KEY);
+    }
+    nodeIds.removeAll(listenerNodeIds);
+
     return nodeIds;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -382,23 +382,6 @@ public final class OmUtils {
   }
 
   /**
-   * Returns a collection of OM node IDs configured as listeners
-   * for the given OM service ID. The result aggregates IDs from both
-   * the service-specific and global listener configuration keys.
-   *
-   * @param conf        Configuration source to read OM node settings.
-   * @param omServiceId The OM service ID to scope the search.
-   * @return A collection of OM node IDs configured as listeners.
-   */
-  public static Collection<String> getListenerOMNodeIds(
-      ConfigurationSource conf, String omServiceId) {
-    String listenerNodesKeyWithServiceIdSuffix = ConfUtils.addKeySuffixes(OZONE_OM_LISTENER_NODES_KEY, omServiceId);
-    HashSet<String> listenerNodeIds = new HashSet<>(
-        conf.getTrimmedStringCollection(listenerNodesKeyWithServiceIdSuffix));
-    return listenerNodeIds;
-  }
-
-  /**
    * Returns active OM node IDs that are not listener nodes for the given service
    * ID.
    *
@@ -434,6 +417,17 @@ public final class OmUtils {
           conf.getTrimmedStringCollection(OZONE_OM_DECOMMISSIONED_NODES_KEY));
     }
     return decommissionedNodeIds;
+  }
+
+  /**
+   * Get a collection of listener omNodeIds for the given omServiceId.
+   */
+  public static Collection<String> getListenerOMNodeIds(ConfigurationSource conf,
+      String omServiceId) {
+    String listenerNodesKey = ConfUtils.addKeySuffixes(
+        OZONE_OM_LISTENER_NODES_KEY, omServiceId);
+    return conf.getTrimmedStringCollection(
+        listenerNodesKey);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
@@ -67,7 +67,7 @@ public class GrpcOMFailoverProxyProvider<T> extends
   protected void loadOMClientConfigs(ConfigurationSource config, String omSvcId)
       throws IOException {
 
-    Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(config, omSvcId);
+    Collection<String> omNodeIds = OmUtils.getActiveNonListenerOMNodeIds(config, omSvcId);
     Map<String, ProxyInfo<T>> omProxies = new HashMap<>();
     List<String> omNodeIDList = new ArrayList<>();
     Map<String, InetSocketAddress> omNodeAddressMap = new HashMap<>();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
@@ -74,7 +74,7 @@ public class HadoopRpcOMFailoverProxyProvider<T> extends
     List<String> omNodeIDList = new ArrayList<>();
     Map<String, InetSocketAddress> omNodeAddressMap = new HashMap<>();
 
-    Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(config,
+    Collection<String> omNodeIds = OmUtils.getActiveNonListenerOMNodeIds(config,
         omSvcId);
 
     for (String nodeId : OmUtils.emptyAsSingletonNull(omNodeIds)) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -218,5 +218,44 @@ public class TestOmUtils {
     assertEquals("0.0.0.0", addr.getHostString());
     assertEquals(OMConfigKeys.OZONE_OM_PORT_DEFAULT, addr.getPort());
   }
+
+  @Test
+  public void testGetListenerOMNodeIdsUnion() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    String serviceId = "om-service-test1";
+    conf.set(org.apache.hadoop.ozone.ha.ConfUtils.addKeySuffixes(
+        org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_LISTENER_NODES_KEY,
+        serviceId), "s1,s2");
+
+    java.util.Collection<String> result = OmUtils.getListenerOMNodeIds(conf, serviceId);
+    java.util.Set<String> expected = new java.util.HashSet<>();
+    expected.add("s1");
+    expected.add("s2");
+
+    assertEquals(expected.size(), result.size());
+    assertTrue(result.containsAll(expected));
+  }
+
+  @Test
+  public void testGetActiveNonListenerOMNodeIdsFiltering() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String serviceId = "om-service-test1";
+
+    conf.set(org.apache.hadoop.ozone.ha.ConfUtils.addKeySuffixes(
+        org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY, serviceId),
+        "n1,n2,n3");
+    conf.set(org.apache.hadoop.ozone.ha.ConfUtils.addKeySuffixes(
+        org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_LISTENER_NODES_KEY,
+        serviceId), "n2");
+
+    java.util.Collection<String> result = OmUtils.getActiveNonListenerOMNodeIds(conf, serviceId);
+    java.util.Set<String> expected = new java.util.HashSet<>();
+    expected.add("n1");
+    expected.add("n3");
+
+    assertEquals(expected.size(), result.size());
+    assertTrue(result.containsAll(expected));
+  }
 }
 


### PR DESCRIPTION
This should be put off until https://github.com/apache/ozone/pull/7262 got merged.

## What changes were proposed in this pull request?

OM Client should normally skip send request to listener OM to reduce the latency introduced by communication with listener OM. 


https://github.com/apache/ozone/pull/7262#pullrequestreview-3171311111

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13537

## How was this patch tested?

- [x] I would add some test coverage on this (simple config related unit test and a IT to check client failover process really skip those liseners.