### PR TITLE
HDDS-13719. Replace HadoopIllegalArgumentException

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchema.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchema.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.net;
 
 import java.util.List;
-import org.apache.hadoop.HadoopIllegalArgumentException;
 
 /**
  * Network topology schema to housekeeper relevant information.
@@ -66,7 +65,7 @@ public final class NodeSchema {
 
     public NodeSchema build() {
       if (type == null) {
-        throw new HadoopIllegalArgumentException("Type is mandatory for a " +
+        throw new IllegalArgumentException("Type is mandatory for a " +
             "network topology node layer definition");
       }
       if (cost == -1) {

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/ByteArrayEncodingState.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/ByteArrayEncodingState.java
@@ -18,7 +18,6 @@
 package org.apache.ozone.erasurecode.rawcoder;
 
 import java.nio.ByteBuffer;
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
@@ -91,12 +90,12 @@ class ByteArrayEncodingState extends EncodingState {
   void checkBuffers(byte[][] buffers) {
     for (byte[] buffer : buffers) {
       if (buffer == null) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Invalid buffer found, not allowing null");
       }
 
       if (buffer.length != encodeLength) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Invalid buffer not of length " + encodeLength);
       }
     }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/ByteBufferEncodingState.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/ByteBufferEncodingState.java
@@ -18,7 +18,6 @@
 package org.apache.ozone.erasurecode.rawcoder;
 
 import java.nio.ByteBuffer;
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
@@ -91,17 +90,17 @@ class ByteBufferEncodingState extends EncodingState {
   void checkBuffers(ByteBuffer[] buffers) {
     for (ByteBuffer buffer : buffers) {
       if (buffer == null) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Invalid buffer found, not allowing null");
       }
 
       if (buffer.remaining() != encodeLength) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Invalid buffer remaining " + buffer.remaining()
                 + ", not of length " + encodeLength);
       }
       if (buffer.isDirect() != usingDirectBuffer) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Invalid buffer, isDirect should be " + usingDirectBuffer);
       }
     }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/EncodingState.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/EncodingState.java
@@ -17,7 +17,6 @@
 
 package org.apache.ozone.erasurecode.rawcoder;
 
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
@@ -36,11 +35,11 @@ abstract class EncodingState {
    */
   <T> void checkParameters(T[] inputs, T[] outputs) {
     if (inputs.length != encoder.getNumDataUnits()) {
-      throw new HadoopIllegalArgumentException("Invalid inputs length "
+      throw new IllegalArgumentException("Invalid inputs length "
           + inputs.length + " !=" + encoder.getNumDataUnits());
     }
     if (outputs.length != encoder.getNumParityUnits()) {
-      throw new HadoopIllegalArgumentException("Invalid outputs length "
+      throw new IllegalArgumentException("Invalid outputs length "
           + outputs.length + " !=" + encoder.getNumParityUnits());
     }
   }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/RSRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/RSRawDecoder.java
@@ -19,7 +19,6 @@ package org.apache.ozone.erasurecode.rawcoder;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.ozone.erasurecode.rawcoder.util.DumpUtil;
@@ -60,7 +59,7 @@ public class RSRawDecoder extends RawErasureDecoder {
 
     int numAllUnits = getNumAllUnits();
     if (getNumAllUnits() >= RSUtil.GF.getFieldSize()) {
-      throw new HadoopIllegalArgumentException(
+      throw new IllegalArgumentException(
               "Invalid getNumDataUnits() and numParityUnits");
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpConfig.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.server.http;
 
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
@@ -66,7 +65,7 @@ public final class HttpConfig {
         OzoneConfigKeys.OZONE_HTTP_POLICY_DEFAULT);
     HttpConfig.Policy policy = HttpConfig.Policy.fromString(policyStr);
     if (policy == null) {
-      throw new HadoopIllegalArgumentException("Unrecognized value '"
+      throw new IllegalArgumentException("Unrecognized value '"
           + policyStr + "' for " + OzoneConfigKeys.OZONE_HTTP_POLICY_KEY);
     }
     conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -59,7 +59,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.ConfServlet;
 import org.apache.hadoop.conf.Configuration.IntegerRanges;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -509,7 +508,7 @@ public final class HttpServer2 implements FilterContainer {
           connector = createHttpsChannelConnector(server.webServer,
               httpConfig);
         } else {
-          throw new HadoopIllegalArgumentException(
+          throw new IllegalArgumentException(
               "unknown scheme for endpoint:" + ep);
         }
         connector.setHost(ep.getHost());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/LogLevel.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/LogLevel.java
@@ -33,7 +33,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -144,7 +143,7 @@ public final class LogLevel {
       try {
         parseArguments(args);
         sendLogLevelRequest();
-      } catch (HadoopIllegalArgumentException e) {
+      } catch (IllegalArgumentException e) {
         printUsage();
         return -1;
       }
@@ -153,11 +152,11 @@ public final class LogLevel {
 
     /**
      * Send HTTP/HTTPS request to the daemon.
-     * @throws HadoopIllegalArgumentException if arguments are invalid.
+     * @throws IllegalArgumentException if arguments are invalid.
      * @throws Exception if unable to connect
      */
     private void sendLogLevelRequest()
-        throws HadoopIllegalArgumentException, Exception {
+        throws IllegalArgumentException, Exception {
       switch (operation) {
       case GETLEVEL:
         doGetLevel();
@@ -166,15 +165,15 @@ public final class LogLevel {
         doSetLevel();
         break;
       default:
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
           "Expect either -getlevel or -setlevel");
       }
     }
 
     public void parseArguments(String[] args) throws
-        HadoopIllegalArgumentException {
+        IllegalArgumentException {
       if (args.length == 0) {
-        throw new HadoopIllegalArgumentException("No arguments specified");
+        throw new IllegalArgumentException("No arguments specified");
       }
       int nextArgIndex = 0;
       while (nextArgIndex < args.length) {
@@ -185,14 +184,14 @@ public final class LogLevel {
         } else if (args[nextArgIndex].equals("-protocol")) {
           nextArgIndex = parseProtocolArgs(args, nextArgIndex);
         } else {
-          throw new HadoopIllegalArgumentException(
+          throw new IllegalArgumentException(
               "Unexpected argument " + args[nextArgIndex]);
         }
       }
 
       // if operation is never specified in the arguments
       if (operation == Operations.UNKNOWN) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Must specify either -getlevel or -setlevel");
       }
 
@@ -203,15 +202,15 @@ public final class LogLevel {
     }
 
     private int parseGetLevelArgs(String[] args, int index) throws
-        HadoopIllegalArgumentException {
+        IllegalArgumentException {
       // fail if multiple operations are specified in the arguments
       if (operation != Operations.UNKNOWN) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Redundant -getlevel command");
       }
       // check number of arguments is sufficient
       if (index + 2 >= args.length) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "-getlevel needs two parameters");
       }
       operation = Operations.GETLEVEL;
@@ -221,15 +220,15 @@ public final class LogLevel {
     }
 
     private int parseSetLevelArgs(String[] args, int index) throws
-        HadoopIllegalArgumentException {
+        IllegalArgumentException {
       // fail if multiple operations are specified in the arguments
       if (operation != Operations.UNKNOWN) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Redundant -setlevel command");
       }
       // check number of arguments is sufficient
       if (index + 3 >= args.length) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "-setlevel needs three parameters");
       }
       operation = Operations.SETLEVEL;
@@ -240,21 +239,21 @@ public final class LogLevel {
     }
 
     private int parseProtocolArgs(String[] args, int index) throws
-        HadoopIllegalArgumentException {
+        IllegalArgumentException {
       // make sure only -protocol is specified
       if (protocol != null) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Redundant -protocol command");
       }
       // check number of arguments is sufficient
       if (index + 1 >= args.length) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "-protocol needs one parameter");
       }
       // check protocol is valid
       protocol = args[index + 1];
       if (!isValidProtocol(protocol)) {
-        throw new HadoopIllegalArgumentException(
+        throw new IllegalArgumentException(
             "Invalid protocol: " + protocol);
       }
       return index + 2;
@@ -263,7 +262,7 @@ public final class LogLevel {
     /**
      * Send HTTP/HTTPS request to get log level.
      *
-     * @throws HadoopIllegalArgumentException if arguments are invalid.
+     * @throws IllegalArgumentException if arguments are invalid.
      * @throws Exception if unable to connect
      */
     private void doGetLevel() throws Exception {
@@ -273,7 +272,7 @@ public final class LogLevel {
     /**
      * Send HTTP/HTTPS request to set log level.
      *
-     * @throws HadoopIllegalArgumentException if arguments are invalid.
+     * @throws IllegalArgumentException if arguments are invalid.
      * @throws Exception if unable to connect
      */
     private void doSetLevel() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -2021,6 +2021,17 @@
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
+                    <reason>Prefer JDK built-in</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.HadoopIllegalArgumentException</bannedImport>
+                    </bannedImports>
+                    <excludedSourceRoots>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/java</excludedSourceRoot>
+                      <excludedSourceRoot>${project.build.directory}/generated-sources/protobuf/java</excludedSourceRoot>
+                    </excludedSourceRoots>
+                  </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
                     <reason>Use Ozone's version of the same class</reason>
                     <bannedImports>
                       <bannedImport>org.apache.hadoop.test.GenericTestUtils</bannedImport>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some code copied long time ago from Hadoop references `HadoopIllegalArgumentException`.  Use Java's built-in `IllegalArgumentException` instead.

https://issues.apache.org/jira/browse/HDDS-13719

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/18087181224