### PR TITLE
HDDS-13741. Invalid OTEL_EXPORTER_OTLP_ENDPOINT, must be full Jaeger URL

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.conf
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.conf
@@ -19,7 +19,7 @@ OZONE-SITE.XML_hdds.tracing.enabled=true
 OZONE-SITE.XML_ozone.metastore.rocksdb.statistics=ALL
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
-OTEL_EXPORTER_OTLP_ENDPOINT=jaeger
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
 OTEL_TRACES_SAMPLER_ARG=1
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently exporting the traces in a docker environment fails as the Jaeger endpoint URL is incorrect. 

This PR sets the correct endpoint URL.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13741

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/18241559029

Tested the docker environment manually. Jaeger UI shows the exported traces.
<img width="1721" height="955" alt="Screenshot 2025-10-04 at 12 50 27 AM" src="https://github.com/user-attachments/assets/a57dcb1a-9760-45f3-8599-0152b0cfb594" />

