### PR TITLE
HDDS-13701. Rename StorageVolumeScannerMetrics to BackgroundVolumeScannerMetrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/BackgroundVolumeScannerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/BackgroundVolumeScannerMetrics.java
@@ -26,12 +26,12 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 /**
- * This class captures the Storage Volume Scanner Metrics.
+ * This class captures the Background Storage Volume Scanner Metrics.
  **/
 @InterfaceAudience.Private
-@Metrics(about = "Storage Volume Scanner Metrics", context = "dfs")
-public class StorageVolumeScannerMetrics {
-  public static final String SOURCE_NAME = StorageVolumeScannerMetrics.class.getSimpleName();
+@Metrics(about = "Background Volume Scanner Metrics", context = "dfs")
+public class BackgroundVolumeScannerMetrics {
+  public static final String SOURCE_NAME = BackgroundVolumeScannerMetrics.class.getSimpleName();
 
   @Metric("number of volumes scanned in the last iteration")
   private MutableGaugeLong numVolumesScannedInLastIteration;
@@ -49,12 +49,12 @@ public class StorageVolumeScannerMetrics {
       "since the last iteration had not elapsed")
   private MutableCounterLong numIterationsSkipped;
 
-  public StorageVolumeScannerMetrics() {
+  public BackgroundVolumeScannerMetrics() {
   }
 
-  public static StorageVolumeScannerMetrics create() {
+  public static BackgroundVolumeScannerMetrics create() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(SOURCE_NAME, "Storage Volume Scanner Metrics", new StorageVolumeScannerMetrics());
+    return ms.register(SOURCE_NAME, "Background Volume Scanner Metrics", new BackgroundVolumeScannerMetrics());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeChecker.java
@@ -65,7 +65,7 @@ public class StorageVolumeChecker {
 
   private AsyncChecker<Boolean, VolumeCheckResult> delegateChecker;
 
-  private final StorageVolumeScannerMetrics metrics;
+  private final BackgroundVolumeScannerMetrics metrics;
 
   /**
    * Max allowed time for a disk check in milliseconds. If the check
@@ -105,7 +105,7 @@ public class StorageVolumeChecker {
   public StorageVolumeChecker(ConfigurationSource conf, Timer timer,
       String threadNamePrefix) {
 
-    metrics = StorageVolumeScannerMetrics.create();
+    metrics = BackgroundVolumeScannerMetrics.create();
 
     this.timer = timer;
 
@@ -441,7 +441,7 @@ public class StorageVolumeChecker {
   }
 
   @VisibleForTesting
-  public StorageVolumeScannerMetrics getMetrics() {
+  public BackgroundVolumeScannerMetrics getMetrics() {
     return metrics;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
@@ -79,7 +79,7 @@ public class TestPeriodicVolumeChecker {
     FakeTimer timer = new FakeTimer();
 
     StorageVolumeChecker volumeChecker = new StorageVolumeChecker(conf, timer, "");
-    StorageVolumeScannerMetrics metrics = volumeChecker.getMetrics();
+    BackgroundVolumeScannerMetrics metrics = volumeChecker.getMetrics();
 
     try {
       volumeChecker.registerVolumeSet(new ImmutableVolumeSet(makeVolumes(2, HEALTHY)));


### PR DESCRIPTION
## What changes were proposed in this pull request?

StorageVolumeScannerMetrics handles only the metrics related to the background volume scanners. It does not include any metrics related to on-demand scanners.

To improve readability, StorageVolumeScannerMetrics is renamed to BackgroundVolumeScannerMetrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13701

## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/17874514738