### PR TITLE
HDDS-13621. NPE in OzoneManagerRatisServer.checkRetryCache

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -538,7 +538,7 @@ public final class OzoneManagerRatisServer {
     //cache hit
     try {
       RaftClientReply reply = cacheEntry.getReplyFuture().get();
-      if(!reply.isSuccess()) {
+      if (!reply.isSuccess()) {
         return null;
       }
       return getOMResponse(reply);


### PR DESCRIPTION
In HDDS-11558, we introduced a retry idempotent. If a retry came from the client, we always want to return the existing reply. But it doesn't cover the case when a failed request landed in the retry cache. In this case, we can't build the response properly, and NPE is thrown. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13621

## How was this patch tested?
ozone freon ommg on the cluster where the OM process is continuously struggling from the JVM pauses. Without the patch, the retry operation never succeeded, so the number of correct writes was always less than expected. With the provided patch, the success rate of retries was always 100%. 
I attempted to create a unit test, but I found it quite challenging to replicate the scenario where a pause occurs after the request passes the check for the active leader. As a result, the request ended up in the RetryCache, but it failed due to the absence of a leader after that.