### PR TITLE
HDDS-14699. Fix orphan snapshot versions handling when snapshot chain tableKey mapping is stale

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -284,12 +284,23 @@ public final class OmSnapshotManager implements AutoCloseable {
 
   public static boolean isSnapshotPurged(SnapshotChainManager chainManager, OMMetadataManager omMetadataManager,
       UUID snapshotId, TransactionInfo transactionInfo) throws IOException {
+    boolean purgeFlushed = transactionInfo != null &&
+        isTransactionFlushedToDisk(omMetadataManager, transactionInfo);
     String tableKey = chainManager.getTableKey(snapshotId);
     if (tableKey == null) {
-      return true;
+      // Snapshot chain is rebuilt from DB on every OM restart (loadFromSnapshotInfoTable),
+      // but entries committed to the Raft log (but not yet flushed) after the restart
+      // are applied in addToDBBatch (skipping validateAndUpdateCache), so they never call
+      // addSnapshot(). This can affect any OM (leader or follower) after a restart.
+      //
+      // Need to fall back to transactionInfo. null means no purge has been recorded. Treat as active.
+      LOG.debug("snapshotId {} has null tableKey in SnapshotChainManager. "
+              + "transactionInfo={} purgeFlushed={}. Returning {}",
+          snapshotId, transactionInfo, purgeFlushed, purgeFlushed);
+      return purgeFlushed;
     }
-    return !omMetadataManager.getSnapshotInfoTable().isExist(tableKey) && transactionInfo != null &&
-        isTransactionFlushedToDisk(omMetadataManager, transactionInfo);
+    boolean inDB = omMetadataManager.getSnapshotInfoTable().isExist(tableKey);
+    return !inDB && purgeFlushed;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -382,8 +382,12 @@ public final class OmSnapshotManager implements AutoCloseable {
           }
           try (OmSnapshotLocalDataManager.ReadableOmSnapshotLocalDataMetaProvider snapshotLocalDataProvider =
                    snapshotLocalDataManager.getOmSnapshotLocalDataMeta(snapshotInfo)) {
+            final OmSnapshotLocalDataManager.SnapshotVersionsMeta snapshotMeta = snapshotLocalDataProvider.getMeta();
+            if (snapshotMeta == null) {
+              throw new OMException("Snapshot local metadata is missing for snapshotId: " + snapshotId, FILE_NOT_FOUND);
+            }
             snapshotMetadataManager = getSnapshotOmMetadataManager(snapshotInfo,
-                snapshotLocalDataProvider.getMeta().getVersion(), maxOpenSstFilesInSnapshotDb, conf);
+                snapshotMeta.getVersion(), maxOpenSstFilesInSnapshotDb, conf);
           }
         } catch (IOException e) {
           LOG.error("Failed to retrieve snapshot: {}", snapshotTableKey, e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -362,15 +362,6 @@ public class SnapshotChainManager {
   }
 
   /**
-   * Used by OMSnapshotCreateResponse#addToDBBatch to add to snapshotIdToTableKey map during Raft replay.
-   */
-  public synchronized void addSnapshotToTableKey(UUID snapshotId, String tableKey) throws IOException {
-    validateSnapshotChain();
-    LOG.debug("Adding to snapshotIdToTableKey: snapshotId={} tableKey={}", snapshotId, tableKey);
-    snapshotIdToTableKey.putIfAbsent(snapshotId, tableKey);
-  }
-
-  /**
    * Update snapshot chain when snapshot changes (e.g. renamed).
    */
   public synchronized void updateSnapshot(SnapshotInfo snapshotInfo) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -385,8 +385,7 @@ public class SnapshotChainManager {
   public synchronized void removeFromSnapshotIdToTable(UUID snapshotId) throws IOException {
     validateSnapshotChain();
     String tableKey = snapshotIdToTableKey.remove(snapshotId);
-    LOG.debug("Removed from snapshotIdToTableKey: snapshotId={} tableKey={}. caller: {}",
-        snapshotId, tableKey, Thread.currentThread().getStackTrace()[2]);
+    LOG.debug("Removed from snapshotIdToTableKey: snapshotId={} tableKey={}", snapshotId, tableKey);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -75,5 +76,9 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
     // Create the snapshot checkpoint. Also cleans up some tables.
     OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
         snapshotInfo, batchOperation);
+
+    // Add entries to snapshotIdToTableKey in case of Raft replay
+    ((OmMetadataManagerImpl) omMetadataManager).getSnapshotChainManager()
+        .addSnapshotToTableKey(snapshotInfo.getSnapshotId(), snapshotInfo.getTableKey());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -25,7 +25,6 @@ import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -76,9 +75,5 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
     // Create the snapshot checkpoint. Also cleans up some tables.
     OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
         snapshotInfo, batchOperation);
-
-    // Add entries to snapshotIdToTableKey in case of Raft replay
-    ((OmMetadataManagerImpl) omMetadataManager).getSnapshotChainManager()
-        .addSnapshotToTableKey(snapshotInfo.getSnapshotId(), snapshotInfo.getTableKey());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In isSnapshotPurged() check, snapshot chain tableKey returning null should not be the sole indicator for judging whether the snapshot is still active or not.

isSnapshotPurged() incorrectly returning true causes checkOrphanSnapshotVersions() to incorrectly removing active snapshot's YAML metadata (in OmSnapshotLocalDataManagerService runs). This in turn causes NPE in CacheLoader when attempting to load the snapshot.

- Fixed `isSnapshotPurged()` check
- Added relevant debug logging messages that might be helpful at some point
- ~~Add entries to snapshotIdToTableKey in case of Raft replay in OMSnapshotCreateResponse#addToDBBatch (which was a bug / an oversight previously)~~
- Check getMeta() nullness first, throw OMEx if null instead of NPE

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14699

## How was this patch tested?

- Added test `testCheckOrphanSnapshotVersionsWithStaleSnapshotChain`
- Manually tested downstream that with the patch, the issue does not appear in the system test suite again