### PR TITLE
HDDS-11314. OM system audit for internal request and leader change

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMSystemAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMSystemAction.java
@@ -23,6 +23,8 @@ package org.apache.hadoop.ozone.audit;
  */
 public enum OMSystemAction implements AuditAction {
   STARTUP,
+  LEADER_CHANGE,
+  OPEN_KEY_CLEANUP,
   DIRECTORY_DELETION,
   KEY_DELETION,
   SNAPSHOT_MOVE_DEL_KEYS,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -26,7 +26,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -34,6 +36,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.utils.NettyMetrics;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditLoggerType;
+import org.apache.hadoop.ozone.audit.OMSystemAction;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
@@ -85,6 +90,10 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerStateMachine.class);
+  private static final AuditLogger AUDIT = new AuditLogger(AuditLoggerType.OMSYSTEMLOGGER);
+  private static final String AUDIT_PARAM_PREVIOUS_LEADER = "previousLeader";
+  private static final String AUDIT_PARAM_NEW_LEADER = "newLeader";
+  private RaftPeerId previousLeaderId = null;
   private final SimpleStateMachineStorage storage =
       new SimpleStateMachineStorage();
   private final OzoneManager ozoneManager;
@@ -169,8 +178,19 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
       // warmup cache
       ozoneManager.initializeEdekCache(ozoneManager.getConfiguration());
     }
+    // Store the previous leader before updating
+    RaftPeerId actualPreviousLeader = previousLeaderId;
+
+    // Update the previous leader for next time
+    previousLeaderId = newLeaderId;
     // Initialize OMHAMetrics
     ozoneManager.omHAMetricsInit(newLeaderId.toString());
+
+    Map<String, String> auditParams = new LinkedHashMap<>();
+    auditParams.put(AUDIT_PARAM_PREVIOUS_LEADER, String.valueOf(actualPreviousLeader));
+    auditParams.put(AUDIT_PARAM_NEW_LEADER, String.valueOf(newLeaderId));
+    AUDIT.logWriteSuccess(ozoneManager.buildAuditMessageForSuccess(OMSystemAction.LEADER_CHANGE, auditParams));
+
     LOG.info("{}: leader changed to {}", groupMemberId, newLeaderId);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
@@ -21,6 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,6 +37,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.ozone.audit.OMSystemAction;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -295,6 +300,42 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
     assertEquals(numExistentKeys + numNonExistentKeys,
         metrics.getNumOpenKeysSubmittedForDeletion());
     assertEquals(numExistentKeys, metrics.getNumOpenKeysDeleted());
+  }
+
+  /**
+   * Test OPEN_KEY_CLEANUP audit logging when open keys are deleted.
+   */
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testOpenKeyCleanupAuditLogging(BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
+    final String volume = UUID.randomUUID().toString();
+    final String bucket = UUID.randomUUID().toString();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volume, bucket,
+        omMetadataManager, getBucketLayout());
+
+    List<Pair<Long, OmKeyInfo>> openKeys = makeOpenKeys(volume, bucket, 3);
+    addToOpenKeyTableDB(openKeys);
+
+    OMRequest omRequest = doPreExecute(createDeleteOpenKeyRequest(openKeys));
+    OMOpenKeysDeleteRequest openKeyDeleteRequest =
+        new OMOpenKeysDeleteRequest(omRequest, getBucketLayout());
+
+    OMClientResponse omClientResponse =
+        openKeyDeleteRequest.validateAndUpdateCache(ozoneManager, 100L);
+
+    assertEquals(Status.OK, omClientResponse.getOMResponse().getStatus());
+
+    verify(ozoneManager, times(1))
+        .buildAuditMessageForSuccess(eq(OMSystemAction.OPEN_KEY_CLEANUP),
+            argThat(params -> {
+              assertEquals("3", params.get("numOpenKeysDeleted"));
+              assertTrue(params.containsKey("openKeysDeleted"));
+              return true;
+            }));
+
+    assertNotInOpenKeyTable(openKeys);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added OM System Audit Logs for `LEADER_CHANGE` and `OPEN_KEY_CLEANUP`

## What is the link to the Apache JIRA
[HDDS-11314](https://issues.apache.org/jira/browse/HDDS-11314)

## How was this patch tested?
- `LEADER CHANGE`
```
bash-5.1$ ozone admin om roles
om1 : FOLLOWER (om1)
om3 : FOLLOWER (om3)
om2 : LEADER (om2)

bash-5.1$ ozone admin om transfer --newLeaderId om1
Transfer leadership successfully to om1.

bash-5.1$ ozone admin om roles
om3 : FOLLOWER (om3)
om2 : FOLLOWER (om2)
om1 : LEADER (om1)

bash-5.1$ cat /var/log/hadoop/om-sys-audit-om1.log
2025-10-03 04:44:38,377 | INFO  | OMSystemAudit | user=null | ip= | op=STARTUP {"NewOmState":"RUNNING","OmState":"INITIALIZED"} | ret=SUCCESS |  
2025-10-03 04:44:48,409 | INFO  | OMSystemAudit | user=null | ip= | op=LEADER_CHANGE {"previousLeader":"null","newLeader":"om2"} | ret=SUCCESS |  
2025-10-03 04:46:10,281 | INFO  | OMSystemAudit | user=null | ip= | op=LEADER_CHANGE {"previousLeader":"om2","newLeader":"om1"} | ret=SUCCESS |  
```

- `OPEN_KEY_CLEANUP`
Added `TestOMOpenKeysDeleteRequest#testOpenKeyCleanupAuditLogging`
```
numOpenKeysDeleted=3, openKeysDeleted={
/78b31c91-c693-4ca0-b7fc-419cb333b6b6/294888ee-377d-41ce-9f0f-bf14be53ac91/b1a95e91-7705-4919-ba3e-48d8022335c2/4913887302444934892=OmKeyInfo{volumeName='78b31c91-c693-4ca0-b7fc-419cb333b6b6', bucketName='294888ee-377d-41ce-9f0f-bf14be53ac91', keyName='b1a95e91-7705-4919-ba3e-48d8022335c2', dataSize=0, keyLocationVersions=[], creationTime=0, modificationTime=0, replicationConfig=RATIS/THREE, encInfo=null, fileChecksum=null, isFile=false, fileName='b1a95e91-7705-4919-ba3e-48d8022335c2', acls=[]}, 
/78b31c91-c693-4ca0-b7fc-419cb333b6b6/294888ee-377d-41ce-9f0f-bf14be53ac91/b55c4f6d-8ddd-4b8b-8096-a4a5c4c45515/4920641604437566819=OmKeyInfo{volumeName='78b31c91-c693-4ca0-b7fc-419cb333b6b6', bucketName='294888ee-377d-41ce-9f0f-bf14be53ac91', keyName='b55c4f6d-8ddd-4b8b-8096-a4a5c4c45515', dataSize=0, keyLocationVersions=[], creationTime=0, modificationTime=0, replicationConfig=RATIS/THREE, encInfo=null, fileChecksum=null, isFile=false, fileName='b55c4f6d-8ddd-4b8b-8096-a4a5c4c45515', acls=[]}, 
/78b31c91-c693-4ca0-b7fc-419cb333b6b6/294888ee-377d-41ce-9f0f-bf14be53ac91/d69b90fc-dca0-4a59-95e8-fd55bc07af1d/-6987281019837032095=OmKeyInfo{volumeName='78b31c91-c693-4ca0-b7fc-419cb333b6b6', bucketName='294888ee-377d-41ce-9f0f-bf14be53ac91', keyName='d69b90fc-dca0-4a59-95e8-fd55bc07af1d', dataSize=0, keyLocationVersions=[], creationTime=0, modificationTime=0, replicationConfig=RATIS/THREE, encInfo=null, fileChecksum=null, isFile=false, fileName='d69b90fc-dca0-4a59-95e8-fd55bc07af1d', acls=[]}}
```