### PR TITLE
HDDS-13693. NodeStatusInfo shows HTTP port instead of HTTPS

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -310,7 +310,7 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
         }
 
         if (policy.isHttpsEnabled()) {
-          int httpsPort = httpServer.getHttpAddress().getPort();
+          int httpsPort = httpServer.getHttpsAddress().getPort();
           datanodeDetails.setPort(DatanodeDetails.newPort(HTTPS, httpsPort));
           serviceRuntimeInfo.setHttpsPort(String.valueOf(httpsPort));
         }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,7 +37,9 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
@@ -52,6 +55,7 @@ import org.apache.hadoop.util.ServicePlugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -152,6 +156,33 @@ public class TestHddsDatanodeService {
         hddsVolume.getDeletedContainerDir().listFiles();
     assertNotNull(deletedContainersAfterShutdown);
     assertEquals(0, deletedContainersAfterShutdown.length);
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  void testHttpPorts(HttpConfig.Policy policy) {
+    try {
+      conf.setEnum(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy);
+      service.start(conf);
+
+      DatanodeDetails dn = service.getDatanodeDetails();
+      DatanodeDetails.Port httpPort = dn.getPort(DatanodeDetails.Port.Name.HTTP);
+      DatanodeDetails.Port httpsPort = dn.getPort(DatanodeDetails.Port.Name.HTTPS);
+      if (policy.isHttpEnabled()) {
+        assertNotNull(httpPort);
+      }
+      if (policy.isHttpsEnabled()) {
+        assertNotNull(httpsPort);
+      }
+      if (policy.isHttpEnabled() && policy.isHttpsEnabled()) {
+        assertNotEquals(httpPort.getValue(), httpsPort.getValue());
+      }
+    } finally {
+      service.stop();
+      service.join();
+      service.close();
+      DefaultMetricsSystem.shutdown();
+    }
   }
 
   static class MockService implements ServicePlugin {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix typo that HTTPS port is incorrectly taken from `getHttpAddress` instead of `getHttpsAddress`.

https://issues.apache.org/jira/browse/HDDS-13693

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/ozone/actions/runs/17825188805
