### PR TITLE
HDDS-13735. DBConfigFromFile warns about trying to read from ""

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
@@ -82,7 +82,7 @@ public final class DBConfigFromFile {
    */
   public static String getOptionsFileNameFromDB(String dbFileName) {
     Preconditions.checkNotNull(dbFileName);
-    return dbFileName + ".ini";
+    return dbFileName.isEmpty() ? "" : dbFileName + ".ini";
   }
 
   /**
@@ -113,8 +113,11 @@ public final class DBConfigFromFile {
    */
   public static ManagedDBOptions readDBOptionsFromFile(Path dbPath) throws RocksDBException {
     Path generatedDBPath = generateDBPath(dbPath);
+    if (generatedDBPath.toString().isEmpty()) {
+      return null;
+    }
     if (!generatedDBPath.toFile().exists()) {
-      LOG.debug("Error trying to read generated rocksDB file: {}, file does not exists.", generatedDBPath);
+      LOG.warn("Error trying to read generated rocksDB file: {}, file does not exists.", generatedDBPath);
       return null;
     }
     List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
@@ -137,8 +140,11 @@ public final class DBConfigFromFile {
   public static ManagedColumnFamilyOptions readCFOptionsFromFile(Path optionsPath, String cfName)
       throws RocksDBException {
     Path generatedDBPath = generateDBPath(optionsPath);
+    if (generatedDBPath.toString().isEmpty()) {
+      return null;
+    }
     if (!generatedDBPath.toFile().exists()) {
-      LOG.debug("Error trying to read column family options from file: {}, file does not exists.", generatedDBPath);
+      LOG.warn("Error trying to read column family options from file: {}, file does not exists.", generatedDBPath);
       return null;
     }
     List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
@@ -173,6 +179,10 @@ public final class DBConfigFromFile {
    * @throws RocksDBException
    */
   private static Path generateDBPath(Path path) {
+    String dbPath = path == null ? "" : path.toString();
+    if (dbPath.isEmpty()) {
+      return Paths.get("");
+    }
     if (path.toFile().exists()) {
       LOG.debug("RocksDB path found: {}, opening db from it.", path);
       return path;
@@ -190,5 +200,4 @@ public final class DBConfigFromFile {
     LOG.info("No RocksDB path found");
     return Paths.get("");
   }
-
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
@@ -114,7 +114,7 @@ public final class DBConfigFromFile {
   public static ManagedDBOptions readDBOptionsFromFile(Path dbPath) throws RocksDBException {
     Path generatedDBPath = generateDBPath(dbPath);
     if (!generatedDBPath.toFile().exists()) {
-      LOG.warn("Error trying to read generated rocksDB file: {}, file does not exists.", generatedDBPath);
+      LOG.debug("Error trying to read generated rocksDB file: {}, file does not exists.", generatedDBPath);
       return null;
     }
     List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
@@ -138,7 +138,7 @@ public final class DBConfigFromFile {
       throws RocksDBException {
     Path generatedDBPath = generateDBPath(optionsPath);
     if (!generatedDBPath.toFile().exists()) {
-      LOG.warn("Error trying to read column family options from file: {}, file does not exists.", generatedDBPath);
+      LOG.debug("Error trying to read column family options from file: {}, file does not exists.", generatedDBPath);
       return null;
     }
     List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBConfigFromFile.java
@@ -80,6 +80,13 @@ public class TestDBConfigFromFile {
   }
 
   @Test
+  public void readFromEmptyFilePath() throws RocksDBException {
+    final DBOptions options = DBConfigFromFile.readDBOptionsFromFile(Paths.get(""));
+    // This has to return a Null, since the path is empty.
+    assertNull(options);
+  }
+
+  @Test
   public void readFromEmptyFile() throws IOException {
     File emptyFile = new File(Paths.get(System.getProperty(DBConfigFromFile.CONFIG_DIR)).toString(), "empty.ini");
     assertTrue(emptyFile.createNewFile());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changed the log to debug from warning for showing message if file doesn't exist since log floods on startups.

## What is the link to the Apache JIRA
HDDS-13735

## How was this patch tested?

Tested using docker and existing testcases.