### PR TITLE
HDDS-13656. Fix aspectj settings for java9-or-later compilation

### DIFF
--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -453,17 +453,24 @@
         <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
           <argumentFileDirectory>${project.build.directory}/aspectj-build</argumentFileDirectory>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjtools</artifactId>
+            <version>${aspectj.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>
               <goal>compile</goal>
             </goals>
             <configuration>
-              <complianceLevel>1.8</complianceLevel>
+              <complianceLevel>${maven.compiler.source}</complianceLevel>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <aopalliance.version>1.0</aopalliance.version>
     <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version>
     <aspectj-plugin.version>1.14.1</aspectj-plugin.version>
+    <aspectj.java9.version>1.9.24</aspectj.java9.version>
     <aspectj.version>1.9.7</aspectj.version>
     <assertj.version>3.27.4</assertj.version>
     <aws-java-sdk.version>1.12.788</aws-java-sdk.version>
@@ -2688,7 +2689,10 @@
       </activation>
       <properties>
         <!-- supported since Java 9 -->
+        <aspectj.version>${aspectj.java9.version}</aspectj.version>
         <maven.compiler.release>${javac.version}</maven.compiler.release>
+        <maven.compiler.source>${javac.version}</maven.compiler.source>
+        <maven.compiler.target>${javac.version}</maven.compiler.target>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
     <aopalliance.version>1.0</aopalliance.version>
     <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version>
     <aspectj-plugin.version>1.14.1</aspectj-plugin.version>
-    <aspectj.java9.version>1.9.24</aspectj.java9.version>
+    <aspectj.java11.version>1.9.20</aspectj.java11.version>
+    <aspectj.java21.version>1.9.24</aspectj.java21.version>
     <aspectj.version>1.9.7</aspectj.version>
     <assertj.version>3.27.4</assertj.version>
     <aws-java-sdk.version>1.12.788</aws-java-sdk.version>
@@ -2683,13 +2684,24 @@
       </properties>
     </profile>
     <profile>
-      <id>java9-or-later</id>
+      <id>java11-20</id>
+      <activation><jdk>[11,20]</jdk></activation>
+      <properties>
+        <aspectj.version>${aspectj.java11.version}</aspectj.version>
+        <!-- supported since Java 9 -->
+        <maven.compiler.release>${javac.version}</maven.compiler.release>
+        <maven.compiler.source>${javac.version}</maven.compiler.source>
+        <maven.compiler.target>${javac.version}</maven.compiler.target>
+      </properties>
+    </profile>
+    <profile>
+      <id>java21-or-later</id>
       <activation>
-        <jdk>[9,]</jdk>
+        <jdk>[21,]</jdk>
       </activation>
       <properties>
+        <aspectj.version>${aspectj.java21.version}</aspectj.version>
         <!-- supported since Java 9 -->
-        <aspectj.version>${aspectj.java9.version}</aspectj.version>
         <maven.compiler.release>${javac.version}</maven.compiler.release>
         <maven.compiler.source>${javac.version}</maven.compiler.source>
         <maven.compiler.target>${javac.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -2685,7 +2685,9 @@
     </profile>
     <profile>
       <id>java11-20</id>
-      <activation><jdk>[11,20]</jdk></activation>
+      <activation>
+        <jdk>[11,20]</jdk>
+      </activation>
       <properties>
         <aspectj.version>${aspectj.java11.version}</aspectj.version>
         <!-- supported since Java 9 -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

The jdk version is set to 1.8 by aspect-maven-plugin, this ticket is fix the settings related to aspectj so that we can use user specified jdk for compilation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13656

## How was this patch tested?

```
MUST_HAVE=OzoneManagerStarter
javap -verbose "$(find . -type f -name ${MUST_HAVE}.class -print -quit)" 2>/dev/null | awk '/major version/{print $3; exit}'
```
The result should be based on "javac.version", thus not stick to 52.
