### PR TITLE
HDDS-13631. Encrypted bucket creation correction on --key option

### DIFF
--- a/hadoop-hdds/docs/content/security/SecuringTDE.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.md
@@ -67,16 +67,16 @@ For example:
 
 ### Creating an Encrypted Bucket
 
-Use the Ozone shell `ozone sh bucket create` command with the `-k` (or `--key`) option to specify the encryption key:
+Use the Ozone shell `ozone sh bucket create` command with the `-k` (or `--bucketkey`) option to specify the encryption key:
 
 ```shell
-  ozone sh bucket create --key <key_name> /<volume_name>/<bucket_name>
+  ozone sh bucket create --bucketkey <key_name> /<volume_name>/<bucket_name>
 ```
 
 For example:
 
 ```shell
-  ozone sh bucket create --key enckey /vol1/encrypted_bucket
+  ozone sh bucket create --bucketkey enckey /vol1/encrypted_bucket
 ```
 
 Now, all data written to `/vol1/encrypted_bucket` will be encrypted at rest. As long as the client is configured correctly to use the key, such encryption is completely transparent to the end users.

--- a/hadoop-hdds/docs/content/security/SecuringTDE.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.md
@@ -132,13 +132,13 @@ When creating an encrypted bucket that will be accessed via S3G:
     The `/s3v` volume is the default volume for S3 buckets.
 
 ```shell
-  ozone sh bucket create --key <key_name> /s3v/<bucket_name> --layout=OBJECT_STORE
+  ozone sh bucket create --bucketkey <key_name> /s3v/<bucket_name> --layout=OBJECT_STORE
 ```
 
 2.  **Alternatively, create an encrypted bucket elsewhere and link it:**
 
 ```shell
-  ozone sh bucket create --key <key_name> /<volume_name>/<bucket_name> --layout=OBJECT_STORE
+  ozone sh bucket create --bucketkey <key_name> /<volume_name>/<bucket_name> --layout=OBJECT_STORE
   ozone sh bucket link /<volume_name>/<bucket_name> /s3v/<link_name>
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The create bucket commands in the doc mentions --key option instead of --bucketkey for creating encrypted bucket. This change is to correct it.

Please describe your PR in detail:
Replaced --key with --bucketkey 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13631 

## How was this patch tested?
Tested in my local cluster