### PR TITLE
HDDS-13707. Update docker quick start section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Latest release artifacts (source release and binary packages) are [available](ht
 
 ## Quick start
 
-### Run Ozone from Docker Compose
+### Run Ozone with Docker Compose
 
-The easiest way to start a cluster with docker is to use docker compose:
+The easiest way to start a cluster with docker is by using Docker Compose:
 
 - Obtain Ozone’s sample Docker Compose configuration:
 ```bash
@@ -63,6 +63,8 @@ curl -O https://raw.githubusercontent.com/apache/ozone-docker/refs/heads/latest/
 ```bash
 docker compose up -d --scale datanode=3
 ```
+
+- Note: By default, the cluster will be started with replication factor set to 1. It can be changed by setting the environment variable `OZONE_REPLICATION_FACTOR` to the desired value.
 
 And you can use AWS S3 cli:
 

--- a/README.md
+++ b/README.md
@@ -50,18 +50,33 @@ Latest release artifacts (source release and binary packages) are [available](ht
 
 ## Quick start
 
-### Run Ozone from published Docker image
+### Run Ozone from Docker Compose
 
-The easiest way to start a cluster with docker is:
+The easiest way to start a cluster with docker is to use docker compose:
 
+- Obtain Ozone’s sample Docker Compose configuration:
+```bash
+curl -O https://raw.githubusercontent.com/apache/ozone-docker/refs/heads/latest/docker-compose.yaml
 ```
-docker run -p 9878:9878 apache/ozone
+
+- Start the cluster
+```bash
+docker compose up -d --scale datanode=3
 ```
 
 And you can use AWS S3 cli:
 
+- First, let’s configure AWS access key and secret key. Because the cluster is not secured, you can use any arbitrary access key and secret key. For example:
+```bash
+export AWS_ACCESS_KEY_ID=testuser/scm@EXAMPLE.COM
+export AWS_SECRET_ACCESS_KEY=c261b6ecabf7d37d5f9ded654b1c724adac9bd9f13e247a235e567e8296d2999
+```
+
+- Then we can create a bucket and upload a file to it:
 ```
 aws s3api --endpoint http://localhost:9878/ create-bucket --bucket=wordcount
+# create a temporary file to upload to Ozone via S3 support 
+ls -1 > /tmp/testfile
 aws s3 --endpoint http://localhost:9878 cp --storage-class REDUCED_REDUNDANCY  /tmp/testfile  s3://wordcount/testfile
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updated docker quick start section in README to be in sync with latest [changes](https://ozone.apache.org/docs/edge/start/startfromdockerhub.html.).

## Please describe your PR in detail:
- The Docker quick start section in the [README](https://github.com/apache/ozone/blob/master/README.md) is out of date. [This](https://ozone.apache.org/docs/edge/start/startfromdockerhub.html) page is more up to date, hence updated the README file to be in sync with that.
- Also added detailed steps on how to use the AWS S3 cli after setup via docker.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13707

## How was this patch tested?
N/A