### PR TITLE
HDDS-14403. Update Snapshot configuration default values

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2320,7 +2320,7 @@
   </property>
   <property>
     <name>ozone.om.ratis.snapshot.max.total.sst.size</name>
-    <value>100000000</value>
+    <value>10737418240</value>
     <tag>OZONE, OM, RATIS</tag>
     <description>
       Max size of SST files in OM Ratis Snapshot tarball.

--- a/hadoop-hdds/docs/content/feature/Snapshot-Configuration-Properties.md
+++ b/hadoop-hdds/docs/content/feature/Snapshot-Configuration-Properties.md
@@ -33,7 +33,7 @@ These parameters, defined in `ozone-site.xml`, control how Ozone manages snapsho
 *   **General Snapshot Management**
     *   `ozone.om.fs.snapshot.max.limit`: Max snapshots per bucket (Default: 10000). Safety limit.
     *   `ozone.om.ratis.snapshot.dir`: The directory where OM Ratis snapshots are stored (Default: ratis-snapshot under OM DB dir).
-    *   `ozone.om.ratis.snapshot.max.total.sst.size`: The maximum total size of SST files to be included in a Ratis snapshot (Default: 100000000).
+    *   `ozone.om.ratis.snapshot.max.total.sst.size`: The maximum total size of SST files to be included in a Ratis snapshot (Default: 10737418240).
     *   `ozone.om.snapshot.load.native.lib`: Use native RocksDB library for snapshot operations (Default: true). Set to false as a workaround for native library issues.
     *   `ozone.om.snapshot.checkpoint.dir.creation.poll.timeout`: Timeout for polling the creation of the snapshot checkpoint directory (Default: 20s).
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -224,7 +224,7 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY
       = "ozone.om.ratis.snapshot.max.total.sst.size";
   public static final long
-      OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_DEFAULT = 100_000_000;
+      OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_DEFAULT = 10737418240L;
 
   // OM Ratis server configurations
   public static final String OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_KEY


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Increased the default value of `ozone.om.ratis.snapshot.max.total.sst.size` from 100MB to 10GB to better support production clusters.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14403
## How was this patch tested?
- All CI checks passed.
   - https://github.com/Russole/ozone/actions/runs/21776638347
