### PR TITLE
HDDS-13649. [DiskBalancer] Refine Disk Balancer CLI, Documentation, and Naming for Improved Usability

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/DiskBalancerConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/DiskBalancerConfiguration.java
@@ -53,7 +53,7 @@ public final class DiskBalancerConfiguration {
           " of the entire datanode) no more than the threshold.")
   private double threshold = 10d;
 
-  @Config(key = "max.disk.throughputInMBPerSec", type = ConfigType.LONG,
+  @Config(key = "max.disk.throughput.mb.per.sec", type = ConfigType.LONG,
       defaultValue = "10", tags = {ConfigTag.DISKBALANCER},
       description = "The max balance speed.")
   private long diskBandwidthInMB = 10;

--- a/hadoop-hdds/docs/content/design/diskbalancer.md
+++ b/hadoop-hdds/docs/content/design/diskbalancer.md
@@ -129,6 +129,11 @@ The feature can be enabled by setting the following property to `true` in the `o
 Developers who wish to test or use the Disk Balancer must explicitly enable it. Once the feature is 
 considered stable, the default value may be changed to `true` in a future release.
 
+**Note:** This command is hidden from the main help message (`ozone admin datanode --help`). This is because the feature
+is currently considered experimental and is disabled by default. Hiding the command prevents accidental use and keeps
+the help output clean for general users. The command is, however, fully functional for those who wish to enable and use
+the feature.
+
 ## DiskBalancer Metrics
 
 The DiskBalancer service exposes JMX metrics on each Datanode for real-time monitoring. These metrics provide insights

--- a/hadoop-hdds/docs/content/feature/DiskBalancer.md
+++ b/hadoop-hdds/docs/content/feature/DiskBalancer.md
@@ -41,8 +41,21 @@ A disk is considered a candidate for balancing if its
 
 ![Data spread across disks](diskBalancer.png)
 
+## Feature Flag
+
+The Disk Balancer feature is introduced with a feature flag. By default, this feature is disabled to prevent it from
+running until it has undergone thorough testing.
+
+The feature can be **enabled** by setting the following property to `true` in the `ozone-site.xml` configuration file:
+`hdds.datanode.disk.balancer.enabled = false`
+
 ## Command Line Usage
 The DiskBalancer is managed through the `ozone admin datanode diskbalancer` command.
+
+**Note:** This command is hidden from the main help message (`ozone admin datanode --help`). This is because the feature
+is currently considered experimental and is disabled by default. Hiding the command prevents accidental use and keeps
+the help output clean for general users. The command is, however, fully functional for those who wish to enable and use
+the feature.
 
 ### **Start DiskBalancer**
 To start diskBalancer on all Datanodes with default configurations :
@@ -65,14 +78,14 @@ ozone admin datanode diskbalancer update [options]
 ```
 **Options include:**
 
-| Options                               | Description                                                                                           |                                                                                                                                                             
-|---------------------------------------|-------------------------------------------------------------------------------------------------------|
-| `-t, --threshold`                     | Percentage deviation from average utilization of the disks after which a datanode will be rebalanced. |
-| `-b, --bandwithInMB`                  | Maximum bandwidth for DiskBalancer per second.                                                        |
-| `-p, --parallelThread`                | Max parallelThread for DiskBalancer.                                                                  |
-| `-s, --stop-after-disk-even`          | Stop DiskBalancer automatically after disk utilization is even.                                       |
-| `-a, --all`                           | Run commands on all datanodes.                                                                        |
-| `-d, --datanodes`                     | Run commands on specific datanodes                                                                    |
+| Options                      | Description                                                                                           |                                                                                                                                                             
+|------------------------------|-------------------------------------------------------------------------------------------------------|
+| `-t, --threshold`            | Percentage deviation from average utilization of the disks after which a datanode will be rebalanced. |
+| `-b, --bandwith-in-mb`       | Maximum bandwidth for DiskBalancer per second.                                                        |
+| `-p, --parallel-thread`      | Max parallelThread for DiskBalancer.                                                                  |
+| `-s, --stop-after-disk-even` | Stop DiskBalancer automatically after disk utilization is even.                                       |
+| `-a, --all`                  | Run commands on all datanodes.                                                                        |
+| `-d, --datanodes`            | Run commands on specific datanodes                                                                    |
 
 ### **Stop DiskBalancer**
 To stop DiskBalancer on all Datanodes:
@@ -108,16 +121,16 @@ ozone admin datanode diskbalancer report --count <N>
 
 The DiskBalancer's behavior can be controlled using the following configuration properties in `ozone-site.xml`.
 
-| Property                                                    | Default Value                                                                          | Description                                                                                                                                                               |
-|-------------------------------------------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `hdds.datanode.disk.balancer.enabled`                       | `false`                                                                                | if false, the DiskBalancer service on the Datanode is disabled. Configure it to true for diskBalancer to be enabled.                                                      |                                                            |                                                                                        |                                                                                                                                                                              |
-| `hdds.datanode.disk.balancer.volume.density.threshold`      | `10.0`                                                                                 | A percentage (0-100). A datanode is considered balanced if for each volume, its utilization differs from the average datanode utilization by no more than this threshold. |
-| `hdds.datanode.disk.balancer.max.disk.throughputInMBPerSec` | `10`                                                                                   | The maximum bandwidth (in MB/s) that the balancer can use for moving data, to avoid impacting client I/O.                                                                 |
-| `hdds.datanode.disk.balancer.parallel.thread`               | `5`                                                                                    | The number of worker threads to use for moving containers in parallel.                                                                                                    |
-| `hdds.datanode.disk.balancer.service.interval`              | `60s`                                                                                  | The time interval at which the Datanode DiskBalancer service checks for imbalance and updates its configuration.                                                          |
-| `hdds.datanode.disk.balancer.stop.after.disk.even`          | `true`                                                                                 | If true, the DiskBalancer will automatically stop its balancing activity once disks are considered balanced (i.e., all volume densities are within the threshold).        |
-| `hdds.datanode.disk.balancer.volume.choosing.policy`        | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultVolumeChoosingPolicy`    | The policy class for selecting source and destination volumes for balancing.                                                                                              |
-| `hdds.datanode.disk.balancer.container.choosing.policy`     | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultContainerChoosingPolicy` | The policy class for selecting which containers to move from a source volume to destination volume.                                                                       |
-| `hdds.datanode.disk.balancer.service.timeout`               | `300s`                                                                                 | Timeout for the Datanode DiskBalancer service operations.                                                                                                                 |
-| `hdds.datanode.disk.balancer.should.run.default`            | `false`                                                                                | If the balancer fails to read its persisted configuration, this value determines if the service should run by default.                                                    |
+| Property                                                     | Default Value                                                                          | Description                                                                                                                                                               |
+|--------------------------------------------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `hdds.datanode.disk.balancer.enabled`                        | `false`                                                                                | if false, the DiskBalancer service on the Datanode is disabled. Configure it to true for diskBalancer to be enabled.                                                      |                                                            |                                                                                        |                                                                                                                                                                              |
+| `hdds.datanode.disk.balancer.volume.density.threshold`       | `10.0`                                                                                 | A percentage (0-100). A datanode is considered balanced if for each volume, its utilization differs from the average datanode utilization by no more than this threshold. |
+| `hdds.datanode.disk.balancer.max.disk.throughput.mb.per.sec` | `10`                                                                                   | The maximum bandwidth (in MB/s) that the balancer can use for moving data, to avoid impacting client I/O.                                                                 |
+| `hdds.datanode.disk.balancer.parallel.thread`                | `5`                                                                                    | The number of worker threads to use for moving containers in parallel.                                                                                                    |
+| `hdds.datanode.disk.balancer.service.interval`               | `60s`                                                                                  | The time interval at which the Datanode DiskBalancer service checks for imbalance and updates its configuration.                                                          |
+| `hdds.datanode.disk.balancer.stop.after.disk.even`           | `true`                                                                                 | If true, the DiskBalancer will automatically stop its balancing activity once disks are considered balanced (i.e., all volume densities are within the threshold).        |
+| `hdds.datanode.disk.balancer.volume.choosing.policy`         | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultVolumeChoosingPolicy`    | The policy class for selecting source and destination volumes for balancing.                                                                                              |
+| `hdds.datanode.disk.balancer.container.choosing.policy`      | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultContainerChoosingPolicy` | The policy class for selecting which containers to move from a source volume to destination volume.                                                                       |
+| `hdds.datanode.disk.balancer.service.timeout`                | `300s`                                                                                 | Timeout for the Datanode DiskBalancer service operations.                                                                                                                 |
+| `hdds.datanode.disk.balancer.should.run.default`             | `false`                                                                                | If the balancer fails to read its persisted configuration, this value determines if the service should run by default.                                                    |
 

--- a/hadoop-hdds/docs/content/feature/DiskBalancer.zh.md
+++ b/hadoop-hdds/docs/content/feature/DiskBalancer.zh.md
@@ -37,8 +37,18 @@ summary: 数据节点的磁盘平衡器.
 
 ![Disk Even](diskBalancer.png)
 
+## 功能标记
+
+磁盘平衡器功能已通过功能标记引入。默认情况下，此功能处于禁用状态，以防止其在经过全面测试之前运行。
+
+可以通过在“ozone-site.xml”配置文件中将以下属性设置为“true”来**启用**该功能：
+`hdds.datanode.disk.balancer.enabled = false`
+
 ## 命令行用法
 DiskBalancer 通过 `ozone admin datanode diskbalancer` 命令进行管理。
+
+**注意：**此命令在主帮助信息（`ozone admin datanode --help`）中隐藏。这是因为该功能目前处于实验阶段，默认禁用。隐藏该命令可防止意外使用，
+并为普通用户提供清晰的帮助输出。但是，对于希望启用和使用该功能的用户，该命令仍然完全可用。
 
 ### **启动 DiskBalancer**
 要在所有 Datanode 上使用默认配置启动 DiskBalancer，请执行以下操作：
@@ -102,16 +112,16 @@ ozone admin datanode diskbalancer report --count <N>
 
 The DiskBalancer's behavior can be controlled using the following configuration properties in `ozone-site.xml`.
 
-| Property                                                    | Default Value                          | Description                                                                                                                                                                 |
-|-------------------------------------------------------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `hdds.datanode.disk.balancer.enabled`                       | `false`                                | 如果为 false，则 Datanode 上的 DiskBalancer 服务将被禁用。将其配置为 true 可启用 DiskBalancer。                                                      |                                                            |                                                                                        |                                                                                                                                                                              |
-| `hdds.datanode.disk.balancer.volume.density.threshold`      | `10.0`                                 | 百分比（0-100）。如果对于每个卷，其利用率与平均数据节点利用率之差不超过此阈值，则认为数据节点处于平衡状态。    |
-| `hdds.datanode.disk.balancer.max.disk.throughputInMBPerSec` | `10`                                   | 平衡器可用于移动数据的最大带宽（以 MB/s 为单位），以避免影响客户端 I/O。                                                                    |
-| `hdds.datanode.disk.balancer.parallel.thread`               | `5`                                    | 用于并行移动容器的工作线程数。                                                                                                       |
-| `hdds.datanode.disk.balancer.service.interval`              | `60s`                                  | Datanode DiskBalancer 服务检查不平衡并更新其配置的时间间隔。                                                             |
-| `hdds.datanode.disk.balancer.stop.after.disk.even`          | `true`                                 | 如果为真，则一旦磁盘被视为平衡（即所有卷密度都在阈值内），DiskBalancer 将自动停止其平衡活动。           |
-| `hdds.datanode.disk.balancer.volume.choosing.policy`        | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultVolumeChoosingPolicy` | 用于选择平衡的源卷和目标卷的策略类。                                                                                                 |
-| `hdds.datanode.disk.balancer.container.choosing.policy`     | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultContainerChoosingPolicy` | 用于选择将哪些容器从源卷移动到目标卷的策略类。                                                                         |
-| `hdds.datanode.disk.balancer.service.timeout`               | `300s`                                 | Datanode DiskBalancer 服务操作超时。                                                                                                                    |
-| `hdds.datanode.disk.balancer.should.run.default`            | `false`                                | 如果平衡器无法读取其持久配置，则该值决定服务是否应默认运行。                                                       |
+| Property                                                     | Default Value                          | Description                                                                                                                                                                 |
+|--------------------------------------------------------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `hdds.datanode.disk.balancer.enabled`                        | `false`                                | 如果为 false，则 Datanode 上的 DiskBalancer 服务将被禁用。将其配置为 true 可启用 DiskBalancer。                                                      |                                                            |                                                                                        |                                                                                                                                                                              |
+| `hdds.datanode.disk.balancer.volume.density.threshold`       | `10.0`                                 | 百分比（0-100）。如果对于每个卷，其利用率与平均数据节点利用率之差不超过此阈值，则认为数据节点处于平衡状态。    |
+| `hdds.datanode.disk.balancer.max.disk.throughput.mb.per.sec` | `10`                                   | 平衡器可用于移动数据的最大带宽（以 MB/s 为单位），以避免影响客户端 I/O。                                                                    |
+| `hdds.datanode.disk.balancer.parallel.thread`                | `5`                                    | 用于并行移动容器的工作线程数。                                                                                                       |
+| `hdds.datanode.disk.balancer.service.interval`               | `60s`                                  | Datanode DiskBalancer 服务检查不平衡并更新其配置的时间间隔。                                                             |
+| `hdds.datanode.disk.balancer.stop.after.disk.even`           | `true`                                 | 如果为真，则一旦磁盘被视为平衡（即所有卷密度都在阈值内），DiskBalancer 将自动停止其平衡活动。           |
+| `hdds.datanode.disk.balancer.volume.choosing.policy`         | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultVolumeChoosingPolicy` | 用于选择平衡的源卷和目标卷的策略类。                                                                                                 |
+| `hdds.datanode.disk.balancer.container.choosing.policy`      | `org.apache.hadoop.ozone.container.diskbalancer.policy.DefaultContainerChoosingPolicy` | 用于选择将哪些容器从源卷移动到目标卷的策略类。                                                                         |
+| `hdds.datanode.disk.balancer.service.timeout`                | `300s`                                 | Datanode DiskBalancer 服务操作超时。                                                                                                                    |
+| `hdds.datanode.disk.balancer.should.run.default`             | `false`                                | 如果平衡器无法读取其持久配置，则该值决定服务是否应默认运行。                                                       |
 

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -86,7 +86,7 @@ message ScmContainerLocationRequest {
   optional GetMetricsRequestProto getMetricsRequest = 47;
   optional ContainerBalancerStatusInfoRequestProto containerBalancerStatusInfoRequest = 48;
   optional ReconcileContainerRequestProto reconcileContainerRequest = 49;
-  optional DatanodeDiskBalancerInfoRequestProto DatanodeDiskBalancerInfoRequest = 50;
+  optional DatanodeDiskBalancerInfoRequestProto datanodeDiskBalancerInfoRequest = 50;
   optional DatanodeDiskBalancerOpRequestProto datanodeDiskBalancerOpRequest = 51;
 }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommands.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommands.java
@@ -32,8 +32,8 @@ import picocli.CommandLine.Command;
  * To start:
  *      ozone admin datanode diskbalancer start
  *      [ -t/--threshold {@literal <threshold>}]
- *      [ -b/--bandwidthInMB {@literal <bandwidthInMB>}]
- *      [ -p/--parallelThread {@literal <parallelThread>}]
+ *      [ -b/--bandwidth-in-mb {@literal <bandwidthInMB>}]
+ *      [ -p/--parallel-thread {@literal <parallelThread>}]
  *      [ -s/--stop-after-disk-even {@literal <stopAfterDiskEven>}]
  *      [ -a/--all {@literal <alldatanodes>}]
  *      [ -d/--datanodes {@literal <datanodes>}]
@@ -78,9 +78,11 @@ import picocli.CommandLine.Command;
 
 @Command(
     name = "diskbalancer",
-    description = "DiskBalancer specific operations",
+    description = "DiskBalancer specific operations. It is disabled by default." +
+        " To enable it, set 'hdds.datanode.disk.balancer.enabled' as true",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class,
+    hidden = true,
     subcommands = {
         DiskBalancerStartSubcommand.class,
         DiskBalancerStopSubcommand.class,

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommonOptions.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommonOptions.java
@@ -33,7 +33,8 @@ public class DiskBalancerCommonOptions {
   @CommandLine.Option(names = {"-d", "--datanodes"},
       description = "Run commands on specific datanodes, the content can be " +
           "a list of hostnames or IPs. " +
-          "Examples: hostname1,hostname2,hostname3 or ip1,ip2,ip3")
+          "Examples: hostname1,hostname2,hostname3 or ip1,ip2,ip3",
+      split = ",")
   private List<String> datanodes = new ArrayList<>();
 
   /**

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
@@ -44,11 +44,11 @@ public class DiskBalancerStartSubcommand extends ScmSubcommand {
           "example, '10' for 10%%).")
   private Double threshold;
 
-  @Option(names = {"-b", "--bandwidthInMB"},
+  @Option(names = {"-b", "--bandwidth-in-mb"},
       description = "Maximum bandwidth for DiskBalancer per second.")
   private Long bandwidthInMB;
 
-  @Option(names = {"-p", "--parallelThread"},
+  @Option(names = {"-p", "--parallel-thread"},
       description = "Max parallelThread for DiskBalancer.")
   private Integer parallelThread;
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
@@ -44,11 +44,11 @@ public class DiskBalancerUpdateSubcommand extends ScmSubcommand {
           "example, '10' for 10%%).")
   private Double threshold;
 
-  @Option(names = {"-b", "--bandwidthInMB"},
+  @Option(names = {"-b", "--bandwidth-in-mb"},
       description = "Maximum bandwidth for DiskBalancer per second.")
   private Long bandwidthInMB;
 
-  @Option(names = {"-p", "--parallelThread"},
+  @Option(names = {"-p", "--parallel-thread"},
       description = "Max parallelThread for DiskBalancer.")
   private Integer parallelThread;
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

1. naming of variable DatanodeDiskBalancerInfoRequest should start with small letter, same for DatanodeDiskBalancerInfoResponse
2. Update the config description added in https://github.com/apache/ozone/pull/8869 to indicate the same.
3. Update the CLI help message to indicate the same.
4. Hide the CLI so it does not appear in help messages.
5. fix misleading description for running on multipleDatanodes.
6. make all the CLI flags kebab-case. They are using a mix of kebab and camel case right now. 
7. config can be named as, max.disk.throughput.mb.per.sec

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13649

## How was this patch tested?

Tested locally on docker.
```
bash-5.1$ ozone admin datanode -h
Usage: ozone admin datanode [-hV] [--verbose] [COMMAND]
Datanode specific operations
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
      --verbose   More verbose output. Show the stack trace of the errors.
Commands:
  list          List info of datanodes
  decommission  Decommission a datanode
  maintenance   Put a datanode into Maintenance Mode
  recommission  Return a datanode to service
  status        Show status of datanodes
  usageinfo     List usage information (such as Capacity, SCMUsed, Remaining)
                  of a datanode by IP address or Host name or UUID
bash-5.1$ ozone admin datanode diskbalancer -h
Usage: ozone admin datanode diskbalancer [-hV] [--verbose] [COMMAND]
DiskBalancer specific operations. It is disabled by deafult. To enable it, set
'hdds.datanode.disk.balancer.enabled' as true
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
      --verbose   More verbose output. Show the stack trace of the errors.
Commands:
  start   Start DiskBalancer
  stop    Stop DiskBalancer
  update  Update DiskBalancer Configuration
  report  Get Datanode Volume Density Report
  status  Get Datanode DiskBalancer Status for inServiceHealthy DNs
bash-5.1$ 
```

```
bash-5.1$ ozone admin datanode diskbalancer update -t 20 -b 30 -p 12 -d ozone-datanode-4,ozone-datanode-5,ozone-datanode-3 
Update DiskBalancer Configuration on datanode(s):
ozone-datanode-4
ozone-datanode-5
ozone-datanode-3
bash-5.1$ ozone admin datanode diskbalancer status
Status result:
Datanode                            Status          Threshold(%)    BandwidthInMB   Threads      SuccessMove  FailureMove  BytesMoved(MB)  EstBytesToMove(MB) EstTimeLeft(min)
ozone-datanode-3.ozone_default      STOPPED         20.0000         30              12           0            0            0               0               0              
ozone-datanode-1.ozone_default      STOPPED         10.0000         10              5            0            0            0               0               0              
ozone-datanode-2.ozone_default      STOPPED         10.0000         10              5            0            0            0               0               0              
ozone-datanode-5.ozone_default      STOPPED         20.0000         30              12           0            0            0               0               0              
ozone-datanode-4.ozone_default      STOPPED         20.0000         30              12           0            0            0               0               0              

Note: Estimated time left is calculated based on the estimated bytes to move and the configured disk bandwidth.
```
