### PR TITLE
HDDS-13709. Fix freon streaming command with duration.

### DIFF
--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -327,8 +327,7 @@ public class BaseFreonGenerator implements FreonSubcommand {
     LongSupplier supplier;
     if (duration != null) {
       maxValue = durationInSecond;
-      supplier = () -> Duration.between(
-          Instant.ofEpochMilli(startTime), Instant.now()).getSeconds();
+      supplier = () -> (Time.monotonicNow() - startTime) / 1000;
     } else {
       maxValue = testNo;
       supplier = () -> successCounter.get() + failureCounter.get();

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -26,8 +26,6 @@ import com.codahale.metrics.Slf4jReporter;
 import io.opentelemetry.api.trace.StatusCode;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;


### PR DESCRIPTION
## What changes were proposed in this pull request?

System time with monotonic time was mixed to calculate duration, which is leading to some big number and causing OOM. In this PR we are making only monotonic time for calculating duration in freon.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13709

## How was this patch tested?

Verified manually in docker
