### PR TITLE
HDDS-13665. [DiskBalancer] Cleanup for multiple DiskBalancerReport sent to SCM

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/DiskBalancerReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/DiskBalancerReportPublisher.java
@@ -24,18 +24,29 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerInfo;
+import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerService;
 
 /**
  * Publishes DiskBalancer report which will be sent to SCM as part of heartbeat.
+ * Report is only published is lastPublishedReport is different from currentReport,
+ * when balancer is in stopped state.
+ * But when balancer is running or paused by node state, report is actively sent to SCM.
  * DiskBalancer Report consist of the following information:
  *   - isBalancerRunning
  *   - balancedBytes
  *   - DiskBalancerConfiguration
+ *   - successCount
+ *   - failureCount
+ *   - bytesToMove
  */
 public class DiskBalancerReportPublisher extends
     ReportPublisher<DiskBalancerReportProto> {
 
   private Long diskBalancerReportInterval = null;
+
+  // Cache the last published report to detect changes when balancer is stopped
+  private DiskBalancerReportProto lastPublishedReport = null;
 
   @Override
   protected long getReportFrequency() {
@@ -59,6 +70,28 @@ public class DiskBalancerReportPublisher extends
 
   @Override
   protected DiskBalancerReportProto getReport() {
-    return getContext().getParent().getContainer().getDiskBalancerReport();
+    DiskBalancerInfo info = getContext().getParent().getContainer().getDiskBalancerInfo();
+    if (info == null) {
+      return null;
+    }
+
+    DiskBalancerReportProto currentReport = info.toDiskBalancerReportProto();
+
+    // Always publish if DiskBalancer state is running or paused by node state
+    if (info.getOperationalState() == DiskBalancerService.DiskBalancerOperationalState.RUNNING
+        || info.getOperationalState() == DiskBalancerService.DiskBalancerOperationalState.PAUSED_BY_NODE_STATE) {
+      lastPublishedReport = currentReport;
+      return currentReport;
+    }
+
+    // DiskBalancer is in stopped state.
+    // Publish if there is a change in the report since last publish
+    if (!currentReport.equals(lastPublishedReport)) {
+      lastPublishedReport = currentReport;
+      return currentReport;
+    }
+    // the balancer is stopped and lastPublishedReport
+    // is unchanged, so don't send any report.
+    return null;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
@@ -288,6 +289,7 @@ public class DatanodeStateMachine implements Closeable {
         .addPublisherFor(ContainerReportsProto.class)
         .addPublisherFor(CommandStatusReportsProto.class)
         .addPublisherFor(PipelineReportsProto.class)
+        .addPublisherFor(DiskBalancerReportProto.class)
         .addThreadNamePrefix(threadNamePrefix)
         .build();
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.ozone.container.common.helpers.DeletedContainerBlocksSu
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
-import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerInfo;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ClosePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
@@ -146,7 +145,6 @@ public class HeartbeatEndpointTask
       addContainerActions(requestBuilder);
       addPipelineActions(requestBuilder);
       addQueuedCommandCounts(requestBuilder);
-      addDiskBalancerReport(requestBuilder);
       SCMHeartbeatRequestProto request = requestBuilder.build();
       LOG.debug("Sending heartbeat message : {}", request);
       SCMHeartbeatResponseProto response = rpcEndpoint.getEndPoint()
@@ -255,13 +253,6 @@ public class HeartbeatEndpointTask
           .addCount(entry.getValue());
     }
     requestBuilder.setCommandQueueReport(reportProto.build());
-  }
-
-  private void addDiskBalancerReport(SCMHeartbeatRequestProto.Builder requestBuilder) {
-    DiskBalancerInfo info = context.getParent().getContainer().getDiskBalancerInfo();
-    if (info != null) {
-      requestBuilder.setDiskBalancerReport(info.toDiskBalancerReportProto());
-    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
@@ -356,21 +355,6 @@ public class DiskBalancerService extends BackgroundService {
 
   public void setVersion(DiskBalancerVersion version) {
     this.version = version;
-  }
-
-  public DiskBalancerReportProto getDiskBalancerReportProto() {
-    DiskBalancerReportProto.Builder builder =
-        DiskBalancerReportProto.newBuilder();
-    return builder.setIsRunning(this.operationalState == DiskBalancerOperationalState.RUNNING)
-        .setBalancedBytes(totalBalancedBytes.get())
-        .setDiskBalancerConf(
-            HddsProtos.DiskBalancerConfigurationProto.newBuilder()
-                .setThreshold(threshold)
-                .setDiskBandwidthInMB(bandwidthInMB)
-                .setParallelThread(parallelThread)
-                .setStopAfterDiskEven(stopAfterDiskEven)
-                .build())
-        .build();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -717,13 +716,6 @@ public class OzoneContainer {
 
   public WitnessedContainerMetadataStore getWitnessedContainerMetadataStore() {
     return witnessedContainerMetadataStore;
-  }
-
-  public DiskBalancerReportProto getDiskBalancerReport() {
-    if (diskBalancerService == null) {
-      return null;
-    }
-    return diskBalancerService.getDiskBalancerReportProto();
   }
 
   public DiskBalancerInfo getDiskBalancerInfo() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerInfo;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CommandStatus;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
@@ -180,6 +181,7 @@ public class TestReportPublisher {
     DatanodeStateMachine dummyStateMachine =
         mock(DatanodeStateMachine.class);
     OzoneContainer dummyContainer = mock(OzoneContainer.class);
+    DiskBalancerInfo dummyInfo = mock(DiskBalancerInfo.class);
 
     DiskBalancerReportProto.Builder builder = DiskBalancerReportProto.newBuilder();
     builder.setIsRunning(true);
@@ -191,7 +193,8 @@ public class TestReportPublisher {
     ReportPublisher publisher = new DiskBalancerReportPublisher();
     when(dummyContext.getParent()).thenReturn(dummyStateMachine);
     when(dummyStateMachine.getContainer()).thenReturn(dummyContainer);
-    when(dummyContainer.getDiskBalancerReport()).thenReturn(dummyReport);
+    when(dummyContainer.getDiskBalancerInfo()).thenReturn(dummyInfo);
+    when(dummyInfo.toDiskBalancerReportProto()).thenReturn(dummyReport);
     publisher.setConf(config);
 
     ScheduledExecutorService executorService = HadoopExecutors

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -357,6 +357,8 @@ public class TestHeartbeatEndpointTask {
                         .getDatanodeDetails().getUuid())
                 .build());
 
+    DiskBalancerInfo mockInfo = container.getDiskBalancerInfo();
+
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
     context.addEndpoint(TEST_SCM_ENDPOINT);
@@ -365,6 +367,7 @@ public class TestHeartbeatEndpointTask {
     context.addIncrementalReport(
         CommandStatusReportsProto.getDefaultInstance());
     context.addContainerAction(getContainerAction());
+    context.refreshFullReport(mockInfo.toDiskBalancerReportProto());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
     assertTrue(heartbeat.hasDatanodeDetails());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancerDuringDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancerDuringDecommissionAndMaintenance.java
@@ -74,6 +74,7 @@ public class TestDiskBalancerDuringDecommissionAndMaintenance {
   public static void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(HddsConfigKeys.HDDS_DATANODE_DISK_BALANCER_ENABLED_KEY, true);
+    conf.setStrings(HddsConfigKeys.HDDS_DISK_BALANCER_REPORT_INTERVAL, "2s");
     conf.setClass(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         SCMContainerPlacementCapacity.class, PlacementPolicy.class);
     conf.setTimeDuration("hdds.datanode.disk.balancer.service.interval", 2, TimeUnit.SECONDS);


### PR DESCRIPTION
## What changes were proposed in this pull request?
In **HeartbeatEndpointTask** there are two reports sent to scm by DN for diskBalancer, one is by addReport using **DiskBalancerReportPublisher**  and second is by  **addDiskBalancerReport** . 

DiskBalancer Report should be sent actively only when diskBalancer is running or paused by node state and if diskBalancer is stopped then report should only be sent if there is any changes since last published report.

Proposed Solution: 
Remove **addDiskBalancerReport** .

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13665

## How was this patch tested?

Passed Existing tests.
