### PR TITLE
HDDS-13692. Clarify --all option usage in ListLimitOptions

### DIFF
--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListLimitOptions.java
@@ -49,7 +49,7 @@ public class ListLimitOptions {
     private int limit;
 
     @CommandLine.Option(names = {"--all", "-a"},
-        description = "List all results",
+        description = "List all results (without pagination limit)",
         defaultValue = "false")
     private boolean all;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expand `--all` option description in `ListLimitOptions` so that it is less easily confused with other options, such as `--all-status` in `ozone sh snapshot lsDiff`.

Before:

```bash
bash-5.1$ ozone sh snapshot lsDiff -h
Usage: ozone sh snapshot listDiff [-hV] [--all-status] [--verbose]
                                  [--job-status=<jobStatus>] [-s=<startItem>]
                                  [[-l=<limit>] | [-a]] <value>
List snapshotDiff jobs for a bucket.
...
  -a, --all                 List all results
      --all-status          List all jobs regardless of status.
...
```

After:

```bash
bash-5.1$ ozone sh snapshot lsDiff -h
Usage: ozone sh snapshot listDiff [-hV] [--all-status] [--verbose]
                                  [--job-status=<jobStatus>] [-s=<startItem>]
                                  [[-l=<limit>] | [-a]] <value>
List snapshotDiff jobs for a bucket.
...
  -a, --all                 List all results (without pagination limit)
      --all-status          List all jobs regardless of status.
...
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13692

## How was this patch tested?

- Locally built and checked description.