### PR TITLE
HDDS-13742. Upgrade Jaeger to v2

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
@@ -21,9 +21,7 @@ x-monitoring-config:
 
 services:
   jaeger:
-    image: jaegertracing/all-in-one:latest
-    environment:
-      COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+    image: jaegertracing/jaeger:latest
     ports:
       - 16686:16686
       - 4317:4317

--- a/hadoop-ozone/dist/src/main/k8s/definitions/jaeger/jaeger.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/jaeger/jaeger.yaml
@@ -45,12 +45,9 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: jaegertracing/all-in-one:latest
+          image: jaegertracing/jaeger:latest
           ports:
             - containerPort: 16686
               name: web
             - containerPort: 4317
               name: otlp-grpc
-          env:
-            - name: COLLECTOR_ZIPKIN_HTTP_PORT
-              value: "9411"

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/jaeger-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/jaeger-statefulset.yaml
@@ -32,10 +32,10 @@ spec:
         component: jaeger
     spec:
       containers:
-        - name: jaeger
-          image: jaegertracing/jaeger:latest
-          ports:
-            - containerPort: 16686
-              name: web
-            - containerPort: 4317
-              name: otlp-grpc
+      - name: jaeger
+        image: jaegertracing/jaeger:latest
+        ports:
+        - containerPort: 16686
+          name: web
+        - containerPort: 4317
+          name: otlp-grpc

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/jaeger-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/jaeger-statefulset.yaml
@@ -32,13 +32,10 @@ spec:
         component: jaeger
     spec:
       containers:
-      - name: jaeger
-        image: jaegertracing/all-in-one:latest
-        ports:
-        - containerPort: 16686
-          name: web
-        - containerPort: 4317
-          name: otlp-grpc
-        env:
-        - name: COLLECTOR_ZIPKIN_HTTP_PORT
-          value: "9411"
+        - name: jaeger
+          image: jaegertracing/jaeger:latest
+          ports:
+            - containerPort: 16686
+              name: web
+            - containerPort: 4317
+              name: otlp-grpc


### PR DESCRIPTION
## What changes were proposed in this pull request?

Jaeger v1 is going EOL soon. 
This PR upgrades the docker images to v2.
Documentation on Jaeger v2 images: https://www.jaegertracing.io/download/#container-images


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13742

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/18242248102

Tested locally:
<img width="1727" height="833" alt="Screenshot 2025-10-04 at 2 00 10 AM" src="https://github.com/user-attachments/assets/dadcd0f4-6229-4ce9-80bd-2604a2c31454" />

