### PR TITLE
HDDS-13751. Rename all occurrences of "compact" related to HDDS-13003 into "defrag"

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -210,8 +210,8 @@ public final class OzoneConsts {
   public static final String OM_SLD_VERSION = "version";
   public static final String OM_SLD_CHECKSUM = "checksum";
   public static final String OM_SLD_IS_SST_FILTERED = "isSSTFiltered";
-  public static final String OM_SLD_LAST_COMPACTION_TIME = "lastCompactionTime";
-  public static final String OM_SLD_NEEDS_COMPACTION = "needsCompaction";
+  public static final String OM_SLD_LAST_DEFRAG_TIME = "lastDefragTime";
+  public static final String OM_SLD_NEEDS_DEFRAG = "needsDefrag";
   public static final String OM_SLD_VERSION_SST_FILE_INFO = "versionSstFileInfos";
   public static final String OM_SLD_PREV_SNAP_ID = "previousSnapshotId";
   public static final String OM_SLD_VERSION_META_SST_FILES = "sstFiles";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalData.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalData.java
@@ -123,24 +123,24 @@ public abstract class OmSnapshotLocalData {
   }
 
   /**
-   * Sets the last compaction time, in epoch milliseconds.
-   * @param lastDefragTime Timestamp of the last compaction
+   * Sets the last defrag time, in epoch milliseconds.
+   * @param lastDefragTime Timestamp of the last defrag
    */
   public void setLastDefragTime(Long lastDefragTime) {
     this.lastDefragTime = lastDefragTime;
   }
 
   /**
-   * Returns whether the snapshot needs compaction.
-   * @return true if the snapshot needs compaction, false otherwise
+   * Returns whether the snapshot needs defrag.
+   * @return true if the snapshot needs defrag, false otherwise
    */
   public boolean getNeedsDefrag() {
     return needsDefrag;
   }
 
   /**
-   * Sets whether the snapshot needs compaction.
-   * @param needsDefrag true if the snapshot needs compaction, false otherwise
+   * Sets whether the snapshot needs defrag.
+   * @param needsDefrag true if the snapshot needs defrag, false otherwise
    */
   public void setNeedsDefrag(boolean needsDefrag) {
     this.needsDefrag = needsDefrag;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalData.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalData.java
@@ -41,8 +41,8 @@ import org.yaml.snakeyaml.Yaml;
  */
 public abstract class OmSnapshotLocalData {
 
-  // Version of the snapshot local data. 0 indicates uncompacted snapshot.
-  // compacted snapshots will have version > 0.
+  // Version of the snapshot local data. 0 indicates not defragged snapshot.
+  // defragged snapshots will have version > 0.
   private int version;
 
   // Checksum of the YAML representation
@@ -51,11 +51,11 @@ public abstract class OmSnapshotLocalData {
   // Whether SST is filtered
   private boolean isSSTFiltered;
 
-  // Time of last compaction, in epoch milliseconds
-  private long lastCompactionTime;
+  // Time of last defrag, in epoch milliseconds
+  private long lastDefragTime;
 
-  // Whether the snapshot needs compaction
-  private boolean needsCompaction;
+  // Whether the snapshot needs defrag
+  private boolean needsDefrag;
 
   // Previous snapshotId based on which the snapshot local data is built.
   private UUID previousSnapshotId;
@@ -70,13 +70,13 @@ public abstract class OmSnapshotLocalData {
   /**
    * Creates a OmSnapshotLocalData object with default values.
    */
-  public OmSnapshotLocalData(List<LiveFileMetaData> uncompactedSSTFileList, UUID previousSnapshotId) {
+  public OmSnapshotLocalData(List<LiveFileMetaData> notDefraggedSSTFileList, UUID previousSnapshotId) {
     this.isSSTFiltered = false;
-    this.lastCompactionTime = 0L;
-    this.needsCompaction = false;
+    this.lastDefragTime = 0L;
+    this.needsDefrag = false;
     this.versionSstFileInfos = new LinkedHashMap<>();
     versionSstFileInfos.put(0,
-        new VersionMeta(0, uncompactedSSTFileList.stream().map(SstFileInfo::new).collect(Collectors.toList())));
+        new VersionMeta(0, notDefraggedSSTFileList.stream().map(SstFileInfo::new).collect(Collectors.toList())));
     this.version = 0;
     this.previousSnapshotId = previousSnapshotId;
     setChecksumTo0ByteArray();
@@ -89,13 +89,11 @@ public abstract class OmSnapshotLocalData {
   public OmSnapshotLocalData(OmSnapshotLocalData source) {
     // Copy primitive fields directly
     this.isSSTFiltered = source.isSSTFiltered;
-    this.lastCompactionTime = source.lastCompactionTime;
-    this.needsCompaction = source.needsCompaction;
+    this.lastDefragTime = source.lastDefragTime;
+    this.needsDefrag = source.needsDefrag;
     this.checksum = source.checksum;
     this.version = source.version;
     this.previousSnapshotId = source.previousSnapshotId;
-
-    // Deep copy for compactedSSTFileList
     this.versionSstFileInfos = new LinkedHashMap<>();
     setVersionSstFileInfos(source.versionSstFileInfos);
   }
@@ -117,48 +115,48 @@ public abstract class OmSnapshotLocalData {
   }
 
   /**
-   * Returns the last compaction time, in epoch milliseconds.
-   * @return Timestamp of the last compaction
+   * Returns the last defrag time, in epoch milliseconds.
+   * @return Timestamp of the last defrag
    */
-  public long getLastCompactionTime() {
-    return lastCompactionTime;
+  public long getLastDefragTime() {
+    return lastDefragTime;
   }
 
   /**
    * Sets the last compaction time, in epoch milliseconds.
-   * @param lastCompactionTime Timestamp of the last compaction
+   * @param lastDefragTime Timestamp of the last compaction
    */
-  public void setLastCompactionTime(Long lastCompactionTime) {
-    this.lastCompactionTime = lastCompactionTime;
+  public void setLastDefragTime(Long lastDefragTime) {
+    this.lastDefragTime = lastDefragTime;
   }
 
   /**
    * Returns whether the snapshot needs compaction.
    * @return true if the snapshot needs compaction, false otherwise
    */
-  public boolean getNeedsCompaction() {
-    return needsCompaction;
+  public boolean getNeedsDefrag() {
+    return needsDefrag;
   }
 
   /**
    * Sets whether the snapshot needs compaction.
-   * @param needsCompaction true if the snapshot needs compaction, false otherwise
+   * @param needsDefrag true if the snapshot needs compaction, false otherwise
    */
-  public void setNeedsCompaction(boolean needsCompaction) {
-    this.needsCompaction = needsCompaction;
+  public void setNeedsDefrag(boolean needsDefrag) {
+    this.needsDefrag = needsDefrag;
   }
 
   /**
-   * Returns the compacted SST file list.
-   * @return Map of version to compacted SST file list
+   * Returns the defragged SST file list.
+   * @return Map of version to defragged SST file list
    */
   public Map<Integer, VersionMeta> getVersionSstFileInfos() {
     return Collections.unmodifiableMap(this.versionSstFileInfos);
   }
 
   /**
-   * Sets the compacted SST file list.
-   * @param versionSstFileInfos Map of version to compacted SST file list
+   * Sets the defragged SST file list.
+   * @param versionSstFileInfos Map of version to defragged SST file list
    */
   public void setVersionSstFileInfos(Map<Integer, VersionMeta> versionSstFileInfos) {
     this.versionSstFileInfos.clear();
@@ -174,7 +172,7 @@ public abstract class OmSnapshotLocalData {
   }
 
   /**
-   * Adds an entry to the compacted SST file list.
+   * Adds an entry to the defragged SST file list.
    * @param sstFiles SST file name
    */
   public void addVersionSSTFileInfos(List<SstFileInfo> sstFiles, int previousSnapshotVersion) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalDataYaml.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalDataYaml.java
@@ -238,15 +238,15 @@ public final class OmSnapshotLocalDataYaml extends OmSnapshotLocalData {
         snapshotLocalData.setSstFiltered((Boolean) nodes.getOrDefault(OzoneConsts.OM_SLD_IS_SST_FILTERED, false));
 
         // Handle potential Integer/Long type mismatch from YAML parsing
-        Object lastCompactionTimeObj = nodes.getOrDefault(OzoneConsts.OM_SLD_LAST_DEFRAG_TIME, -1L);
-        long lastCompactionTime;
-        if (lastCompactionTimeObj instanceof Number) {
-          lastCompactionTime = ((Number) lastCompactionTimeObj).longValue();
+        Object lastDefragTimeObj = nodes.getOrDefault(OzoneConsts.OM_SLD_LAST_DEFRAG_TIME, -1L);
+        long lastDefragTime;
+        if (lastDefragTimeObj instanceof Number) {
+          lastDefragTime = ((Number) lastDefragTimeObj).longValue();
         } else {
-          throw new IllegalArgumentException("Invalid type for lastCompactionTime: " +
-              lastCompactionTimeObj.getClass().getName() + ". Expected Number type.");
+          throw new IllegalArgumentException("Invalid type for lastDefragTime: " +
+              lastDefragTimeObj.getClass().getName() + ". Expected Number type.");
         }
-        snapshotLocalData.setLastDefragTime(lastCompactionTime);
+        snapshotLocalData.setLastDefragTime(lastDefragTime);
 
         snapshotLocalData.setNeedsDefrag((Boolean) nodes.getOrDefault(OzoneConsts.OM_SLD_NEEDS_DEFRAG, false));
         Map<Integer, VersionMeta> versionMetaMap =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalDataYaml.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotLocalDataYaml.java
@@ -238,7 +238,7 @@ public final class OmSnapshotLocalDataYaml extends OmSnapshotLocalData {
         snapshotLocalData.setSstFiltered((Boolean) nodes.getOrDefault(OzoneConsts.OM_SLD_IS_SST_FILTERED, false));
 
         // Handle potential Integer/Long type mismatch from YAML parsing
-        Object lastCompactionTimeObj = nodes.getOrDefault(OzoneConsts.OM_SLD_LAST_COMPACTION_TIME, -1L);
+        Object lastCompactionTimeObj = nodes.getOrDefault(OzoneConsts.OM_SLD_LAST_DEFRAG_TIME, -1L);
         long lastCompactionTime;
         if (lastCompactionTimeObj instanceof Number) {
           lastCompactionTime = ((Number) lastCompactionTimeObj).longValue();
@@ -246,9 +246,9 @@ public final class OmSnapshotLocalDataYaml extends OmSnapshotLocalData {
           throw new IllegalArgumentException("Invalid type for lastCompactionTime: " +
               lastCompactionTimeObj.getClass().getName() + ". Expected Number type.");
         }
-        snapshotLocalData.setLastCompactionTime(lastCompactionTime);
+        snapshotLocalData.setLastDefragTime(lastCompactionTime);
 
-        snapshotLocalData.setNeedsCompaction((Boolean) nodes.getOrDefault(OzoneConsts.OM_SLD_NEEDS_COMPACTION, false));
+        snapshotLocalData.setNeedsDefrag((Boolean) nodes.getOrDefault(OzoneConsts.OM_SLD_NEEDS_DEFRAG, false));
         Map<Integer, VersionMeta> versionMetaMap =
             (Map<Integer, VersionMeta>) nodes.get(OzoneConsts.OM_SLD_VERSION_SST_FILE_INFO);
         if (versionMetaMap != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -625,7 +625,7 @@ public final class OmSnapshotManager implements AutoCloseable {
 
   /**
    * Captures the list of SST files for keyTable, fileTable and directoryTable in the DB.
-   * @param store AOS or snapshot DB for uncompacted or compacted snapshot respectively.
+   * @param store AOS or snapshot DB for not defragged or defragged snapshot respectively.
    * @return a Map of (table, set of SST files corresponding to the table)
    */
   private static List<LiveFileMetaData> getSnapshotSSTFileList(RDBStore store)
@@ -636,7 +636,7 @@ public final class OmSnapshotManager implements AutoCloseable {
   }
 
   /**
-   * Creates and writes snapshot local properties to a YAML file with uncompacted SST file list.
+   * Creates and writes snapshot local properties to a YAML file with not defragged SST file list.
    * @param snapshotManager snapshot manager instance.
    * @param snapshotStore snapshot metadata manager.
    * @param snapshotInfo snapshot info instance corresponding to snapshot.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotLocalDataYaml.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotLocalDataYaml.java
@@ -107,31 +107,31 @@ public class TestOmSnapshotLocalDataYaml {
   private Pair<File, UUID> writeToYaml(String snapshotName) throws IOException {
     String yamlFilePath = snapshotName + ".yaml";
     UUID previousSnapshotId = UUID.randomUUID();
-    // Create snapshot data with uncompacted SST files
-    List<LiveFileMetaData> uncompactedSSTFileList = asList(
+    // Create snapshot data with not defragged SST files
+    List<LiveFileMetaData> notDefraggedSSTFileList = asList(
         createLiveFileMetaData("sst1", "table1", "k1", "k2"),
         createLiveFileMetaData("sst2", "table1", "k3", "k4"),
         createLiveFileMetaData("sst3", "table2", "k4", "k5"));
-    OmSnapshotLocalDataYaml dataYaml = new OmSnapshotLocalDataYaml(uncompactedSSTFileList, previousSnapshotId);
+    OmSnapshotLocalDataYaml dataYaml = new OmSnapshotLocalDataYaml(notDefraggedSSTFileList, previousSnapshotId);
 
     // Set version
     dataYaml.setVersion(42);
     // Set SST filtered flag
     dataYaml.setSstFiltered(true);
 
-    // Set last compaction time
-    dataYaml.setLastCompactionTime(NOW.toEpochMilli());
+    // Set last defrag time
+    dataYaml.setLastDefragTime(NOW.toEpochMilli());
 
-    // Set needs compaction flag
-    dataYaml.setNeedsCompaction(true);
+    // Set needs defrag flag
+    dataYaml.setNeedsDefrag(true);
 
-    // Add some compacted SST files
+    // Add some defragged SST files
     dataYaml.addVersionSSTFileInfos(ImmutableList.of(
-        new SstFileInfo("compacted-sst1", "k1", "k2", "table1"),
-        new SstFileInfo("compacted-sst2", "k3", "k4", "table2")),
+        new SstFileInfo("defragged-sst1", "k1", "k2", "table1"),
+        new SstFileInfo("defragged-sst2", "k3", "k4", "table2")),
         1);
     dataYaml.addVersionSSTFileInfos(Collections.singletonList(
-        new SstFileInfo("compacted-sst3", "k4", "k5", "table1")), 3);
+        new SstFileInfo("defragged-sst3", "k4", "k5", "table1")), 3);
 
     File yamlFile = new File(testRoot, yamlFilePath);
 
@@ -157,20 +157,20 @@ public class TestOmSnapshotLocalDataYaml {
     assertEquals(44, snapshotData.getVersion());
     assertTrue(snapshotData.getSstFiltered());
 
-    VersionMeta uncompactedFiles = snapshotData.getVersionSstFileInfos().get(0);
+    VersionMeta notDefraggedSSTFiles = snapshotData.getVersionSstFileInfos().get(0);
     assertEquals(new VersionMeta(0,
         ImmutableList.of(new SstFileInfo("sst1", "k1", "k2", "table1"),
             new SstFileInfo("sst2", "k3", "k4", "table1"),
-            new SstFileInfo("sst3", "k4", "k5", "table2"))), uncompactedFiles);
-    assertEquals(NOW.toEpochMilli(), snapshotData.getLastCompactionTime());
-    assertTrue(snapshotData.getNeedsCompaction());
+            new SstFileInfo("sst3", "k4", "k5", "table2"))), notDefraggedSSTFiles);
+    assertEquals(NOW.toEpochMilli(), snapshotData.getLastDefragTime());
+    assertTrue(snapshotData.getNeedsDefrag());
 
-    Map<Integer, VersionMeta> compactedFiles = snapshotData.getVersionSstFileInfos();
-    assertEquals(3, compactedFiles.size());
-    assertTrue(compactedFiles.containsKey(43));
-    assertTrue(compactedFiles.containsKey(44));
-    assertEquals(2, compactedFiles.get(43).getSstFiles().size());
-    assertEquals(1, compactedFiles.get(44).getSstFiles().size());
+    Map<Integer, VersionMeta> defraggedSSTFiles = snapshotData.getVersionSstFileInfos();
+    assertEquals(3, defraggedSSTFiles.size());
+    assertTrue(defraggedSSTFiles.containsKey(43));
+    assertTrue(defraggedSSTFiles.containsKey(44));
+    assertEquals(2, defraggedSSTFiles.get(43).getSstFiles().size());
+    assertEquals(1, defraggedSSTFiles.get(44).getSstFiles().size());
     assertEquals(prevSnapId, snapshotData.getPreviousSnapshotId());
     assertEquals(ImmutableMap.of(
         0, new VersionMeta(0,
@@ -178,10 +178,10 @@ public class TestOmSnapshotLocalDataYaml {
                 new SstFileInfo("sst2", "k3", "k4", "table1"),
                 new SstFileInfo("sst3", "k4", "k5", "table2"))),
         43, new VersionMeta(1,
-            ImmutableList.of(new SstFileInfo("compacted-sst1", "k1", "k2", "table1"),
-                new SstFileInfo("compacted-sst2", "k3", "k4", "table2"))),
+            ImmutableList.of(new SstFileInfo("defragged-sst1", "k1", "k2", "table1"),
+                new SstFileInfo("defragged-sst2", "k3", "k4", "table2"))),
         44, new VersionMeta(3,
-            ImmutableList.of(new SstFileInfo("compacted-sst3", "k4", "k5", "table1")))), compactedFiles);
+            ImmutableList.of(new SstFileInfo("defragged-sst3", "k4", "k5", "table1")))), defraggedSSTFiles);
   }
 
   @Test
@@ -194,9 +194,9 @@ public class TestOmSnapshotLocalDataYaml {
 
     // Update snapshot data
     dataYaml.setSstFiltered(false);
-    dataYaml.setNeedsCompaction(false);
+    dataYaml.setNeedsDefrag(false);
     dataYaml.addVersionSSTFileInfos(
-        singletonList(new SstFileInfo("compacted-sst4", "k5", "k6", "table3")), 5);
+        singletonList(new SstFileInfo("defragged-sst4", "k5", "k6", "table3")), 5);
 
     // Write updated data back to file
     dataYaml.writeToYaml(omSnapshotManager, yamlFile);
@@ -206,13 +206,13 @@ public class TestOmSnapshotLocalDataYaml {
 
     // Verify updated data
     assertThat(dataYaml.getSstFiltered()).isFalse();
-    assertThat(dataYaml.getNeedsCompaction()).isFalse();
+    assertThat(dataYaml.getNeedsDefrag()).isFalse();
 
-    Map<Integer, VersionMeta> compactedFiles = dataYaml.getVersionSstFileInfos();
-    assertEquals(4, compactedFiles.size());
-    assertTrue(compactedFiles.containsKey(45));
-    assertEquals(new VersionMeta(5, ImmutableList.of(new SstFileInfo("compacted-sst4", "k5", "k6", "table3"))),
-        compactedFiles.get(45));
+    Map<Integer, VersionMeta> defraggedFiles = dataYaml.getVersionSstFileInfos();
+    assertEquals(4, defraggedFiles.size());
+    assertTrue(defraggedFiles.containsKey(45));
+    assertEquals(new VersionMeta(5, ImmutableList.of(new SstFileInfo("defragged-sst4", "k5", "k6", "table3"))),
+        defraggedFiles.get(45));
   }
 
   @Test
@@ -252,8 +252,8 @@ public class TestOmSnapshotLocalDataYaml {
     assertThat(content).contains(OzoneConsts.OM_SLD_VERSION);
     assertThat(content).contains(OzoneConsts.OM_SLD_CHECKSUM);
     assertThat(content).contains(OzoneConsts.OM_SLD_IS_SST_FILTERED);
-    assertThat(content).contains(OzoneConsts.OM_SLD_LAST_COMPACTION_TIME);
-    assertThat(content).contains(OzoneConsts.OM_SLD_NEEDS_COMPACTION);
+    assertThat(content).contains(OzoneConsts.OM_SLD_LAST_DEFRAG_TIME);
+    assertThat(content).contains(OzoneConsts.OM_SLD_NEEDS_DEFRAG);
     assertThat(content).contains(OzoneConsts.OM_SLD_VERSION_SST_FILE_INFO);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -282,20 +282,20 @@ class TestOmSnapshotManager {
   public void testCreateNewSnapshotLocalYaml() throws IOException {
     SnapshotInfo snapshotInfo = createSnapshotInfo("vol1", "buck1");
 
-    Map<String, List<String>> expUncompactedSSTFileList = new TreeMap<>();
-    OmSnapshotLocalData.VersionMeta uncompactedVersionMeta = new OmSnapshotLocalData.VersionMeta(0,
+    Map<String, List<String>> expNotDefraggedSSTFileList = new TreeMap<>();
+    OmSnapshotLocalData.VersionMeta notDefraggedVersionMeta = new OmSnapshotLocalData.VersionMeta(0,
         ImmutableList.of(new SstFileInfo("dt1.sst", "k1", "k2", DIRECTORY_TABLE),
             new SstFileInfo("dt2.sst", "k1", "k2", DIRECTORY_TABLE),
             new SstFileInfo("ft1.sst", "k1", "k2", FILE_TABLE),
             new SstFileInfo("ft2.sst", "k1", "k2", FILE_TABLE),
             new SstFileInfo("kt1.sst", "k1", "k2", KEY_TABLE),
             new SstFileInfo("kt2.sst", "k1", "k2", KEY_TABLE)));
-    expUncompactedSSTFileList.put(KEY_TABLE, Stream.of("kt1.sst", "kt2.sst").collect(Collectors.toList()));
-    expUncompactedSSTFileList.put(FILE_TABLE, Stream.of("ft1.sst", "ft2.sst").collect(Collectors.toList()));
-    expUncompactedSSTFileList.put(DIRECTORY_TABLE, Stream.of("dt1.sst", "dt2.sst").collect(Collectors.toList()));
+    expNotDefraggedSSTFileList.put(KEY_TABLE, Stream.of("kt1.sst", "kt2.sst").collect(Collectors.toList()));
+    expNotDefraggedSSTFileList.put(FILE_TABLE, Stream.of("ft1.sst", "ft2.sst").collect(Collectors.toList()));
+    expNotDefraggedSSTFileList.put(DIRECTORY_TABLE, Stream.of("dt1.sst", "dt2.sst").collect(Collectors.toList()));
 
     List<LiveFileMetaData> mockedLiveFiles = new ArrayList<>();
-    for (Map.Entry<String, List<String>> entry : expUncompactedSSTFileList.entrySet()) {
+    for (Map.Entry<String, List<String>> entry : expNotDefraggedSSTFileList.entrySet()) {
       String cfname = entry.getKey();
       for (String fname : entry.getValue()) {
         mockedLiveFiles.add(createMockLiveFileMetadata(cfname, fname));
@@ -325,10 +325,10 @@ class TestOmSnapshotManager {
     OmSnapshotLocalData localData = OmSnapshotLocalDataYaml.getFromYamlFile(omSnapshotManager, snapshotYaml.toFile());
     assertNotNull(localData);
     assertEquals(0, localData.getVersion());
-    assertEquals(uncompactedVersionMeta, localData.getVersionSstFileInfos().get(0));
+    assertEquals(notDefraggedVersionMeta, localData.getVersionSstFileInfos().get(0));
     assertFalse(localData.getSstFiltered());
-    assertEquals(0L, localData.getLastCompactionTime());
-    assertFalse(localData.getNeedsCompaction());
+    assertEquals(0L, localData.getLastDefragTime());
+    assertFalse(localData.getNeedsDefrag());
     assertEquals(1, localData.getVersionSstFileInfos().size());
 
     // Cleanup


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a refactoring patch. Snapshot Defragmentation was previously called Snapshot Compaction during development and in the design doc. It is renamed because the Snapshot Compaction name can be easily confused with RocksDB Compaction, which is a different concept.

It is cleaner to have a separate refactoring jira like this to rename all the occurrences of "compact" that are related to [HDDS-13003](https://issues.apache.org/jira/browse/HDDS-13003) into "defrag".

> compaction -> defrag
compacted -> defragged
uncompacted -> not defragged

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13751

## How was this patch tested?

- Existing tests.