### PR TITLE
HDDS-13754. Add a word of caution in validateAndUpdateCache javadoc

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -134,8 +134,12 @@ public abstract class OMClientRequest implements RequestAuditor {
    * Validate the OMRequest and update the cache.
    * This step should verify that the request can be executed, perform
    * any authorization steps and update the in-memory cache.
-
+   *
    * This step does not persist the changes to the database.
+   *
+   * To coders and reviewers, CAUTION: Do NOT bring external dependencies into this method, doing so could potentially
+   * cause divergence in OM DB states in HA. If you have to, be extremely careful.
+   * e.g. Do NOT invoke ACL check inside validateAndUpdateCache, which can use Ranger plugin that relies on external DB.
    *
    * @return the response that will be returned to the client.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a word of caution in javadoc of validateAndUpdateCache to pass the message.

Lesson learnt from [HDDS-9388](https://issues.apache.org/jira/browse/HDDS-9388) and [HDDS-13634](https://issues.apache.org/jira/browse/HDDS-13634).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13754

## How was this patch tested?

- n/a