### PR TITLE
HDDS-14369. RatisPipelineProvider does not honor OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -133,7 +133,7 @@ public class SCMNodeManager implements NodeManager {
   private final boolean useHostname;
   private final Map<String, Set<DatanodeID>> dnsToDnIdMap = new ConcurrentHashMap<>();
   private final int numPipelinesPerMetadataVolume;
-  private final int heavyNodeCriteria;
+  private final int datanodePipelineLimit;
   private final HDDSLayoutVersionManager scmLayoutVersionManager;
   private final EventPublisher scmNodeEventPublisher;
   private final SCMContext scmContext;
@@ -194,7 +194,7 @@ public class SCMNodeManager implements NodeManager {
     this.numPipelinesPerMetadataVolume =
         conf.getInt(ScmConfigKeys.OZONE_SCM_PIPELINE_PER_METADATA_VOLUME,
             ScmConfigKeys.OZONE_SCM_PIPELINE_PER_METADATA_VOLUME_DEFAULT);
-    this.heavyNodeCriteria = conf.getInt(
+    this.datanodePipelineLimit = conf.getInt(
         ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
         ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
     this.scmContext = scmContext;
@@ -1602,8 +1602,8 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public int pipelineLimit(DatanodeDetails dn) {
     try {
-      if (heavyNodeCriteria > 0) {
-        return heavyNodeCriteria;
+      if (datanodePipelineLimit > 0) {
+        return datanodePipelineLimit;
       } else if (nodeStateManager.getNode(dn).getHealthyVolumeCount() > 0) {
         return numPipelinesPerMetadataVolume *
             nodeStateManager.getNode(dn).getMetaDataVolumeCount();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -195,8 +195,9 @@ public class SCMNodeManager implements NodeManager {
     this.numPipelinesPerMetadataVolume =
         conf.getInt(ScmConfigKeys.OZONE_SCM_PIPELINE_PER_METADATA_VOLUME,
             ScmConfigKeys.OZONE_SCM_PIPELINE_PER_METADATA_VOLUME_DEFAULT);
-    String dnLimit = conf.get(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT);
-    this.heavyNodeCriteria = dnLimit == null ? 0 : Integer.parseInt(dnLimit);
+    this.heavyNodeCriteria = conf.getInt(
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
     this.scmContext = scmContext;
     this.sendCommandNotifyMap = new HashMap<>();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -54,7 +54,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       LoggerFactory.getLogger(PipelinePlacementPolicy.class);
   private final NodeManager nodeManager;
   private final PipelineStateManager stateManager;
-  private final int heavyNodeCriteria;
+  private final int datanodePipelineLimit;
   private static final int REQUIRED_RACKS = 2;
 
   public static final String MULTIPLE_RACK_PIPELINE_MSG =
@@ -76,7 +76,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     super(nodeManager, conf);
     this.nodeManager = nodeManager;
     this.stateManager = stateManager;
-    this.heavyNodeCriteria = conf.getInt(
+    this.datanodePipelineLimit = conf.getInt(
         ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
         ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
   }
@@ -183,7 +183,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     if (healthyList.size() < nodesRequired) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Unable to find enough nodes that meet the criteria that" +
-            " cannot engage in more than" + heavyNodeCriteria +
+            " cannot engage in more than" + datanodePipelineLimit +
             " pipelines. Nodes required: " + nodesRequired + " Excluded: " +
             excludedNodesSize + " Found:" +
             healthyList.size() + " healthy nodes count in NodeManager: " +
@@ -192,7 +192,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       msg = String.format("Pipeline creation failed because nodes are engaged" +
               " in other pipelines and every node can only be engaged in" +
               " max %d pipelines. Required %d. Found %d. Excluded: %d.",
-          heavyNodeCriteria, nodesRequired, healthyList.size(),
+          datanodePipelineLimit, nodesRequired, healthyList.size(),
           excludedNodesSize);
       throw new SCMException(msg,
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -76,8 +76,9 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     super(nodeManager, conf);
     this.nodeManager = nodeManager;
     this.stateManager = stateManager;
-    String dnLimit = conf.get(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT);
-    this.heavyNodeCriteria = dnLimit == null ? 0 : Integer.parseInt(dnLimit);
+    this.heavyNodeCriteria = conf.getInt(
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
   }
 
   public static int currentRatisThreePipelineCount(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -60,7 +60,7 @@ public class RatisPipelineProvider
   private final EventPublisher eventPublisher;
   private final PlacementPolicy placementPolicy;
   private final int pipelineNumberLimit;
-  private final int maxPipelinePerDatanode;
+  private final int datanodePipelineLimit;
   private final LeaderChoosePolicy leaderChoosePolicy;
   private final SCMContext scmContext;
   private final long containerSizeBytes;
@@ -80,7 +80,7 @@ public class RatisPipelineProvider
     this.pipelineNumberLimit = conf.getInt(
         ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT,
         ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT_DEFAULT);
-    this.maxPipelinePerDatanode = conf.getInt(
+    this.datanodePipelineLimit = conf.getInt(
         ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
         ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
     this.containerSizeBytes = (long) conf.getStorageSize(
@@ -110,10 +110,10 @@ public class RatisPipelineProvider
     int closedPipelines = pipelineStateManager.getPipelines(replicationConfig, PipelineState.CLOSED).size();
     int openPipelines = totalActivePipelines - closedPipelines;
     // Check per-datanode pipeline limit
-    if (maxPipelinePerDatanode > 0) {
+    if (datanodePipelineLimit > 0) {
       int healthyNodeCount = getNodeManager()
           .getNodeCount(NodeStatus.inServiceHealthy());
-      int allowedOpenPipelines = (maxPipelinePerDatanode * healthyNodeCount)
+      int allowedOpenPipelines = (datanodePipelineLimit * healthyNodeCount)
           / replicationConfig.getRequiredNodes();
       return openPipelines >= allowedOpenPipelines;
     }
@@ -145,8 +145,8 @@ public class RatisPipelineProvider
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
       throws IOException {
     if (exceedPipelineNumberLimit(replicationConfig)) {
-      String limitInfo = (maxPipelinePerDatanode > 0)
-          ? String.format("per datanode: %d", maxPipelinePerDatanode)
+      String limitInfo = (datanodePipelineLimit > 0)
+          ? String.format("per datanode: %d", datanodePipelineLimit)
           : String.format(": %d", pipelineNumberLimit);
 
       throw new SCMException(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -82,9 +82,9 @@ public class RatisPipelineProvider
     this.pipelineNumberLimit = conf.getInt(
         ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT,
         ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT_DEFAULT);
-    String dnLimit = conf.get(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT);
-    this.maxPipelinePerDatanode = dnLimit == null ? 0 :
-        Integer.parseInt(dnLimit);
+    this.maxPipelinePerDatanode = conf.getInt(
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
     this.containerSizeBytes = (long) this.conf.getStorageSize(
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -2059,7 +2059,7 @@ public class TestSCMNodeManager {
    * Test that pipelineLimit() uses the default value when the config is not set.
    */
   @Test
-  public void testPipelineLimitDefaultIsTwoWhenUnset()
+  public void testUsesDefaultPipelineLimitWhenUnset()
       throws IOException, AuthenticationException {
 
     // Creates node manager with config without limit set
@@ -2071,10 +2071,9 @@ public class TestSCMNodeManager {
       // Registers datanode with healthy volumes
       DatanodeDetails dn = registerWithCapacity(nodeManager);
 
-      // Calls pipelineLimit() and verifies returns 2
+      // Calls pipelineLimit() and verifies returns default value
       int limit = nodeManager.pipelineLimit(dn);
       assertEquals(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT, limit);
-      assertEquals(2, limit);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -2055,6 +2055,29 @@ public class TestSCMNodeManager {
     }
   }
 
+  /**
+   * Test that pipelineLimit() uses the default value when the config is not set.
+   */
+  @Test
+  public void testPipelineLimitDefaultIsTwoWhenUnset()
+      throws IOException, AuthenticationException {
+
+    // Creates node manager with config without limit set
+    OzoneConfiguration conf = getConf();
+    conf.unset(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT);
+
+    try (SCMNodeManager nodeManager = createNodeManager(conf)) {
+
+      // Registers datanode with healthy volumes
+      DatanodeDetails dn = registerWithCapacity(nodeManager);
+
+      // Calls pipelineLimit() and verifies returns 2
+      int limit = nodeManager.pipelineLimit(dn);
+      assertEquals(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT, limit);
+      assertEquals(2, limit);
+    }
+  }
+
   private static Stream<Arguments> nodeStateTransitions() {
     return Stream.of(
         // start decommissioning or entering maintenance

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -722,6 +722,60 @@ public class TestPipelinePlacementPolicy {
     assertEquals(pipelineCount, 2);
   }
 
+  @Test
+  public void testPipelinePlacementPolicyDefaultLimitFiltersNodeAtLimit()
+      throws IOException, TimeoutException {
+
+    // 1) Creates policy with config without limit set
+    OzoneConfiguration localConf = new OzoneConfiguration(conf);
+    localConf.unset(OZONE_DATANODE_PIPELINE_LIMIT);
+
+    MockNodeManager localNodeManager = new MockNodeManager(cluster,
+        getNodesWithRackAwareness(), false, PIPELINE_PLACEMENT_MAX_NODES_COUNT);
+
+    // Ensure NodeManager uses default limit (=2) when limit is not set in conf
+    localNodeManager.setNumPipelinePerDatanode(
+        ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT);
+
+    PipelineStateManager localStateManager = PipelineStateManagerImpl.newBuilder()
+        .setPipelineStore(SCMDBDefinition.PIPELINES.getTable(dbStore))
+        .setRatisServer(scmhaManager.getRatisServer())
+        .setNodeManager(localNodeManager)
+        .setSCMDBTransactionBuffer(scmhaManager.getDBTransactionBuffer())
+        .build();
+
+    PipelinePlacementPolicy localPolicy = new PipelinePlacementPolicy(
+        localNodeManager, localStateManager, localConf);
+
+    List<DatanodeDetails> healthy =
+        localNodeManager.getNodes(NodeStatus.inServiceHealthy());
+    DatanodeDetails target = healthy.get(0);
+
+    // 2) Adds exactly 2 pipelines to test node (default limit)
+    List<DatanodeDetails> p1Dns = new ArrayList<>();
+    p1Dns.add(target);
+    p1Dns.add(healthy.get(1));
+    p1Dns.add(healthy.get(2));
+    createPipelineWithReplicationConfig(p1Dns, RATIS, THREE);
+
+    List<DatanodeDetails> p2Dns = new ArrayList<>();
+    p2Dns.add(target);
+    p2Dns.add(healthy.get(3));
+    p2Dns.add(healthy.get(4));
+    createPipelineWithReplicationConfig(p2Dns, RATIS, THREE);
+
+    assertEquals(2, PipelinePlacementPolicy.currentRatisThreePipelineCount(
+        localNodeManager, localStateManager, target));
+
+    // 3) Verifies node is filtered out when choosing nodes for new pipeline
+    int nodesRequired = HddsProtos.ReplicationFactor.THREE.getNumber();
+    List<DatanodeDetails> chosen = localPolicy.chooseDatanodes(
+        new ArrayList<>(), new ArrayList<>(), nodesRequired, 0, 0);
+
+    assertEquals(nodesRequired, chosen.size());
+    assertThat(chosen).doesNotContain(target);
+  }
+
   private void createPipelineWithReplicationConfig(List<DatanodeDetails> dnList,
                                                    HddsProtos.ReplicationType
                                                        replicationType,


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Fix inconsistent default handling for `OZONE_DATANODE_PIPELINE_LIMIT`
* Use `conf.getInt(..., DEFAULT)` instead of falling back to 0 when the config is unset
* Ensure the behavior matches `OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT` (default = 2)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14369

## How was this patch tested?
All CI checks passed.
https://github.com/Russole/ozone/actions/runs/20823196572
