### PR TITLE
HDDS-13615. ofs.listStatusIterator() reports files in encrypted buckets as unencrypted

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -42,6 +42,7 @@ public final class BasicOmKeyInfo {
   private final boolean isFile;
   private final String eTag;
   private String ownerName;
+  private final boolean isEncrypted;
 
   private BasicOmKeyInfo(Builder b) {
     this.volumeName = b.volumeName;
@@ -54,6 +55,7 @@ public final class BasicOmKeyInfo {
     this.isFile = b.isFile;
     this.eTag = StringUtils.isNotEmpty(b.eTag) ? b.eTag : null;
     this.ownerName = b.ownerName;
+    this.isEncrypted = b.isEncrypted;
   }
 
   private BasicOmKeyInfo(OmKeyInfo b) {
@@ -67,6 +69,7 @@ public final class BasicOmKeyInfo {
     this.isFile = b.isFile();
     this.eTag = b.getMetadata().get(ETAG);
     this.ownerName = b.getOwnerName();
+    this.isEncrypted = b.getFileEncryptionInfo() != null;
   }
 
   public String getVolumeName() {
@@ -109,6 +112,10 @@ public final class BasicOmKeyInfo {
     return ownerName;
   }
 
+  public boolean isEncrypted() {
+    return isEncrypted;
+  }
+
   public long getReplicatedSize() {
     return QuotaUtil.getReplicatedSize(getDataSize(), replicationConfig);
   }
@@ -127,6 +134,7 @@ public final class BasicOmKeyInfo {
     private boolean isFile;
     private String eTag;
     private String ownerName;
+    private boolean isEncrypted;
 
     public Builder setVolumeName(String volumeName) {
       this.volumeName = volumeName;
@@ -178,6 +186,11 @@ public final class BasicOmKeyInfo {
       return this;
     }
 
+    public Builder setIsEncrypted(boolean isEncrypted) {
+      this.isEncrypted = isEncrypted;
+      return this;
+    }
+
     public BasicOmKeyInfo build() {
       return new BasicOmKeyInfo(this);
     }
@@ -189,7 +202,8 @@ public final class BasicOmKeyInfo {
         .setDataSize(dataSize)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
-        .setType(replicationConfig.getReplicationType());
+        .setType(replicationConfig.getReplicationType())
+        .setIsEncrypted(isEncrypted);
     if (ownerName != null) {
       builder.setOwnerName(ownerName);
     }
@@ -228,7 +242,8 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getEcReplicationConfig()))
         .setETag(basicKeyInfo.getETag())
         .setIsFile(!keyName.endsWith("/"))
-        .setOwnerName(basicKeyInfo.getOwnerName());
+        .setOwnerName(basicKeyInfo.getOwnerName())
+        .setIsEncrypted(basicKeyInfo.getIsEncrypted());
 
     return builder.build();
   }
@@ -254,7 +269,8 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getEcReplicationConfig()))
         .setETag(basicKeyInfo.getETag())
         .setIsFile(!keyName.endsWith("/"))
-        .setOwnerName(basicKeyInfo.getOwnerName());
+        .setOwnerName(basicKeyInfo.getOwnerName())
+        .setIsEncrypted(basicKeyInfo.getIsEncrypted());
 
     return builder.build();
   }
@@ -277,7 +293,8 @@ public final class BasicOmKeyInfo {
         replicationConfig.equals(basicOmKeyInfo.replicationConfig) &&
         Objects.equals(eTag, basicOmKeyInfo.eTag) &&
         isFile == basicOmKeyInfo.isFile &&
-        ownerName.equals(basicOmKeyInfo.ownerName);
+        ownerName.equals(basicOmKeyInfo.ownerName) &&
+        isEncrypted == basicOmKeyInfo.isEncrypted;
   }
 
   @Override

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1201,6 +1201,7 @@ message BasicKeyInfo {
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
     optional string eTag = 8;
     optional string ownerName = 9;
+    optional bool isEncrypted = 10;
 }
 
 message DirectoryInfo {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
@@ -19,9 +19,14 @@ package org.apache.hadoop.ozone.protocolPB;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.hadoop.crypto.CipherSuite;
+import org.apache.hadoop.crypto.CryptoProtocolVersion;
+import org.apache.hadoop.fs.FileEncryptionInfo;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.OmConfig;
@@ -31,9 +36,12 @@ import org.apache.hadoop.ozone.om.helpers.ListKeysLightResult;
 import org.apache.hadoop.ozone.om.helpers.ListKeysResult;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
@@ -73,6 +81,39 @@ public class TestOzoneManagerRequestHandler {
 
   private OzoneFileStatus getMockedOzoneFileStatus() {
     return new OzoneFileStatus(getMockedOmKeyInfo(), 256, false);
+  }
+
+  /**
+   * Create OmKeyInfo object with or without FileEncryptionInfo.
+   */
+  private OmKeyInfo createOmKeyInfoWithEncryption(String keyName, boolean isEncrypted) {
+    OmKeyInfo.Builder builder = new OmKeyInfo.Builder()
+        .setVolumeName("testVolume")
+        .setBucketName("testBucket")
+        .setKeyName(keyName)
+        .setDataSize(1024L)
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE))
+        .setOmKeyLocationInfos(Collections.singletonList(new OmKeyLocationInfoGroup(0, Collections.emptyList())))
+        .setAcls(Collections.emptyList())
+        .setObjectID(1L)
+        .setUpdateID(1L)
+        .setOwnerName("testOwner");
+
+    if (isEncrypted) {
+      FileEncryptionInfo fileEncryptionInfo = new FileEncryptionInfo(
+          CipherSuite.AES_CTR_NOPADDING,
+          CryptoProtocolVersion.ENCRYPTION_ZONES,
+          new byte[32],
+          new byte[16],
+          "testkey1",
+          "testkey1@0"
+      );
+      builder.setFileEncryptionInfo(fileEncryptionInfo);
+    }
+
+    return builder.build();
   }
 
   private void mockOmRequest(OzoneManagerProtocolProtos.OMRequest request,
@@ -166,5 +207,39 @@ public class TestOzoneManagerRequestHandler {
       int expectedSize = Math.max(Math.min(Math.min(10, requestSize), resultSize), 0);
       Assertions.assertEquals(expectedSize, omResponse.getListStatusResponse().getStatusesList().size());
     }
+  }
+
+  /**
+   * Test to verify BasicOmKeyInfo encryption field works in listKeysLight.
+   */
+  @Test
+  public void testListKeysLightEncryptionFromOmKeyInfo() throws IOException {
+    // Create OmKeyInfo objects with and without FileEncryptionInfo
+    OmKeyInfo encryptedOmKeyInfo = createOmKeyInfoWithEncryption("encrypted-key", true);
+    OmKeyInfo normalOmKeyInfo = createOmKeyInfoWithEncryption("normal-key", false);
+
+    // Convert to BasicOmKeyInfo
+    BasicOmKeyInfo encryptedBasicKey = BasicOmKeyInfo.fromOmKeyInfo(encryptedOmKeyInfo);
+    BasicOmKeyInfo normalBasicKey = BasicOmKeyInfo.fromOmKeyInfo(normalOmKeyInfo);
+
+    Assertions.assertTrue(encryptedBasicKey.isEncrypted());
+    Assertions.assertFalse(normalBasicKey.isEncrypted());
+
+    List<BasicOmKeyInfo> keyInfos = Arrays.asList(encryptedBasicKey, normalBasicKey);
+    OzoneManagerRequestHandler requestHandler = getRequestHandler(10);
+    OzoneManager ozoneManager = requestHandler.getOzoneManager();
+    Mockito.when(ozoneManager.listKeysLight(Mockito.anyString(), Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+        .thenReturn(new ListKeysLightResult(keyInfos, false));
+    OzoneManagerProtocolProtos.OMRequest request = Mockito.mock(OzoneManagerProtocolProtos.OMRequest.class);
+    mockOmRequest(request, OzoneManagerProtocolProtos.Type.ListKeysLight, 10);
+    OzoneManagerProtocolProtos.OMResponse omResponse = requestHandler.handleReadRequest(request);
+
+    List<OzoneManagerProtocolProtos.BasicKeyInfo> basicKeyInfoList =
+        omResponse.getListKeysLightResponse().getBasicKeyInfoList();
+
+    Assertions.assertEquals(2, basicKeyInfoList.size());
+    Assertions.assertTrue(basicKeyInfoList.get(0).getIsEncrypted(), "encrypted-key should have isEncrypted=true");
+    Assertions.assertFalse(basicKeyInfoList.get(1).getIsEncrypted(), "normal-key should have isEncrypted=false");
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -577,7 +577,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         owner,
         null,
         getBlockLocations(null),
-        false,
+        keyInfo.isEncrypted(),
         OzoneClientUtils.isKeyErasureCode(keyInfo)
     );
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1074,7 +1074,7 @@ public class BasicRootedOzoneClientAdapterImpl
         owner,
         null,
         getBlockLocations(null),
-        false,
+        keyInfo.isEncrypted(),
         OzoneClientUtils.isKeyErasureCode(keyInfo)
     );
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Similar to [HDDS-12094](https://issues.apache.org/jira/browse/HDDS-12094), `ofs.listStatusIterator()` returns FileStatus objects that don't recognise a file is encrypted.
Internally, the method relies on BasicOmKeyInfo returned from OM, which does not have FileEncryptionInfo, and it has no way to tell if a file is encrypted or not.

To keep BasicOmKeyInfo lightweight, added an `isEncrypted` field to BasicOmKeyInfo to identify encrypted files.

## What is the link to the Apache JIRA
[HDDS-13615](https://issues.apache.org/jira/browse/HDDS-13615)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/17359661478
