### PR TITLE
HDDS-13733. RepeatedOmKeyInfo in deletedKeyTable should track bucket id

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -539,7 +539,7 @@ public final class OmUtils {
    *                     the same updateID as is in keyInfo.
    * @return {@link RepeatedOmKeyInfo}
    */
-  public static RepeatedOmKeyInfo prepareKeyForDelete(OmKeyInfo keyInfo, long bucketId,
+  public static RepeatedOmKeyInfo prepareKeyForDelete(long bucketId, OmKeyInfo keyInfo,
       long trxnLogIndex) {
     // If this key is in a GDPR enforced bucket, then before moving
     // KeyInfo to deletedTable, remove the GDPR related metadata and

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -531,6 +531,7 @@ public final class OmUtils {
    * repeatedOmKeyInfo instance.
    * 3. Set the updateID to the transactionLogIndex.
    * @param keyInfo args supplied by client
+   * @param bucketId bucket id
    * @param trxnLogIndex For Multipart keys, this is the transactionLogIndex
    *                     of the MultipartUploadAbort request which needs to
    *                     be set as the updateID of the partKeyInfos.
@@ -538,7 +539,7 @@ public final class OmUtils {
    *                     the same updateID as is in keyInfo.
    * @return {@link RepeatedOmKeyInfo}
    */
-  public static RepeatedOmKeyInfo prepareKeyForDelete(OmKeyInfo keyInfo,
+  public static RepeatedOmKeyInfo prepareKeyForDelete(OmKeyInfo keyInfo, long bucketId,
       long trxnLogIndex) {
     // If this key is in a GDPR enforced bucket, then before moving
     // KeyInfo to deletedTable, remove the GDPR related metadata and
@@ -556,7 +557,7 @@ public final class OmUtils {
     keyInfo.setUpdateID(trxnLogIndex);
 
     //The key doesn't exist in deletedTable, so create a new instance.
-    return new RepeatedOmKeyInfo(keyInfo);
+    return new RepeatedOmKeyInfo(keyInfo, bucketId);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -106,7 +106,11 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
     for (KeyInfo k : repeatedKeyInfo.getKeyInfoList()) {
       list.add(OmKeyInfo.getFromProtobuf(k));
     }
-    return new RepeatedOmKeyInfo.Builder().setOmKeyInfos(list).build();
+    RepeatedOmKeyInfo.Builder builder = new RepeatedOmKeyInfo.Builder().setOmKeyInfos(list);
+    if (repeatedKeyInfo.hasBucketId()) {
+      builder.setBucketId(repeatedKeyInfo.getBucketId());
+    }
+    return builder.build();
   }
 
   /**
@@ -119,7 +123,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
     }
 
     RepeatedKeyInfo.Builder builder = RepeatedKeyInfo.newBuilder()
-        .addAllKeyInfo(list);
+        .addAllKeyInfo(list).setBucketId(bucketId);
     return builder.build();
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -41,6 +41,14 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
   private static final Codec<RepeatedOmKeyInfo> CODEC_FALSE = newCodec(false);
 
   private final List<OmKeyInfo> omKeyInfoList;
+  /**
+   * Represents the unique identifier for a bucket. This variable is used to
+   * distinguish between different instances of a bucket, even if a bucket
+   * with the same name is deleted and recreated.
+   *
+   * It is particularly useful for tracking and updating the quota usage
+   * associated with a bucket.
+   */
   private final long bucketId;
 
   private static Codec<RepeatedOmKeyInfo> newCodec(boolean ignorePipeline) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -41,6 +41,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
   private static final Codec<RepeatedOmKeyInfo> CODEC_FALSE = newCodec(false);
 
   private final List<OmKeyInfo> omKeyInfoList;
+  private final long bucketId;
 
   private static Codec<RepeatedOmKeyInfo> newCodec(boolean ignorePipeline) {
     return new DelegatedCodec<>(
@@ -54,17 +55,20 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
     return ignorePipeline ? CODEC_TRUE : CODEC_FALSE;
   }
 
-  public RepeatedOmKeyInfo() {
+  public RepeatedOmKeyInfo(long bucketId) {
     this.omKeyInfoList = new ArrayList<>();
+    this.bucketId = bucketId;
   }
 
-  public RepeatedOmKeyInfo(List<OmKeyInfo> omKeyInfos) {
+  public RepeatedOmKeyInfo(List<OmKeyInfo> omKeyInfos, long bucketId) {
     this.omKeyInfoList = omKeyInfos;
+    this.bucketId = bucketId;
   }
 
-  public RepeatedOmKeyInfo(OmKeyInfo omKeyInfos) {
+  public RepeatedOmKeyInfo(OmKeyInfo omKeyInfos, long bucketId) {
     this.omKeyInfoList = new ArrayList<>();
     this.omKeyInfoList.add(omKeyInfos);
+    this.bucketId = bucketId;
   }
 
   public void addOmKeyInfo(OmKeyInfo info) {
@@ -119,6 +123,10 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
     return builder.build();
   }
 
+  public long getBucketId() {
+    return bucketId;
+  }
+
   @Override
   public String toString() {
     return "RepeatedOmKeyInfo{" +
@@ -131,6 +139,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
    */
   public static class Builder {
     private List<OmKeyInfo> omKeyInfos;
+    private long bucketId;
 
     public Builder() { }
 
@@ -139,13 +148,18 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
       return this;
     }
 
+    public Builder setBucketId(long bucketId) {
+      this.bucketId = bucketId;
+      return this;
+    }
+
     public RepeatedOmKeyInfo build() {
-      return new RepeatedOmKeyInfo(omKeyInfos);
+      return new RepeatedOmKeyInfo(omKeyInfos, bucketId);
     }
   }
 
   @Override
   public RepeatedOmKeyInfo copyObject() {
-    return new RepeatedOmKeyInfo(new ArrayList<>(omKeyInfoList));
+    return new RepeatedOmKeyInfo(new ArrayList<>(omKeyInfoList), bucketId);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -4431,7 +4431,6 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       verifyReplication(volumeName, bucketName, keyName,
           RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
     }
-    ozoneManager.awaitDoubleBufferFlush();
     //Step 4
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -4431,7 +4431,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
       verifyReplication(volumeName, bucketName, keyName,
           RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
     }
-
+    ozoneManager.awaitDoubleBufferFlush();
     //Step 4
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1219,6 +1219,7 @@ message DirectoryInfo {
 
 message RepeatedKeyInfo {
     repeated KeyInfo keyInfo = 1;
+    optional uint64 bucketId = 2;
 }
 
 message OzoneFileStatusProto {
@@ -2042,6 +2043,7 @@ message SnapshotMoveTableKeysRequest {
 message SnapshotMoveKeyInfos {
   optional string key = 1;
   repeated KeyInfo keyInfos = 2;
+  optional uint64 bucketId = 3;
 }
 
 message SnapshotPurgeRequest {

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -95,12 +96,14 @@ public class TestRepeatedOmKeyInfoCodec
   public void testWithoutPipeline(int chunkNum) throws IOException {
     final Codec<RepeatedOmKeyInfo> codec = RepeatedOmKeyInfo.getCodec(true);
     OmKeyInfo originKey = getKeyInfo(chunkNum);
-    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(originKey);
+    long bucketId = Time.now();
+    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(originKey, bucketId);
 
     byte[] rawData = codec.toPersistedFormat(repeatedOmKeyInfo);
     RepeatedOmKeyInfo key = codec.fromPersistedFormat(rawData);
     assertNull(key.getOmKeyInfoList().get(0).getLatestVersionLocations()
         .getLocationList().get(0).getPipeline());
+    assertEquals(bucketId, key.getBucketId());
   }
 
   public void testCompatibility(int chunkNum) throws IOException {
@@ -109,16 +112,19 @@ public class TestRepeatedOmKeyInfoCodec
     final Codec<RepeatedOmKeyInfo> codecWithPipeline
         = RepeatedOmKeyInfo.getCodec(false);
     OmKeyInfo originKey = getKeyInfo(chunkNum);
-    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(originKey);
+    long bucketId = Time.now();
+    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(originKey, bucketId);
     byte[] rawData = codecWithPipeline.toPersistedFormat(repeatedOmKeyInfo);
     RepeatedOmKeyInfo key = codecWithoutPipeline.fromPersistedFormat(rawData);
     assertNotNull(key.getOmKeyInfoList().get(0).getLatestVersionLocations()
         .getLocationList().get(0).getPipeline());
+    assertEquals(bucketId, key.getBucketId());
   }
 
   public void threadSafety() throws InterruptedException {
     final OmKeyInfo key = getKeyInfo(1);
-    final RepeatedOmKeyInfo subject = new RepeatedOmKeyInfo(key);
+    long bucketId = Time.now();
+    final RepeatedOmKeyInfo subject = new RepeatedOmKeyInfo(key, bucketId);
     final Codec<RepeatedOmKeyInfo> codec = RepeatedOmKeyInfo.getCodec(true);
     final AtomicBoolean failed = new AtomicBoolean();
     ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -759,9 +759,9 @@ public class KeyManagerImpl implements KeyManager {
       }
       int currentCount = 0;
       while (delKeyIter.hasNext() && currentCount < count) {
-        RepeatedOmKeyInfo notReclaimableKeyInfo = new RepeatedOmKeyInfo();
         KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
         if (kv != null) {
+          RepeatedOmKeyInfo notReclaimableKeyInfo = new RepeatedOmKeyInfo(kv.getValue().getBucketId());
           List<BlockGroup> blockGroupList = Lists.newArrayList();
           // Multiple keys with the same path can be queued in one DB entry
           RepeatedOmKeyInfo infoList = kv.getValue();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -320,7 +320,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         // Subtract the size of blocks to be overwritten.
         correctedSpace -= keyToDelete.getReplicatedSize();
         RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(
-            keyToDelete, trxnLogIndex);
+            keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
         // using pseudoObjId as objectId can be same in case of overwrite key
@@ -352,7 +352,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       final OmKeyInfo pseudoKeyInfo = isHSync ? null
           : wrapUncommittedBlocksAsPseudoKey(uncommitted, omKeyInfo);
       oldKeyVersionsToDeleteMap = addKeyInfoToDeleteMap(ozoneManager, trxnLogIndex, dbOzoneKey,
-          pseudoKeyInfo, oldKeyVersionsToDeleteMap);
+          omBucketInfo.getObjectID(), pseudoKeyInfo, oldKeyVersionsToDeleteMap);
 
       // Add to cache of open key table and key table.
       if (!isHSync) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -95,7 +95,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
     Exception exception = null;
     OmKeyInfo omKeyInfo = null;
-    OmBucketInfo omBucketInfo = null;
+    OmBucketInfo omBucketInfo;
     OMClientResponse omClientResponse = null;
     boolean bucketLockAcquired = false;
     Result result;
@@ -250,7 +250,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         // Subtract the size of blocks to be overwritten.
         correctedSpace -= keyToDelete.getReplicatedSize();
         RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(
-            keyToDelete, trxnLogIndex);
+            keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
         String delKeyName = omMetadataManager
@@ -293,7 +293,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
           oldKeyVersionsToDeleteMap = new HashMap<>();
         }
         oldKeyVersionsToDeleteMap.computeIfAbsent(delKeyName,
-            key -> new RepeatedOmKeyInfo()).addOmKeyInfo(pseudoKeyInfo);
+            key -> new RepeatedOmKeyInfo(omBucketInfo.getObjectID())).addOmKeyInfo(pseudoKeyInfo);
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1141,7 +1141,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
    */
   protected RepeatedOmKeyInfo getOldVersionsToCleanUp(
       @Nonnull OmKeyInfo keyToDelete, long bucketId, long trxnLogIndex) throws IOException {
-    return OmUtils.prepareKeyForDelete(keyToDelete, bucketId, trxnLogIndex);
+    return OmUtils.prepareKeyForDelete(bucketId, keyToDelete, trxnLogIndex);
   }
 
   protected OzoneLockStrategy getOzoneLockStrategy(OzoneManager ozoneManager) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -907,7 +907,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * Return bucket info for the specified bucket.
    */
   @Nullable
-  protected OmBucketInfo getBucketInfo(OMMetadataManager omMetadataManager,
+  public static OmBucketInfo getBucketInfo(OMMetadataManager omMetadataManager,
       String volume, String bucket) {
     String bucketKey = omMetadataManager.getBucketKey(volume, bucket);
 
@@ -1134,13 +1134,14 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * Prepare key for deletion service on overwrite.
    *
    * @param keyToDelete OmKeyInfo of a key to be in deleteTable
+   * @param bucketId
    * @param trxnLogIndex
    * @return Old keys eligible for deletion.
    * @throws IOException
    */
   protected RepeatedOmKeyInfo getOldVersionsToCleanUp(
-      @Nonnull OmKeyInfo keyToDelete, long trxnLogIndex) throws IOException {
-    return OmUtils.prepareKeyForDelete(keyToDelete, trxnLogIndex);
+      @Nonnull OmKeyInfo keyToDelete, long bucketId, long trxnLogIndex) throws IOException {
+    return OmUtils.prepareKeyForDelete(keyToDelete, bucketId, trxnLogIndex);
   }
 
   protected OzoneLockStrategy getOzoneLockStrategy(OzoneManager ozoneManager) {
@@ -1176,7 +1177,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
   }
 
   protected static Map<String, RepeatedOmKeyInfo> addKeyInfoToDeleteMap(OzoneManager om,
-      long trxnLogIndex, String ozoneKey, OmKeyInfo keyInfo, Map<String, RepeatedOmKeyInfo> deleteMap) {
+      long trxnLogIndex, String ozoneKey, long bucketId, OmKeyInfo keyInfo, Map<String, RepeatedOmKeyInfo> deleteMap) {
     if (keyInfo == null) {
       return deleteMap;
     }
@@ -1185,7 +1186,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (deleteMap == null) {
       deleteMap = new HashMap<>();
     }
-    deleteMap.computeIfAbsent(delKeyName, key -> new RepeatedOmKeyInfo())
+    deleteMap.computeIfAbsent(delKeyName, key -> new RepeatedOmKeyInfo(bucketId))
         .addOmKeyInfo(keyInfo);
     return deleteMap;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -97,6 +97,7 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
         updateOpenKeyTableCache(ozoneManager, trxnLogIndex,
             openKeyBucket, deletedOpenKeys);
       }
+
       omClientResponse = new OMOpenKeysDeleteResponse(omResponse.build(),
           deletedOpenKeys, getBucketLayout());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -234,7 +234,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         OmKeyInfo partKeyToBeDeleted =
             OmKeyInfo.getFromProtobuf(oldPartKeyInfo.getPartKeyInfo());
         correctedSpace -= partKeyToBeDeleted.getReplicatedSize();
-        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(partKeyToBeDeleted, trxnLogIndex);
+        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(partKeyToBeDeleted, omBucketInfo.getObjectID(),
+            trxnLogIndex);
         // Unlike normal key commit, we can reuse the objectID for MPU part key because MPU part key
         // always use a new object ID regardless whether there is an existing key.
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
@@ -252,7 +253,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
       final OmKeyInfo pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted, omKeyInfo);
-      keyVersionsToDeleteMap = addKeyInfoToDeleteMap(ozoneManager, trxnLogIndex, ozoneKey,
+      keyVersionsToDeleteMap = addKeyInfoToDeleteMap(ozoneManager, trxnLogIndex, ozoneKey, omBucketInfo.getObjectID(),
           pseudoKeyInfo, keyVersionsToDeleteMap);
 
       MultipartCommitUploadPartResponse.Builder commitResponseBuilder = MultipartCommitUploadPartResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -139,7 +139,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       acquiredLock = getOmLockDetails().isLockAcquired();
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
+      copyBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
       String uploadID = keyArgs.getMultipartUploadID();
       multipartKey = getMultipartKey(volumeName, bucketName, keyName,
               omMetadataManager, uploadID);
@@ -222,7 +222,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           new CacheKey<>(openKey),
           CacheValue.get(trxnLogIndex));
 
-      omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+      omBucketInfo = copyBucketInfo;
 
       // This map should contain maximum of two entries
       // 1. Overwritten part

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
@@ -72,10 +72,10 @@ public class S3MultipartUploadCommitPartRequestWithFSO
       Map<String, RepeatedOmKeyInfo> keyToDeleteMap, String openKey,
       OmKeyInfo omKeyInfo, String multipartKey,
       OmMultipartKeyInfo multipartKeyInfo,
-      OzoneManagerProtocolProtos.OMResponse build, OmBucketInfo omBucketInfo) {
+      OzoneManagerProtocolProtos.OMResponse build, OmBucketInfo omBucketInfo, long bucketId) {
 
     return new S3MultipartUploadCommitPartResponseWithFSO(build, multipartKey,
         openKey, multipartKeyInfo, keyToDeleteMap, omKeyInfo,
-        omBucketInfo, getBucketLayout());
+        omBucketInfo, bucketId, getBucketLayout());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -398,7 +398,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
 
     return new S3MultipartUploadCompleteResponse(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, allKeyInfoToRemove,
-        getBucketLayout(), omBucketInfo);
+        getBucketLayout(), omBucketInfo, bucketId);
   }
 
   protected void checkDirectoryAlreadyExists(OzoneManager ozoneManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -318,7 +318,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         boolean isNamespaceUpdate = false;
         if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
           RepeatedOmKeyInfo oldKeyVersionsToDelete = getOldVersionsToCleanUp(
-              keyToDelete, trxnLogIndex);
+              keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
           allKeyInfoToRemove.addAll(oldKeyVersionsToDelete.getOmKeyInfoList());
           usedBytesDiff -= keyToDelete.getReplicatedSize();
         } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -31,8 +31,10 @@ import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotMoveDeletedKeysResponse;
@@ -98,11 +100,12 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
       List<SnapshotMoveKeyInfos> reclaimKeysList = moveDeletedKeysRequest.getReclaimKeysList();
       List<HddsProtos.KeyValue> renamedKeysList = moveDeletedKeysRequest.getRenamedKeysList();
       List<String> movedDirs = moveDeletedKeysRequest.getDeletedDirsToMoveList();
-
+      OmBucketInfo omBucketInfo = OMKeyRequest.getBucketInfo(omMetadataManager, snapshotInfo.getVolumeName(),
+          snapshotInfo.getBucketName());
       OMSnapshotMoveUtils.updateCache(ozoneManager, fromSnapshot, nextSnapshot, context);
       omClientResponse = new OMSnapshotMoveDeletedKeysResponse(
           omResponse.build(), fromSnapshot, nextSnapshot,
-          nextDBKeysList, reclaimKeysList, renamedKeysList, movedDirs);
+          nextDBKeysList, reclaimKeysList, renamedKeysList, movedDirs, omBucketInfo.getObjectID());
 
       auditParams.put(AUDIT_PARAM_FROM_SNAPSHOT_ID, fromSnapshot.getSnapshotId().toString());
       auditParams.put(AUDIT_PARAM_FROM_SNAPSHOT_TABLE_KEY, fromSnapshot.getTableKey());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -58,7 +58,8 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       BatchOperation batchOperation,
       Table<String, ?> fromTable,
       String keyName,
-      OmKeyInfo omKeyInfo) throws IOException {
+      OmKeyInfo omKeyInfo,
+      long bucketId) throws IOException {
 
     // For OmResponse with failure, this should do nothing. This method is
     // not called in failure scenario in OM code.
@@ -76,7 +77,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       // if it is not null, then we simply add to the list and store this
       // instance in deletedTable.
       RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, omKeyInfo.getUpdateID()
+          omKeyInfo, bucketId, omKeyInfo.getUpdateID()
       );
       String delKeyName = omMetadataManager.getOzoneDeletePathKey(
           omKeyInfo.getObjectID(), keyName);
@@ -101,7 +102,8 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       BatchOperation batchOperation,
       Table<String, ?> fromTable,
       String keyName, String deleteKeyName,
-      OmKeyInfo omKeyInfo) throws IOException {
+      OmKeyInfo omKeyInfo,
+      long bucketId) throws IOException {
 
     // For OmResponse with failure, this should do nothing. This method is
     // not called in failure scenario in OM code.
@@ -119,7 +121,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       // if it is not null, then we simply add to the list and store this
       // instance in deletedTable.
       RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, omKeyInfo.getUpdateID()
+          omKeyInfo, bucketId, omKeyInfo.getUpdateID()
       );
       omMetadataManager.getDeletedTable().putWithBatch(
           batchOperation, deleteKeyName, repeatedOmKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -76,8 +76,8 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       // if RepeatedOMKeyInfo structure is null, we create a new instance,
       // if it is not null, then we simply add to the list and store this
       // instance in deletedTable.
-      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, bucketId, omKeyInfo.getUpdateID()
+      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(bucketId,
+          omKeyInfo, omKeyInfo.getUpdateID()
       );
       String delKeyName = omMetadataManager.getOzoneDeletePathKey(
           omKeyInfo.getObjectID(), keyName);
@@ -120,8 +120,8 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       // if RepeatedOMKeyInfo structure is null, we create a new instance,
       // if it is not null, then we simply add to the list and store this
       // instance in deletedTable.
-      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, bucketId, omKeyInfo.getUpdateID()
+      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(bucketId,
+          omKeyInfo, omKeyInfo.getUpdateID()
       );
       omMetadataManager.getDeletedTable().putWithBatch(
           batchOperation, deleteKeyName, repeatedOmKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -155,7 +155,7 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
         }
 
         RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            keyInfo, keyInfo.getUpdateID());
+            keyInfo, bucketId, keyInfo.getUpdateID());
 
         String deletedKey = keySpaceOmMetadataManager
             .getOzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -154,8 +154,8 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
               keyInfo.getKeyName(), ozoneDbKey);
         }
 
-        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            keyInfo, bucketId, keyInfo.getUpdateID());
+        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(bucketId,
+            keyInfo, keyInfo.getUpdateID());
 
         String deletedKey = keySpaceOmMetadataManager
             .getOzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -75,7 +75,7 @@ public class OMKeyDeleteResponse extends AbstractOMKeyDeleteResponse {
     Table<String, OmKeyInfo> keyTable =
         omMetadataManager.getKeyTable(getBucketLayout());
     addDeletionToBatch(omMetadataManager, batchOperation, keyTable, ozoneKey,
-        omKeyInfo);
+        omKeyInfo, omBucketInfo.getObjectID());
 
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
@@ -101,7 +101,7 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
       deletedKey = omMetadataManager.getOzoneDeletePathKey(
           omKeyInfo.getObjectID(), deletedKey);
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
-          ozoneDbKey, deletedKey, omKeyInfo);
+          ozoneDbKey, deletedKey, omKeyInfo, getOmBucketInfo().getObjectID());
     }
 
     // update bucket usedBytes.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -106,7 +106,7 @@ public class OMKeyPurgeResponse extends OmKeyResponse {
 
     for (SnapshotMoveKeyInfos keyToUpdate : keysToUpdateList) {
       List<KeyInfo> keyInfosList = keyToUpdate.getKeyInfosList();
-      RepeatedOmKeyInfo repeatedOmKeyInfo = createRepeatedOmKeyInfo(keyInfosList);
+      RepeatedOmKeyInfo repeatedOmKeyInfo = createRepeatedOmKeyInfo(keyInfosList, keyToUpdate.getBucketId());
       metadataManager.getDeletedTable().putWithBatch(batchOp,
           keyToUpdate.getKey(), repeatedOmKeyInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -93,7 +93,7 @@ public class OMKeysDeleteResponse extends AbstractOMKeyDeleteResponse {
           keyName);
 
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
-          deleteKey, omKeyInfo);
+          deleteKey, omKeyInfo, getOmBucketInfo().getObjectID());
     }
 
     // update bucket usedBytes.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
@@ -87,7 +87,7 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
       deletedKey = omMetadataManager.getOzoneDeletePathKey(
           omKeyInfo.getObjectID(), deletedKey);
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
-          ozoneDbKey, deletedKey, omKeyInfo);
+          ozoneDbKey, deletedKey, omKeyInfo, bucketId);
     }
 
     // update bucket usedBytes.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMOpenKeysDeleteResponse.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -41,11 +42,11 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
     DELETED_TABLE, BUCKET_TABLE})
 public class OMOpenKeysDeleteResponse extends AbstractOMKeyDeleteResponse {
 
-  private Map<String, OmKeyInfo> keysToDelete;
+  private Map<String, Pair<Long, OmKeyInfo>> keysToDelete;
 
   public OMOpenKeysDeleteResponse(
       @Nonnull OMResponse omResponse,
-      @Nonnull Map<String, OmKeyInfo> keysToDelete,
+      @Nonnull Map<String, Pair<Long, OmKeyInfo>> keysToDelete,
       @Nonnull BucketLayout bucketLayout) {
 
     super(omResponse, bucketLayout);
@@ -71,9 +72,9 @@ public class OMOpenKeysDeleteResponse extends AbstractOMKeyDeleteResponse {
     Table<String, OmKeyInfo> openKeyTable =
         omMetadataManager.getOpenKeyTable(getBucketLayout());
 
-    for (Map.Entry<String, OmKeyInfo> keyInfoPair : keysToDelete.entrySet()) {
+    for (Map.Entry<String, Pair<Long, OmKeyInfo>> keyInfoPair : keysToDelete.entrySet()) {
       addDeletionToBatch(omMetadataManager, batchOperation, openKeyTable,
-          keyInfoPair.getKey(), keyInfoPair.getValue());
+          keyInfoPair.getKey(), keyInfoPair.getValue().getValue(), keyInfoPair.getValue().getKey());
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
@@ -83,8 +83,7 @@ public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
         //  MPU part actually contains blocks, and only move the to
         //  deletedTable if it does.
 
-        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            currentKeyPartInfo, omBucketInfo.getObjectID(), omMultipartKeyInfo.getUpdateID()
+        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omBucketInfo.getObjectID(), currentKeyPartInfo, omMultipartKeyInfo.getUpdateID()
         );
 
         // multi-part key format is volumeName/bucketName/keyName/uploadId

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
@@ -84,7 +84,7 @@ public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
         //  deletedTable if it does.
 
         RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            currentKeyPartInfo, omMultipartKeyInfo.getUpdateID()
+            currentKeyPartInfo, omBucketInfo.getObjectID(), omMultipartKeyInfo.getUpdateID()
         );
 
         // multi-part key format is volumeName/bucketName/keyName/uploadId

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
@@ -83,8 +83,8 @@ public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
         //  MPU part actually contains blocks, and only move the to
         //  deletedTable if it does.
 
-        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omBucketInfo.getObjectID(), currentKeyPartInfo, omMultipartKeyInfo.getUpdateID()
-        );
+        RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omBucketInfo.getObjectID(),
+            currentKeyPartInfo, omMultipartKeyInfo.getUpdateID());
 
         // multi-part key format is volumeName/bucketName/keyName/uploadId
         String deleteKey = omMetadataManager.getOzoneDeletePathKey(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -87,9 +87,8 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
       // multipart upload. So, delete this part information.
 
       RepeatedOmKeyInfo repeatedOmKeyInfo =
-          OmUtils.prepareKeyForDelete(openPartKeyInfoToBeDeleted,
-              openPartKeyInfoToBeDeleted.getUpdateID()
-          );
+          OmUtils.prepareKeyForDelete(openPartKeyInfoToBeDeleted, omBucketInfo.getObjectID(),
+              openPartKeyInfoToBeDeleted.getUpdateID());
       // multi-part key format is volumeName/bucketName/keyName/uploadId
       String deleteKey = omMetadataManager.getOzoneDeletePathKey(
           openPartKeyInfoToBeDeleted.getObjectID(), multipartKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -54,6 +54,7 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
   private final Map<String, RepeatedOmKeyInfo> keyToDeleteMap;
   private final OmKeyInfo openPartKeyInfoToBeDeleted;
   private final OmBucketInfo omBucketInfo;
+  private final long bucketId;
 
   /**
    * Regular response.
@@ -68,6 +69,7 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
       @Nullable Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       @Nullable OmKeyInfo openPartKeyInfoToBeDeleted,
       @Nonnull OmBucketInfo omBucketInfo,
+      long bucketId,
       @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);
     this.multipartKey = multipartKey;
@@ -76,6 +78,7 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
     this.keyToDeleteMap = keyToDeleteMap;
     this.openPartKeyInfoToBeDeleted = openPartKeyInfoToBeDeleted;
     this.omBucketInfo = omBucketInfo;
+    this.bucketId = bucketId;
   }
 
   @Override
@@ -87,7 +90,7 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
       // multipart upload. So, delete this part information.
 
       RepeatedOmKeyInfo repeatedOmKeyInfo =
-          OmUtils.prepareKeyForDelete(openPartKeyInfoToBeDeleted, omBucketInfo.getObjectID(),
+          OmUtils.prepareKeyForDelete(bucketId, openPartKeyInfoToBeDeleted,
               openPartKeyInfoToBeDeleted.getUpdateID());
       // multi-part key format is volumeName/bucketName/keyName/uploadId
       String deleteKey = omMetadataManager.getOzoneDeletePathKey(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponseWithFSO.java
@@ -53,10 +53,10 @@ public class S3MultipartUploadCommitPartResponseWithFSO
       @Nullable OmMultipartKeyInfo omMultipartKeyInfo,
       @Nullable Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       @Nullable OmKeyInfo openPartKeyInfoToBeDeleted,
-      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout) {
+      @Nonnull OmBucketInfo omBucketInfo, long bucketId, @Nonnull BucketLayout bucketLayout) {
 
     super(omResponse, multipartKey, openKey, omMultipartKeyInfo,
             keyToDeleteMap, openPartKeyInfoToBeDeleted,
-            omBucketInfo, bucketLayout);
+            omBucketInfo, bucketId, bucketLayout);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -53,7 +53,9 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
   private OmKeyInfo omKeyInfo;
   private List<OmKeyInfo> allKeyInfoToRemove;
   private OmBucketInfo omBucketInfo;
+  private long bucketId;
 
+  @SuppressWarnings("parameternumber")
   public S3MultipartUploadCompleteResponse(
       @Nonnull OMResponse omResponse,
       @Nonnull String multipartKey,
@@ -61,13 +63,15 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
       @Nonnull OmKeyInfo omKeyInfo,
       @Nonnull List<OmKeyInfo> allKeyInfoToRemove,
       @Nonnull BucketLayout bucketLayout,
-      OmBucketInfo omBucketInfo) {
+      OmBucketInfo omBucketInfo,
+      long bucketId) {
     super(omResponse, bucketLayout);
     this.allKeyInfoToRemove = allKeyInfoToRemove;
     this.multipartKey = multipartKey;
     this.multipartOpenKey = multipartOpenKey;
     this.omKeyInfo = omKeyInfo;
     this.omBucketInfo = omBucketInfo;
+    this.bucketId = bucketId;
   }
 
   /**
@@ -100,7 +104,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
         String deleteKey = omMetadataManager.getOzoneDeletePathKey(
             keyInfoToRemove.getObjectID(), multipartKey);
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-            deleteKey, new RepeatedOmKeyInfo(keyInfoToRemove, omBucketInfo.getObjectID()));
+            deleteKey, new RepeatedOmKeyInfo(keyInfoToRemove, bucketId));
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -100,7 +100,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
         String deleteKey = omMetadataManager.getOzoneDeletePathKey(
             keyInfoToRemove.getObjectID(), multipartKey);
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-            deleteKey, new RepeatedOmKeyInfo(keyInfoToRemove));
+            deleteKey, new RepeatedOmKeyInfo(keyInfoToRemove, omBucketInfo.getObjectID()));
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -70,7 +70,7 @@ public class S3MultipartUploadCompleteResponseWithFSO
       List<OmDirectoryInfo> missingParentInfos,
       OmMultipartKeyInfo multipartKeyInfo) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo,
-        allKeyInfoToRemove, bucketLayout, omBucketInfo);
+        allKeyInfoToRemove, bucketLayout, omBucketInfo, bucketId);
     this.volumeId = volumeId;
     this.bucketId = bucketId;
     this.missingParentInfos = missingParentInfos;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
@@ -159,9 +159,7 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
                                   OMMetadataManager metadataManager)
       throws IOException {
     for (SnapshotMoveKeyInfos dBKey : reclaimKeysList) {
-      RepeatedOmKeyInfo omKeyInfos =
-          createRepeatedOmKeyInfo(dBKey.
-              getKeyInfosList(), bucketId);
+      RepeatedOmKeyInfo omKeyInfos = createRepeatedOmKeyInfo(dBKey.getKeyInfosList(), bucketId);
       // omKeyInfos can be null, because everything from RepeatedOmKeyInfo
       // is moved to next snapshot which means this key can be deleted in
       // the current snapshot processed by SDS. The reclaim key here indicates

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
@@ -52,14 +52,17 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
   private List<SnapshotMoveKeyInfos> reclaimKeysList;
   private List<HddsProtos.KeyValue> renamedKeysList;
   private List<String> movedDirs;
+  private long bucketId;
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public OMSnapshotMoveDeletedKeysResponse(OMResponse omResponse,
       @Nonnull SnapshotInfo fromSnapshot,
       SnapshotInfo nextSnapshot,
       List<SnapshotMoveKeyInfos> nextDBKeysList,
       List<SnapshotMoveKeyInfos> reclaimKeysList,
       List<HddsProtos.KeyValue> renamedKeysList,
-      List<String> movedDirs) {
+      List<String> movedDirs,
+      long bucketId) {
     super(omResponse);
     this.fromSnapshot = fromSnapshot;
     this.nextSnapshot = nextSnapshot;
@@ -67,6 +70,7 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
     this.reclaimKeysList = reclaimKeysList;
     this.renamedKeysList = renamedKeysList;
     this.movedDirs = movedDirs;
+    this.bucketId = bucketId;
   }
 
   /**
@@ -156,7 +160,8 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
       throws IOException {
     for (SnapshotMoveKeyInfos dBKey : reclaimKeysList) {
       RepeatedOmKeyInfo omKeyInfos =
-          createRepeatedOmKeyInfo(dBKey.getKeyInfosList());
+          createRepeatedOmKeyInfo(dBKey.
+              getKeyInfosList(), bucketId);
       // omKeyInfos can be null, because everything from RepeatedOmKeyInfo
       // is moved to next snapshot which means this key can be deleted in
       // the current snapshot processed by SDS. The reclaim key here indicates
@@ -198,7 +203,8 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
     }
 
     for (SnapshotMoveKeyInfos dBKey : nextDBKeysList) {
-      RepeatedOmKeyInfo omKeyInfos = createMergedRepeatedOmKeyInfoFromDeletedTableEntry(dBKey, metadataManager);
+      RepeatedOmKeyInfo omKeyInfos = createMergedRepeatedOmKeyInfoFromDeletedTableEntry(dBKey, bucketId,
+          metadataManager);
       if (omKeyInfos == null) {
         continue;
       }
@@ -208,12 +214,12 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
   }
 
   public static RepeatedOmKeyInfo createRepeatedOmKeyInfo(
-      List<KeyInfo> keyInfoList) throws IOException {
+      List<KeyInfo> keyInfoList, long bucketId) throws IOException {
     RepeatedOmKeyInfo result = null;
 
     for (KeyInfo keyInfo: keyInfoList) {
       if (result == null) {
-        result = new RepeatedOmKeyInfo(OmKeyInfo.getFromProtobuf(keyInfo));
+        result = new RepeatedOmKeyInfo(OmKeyInfo.getFromProtobuf(keyInfo), bucketId);
       } else {
         result.addOmKeyInfo(OmKeyInfo.getFromProtobuf(keyInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveTableKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveTableKeysResponse.java
@@ -45,6 +45,7 @@ import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 @CleanupTableInfo(cleanupTables = {SNAPSHOT_INFO_TABLE})
 public class OMSnapshotMoveTableKeysResponse extends OMClientResponse {
 
+  private long bucketId;
   private SnapshotInfo fromSnapshot;
   private SnapshotInfo nextSnapshot;
   private List<SnapshotMoveKeyInfos> deletedKeys;
@@ -53,6 +54,7 @@ public class OMSnapshotMoveTableKeysResponse extends OMClientResponse {
 
   public OMSnapshotMoveTableKeysResponse(OMResponse omResponse,
                                          @Nonnull SnapshotInfo fromSnapshot, SnapshotInfo nextSnapshot,
+                                         long bucketId,
                                          List<SnapshotMoveKeyInfos> deletedKeys,
                                          List<SnapshotMoveKeyInfos> deletedDirs,
                                          List<HddsProtos.KeyValue> renamedKeys) {
@@ -62,6 +64,7 @@ public class OMSnapshotMoveTableKeysResponse extends OMClientResponse {
     this.deletedKeys = deletedKeys;
     this.renameKeysList = renamedKeys;
     this.deletedDirs = deletedDirs;
+    this.bucketId = bucketId;
   }
 
   /**
@@ -146,7 +149,7 @@ public class OMSnapshotMoveTableKeysResponse extends OMClientResponse {
     }
     // Add deleted keys to the next snapshot or active DB.
     for (SnapshotMoveKeyInfos deletedKeyInfo : deletedKeys) {
-      RepeatedOmKeyInfo omKeyInfos = createMergedRepeatedOmKeyInfoFromDeletedTableEntry(deletedKeyInfo,
+      RepeatedOmKeyInfo omKeyInfos = createMergedRepeatedOmKeyInfoFromDeletedTableEntry(deletedKeyInfo, bucketId,
           metadataManager);
       metadataManager.getDeletedTable().putWithBatch(batchOp, deletedKeyInfo.getKey(), omKeyInfos);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -234,6 +234,7 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
                 .map(k -> k.getProtobuf(ClientVersion.CURRENT_VERSION))
                 .collect(Collectors.toList());
         keyToUpdate.addAllKeyInfos(keyInfos);
+        keyToUpdate.setBucketId(keyToModify.getValue().getBucketId());
         keysToUpdateList.add(keyToUpdate.build());
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -244,7 +244,8 @@ public final class SnapshotUtils {
    * @throws IOException
    */
   public static RepeatedOmKeyInfo createMergedRepeatedOmKeyInfoFromDeletedTableEntry(
-      OzoneManagerProtocolProtos.SnapshotMoveKeyInfos snapshotMoveKeyInfos, OMMetadataManager metadataManager) throws
+      OzoneManagerProtocolProtos.SnapshotMoveKeyInfos snapshotMoveKeyInfos, long bucketId,
+      OMMetadataManager metadataManager) throws
       IOException {
     String dbKey = snapshotMoveKeyInfos.getKey();
     List<OmKeyInfo> keyInfoList = new ArrayList<>();
@@ -260,7 +261,7 @@ public final class SnapshotUtils {
     // can happen on om transaction replay on snapshotted rocksdb.
     RepeatedOmKeyInfo result = metadataManager.getDeletedTable().get(dbKey);
     if (result == null) {
-      result = new RepeatedOmKeyInfo(keyInfoList);
+      result = new RepeatedOmKeyInfo(keyInfoList, bucketId);
     } else if (!isSameAsLatestOmKeyInfo(keyInfoList, result)) {
       keyInfoList.forEach(result::addOmKeyInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -717,7 +717,8 @@ public final class OMRequestTestUtils {
       BucketLayout bucketLayout)
       throws Exception {
     return addBucketToDB(omMetadataManager,
-        OmBucketInfo.newBuilder().setVolumeName(volumeName).setObjectID(System.currentTimeMillis())
+        OmBucketInfo.newBuilder().setVolumeName(volumeName)
+            .setObjectID(System.currentTimeMillis())
             .setBucketName(bucketName)
             .setBucketLayout(bucketLayout)
     );

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -1011,7 +1011,7 @@ public final class OMRequestTestUtils {
     // Delete key from KeyTable and put in DeletedKeyTable
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).delete(ozoneKey);
 
-    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omKeyInfo, bucketId, trxnLogIndex);
+    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(bucketId, omKeyInfo, trxnLogIndex);
 
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -122,14 +122,13 @@ public final class OMRequestTestUtils {
    * @param omMetadataManager
    * @throws Exception
    */
-  public static void addVolumeAndBucketToDB(String volumeName,
+  public static OmBucketInfo addVolumeAndBucketToDB(String volumeName,
       String bucketName, OMMetadataManager omMetadataManager) throws Exception {
-
-    addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager,
+    return addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager,
         BucketLayout.DEFAULT);
   }
 
-  public static void addVolumeAndBucketToDB(String volumeName,
+  public static OmBucketInfo addVolumeAndBucketToDB(String volumeName,
       String bucketName, OMMetadataManager omMetadataManager,
       BucketLayout bucketLayout) throws Exception {
 
@@ -137,11 +136,12 @@ public final class OMRequestTestUtils {
             omMetadataManager.getVolumeKey(volumeName))) {
       addVolumeToDB(volumeName, omMetadataManager);
     }
-
-    if (!omMetadataManager.getBucketTable().isExist(
-            omMetadataManager.getBucketKey(volumeName, bucketName))) {
-      addBucketToDB(volumeName, bucketName, omMetadataManager, bucketLayout);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    if (omBucketInfo == null) {
+      return addBucketToDB(volumeName, bucketName, omMetadataManager, bucketLayout);
     }
+    return omBucketInfo;
   }
 
   public static void addVolumeAndBucketToDB(
@@ -706,11 +706,10 @@ public final class OMRequestTestUtils {
    * @param omMetadataManager
    * @throws Exception
    */
-  public static void addBucketToDB(String volumeName, String bucketName,
+  public static long addBucketToDB(String volumeName, String bucketName,
       OMMetadataManager omMetadataManager) throws Exception {
-
-    addBucketToDB(volumeName, bucketName, omMetadataManager,
-        BucketLayout.DEFAULT);
+    return addBucketToDB(volumeName, bucketName, omMetadataManager,
+        BucketLayout.DEFAULT).getObjectID();
   }
 
   public static OmBucketInfo addBucketToDB(String volumeName,
@@ -718,7 +717,7 @@ public final class OMRequestTestUtils {
       BucketLayout bucketLayout)
       throws Exception {
     return addBucketToDB(omMetadataManager,
-        OmBucketInfo.newBuilder().setVolumeName(volumeName)
+        OmBucketInfo.newBuilder().setVolumeName(volumeName).setObjectID(System.currentTimeMillis())
             .setBucketName(bucketName)
             .setBucketLayout(bucketLayout)
     );
@@ -1004,18 +1003,15 @@ public final class OMRequestTestUtils {
    * Deletes key from Key table and adds it to DeletedKeys table.
    * @return the deletedKey name
    */
-  public static String deleteKey(String ozoneKey,
-      OMMetadataManager omMetadataManager, long trxnLogIndex)
-      throws IOException {
+  public static String deleteKey(String ozoneKey, long bucketId, OMMetadataManager omMetadataManager,
+      long trxnLogIndex) throws IOException {
     // Retrieve the keyInfo
-    OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getDefaultBucketLayout()).get(ozoneKey);
+    OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getDefaultBucketLayout()).get(ozoneKey);
 
     // Delete key from KeyTable and put in DeletedKeyTable
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).delete(ozoneKey);
 
-    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-        omKeyInfo, trxnLogIndex);
+    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omKeyInfo, bucketId, trxnLogIndex);
 
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -79,6 +79,9 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     // Add volume, bucket and key entries to OM DB.
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucket,
         omMetadataManager);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucket);
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(
+        bucketKey);
 
     List<OmKeyInfo> deletedKeyNames = new ArrayList<>(numKeys);
     List<String> ozoneKeyNames = new ArrayList<>(numKeys);
@@ -98,7 +101,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
 
     for (String ozoneKey : ozoneKeyNames) {
       OMRequestTestUtils.deleteKey(
-          ozoneKey, omMetadataManager, trxnIndex++);
+          ozoneKey, omBucketInfo.getObjectID(), omMetadataManager, trxnIndex++);
     }
 
     return deletedKeyNames;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OmSnapshot;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
@@ -63,7 +64,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
       bucket = bucketName;
     }
     // Add volume, bucket and key entries to OM DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucket,
+    OmBucketInfo omBucketInfo = OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucket,
         omMetadataManager);
 
     List<String> ozoneKeyNames = new ArrayList<>(numKeys);
@@ -82,7 +83,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     List<String> deletedKeyNames = new ArrayList<>(numKeys);
     for (String ozoneKey : ozoneKeyNames) {
       String deletedKeyName = OMRequestTestUtils.deleteKey(
-          ozoneKey, omMetadataManager, trxnIndex++);
+          ozoneKey, omBucketInfo.getObjectID(), omMetadataManager, trxnIndex++);
       deletedKeyNames.add(deletedKeyName);
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -393,13 +393,14 @@ public class TestOMSnapshotCreateRequest extends TestSnapshotRequestAndResponse 
     String bucket1Name = getBucketName();
     String bucket2Name = getBucketName() + "0";
     String volumeName = getVolumeName();
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucket2Name, getOmMetadataManager());
+    OmBucketInfo bucketInfo = OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucket2Name,
+        getOmMetadataManager());
 
     // 2. Add and delete keys from both buckets
     OmKeyInfo key1 = addKeyInBucket(volumeName, bucket1Name, "key1", 100L);
     OmKeyInfo key2 = addKeyInBucket(volumeName, bucket2Name, "key2", 200L);
-    deleteKey(key1);
-    deleteKey(key2);
+    deleteKey(key1, bucketInfo.getObjectID());
+    deleteKey(key2, bucketInfo.getObjectID());
 
     // 3. Verify deletedTable contains both deleted keys (2 rows)
     assertEquals(2, getOmMetadataManager().countRowsInTable(deletedTable));
@@ -467,10 +468,10 @@ public class TestOMSnapshotCreateRequest extends TestSnapshotRequestAndResponse 
     getOmMetadataManager().getStore().commitBatchOperation(getBatchOperation());
   }
 
-  private void deleteKey(OmKeyInfo keyInfo) throws IOException {
+  private void deleteKey(OmKeyInfo keyInfo, long bucketId) throws IOException {
     String ozoneKey = getOmMetadataManager().getOzoneKey(keyInfo.getVolumeName(),
         keyInfo.getBucketName(), keyInfo.getKeyName());
-    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(keyInfo);
+    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(keyInfo, bucketId);
     getOmMetadataManager().getDeletedTable().putWithBatch(getBatchOperation(),
         ozoneKey, repeatedOmKeyInfo);
     getOmMetadataManager().getStore().commitBatchOperation(getBatchOperation());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -116,7 +116,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   public void testAddToDBBatchOnOverwrite() throws Exception {
     OmKeyInfo omKeyInfo = getOmKeyInfo();
     keysToDelete =
-            OmUtils.prepareKeyForDelete(omKeyInfo, 100);
+            OmUtils.prepareKeyForDelete(omKeyInfo, omBucketInfo.getObjectID(), 100);
     assertNotNull(keysToDelete);
     testAddToDBBatch();
 
@@ -153,7 +153,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     if (null != deleteKeys) {
       deleteKeys.getOmKeyInfoList().stream().forEach(e -> deleteKeyMap.put(
           omMetadataManager.getOzoneDeletePathKey(e.getObjectID(), ozoneKey),
-          new RepeatedOmKeyInfo(e)));
+          new RepeatedOmKeyInfo(e, omBucketInfo.getObjectID())));
     }
     return new OMKeyCommitResponse(omResponse, omKeyInfo, ozoneKey, openKey,
         omBucketInfo, deleteKeyMap, isHSync, newOpenKeyInfo, null, null);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -116,7 +116,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   public void testAddToDBBatchOnOverwrite() throws Exception {
     OmKeyInfo omKeyInfo = getOmKeyInfo();
     keysToDelete =
-            OmUtils.prepareKeyForDelete(omKeyInfo, omBucketInfo.getObjectID(), 100);
+            OmUtils.prepareKeyForDelete(omBucketInfo.getObjectID(), omKeyInfo, 100);
     assertNotNull(keysToDelete);
     testAddToDBBatch();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -51,7 +51,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
           bucketName, keyName);
       deleteKeys.getOmKeyInfoList().stream().forEach(e -> deleteKeyMap.put(
           omMetadataManager.getOzoneDeletePathKey(e.getObjectID(), deleteKey),
-          new RepeatedOmKeyInfo(e)));
+          new RepeatedOmKeyInfo(e, omBucketInfo.getObjectID())));
     }
     return new OMKeyCommitResponseWithFSO(omResponse, omKeyInfo, ozoneKey,
         openKey, omBucketInfo, deleteKeyMap, volumeId, isHSync, newOpenKeyInfo, null, null);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -26,7 +26,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -66,8 +68,8 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
     this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
-    Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3);
-    Map<String, OmKeyInfo> keysToKeep = addOpenKeysToDB(volumeName, 3);
+    Map<String, Pair<Long, OmKeyInfo>> keysToDelete = addOpenKeysToDB(volumeName, 3);
+    Map<String, Pair<Long, OmKeyInfo>> keysToKeep = addOpenKeysToDB(volumeName, 3);
 
     createAndCommitResponse(keysToDelete, Status.OK);
 
@@ -96,31 +98,31 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
     this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
-    Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3,
+    Map<String, Pair<Long, OmKeyInfo>> keysToDelete = addOpenKeysToDB(volumeName, 3,
         KEY_LENGTH);
-    Map<String, OmKeyInfo> keysToKeep = addOpenKeysToDB(volumeName, 3,
+    Map<String, Pair<Long, OmKeyInfo>> keysToKeep = addOpenKeysToDB(volumeName, 3,
         KEY_LENGTH);
 
     createAndCommitResponse(keysToDelete, Status.OK);
 
-    for (Map.Entry<String, OmKeyInfo> entry: keysToDelete.entrySet()) {
+    for (Map.Entry<String, Pair<Long, OmKeyInfo>> entry: keysToDelete.entrySet()) {
       // These keys should have been moved from the open key table to the
       // delete table.
       assertFalse(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(
               entry.getKey()));
       String deleteKey = omMetadataManager.getOzoneDeletePathKey(
-          entry.getValue().getObjectID(), entry.getKey());
+          entry.getValue().getValue().getObjectID(), entry.getKey());
       assertTrue(omMetadataManager.getDeletedTable().isExist(deleteKey));
     }
 
-    for (Map.Entry<String, OmKeyInfo> entry: keysToKeep.entrySet()) {
+    for (Map.Entry<String, Pair<Long, OmKeyInfo>> entry: keysToKeep.entrySet()) {
       // These keys should not have been moved out of the open key table.
       assertTrue(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(
               entry.getKey()));
       String deleteKey = omMetadataManager.getOzoneDeletePathKey(
-          entry.getValue().getObjectID(), entry.getKey());
+          entry.getValue().getValue().getObjectID(), entry.getKey());
       assertFalse(omMetadataManager.getDeletedTable().isExist(deleteKey));
     }
   }
@@ -137,7 +139,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
     this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
-    Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3);
+    Map<String, Pair<Long, OmKeyInfo>> keysToDelete = addOpenKeysToDB(volumeName, 3);
 
     createAndCommitResponse(keysToDelete, Status.INTERNAL_ERROR);
 
@@ -156,7 +158,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
    * to a batch operation and committed to the database.
    * @throws Exception
    */
-  private void createAndCommitResponse(Map<String, OmKeyInfo> keysToDelete,
+  private void createAndCommitResponse(Map<String, Pair<Long, OmKeyInfo>> keysToDelete,
       Status status) throws Exception {
 
     OMResponse omResponse = OMResponse.newBuilder()
@@ -179,7 +181,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
    * new {@link OmKeyInfo} object, adds them to the open key table cache, and
    * returns them. These keys will have no associated block data.
    */
-  private Map<String, OmKeyInfo> addOpenKeysToDB(String volume, int numKeys)
+  private Map<String, Pair<Long, OmKeyInfo>> addOpenKeysToDB(String volume, int numKeys)
       throws Exception {
     return addOpenKeysToDB(volume, numKeys, 0);
   }
@@ -192,15 +194,15 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
    * bytes of data for each key.
    * @throws Exception
    */
-  private Map<String, OmKeyInfo> addOpenKeysToDB(String volume, int numKeys,
+  private Map<String, Pair<Long, OmKeyInfo>> addOpenKeysToDB(String volume, int numKeys,
       long keyLength) throws Exception {
 
-    Map<String, OmKeyInfo> newOpenKeys = new HashMap<>();
+    Map<String, Pair<Long, OmKeyInfo>> newOpenKeys = new HashMap<>();
 
     for (int i = 0; i < numKeys; i++) {
       String bucket = UUID.randomUUID().toString();
       String key = UUID.randomUUID().toString();
-      addBucketToDB(volume, bucket, omMetadataManager, getBucketLayout());
+      OmBucketInfo bucketInfo = addBucketToDB(volume, bucket, omMetadataManager, getBucketLayout());
       long clientID = random.nextLong();
       long parentID = random.nextLong();
 
@@ -234,7 +236,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
       assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
           .isExist(openKey));
 
-      newOpenKeys.put(openKey, omKeyInfo);
+      newOpenKeys.put(openKey, Pair.of(bucketInfo.getObjectID(), omKeyInfo));
     }
 
     return newOpenKeys;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -288,7 +288,7 @@ public class TestS3MultipartResponse {
       String delKeyName = omMetadataManager.getOzoneDeletePathKey(
           partKeyToBeDeleted.getObjectID(), multipartKey);
 
-      keyToDeleteMap.put(delKeyName, new RepeatedOmKeyInfo(partKeyToBeDeleted));
+      keyToDeleteMap.put(delKeyName, new RepeatedOmKeyInfo(partKeyToBeDeleted, omBucketInfo.getObjectID()));
     }
 
     return new S3MultipartUploadCommitPartResponseWithFSO(omResponse,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -293,7 +293,7 @@ public class TestS3MultipartResponse {
 
     return new S3MultipartUploadCommitPartResponseWithFSO(omResponse,
         multipartKey, openKey, multipartKeyInfo, keyToDeleteMap,
-        openPartKeyInfoToBeDeleted, omBucketInfo,
+        openPartKeyInfoToBeDeleted, omBucketInfo, omBucketInfo.getObjectID(),
         getBucketLayout());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
@@ -246,7 +246,7 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     String bucketName = UUID.randomUUID().toString();
     String keyName = getKeyName();
 
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OmBucketInfo bucketInfo = OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
     createParentPath(volumeName, bucketName);
 
@@ -257,7 +257,7 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
         .setParentObjectID(parentID)
         .setUpdateID(8)
         .build();
-    RepeatedOmKeyInfo prevKeys = new RepeatedOmKeyInfo(prevKey);
+    RepeatedOmKeyInfo prevKeys = new RepeatedOmKeyInfo(prevKey, bucketInfo.getObjectID());
     String ozoneKey = omMetadataManager
         .getOzoneKey(prevKey.getVolumeName(),
             prevKey.getBucketName(), prevKey.getFileName());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -819,7 +819,7 @@ class TestKeyDeletingService extends OzoneTestBase {
             .setParentObjectID(2)
             .build();
         Map<String, RepeatedOmKeyInfo> keysToModify = Collections.singletonMap("key1",
-            new RepeatedOmKeyInfo(Collections.singletonList(omKeyInfo)));
+            new RepeatedOmKeyInfo(Collections.singletonList(omKeyInfo), 0L));
         keyDeletingService.processKeyDeletes(blockGroups, keysToModify, renameEntriesToBeDeleted, null, null, null);
         assertTrue(purgeRequest.get().getPurgeKeysRequest().getKeysToUpdateList().isEmpty());
         assertEquals(renameEntriesToBeDeleted, purgeRequest.get().getPurgeKeysRequest().getRenamedKeysList());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -408,7 +408,7 @@ public final class OMMetadataManagerTestUtils {
     // Get the Ozone key for the first deleted key
     String omKey = omMetadataManager.getOzoneKey(volName,
         bucketName, keyNames.get(0));
-    RepeatedOmKeyInfo repeatedKeyInfo = new RepeatedOmKeyInfo(infos);
+    RepeatedOmKeyInfo repeatedKeyInfo = new RepeatedOmKeyInfo(infos, 1);
     // Put the deleted key information into the deleted table
     omMetadataManager.getDeletedTable().put(omKey, repeatedKeyInfo);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestDeletedKeysSearchEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestDeletedKeysSearchEndpoint.java
@@ -519,7 +519,7 @@ public class TestDeletedKeysSearchEndpoint extends AbstractReconSqlDBTest {
     omKeyInfos.add(omKeyInfo);
 
     // Create a RepeatedOmKeyInfo object with the list of OmKeyInfo
-    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfos);
+    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfos, 1);
 
     // Write the deleted key information to the OM metadata manager
     writeDeletedKeysToOm(reconOMMetadataManager, deletedKey, repeatedOmKeyInfo);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -1173,15 +1173,15 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         reconOMMetadataManager.getKeyTable(getBucketLayout())
             .get("/sampleVol/bucketOne/key_one");
     assertEquals("key_one", omKeyInfoCopy.getKeyName());
-    RepeatedOmKeyInfo repeatedOmKeyInfo1 = new RepeatedOmKeyInfo(omKeyInfoCopy);
+    RepeatedOmKeyInfo repeatedOmKeyInfo1 = new RepeatedOmKeyInfo(omKeyInfoCopy, 1);
 
     reconOMMetadataManager.getDeletedTable()
         .put("/sampleVol/bucketOne/key_one", repeatedOmKeyInfo1);
     assertEquals("key_one",
         repeatedOmKeyInfo1.getOmKeyInfoList().get(0).getKeyName());
 
-    RepeatedOmKeyInfo repeatedOmKeyInfo2 = new RepeatedOmKeyInfo(omKeyInfo2);
-    RepeatedOmKeyInfo repeatedOmKeyInfo3 = new RepeatedOmKeyInfo(omKeyInfo2);
+    RepeatedOmKeyInfo repeatedOmKeyInfo2 = new RepeatedOmKeyInfo(omKeyInfo2, 1);
+    RepeatedOmKeyInfo repeatedOmKeyInfo3 = new RepeatedOmKeyInfo(omKeyInfo2, 1);
     reconOMMetadataManager.getDeletedTable()
         .put("/sampleVol/bucketOne/key_two", repeatedOmKeyInfo2);
     reconOMMetadataManager.getDeletedTable()
@@ -1207,9 +1207,9 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfo3 =
         getOmKeyInfo("sampleVol", "bucketOne", "key_three", true);
 
-    RepeatedOmKeyInfo repeatedOmKeyInfo1 = new RepeatedOmKeyInfo(omKeyInfo1);
-    RepeatedOmKeyInfo repeatedOmKeyInfo2 = new RepeatedOmKeyInfo(omKeyInfo2);
-    RepeatedOmKeyInfo repeatedOmKeyInfo3 = new RepeatedOmKeyInfo(omKeyInfo3);
+    RepeatedOmKeyInfo repeatedOmKeyInfo1 = new RepeatedOmKeyInfo(omKeyInfo1, 1);
+    RepeatedOmKeyInfo repeatedOmKeyInfo2 = new RepeatedOmKeyInfo(omKeyInfo2, 1);
+    RepeatedOmKeyInfo repeatedOmKeyInfo3 = new RepeatedOmKeyInfo(omKeyInfo3, 1);
 
     reconOMMetadataManager.getDeletedTable()
         .put("/sampleVol/bucketOne/key_one", repeatedOmKeyInfo1);
@@ -1245,7 +1245,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfo1 = reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one");
     assertEquals("key_one", omKeyInfo1.getKeyName());
-    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfo);
+    RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfo, 1);
     reconOMMetadataManager.getDeletedTable()
         .put("/sampleVol/bucketOne/key_one", repeatedOmKeyInfo);
     RepeatedOmKeyInfo repeatedOmKeyInfo1 =
@@ -1271,7 +1271,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
           getOmKeyInfo("sampleVol", "bucketOne", "deleted_key_" + i, true);
       reconOMMetadataManager.getDeletedTable()
           .put("/sampleVol/bucketOne/deleted_key_" + i,
-              new RepeatedOmKeyInfo(omKeyInfo));
+              new RepeatedOmKeyInfo(omKeyInfo, 1));
     }
 
     // Case 1: prevKey provided, startPrefix empty
@@ -1297,7 +1297,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
       OmKeyInfo omKeyInfo =
           getOmKeyInfo("sampleVol", "bucketOne", "deleted_key_" + i, true);
       reconOMMetadataManager.getDeletedTable()
-          .put("/sampleVol/bucketOne/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo));
+          .put("/sampleVol/bucketOne/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo, 1));
     }
 
     // Case 2: prevKey empty, startPrefix empty
@@ -1323,13 +1323,13 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
       OmKeyInfo omKeyInfo =
           getOmKeyInfo("sampleVol", "bucketOne", "deleted_key_" + i, true);
       reconOMMetadataManager.getDeletedTable()
-          .put("/sampleVol/bucketOne/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo));
+          .put("/sampleVol/bucketOne/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo, 1));
     }
     for (int i = 5; i < 10; i++) {
       OmKeyInfo omKeyInfo =
           getOmKeyInfo("sampleVol", "bucketTwo", "deleted_key_" + i, true);
       reconOMMetadataManager.getDeletedTable()
-          .put("/sampleVol/bucketTwo/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo));
+          .put("/sampleVol/bucketTwo/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo, 1));
     }
 
     // Case 3: startPrefix provided, prevKey empty
@@ -1356,13 +1356,13 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
       OmKeyInfo omKeyInfo =
           getOmKeyInfo("sampleVol", "bucketOne", "deleted_key_" + i, true);
       reconOMMetadataManager.getDeletedTable()
-          .put("/sampleVol/bucketOne/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo));
+          .put("/sampleVol/bucketOne/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo, 1));
     }
     for (int i = 10; i < 15; i++) {
       OmKeyInfo omKeyInfo =
           getOmKeyInfo("sampleVol", "bucketTwo", "deleted_key_" + i, true);
       reconOMMetadataManager.getDeletedTable()
-          .put("/sampleVol/bucketTwo/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo));
+          .put("/sampleVol/bucketTwo/deleted_key_" + i, new RepeatedOmKeyInfo(omKeyInfo, 1));
     }
 
     // Case 4: startPrefix and prevKey provided

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -306,7 +306,7 @@ public class TestOMDBUpdatesHandler {
     omMetadataManager.getFileTable().put("/sampleVol/bucketOne/parentId/sameName", fileKeyInfo);
 
     // Step 2: Delete the file by adding its information to the deletedTable
-    RepeatedOmKeyInfo repeatedKeyInfo = new RepeatedOmKeyInfo(fileKeyInfo);
+    RepeatedOmKeyInfo repeatedKeyInfo = new RepeatedOmKeyInfo(fileKeyInfo, 0);
     omMetadataManager.getDeletedTable().put("/sampleVol/bucketOne/parentId/sameName", repeatedKeyInfo);
 
     // Step 3: Create a directory with the same name "sameName" in the directoryTable

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -438,8 +438,8 @@ public class FSORepairTool extends RepairTool {
         fileTable.deleteWithBatch(batch, fileKey);
 
         RepeatedOmKeyInfo originalRepeatedKeyInfo = deletedTable.get(fileKey);
-        RepeatedOmKeyInfo updatedRepeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            fileInfo, fileInfo.getUpdateID(), bucketInfo.getObjectID());
+        RepeatedOmKeyInfo updatedRepeatedOmKeyInfo = OmUtils.prepareKeyForDelete(bucketInfo.getObjectID(),
+            fileInfo, fileInfo.getUpdateID());
         // NOTE: The FSO code seems to write the open key entry with the whole
         // path, using the object's names instead of their ID. This would only
         // be possible when the file is deleted explicitly, and not part of a

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -420,7 +420,7 @@ public class FSORepairTool extends RepairTool {
 
               info("Deleting unreferenced file " + fileKey);
               if (!isDryRun()) {
-                markFileForDeletion(fileKey, fileInfo);
+                markFileForDeletion(bucket, fileKey, fileInfo);
               }
             }
           } else {
@@ -433,13 +433,13 @@ public class FSORepairTool extends RepairTool {
       }
     }
 
-    protected void markFileForDeletion(String fileKey, OmKeyInfo fileInfo) throws IOException {
+    protected void markFileForDeletion(OmBucketInfo bucketInfo, String fileKey, OmKeyInfo fileInfo) throws IOException {
       try (BatchOperation batch = store.initBatchOperation()) {
         fileTable.deleteWithBatch(batch, fileKey);
 
         RepeatedOmKeyInfo originalRepeatedKeyInfo = deletedTable.get(fileKey);
         RepeatedOmKeyInfo updatedRepeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            fileInfo, fileInfo.getUpdateID());
+            fileInfo, fileInfo.getUpdateID(), bucketInfo.getObjectID());
         // NOTE: The FSO code seems to write the open key entry with the whole
         // path, using the object's names instead of their ID. This would only
         // be possible when the file is deleted explicitly, and not part of a


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently there are no traces of bucket information in deletedKeyTable. However a bucket could be deleted and recreated with the same name even having leftover keys from older bucket in the deletedTable and the bucket quota could be erroneously be updated for the newer bucket when updated with just the bucket name check. Thus for each RepeatedKeyInfo in deletedTable should have bucketId which would notify whether a bucket quota needs to be updated or not.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13733

## How was this patch tested?
Updated existing unit tests