### PR TITLE
HDDS-13638. Update the default backup SST pruning interval to 10min.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -637,7 +637,7 @@ public final class OzoneConfigKeys {
 
   public static final long
       OZONE_OM_SNAPSHOT_PRUNE_COMPACTION_DAG_DAEMON_RUN_INTERVAL_DEFAULT =
-      TimeUnit.HOURS.toMillis(1);
+      TimeUnit.MINUTES.toMillis(10);
 
   public static final String
       OZONE_OM_SNAPSHOT_PRUNE_COMPACTION_BACKUP_BATCH_SIZE =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4412,7 +4412,7 @@
 
   <property>
     <name>ozone.om.snapshot.compaction.dag.prune.daemon.run.interval</name>
-    <value>3600s</value>
+    <value>10m</value>
     <tag>OZONE, OM</tag>
     <description>
       Interval at which compaction DAG pruning daemon thread is running to remove older snapshots with compaction


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated default value of `ozone.om.snapshot.compaction.dag.prune.daemon.run.interval = 10min (1h previous value)` to keep up with AOS rocks DB compaction under production workloads triggering a compaction every few minutes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13638

## How was this patch tested?

Existing tests should not fail
