### PR TITLE
HDDS-13667. [DiskBalancer] Improve DiskBalancer CLI message for failed commands

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommonOptions.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommonOptions.java
@@ -57,7 +57,8 @@ public class DiskBalancerCommonOptions {
   }
 
   public String getHostString() {
-    return isAllHosts() ? "All datanodes" : String.join("\n", getDatanodes());
+    return isAllHosts() ? "All datanodes which are IN_SERVICE and HEALTHY."
+        : String.join("\n", getDatanodes());
   }
 
   public List<String> getSpecifiedDatanodes() {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
@@ -69,10 +69,10 @@ public class DiskBalancerStartSubcommand extends ScmSubcommand {
         scmClient.startDiskBalancer(threshold, bandwidthInMB, parallelThread, stopAfterDiskEven,
             commonOptions.getSpecifiedDatanodes());
 
-    System.out.println("Start DiskBalancer on datanode(s):\n" +
-        commonOptions.getHostString());
-
-    if (!errors.isEmpty()) {
+    if (errors.isEmpty()) {
+      System.out.println("Start DiskBalancer on datanode(s):\n" +
+          commonOptions.getHostString());
+    } else {
       for (DatanodeAdminError error : errors) {
         System.err.println("Error: " + error.getHostname() + ": "
             + error.getError());

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStopSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStopSubcommand.java
@@ -49,9 +49,10 @@ public class DiskBalancerStopSubcommand extends ScmSubcommand {
     List<DatanodeAdminError> errors = scmClient.stopDiskBalancer(
         commonOptions.getSpecifiedDatanodes());
 
-    System.out.println("Stopping DiskBalancer on datanode(s):\n" +
-        commonOptions.getHostString());
-    if (!errors.isEmpty()) {
+    if (errors.isEmpty()) {
+      System.out.println("Stopping DiskBalancer on datanode(s):\n" +
+          commonOptions.getHostString());
+    } else {
       for (DatanodeAdminError error : errors) {
         System.err.println("Error: " + error.getHostname() + ": "
             + error.getError());

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
@@ -69,10 +69,10 @@ public class DiskBalancerUpdateSubcommand extends ScmSubcommand {
         scmClient.updateDiskBalancerConfiguration(threshold, bandwidthInMB,
             parallelThread, stopAfterDiskEven, commonOptions.getSpecifiedDatanodes());
 
-    System.out.println("Update DiskBalancer Configuration on datanode(s):\n" +
-        commonOptions.getHostString());
-
-    if (!errors.isEmpty()) {
+    if (errors.isEmpty()) {
+      System.out.println("Update DiskBalancer Configuration on datanode(s):\n" +
+          commonOptions.getHostString());
+    } else {
       for (DatanodeAdminError error : errors) {
         System.err.println("Error: " + error.getHostname() + ": "
             + error.getError());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancerDuringDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancerDuringDecommissionAndMaintenance.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -256,28 +257,26 @@ public class TestDiskBalancerDuringDecommissionAndMaintenance {
         100, 5000);
 
     // Attempt to stop disk balancer on the decommissioning DN
-    diskBalancerManager.stopDiskBalancer(dnAddressList);
+    List<DatanodeAdminError> dnErrors = diskBalancerManager.stopDiskBalancer(dnAddressList);
 
-    // Verify disk balancer is now explicitly stopped (operationalState becomes STOPPED)
-    final String expectedLogForStop =
-        "DiskBalancer operational state changing from PAUSED_BY_NODE_STATE to STOPPED";
-    GenericTestUtils.waitFor(() -> serviceLog.getOutput().contains(expectedLogForStop),
-        100, 5000);
+    // Verify disk balancer stop command is not sent to decommissioning DN
+    assertEquals(1, dnErrors.size());
+    assertTrue(dnErrors.get(0).getError()
+        .contains("Datanode is not in an optimal state for disk balancing"));
 
     //Recommission the node
     scmClient.recommissionNodes(dnAddressList);
     waitForDnToReachOpState(nm, dn, IN_SERVICE);
 
-    // Verify it does not automatically restart (since it was explicitly stopped)
-    HddsProtos.DatanodeDiskBalancerInfoProto statusAfterRecommission =
-        diskBalancerManager.getDiskBalancerStatus(dnAddressList, null,
-            ClientVersion.CURRENT_VERSION).stream().findFirst().orElse(null);
-    assertEquals(HddsProtos.DiskBalancerRunningStatus.STOPPED, statusAfterRecommission.getRunningStatus());
+    // Verify it automatically resumes (since explicit stop command was not sent)
+    GenericTestUtils.waitFor(() -> {
+      String dnLogs = serviceLog.getOutput();
+      return dnLogs.contains("Resuming DiskBalancerService to running state as Node state changed to IN_SERVICE.");
+    }, 100, 5000);
   }
 
   @Test
   public void testStartDiskBalancerOnDecommissioningNode() throws Exception {
-    LogCapturer serviceLog = LogCapturer.captureLogs(DiskBalancerService.class);
     LogCapturer supervisorLog = LogCapturer.captureLogs(ReplicationSupervisor.class);
 
     List<HddsDatanodeService> dns = cluster.getHddsDatanodes();
@@ -307,30 +306,26 @@ public class TestDiskBalancerDuringDecommissionAndMaintenance {
         100, 5000);
 
     // Attempt to start disk balancer on the decommissioning DN
-    diskBalancerManager.startDiskBalancer(
-        10.0,
-        10L,
-        1,
-        false,
-        dnAddressList);
+    List<DatanodeAdminError> dnErrors = diskBalancerManager.startDiskBalancer(
+        10.0, 10L, 1, false, dnAddressList);
 
-    // Verify disk balancer goes to PAUSED_BY_NODE_STATE
-    final String expectedLogForPause =
-        "DiskBalancer operational state changing from STOPPED to PAUSED_BY_NODE_STATE";
-    GenericTestUtils.waitFor(() -> serviceLog.getOutput().contains(expectedLogForPause),
-        100, 5000);
+    // Verify disk balancer start command is not sent to decommissioning DN
+    assertEquals(1, dnErrors.size());
+    assertTrue(dnErrors.get(0).getError()
+        .contains("Datanode is not in an optimal state for disk balancing"));
 
     //Recommission the node
     scmClient.recommissionNodes(dnAddressList);
     waitForDnToReachOpState(nm, dn, IN_SERVICE);
 
-    // Verify it automatically restart (since it was explicitly started)
+    // Verify it does not automatically resume (since it was explicit
+    // start command was not sent to decommissioning DN)
     GenericTestUtils.waitFor(() -> {
       try {
         HddsProtos.DatanodeDiskBalancerInfoProto status =
             diskBalancerManager.getDiskBalancerStatus(dnAddressList, null,
                 ClientVersion.CURRENT_VERSION).stream().findFirst().orElse(null);
-        return status != null && status.getRunningStatus() == HddsProtos.DiskBalancerRunningStatus.RUNNING;
+        return status != null && status.getRunningStatus() == HddsProtos.DiskBalancerRunningStatus.STOPPED;
       } catch (IOException e) {
         return false;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently DiskBalancer start, stop and update command is send only to  **IN_SERVICE_HEALTHY**  DN but user has no info about this so improve cli output message to show as below:
```
bash-5.1$ ozone admin datanode diskbalancer start -t 0.0001 -a
Start DiskBalancer on datanode(s):
All datanodes which are IN_SERVICE and HEALTHY. 
```
When start, stop and update command is sent to a specific DN which is not **IN_SERVICE_HEALTHY**, command should be rejected same as when sent to all DN.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13667

## How was this patch tested?

Updated existing Integration Test `TestDiskBalancerDuringDecommissionAndMaintenance` .
Also tested manually on docker-cluster:
```
bash-5.1$ ozone admin datanode decommission -id scmservice ozone-ha-datanode-5
Started decommissioning datanode(s):
ozone-ha-datanode-5

bash-5.1$ ozone admin datanode diskbalancer status
Status result:
Datanode                            Status          Threshold(%)    BandwidthInMB   Threads      SuccessMove  FailureMove  BytesMoved(MB)  EstBytesToMove(MB) EstTimeLeft(min)
ozone-ha-datanode-3.ozone-ha_default STOPPED         10.0000         200             5            0            0            0               0               0              
ozone-ha-datanode-2.ozone-ha_default STOPPED         10.0000         200             5            0            0            0               0               0              
ozone-ha-datanode-4.ozone-ha_default STOPPED         10.0000         200             5            0            0            0               0               0              
ozone-ha-datanode-1.ozone-ha_default STOPPED         10.0000         200             5            0            0            0               0               0              

Note: Estimated time left is calculated based on the estimated bytes to move and the configured disk bandwidth.

bash-5.1$ ozone admin datanode diskbalancer start -b 200 -d ozone-ha-datanode-5
Error: ozone-ha-datanode-5.ozone-ha_default: Datanode is not in optimal state for disk balancing. NodeStatus: DECOMMISSIONING(no expiry)-HEALTHY
Some nodes could not start DiskBalancer.
```

```
bash-5.1$ ozone admin datanode decommission -id scmservice ozone-ha-datanode-3 
Started decommissioning datanode(s):
ozone-ha-datanode-3

bash-5.1$ ozone admin datanode decommission -id scmservice ozone-ha-datanode-4 
Started decommissioning datanode(s):
ozone-ha-datanode-4

bash-5.1$ ozone admin datanode diskbalancer start -t 0.002 -a
Start DiskBalancer on datanode(s):
All datanodes which are IN_SERVICE and HEALTHY.

```

