### PR TITLE
HDDS-13687. Tests are not capable of being run in parallel due to port clashes

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
@@ -45,9 +45,16 @@ class TestBaseHttpServer {
   private static final String BIND_HOST_HTTP_KEY = "bind-host.http";
   private static final String BIND_HOST_HTTPS_KEY = "bind-host.https";
   private static final String BIND_HOST_DEFAULT = "0.0.0.0";
-  private static final int BIND_PORT_HTTP_DEFAULT = PortAllocator.getFreePort();
-  private static final int BIND_PORT_HTTPS_DEFAULT = PortAllocator.getFreePort();
   private static final String ENABLED_KEY = "enabled";
+
+  // Use dynamic port allocation to avoid conflicts in parallel tests
+  private static int getHttpPort() {
+    return PortAllocator.getFreePort();
+  }
+
+  private static int getHttpsPort() {
+    return PortAllocator.getFreePort();
+  }
 
   private String hostname;
 
@@ -200,12 +207,12 @@ class TestBaseHttpServer {
 
     @Override
     protected int getHttpBindPortDefault() {
-      return BIND_PORT_HTTP_DEFAULT;
+      return getHttpPort();
     }
 
     @Override
     protected int getHttpsBindPortDefault() {
-      return BIND_PORT_HTTPS_DEFAULT;
+      return getHttpsPort();
     }
 
     @Override

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/UniformDatanodesFactory.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/UniformDatanodesFactory.java
@@ -33,8 +33,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATAS
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_IPC_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_SERVER_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_RATIS_LEADER_FIRST_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -50,6 +48,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationTarget;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
+import org.apache.ozone.test.GenericTestUtils;
 
 /**
  * Creates datanodes with similar configuration (same number of volumes, same layout version, etc.).
@@ -123,14 +122,15 @@ public class UniformDatanodesFactory implements MiniOzoneCluster.DatanodeFactory
   }
 
   private void configureDatanodePorts(ConfigurationTarget conf) {
-    conf.set(HDDS_DATANODE_HTTP_ADDRESS_KEY, anyHostWithFreePort());
-    conf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY, anyHostWithFreePort());
-    conf.setInt(HDDS_CONTAINER_IPC_PORT, getFreePort());
-    conf.setInt(HDDS_CONTAINER_RATIS_IPC_PORT, getFreePort());
-    conf.setInt(HDDS_CONTAINER_RATIS_ADMIN_PORT, getFreePort());
-    conf.setInt(HDDS_CONTAINER_RATIS_SERVER_PORT, getFreePort());
-    conf.setInt(HDDS_CONTAINER_RATIS_DATASTREAM_PORT, getFreePort());
-    conf.setFromObject(new ReplicationServer.ReplicationConfig().setPort(getFreePort()));
+    // Use the improved thread-safe port allocation directly
+    conf.set(HDDS_DATANODE_HTTP_ADDRESS_KEY, GenericTestUtils.PortAllocator.anyHostWithFreePort());
+    conf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY, GenericTestUtils.PortAllocator.anyHostWithFreePort());
+    conf.setInt(HDDS_CONTAINER_IPC_PORT, GenericTestUtils.PortAllocator.getFreePort());
+    conf.setInt(HDDS_CONTAINER_RATIS_IPC_PORT, GenericTestUtils.PortAllocator.getFreePort());
+    conf.setInt(HDDS_CONTAINER_RATIS_ADMIN_PORT, GenericTestUtils.PortAllocator.getFreePort());
+    conf.setInt(HDDS_CONTAINER_RATIS_SERVER_PORT, GenericTestUtils.PortAllocator.getFreePort());
+    conf.setInt(HDDS_CONTAINER_RATIS_DATASTREAM_PORT, GenericTestUtils.PortAllocator.getFreePort());
+    conf.setFromObject(new ReplicationServer.ReplicationConfig().setPort(GenericTestUtils.PortAllocator.getFreePort()));
   }
 
   public static Builder newBuilder() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
@@ -17,6 +17,11 @@
 
 package org.apache.hadoop.ozone.om;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_GRPC_PORT_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_KEY;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
 import static org.mockito.Mockito.mock;
 
@@ -36,6 +41,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.ozone.test.GenericTestUtils.PortAllocator;
 
 /**
  * Test utility for creating a dummy OM, the associated
@@ -103,6 +109,13 @@ public final class OmTestManagers {
     }
     scmBlockClient = blockClient != null ? blockClient :
         new ScmBlockLocationTestingClient(null, null, 0);
+
+    // Configure dynamic ports for OM to avoid conflicts in parallel testing
+    conf.set(OZONE_OM_ADDRESS_KEY, "127.0.0.1:" + PortAllocator.getFreePort());
+    conf.set(OZONE_OM_HTTP_ADDRESS_KEY, "127.0.0.1:" + PortAllocator.getFreePort());
+    conf.set(OZONE_OM_HTTPS_ADDRESS_KEY, "127.0.0.1:" + PortAllocator.getFreePort());
+    conf.setInt(OZONE_OM_RATIS_PORT_KEY, PortAllocator.getFreePort());
+    conf.setInt(OZONE_OM_GRPC_PORT_KEY, PortAllocator.getFreePort());
 
     conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY, "127.0.0.1:0");
     DefaultMetricsSystem.setMiniClusterMode(true);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdater;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdaterManager;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.recon.schema.generated.tables.daos.ReconTaskStatusDao;
+import org.apache.ozone.test.GenericTestUtils.PortAllocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,7 +84,7 @@ public class TestTriggerDBSyncEndpoint {
     configuration.set(OZONE_RECON_DB_DIR,
         Files.createDirectory(temporaryFolder.resolve("ReconDb"))
             .toFile().getAbsolutePath());
-    configuration.set(OZONE_OM_ADDRESS_KEY, "localhost:9862");
+    configuration.set(OZONE_OM_ADDRESS_KEY, "localhost:" + PortAllocator.getFreePort());
     CommonUtils commonUtils = new CommonUtils();
     OzoneManagerProtocol ozoneManagerProtocol
         = mock(OzoneManagerProtocol.class);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.ozone.recon.tasks.ReconTaskReInitializationEvent;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdater;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdaterManager;
 import org.apache.ozone.recon.schema.generated.tables.daos.ReconTaskStatusDao;
+import org.apache.ozone.test.GenericTestUtils.PortAllocator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,7 +103,7 @@ public class TestOzoneManagerServiceProviderImpl {
         dirReconSnapDB.getAbsolutePath());
     configuration.set(OZONE_RECON_DB_DIR,
         dirReconDB.getAbsolutePath());
-    configuration.set("ozone.om.address", "localhost:9862");
+    configuration.set("ozone.om.address", "localhost:" + PortAllocator.getFreePort());
     ozoneManagerProtocol = getMockOzoneManagerClient(new DBUpdates());
     commonUtils = new CommonUtils();
     reconContext = new ReconContext(configuration, new ReconUtils());


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13687. Tests are not capable of being run in parallel due to port clashes

Please describe your PR in detail:
Each process/fork gets a unique 40-port range based on PID + fork ID to prevent inter-process collisions
Within each process range, ports are allocated sequentially using atomic counters with synchronized methods.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13687

## How was this patch tested?
maven tests running with multiple threads/forks:
mvn clean package -T10 -DforkCount=10 -DreuseForks=false -Dparallel=classes -DthreadCount=10