### PR TITLE
HDDS-13659. Recon frontend build not skipped with skipRecon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2697,8 +2697,8 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.shade.skip>true</maven.shade.skip>
         <mdep.analyze.skip>true</mdep.analyze.skip>
-        <skip.installnodenpm>true</skip.installnodenpm>
-        <skip.npx>true</skip.npx>
+        <skip.installnodepnpm>true</skip.installnodepnpm>
+        <skip.pnpm>true</skip.pnpm>
         <skipDocs>true</skipDocs>
         <test>void</test>
       </properties>
@@ -2711,8 +2711,8 @@
         </property>
       </activation>
       <properties>
-        <skip.installnodenpm>true</skip.installnodenpm>
-        <skip.npx>true</skip.npx>
+        <skip.installnodepnpm>true</skip.installnodepnpm>
+        <skip.pnpm>true</skip.pnpm>
       </properties>
     </profile>
     <!-- The following profiles define test splits for CI -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-13620 changed frontend build, but properties to skip it in profiles were not updated.  Thus, Recon frontend is always built.

```
$ mvn -DskipTests -DskipRecon -am -pl :ozone-recon clean verify
...
[INFO] --- frontend:1.15.1:install-node-and-pnpm (Install node and npm locally to the project) @ ozone-recon ---
...
[INFO] Installed pnpm locally.
...
[INFO] --- frontend:1.15.1:pnpm (install frontend dependencies) @ ozone-recon ---
...
[INFO] Done in 1.5s
...
[INFO] --- frontend:1.15.1:pnpm (Build frontend) @ ozone-recon ---
...
[INFO] ✓ built in 11.84s
...
[INFO] Apache Ozone Recon ................................. SUCCESS [ 23.734 s]
```

https://issues.apache.org/jira/browse/HDDS-13659

## How was this patch tested?

```
$ mvn -DskipTests -DskipRecon -am -pl :ozone-recon clean verify
...
[INFO] --- frontend:1.15.1:install-node-and-pnpm (Install node and npm locally to the project) @ ozone-recon ---
[INFO] Skipping execution.
...
[INFO] --- frontend:1.15.1:pnpm (install frontend dependencies) @ ozone-recon ---
[INFO] Skipping execution.
[INFO] 
[INFO] --- frontend:1.15.1:pnpm (Build frontend) @ ozone-recon ---
[INFO] Skipping execution.
[INFO] 
...
[INFO] Apache Ozone Recon ................................. SUCCESS [  4.863 s]
```

https://github.com/adoroszlai/ozone/actions/runs/17552143858
