### PR TITLE
HDDS-13764. KeyDeletingService and DirectoryDeletingService should reduce snapshot bucket quota usage

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/ProtobufUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/ProtobufUtils.java
@@ -46,4 +46,8 @@ public final class ProtobufUtils {
   public static int computeRepeatedStringSize(String value) {
     return CodedOutputStream.computeStringSizeNoTag(value);
   }
+
+  public static int computeLongSizeWithTag(int fieldNumber, long value) {
+    return CodedOutputStream.computeInt64Size(fieldNumber, value);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
@@ -127,7 +127,7 @@ public class TestKeyPurging {
         () -> {
           try {
             return keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE)
-                .getKeyBlocksList().isEmpty();
+                .getPurgedKeys().isEmpty();
           } catch (IOException e) {
             return false;
           }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1417,6 +1417,13 @@ message PurgeKeysRequest {
     // previous snapshotID can also be null & this field would be absent in older requests.
     optional NullableUUID expectedPreviousSnapshotID = 4;
     repeated string renamedKeys = 5;
+    repeated BucketPurgeKeysSize bucketPurgeKeysSize = 6;
+}
+
+message BucketPurgeKeysSize {
+  optional BucketNameInfo bucketNameInfo = 1;
+  optional uint64 purgedBytes = 2;
+  optional uint64 purgedNamespace = 3;
 }
 
 message PurgeKeysResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -80,7 +80,7 @@ import static org.apache.hadoop.util.Time.monotonicNow;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -138,6 +138,7 @@ import org.apache.hadoop.net.TableMapping;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.common.BlockGroup;
+import org.apache.hadoop.ozone.om.PendingKeysDeletion.PurgedKey;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
@@ -161,6 +162,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.service.CompactionService;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
@@ -741,9 +743,8 @@ public class KeyManagerImpl implements KeyManager {
       String volume, String bucket, String startKey,
       CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> filter,
       int count) throws IOException {
-    List<BlockGroup> keyBlocksList = Lists.newArrayList();
+    Map<String, PurgedKey> purgedKeys = Maps.newHashMap();
     Map<String, RepeatedOmKeyInfo> keysToModify = new HashMap<>();
-    Map<String, Long> keyBlockReplicatedSize = new HashMap<>();
     int notReclaimableKeyCount = 0;
 
     // Bucket prefix would be empty if volume is empty i.e. either null or "".
@@ -762,9 +763,11 @@ public class KeyManagerImpl implements KeyManager {
         KeyValue<String, RepeatedOmKeyInfo> kv = delKeyIter.next();
         if (kv != null) {
           RepeatedOmKeyInfo notReclaimableKeyInfo = new RepeatedOmKeyInfo(kv.getValue().getBucketId());
-          List<BlockGroup> blockGroupList = Lists.newArrayList();
+          Map<String, PurgedKey> reclaimableKeys = Maps.newHashMap();
           // Multiple keys with the same path can be queued in one DB entry
           RepeatedOmKeyInfo infoList = kv.getValue();
+          long bucketId = infoList.getBucketId();
+          int reclaimableKeyCount = 0;
           for (OmKeyInfo info : infoList.getOmKeyInfoList()) {
 
             // Skip the key if the filter doesn't allow the file to be deleted.
@@ -772,10 +775,12 @@ public class KeyManagerImpl implements KeyManager {
               List<BlockID> blockIDS = info.getKeyLocationVersions().stream()
                   .flatMap(versionLocations -> versionLocations.getLocationList().stream()
                       .map(b -> new BlockID(b.getContainerID(), b.getLocalID()))).collect(Collectors.toList());
-              BlockGroup keyBlocks = BlockGroup.newBuilder().setKeyName(kv.getKey())
+              String blockGroupName = kv.getKey() + "/" + reclaimableKeyCount++;
+              BlockGroup keyBlocks = BlockGroup.newBuilder().setKeyName(blockGroupName)
                   .addAllBlockIDs(blockIDS).build();
-              keyBlockReplicatedSize.put(keyBlocks.getGroupID(), info.getReplicatedSize());
-              blockGroupList.add(keyBlocks);
+              reclaimableKeys.put(blockGroupName,
+                  new PurgedKey(info.getVolumeName(), info.getBucketName(), bucketId,
+                  keyBlocks, kv.getKey(), OMKeyRequest.sumBlockLengths(info), info.isDeletedKeyCommitted()));
               currentCount++;
             } else {
               notReclaimableKeyInfo.addOmKeyInfo(info);
@@ -789,12 +794,12 @@ public class KeyManagerImpl implements KeyManager {
               notReclaimableKeyInfoList.size() != infoList.getOmKeyInfoList().size()) {
             keysToModify.put(kv.getKey(), notReclaimableKeyInfo);
           }
-          keyBlocksList.addAll(blockGroupList);
+          purgedKeys.putAll(reclaimableKeys);
           notReclaimableKeyCount += notReclaimableKeyInfoList.size();
         }
       }
     }
-    return new PendingKeysDeletion(keyBlocksList, keysToModify, keyBlockReplicatedSize, notReclaimableKeyCount);
+    return new PendingKeysDeletion(purgedKeys, keysToModify, notReclaimableKeyCount);
   }
 
   private <V, R> List<KeyValue<String, R>> getTableEntries(String startKey,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PendingKeysDeletion.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PendingKeysDeletion.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om;
 
-import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -35,18 +34,15 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
  */
 public class PendingKeysDeletion {
 
-  private Map<String, RepeatedOmKeyInfo> keysToModify;
-  private List<BlockGroup> keyBlocksList;
-  private Map<String, Long> keyBlockReplicatedSize;
+  private final Map<String, RepeatedOmKeyInfo> keysToModify;
+  private final Map<String, PurgedKey> purgedKeys;
   private int notReclaimableKeyCount;
 
-  public PendingKeysDeletion(List<BlockGroup> keyBlocksList,
-       Map<String, RepeatedOmKeyInfo> keysToModify,
-       Map<String, Long> keyBlockReplicatedSize,
-       int notReclaimableKeyCount) {
+  public PendingKeysDeletion(Map<String, PurgedKey> purgedKeys,
+      Map<String, RepeatedOmKeyInfo> keysToModify,
+      int notReclaimableKeyCount) {
     this.keysToModify = keysToModify;
-    this.keyBlocksList = keyBlocksList;
-    this.keyBlockReplicatedSize = keyBlockReplicatedSize;
+    this.purgedKeys = purgedKeys;
     this.notReclaimableKeyCount = notReclaimableKeyCount;
   }
 
@@ -54,12 +50,77 @@ public class PendingKeysDeletion {
     return keysToModify;
   }
 
-  public List<BlockGroup> getKeyBlocksList() {
-    return keyBlocksList;
+  public Map<String, PurgedKey> getPurgedKeys() {
+    return purgedKeys;
   }
 
-  public Map<String, Long> getKeyBlockReplicatedSize() {
-    return keyBlockReplicatedSize;
+  /**
+   * Represents metadata for a key that has been purged.
+   *
+   * This class holds information about a specific purged key,
+   * including its volume, bucket, associated block group,
+   * and the amount of data purged in bytes.
+   */
+  public static class PurgedKey {
+    private final String volume;
+    private final String bucket;
+    private final long bucketId;
+    private final BlockGroup blockGroup;
+    private final long purgedBytes;
+    private final boolean isCommittedKey;
+    private final String deleteKeyName;
+
+    public PurgedKey(String volume, String bucket, long bucketId, BlockGroup group, String deleteKeyName,
+        long purgedBytes, boolean isCommittedKey) {
+      this.volume = volume;
+      this.bucket = bucket;
+      this.bucketId = bucketId;
+      this.blockGroup = group;
+      this.purgedBytes = purgedBytes;
+      this.isCommittedKey = isCommittedKey;
+      this.deleteKeyName = deleteKeyName;
+    }
+
+    public BlockGroup getBlockGroup() {
+      return blockGroup;
+    }
+
+    public long getPurgedBytes() {
+      return purgedBytes;
+    }
+
+    public String getVolume() {
+      return volume;
+    }
+
+    public String getBucket() {
+      return bucket;
+    }
+
+    public long getBucketId() {
+      return bucketId;
+    }
+
+    public boolean isCommittedKey() {
+      return isCommittedKey;
+    }
+
+    public String getDeleteKeyName() {
+      return deleteKeyName;
+    }
+
+    @Override
+    public String toString() {
+      return "PurgedKey{" +
+          "blockGroup=" + blockGroup +
+          ", volume='" + volume + '\'' +
+          ", bucket='" + bucket + '\'' +
+          ", bucketId=" + bucketId +
+          ", purgedBytes=" + purgedBytes +
+          ", isCommittedKey=" + isCommittedKey +
+          ", deleteKeyName='" + deleteKeyName + '\'' +
+          '}';
+    }
   }
 
   public int getNotReclaimableKeyCount() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
@@ -41,6 +42,7 @@ import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditLoggerType;
 import org.apache.hadoop.ozone.audit.OMSystemAction;
 import org.apache.hadoop.ozone.om.DeletingServiceMetrics;
+import org.apache.hadoop.ozone.om.OMMetadataManager.VolumeBucketId;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -55,6 +57,7 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMDirectoriesPurgeResponseWithFSO;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketNameInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgeDirectoriesRequest;
@@ -130,9 +133,12 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
     }
     try {
       int numSubDirMoved = 0, numSubFilesMoved = 0, numDirsDeleted = 0;
+      Map<VolumeBucketId, BucketNameInfo> volumeBucketIdMap = purgeDirsRequest.getBucketNameInfosList().stream()
+          .collect(Collectors.toMap(bucketNameInfo ->
+                  new VolumeBucketId(bucketNameInfo.getVolumeId(), bucketNameInfo.getBucketId()),
+              Function.identity()));
       for (OzoneManagerProtocolProtos.PurgePathRequest path : purgeRequests) {
-        for (OzoneManagerProtocolProtos.KeyInfo key :
-            path.getMarkDeletedSubDirsList()) {
+        for (OzoneManagerProtocolProtos.KeyInfo key : path.getMarkDeletedSubDirsList()) {
           ProcessedKeyInfo processed = processDeleteKey(key, path, omMetadataManager);
           subDirNames.add(processed.deleteKey);
 
@@ -152,8 +158,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
           }
         }
 
-        for (OzoneManagerProtocolProtos.KeyInfo key :
-            path.getDeletedSubFilesList()) {
+        for (OzoneManagerProtocolProtos.KeyInfo key : path.getDeletedSubFilesList()) {
           ProcessedKeyInfo processed = processDeleteKey(key, path, omMetadataManager);
           subFileNames.add(processed.deleteKey);
 
@@ -192,6 +197,13 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
         }
         if (path.hasDeletedDir()) {
           deletedDirNames.add(path.getDeletedDir());
+          BucketNameInfo bucketNameInfo = volumeBucketIdMap.get(new VolumeBucketId(path.getVolumeId(),
+              path.getBucketId()));
+          OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
+              bucketNameInfo.getVolumeName(), bucketNameInfo.getBucketName());
+          if (omBucketInfo != null && omBucketInfo.getObjectID() == path.getBucketId()) {
+            omBucketInfo.purgeSnapshotUsedNamespace(1);
+          }
           numDirsDeleted++;
         }
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 import static org.apache.hadoop.hdds.HddsUtils.fromProtobuf;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.validatePreviousSnapshotId;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -33,15 +35,19 @@ import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditLoggerType;
 import org.apache.hadoop.ozone.audit.OMSystemAction;
 import org.apache.hadoop.ozone.om.DeletingServiceMetrics;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketNameInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketPurgeKeysSize;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeletedKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -151,9 +157,60 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
       AUDIT.logWriteFailure(ozoneManager.buildAuditMessageForFailure(OMSystemAction.KEY_DELETION, null, e));
       return new OMKeyPurgeResponse(createErrorOMResponse(omResponse, e));
     }
+    try {
+      List<OmBucketInfo> bucketInfoList = updateBucketSize(purgeKeysRequest.getBucketPurgeKeysSizeList(),
+          omMetadataManager);
+      return new OMKeyPurgeResponse(omResponse.build(),
+          keysToBePurgedList, renamedKeysToBePurged, fromSnapshotInfo, keysToUpdateList, bucketInfoList);
+    } catch (OMException oe) {
+      AUDIT.logWriteFailure(ozoneManager.buildAuditMessageForFailure(OMSystemAction.KEY_DELETION, null, oe));
+      return new OMKeyPurgeResponse(createErrorOMResponse(omResponse, oe));
+    }
+  }
 
-    return new OMKeyPurgeResponse(omResponse.build(),
-        keysToBePurgedList, renamedKeysToBePurged, fromSnapshotInfo, keysToUpdateList);
+  private List<OmBucketInfo> updateBucketSize(List<BucketPurgeKeysSize> bucketPurgeKeysSizeList,
+      OMMetadataManager omMetadataManager) throws OMException {
+    Map<String, Map<String, List<BucketPurgeKeysSize>>> bucketPurgeKeysSizes = bucketPurgeKeysSizeList.stream()
+            .collect(Collectors.groupingBy(bucketPurgeKey -> bucketPurgeKey.getBucketNameInfo().getVolumeName(),
+                Collectors.groupingBy(bucketPurgeKey -> bucketPurgeKey.getBucketNameInfo().getBucketName())));
+    List<String[]> bucketKeyList = bucketPurgeKeysSizes.entrySet().stream()
+        .flatMap(volEntry -> volEntry.getValue().keySet().stream()
+            .map(bucketEntry -> new String[]{volEntry.getKey(), bucketEntry}))
+        .collect(Collectors.toList());
+    mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLocks(BUCKET_LOCK, bucketKeyList));
+    boolean acquiredLock = getOmLockDetails().isLockAcquired();
+    if (!acquiredLock) {
+      throw new OMException("Failed to acquire bucket lock for purging keys.",
+          OMException.ResultCodes.KEY_DELETION_ERROR);
+    }
+    List<OmBucketInfo> bucketInfoList = new ArrayList<>();
+    try {
+      for (Map.Entry<String, Map<String, List<BucketPurgeKeysSize>>> volEntry : bucketPurgeKeysSizes.entrySet()) {
+        String volumeName = volEntry.getKey();
+        for (Map.Entry<String, List<BucketPurgeKeysSize>> bucketEntry : volEntry.getValue().entrySet()) {
+          String bucketName = bucketEntry.getKey();
+          OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+          // Check null if bucket has been deleted.
+          if (omBucketInfo != null) {
+            boolean bucketUpdated = false;
+            for (BucketPurgeKeysSize bucketPurgeKeysSize : bucketEntry.getValue()) {
+              BucketNameInfo bucketNameInfo = bucketPurgeKeysSize.getBucketNameInfo();
+              if (bucketNameInfo.getBucketId() == omBucketInfo.getObjectID()) {
+                omBucketInfo.purgeSnapshotUsedBytes(bucketPurgeKeysSize.getPurgedBytes());
+                omBucketInfo.purgeSnapshotUsedNamespace(bucketPurgeKeysSize.getPurgedNamespace());
+                bucketUpdated = true;
+              }
+            }
+            if (bucketUpdated) {
+              bucketInfoList.add(omBucketInfo.copyObject());
+            }
+          }
+        }
+      }
+      return bucketInfoList;
+    } finally {
+      mergeOmLockDetails(omMetadataManager.getLock().releaseWriteLocks(BUCKET_LOCK, bucketKeyList));
+    }
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotMoveDeleted
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -30,6 +31,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.key.OMKeyPurgeRequest;
@@ -44,6 +46,7 @@ import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
  */
 @CleanupTableInfo(cleanupTables = {DELETED_TABLE, SNAPSHOT_INFO_TABLE})
 public class OMKeyPurgeResponse extends OmKeyResponse {
+  private List<OmBucketInfo> bucketInfosToBeUpdated;
   private List<String> purgeKeyList;
   private List<String> renamedList;
   private SnapshotInfo fromSnapshot;
@@ -53,12 +56,14 @@ public class OMKeyPurgeResponse extends OmKeyResponse {
       @Nonnull List<String> keyList,
       @Nonnull List<String> renamedList,
       SnapshotInfo fromSnapshot,
-      List<SnapshotMoveKeyInfos> keysToUpdate) {
+      List<SnapshotMoveKeyInfos> keysToUpdate,
+      List<OmBucketInfo> bucketInfosToBeUpdated) {
     super(omResponse);
     this.purgeKeyList = keyList;
     this.renamedList = renamedList;
     this.fromSnapshot = fromSnapshot;
     this.keysToUpdateList = keysToUpdate;
+    this.bucketInfosToBeUpdated = bucketInfosToBeUpdated == null ? Collections.emptyList() : bucketInfosToBeUpdated;
   }
 
   /**
@@ -95,6 +100,10 @@ public class OMKeyPurgeResponse extends OmKeyResponse {
     } else {
       processKeys(batchOperation, omMetadataManager);
       processKeysToUpdate(batchOperation, omMetadataManager);
+    }
+    for (OmBucketInfo bucketInfo : bucketInfosToBeUpdated) {
+      String bucketKey = omMetadataManager.getBucketKey(bucketInfo.getVolumeName(), bucketInfo.getBucketName());
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation, bucketKey, bucketInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -163,7 +163,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
       OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(
           omResponse, deleteKeysAndRenamedEntry.getKey(), deleteKeysAndRenamedEntry.getValue(), null,
-          null);
+          null, null);
       omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
 
       // Do manual commit and see whether addToBatch is successful or not.
@@ -239,7 +239,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
         omMetadataManager.getStore().initBatchOperation()) {
 
       OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(omResponse, deleteKeysAndRenamedEntry.getKey(),
-          deleteKeysAndRenamedEntry.getValue(), snapInfo, null);
+          deleteKeysAndRenamedEntry.getValue(), snapInfo, null, null);
       omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
 
       // Do manual commit and see whether addToBatch is successful or not.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -50,6 +50,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,7 @@ import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OmTestManagers;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.PendingKeysDeletion;
+import org.apache.hadoop.ozone.om.PendingKeysDeletion.PurgedKey;
 import org.apache.hadoop.ozone.om.ScmBlockLocationTestingClient;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -96,6 +98,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
@@ -140,8 +143,6 @@ class TestKeyDeletingService extends OzoneTestBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyDeletingService.class);
   private static final AtomicInteger OBJECT_COUNTER = new AtomicInteger();
-  private static final long DATA_SIZE = 1000L;
-
   private OzoneConfiguration conf;
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
@@ -240,7 +241,7 @@ class TestKeyDeletingService extends OzoneTestBase {
       assertThat(getRunCount()).isGreaterThan(initialRunCount);
       assertThat(keyManager.getPendingDeletionKeys(new ReclaimableKeyFilter(om, om.getOmSnapshotManager(),
               ((OmMetadataManagerImpl)om.getMetadataManager()).getSnapshotChainManager(), null,
-              keyManager, om.getMetadataManager().getLock()), Integer.MAX_VALUE).getKeyBlocksList())
+              keyManager, om.getMetadataManager().getLock()), Integer.MAX_VALUE).getPurgedKeys())
           .isEmpty();
     }
 
@@ -269,7 +270,7 @@ class TestKeyDeletingService extends OzoneTestBase {
           1000, 10000);
       assertThat(getRunCount())
           .isGreaterThan(initialRunCount);
-      assertThat(keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE).getKeyBlocksList())
+      assertThat(keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE).getPurgedKeys())
           .isEmpty();
 
       // The 1st version of the key has 1 block and the 2nd version has 2
@@ -300,21 +301,34 @@ class TestKeyDeletingService extends OzoneTestBase {
       // Create snapshot
       String snapName = uniqueObjectName("snap");
       writeClient.createSnapshot(volumeName, bucketName1, snapName);
-
+      keyDeletingService.suspend();
       // Delete the key
       writeClient.deleteKey(key1);
       writeClient.deleteKey(key2);
+      // Create a key3 in bucket1 which should be reclaimable to check quota usage.
+      OmKeyArgs key3 = createAndCommitKey(volumeName, bucketName1, uniqueObjectName(keyName), 3);
+      OmBucketInfo bucketInfo = writeClient.getBucketInfo(volumeName, bucketName1);
+      long key1Size = QuotaUtil.getReplicatedSize(key1.getDataSize(), key1.getReplicationConfig());
+      long key3Size = QuotaUtil.getReplicatedSize(key3.getDataSize(), key3.getReplicationConfig());
 
+      assertEquals(key1Size, bucketInfo.getSnapshotUsedBytes());
+      assertEquals(1, bucketInfo.getSnapshotUsedNamespace());
+      writeClient.deleteKey(key3);
+      bucketInfo = writeClient.getBucketInfo(volumeName, bucketName1);
+      assertEquals(key1Size + key3Size, bucketInfo.getSnapshotUsedBytes());
+      assertEquals(2, bucketInfo.getSnapshotUsedNamespace());
+      writeClient.getBucketInfo(volumeName, bucketName1);
+      keyDeletingService.resume();
       // Run KeyDeletingService
       GenericTestUtils.waitFor(
-          () -> getDeletedKeyCount() >= initialDeletedCount + 1,
-          1000, 10000);
+          () -> getDeletedKeyCount() >= initialDeletedCount + 2,
+          1000, 100000);
       assertThat(getRunCount())
           .isGreaterThan(initialRunCount);
       assertThat(keyManager.getPendingDeletionKeys(new ReclaimableKeyFilter(om, om.getOmSnapshotManager(),
               ((OmMetadataManagerImpl)om.getMetadataManager()).getSnapshotChainManager(), null,
               keyManager, om.getMetadataManager().getLock()),
-          Integer.MAX_VALUE).getKeyBlocksList())
+          Integer.MAX_VALUE).getPurgedKeys())
           .isEmpty();
 
       // deletedTable should have deleted key of the snapshot bucket
@@ -323,6 +337,9 @@ class TestKeyDeletingService extends OzoneTestBase {
           metadataManager.getOzoneKey(volumeName, bucketName1, keyName);
       String ozoneKey2 =
           metadataManager.getOzoneKey(volumeName, bucketName2, keyName);
+      String ozoneKey3 =
+          metadataManager.getOzoneKey(volumeName, bucketName2, key3.getKeyName());
+
 
       // key1 belongs to snapshot, so it should not be deleted when
       // KeyDeletingService runs. But key2 can be reclaimed as it doesn't
@@ -335,6 +352,13 @@ class TestKeyDeletingService extends OzoneTestBase {
           = metadataManager.getDeletedTable().getRangeKVs(
           null, 100, ozoneKey2);
       assertEquals(0, rangeKVs.size());
+      rangeKVs
+          = metadataManager.getDeletedTable().getRangeKVs(
+          null, 100, ozoneKey3);
+      assertEquals(0, rangeKVs.size());
+      bucketInfo = writeClient.getBucketInfo(volumeName, bucketName1);
+      assertEquals(key1Size, bucketInfo.getSnapshotUsedBytes());
+      assertEquals(1, bucketInfo.getSnapshotUsedNamespace());
     }
 
     /*
@@ -418,8 +442,8 @@ class TestKeyDeletingService extends OzoneTestBase {
       assertTableRowCount(snapshotInfoTable, initialSnapshotCount + 1, metadataManager);
       doAnswer(i -> {
         PendingKeysDeletion pendingKeysDeletion = (PendingKeysDeletion) i.callRealMethod();
-        for (BlockGroup group : pendingKeysDeletion.getKeyBlocksList()) {
-          Assertions.assertNotEquals(deletePathKey[0], group.getGroupID());
+        for (PurgedKey purgedKey : pendingKeysDeletion.getPurgedKeys().values()) {
+          Assertions.assertNotEquals(deletePathKey[0], purgedKey.getBlockGroup().getGroupID());
         }
         return pendingKeysDeletion;
       }).when(km).getPendingDeletionKeys(any(), anyInt());
@@ -663,13 +687,13 @@ class TestKeyDeletingService extends OzoneTestBase {
       final String testVolumeName = getTestName();
       final String testBucketName = uniqueObjectName("bucket");
       final String keyName = uniqueObjectName("key");
-
+      Map<Integer, Long> keySizeMap = new HashMap<>();
       // Create Volume and Buckets
       createVolumeAndBucket(testVolumeName, testBucketName, false);
 
       // Create 3 keys
       for (int i = 1; i <= 3; i++) {
-        createAndCommitKey(testVolumeName, testBucketName, keyName + i, 3);
+        keySizeMap.put(i, createAndCommitKey(testVolumeName, testBucketName, keyName + i, 3).getDataSize());
       }
       assertTableRowCount(keyTable, initialKeyCount + 3, metadataManager);
 
@@ -681,7 +705,7 @@ class TestKeyDeletingService extends OzoneTestBase {
 
       // Create 2 keys
       for (int i = 4; i <= 5; i++) {
-        createAndCommitKey(testVolumeName, testBucketName, keyName + i, 3);
+        keySizeMap.put(i, createAndCommitKey(testVolumeName, testBucketName, keyName + i, 3).getDataSize());
       }
       // Delete a key, rename 2 keys. We will be using this to test
       // how we handle renamed key for exclusive size calculation.
@@ -699,7 +723,7 @@ class TestKeyDeletingService extends OzoneTestBase {
 
       // Create 2 keys
       for (int i = 6; i <= 7; i++) {
-        createAndCommitKey(testVolumeName, testBucketName, keyName + i, 3);
+        keySizeMap.put(i, createAndCommitKey(testVolumeName, testBucketName, keyName + i, 3).getDataSize());
       }
 
       deleteKey(testVolumeName, testBucketName, "renamedKey1");
@@ -734,13 +758,11 @@ class TestKeyDeletingService extends OzoneTestBase {
       keyDeletingService.resume();
 
       Map<String, Long> expectedSize = new ImmutableMap.Builder<String, Long>()
-          .put(snap1, 1000L)
-          .put(snap2, 1000L)
-          .put(snap3, 2000L)
+          .put(snap1, keySizeMap.get(3))
+          .put(snap2, keySizeMap.get(4))
+          .put(snap3, keySizeMap.get(6) + keySizeMap.get(7))
           .put(snap4, 0L)
           .build();
-      System.out.println(expectedSize);
-
       // Let KeyDeletingService to run for some iterations
       GenericTestUtils.waitFor(
           () -> (getRunCount() > prevKdsRunCount + 20),
@@ -756,7 +778,6 @@ class TestKeyDeletingService extends OzoneTestBase {
 
           Long expected = expectedSize.getOrDefault(snapshotName, snapshotInfo.getExclusiveSize());
           assertNotNull(expected);
-          System.out.println(snapshotName);
           assertEquals(expected, snapshotInfo.getExclusiveSize());
           // Since for the test we are using RATIS/THREE
           assertEquals(expected * 3, snapshotInfo.getExclusiveReplicatedSize());
@@ -805,8 +826,10 @@ class TestKeyDeletingService extends OzoneTestBase {
               return OzoneManagerProtocolProtos.OMResponse.newBuilder().setCmdType(purgeRequest.get().getCmdType())
                   .setStatus(OzoneManagerProtocolProtos.Status.TIMEOUT).build();
             });
-        List<BlockGroup> blockGroups = Collections.singletonList(BlockGroup.newBuilder().setKeyName("key1")
-            .addAllBlockIDs(Collections.singletonList(new BlockID(1, 1))).build());
+        BlockGroup blockGroup = BlockGroup.newBuilder().setKeyName("key1/1")
+            .addAllBlockIDs(Collections.singletonList(new BlockID(1, 1))).build();
+        Map<String, PurgedKey> blockGroups = Collections.singletonMap(blockGroup.getGroupID(), new PurgedKey("vol",
+            "buck", 1, blockGroup, "key1", 30, true));
         List<String> renameEntriesToBeDeleted = Collections.singletonList("key2");
         OmKeyInfo omKeyInfo = new OmKeyInfo.Builder()
             .setBucketName("buck")
@@ -820,7 +843,7 @@ class TestKeyDeletingService extends OzoneTestBase {
             .build();
         Map<String, RepeatedOmKeyInfo> keysToModify = Collections.singletonMap("key1",
             new RepeatedOmKeyInfo(Collections.singletonList(omKeyInfo), 0L));
-        keyDeletingService.processKeyDeletes(blockGroups, keysToModify, renameEntriesToBeDeleted, null, null, null);
+        keyDeletingService.processKeyDeletes(blockGroups, keysToModify, renameEntriesToBeDeleted, null, null);
         assertTrue(purgeRequest.get().getPurgeKeysRequest().getKeysToUpdateList().isEmpty());
         assertEquals(renameEntriesToBeDeleted, purgeRequest.get().getPurgeKeysRequest().getRenamedKeysList());
       }
@@ -967,9 +990,11 @@ class TestKeyDeletingService extends OzoneTestBase {
       writeClient.createSnapshot(volumeName, bucketName, snap2);
 
       // Create and delete 5 more keys.
+      long dataSize = 0L;
       for (int i = 16; i <= 20; i++) {
         OmKeyArgs args = createAndCommitKey(volumeName, bucketName, uniqueObjectName("key"), 1);
         createdKeys.add(args);
+        dataSize = args.getDataSize();
       }
       for (int i = 15; i < 20; i++) {
         writeClient.deleteKey(createdKeys.get(i));
@@ -997,17 +1022,17 @@ class TestKeyDeletingService extends OzoneTestBase {
       GenericTestUtils.waitFor(() -> getDeletedKeyCount() == 10, 100, 10000);
       // Verify last run AOS deletion metrics.
       assertEquals(5, metrics.getAosKeysReclaimedLast());
-      assertEquals(5 * DATA_SIZE * 3, metrics.getAosReclaimedSizeLast());
+      assertEquals(5 * dataSize * 3, metrics.getAosReclaimedSizeLast());
       assertEquals(5, metrics.getAosKeysIteratedLast());
       assertEquals(0, metrics.getAosKeysNotReclaimableLast());
       // Verify last run Snapshot deletion metrics.
       assertEquals(5, metrics.getSnapKeysReclaimedLast());
-      assertEquals(5 * DATA_SIZE * 3, metrics.getSnapReclaimedSizeLast());
+      assertEquals(5 * dataSize * 3, metrics.getSnapReclaimedSizeLast());
       assertEquals(15, metrics.getSnapKeysIteratedLast());
       assertEquals(10, metrics.getSnapKeysNotReclaimableLast());
       // Verify 24h deletion metrics.
       assertEquals(10, metrics.getKeysReclaimedInInterval());
-      assertEquals(10 * DATA_SIZE * 3, metrics.getReclaimedSizeInInterval());
+      assertEquals(10 * dataSize * 3, metrics.getReclaimedSizeInInterval());
 
       // Delete snap1. Which also sets the snap2 to be deep cleaned.
       writeClient.deleteSnapshot(volumeName, bucketName, snap1);
@@ -1035,12 +1060,12 @@ class TestKeyDeletingService extends OzoneTestBase {
       assertEquals(0, metrics.getAosKeysNotReclaimableLast());
       // Verify last run Snapshot deletion metrics.
       assertEquals(10, metrics.getSnapKeysReclaimedLast());
-      assertEquals(10 * DATA_SIZE * 3, metrics.getSnapReclaimedSizeLast());
+      assertEquals(10 * dataSize * 3, metrics.getSnapReclaimedSizeLast());
       assertEquals(10, metrics.getSnapKeysIteratedLast());
       assertEquals(0, metrics.getSnapKeysNotReclaimableLast());
       // Verify 24h deletion metrics.
       assertEquals(20, metrics.getKeysReclaimedInInterval());
-      assertEquals(20 * DATA_SIZE * 3, metrics.getReclaimedSizeInInterval());
+      assertEquals(20 * dataSize * 3, metrics.getReclaimedSizeInInterval());
     }
   }
 
@@ -1245,6 +1270,7 @@ class TestKeyDeletingService extends OzoneTestBase {
     OMRequestTestUtils.addBucketToOM(keyManager.getMetadataManager(),
         OmBucketInfo.newBuilder().setVolumeName(volumeName)
             .setBucketName(bucketName)
+            .setObjectID(OBJECT_COUNTER.incrementAndGet())
             .setIsVersionEnabled(isVersioningEnabled)
             .build());
   }
@@ -1314,10 +1340,11 @@ class TestKeyDeletingService extends OzoneTestBase {
 
     List<OmKeyLocationInfo> latestBlocks = keyLocationVersions
         .getBlocksLatestVersionOnly();
-
+    long size = 0;
     int preAllocatedSize = latestBlocks.size();
     for (OmKeyLocationInfo block : latestBlocks) {
       keyArg.addLocationInfo(block);
+      size += block.getLength();
     }
 
     LinkedList<OmKeyLocationInfo> allocated = new LinkedList<>();
@@ -1331,8 +1358,9 @@ class TestKeyDeletingService extends OzoneTestBase {
 
     for (OmKeyLocationInfo block : allocated) {
       keyArg.addLocationInfo(block);
+      size += block.getLength();
     }
-
+    keyArg.setDataSize(size);
     customWriteClient.commitKey(keyArg, session.getId());
     return keyArg;
   }
@@ -1352,7 +1380,7 @@ class TestKeyDeletingService extends OzoneTestBase {
   private int countKeysPendingDeletion() {
     try {
       final int count = keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE)
-          .getKeyBlocksList().size();
+          .getPurgedKeys().size();
       LOG.debug("KeyManager keys pending deletion: {}", count);
       return count;
     } catch (IOException e) {
@@ -1363,8 +1391,9 @@ class TestKeyDeletingService extends OzoneTestBase {
   private long countBlocksPendingDeletion() {
     try {
       return keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE)
-          .getKeyBlocksList()
+          .getPurgedKeys().values()
           .stream()
+          .map(PurgedKey::getBlockGroup)
           .map(BlockGroup::getBlockIDList)
           .mapToLong(Collection::size)
           .sum();
@@ -1374,6 +1403,6 @@ class TestKeyDeletingService extends OzoneTestBase {
   }
 
   private static String uniqueObjectName(String prefix) {
-    return prefix + OBJECT_COUNTER.getAndIncrement();
+    return prefix + String.format("%010d", OBJECT_COUNTER.getAndIncrement());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
SnapshotUsedBytes and snapshotUsedNamespace should be reduced as part of the OMKeyPurgeRequest and OmDirectoriesPurgeRequest submitted by the background KeyDeletingService and DirectoryDeletingService.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13764

## How was this patch tested?
Added additional unit tests and updated existing unit tests
