### PR TITLE
HDDS-13666. [DiskBalancer]Avoid reverse looping in destination selection when thresholds are low

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -389,7 +389,7 @@ public class DiskBalancerService extends BackgroundService {
       HddsVolume sourceVolume = pair.getLeft(), destVolume = pair.getRight();
       ContainerData toBalanceContainer = containerChoosingPolicy
           .chooseContainer(ozoneContainer, sourceVolume, destVolume,
-              inProgressContainers, threshold, volumeSet);
+              inProgressContainers, threshold, volumeSet, deltaSizes);
       if (toBalanceContainer != null) {
         DiskBalancerTask task = new DiskBalancerTask(toBalanceContainer, sourceVolume,
             destVolume);
@@ -644,7 +644,7 @@ public class DiskBalancerService extends BackgroundService {
     }
 
     // Calculate ideal usage
-    double idealUsage = DiskBalancerVolumeCalculation.getIdealUsage(inputVolumeSet);
+    double idealUsage = DiskBalancerVolumeCalculation.getIdealUsage(inputVolumeSet, deltaSizes);
     double normalizedThreshold = threshold / 100.0;
 
     long totalBytesToMove = 0;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/ContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/ContainerChoosingPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.container.diskbalancer.policy;
 
+import java.util.Map;
 import java.util.Set;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
@@ -37,10 +38,12 @@ public interface ContainerChoosingPolicy {
    - avoided as these containers are already under move by diskBalancer.
    * @param threshold the threshold value
    * @param volumeSet the volumeSet instance
+   * @param deltaMap the deltaMap instance of source volume
    * @return a Container
    */
   ContainerData chooseContainer(OzoneContainer ozoneContainer,
       HddsVolume srcVolume, HddsVolume destVolume,
       Set<ContainerID> inProgressContainerIDs,
-      Double threshold, MutableVolumeSet volumeSet);
+      Double threshold, MutableVolumeSet volumeSet,
+      Map<HddsVolume, Long> deltaMap);
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultVolumeChoosingPolicy.java
@@ -61,7 +61,7 @@ public class DefaultVolumeChoosingPolicy implements DiskBalancerVolumeChoosingPo
       }
       
       // Calculate ideal usage using the same immutable volume
-      double idealUsage = DiskBalancerVolumeCalculation.getIdealUsage(allVolumes);
+      double idealUsage = DiskBalancerVolumeCalculation.getIdealUsage(allVolumes, deltaMap);
 
       // Threshold is given as a percentage
       double normalizedThreshold = threshold / 100;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDefaultContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDefaultContainerChoosingPolicy.java
@@ -79,12 +79,14 @@ public class TestDefaultContainerChoosingPolicy {
   private HddsVolume destVolume1;
   private HddsVolume destVolume2;
   private Set<ContainerID> inProgressContainerIDs;
+  private Map<HddsVolume, Long> deltaMap;
 
   @BeforeEach
   public void setup() throws Exception {
     policy = new DefaultContainerChoosingPolicy();
     setupVolumesAndContainer();
     inProgressContainerIDs = new HashSet<>();
+    deltaMap = new HashMap<>();
   }
 
   /**
@@ -157,6 +159,7 @@ public class TestDefaultContainerChoosingPolicy {
         UUID.randomUUID().toString(), UUID.randomUUID().toString());
     containerData.setState(ContainerDataProto.State.CLOSED);
     containerData.setVolume(vol);
+    containerData.getStatistics().setBlockBytesForTesting(size);
     KeyValueContainer container = new KeyValueContainer(containerData, CONF);
     containerSet.addContainer(container);
   }
@@ -174,7 +177,7 @@ public class TestDefaultContainerChoosingPolicy {
     // The policy iterates by container ID, so it will find and return C1.
 
     ContainerData chosenContainer = policy.chooseContainer(ozoneContainer,
-        sourceVolume, destVolume1, inProgressContainerIDs, THRESHOLD, volumeSet);
+        sourceVolume, destVolume1, inProgressContainerIDs, THRESHOLD, volumeSet, deltaMap);
 
     // first container should be chosen
     assertNotNull(chosenContainer);
@@ -192,7 +195,7 @@ public class TestDefaultContainerChoosingPolicy {
     // than 166.75MB. Therefore, no container should be chosen.
 
     ContainerData chosenContainer = policy.chooseContainer(ozoneContainer,
-        sourceVolume, destVolume2, inProgressContainerIDs, THRESHOLD, volumeSet);
+        sourceVolume, destVolume2, inProgressContainerIDs, THRESHOLD, volumeSet, deltaMap);
 
     // No containers should not be chosen
     assertNull(chosenContainer);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -293,7 +293,7 @@ public class TestDiskBalancerService {
     when(containerData.getBytesUsed()).thenReturn(100L);
 
     when(volumePolicy.chooseVolume(any(), anyDouble(), any(), anyLong())).thenReturn(Pair.of(source, dest));
-    when(containerPolicy.chooseContainer(any(), any(), any(), any(), any(), any())).thenReturn(containerData);
+    when(containerPolicy.chooseContainer(any(), any(), any(), any(), any(), any(), any())).thenReturn(containerData);
 
     // Test when no tasks are in progress, it should schedule up to the limit
     BackgroundTaskQueue queue = svc.getTasks();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestContainerChoosingPolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestContainerChoosingPolicy.java
@@ -153,14 +153,14 @@ public class TestContainerChoosingPolicy {
     inProgressContainerIDs.clear();
 
     ContainerData container = containerChoosingPolicy.chooseContainer(ozoneContainer, volume, destVolume,
-        inProgressContainerIDs, THRESHOLD, volumeSet);
+        inProgressContainerIDs, THRESHOLD, volumeSet, null);
     assertNotNull(container);
     assertEquals(containerList.get(0).getContainerData().getContainerID(), container.getContainerID());
 
     ozoneContainer.getContainerSet().removeContainer(containerList.get(1).getContainerData().getContainerID());
     inProgressContainerIDs.add(ContainerID.valueOf(container.getContainerID()));
     container = containerChoosingPolicy.chooseContainer(ozoneContainer, volume,
-        destVolume, inProgressContainerIDs, THRESHOLD, volumeSet);
+        destVolume, inProgressContainerIDs, THRESHOLD, volumeSet, null);
     assertEquals(containerList.get(1).getContainerData().getContainerID(), container.getContainerID());
   }
 
@@ -195,7 +195,7 @@ public class TestContainerChoosingPolicy {
           for (int j = 0; j < NUM_ITERATIONS; j++) {
             try {
               ContainerData c = policy.chooseContainer(ozoneContainer, srcVolume,
-                  destVolume, inProgressContainerIDs, THRESHOLD, volumeSet);
+                  destVolume, inProgressContainerIDs, THRESHOLD, volumeSet, null);
               if (c == null) {
                 containerNotChosen++;
               } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sorting based on density is ok to choose source and possible destination, but the logic of choosing destination here can not be direct reverse loop, and need care for choosing destination should be make that node as candidate for reverse movement. And if no destination is possible to choose, should mark disk as balanced.
This reverse looping is especially seen in case of very low threshold such that the volume utilisation of source and destination disk is close making diskbalancer running forever without doing actual balancing.

As a solution to this while choosing container from source volume, we can check if movement of this container should satisfy the below condition.
```
if (newDestUtilization <= (average utilization + threshold)) {
// container move is productive
    return containerData;
}    
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13666

## How was this patch tested?

Added new UT `TestDefaultContainerChoosingPolicy`.
