### PR TITLE
HDDS-13532. Refactor BucketEndpoint.get() method

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -99,6 +99,7 @@ public class BucketEndpoint extends EndpointBase {
       @PathParam(BUCKET) String bucketName
   ) throws OS3Exception, IOException {
     long startNanos = Time.monotonicNowNanos();
+    S3GAction s3GAction = S3GAction.GET_BUCKET;
 
     // Chain of responsibility: let each handler try to handle the request
     for (BucketOperationHandler handler : handlers) {
@@ -275,20 +276,6 @@ public class BucketEndpoint extends EndpointBase {
     public ContinueToken getDecodedToken() {
       return decodedToken;
     }
-  }
-
-  /**
-   * Handle GetBucketAcl request.
-   * Implements the GetBucketAcl API operation.
-   * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAcl.html">GetBucketAcl</a>
-   */
-  Response handleGetBucketAcl(String bucketName, long startNanos) 
-      throws OS3Exception, IOException {
-    S3GAction s3GAction = S3GAction.GET_ACL;
-    S3BucketAcl result = getAcl(bucketName);
-    getMetrics().updateGetAclSuccessStats(startNanos);
-    auditReadSuccess(s3GAction);
-    return Response.ok(result, MediaType.APPLICATION_XML_TYPE).build();
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketEndpoint.java
@@ -22,9 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.hadoop.ozone.s3.util.S3Consts.QueryParams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -134,5 +136,18 @@ public class TestBucketEndpoint {
             continueToken, startAfter));
     
     assertEquals(S3ErrorTable.NO_SUCH_BUCKET.getCode(), exception.getCode());
+  }
+
+  @Test
+  public void testGetDelegatesToAclHandler() throws Exception {
+    // When ?acl is present, BucketEndpoint should delegate to BucketAclHandler.
+    bucketEndpoint.queryParamsForTest().set(QueryParams.ACL, "");
+
+    Response response = bucketEndpoint.get(TEST_BUCKET_NAME);
+
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getEntity());
+    assertEquals("S3BucketAcl", response.getEntity().getClass().getSimpleName());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR refactors the `BucketEndpoint.get()` method to improve code maintainability and readability. 
The original method was nearly 200 lines long and contained multiple unrelated logic blocks, making it difficult to understand, test, and maintain.

Changes in this PRr
- Extracted 5 methods from the `get()` method
- add `BucketListingContext` class to encapsulate parameters
- added test coverage (unit, integration, performance)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13532

## How was this patch tested?
- Unit tests: `TestBucketEndpointRefactoredSimple.java`
- Integration tests: `TestBucketEndpointIntegration.java`
- Performance tests: `TestBucketEndpointPerformance.java`