### PR TITLE
HDDS-13727. Use TextFormat.shortDebugString(..) in processForDebug(..) methods.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -69,9 +69,12 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProtoOrBuilder;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
@@ -88,6 +91,7 @@ import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.com.google.protobuf.TextFormat;
 import org.apache.ratis.util.SizeInBytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,8 +105,8 @@ public final class HddsUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(HddsUtils.class);
 
-  public static final ByteString REDACTED =
-      ByteString.copyFromUtf8("<redacted>");
+  public static final String REDACTED_STRING = "<redacted>";
+  public static final ByteString REDACTED = ByteString.copyFromUtf8(REDACTED_STRING);
 
   private static final int ONE_MB = SizeInBytes.valueOf("1m").getSizeInt();
 
@@ -463,8 +467,7 @@ public final class HddsUtils {
    * false if block token does not apply to the command.
    *
    */
-  public static boolean requireBlockToken(
-      ContainerProtos.Type cmdType) {
+  public static boolean requireBlockToken(Type cmdType) {
     switch (cmdType) {
     case DeleteBlock:
     case DeleteChunk:
@@ -482,8 +485,7 @@ public final class HddsUtils {
     }
   }
 
-  public static boolean requireContainerToken(
-      ContainerProtos.Type cmdType) {
+  public static boolean requireContainerToken(Type cmdType) {
     switch (cmdType) {
     case CloseContainer:
     case CreateContainer:
@@ -503,7 +505,7 @@ public final class HddsUtils {
    * @return block ID.
    */
   public static BlockID getBlockID(ContainerCommandRequestProtoOrBuilder msg) {
-    ContainerProtos.DatanodeBlockID blockID = null;
+    DatanodeBlockID blockID = null;
     switch (msg.getCmdType()) {
     case DeleteBlock:
       if (msg.hasDeleteBlock()) {
@@ -727,42 +729,37 @@ public final class HddsUtils {
    * Remove binary data from request {@code msg}.  (May be incomplete, feel
    * free to add any missing cleanups.)
    */
-  public static ContainerProtos.ContainerCommandRequestProto processForDebug(
-      ContainerProtos.ContainerCommandRequestProto msg) {
-
+  public static String processForDebug(ContainerCommandRequestProto msg) {
     if (msg == null) {
       return null;
     }
 
     if (msg.hasWriteChunk() || msg.hasPutSmallFile()) {
-      ContainerProtos.ContainerCommandRequestProto.Builder builder =
-          msg.toBuilder();
+      final ContainerCommandRequestProto.Builder builder = msg.toBuilder();
       if (msg.hasWriteChunk()) {
         builder.getWriteChunkBuilder().setData(REDACTED);
       }
       if (msg.hasPutSmallFile()) {
         builder.getPutSmallFileBuilder().setData(REDACTED);
       }
-      return builder.build();
+      return TextFormat.shortDebugString(builder);
     }
 
-    return msg;
+    return TextFormat.shortDebugString(msg);
   }
 
   /**
    * Remove binary data from response {@code msg}.  (May be incomplete, feel
    * free to add any missing cleanups.)
    */
-  public static ContainerProtos.ContainerCommandResponseProto processForDebug(
-      ContainerProtos.ContainerCommandResponseProto msg) {
+  public static String processForDebug(ContainerCommandResponseProto msg) {
 
     if (msg == null) {
       return null;
     }
 
     if (msg.hasReadChunk() || msg.hasGetSmallFile()) {
-      ContainerProtos.ContainerCommandResponseProto.Builder builder =
-          msg.toBuilder();
+      final ContainerCommandResponseProto.Builder builder = msg.toBuilder();
       if (msg.hasReadChunk()) {
         if (msg.getReadChunk().hasData()) {
           builder.getReadChunkBuilder().setData(REDACTED);
@@ -784,10 +781,10 @@ public final class HddsUtils {
                   .addBuffers(REDACTED);
         }
       }
-      return builder.build();
+      return TextFormat.shortDebugString(builder);
     }
 
-    return msg;
+    return TextFormat.shortDebugString(msg);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.server;
 
 import com.google.protobuf.ServiceException;
 import io.opentelemetry.api.trace.Span;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.ratis.util.UncheckedAutoCloseable;
@@ -42,20 +42,22 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
       protocolMessageMetrics;
 
   private final Logger logger;
-  private final UnaryOperator<REQUEST> requestPreprocessor;
-  private final UnaryOperator<RESPONSE> responsePreprocessor;
+  private final Function<REQUEST, String> requestPreprocessor;
+  private final Function<RESPONSE, String> responsePreprocessor;
 
   public OzoneProtocolMessageDispatcher(String serviceName,
       ProtocolMessageMetrics<TYPE> protocolMessageMetrics,
       Logger logger) {
-    this(serviceName, protocolMessageMetrics, logger, req -> req, resp -> resp);
+    this(serviceName, protocolMessageMetrics, logger,
+        OzoneProtocolMessageDispatcher::escapeNewLines,
+        OzoneProtocolMessageDispatcher::escapeNewLines);
   }
 
   public OzoneProtocolMessageDispatcher(String serviceName,
       ProtocolMessageMetrics<TYPE> protocolMessageMetrics,
       Logger logger,
-      UnaryOperator<REQUEST> requestPreprocessor,
-      UnaryOperator<RESPONSE> responsePreprocessor) {
+      Function<REQUEST, String> requestPreprocessor,
+      Function<RESPONSE, String> responsePreprocessor) {
     this.serviceName = serviceName;
     this.protocolMessageMetrics = protocolMessageMetrics;
     this.logger = logger;
@@ -75,7 +77,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
             "[service={}] [type={}] request is received: <json>{}</json>",
             serviceName,
             type,
-            escapeNewLines(requestPreprocessor.apply(request)));
+            requestPreprocessor.apply(request));
       } else if (logger.isDebugEnabled()) {
         logger.debug("{} {} request is received",
             serviceName, type);
@@ -93,7 +95,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
                 + "<json>{}</json>",
             serviceName,
             type,
-            escapeNewLines(responsePreprocessor.apply(response)));
+            responsePreprocessor.apply(response));
       }
       return response;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdds.scm.protocolPB.OzonePBHelper.getByteString;
 import static org.apache.hadoop.hdds.scm.protocolPB.OzonePBHelper.getFixedByteString;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.TextFormat;
 import java.io.IOException;
 import org.apache.hadoop.crypto.CipherSuite;
 import org.apache.hadoop.crypto.CryptoProtocolVersion;
@@ -366,11 +367,11 @@ public final class OMPBHelper {
     }
   }
 
-  public static OMRequest processForDebug(OMRequest msg) {
-    return msg;
+  public static String processForDebug(OMRequest msg) {
+    return TextFormat.shortDebugString(msg);
   }
 
-  public static OMResponse processForDebug(OMResponse msg) {
+  public static String processForDebug(OMResponse msg) {
     if (msg == null) {
       return null;
     }
@@ -381,9 +382,9 @@ public final class OMPBHelper {
       builder.getDbUpdatesResponseBuilder()
           .clearData().addData(REDACTED);
 
-      return builder.build();
+      return TextFormat.shortDebugString(builder);
     }
 
-    return msg;
+    return TextFormat.shortDebugString(msg);
   }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

The processForDebug(..) methods currently return proto objects. Then, the proto object is printed using the toString() method which will generate multiple lines for a single object. Let's change the processForDebug(..) methods to return String and use TextFormat.shortDebugString(..).

## What is the link to the Apache JIRA

HDDS-13727

## How was this patch tested?

By updating existing tests.