### PR TITLE
HDDS-13689. Remove unnecessary usage of Guava from ozonefs

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -30,10 +30,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.fs.ozone;
 
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -60,7 +59,7 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
   public OzoneFileSystem() {
     this.storageStatistics = new OzoneFSStorageStatistics();
     String force = System.getProperty(FORCE_LEASE_RECOVERY_ENV);
-    forceRecovery = Strings.isNullOrEmpty(force) ? false : Boolean.parseBoolean(force);
+    forceRecovery = Boolean.parseBoolean(force);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.fs.ozone;
 
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -60,7 +59,7 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
   public RootedOzoneFileSystem() {
     this.storageStatistics = new OzoneFSStorageStatistics();
     String force = System.getProperty(FORCE_LEASE_RECOVERY_ENV);
-    forceRecovery = Strings.isNullOrEmpty(force) ? false : Boolean.parseBoolean(force);
+    forceRecovery = Boolean.parseBoolean(force);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -30,10 +30,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
     </dependency>

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.fs.ozone;
 
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -60,7 +59,7 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
   public OzoneFileSystem() {
     this.storageStatistics = new OzoneFSStorageStatistics();
     String force = System.getProperty(FORCE_LEASE_RECOVERY_ENV);
-    forceRecovery = Strings.isNullOrEmpty(force) ? false : Boolean.parseBoolean(force);
+    forceRecovery = Boolean.parseBoolean(force);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.fs.ozone;
 
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
-import com.google.common.base.Strings;
 import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,7 +61,7 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
   public RootedOzoneFileSystem() {
     this.storageStatistics = new OzoneFSStorageStatistics();
     String force = System.getProperty(FORCE_LEASE_RECOVERY_ENV);
-    forceRecovery = Strings.isNullOrEmpty(force) ? false : Boolean.parseBoolean(force);
+    forceRecovery = Boolean.parseBoolean(force);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OzoneFileSystem` and `RootedOzoneFileSystem` use `Strings.isNullOrEmpty` unnecessarily, `Boolean.parseBoolean` already handles both cases (`null` and empty).

```
$ jshell

jshell> Boolean.parseBoolean(null)
$1 ==> false

jshell> Boolean.parseBoolean("")
$2 ==> false

jshell> Boolean.parseBoolean("asdf")
$3 ==> false

jshell> Boolean.parseBoolean("false")
$4 ==> false

jshell> Boolean.parseBoolean("true")
$5 ==> true
```

https://issues.apache.org/jira/browse/HDDS-13689

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/17801676456