### PR TITLE
HDDS-13731. Extra parent dir appeared in CI artifacts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -254,9 +254,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ (inputs.split && format('{0}-{1}', inputs.script, inputs.split)) || inputs.script }}
-          path: |
-            target/${{ inputs.script }}
-            target/reports/apidocs
+          # please keep path as a single item; move to that directory all files needed in the artifact
+          path: target/${{ inputs.script }}
         continue-on-error: true
 
       # The following steps are hard-coded to be run only for 'build' check,


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-13144 introduced a new CI check (`javadoc`) for aggregate API docs. Results are stored in `target/reports/apidocs` instead of `target/javadoc`, the location expected by `check.yml`.  To account for that, HDDS-13144 modified the CI step so that all checks attempt to include this directory in their artifact, although it only exists for `javadoc`:

https://github.com/apache/ozone/blob/f4c8a12edb0d5256cbbcc5d11fd2396c79470b15/.github/workflows/check.yml#L252-L260

This introduces an unnecessary parent directory for all other checks:

```
# BEFORE
$ unzip -t build.zip 
Archive:  build.zip
    testing: failures                 OK
    testing: output.log               OK
    testing: summary.txt              OK
No errors detected in compressed data of build.zip.

# AFTER
$ unzip -t build.zip 
Archive:  build.zip
    testing: build/failures           OK
    testing: build/output.log         OK
    testing: build/summary.txt        OK
No errors detected in compressed data of build.zip.
```

Also, `javadoc`'s artifact does not include these standard `summary.txt`, `failures` and `output.log` files.

Changes in this PR:

1. Move `javadoc` check output to standard location to avoid extra parent dir in other checks' artifacts.
2. Generate common CI output files.
3. Allow passing options to Maven, which makes it possible to test locally without having to install into local Maven repo.

https://issues.apache.org/jira/browse/HDDS-13731

## How was this patch tested?

Tested locally:

```
$ MAVEN_OPTIONS='-DskipRecon -DskipShade -DskipTests verify' ./hadoop-ozone/dev-support/checks/javadoc.sh
...
[INFO] BUILD SUCCESS

$ find target/javadoc -mindepth 1 -maxdepth 1 | sort
target/javadoc/apidocs
target/javadoc/failures
target/javadoc/output.log
target/javadoc/summary.txt

$ du -sh target/javadoc/apidocs
137M	target/javadoc/apidocs
```

Verified [CI](https://github.com/adoroszlai/ozone/actions/runs/18194528987) artifacts:

```
$ unzip -t build.zip 
Archive:  build.zip
    testing: failures                 OK
    testing: output.log               OK
    testing: summary.txt              OK
No errors detected in compressed data of build.zip.

$ unzip -t javadoc.zip | tail
    testing: apidocs/search.html      OK
    testing: apidocs/search.js        OK
    testing: apidocs/serialized-form.html   OK
    testing: apidocs/stylesheet.css   OK
    testing: apidocs/tag-search-index.js   OK
    testing: apidocs/type-search-index.js   OK
    testing: failures                 OK
    testing: output.log               OK
    testing: summary.txt              OK
No errors detected in compressed data of javadoc.zip.

$ unzip -cq javadoc.zip failures
0

$ unzip -cq javadoc.zip output.log | tail -6
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:16 min
[INFO] Finished at: 2025-10-02T13:45:26Z
[INFO] ------------------------------------------------------------------------
[INFO] 525 goals, 525 executed
```
