### PR TITLE
HDDS-13618. Avoid frequent pipeline close action from DN

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Queue;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -70,6 +71,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.ClosePipelineCommandHandler;
 import org.apache.hadoop.ozone.container.common.states.DatanodeState;
 import org.apache.hadoop.ozone.container.common.states.datanode.InitDatanodeState;
 import org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState;
@@ -805,6 +807,12 @@ public class StateContext {
       lock.unlock();
     }
     return summary;
+  }
+
+  public boolean isPipelineCloseInProgress(UUID pipelineID) {
+    ClosePipelineCommandHandler handler = parentDatanodeStateMachine.getCommandDispatcher()
+        .getClosePipelineCommandHandler();
+    return handler.isPipelineInProgress(pipelineID);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -812,7 +812,7 @@ public class StateContext {
   public boolean isPipelineCloseInProgress(UUID pipelineID) {
     ClosePipelineCommandHandler handler = parentDatanodeStateMachine.getCommandDispatcher()
         .getClosePipelineCommandHandler();
-    return handler.isPipelineInProgress(pipelineID);
+    return handler.isPipelineCloseInProgress(pipelineID);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -91,11 +91,11 @@ public class ClosePipelineCommandHandler implements CommandHandler {
   }
 
   /**
-   * Returns true if pipeline is in progress, else false.
+   * Returns true if pipeline close is in progress, else false.
    *
    * @return boolean
    */
-  public boolean isPipelineInProgress(UUID pipelineID) {
+  public boolean isPipelineCloseInProgress(UUID pipelineID) {
     return pipelinesInProgress.contains(pipelineID);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -91,6 +91,15 @@ public class ClosePipelineCommandHandler implements CommandHandler {
   }
 
   /**
+   * Returns true if pipeline is in progress, else false.
+   *
+   * @return boolean
+   */
+  public boolean isPipelineInProgress(UUID pipelineID) {
+    return pipelinesInProgress.contains(pipelineID);
+  }
+
+  /**
    * Handles a given SCM command.
    *
    * @param command           - SCM Command

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
@@ -80,7 +80,6 @@ public final class CommandDispatcher {
     return handlerMap.get(Type.deleteBlocksCommand);
   }
 
-  @VisibleForTesting
   public ClosePipelineCommandHandler getClosePipelineCommandHandler() {
     return (ClosePipelineCommandHandler) handlerMap.get(Type.closePipelineCommand);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
@@ -80,6 +80,11 @@ public final class CommandDispatcher {
     return handlerMap.get(Type.deleteBlocksCommand);
   }
 
+  @VisibleForTesting
+  public ClosePipelineCommandHandler getClosePipelineCommandHandler() {
+    return (ClosePipelineCommandHandler) handlerMap.get(Type.closePipelineCommand);
+  }
+
   /**
    * Dispatch the command to the correct handler.
    *

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -741,7 +741,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     triggerPipelineClose(groupId, b.toString(), ClosePipelineInfo.Reason.PIPELINE_FAILED);
   }
 
-  private void triggerPipelineClose(RaftGroupId groupId, String detail,
+  @VisibleForTesting
+  public void triggerPipelineClose(RaftGroupId groupId, String detail,
       ClosePipelineInfo.Reason reasonCode) {
     PipelineID pipelineID = PipelineID.valueOf(groupId.getUuid());
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -744,6 +744,15 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   private void triggerPipelineClose(RaftGroupId groupId, String detail,
       ClosePipelineInfo.Reason reasonCode) {
     PipelineID pipelineID = PipelineID.valueOf(groupId.getUuid());
+
+    if (context != null) {
+      if (context.isPipelineCloseInProgress(pipelineID.getId())) {
+        LOG.debug("Skipped triggering pipeline close for {} as it is already in progress. Reason: {}",
+            pipelineID.getId(), detail);
+        return;
+      }
+    }
+
     ClosePipelineInfo.Builder closePipelineInfo =
         ClosePipelineInfo.newBuilder()
             .setPipelineID(pipelineID.getProtobuf())

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestClosePipelineCommandHandler.java
@@ -176,7 +176,7 @@ public class TestClosePipelineCommandHandler {
 
     final ClosePipelineCommandHandler commandHandler =
         new ClosePipelineCommandHandler((leader, tls) -> raftClient, singleThreadExecutor);
-    assertFalse(commandHandler.isPipelineInProgress(pipelineUUID));
+    assertFalse(commandHandler.isPipelineCloseInProgress(pipelineUUID));
     commandHandler.handle(command1, ozoneContainer, stateContext, connectionManager);
     assertTrue(firstCommandStarted.await(5, TimeUnit.SECONDS));
     commandHandler.handle(command2, ozoneContainer, stateContext, connectionManager);
@@ -187,7 +187,7 @@ public class TestClosePipelineCommandHandler {
     
     // Only one command should have been processed due to duplicate prevention
     assertEquals(1, commandHandler.getInvocationCount());
-    assertFalse(commandHandler.isPipelineInProgress(pipelineUUID));
+    assertFalse(commandHandler.isPipelineCloseInProgress(pipelineUUID));
   }
 
   private List<DatanodeDetails> getDatanodes() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -27,11 +27,13 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -39,6 +41,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -56,6 +59,8 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.ClosePipelineCommandHandler;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
@@ -66,6 +71,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.event.Level;
 
 /**
  * Tests for Pipeline Closing.
@@ -254,6 +260,39 @@ public class TestPipelineClose {
 
     // match the pipeline id
     verifyCloseForPipeline(openPipeline, actionsFromDatanode);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testDuplicatePipelineClosePrevention() throws Exception {
+    DatanodeStateMachine datanodeStateMachine = cluster.getHddsDatanodes().get(0).getDatanodeStateMachine();
+    XceiverServerRatis xceiverRatis = (XceiverServerRatis) datanodeStateMachine.getContainer().getWriteChannel();
+
+    GenericTestUtils.setLogLevel(XceiverServerRatis.class, Level.DEBUG);
+    GenericTestUtils.LogCapturer xceiverLogCapturer =
+        GenericTestUtils.LogCapturer.captureLogs(XceiverServerRatis.class);
+
+    RaftGroupId groupId = RaftGroupId.valueOf(ratisContainer.getPipeline().getId().getId());
+    PipelineID pipelineID = PipelineID.valueOf(groupId.getUuid());
+
+    ClosePipelineCommandHandler handler = datanodeStateMachine.getCommandDispatcher().getClosePipelineCommandHandler();
+     
+    Field pipelinesInProgressField = handler.getClass().getDeclaredField("pipelinesInProgress");
+    pipelinesInProgressField.setAccessible(true);
+    Set<UUID> pipelinesInProgress = (Set<UUID>) pipelinesInProgressField.get(handler);
+    pipelinesInProgress.add(pipelineID.getId());
+
+    String detail = "test duplicate trigger ";
+    int numOfDuplicateTriggers = 10;
+    for (int i = 1; i <= numOfDuplicateTriggers; i++) {
+      xceiverRatis.triggerPipelineClose(groupId, detail + i, ClosePipelineInfo.Reason.PIPELINE_FAILED);
+    }
+
+    String xceiverLogs = xceiverLogCapturer.getOutput();
+    int skippedCount = StringUtils.countMatches(xceiverLogs.toLowerCase(), "skipped triggering pipeline close");
+    assertEquals(numOfDuplicateTriggers, skippedCount);
+     
+    xceiverLogCapturer.stopCapturing();
   }
 
   private boolean verifyCloseForPipeline(Pipeline pipeline,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;


### PR DESCRIPTION
## What changes were proposed in this pull request?
When DN ratis identifies issues with a pipeline, it triggers close pipeline action for below cases:

- When follower is slow
- When leader is not elected and remain in candidate for longer duration
- Any other issue in pipeline like disk out of space trigger failure

This keeps triggering close pipeline action, even though close actions are queued in DN command queue. If there is any issue in DN pipeline closure, it can result in huge such action every HB.
There is an optimisation that within one HB, it will avoid duplicate pipeline close action.

With this change, repeated triggers across HBs are also prevented by checking the command queue before adding new close actions.

## What is the link to the Apache JIRA
[HDDS-13618](https://issues.apache.org/jira/browse/HDDS-13618)

## How was this patch tested?
Added a unit test in `TestClosePipelineCommandHandler`.
