### PR TITLE
HDDS-14005. EventNotification: add the plugin framework

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -553,6 +553,11 @@ public final class OzoneConsts {
       "compactionLogTable";
 
   /**
+   * DB completed request info table name. Referenced in RDBStore.
+   */
+  public static final String COMPLETED_REQUEST_INFO_TABLE = "completedRequestInfoTable";
+
+  /**
    * S3G multipart upload request's ETag header key.
    */
   public static final String ETAG = "ETag";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListener.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListener.java
@@ -1,0 +1,15 @@
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+/**
+ * Interface for event listener plugin implementations
+ */
+public interface OMEventListener {
+
+  void initialize(OzoneConfiguration conf, OMEventListenerPluginContext pluginContext);
+
+  void start();
+
+  void shutdown();
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContext.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContext.java
@@ -1,0 +1,9 @@
+package org.apache.hadoop.ozone.om.eventlistener;
+
+/**
+ * A narrow set of functionality we are ok with exposing to plugin
+ * implementations
+ */
+public interface OMEventListenerPluginContext {
+
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmCompletedRequestInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmCompletedRequestInfo.java
@@ -1,0 +1,524 @@
+package org.apache.hadoop.ozone.om.helpers;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.Proto2Codec;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.audit.Auditable;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import java.time.format.DateTimeFormatter;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+import static org.apache.hadoop.hdds.HddsUtils.fromProtobuf;
+import static org.apache.hadoop.hdds.HddsUtils.toProtobuf;
+
+/**
+ * This class is used for storing info related to completed operations.
+ *
+ * Each successfully completion operation has an associated
+ * OmCompletedRequestInfo entry the trxLogIndex, op, volumeName, bucketName,
+ * keyName and creationTime
+ */
+public final class OmCompletedRequestInfo implements Auditable, CopyObject<OmCompletedRequestInfo> {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(OmCompletedRequestInfo.class);
+
+  private static final Codec<OmCompletedRequestInfo> CODEC = new DelegatedCodec<>(
+      Proto2Codec.get(OzoneManagerProtocolProtos.CompletedRequestInfo.getDefaultInstance()),
+      OmCompletedRequestInfo::getFromProtobuf,
+      OmCompletedRequestInfo::getProtobuf,
+      OmCompletedRequestInfo.class);
+
+  /**
+   * OperationType enum
+   */
+  public enum OperationType {
+    CREATE_KEY,
+    RENAME_KEY,
+    DELETE_KEY,
+    COMMIT_KEY,
+    CREATE_DIRECTORY,
+    CREATE_FILE;
+  }
+
+  private static final long INVALID_TIMESTAMP = -1;
+
+  private long trxLogIndex;
+  private final String volumeName;
+  private final String bucketName;
+  private final String keyName;
+  private final long creationTime;
+  private final OperationArgs opArgs;
+
+  /**
+   * Private constructor, constructed via builder.
+   * @param snapshotId - Snapshot UUID.
+   * @param name - snapshot name.
+   * @param volumeName - volume name.
+   * @param bucketName - bucket name.
+   * @param snapshotStatus - status: SNAPSHOT_ACTIVE, SNAPSHOT_DELETED
+   * @param creationTime - Snapshot creation time.
+   * @param deletionTime - Snapshot deletion time.
+   * @param pathPreviousSnapshotId - Snapshot path previous snapshot id.
+   * @param globalPreviousSnapshotId - Snapshot global previous snapshot id.
+   * @param snapshotPath - Snapshot path, bucket .snapshot path.
+   * @param checkpointDir - Snapshot checkpoint directory.
+   * @param dbTxSequenceNumber - RDB latest transaction sequence number.
+   * @param deepCleaned - To be deep cleaned status for snapshot.
+   * @param referencedSize - Snapshot referenced size.
+   * @param referencedReplicatedSize - Snapshot referenced size w/ replication.
+   * @param exclusiveSize - Snapshot exclusive size.
+   * @param exclusiveReplicatedSize - Snapshot exclusive size w/ replication.
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private OmCompletedRequestInfo(long trxLogIndex,
+                        String volumeName,
+                        String bucketName,
+                        String keyName,
+                        long creationTime,
+                        OperationArgs opArgs) {
+    this.trxLogIndex = trxLogIndex;
+    this.volumeName = volumeName;
+    this.bucketName = bucketName;
+    this.keyName = keyName;
+    this.creationTime = creationTime;
+    this.opArgs = opArgs;
+  }
+
+  public static Codec<OmCompletedRequestInfo> getCodec() {
+    return CODEC;
+  }
+
+  public void setTrxLogIndex(long trxLogIndex) {
+    this.trxLogIndex = trxLogIndex;
+  }
+
+  // the db version of the key is left padded with 0s so that it can be
+  // "seeked" in in lexigroaphical order
+  // TODO: is this an appropriate key?
+  public String getDbKey() {
+    return StringUtils.leftPad(String.valueOf(trxLogIndex), 20, '0');
+  }
+
+  public long getTrxLogIndex() {
+    return trxLogIndex;
+  }
+
+  public String getVolumeName() {
+    return volumeName;
+  }
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+
+  public long getCreationTime() {
+    return creationTime;
+  }
+
+  public OperationArgs getOpArgs() {
+    return opArgs;
+  }
+
+  public static org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.Builder
+      newBuilder() {
+    return new org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.Builder();
+  }
+
+  public OmCompletedRequestInfo.Builder toBuilder() {
+    return new Builder()
+        .setTrxLogIndex(trxLogIndex)
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setCreationTime(creationTime)
+        .setOpArgs(opArgs);
+  }
+
+  /**
+   * Builder of OmCompletedRequestInfo.
+   */
+  public static class Builder {
+    private long trxLogIndex;
+    private String volumeName;
+    private String bucketName;
+    private String keyName;
+    private long creationTime;
+    private OperationArgs opArgs;
+
+    public Builder() {
+      // default values
+    }
+
+    public Builder setTrxLogIndex(long trxLogIndex) {
+      this.trxLogIndex = trxLogIndex;
+      return this;
+    }
+
+    public Builder setVolumeName(String volumeName) {
+      this.volumeName = volumeName;
+      return this;
+    }
+
+    public Builder setBucketName(String bucketName) {
+      this.bucketName = bucketName;
+      return this;
+    }
+
+    public Builder setKeyName(String keyName) {
+      this.keyName = keyName;
+      return this;
+    }
+
+    public Builder setCreationTime(long crTime) {
+      this.creationTime = crTime;
+      return this;
+    }
+
+    public Builder setOpArgs(OperationArgs opArgs) {
+      this.opArgs = opArgs;
+      return this;
+    }
+
+    public OmCompletedRequestInfo build() {
+      //Preconditions.checkNotNull(name);
+      return new OmCompletedRequestInfo(
+          trxLogIndex,
+          volumeName,
+          bucketName,
+          keyName,
+          creationTime,
+          opArgs
+      );
+    }
+  }
+
+  /**
+   * Creates OmCompletedRequestInfo protobuf from OmCompletedRequestInfo.
+   */
+  public OzoneManagerProtocolProtos.CompletedRequestInfo getProtobuf() {
+    OzoneManagerProtocolProtos.CompletedRequestInfo.Builder sib =
+        OzoneManagerProtocolProtos.CompletedRequestInfo.newBuilder()
+            .setTrxLogIndex(trxLogIndex)
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .setCreationTime(creationTime);
+
+    switch (opArgs.getOperationType()) {
+      case CREATE_KEY:
+        sib.setCmdType(OzoneManagerProtocolProtos.Type.CreateKey);
+        sib.setCreateKeyArgs(OzoneManagerProtocolProtos.CreateKeyOperationArgs.newBuilder()
+            .build());
+        break;
+      case RENAME_KEY:
+        sib.setCmdType(OzoneManagerProtocolProtos.Type.RenameKey);
+        sib.setRenameKeyArgs(OzoneManagerProtocolProtos.RenameKeyOperationArgs.newBuilder()
+            .setToKeyName(((OperationArgs.RenameKeyArgs) opArgs).getToKeyName())
+            .build());
+        break;
+      case DELETE_KEY:
+        sib.setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey);
+        sib.setDeleteKeyArgs(OzoneManagerProtocolProtos.DeleteKeyOperationArgs.newBuilder()
+            .build());
+        break;
+      case COMMIT_KEY:
+        sib.setCmdType(OzoneManagerProtocolProtos.Type.CommitKey);
+        sib.setCommitKeyArgs(OzoneManagerProtocolProtos.CommitKeyOperationArgs.newBuilder()
+            .build());
+        break;
+      case CREATE_DIRECTORY:
+        sib.setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory);
+        sib.setCreateDirectoryArgs(OzoneManagerProtocolProtos.CreateDirectoryOperationArgs.newBuilder()
+            .build());
+        break;
+      case CREATE_FILE:
+        sib.setCmdType(OzoneManagerProtocolProtos.Type.CreateFile);
+        sib.setCreateFileArgs(OzoneManagerProtocolProtos.CreateFileOperationArgs.newBuilder()
+            .setIsRecursive(((OperationArgs.CreateFileArgs) opArgs).isRecursive())
+            .setIsOverwrite(((OperationArgs.CreateFileArgs) opArgs).isOverwrite())
+            .build());
+        break;
+      default:
+        LOG.error("Unexpected operationType={}", opArgs.getOperationType());
+        break;
+    }
+
+    return sib.build();
+  }
+
+  /**
+   * Parses OmCompletedRequestInfo protobuf and creates OmCompletedRequestInfo.
+   * @param completedRequestInfoProto protobuf
+   * @return instance of OmCompletedRequestInfo
+   */
+  public static OmCompletedRequestInfo getFromProtobuf(
+      OzoneManagerProtocolProtos.CompletedRequestInfo completedRequestInfoProto) {
+
+    OmCompletedRequestInfo.Builder osib = OmCompletedRequestInfo.newBuilder()
+        .setTrxLogIndex(completedRequestInfoProto.getTrxLogIndex())
+        .setVolumeName(completedRequestInfoProto.getVolumeName())
+        .setBucketName(completedRequestInfoProto.getBucketName())
+        .setKeyName(completedRequestInfoProto.getKeyName())
+        .setCreationTime(completedRequestInfoProto.getCreationTime());
+
+    switch (completedRequestInfoProto.getCmdType()) {
+      case CreateKey:
+        osib.setOpArgs(new OperationArgs.CreateKeyArgs());
+        break;
+      case RenameKey:
+        OzoneManagerProtocolProtos.RenameKeyOperationArgs renameArgs
+            = (OzoneManagerProtocolProtos.RenameKeyOperationArgs) completedRequestInfoProto.getRenameKeyArgs();
+
+        osib.setOpArgs(new OperationArgs.RenameKeyArgs(renameArgs.getToKeyName()));
+        break;
+      case DeleteKey:
+        osib.setOpArgs(new OperationArgs.DeleteKeyArgs());
+        break;
+      case CommitKey:
+        osib.setOpArgs(new OperationArgs.CommitKeyArgs());
+        break;
+      case CreateDirectory:
+        osib.setOpArgs(new OperationArgs.CreateDirectoryArgs());
+        break;
+      case CreateFile:
+        OzoneManagerProtocolProtos.CreateFileOperationArgs createFileArgs
+            = (OzoneManagerProtocolProtos.CreateFileOperationArgs) completedRequestInfoProto.getCreateFileArgs();
+
+        osib.setOpArgs(new OperationArgs.CreateFileArgs(createFileArgs.getIsOverwrite(), createFileArgs.getIsRecursive()));
+        break;
+      default:
+        LOG.error("Unexpected cmdType={}", completedRequestInfoProto.getCmdType());
+        break;
+    }
+
+    return osib.build();
+  }
+
+  @Override
+  public Map<String, String> toAuditMap() {
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    //auditMap.put(OzoneConsts.VOLUME, getVolumeName());
+    //auditMap.put(OzoneConsts.BUCKET, getBucketName());
+    //auditMap.put(OzoneConsts.OM_SNAPSHOT_NAME, this.name);
+    return auditMap;
+  }
+
+  /**
+   * Factory for making standard instance.
+   */
+  /*
+  public static OmCompletedRequestInfo newInstance(long trxLogIndex,
+                                          Operation op,
+                                          long creationTime) {
+    OmCompletedRequestInfo.Builder builder = new OmCompletedRequestInfo.Builder();
+    builder.setTrxLogIndex(trxLogIndex)
+        .setOp(op)
+        .setCreationTime(creationTime);
+
+    return builder.build();
+  }
+  */
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OmCompletedRequestInfo that = (OmCompletedRequestInfo) o;
+    return trxLogIndex == that.trxLogIndex &&
+        creationTime == that.creationTime &&
+        volumeName.equals(that.volumeName) &&
+        bucketName.equals(that.bucketName) &&
+        keyName.equals(that.keyName) &&
+        volumeName == that.bucketName &&
+        opArgs.equals(that.opArgs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(trxLogIndex, volumeName, bucketName,
+        keyName, creationTime, opArgs);
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  @Override
+  public OmCompletedRequestInfo copyObject() {
+    return new Builder()
+        .setTrxLogIndex(trxLogIndex)
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setCreationTime(creationTime)
+        .setOpArgs(opArgs)
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return "OmCompletedRequestInfo{" +
+        "trxLogIndex: '" + trxLogIndex + '\'' +
+        ", volumeName: '" + volumeName + '\'' +
+        ", bucketName: '" + bucketName + '\'' +
+        ", keyName: '" + keyName + '\'' +
+        ", creationTime: '" + creationTime + '\'' +
+        ", opArgs : '" + opArgs + '\'' +
+        '}';
+  }
+
+  public static abstract class OperationArgs {
+
+    public abstract OperationType getOperationType();
+
+    public static class CreateKeyArgs extends OperationArgs {
+
+      @Override
+      public OperationType getOperationType() {
+        return OperationType.CREATE_KEY;
+      }
+
+      @Override
+      public String toString() {
+        return "CreateKeyArgs{}";
+      }
+    }
+
+    public static class RenameKeyArgs extends OperationArgs {
+      private final String toKeyName;
+
+      public RenameKeyArgs(String toKeyName) {
+        this.toKeyName = toKeyName;
+      }
+
+      @Override
+      public OperationType getOperationType() {
+        return OperationType.RENAME_KEY;
+      }
+
+      public String getToKeyName() {
+        return toKeyName;
+      }
+
+      @Override
+      public String toString() {
+        return "RenameKeyArgs{" +
+          "toKeyName: '" + toKeyName + '\'' +
+          '}';
+      }
+    }
+
+    public static class DeleteKeyArgs extends OperationArgs {
+
+      @Override
+      public OperationType getOperationType() {
+        return OperationType.DELETE_KEY;
+      }
+
+      @Override
+      public String toString() {
+        return "DeleteKeyArgs{}";
+      }
+    }
+
+    public static class CommitKeyArgs extends OperationArgs {
+
+      @Override
+      public OperationType getOperationType() {
+        return OperationType.COMMIT_KEY;
+      }
+
+      @Override
+      public String toString() {
+        return "CommitKeyArgs{}";
+      }
+    }
+
+    public static class CreateDirectoryArgs extends OperationArgs {
+
+      @Override
+      public OperationType getOperationType() {
+        return OperationType.CREATE_DIRECTORY;
+      }
+
+      @Override
+      public String toString() {
+        return "CreateDirectoryArgs{}";
+      }
+    }
+
+    public static class CreateFileArgs extends OperationArgs {
+      // hsync?
+      private final boolean recursive;
+      private final boolean overwrite;
+
+      public CreateFileArgs(boolean recursive, boolean overwrite) {
+        this.recursive = recursive;
+        this.overwrite = overwrite;
+      }
+
+      @Override
+      public OperationType getOperationType() {
+        return OperationType.CREATE_FILE;
+      }
+
+      public boolean isRecursive() {
+        return recursive;
+      }
+
+      public boolean isOverwrite() {
+        return overwrite;
+      }
+
+      @Override
+      public String toString() {
+        return "CreateFileArgs{" +
+          "recursive: '" + recursive + '\'' +
+          ", overwrite: '" + overwrite + '\'' +
+          '}';
+      }
+    }
+  }
+}

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -917,6 +917,48 @@ message SnapshotDiffJobProto {
   optional double keysProcessedPct = 13;
 }
 
+message CreateKeyOperationArgs {
+}
+
+message RenameKeyOperationArgs {
+    required string toKeyName = 1;
+}
+
+message DeleteKeyOperationArgs {
+}
+
+message CommitKeyOperationArgs {
+}
+
+message CreateDirectoryOperationArgs {
+}
+
+message CreateFileOperationArgs {
+    required bool isRecursive = 2;
+    required bool isOverwrite = 3;
+}
+
+
+/**
+ * CompletedRequestInfo table entry
+ */
+message CompletedRequestInfo {
+
+  optional int64 trxLogIndex = 1;
+  required Type cmdType = 2; // Type of the command
+  optional string volumeName = 3;
+  optional string bucketName = 4;
+  optional string keyName = 5;
+  optional uint64 creationTime = 6;
+
+  optional CreateKeyOperationArgs       createKeyArgs = 7;
+  optional RenameKeyOperationArgs       renameKeyArgs = 8;
+  optional DeleteKeyOperationArgs       deleteKeyArgs = 9;
+  optional CommitKeyOperationArgs       commitKeyArgs = 10;
+  optional CreateDirectoryOperationArgs createDirectoryArgs = 11;
+  optional CreateFileOperationArgs      createFileArgs = 12;
+}
+
 message OzoneObj {
   enum ObjectType {
     VOLUME = 1;

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.ListKeysResult;
 import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
@@ -477,6 +478,8 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
   Table<String, String> getSnapshotRenamedTable();
 
   Table<String, CompactionLogEntry> getCompactionLogTable();
+
+  Table<String, OmCompletedRequestInfo> getCompletedRequestInfoTable();
 
   /**
    * Gets the OM Meta table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -101,6 +101,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.ListKeysResult;
 import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
@@ -180,6 +181,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   private TypedTable<String, SnapshotInfo> snapshotInfoTable;
   private TypedTable<String, String> snapshotRenamedTable;
   private TypedTable<String, CompactionLogEntry> compactionLogTable;
+  private TypedTable<String, OmCompletedRequestInfo> completedRequestInfoTable;
 
   private OzoneManager ozoneManager;
 
@@ -486,6 +488,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     // TODO: [SNAPSHOT] Initialize table lock for snapshotRenamedTable.
 
     compactionLogTable = initializer.get(OMDBDefinition.COMPACTION_LOG_TABLE_DEF);
+
+    completedRequestInfoTable = initializer.get(OMDBDefinition.COMPLETED_REQUEST_INFO_TABLE_DEF);
   }
 
   /**
@@ -1681,6 +1685,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   @Override
   public Table<String, CompactionLogEntry> getCompactionLogTable() {
     return compactionLogTable;
+  }
+
+  @Override
+  public Table<String, OmCompletedRequestInfo> getCompletedRequestInfoTable() {
+    return completedRequestInfoTable;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
@@ -315,6 +316,15 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
           StringCodec.get(),
           CompactionLogEntry.getCodec());
 
+  public static final String COMPLETED_REQUEST_INFO_TABLE = "completedRequestInfoTable";
+  /** completedOperationnfoTable: txId :- OmCompletedRequestInfo. */
+  public static final DBColumnFamilyDefinition<String, OmCompletedRequestInfo> COMPLETED_REQUEST_INFO_TABLE_DEF
+      = new DBColumnFamilyDefinition<>(COMPLETED_REQUEST_INFO_TABLE,
+          StringCodec.get(), // txid (left zeropadded)
+          OmCompletedRequestInfo.getCodec());
+
+
+
   //---------------------------------------------------------------------------
   private static final Map<String, DBColumnFamilyDefinition<?, ?>> COLUMN_FAMILIES
       = DBColumnFamilyDefinition.newUnmodifiableMap(
@@ -339,7 +349,8 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
           TENANT_STATE_TABLE_DEF,
           TRANSACTION_INFO_TABLE_DEF,
           USER_TABLE_DEF,
-          VOLUME_TABLE_DEF);
+          VOLUME_TABLE_DEF,
+          COMPLETED_REQUEST_INFO_TABLE_DEF);
 
   private static final OMDBDefinition INSTANCE = new OMDBDefinition();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContextImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContextImpl.java
@@ -1,0 +1,18 @@
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import org.apache.hadoop.ozone.om.OzoneManager;
+
+/**
+ * A narrow set of functionality we are ok with exposing to plugin
+ * implementations
+ */
+public final class OMEventListenerPluginContextImpl implements OMEventListenerPluginContext {
+  private final OzoneManager ozoneManager;
+
+  public OMEventListenerPluginContextImpl(OzoneManager ozoneManager) {
+    this.ozoneManager = ozoneManager;
+  }
+
+  // TODO: fill this out with capabilities we would like to expose to
+  // plugin implementations.
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginManager.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is a manager for plugins which implement OMEventListener which
+ * manages the lifecycle of constructing starting/stopping configured
+ * plugins.
+ */
+public class OMEventListenerPluginManager {
+  public static final Logger LOG = LoggerFactory.getLogger(OMEventListenerPluginManager.class);
+
+  public static final String PLUGIN_DEST_BASE = "ozone.om.plugin.destination";
+
+  private final List<OMEventListener> plugins;
+
+  public OMEventListenerPluginManager(OzoneManager ozoneManager, OzoneConfiguration conf) {
+    this.plugins = loadAll(ozoneManager, conf);
+  }
+
+  public List<OMEventListener> getLoaded() {
+    return plugins;
+  }
+
+  public void startAll() {
+    for (OMEventListener plugin : plugins) {
+      plugin.start();
+    }
+  }
+
+  public void shutdownAll() {
+    for (OMEventListener plugin : plugins) {
+      plugin.shutdown();
+    }
+  }
+
+  // Configuration is based on ranger plugins
+  //
+  // For example, a plugin named FooPlugin would be configured via
+  // OzoneConfiguration properties as follows:
+  //
+  //   conf.set("ozone.om.plugin.destination.foo", "enabled");
+  //   conf.set("ozone.om.plugin.destination.foo.classname", "org.apache.hadoop.ozone.om.eventlistener.FooPlugin");
+  //
+  static List<OMEventListener> loadAll(OzoneManager ozoneManager, OzoneConfiguration conf) {
+    List<OMEventListener> plugins = new ArrayList<>();
+
+    Map<String, String> props = conf.getPropsMatchPrefixAndTrimPrefix(PLUGIN_DEST_BASE);
+    List<String> destNameList = new ArrayList<>();
+    for (Map.Entry<String, String> entry : props.entrySet()) {
+      String destName = entry.getKey();
+      String value = entry.getValue();
+      LOG.info("Found event listener plugin with name={} and value={}", destName, value);
+
+      if (value.equalsIgnoreCase("enable") || value.equalsIgnoreCase("enabled") || value.equalsIgnoreCase("true")) {
+        destNameList.add(destName);
+        LOG.info("Event listener plugin {}{} is set to {}", PLUGIN_DEST_BASE, destName, value);
+      }
+    }
+
+    OMEventListenerPluginContext pluginContext = new OMEventListenerPluginContextImpl(ozoneManager);
+
+    for (String destName : destNameList) {
+      try {
+        Class<? extends OMEventListener> cls = resolvePluginClass(conf, destName);
+        LOG.info("Event listener plugin class is {}", cls);
+
+        OMEventListener impl = cls.newInstance();
+        impl.initialize(conf, pluginContext);
+
+        plugins.add(impl);
+      } catch (Exception ex) {
+        LOG.error("Can't make instance of event listener plugin {}{}", PLUGIN_DEST_BASE, destName, ex);
+      }
+    }
+
+    return plugins;
+  }
+
+  private static Class<? extends OMEventListener> resolvePluginClass(OzoneConfiguration conf,
+                                                                     String destName) {
+    String classnameProp = PLUGIN_DEST_BASE + destName + ".classname";
+    LOG.info("Gettting classname for {} with propety {}", destName, classnameProp);
+    Class<? extends OMEventListener> cls = conf.getClass(classnameProp, null, OMEventListener.class);
+    if (null == cls) {
+      throw new RuntimeException(String.format(
+          "Unable to load plugin %s, classname property %s is missing or does not implement OMEventListener",
+          destName, classnameProp));
+    }
+    return cls;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerSuccessfulRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerSuccessfulRequestHandler.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ratis;
+
+import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.OperationArgs;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.OperationType;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is a simple hook on a successful write operation.  It's
+ * only purpose at the moment is to write an OmCompletedRequestInfo record to the DB
+ */
+public final class OzoneManagerSuccessfulRequestHandler {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OzoneManagerSuccessfulRequestHandler.class);
+
+  private final OzoneManager ozoneManager;
+  private final OMMetadataManager omMetadataManager;
+
+  public OzoneManagerSuccessfulRequestHandler(OzoneManager ozoneManager) {
+    this.ozoneManager = ozoneManager;
+    this.omMetadataManager = ozoneManager.getMetadataManager();
+  }
+
+  public void handle(long trxLogIndex, OzoneManagerProtocolProtos.OMRequest omRequest) {
+
+    switch (omRequest.getCmdType()) {
+      case CreateKey:
+        logRequest("CreateKey", omRequest);
+        storeCompletedRequestInfo(buildOmCompletedRequestInfo(trxLogIndex,
+            omRequest.getCreateKeyRequest().getKeyArgs(),
+            new OperationArgs.CreateKeyArgs()));
+        break;
+      case RenameKey:
+        logRequest("RenameKey", omRequest);
+        OzoneManagerProtocolProtos.RenameKeyRequest renameReq
+            = (OzoneManagerProtocolProtos.RenameKeyRequest) omRequest.getRenameKeyRequest();
+
+        storeCompletedRequestInfo(buildOmCompletedRequestInfo(trxLogIndex,
+            omRequest.getRenameKeyRequest().getKeyArgs(),
+            new OperationArgs.RenameKeyArgs(renameReq.getToKeyName())));
+
+        break;
+      case DeleteKey:
+        logRequest("DeleteKey", omRequest);
+        storeCompletedRequestInfo(buildOmCompletedRequestInfo(trxLogIndex,
+            omRequest.getDeleteKeyRequest().getKeyArgs(),
+            new OperationArgs.DeleteKeyArgs()));
+        break;
+      case CommitKey:
+        logRequest("CommitKey", omRequest);
+        storeCompletedRequestInfo(buildOmCompletedRequestInfo(trxLogIndex,
+            omRequest.getCommitKeyRequest().getKeyArgs(),
+            new OperationArgs.CommitKeyArgs()));
+        break;
+      case CreateDirectory:
+        logRequest("CreateDirectory", omRequest);
+        storeCompletedRequestInfo(buildOmCompletedRequestInfo(trxLogIndex,
+            omRequest.getCreateDirectoryRequest().getKeyArgs(),
+            new OperationArgs.CreateDirectoryArgs()));
+        break;
+      case CreateFile:
+        logRequest("CreateFile", omRequest);
+
+        OzoneManagerProtocolProtos.CreateFileRequest createFileReq
+            = (OzoneManagerProtocolProtos.CreateFileRequest) omRequest.getCreateFileRequest();
+
+        storeCompletedRequestInfo(buildOmCompletedRequestInfo(trxLogIndex,
+            omRequest.getCreateFileRequest().getKeyArgs(),
+            new OperationArgs.CreateFileArgs(createFileReq.getIsRecursive(),
+                                             createFileReq.getIsOverwrite())));
+        break;
+      default:
+        LOG.error("Unhandled cmdType={}", omRequest.getCmdType());
+        break;
+    }
+  }
+
+  private static void logRequest(String label, OzoneManagerProtocolProtos.OMRequest omRequest) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("---> {} {}", label, omRequest);
+    }
+  }
+
+  private OmCompletedRequestInfo buildOmCompletedRequestInfo(long trxLogIndex,
+                                                             OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                                                             OperationArgs opArgs) {
+    return OmCompletedRequestInfo.newBuilder()
+        .setTrxLogIndex(trxLogIndex)
+        .setVolumeName(keyArgs.getVolumeName())
+        .setBucketName(keyArgs.getBucketName())
+        .setKeyName(keyArgs.getKeyName())
+        .setCreationTime(System.currentTimeMillis())
+        .setOpArgs(opArgs)
+        .build();
+  }
+
+  private void storeCompletedRequestInfo(OmCompletedRequestInfo requestInfo) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Storing request info {}", requestInfo);
+    }
+
+    // XXX: not sure if this string key is necessary.  I added it as an
+    // identifier which consumers of the ledger could use an efficient
+    // (lexiographically sortable) key which could serve as a "seek
+    // position" to continue reading where they left off (and to
+    // persist to remember where they needed to carry on from).  But
+    // that may be unnecessary.  TODO: can we just use a plain integer
+    // key?
+    String key = requestInfo.getDbKey();
+
+    // XXX: should this be part of an atomic db txn that happens at the end
+    // of each replayed event or batch of events so that the completed
+    // request info "ledger" table is consistent with the processed
+    // raits events?  e.g. OzoneManagerDoubleBuffer?
+
+    try (BatchOperation batchOperation = omMetadataManager.getStore()
+        .initBatchOperation()) {
+
+      omMetadataManager.getCompletedRequestInfoTable().putWithBatch(batchOperation, key, requestInfo);
+
+      // TODO: cap the size of the table to some configured limit.
+      //
+      // The following code is taken from
+      // https://github.com/apache/ozone/pull/8779/files#r2510853726
+      //
+      // ... as a suggested approach but I think it will need amended to
+      // work here because the code seems to be predicated on all txnids
+      // being held (and therefore we can count the nuber of IDs to
+      // delete by subtracting new txnid from the first) whereas
+      // CompletedRequestInfoTable only holds the details of a subset of
+      // "interesting" write requests and therefore there are gaps in
+      // the IDs.
+      //
+      // I'm not sure how best to approach this.  A couple of( strawman)
+      // ideas:
+      //
+      // 1. we could store every operation wherther interesting or not (or we
+      // add dummy rows for the "non interesting" requests).
+      // 2. we store an in memory count of the CompletedRequestInfoTable
+      // which is initialized on startup and updated as rows are
+      // added/cycled out. Therefore we know how many to cap the table
+      // size as.
+      //
+      // TODO: revisit this
+      //
+      //omMetadataManager.getCompletedRequestInfoTable().deleteRangeWithBatch(batchOperation, 0L,
+      //    Math.max(lastTransaction.getIndex() - maxFlushedTransactionGap, 0L));
+
+      omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    //} catch (IOException ex) {
+    //  LOG.error("Unable to write operation {}", requestInfo, ex);
+    } catch (Exception ex) {
+      LOG.error("Unable to write operation {}", requestInfo, ex);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmCompletedRequestInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmCompletedRequestInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.OperationArgs;
+import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
+
+/**
+ * Tests OmCompletedRequestInfo om database table for Ozone object storage operations.
+ */
+public class TestOmCompletedRequestInfo {
+
+  private OMMetadataManager omMetadataManager;
+  private static final long EXPECTED_OPERATION_ID = 123L;
+  private static final String EXPECTED_OPERATION_KEY = "123";
+
+  private static final String VOLUME_NAME = "vol1";
+  private static final String BUCKET_NAME = "bucket1";
+  private static final String KEY_NAME = "bucket1";
+  private static final long CLIENT_ID = 321L;
+
+  @TempDir
+  private Path folder;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_DB_DIRS,
+        folder.toAbsolutePath().toString());
+    omMetadataManager = new OmMetadataManagerImpl(conf, null);
+  }
+
+  private OmCompletedRequestInfo createRequestInfo() {
+    return new OmCompletedRequestInfo.Builder()
+        .setTrxLogIndex(123L)
+        .setVolumeName(VOLUME_NAME)
+        .setBucketName(BUCKET_NAME)
+        .setKeyName(KEY_NAME)
+        .setCreationTime(Time.now())
+        .setOpArgs(new OperationArgs.CreateKeyArgs())
+        .build();
+  }
+
+  @Test
+  public void testTableExists() throws Exception {
+    Table<String, OmCompletedRequestInfo> requestInfo =
+        omMetadataManager.getCompletedRequestInfoTable();
+    Assertions.assertTrue(requestInfo.isEmpty());
+  }
+
+  @Test
+  public void testAddNewOperation() throws Exception {
+    Table<String, OmCompletedRequestInfo> requestInfo =
+        omMetadataManager.getCompletedRequestInfoTable();
+    requestInfo.put(EXPECTED_OPERATION_KEY, createRequestInfo());
+    Assertions.assertEquals(EXPECTED_OPERATION_ID,
+        requestInfo.get(EXPECTED_OPERATION_KEY).getTrxLogIndex());
+  }
+
+  @Test
+  public void testDeleteOmCompletedRequestInfo() throws Exception {
+    Table<String, OmCompletedRequestInfo> requestInfo =
+        omMetadataManager.getCompletedRequestInfoTable();
+
+    Assertions.assertFalse(requestInfo.isExist(EXPECTED_OPERATION_KEY));
+    requestInfo.put(EXPECTED_OPERATION_KEY, createRequestInfo());
+    Assertions.assertTrue(requestInfo.isExist(EXPECTED_OPERATION_KEY));
+    requestInfo.delete(EXPECTED_OPERATION_KEY);
+    Assertions.assertFalse(requestInfo.isExist(EXPECTED_OPERATION_KEY));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/BarPlugin.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/BarPlugin.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+public class BarPlugin implements OMEventListener {
+
+  private boolean initialized = false;
+  private boolean started = false;
+  private boolean shutdown = false;
+
+  @Override
+  public void initialize(OzoneConfiguration conf, OMEventListenerPluginContext pluginContext) {
+    initialized = true;
+  }
+
+  @Override
+  public void start() {
+    started = true;
+  }
+
+  @Override
+  public void shutdown() {
+    shutdown = true;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/FooPlugin.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/FooPlugin.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+public class FooPlugin implements OMEventListener {
+
+  private boolean initialized = false;
+  private boolean started = false;
+  private boolean shutdown = false;
+
+  @Override
+  public void initialize(OzoneConfiguration conf, OMEventListenerPluginContext pluginContext) {
+    initialized = true;
+  }
+
+  @Override
+  public void start() {
+    started = true;
+  }
+
+  @Override
+  public void shutdown() {
+    shutdown = true;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOMEventListenerPluginManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOMEventListenerPluginManager.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests {@link OMEventListenerPluginManager}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestOMEventListenerPluginManager {
+
+  @Mock
+  private OzoneManager ozoneManager;
+
+  static List<String> getLoadedPlugins(OMEventListenerPluginManager pluginManager) {
+    List<String> loadedClasses = new ArrayList<>();
+    for (OMEventListener plugin : pluginManager.getLoaded()) {
+      loadedClasses.add(plugin.getClass().getName());
+    }
+
+    // normalize
+    Collections.sort(loadedClasses);
+
+    return loadedClasses;
+  }
+
+  private static class BrokenFooPlugin {
+
+  }
+
+  @Test
+  public void testLoadSinglePlugin() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.destination.foo", "enabled");
+    conf.set("ozone.om.plugin.destination.foo.classname", "org.apache.hadoop.ozone.om.eventlistener.FooPlugin");
+
+    OMEventListenerPluginManager pluginManager = new OMEventListenerPluginManager(ozoneManager, conf);
+
+    Assertions.assertEquals(Arrays.asList("org.apache.hadoop.ozone.om.eventlistener.FooPlugin"),
+                            getLoadedPlugins(pluginManager));
+  }
+
+  @Test
+  public void testLoadMultiplePlugins() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.destination.foo", "enabled");
+    conf.set("ozone.om.plugin.destination.foo.classname", "org.apache.hadoop.ozone.om.eventlistener.FooPlugin");
+    conf.set("ozone.om.plugin.destination.bar", "enabled");
+    conf.set("ozone.om.plugin.destination.bar.classname", "org.apache.hadoop.ozone.om.eventlistener.BarPlugin");
+
+    OMEventListenerPluginManager pluginManager = new OMEventListenerPluginManager(ozoneManager, conf);
+
+    Assertions.assertEquals(Arrays.asList("org.apache.hadoop.ozone.om.eventlistener.BarPlugin",
+                                          "org.apache.hadoop.ozone.om.eventlistener.FooPlugin"),
+
+                            getLoadedPlugins(pluginManager));
+  }
+
+  @Test
+  public void testPluginMissingClassname() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.destination.foo", "enabled");
+
+    OMEventListenerPluginManager pluginManager = new OMEventListenerPluginManager(ozoneManager, conf);
+
+    Assertions.assertEquals(Arrays.asList(),
+                            getLoadedPlugins(pluginManager));
+  }
+
+  @Test
+  public void testPluginClassDoesNotExist() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.destination.foo", "enabled");
+    conf.set("ozone.om.plugin.destination.foo.classname", "org.apache.hadoop.ozone.om.eventlistener.NotExistingPlugin");
+
+    OMEventListenerPluginManager pluginManager = new OMEventListenerPluginManager(ozoneManager, conf);
+
+    Assertions.assertEquals(Arrays.asList(),
+                            getLoadedPlugins(pluginManager));
+  }
+
+  @Test
+  public void testPluginClassDoesNotImplementInterface() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.destination.foo", "enabled");
+    conf.set("ozone.om.plugin.destination.foo.classname", "org.apache.hadoop.ozone.om.eventlistener.BrokenFooPlugin");
+
+    OMEventListenerPluginManager pluginManager = new OMEventListenerPluginManager(ozoneManager, conf);
+
+    Assertions.assertEquals(Arrays.asList(),
+                            getLoadedPlugins(pluginManager));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerSuccessfulRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerSuccessfulRequestHandler.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.ratis;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.OperationArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockedConstruction;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Testing OzoneManagerSuccessfulRequestHandler class.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestOzoneManagerSuccessfulRequestHandler {
+
+  private static final String TEST_VOLUME_NAME = "testVol";
+  private static final String TEST_BUCKET_NAME = "testBucket";
+  private static final String TEST_KEY = "/foo/bar/baz/key";
+  private static final String TEST_KEY_RENAMED = TEST_KEY + "_RENAMED";
+
+  private static final KeyArgs TEST_KEY_ARGS = KeyArgs.newBuilder()
+        .setKeyName(TEST_KEY)
+        .setVolumeName(TEST_VOLUME_NAME)
+        .setBucketName(TEST_BUCKET_NAME)
+        .build();
+
+  @Mock
+  private OzoneManager ozoneManager;
+
+  @Mock
+  private OMMetadataManager omMetadataManager;
+
+  @Mock
+  private OzoneConfiguration configuration;
+
+  @Mock
+  private DBStore dbStore;
+
+  @Mock
+  private BatchOperation batchOperation;
+
+  @Mock
+  private Table<String, OmCompletedRequestInfo> completedRequestInfoTable;
+
+  protected OMRequest createCreateKeyRequest() {
+    CreateKeyRequest createKeyRequest = CreateKeyRequest.newBuilder()
+            .setKeyArgs(TEST_KEY_ARGS).build();
+
+    return OMRequest.newBuilder()
+        .setClientId(UUID.randomUUID().toString())
+        .setCreateKeyRequest(createKeyRequest)
+        .setCmdType(Type.CreateKey).build();
+  }
+
+  protected OMRequest createRenameKeyRequest() {
+    RenameKeyRequest renameKeyRequest = RenameKeyRequest.newBuilder()
+            .setKeyArgs(TEST_KEY_ARGS).setToKeyName(TEST_KEY_RENAMED).build();
+
+    return OMRequest.newBuilder()
+        .setClientId(UUID.randomUUID().toString())
+        .setRenameKeyRequest(renameKeyRequest)
+        .setCmdType(Type.RenameKey).build();
+  }
+
+  @Test
+  public void testCreateKeyRequest() throws IOException {
+
+    when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    when(omMetadataManager.getCompletedRequestInfoTable()).thenReturn(completedRequestInfoTable);
+    when(omMetadataManager.getStore()).thenReturn(dbStore);
+    when(dbStore.initBatchOperation()).thenReturn(batchOperation);
+
+    OzoneManagerSuccessfulRequestHandler requestHandler
+        = new OzoneManagerSuccessfulRequestHandler(ozoneManager);
+
+    requestHandler.handle(123L, createCreateKeyRequest());
+
+    ArgumentCaptor<BatchOperation> arg1 = ArgumentCaptor.forClass(BatchOperation.class);
+    ArgumentCaptor<String> arg2 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<OmCompletedRequestInfo> arg3 = ArgumentCaptor.forClass(OmCompletedRequestInfo.class);
+
+    verify(completedRequestInfoTable, times(1)).putWithBatch(arg1.capture(), arg2.capture(), arg3.capture());
+    assertThat(arg1.getValue()).isEqualTo(batchOperation);
+
+    String key = arg2.getValue();
+    assertThat(key).isEqualTo("00000000000000000123");
+
+    OmCompletedRequestInfo requestInfo = arg3.getValue();
+    assertThat(requestInfo.getVolumeName()).isEqualTo(TEST_VOLUME_NAME);
+    assertThat(requestInfo.getBucketName()).isEqualTo(TEST_BUCKET_NAME);
+    assertThat(requestInfo.getKeyName()).isEqualTo(TEST_KEY);
+    assertThat(requestInfo.getOpArgs()).isInstanceOf(OperationArgs.CreateKeyArgs.class);
+  }
+
+  @Test
+  public void testRenameKeyRequest() throws IOException {
+
+    when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    when(omMetadataManager.getCompletedRequestInfoTable()).thenReturn(completedRequestInfoTable);
+    when(omMetadataManager.getStore()).thenReturn(dbStore);
+    when(dbStore.initBatchOperation()).thenReturn(batchOperation);
+
+    OzoneManagerSuccessfulRequestHandler requestHandler
+        = new OzoneManagerSuccessfulRequestHandler(ozoneManager);
+
+    requestHandler.handle(124L, createRenameKeyRequest());
+
+    ArgumentCaptor<BatchOperation> arg1 = ArgumentCaptor.forClass(BatchOperation.class);
+    ArgumentCaptor<String> arg2 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<OmCompletedRequestInfo> arg3 = ArgumentCaptor.forClass(OmCompletedRequestInfo.class);
+
+    verify(completedRequestInfoTable, times(1)).putWithBatch(arg1.capture(), arg2.capture(), arg3.capture());
+    assertThat(arg1.getValue()).isEqualTo(batchOperation);
+
+    String key = arg2.getValue();
+    assertThat(key).isEqualTo("00000000000000000124");
+
+    OmCompletedRequestInfo requestInfo = arg3.getValue();
+    assertThat(requestInfo.getVolumeName()).isEqualTo(TEST_VOLUME_NAME);
+    assertThat(requestInfo.getBucketName()).isEqualTo(TEST_BUCKET_NAME);
+    assertThat(requestInfo.getKeyName()).isEqualTo(TEST_KEY);
+    assertThat(requestInfo.getOpArgs()).isInstanceOf(OperationArgs.RenameKeyArgs.class);
+    OperationArgs.RenameKeyArgs opArgs = (OperationArgs.RenameKeyArgs) requestInfo.getOpArgs();
+    assertThat(opArgs.getToKeyName()).isEqualTo(TEST_KEY_RENAMED);
+  }
+}


### PR DESCRIPTION
Please describe your PR in detail:
* Add the plugin framework for dynamically configurable EventListener plugin
* an event listener plugin will implement the interface OMEventListener
* plugins can be loaded/configured dynamically similarly to ranger plugins, e.g.:

```
ozone.om.plugin.destination.kafka=true
ozone.om.plugin.destination.kafka.classname=org.apache.hadoop.ozone.om.eventlistener.OMEventListenerKafkaPublisher
ozone.notify.kafka.topic=test123
ozone.notify.kafka.bootstrap.servers=kafka-3:29092,kafka-1:29092,kafka-2:29092
```

NOTE: this change does not provide any concrete plugin implementation

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14005

## How was this patch tested?

unit tests
