### PR TITLE
HDDS-13632. Fix impersonation with SPNEGO for Recon UI

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/filters/ReconAuthFilter.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/filters/ReconAuthFilter.java
@@ -35,6 +35,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
+import org.apache.hadoop.security.authentication.server.ProxyUserAuthenticationFilter;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ public class ReconAuthFilter implements Filter {
       LoggerFactory.getLogger(ReconAuthFilter.class);
 
   private final OzoneConfiguration conf;
-  private AuthenticationFilter hadoopAuthFilter;
+  private ProxyUserAuthenticationFilter hadoopAuthFilter;
 
   @Inject
   ReconAuthFilter(OzoneConfiguration conf) {
@@ -59,7 +60,7 @@ public class ReconAuthFilter implements Filter {
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
-    hadoopAuthFilter = new AuthenticationFilter();
+    hadoopAuthFilter = new ProxyUserAuthenticationFilter();
 
     Map<String, String> parameters = getFilterConfigMap(conf,
         OZONE_RECON_HTTP_AUTH_CONFIG_PREFIX);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously the ReconAuthFilter explicitly used the Hadoop `AuthenticationFilter`, this way impersonation was not working. With the switch to use ProxyUserAuthenticationFilter this problem will be solved. `ProxyUserAuthenticationFilter` is extending `AuthenticationFilter` and in both the `init` and `doFilter` method it'll call the super; it'll only do changes if there is a `doAs` user in the request, else it'll behave like the `AuthenticationFilter`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13632

## How was this patch tested?

In a cluster with Knox enabled and the admin pages were properly loaded with the Knox proxy user (after granting access to them with the ozone admin config)
