### PR TITLE
HDDS-13722. Refactor duplicate code in OMDirectoriesPurgeRequestWithFSO

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -81,7 +81,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
         purgeDirsRequest.getSnapshotTableKey() : null;
 
     List<OzoneManagerProtocolProtos.PurgePathRequest> purgeRequests =
-            purgeDirsRequest.getDeletedPathList();
+        purgeDirsRequest.getDeletedPathList();
     Set<Pair<String, String>> lockSet = new HashSet<>();
     Map<Pair<String, String>, OmBucketInfo> volBucketInfoMap = new HashMap<>();
     OmMetadataManagerImpl omMetadataManager = (OmMetadataManagerImpl) ozoneManager.getMetadataManager();
@@ -121,65 +121,38 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
       for (OzoneManagerProtocolProtos.PurgePathRequest path : purgeRequests) {
         for (OzoneManagerProtocolProtos.KeyInfo key :
             path.getMarkDeletedSubDirsList()) {
-          OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(key);
-          
-          String pathKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
-              path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
-          String deleteKey = omMetadataManager.getOzoneDeletePathKey(
-              keyInfo.getObjectID(), pathKey);
-          
-          subDirNames.add(deleteKey);
+          ProcessedKeyInfo processed = processKeyAndAcquireLock(path, key, lockSet, omMetadataManager);
+          subDirNames.add(processed.deleteKey);
 
-          String volumeName = keyInfo.getVolumeName();
-          String bucketName = keyInfo.getBucketName();
-          Pair<String, String> volBucketPair = Pair.of(volumeName, bucketName);
-          if (!lockSet.contains(volBucketPair)) {
-            omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
-                volumeName, bucketName);
-            lockSet.add(volBucketPair);
-          }
           omMetrics.decNumKeys();
           OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
-              volumeName, bucketName);
+              processed.volumeName, processed.bucketName);
+
           // bucketInfo can be null in case of delete volume or bucket
           // or key does not belong to bucket as bucket is recreated
           if (null != omBucketInfo
               && omBucketInfo.getObjectID() == path.getBucketId()) {
             omBucketInfo.incrUsedNamespace(-1L);
             String ozoneDbKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
-                path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
+                path.getBucketId(), processed.keyInfo.getParentObjectID(), processed.keyInfo.getFileName());
             omMetadataManager.getDirectoryTable().addCacheEntry(new CacheKey<>(ozoneDbKey),
                 CacheValue.get(context.getIndex()));
-            volBucketInfoMap.putIfAbsent(volBucketPair, omBucketInfo);
+            volBucketInfoMap.putIfAbsent(processed.volBucketPair, omBucketInfo);
           }
         }
 
         for (OzoneManagerProtocolProtos.KeyInfo key :
             path.getDeletedSubFilesList()) {
-          OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(key);
-
-          String pathKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
-              path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
-          String deleteKey = omMetadataManager.getOzoneDeletePathKey(
-              keyInfo.getObjectID(), pathKey);
-          subFileNames.add(deleteKey);
-
-          String volumeName = keyInfo.getVolumeName();
-          String bucketName = keyInfo.getBucketName();
-          Pair<String, String> volBucketPair = Pair.of(volumeName, bucketName);
-          if (!lockSet.contains(volBucketPair)) {
-            omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
-                volumeName, bucketName);
-            lockSet.add(volBucketPair);
-          }
+          ProcessedKeyInfo processed = processKeyAndAcquireLock(path, key, lockSet, omMetadataManager);
+          subFileNames.add(processed.deleteKey);
 
           // If omKeyInfo has hsync metadata, delete its corresponding open key as well
           String dbOpenKey;
-          String hsyncClientId = keyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
+          String hsyncClientId = processed.keyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
           if (hsyncClientId != null) {
-            long parentId = keyInfo.getParentObjectID();
+            long parentId = processed.keyInfo.getParentObjectID();
             dbOpenKey = omMetadataManager.getOpenFileName(path.getVolumeId(), path.getBucketId(),
-                parentId, keyInfo.getFileName(), hsyncClientId);
+                parentId, processed.keyInfo.getFileName(), hsyncClientId);
             OmKeyInfo openKeyInfo = omMetadataManager.getOpenKeyTable(getBucketLayout()).get(dbOpenKey);
             if (openKeyInfo != null) {
               openKeyInfo.getMetadata().put(DELETED_HSYNC_KEY, "true");
@@ -190,18 +163,18 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
           omMetrics.decNumKeys();
           numSubFilesMoved++;
           OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
-              volumeName, bucketName);
+              processed.volumeName, processed.bucketName);
           // bucketInfo can be null in case of delete volume or bucket
           // or key does not belong to bucket as bucket is recreated
           if (null != omBucketInfo
               && omBucketInfo.getObjectID() == path.getBucketId()) {
-            omBucketInfo.incrUsedBytes(-sumBlockLengths(keyInfo));
+            omBucketInfo.incrUsedBytes(-sumBlockLengths(processed.keyInfo));
             omBucketInfo.incrUsedNamespace(-1L);
             String ozoneDbKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
-                path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
+                path.getBucketId(), processed.keyInfo.getParentObjectID(), processed.keyInfo.getFileName());
             omMetadataManager.getFileTable().addCacheEntry(new CacheKey<>(ozoneDbKey),
                 CacheValue.get(context.getIndex()));
-            volBucketInfoMap.putIfAbsent(volBucketPair, omBucketInfo);
+            volBucketInfoMap.putIfAbsent(processed.volBucketPair, omBucketInfo);
           }
         }
         if (path.hasDeletedDir()) {
@@ -209,7 +182,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
           numDirsDeleted++;
         }
       }
-      
+
       // Remove deletedDirNames from subDirNames to avoid duplication
       subDirNames.removeAll(deletedDirNames);
       numSubDirMoved = subDirNames.size();
@@ -251,5 +224,54 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
     return new OMDirectoriesPurgeResponseWithFSO(
         omResponse.build(), purgeRequests,
         getBucketLayout(), volBucketInfoMap, fromSnapshotInfo, openKeyInfoMap);
+  }
+
+  /**
+   * Helper class to hold processed key information.
+   */
+  private static class ProcessedKeyInfo {
+    final OmKeyInfo keyInfo;
+    final String deleteKey;
+    final String volumeName;
+    final String bucketName;
+    final Pair<String, String> volBucketPair;
+
+    ProcessedKeyInfo(OmKeyInfo keyInfo, String deleteKey, String volumeName,
+                     String bucketName, Pair<String, String> volBucketPair) {
+      this.keyInfo = keyInfo;
+      this.deleteKey = deleteKey;
+      this.volumeName = volumeName;
+      this.bucketName = bucketName;
+      this.volBucketPair = volBucketPair;
+    }
+  }
+
+  /**
+   * Process key info and acquire necessary locks.
+   * Returns ProcessedKeyInfo containing all the extracted information.
+   */
+  private ProcessedKeyInfo processKeyAndAcquireLock(
+      OzoneManagerProtocolProtos.PurgePathRequest path,
+      OzoneManagerProtocolProtos.KeyInfo key,
+      Set<Pair<String, String>> lockSet,
+      OmMetadataManagerImpl omMetadataManager) {
+    OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(key);
+
+    String pathKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
+        path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
+    String deleteKey = omMetadataManager.getOzoneDeletePathKey(
+        keyInfo.getObjectID(), pathKey);
+
+    String volumeName = keyInfo.getVolumeName();
+    String bucketName = keyInfo.getBucketName();
+    Pair<String, String> volBucketPair = Pair.of(volumeName, bucketName);
+
+    if (!lockSet.contains(volBucketPair)) {
+      omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
+          volumeName, bucketName);
+      lockSet.add(volBucketPair);
+    }
+
+    return new ProcessedKeyInfo(keyInfo, deleteKey, volumeName, bucketName, volBucketPair);
   }
 }


### PR DESCRIPTION
Extract duplicate code for processing keys and acquiring locks into a helper method. Both subdirectory and subfile processing loops had identical code for:
- Converting protobuf key to OmKeyInfo
- Creating path and delete keys
- Acquiring write locks for volume/bucket pairs

Introduced ProcessedKeyInfo helper class to encapsulate all extracted information (keyInfo, deleteKey, volumeName, bucketName, volBucketPair) and processKeyAndAcquireLock method to eliminate code duplication.

## What changes were proposed in this pull request?

Remove duplicated code

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13722

## How was this patch tested?

UT: `TestOMDirectoriesPurgeRequestAndResponse`
