### PR TITLE
HDDS-13694. Container Balancer Stop Command Fails with Error as Already Stopped

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -129,6 +129,8 @@ public class TestContainerBalancer {
 
   @Test
   public void testStartBalancerStop() throws Exception {
+    //stop should not throw an exception as it is idempotent
+    assertDoesNotThrow(() -> containerBalancer.stopBalancer());
     startBalancer(balancerConfiguration);
     assertThrows(IllegalContainerBalancerStateException.class,
         () -> containerBalancer.startBalancer(balancerConfiguration),
@@ -144,8 +146,7 @@ public class TestContainerBalancer {
     assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
 
     // If the balancer is already stopped, the stop command should do nothing
-    // and return successfully with exit code 0 as stopBalancer is idempotent
-    assertDoesNotThrow(() -> containerBalancer.stopBalancer());
+    // and return successfully as stopBalancer is idempotent
     assertDoesNotThrow(() -> containerBalancer.stopBalancer());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -142,9 +143,10 @@ public class TestContainerBalancer {
     stopBalancer();
     assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
 
-    assertThrows(Exception.class,
-        () -> containerBalancer.stopBalancer(),
-        "Exception should be thrown when stop again");
+    // If the balancer is already stopped, the stop command should do nothing
+    // and return successfully with exit code 0 as stopBalancer is idempotent
+    assertDoesNotThrow(() -> containerBalancer.stopBalancer());
+    assertDoesNotThrow(() -> containerBalancer.stopBalancer());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerBalancerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerBalancerOperations.java
@@ -19,10 +19,12 @@ package org.apache.hadoop.ozone;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
@@ -177,5 +179,45 @@ public class TestContainerBalancerOperations {
     containerBalancerClient.stopContainerBalancer();
     running = containerBalancerClient.getContainerBalancerStatus();
     assertFalse(running);
+  }
+
+  /**
+   * Tests that stopBalancer is idempotent - once the balancer is in STOPPED state,
+   * invoking stop again should be a no-op and return successfully with exit code 0.
+   */
+  @Test
+  public void testStopBalancerIdempotent() throws IOException {
+    boolean running = containerBalancerClient.getContainerBalancerStatus();
+    assertFalse(running);
+
+    Optional<Double> threshold = Optional.of(0.1);
+    Optional<Integer> iterations = Optional.of(10000);
+    Optional<Integer> maxDatanodesPercentageToInvolvePerIteration =
+        Optional.of(100);
+    Optional<Long> maxSizeToMovePerIterationInGB = Optional.of(1L);
+    Optional<Long> maxSizeEnteringTargetInGB = Optional.of(6L);
+    Optional<Long> maxSizeLeavingSourceInGB = Optional.of(6L);
+    Optional<Integer> balancingInterval = Optional.of(70);
+    Optional<Integer> moveTimeout = Optional.of(65);
+    Optional<Integer> moveReplicationTimeout = Optional.of(50);
+    Optional<Boolean> networkTopologyEnable = Optional.of(false);
+    Optional<String> includeNodes = Optional.of("");
+    Optional<String> excludeNodes = Optional.of("");
+    containerBalancerClient.startContainerBalancer(threshold, iterations,
+        maxDatanodesPercentageToInvolvePerIteration,
+        maxSizeToMovePerIterationInGB, maxSizeEnteringTargetInGB,
+        maxSizeLeavingSourceInGB, balancingInterval, moveTimeout,
+        moveReplicationTimeout, networkTopologyEnable, includeNodes,
+        excludeNodes);
+    running = containerBalancerClient.getContainerBalancerStatus();
+    assertTrue(running);
+
+    containerBalancerClient.stopContainerBalancer();
+    running = containerBalancerClient.getContainerBalancerStatus();
+    assertFalse(running);
+
+    // Calling stop balancer multiple times should not throw an exception
+    assertDoesNotThrow(() -> containerBalancerClient.stopContainerBalancer());
+    assertDoesNotThrow(() -> containerBalancerClient.stopContainerBalancer());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerBalancerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerBalancerOperations.java
@@ -189,6 +189,7 @@ public class TestContainerBalancerOperations {
   public void testStopBalancerIdempotent() throws IOException {
     boolean running = containerBalancerClient.getContainerBalancerStatus();
     assertFalse(running);
+    assertDoesNotThrow(() -> containerBalancerClient.stopContainerBalancer());
 
     Optional<Double> threshold = Optional.of(0.1);
     Optional<Integer> iterations = Optional.of(10000);
@@ -216,8 +217,7 @@ public class TestContainerBalancerOperations {
     running = containerBalancerClient.getContainerBalancerStatus();
     assertFalse(running);
 
-    // Calling stop balancer multiple times should not throw an exception
-    assertDoesNotThrow(() -> containerBalancerClient.stopContainerBalancer());
+    // Calling stop balancer again should not throw an exception
     assertDoesNotThrow(() -> containerBalancerClient.stopContainerBalancer());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`stopBalancer` should be idempotent - meaning that if the balancer is already in a STOPPED state, invoking the stop command again should simply return successfully with exit code 0 and perform no action.

Currently, it instead throws the following error:
```
Caused by: org.apache.hadoop.hdds.scm.container.balancer.IllegalContainerBalancerStateException: Expect ContainerBalancer as running state, but running state is actually STOPPED
```
This behavior is fixed so that repeated stop calls are handled gracefully.

## What is the link to the Apache JIRA
[HDDS-13694](https://issues.apache.org/jira/browse/HDDS-13694)

## How was this patch tested?
Tested in `TestContainerBalancer#testStartBalancerStop`. 
CI: https://github.com/sarvekshayr/ozone/actions/runs/17828304300
