### PR TITLE
HDDS-13652. Enable Atomic Rewrite Key feature by default for Ozone Manager.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/compatibility/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/docker-config
@@ -31,7 +31,7 @@ OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
-OZONE-SITE.XML_ozone.om.features.disabled=ATOMIC_REWRITE_KEY
+OZONE-SITE.XML_ozone.om.features.disabled=NONE
 
 HADOOP_OPTS="-Dhadoop.opts=test"
 HDFS_STORAGECONTAINERMANAGER_OPTS="-Dhdfs.scm.opts=test"


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is just to enable the Atomic Rewrite Key feature by default for Ozone Manager.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13652

## How was this patch tested?
Existing Junit and docker robot tests.
