### PR TITLE
HDDS-13623. Recon UI: Generalize themeIcon to support multiple replication types

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.less
@@ -123,13 +123,20 @@ body {
   .hexagon-shape(20, 12, @orange-7);
 }
 
-.icon-text(@content, @fontcolor) {
+.ec-icon {
+  .hexagon-shape(20, 12, @geekblue-7)
+}
+
+.icon-label-base(@fontcolor) {
   text-align: center;
   font-size: 12px;
   font-weight: 700;
   position: relative;
   top: -3px;
   color: @fontcolor;
+}
+
+.icon-suffix(@content, @fontcolor) {
   &:after {
     content: @content;
     position: absolute;
@@ -143,18 +150,43 @@ body {
   }
 }
 
+.icon-label {
+  .icon-label-base(#ffde36)
+}
+
+.suffix-dot {
+  .icon-suffix(".", #ffde36);
+}
+
+.suffix-ellipsis {
+  .icon-suffix("\2026", #fff);
+}
+
+.icon-ellipsis-leader {
+  .icon-suffix("\2026", #ffde36);
+}
+
+.icon-none {
+  &:after {
+    content: none;
+  }
+}
+
 .icon-text-three-dots {
   // In Unicode, \2026 is the horizontal ellipsis (...)
-  .icon-text("\2026", #fff);
+  .icon-label-base(#fff);
+  .icon-suffix("\2026", #fff);
 }
 
 .icon-text-three-dots-leader {
   // In Unicode, \2026 is the horizontal ellipsis (...)
-  .icon-text("\2026", #ffde36);
+  .icon-label-base(#ffde36);
+  .icon-suffix("\2026", #ffde36);
 }
 
 .icon-text-one-dot {
-  .icon-text(".", #ffde36);
+  .icon-label-base(#ffde36);
+  .icon-suffix(".", #ffde36);
 }
 
 .replication-icon {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx
@@ -19,6 +19,8 @@
 import * as React from 'react';
 import { Tooltip } from 'antd';
 
+const fmtKB = (bytes?: number) =>
+  typeof bytes === 'number' ? `${Math.round(bytes / 1024)}k` : undefined;
 export class FilledIcon extends React.Component {
   render() {
     const path =
@@ -33,19 +35,25 @@ export class FilledIcon extends React.Component {
   }
 }
 
-interface IRatisIconProps {
-  replicationFactor: string;
-  isLeader: boolean;
-}
+export interface IReplicationIconProps {
+  className?: string;
+  replicationType: "RATIS" | "STAND_ALONE" | "EC";
 
-interface IReplicationIconProps {
-  replicationFactor: string;
-  replicationType: string;
-  leaderNode: string;
-  isLeader: boolean;
-}
+  // For RATIS
+  replicationFactor?: "ONE" | "TWO" | "THREE";
+  isLeader?: boolean;
+  leaderNode?: string;
 
-export class RatisIcon extends React.PureComponent<IRatisIconProps> {
+  // For EC
+  ecData?: number;
+  ecParity?: number;
+  ecChunkSize?: number;
+  ecCodec?: string;
+}
+export class RatisIcon extends React.PureComponent<{
+  replicationFactor?: string;
+  isLeader?: boolean;
+}> {
   render() {
     const { replicationFactor, isLeader } = this.props;
     const threeFactorClass = isLeader ? 'icon-text-three-dots-leader' : 'icon-text-three-dots';
@@ -68,33 +76,102 @@ export class StandaloneIcon extends React.PureComponent {
   }
 }
 
+export class ECIcon extends React.PureComponent {
+  render() {
+    return (
+      <div className='ec-icon'>
+        <div className='icon-label suffix-none'>EC</div>
+      </div>
+    );
+  }
+}
+
+// Tooltip for per type
+class RatisTip extends React.PureComponent<Pick<IReplicationIconProps, "replicationFactor" | "leaderNode">> {
+  render() {
+    const { replicationFactor, leaderNode } = this.props;
+    return (
+      <div>
+        <div>Replication Type: RATIS</div>
+        {replicationFactor ? <div>Replication Factor: {replicationFactor}</div> : null}
+        {leaderNode ? <div>Leader Node: {leaderNode}</div> : null}
+      </div>
+    )
+  }
+}
+
+class StandaloneTip extends React.PureComponent {
+  render() {
+    return (
+      <div>
+        <div>Replication Type: STAND_ALONE</div>
+      </div>
+    )
+  }
+}
+
+class ECTip extends React.PureComponent<Pick<IReplicationIconProps, "ecCodec" | "ecData" | "ecParity" | "ecChunkSize">> {
+  static defaultProps = { ecCodec: "RS"};
+  render() {
+    const { ecCodec = 'RS', ecData, ecParity, ecChunkSize } = this.props;
+    const parts = [ecCodec, ecData?.toString(), ecParity?.toString(), fmtKB(ecChunkSize)].filter(Boolean) as string[];
+    return (
+      <div>
+        <div>Replication Type: EC</div>
+        <div>Codec: {ecCodec}</div>
+        {typeof ecData === "number" && typeof ecParity === "number" ? (
+          <div>Data/Parity: {ecData}+{ecParity}</div>
+        ) : null}
+        {typeof ecChunkSize === "number" ? <div>Chunk Size: {fmtKB(ecChunkSize)}</div> : null}
+        {parts.length >= 3 ? <div>Layout: {parts.join('-')}</div> : null}
+      </div>
+    )
+  }
+}
+
 export class ReplicationIcon extends React.PureComponent<IReplicationIconProps> {
   render() {
-    const { replicationType, replicationFactor, isLeader, leaderNode } = this.props;
+    const { replicationType, className } = this.props;
     // Assign icons only for RATIS and STAND_ALONE types
     let icon = null;
+    let tip = null;
+
     if (replicationType === 'RATIS') {
-      icon = <RatisIcon replicationFactor={replicationFactor} isLeader={isLeader} />;
+      icon = (
+        <RatisIcon
+          replicationFactor={this.props.replicationFactor}
+          isLeader={this.props.isLeader}
+        />
+      );
+      tip = (
+        <RatisTip
+          replicationFactor={this.props.replicationFactor}
+          leaderNode={this.props.leaderNode}
+        />
+      )
     } else if (replicationType === 'STAND_ALONE') {
       icon = <StandaloneIcon />;
+      tip = <StandaloneTip />;
+    } else if (replicationType === 'EC') {
+      icon = <ECIcon />;
+      tip = (<ECTip
+        ecCodec={this.props.ecCodec}
+        ecData={this.props.ecData}
+        ecParity={this.props.ecParity}
+        ecChunkSize={this.props.ecChunkSize}
+        />
+      );
     }
 
     // Wrap the icon in a tooltip
-    if (icon) {
-      const tooltip = (
-        <div>
-          <div>Replication Type: {replicationType}</div>
-          <div>Replication Factor: {replicationFactor}</div>
-          <div>Leader Node: {leaderNode}</div>
-        </div>
-      );
-      icon = (
-        <Tooltip title={tooltip} placement='right' className='pointer'>
-          <div className='replication-icon'>{icon}</div>
-        </Tooltip>
-      );
-    }
+    if (!icon) return null;
 
-    return icon;
+    return (
+      <Tooltip title={tip} placement="right" className="pointer">
+        <div className={`replication-icon ${className ?? ''}`.trim()}>{icon}</div>
+      </Tooltip>
+    );
   }
 }
+
+export default ReplicationIcon;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR enhances Recon’s replication “theme icon” system and styles so we can properly visualize EC buckets (alongside existing RATIS/Standalone), and makes the tooltip content informative for each type.

### Code changes

- ```themeIcons.tsx```

    - Add ECIcon and ECTip (shows codec, data+parity, chunk size, and a concise layout string like ```RS-3-2-1024k```).

    - Generalize ```ReplicationIcon``` props:

        - ```replicationType: "RATIS" | "STAND_ALONE" | "EC"```

        - RATIS fields: ```replicationFactor?```, ```isLeader?```, ```leaderNode?```

        - EC fields: ```ecCodec?```, ```ecData?```, ```ecParity?```, ```ecChunkSize?```

        - Optional ```className``` for callers.

    - Keep RATIS/Standalone rendering, but route tooltips per type.

- ```app.less```

    - Add ```.ec-icon``` hexagon style (geekblue).

    - Split previous .icon-text into reusable building blocks:

        - ```.icon-label-base(@color)``` and ```.icon-suffix(@content, @color)```

        - Re-express ```.icon-text-one-dot```, ```.icon-text-three-dots```, ```.icon-text-three-dots-leader```

    - Ensure RATIS(THREE) leader style uses the yellow text variant.

### Screenshots
- Icon
<img width="208" height="340" alt="themeIcon_overall" src="https://github.com/user-attachments/assets/c9d1af33-efb5-4784-a5f4-1ba8dfba6c18" />

- EC Icon w/ tooltip
<img width="252" height="191" alt="themeIcon_ec_tooltips" src="https://github.com/user-attachments/assets/a6e93337-7115-4e5f-815a-0eebfbeb77cf" />

- Ratis Icon w/ tooltip
<img width="262" height="86" alt="themeIcon_ratis_tooltips" src="https://github.com/user-attachments/assets/9c19f076-0fa1-4845-8920-0ab070f9e1d7" />


 ### Why?
Recon UI didn’t have an EC visual language. This adds EC iconography and tooltips consistent with RATIS, and prepares the UI to consume ```replicationConfigInfo``` from the bucket list.

 ### Files changed

```hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.less```

```hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx```

## What is the link to the Apache JIRA
[https://issues.apache.org/jira/browse/HDDS-13623](https://issues.apache.org/jira/browse/HDDS-13623)