### PR TITLE
HDDS-13711. Handle null failedEntry in notifyLogFailed to avoid NPE.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -1265,8 +1265,10 @@ public class ContainerStateMachine extends BaseStateMachine {
 
   @Override
   public void notifyLogFailed(Throwable t, LogEntryProto failedEntry) {
-    LOG.error("{}: {} {}", getGroupId(), TermIndex.valueOf(failedEntry),
-        toStateMachineLogEntryString(failedEntry.getStateMachineLogEntry()), t);
+    String stateMachineLogEntry = failedEntry == null
+        ? "null"
+        : toStateMachineLogEntryString(failedEntry.getStateMachineLogEntry());
+    LOG.error("{}: {} {}", getGroupId(), TermIndex.valueOf(failedEntry), stateMachineLogEntry, t);
     ratisServer.handleNodeLogFailure(getGroupId(), t);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ContainerStateMachine.notifyLogFailed` throws an NPE when a `null` value for the `failedEntry` parameter is passed to it. This is because the `failedEntry` is dereferenced without a null check.

This PR adds a null check for it.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13711

## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/18054346254
