### PR TITLE
HDDS-13676. Update S3 docs for presigned URL

### DIFF
--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -103,9 +103,9 @@ The Ozone S3 Gateway implements a substantial subset of the Amazon S3 REST API. 
 
 ### Additional Operations
 
-| **API Name** | **Feature** | **Note** |
-|--------------|-------------|----------|
-| ✅ Generate Presigned URL | Generates a temporary URL for accessing an object. | Uses AWS Signature V4. **Non-compliant behavior:** The generated URL may include a fixed default region rather than dynamically reflecting the bucket’s location. Currently, Ozone only supports generating presigned URLs for `GetObject`. Support for other operations is tracked in [HDDS-5195](https://issues.apache.org/jira/browse/HDDS-5195) and [HDDS-13393](https://issues.apache.org/jira/browse/HDDS-13393). |
+| **API Name** | **Feature** | **Note**                                                                                                                                                                                                                                                                                                                                                                                                              |
+|--------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅ Generate Presigned URL | Generates a temporary URL for accessing an object. | Uses AWS Signature V4. **Non-compliant behavior:** The generated URL may include a fixed default region rather than dynamically reflecting the bucket’s location. Ozone now supports generating presigned URLs for all major S3 operations, including `GetObject`, `PutObject`, `DeleteObject`, `HeadObject`, `HeadBucket`, `MultipartUpload`. |
 
 ---
 

--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -103,8 +103,8 @@ The Ozone S3 Gateway implements a substantial subset of the Amazon S3 REST API. 
 
 ### Additional Operations
 
-| **API Name** | **Feature** | **Note**                                                                                                                                                                                                                                                                                                                                                                                                              |
-|--------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **API Name** | **Feature** | **Note** |
+|--------------|-------------|----------|
 | ✅ Generate Presigned URL | Generates a temporary URL for accessing an object. | Uses AWS Signature V4. **Non-compliant behavior:** The generated URL may include a fixed default region rather than dynamically reflecting the bucket’s location. Ozone now supports generating presigned URLs for all major S3 operations, including `GetObject`, `PutObject`, `DeleteObject`, `HeadObject`, `HeadBucket`, `MultipartUpload`. |
 
 ---


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update s3 user documents for presigned URL.

Please describe your PR in detail:
* Replaced the "unsupported APIs" list with a clear "supported APIs" list to make the documentation easier to understand.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13676

## How was this patch tested?
Doc only
