### PR TITLE
HDDS-13593. Make container ListSubcommand use JsonUtils#getStdoutSequenceWriter

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
@@ -118,7 +118,6 @@ public class ListSubcommand extends ScmSubcommand {
 
     // Use SequenceWriter to output JSON array format for all cases
     SequenceWriter sequenceWriter = JsonUtils.getStdoutSequenceWriter();
-    sequenceWriter.init(true); // Initialize as a JSON array
 
     if (!all) {
       // Regular listing with count limit


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make container ListSubcommand to use the new JsonUtils#getStdoutSequenceWriter helper method, which prevents premature stream closure.

## What is the link to the Apache JIRA

[HDDS-13593](https://issues.apache.org/jira/browse/HDDS-13593)

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/17602723703
