### PR TITLE
HDDS-14684. Allow deletion of empty quasi-closed containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
@@ -317,17 +318,32 @@ abstract class AbstractContainerReportHandler {
     case DELETING:
       // HDDS-11136: If a DELETING container has a non-empty CLOSED replica, transition the container to CLOSED
       // HDDS-12421: If a DELETING or DELETED container has a non-empty replica, transition the container to CLOSED
-      if (replica.getState() == State.CLOSED && replica.getBlockCommitSequenceId() <= container.getSequenceId()
+      boolean isReplicaClosed = replica.getState() == State.CLOSED;
+      boolean isReplicaQuasiClosed = replica.getState() == State.QUASI_CLOSED;
+      if ((isReplicaClosed || isReplicaQuasiClosed) && replica.getBlockCommitSequenceId() <= container.getSequenceId()
           && container.getReplicationType().equals(HddsProtos.ReplicationType.RATIS)) {
         deleteReplica(containerId, datanode, publisher, "DELETED", true, detailsForLogging);
-        // We should not move back to CLOSED state if replica bcsid <= container bcsid
+        // We should not move back CLOSED or QUASI_CLOSED if replica bcsId <= container bcsId
         return false;
       }
       boolean replicaStateAllowed = (replica.getState() != State.INVALID && replica.getState() != State.DELETED);
       if (!replicaIsEmpty && replicaStateAllowed) {
-        getLogger().info("transitionDeletingToClosed due to non-empty CLOSED replica (keyCount={}) for {}",
-            replica.getKeyCount(), detailsForLogging);
-        containerManager.transitionDeletingOrDeletedToClosedState(containerId);
+        LifeCycleState targetState;
+        if (replica.getState() == State.CLOSED) {
+          targetState = LifeCycleState.CLOSED;
+          getLogger().info("Resurrecting container {} from {} to CLOSED due to non-empty CLOSED replica " +
+              "(keyCount={}, BCSID={}) from {}",
+              containerId, container.getState(), replica.getKeyCount(), replica.getBlockCommitSequenceId(), 
+              detailsForLogging);
+        } else {
+          // For OPEN, CLOSING, UNHEALTHY, QUASI_CLOSED replicas, transition to QUASI_CLOSED state
+          targetState = LifeCycleState.QUASI_CLOSED;
+          getLogger().info("Resurrecting container {} from {} to QUASI_CLOSED due to non-empty {} replica " +
+              "(keyCount={}, BCSID={}) from {}",
+              containerId, container.getState(), replica.getState(), replica.getKeyCount(), 
+              replica.getBlockCommitSequenceId(), detailsForLogging);
+        }
+        containerManager.transitionDeletingOrDeletedToTargetState(containerId, targetState);
       }
       return false;
     default:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -144,6 +144,15 @@ public interface ContainerManager {
   void transitionDeletingOrDeletedToClosedState(ContainerID containerID) throws IOException;
 
   /**
+   * Bypasses the container state machine to change a container's state from DELETING/DELETED to CLOSED/QUASI_CLOSED.
+   *
+   * @param containerID id of the container to transition
+   * @param targetState the target state (must be CLOSED or QUASI_CLOSED)
+   * @throws IOException
+   */
+  void transitionDeletingOrDeletedToTargetState(ContainerID containerID, LifeCycleState targetState) throws IOException;
+
+  /**
    * Returns the latest list of replicas for given containerId.
    *
    * @param containerID Container ID

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -134,16 +134,6 @@ public interface ContainerManager {
       throws IOException, InvalidStateTransitionException;
 
   /**
-   * Bypasses the container state machine to change a container's state from DELETING or DELETED to CLOSED. This API was
-   * introduced to fix a bug (HDDS-11136), and should be used with care otherwise.
-   *
-   * @see <a href="https://issues.apache.org/jira/browse/HDDS-11136">HDDS-11136</a>
-   * @param containerID id of the container to transition
-   * @throws IOException
-   */
-  void transitionDeletingOrDeletedToClosedState(ContainerID containerID) throws IOException;
-
-  /**
    * Bypasses the container state machine to change a container's state from DELETING/DELETED to CLOSED/QUASI_CLOSED.
    *
    * @param containerID id of the container to transition

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -310,6 +310,22 @@ public class ContainerManagerImpl implements ContainerManager {
   }
 
   @Override
+  public void transitionDeletingOrDeletedToTargetState(ContainerID containerID, LifeCycleState targetState)
+          throws IOException {
+    HddsProtos.ContainerID proto = containerID.getProtobuf();
+    lock.lock();
+    try {
+      if (containerExist(containerID)) {
+        containerStateManager.transitionDeletingOrDeletedToTargetState(proto, targetState);
+      } else {
+        throw new ContainerNotFoundException(containerID);
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
   public Set<ContainerReplica> getContainerReplicas(final ContainerID id)
       throws ContainerNotFoundException {
     final Set<ContainerReplica> replicas = containerStateManager.getContainerReplicas(id);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -295,21 +295,6 @@ public class ContainerManagerImpl implements ContainerManager {
   }
 
   @Override
-  public void transitionDeletingOrDeletedToClosedState(ContainerID containerID) throws IOException {
-    HddsProtos.ContainerID proto = containerID.getProtobuf();
-    lock.lock();
-    try {
-      if (containerExist(containerID)) {
-        containerStateManager.transitionDeletingOrDeletedToClosedState(proto);
-      } else {
-        throw new ContainerNotFoundException(containerID);
-      }
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
   public void transitionDeletingOrDeletedToTargetState(ContainerID containerID, LifeCycleState targetState)
           throws IOException {
     HddsProtos.ContainerID proto = containerID.getProtobuf();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -172,17 +172,6 @@ public interface ContainerStateManager {
 
 
   /**
-   * Bypasses the container state machine to change a container's state from DELETING or DELETED to CLOSED. This API was
-   * introduced to fix a bug (HDDS-11136), and should be used with care otherwise.
-   *
-   * @see <a href="https://issues.apache.org/jira/browse/HDDS-11136">HDDS-11136</a>
-   * @param id id of the container to transition
-   * @throws IOException
-   */
-  @Replicate
-  void transitionDeletingOrDeletedToClosedState(HddsProtos.ContainerID id) throws IOException;
-
-  /**
    * Bypasses the container state machine to change a container's state from DELETING/DELETED to CLOSED/QUASI_CLOSED.
    *
    * @param id id of the container to transition

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -183,6 +183,17 @@ public interface ContainerStateManager {
   void transitionDeletingOrDeletedToClosedState(HddsProtos.ContainerID id) throws IOException;
 
   /**
+   * Bypasses the container state machine to change a container's state from DELETING/DELETED to CLOSED/QUASI_CLOSED.
+   *
+   * @param id id of the container to transition
+   * @param targetState the target state (must be CLOSED or QUASI_CLOSED)
+   * @throws IOException
+   */
+  @Replicate
+  void transitionDeletingOrDeletedToTargetState(HddsProtos.ContainerID id, LifeCycleState targetState)
+      throws IOException;
+
+  /**
    *
    */
   // Make this as @Replicate

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -417,6 +417,34 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
+  public void transitionDeletingOrDeletedToTargetState(HddsProtos.ContainerID containerID,
+                                                       LifeCycleState targetState) throws IOException {
+    if (targetState != CLOSED && targetState != QUASI_CLOSED) {
+      throw new IllegalArgumentException("Target state must be CLOSED or QUASI_CLOSED, got: " + targetState);
+    }
+
+    final ContainerID id = ContainerID.getFromProtobuf(containerID);
+
+    try (AutoCloseableLock ignored = writeLock(id)) {
+      if (containers.contains(id)) {
+        final ContainerInfo oldInfo = containers.getContainerInfo(id);
+        final LifeCycleState oldState = oldInfo.getState();
+        if (oldState != DELETING && oldState != DELETED) {
+          throw new InvalidContainerStateException("Cannot transition container " + id + " from " + oldState +
+                  " back to " + targetState + ". The container must be in the DELETING or DELETED state.");
+        }
+        ExecutionUtil.create(() -> {
+          containers.updateState(id, oldState, targetState);
+          transactionBuffer.addToBuffer(containerStore, id, containers.getContainerInfo(id));
+        }).onException(() -> {
+          transactionBuffer.addToBuffer(containerStore, id, oldInfo);
+          containers.updateState(id, targetState, oldState);
+        }).execute();
+      }
+    }
+  }
+
+  @Override
   public Set<ContainerReplica> getContainerReplicas(final ContainerID id) {
     try (AutoCloseableLock ignored = readLock(id)) {
       return containers.getContainerReplicas(id);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -186,6 +186,7 @@ public final class ContainerStateManagerImpl
     containerLifecycleSM.addTransition(CLOSING, QUASI_CLOSED, QUASI_CLOSE);
     containerLifecycleSM.addTransition(CLOSING, CLOSED, CLOSE);
     containerLifecycleSM.addTransition(QUASI_CLOSED, CLOSED, FORCE_CLOSE);
+    containerLifecycleSM.addTransition(QUASI_CLOSED, DELETING, DELETE);
     containerLifecycleSM.addTransition(CLOSED, DELETING, DELETE);
     containerLifecycleSM.addTransition(DELETING, DELETED, CLEANUP);
 
@@ -389,29 +390,6 @@ public final class ContainerStateManagerImpl
           containerStateChangeActions.getOrDefault(event, info -> { })
               .accept(containerInfo);
         }
-      }
-    }
-  }
-
-  @Override
-  public void transitionDeletingOrDeletedToClosedState(HddsProtos.ContainerID containerID) throws IOException {
-    final ContainerID id = ContainerID.getFromProtobuf(containerID);
-
-    try (AutoCloseableLock ignored = writeLock(id)) {
-      if (containers.contains(id)) {
-        final ContainerInfo oldInfo = containers.getContainerInfo(id);
-        final LifeCycleState oldState = oldInfo.getState();
-        if (oldState != DELETING && oldState != DELETED) {
-          throw new InvalidContainerStateException("Cannot transition container " + id + " from " + oldState +
-              " back to CLOSED. The container must be in the DELETING or DELETED state.");
-        }
-        ExecutionUtil.create(() -> {
-          containers.updateState(id, oldState, CLOSED);
-          transactionBuffer.addToBuffer(containerStore, id, containers.getContainerInfo(id));
-        }).onException(() -> {
-          transactionBuffer.addToBuffer(containerStore, id, oldInfo);
-          containers.updateState(id, CLOSED, oldState);
-        }).execute();
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
@@ -61,6 +61,15 @@ public class QuasiClosedStuckUnderReplicationHandler implements UnhealthyReplica
     ContainerInfo containerInfo = result.getContainerInfo();
     LOG.debug("Handling under replicated QuasiClosed Stuck Ratis container {}", containerInfo);
 
+    // Check if container is empty before attempting replication
+    // Empty containers will be deleted by EmptyContainerHandler
+    boolean allReplicasEmpty = !replicas.isEmpty() && replicas.stream().allMatch(ContainerReplica::isEmpty);
+    if (allReplicasEmpty) {
+      LOG.info("Skipping replication for empty QUASI_CLOSED stuck container {}. " +
+          "It will be deleted by EmptyContainerHandler.", containerInfo.containerID());
+      return 0;
+    }
+
     int pendingAdd = 0;
     for (ContainerReplicaOp op : pendingOps) {
       if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -89,6 +89,15 @@ public class RatisUnderReplicationHandler
     ContainerInfo containerInfo = result.getContainerInfo();
     LOG.debug("Handling under replicated Ratis container {}", containerInfo);
 
+    // Check if container is empty before attempting replication
+    // Empty containers will be deleted by EmptyContainerHandler
+    boolean allReplicasEmpty = !replicas.isEmpty() && replicas.stream().allMatch(ContainerReplica::isEmpty);
+    if (allReplicasEmpty && containerInfo.getState() == LifeCycleState.QUASI_CLOSED) {
+      LOG.info("Skipping replication for empty QUASI_CLOSED container {}. " +
+          "It will be deleted by EmptyContainerHandler.", containerInfo.containerID());
+      return 0;
+    }
+
     RatisContainerReplicaCount withUnhealthy =
         new RatisContainerReplicaCount(containerInfo, replicas, pendingOps,
             minHealthyForMaintenance, true);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -82,25 +82,32 @@ public class EmptyContainerHandler extends AbstractCheck {
         String originIds = replicas.stream()
             .map(r -> r.getOriginDatanodeId().toString())
             .collect(Collectors.joining(", "));
-        LOG.info("Deleting empty QUASI_CLOSED container {} with {} replicas from originIds: [{}]. " +
-                "If resurrected, container will transition to CLOSED but may have QUASI_CLOSED replicas.",
-                containerInfo.containerID(), replicas.size(), originIds);
-        // delete replicas if they are quasi-closed and empty
-        deleteContainerReplicas(containerInfo, replicas);
-
-        if (containerInfo.getReplicationType() == HddsProtos.ReplicationType.RATIS) {
-          if (replicas.stream().filter(r -> r.getSequenceId() != null)
-                  .noneMatch(r -> r.getSequenceId() == containerInfo.getSequenceId())) {
-            // don't update container state if replica seqid don't match with container seq id
-            return true;
-          }
+        long maxReplicaBCSID = replicas.stream()
+            .filter(r -> r.getSequenceId() != null)
+            .mapToLong(ContainerReplica::getSequenceId)
+            .max()
+            .orElse(containerInfo.getSequenceId());
+        
+        // Update container bcsId to max replica bcsId before deletion
+        // This ensures resurrection logic uses the correct bcsId for stale replica detection
+        if (maxReplicaBCSID > containerInfo.getSequenceId()) {
+          LOG.info("Updating bcsId for empty QUASI_CLOSED container {} from {} to {} before deletion",
+              containerInfo.containerID(), containerInfo.getSequenceId(), maxReplicaBCSID);
+          containerInfo.updateSequenceId(maxReplicaBCSID);
         }
+        
+        LOG.info("Deleting empty QUASI_CLOSED container {} (container BCSID={}, max replica BCSID={}) with {} " +
+            "replicas from originIds: [{}]. If resurrected, container will transition to QUASI_CLOSED",
+            containerInfo.containerID(), containerInfo.getSequenceId(), maxReplicaBCSID,
+            replicas.size(), originIds);
         // Update the container's state - transition to CLOSED first, then DELETE
         // QUASI_CLOSED -> CLOSED requires FORCE_CLOSE event
         replicationManager.updateContainerState(
                 containerInfo.containerID(), HddsProtos.LifeCycleEvent.FORCE_CLOSE);
         replicationManager.updateContainerState(
                 containerInfo.containerID(), HddsProtos.LifeCycleEvent.DELETE);
+        // Delete replicas AFTER transitioning to DELETING state
+        deleteContainerReplicas(containerInfo, replicas);
       }
       return true;
     } else if (containerInfo.getState() == HddsProtos.LifeCycleState.CLOSED
@@ -161,26 +168,25 @@ public class EmptyContainerHandler extends AbstractCheck {
   /**
    * Deletes the specified container's replicas if they are empty.
    * For CLOSED containers, replicas must also be CLOSED.
-   * For QUASI_CLOSED containers, replicas can be in any state (QUASI_CLOSED, OPEN, CLOSING, UNHEALTHY).
+   * For QUASI_CLOSED containers, replicas can be in any state (QUASI_CLOSED, OPEN, CLOSING, UNHEALTHY),
+   * but delete commands should be sent to replicas in stable states (QUASI_CLOSED or CLOSED).
    *
    * @param containerInfo ContainerInfo to delete
    * @param replicas Set of ContainerReplica
    */
   private void deleteContainerReplicas(final ContainerInfo containerInfo,
       final Set<ContainerReplica> replicas) {
-    boolean isQuasiClosed = containerInfo.getState() == HddsProtos.LifeCycleState.QUASI_CLOSED;
-
-    if (!isQuasiClosed) {
-      Preconditions.assertSame(HddsProtos.LifeCycleState.CLOSED,
-          containerInfo.getState(), "container state");
-    }
-
     for (ContainerReplica rp : replicas) {
-      if (!isQuasiClosed) {
-        Preconditions.assertSame(ContainerReplicaProto.State.CLOSED,
-            rp.getState(), "replica state");
-      }
       Preconditions.assertSame(true, rp.isEmpty(), "replica empty");
+
+      // Only send delete commands to replicas in CLOSED/QUASI_CLOSED states
+      if (rp.getState() != ContainerReplicaProto.State.QUASI_CLOSED
+          && rp.getState() != ContainerReplicaProto.State.CLOSED) {
+        LOG.info("Skipping delete command for replica in {} state for empty container {} on datanode {}. " +
+            "Will retry after replica transitions to QUASI_CLOSED or CLOSED.",
+            rp.getState(), containerInfo.containerID(), rp.getDatanodeDetails());
+        continue;
+      }
 
       try {
         replicationManager.sendDeleteCommand(containerInfo,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -100,10 +100,7 @@ public class EmptyContainerHandler extends AbstractCheck {
             "replicas from originIds: [{}]. If resurrected, container will transition to QUASI_CLOSED",
             containerInfo.containerID(), containerInfo.getSequenceId(), maxReplicaBCSID,
             replicas.size(), originIds);
-        // Update the container's state - transition to CLOSED first, then DELETE
-        // QUASI_CLOSED -> CLOSED requires FORCE_CLOSE event
-        replicationManager.updateContainerState(
-                containerInfo.containerID(), HddsProtos.LifeCycleEvent.FORCE_CLOSE);
+        // Update the container's state
         replicationManager.updateContainerState(
                 containerInfo.containerID(), HddsProtos.LifeCycleEvent.DELETE);
         // Delete replicas AFTER transitioning to DELETING state

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -210,7 +210,7 @@ public class TestContainerManagerImpl {
   @ParameterizedTest
   @EnumSource(value = HddsProtos.LifeCycleState.class,
       names = {"DELETING", "DELETED"})
-  void testTransitionDeletingOrDeletedToClosedState(HddsProtos.LifeCycleState desiredState)
+  void testTransitionDeletingOrDeletedToTargetState(HddsProtos.LifeCycleState desiredState)
       throws IOException, InvalidStateTransitionException {
     // Allocate OPEN Ratis and Ec containers, and do a series of state changes to transition them to DELETING / DELETED
     final ContainerInfo container = containerManager.allocateContainer(
@@ -250,8 +250,8 @@ public class TestContainerManagerImpl {
     }
 
     // DELETING / DELETED -> CLOSED
-    containerManager.transitionDeletingOrDeletedToClosedState(cid);
-    containerManager.transitionDeletingOrDeletedToClosedState(ecCid);
+    containerManager.transitionDeletingOrDeletedToTargetState(cid, LifeCycleState.CLOSED);
+    containerManager.transitionDeletingOrDeletedToTargetState(ecCid, LifeCycleState.CLOSED);
     // the containers should be back in CLOSED state now
     assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(cid).getState());
     assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(ecCid).getState());
@@ -267,13 +267,15 @@ public class TestContainerManagerImpl {
             ReplicationFactor.THREE), "admin");
     final ContainerID cid = container.containerID();
     assertEquals(LifeCycleState.OPEN, containerManager.getContainer(cid).getState());
-    assertThrows(IOException.class, () -> containerManager.transitionDeletingOrDeletedToClosedState(cid));
+    assertThrows(IOException.class, () ->
+            containerManager.transitionDeletingOrDeletedToTargetState(cid, LifeCycleState.CLOSED));
 
     // test for EC container
     final ContainerInfo ecContainer = containerManager.allocateContainer(new ECReplicationConfig(3, 2), "admin");
     final ContainerID ecCid = ecContainer.containerID();
     assertEquals(LifeCycleState.OPEN, containerManager.getContainer(ecCid).getState());
-    assertThrows(IOException.class, () -> containerManager.transitionDeletingOrDeletedToClosedState(ecCid));
+    assertThrows(IOException.class, () ->
+            containerManager.transitionDeletingOrDeletedToTargetState(ecCid, LifeCycleState.CLOSED));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -154,12 +154,6 @@ public class TestContainerReportHandler {
         any(ContainerID.class), any(ContainerReplica.class));
 
     doAnswer(invocation -> {
-      containerStateManager.transitionDeletingOrDeletedToClosedState(
-          ((ContainerID) invocation.getArgument(0)).getProtobuf());
-      return null;
-    }).when(containerManager).transitionDeletingOrDeletedToClosedState(any(ContainerID.class));
-
-    doAnswer(invocation -> {
       containerStateManager.transitionDeletingOrDeletedToTargetState(
           ((ContainerID) invocation.getArgument(0)).getProtobuf(), invocation.getArgument(1));
       return null;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -158,6 +158,13 @@ public class TestContainerReportHandler {
           ((ContainerID) invocation.getArgument(0)).getProtobuf());
       return null;
     }).when(containerManager).transitionDeletingOrDeletedToClosedState(any(ContainerID.class));
+
+    doAnswer(invocation -> {
+      containerStateManager.transitionDeletingOrDeletedToTargetState(
+          ((ContainerID) invocation.getArgument(0)).getProtobuf(), invocation.getArgument(1));
+      return null;
+    }).when(containerManager).transitionDeletingOrDeletedToTargetState(
+        any(ContainerID.class), any(LifeCycleState.class));
   }
 
   @AfterEach
@@ -204,7 +211,8 @@ public class TestContainerReportHandler {
             continue;
           }
           if (replicationType == HddsProtos.ReplicationType.RATIS &&
-              replicaState.equals(ContainerReplicaProto.State.CLOSED) &&
+              (replicaState.equals(ContainerReplicaProto.State.CLOSED) ||
+              replicaState.equals(ContainerReplicaProto.State.QUASI_CLOSED)) &&
               (containerState.equals(HddsProtos.LifeCycleState.DELETED) ||
               containerState.equals(HddsProtos.LifeCycleState.DELETING))) {
             continue;
@@ -563,7 +571,14 @@ public class TestContainerReportHandler {
     ContainerReportsProto closedContainerReport = getContainerReports(validReplica);
     containerReportHandler
         .onMessage(new ContainerReportFromDatanode(dnWithValidReplica, closedContainerReport), publisher);
-    assertEquals(LifeCycleState.CLOSED, containerStateManager.getContainer(container.containerID()).getState());
+    // Determine expected state based on replica state
+    LifeCycleState expectedState;
+    if (replicaState == ContainerReplicaProto.State.CLOSED) {
+      expectedState = LifeCycleState.CLOSED;
+    } else {
+      expectedState = LifeCycleState.QUASI_CLOSED;
+    }
+    assertEquals(expectedState, containerStateManager.getContainer(container.containerID()).getState());
 
     // verify that no delete command is issued for non-empty replica, regardless of container state
     verify(publisher, times(0))
@@ -1172,6 +1187,88 @@ public class TestContainerReportHandler {
 
     // Expect the replica to be deleted when it is empty
     verify(publisher, times(1)).fireEvent(any(), any(CommandForDatanode.class));
+    assertEquals(1, containerManager.getContainerReplicas(containerOne.containerID()).size());
+  }
+
+  /**
+   * Test resurrection of DELETED container to QUASI_CLOSED state when a non-empty
+   * QUASI_CLOSED replica with matching bcsId is reported.
+   */
+  @Test
+  public void testDeletedContainerWithStaleQuasiClosedReplicaDoesNotResurrect()
+          throws NodeNotFoundException, IOException {
+    final ContainerReportHandler reportHandler = new ContainerReportHandler(nodeManager, containerManager);
+    final DatanodeDetails datanodeOne = nodeManager.getNodes(NodeStatus.inServiceHealthy()).iterator().next();
+    // Create container in DELETED state with bcsId=100
+    final ContainerInfo containerOne = getContainer(LifeCycleState.DELETED);
+    assertEquals(10000L, containerOne.getSequenceId());
+
+    final Set<ContainerID> containerIDSet = Stream.of(containerOne.containerID()).collect(Collectors.toSet());
+    nodeManager.setContainers(datanodeOne, containerIDSet);
+    containerStateManager.addContainer(containerOne.getProtobuf());
+
+    // Report non-empty QUASI_CLOSED replica with matching bcsId
+    final ContainerReportsProto containerReport = getContainerReportsProto(
+        containerOne.containerID(), 
+        ContainerReplicaProto.State.QUASI_CLOSED,
+        datanodeOne.getUuidString(), 
+        200L,    // usedBytes
+        10L,     // keyCount (non-empty)
+        10000L,  // bcsId (matches container)
+        0,       // replicaIndex
+        false);  // isEmpty=false
+
+    final ContainerReportFromDatanode containerReportFromDatanode =
+        new ContainerReportFromDatanode(datanodeOne, containerReport);
+    reportHandler.onMessage(containerReportFromDatanode, publisher);
+
+    // Container should NOT resurrect
+    final ContainerInfo container = containerManager.getContainer(containerOne.containerID());
+    assertEquals(LifeCycleState.DELETED, container.getState(),
+        "Container should not resurrect when a stale QUASI_CLOSED replica is reported");
+    
+    // A delete command should be sent for the stale replica
+    verify(publisher, times(1)).fireEvent(eq(SCMEvents.DATANODE_COMMAND), any(CommandForDatanode.class));
+  }
+
+  /**
+   * Test resurrection of DELETING container to QUASI_CLOSED state when a non-empty OPEN replica is reported.
+   * OPEN replicas should trigger resurrection to QUASI_CLOSED state.
+   */
+  @Test
+  public void testDeletingContainerResurrectionToQuasiClosedWithOpenReplica() 
+      throws NodeNotFoundException, IOException {
+    final ContainerReportHandler reportHandler = new ContainerReportHandler(nodeManager, containerManager);
+    final DatanodeDetails datanodeOne = nodeManager.getNodes(
+        NodeStatus.inServiceHealthy()).iterator().next();
+    // Create container in DELETING state
+    final ContainerInfo containerOne = getContainer(LifeCycleState.DELETING);
+
+    final Set<ContainerID> containerIDSet = Stream.of(containerOne.containerID()).collect(Collectors.toSet());
+    nodeManager.setContainers(datanodeOne, containerIDSet);
+    containerStateManager.addContainer(containerOne.getProtobuf());
+
+    // Report non-empty OPEN replica (e.g., stale DN that came back online)
+    final ContainerReportsProto containerReport = getContainerReportsProto(
+        containerOne.containerID(), 
+        ContainerReplicaProto.State.OPEN,
+        datanodeOne.getUuidString(),
+        200L,    // usedBytes
+        10L,     // keyCount (non-empty)
+        10000L,  // bcsId
+        0,       // replicaIndex
+        false);  // isEmpty=false
+
+    final ContainerReportFromDatanode containerReportFromDatanode =
+        new ContainerReportFromDatanode(datanodeOne, containerReport);
+    reportHandler.onMessage(containerReportFromDatanode, publisher);
+
+    // Container should resurrect to QUASI_CLOSED for OPEN replica
+    final ContainerInfo resurrectedContainer = containerManager.getContainer(containerOne.containerID());
+    assertEquals(LifeCycleState.QUASI_CLOSED, resurrectedContainer.getState(),
+        "Container should resurrect to QUASI_CLOSED when OPEN replica is reported");
+    
+    // Replica should be updated in SCM
     assertEquals(1, containerManager.getContainerReplicas(containerOne.containerID()).size());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -159,6 +159,13 @@ public class TestContainerStateManager {
       return null;
     }).when(containerManager).transitionDeletingOrDeletedToClosedState(any(ContainerID.class));
 
+    doAnswer(invocation -> {
+      containerStateManager.transitionDeletingOrDeletedToTargetState(
+          ((ContainerID) invocation.getArgument(0)).getProtobuf(), invocation.getArgument(1));
+      return null;
+    }).when(containerManager).transitionDeletingOrDeletedToTargetState(
+        any(ContainerID.class), any(HddsProtos.LifeCycleState.class));
+
   }
 
   @AfterEach

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -154,12 +154,6 @@ public class TestContainerStateManager {
         any(ContainerID.class), any(ContainerReplica.class));
 
     doAnswer(invocation -> {
-      containerStateManager.transitionDeletingOrDeletedToClosedState(
-          ((ContainerID) invocation.getArgument(0)).getProtobuf());
-      return null;
-    }).when(containerManager).transitionDeletingOrDeletedToClosedState(any(ContainerID.class));
-
-    doAnswer(invocation -> {
       containerStateManager.transitionDeletingOrDeletedToTargetState(
           ((ContainerID) invocation.getArgument(0)).getProtobuf(), invocation.getArgument(1));
       return null;
@@ -221,7 +215,7 @@ public class TestContainerStateManager {
   @ParameterizedTest
   @EnumSource(value = HddsProtos.LifeCycleState.class,
       names = {"DELETING", "DELETED"})
-  public void testTransitionDeletingOrDeletedToClosedState(HddsProtos.LifeCycleState lifeCycleState)
+  public void testTransitionDeletingOrDeletedToTargetState(HddsProtos.LifeCycleState lifeCycleState)
       throws IOException {
     HddsProtos.ContainerInfoProto.Builder builder = HddsProtos.ContainerInfoProto.newBuilder();
     builder.setContainerID(1)
@@ -235,7 +229,7 @@ public class TestContainerStateManager {
     HddsProtos.ContainerInfoProto container = builder.build();
     HddsProtos.ContainerID cid = HddsProtos.ContainerID.newBuilder().setId(container.getContainerID()).build();
     containerStateManager.addContainer(container);
-    containerStateManager.transitionDeletingOrDeletedToClosedState(cid);
+    containerStateManager.transitionDeletingOrDeletedToTargetState(cid, HddsProtos.LifeCycleState.CLOSED);
     assertEquals(HddsProtos.LifeCycleState.CLOSED, containerStateManager.getContainer(ContainerID.getFromProtobuf(cid))
         .getState());
   }
@@ -261,7 +255,7 @@ public class TestContainerStateManager {
     HddsProtos.ContainerID cid = HddsProtos.ContainerID.newBuilder().setId(container.getContainerID()).build();
     containerStateManager.addContainer(container);
     try {
-      containerStateManager.transitionDeletingOrDeletedToClosedState(cid);
+      containerStateManager.transitionDeletingOrDeletedToTargetState(cid, HddsProtos.LifeCycleState.CLOSED);
       fail("Was expecting an Exception, but did not catch any.");
     } catch (IOException e) {
       assertInstanceOf(InvalidContainerStateException.class, e.getCause().getCause());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -317,15 +317,7 @@ public class TestEmptyContainerHandler {
         .build();
 
     assertAndVerify(readRequest, true, 0, 1);
-    
-    // Should delete all 3 replicas and update state twice (FORCE_CLOSE + DELETE)
-    assertTrue(emptyContainerHandler.handle(request));
-    verify(replicationManager, times(3)).sendDeleteCommand(any(ContainerInfo.class), anyInt(),
-        any(DatanodeDetails.class), eq(false));
-    assertEquals(1, request.getReport().getStat(ContainerHealthState.EMPTY));
-    // QUASI_CLOSED requires 2 state updates: FORCE_CLOSE + DELETE
-    verify(replicationManager, times(2)).updateContainerState(
-        any(ContainerID.class), any(HddsProtos.LifeCycleEvent.class));
+    assertAndVerify(request, true, 3, 1);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerIntegration.java
@@ -415,7 +415,7 @@ class TestReplicationManagerIntegration {
     replicationManager.getConfig().setInterval(Duration.ofSeconds(1));
     replicationManager.notifyStatusChanged();
 
-    // QUASI_CLOSED -> CLOSED -> DELETING
+    // QUASI_CLOSED -> DELETING
     GenericTestUtils.waitFor(() -> {
       try {
         ContainerInfo info = containerManager.getContainer(cid);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerIntegration.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
@@ -427,5 +428,92 @@ class TestReplicationManagerIntegration {
     
     containerInfo = containerManager.getContainer(cid);
     assertEquals(HddsProtos.LifeCycleState.DELETING, containerInfo.getState());
+  }
+
+  /**
+   * Test empty QUASI_CLOSED container deletion with mixed replica states.
+   * Only stable replicas (QUASI_CLOSED/CLOSED) should receive delete commands initially.
+   * OPEN replicas should be skipped.
+   */
+  @Test
+  public void testEmptyQuasiClosedContainerDeletionWithMixedReplicaStates() throws Exception {
+    ContainerInfo containerInfo = containerManager.allocateContainer(RATIS_REPLICATION_CONFIG, "TestOwner");
+    ContainerID cid = containerInfo.containerID();
+    containerManager.updateContainerState(cid, HddsProtos.LifeCycleEvent.FINALIZE);
+    containerManager.updateContainerState(cid, HddsProtos.LifeCycleEvent.QUASI_CLOSE);
+    
+    // Wait for container to be QUASI_CLOSED
+    GenericTestUtils.waitFor(() -> {
+      try {
+        ContainerInfo info = containerManager.getContainer(cid);
+        return info.getState() == HddsProtos.LifeCycleState.QUASI_CLOSED;
+      } catch (ContainerNotFoundException e) {
+        return false;
+      }
+    }, 100, 5000);
+    
+    containerInfo = containerManager.getContainer(cid);
+    assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED, containerInfo.getState());
+    assertEquals(0L, containerInfo.getNumberOfKeys());
+    assertEquals(0L, containerInfo.getSequenceId());
+
+    // Add replicas with mixed states: 2 QUASI_CLOSED, 1 OPEN
+    List<DatanodeDetails> datanodes = nodeManager.getAllNodes().stream()
+        .limit(3).collect(Collectors.toList());
+    
+    // Add 2 QUASI_CLOSED replicas
+    for (int i = 0; i < 2; i++) {
+      ContainerReplica replica = ContainerReplica.newBuilder()
+          .setContainerID(cid)
+          .setContainerState(QUASI_CLOSED)
+          .setDatanodeDetails(datanodes.get(i))
+          .setOriginNodeId(datanodes.get(i).getID())
+          .setSequenceId(100L)
+          .setKeyCount(0L)
+          .setBytesUsed(0L)
+          .setEmpty(true)
+          .setReplicaIndex(i)
+          .build();
+      containerManager.updateContainerReplica(cid, replica);
+    }
+    
+    // Add 1 OPEN replica (will be skipped for delete commands)
+    ContainerReplica openReplica = ContainerReplica.newBuilder()
+        .setContainerID(cid)
+        .setContainerState(StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.OPEN)
+        .setDatanodeDetails(datanodes.get(2))
+        .setOriginNodeId(datanodes.get(2).getID())
+        .setSequenceId(50L)  // Lower bcsId (stale)
+        .setKeyCount(0L)
+        .setBytesUsed(0L)
+        .setEmpty(true)
+        .setReplicaIndex(2)
+        .build();
+    containerManager.updateContainerReplica(cid, openReplica);
+    
+    Set<ContainerReplica> replicas = containerManager.getContainerReplicas(cid);
+    assertEquals(3, replicas.size());
+    assertTrue(replicas.stream().allMatch(ContainerReplica::isEmpty), "All replicas should be empty");
+
+    replicationManager.getConfig().setInterval(Duration.ofSeconds(1));
+    replicationManager.notifyStatusChanged();
+
+    // Container should still transition to DELETING
+    // (Delete commands sent to stable replicas, OPEN replica skipped)
+    GenericTestUtils.waitFor(() -> {
+      try {
+        ContainerInfo info = containerManager.getContainer(cid);
+        HddsProtos.LifeCycleState state = info.getState();
+        return state == HddsProtos.LifeCycleState.DELETING;
+      } catch (ContainerNotFoundException e) {
+        return false;
+      }
+    }, 1000, 30000);
+    
+    containerInfo = containerManager.getContainer(cid);
+    assertEquals(HddsProtos.LifeCycleState.DELETING, containerInfo.getState());
+    
+    // Verify bcsId was updated to max (100L from QUASI_CLOSED replicas)
+    assertEquals(100L, containerInfo.getSequenceId(), "Container bcsId should be updated to max replica bcsId");
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
We now support tracking a container again if a new replica shows up with a higher BCSID after all replicas were deleted [HDDS-14416](https://issues.apache.org/jira/browse/HDDS-14416) With this change, we delete empty quasi-closed containers from the system. Even if they were missing some blocks and a new replica shows up with those blocks, it would be tracked and replicated again. 
Added empty QUASI_CLOSED container check and deletion in `EmptyContainerHandler`.

## What is the link to the Apache JIRA
[HDDS-14684](https://issues.apache.org/jira/browse/HDDS-14684)

## How was this patch tested?
Container is in OPEN state 
```
bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: 06f1821c-c6f9-4723-b808-10109148804d
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: OPEN
Container State: OPEN
SequenceId: 0
Datanodes: [debbb446-9562-4fa6-a5d0-6df732b9f08e/ozone-datanode-2.ozone_default,
15d92615-598a-48a6-980f-609931977806/ozone-datanode-3.ozone_default,
4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default]
Replicas: [State: OPEN; ReplicaIndex: 0; SequenceId: 0; Origin: debbb446-9562-4fa6-a5d0-6df732b9f08e; Location: debbb446-9562-4fa6-a5d0-6df732b9f08e/ozone-datanode-2.ozone_default; KeyCount: 0; BytesUsed: 0;,
State: OPEN; ReplicaIndex: 0; SequenceId: 0; Origin: 15d92615-598a-48a6-980f-609931977806; Location: 15d92615-598a-48a6-980f-609931977806/ozone-datanode-3.ozone_default; KeyCount: 0; BytesUsed: 0;,
State: OPEN; ReplicaIndex: 0; SequenceId: 0; Origin: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd; Location: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default; KeyCount: 0; BytesUsed: 0;]
```
Container transitioned to QUASI_CLOSED because replicas have inconsistent states and couldn't reach consensus
```
bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: a1c7358e-1c4e-4716-9ff0-fa9f228330ca
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: CLOSED
Container State: QUASI_CLOSED
SequenceId: 14
Datanodes: [debbb446-9562-4fa6-a5d0-6df732b9f08e/ozone-datanode-2.ozone_default,
15d92615-598a-48a6-980f-609931977806/ozone-datanode-3.ozone_default,
4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default]
Replicas: [State: OPEN; ReplicaIndex: 0; SequenceId: 0; Origin: debbb446-9562-4fa6-a5d0-6df732b9f08e; Location: debbb446-9562-4fa6-a5d0-6df732b9f08e/ozone-datanode-2.ozone_default; KeyCount: 0; BytesUsed: 0;,
State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 11; Origin: 15d92615-598a-48a6-980f-609931977806; Location: 15d92615-598a-48a6-980f-609931977806/ozone-datanode-3.ozone_default; KeyCount: 2; BytesUsed: 18;,
State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 14; Origin: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd; Location: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default; KeyCount: 0; BytesUsed: 0;]
```
Keys were deleted from all replicas. DN2 and DN3 went offline. Only DN1's empty replica remains.
```
bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: 5a1435f2-0cb9-42b3-a272-4efaa2762da9
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: CLOSED
Container State: QUASI_CLOSED
SequenceId: 14
Datanodes: [4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default]
Replicas: [State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 14; Origin: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd; Location: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default; KeyCount: 0; BytesUsed: 0;]
```
`EmptyContainerHandler` detected the empty QUASI_CLOSED container.
QUASI_CLOSED → FORCE_CLOSE → CLOSED → DELETE → DELETING → (replica deleted) → DELETED
```
2026-03-18 10:13:47,354 [ReplicationMonitor] INFO health.EmptyContainerHandler: Deleting empty QUASI_CLOSED container #2 (container BCSID=14, max replica BCSID=14) with 1 replicas from originIds: [4d2a7e6d-79e3-46ee-9792-3a0782906bfd]. If resurrected, container will transition to QUASI_CLOSED.
```
```
bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: d408d100-6e12-49d0-8441-b68e6628a8bc
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: CLOSED
Container State: DELETING
SequenceId: 14
Datanodes: [4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default]
Replicas: [State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 14; Origin: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd; Location: 4d2a7e6d-79e3-46ee-9792-3a0782906bfd/ozone-datanode-1.ozone_default; KeyCount: 0; BytesUsed: 0;]

bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: 6d6f5c15-d191-4f4a-86e9-81947126e9b1
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: CLOSED
Container State: DELETED
SequenceId: 14
Datanodes: []
Replicas: []
```
DN2 (which was offline) came back online and reported a non-empty OPEN replica. Container resurrected to QUASI_CLOSED.
```
2026-03-18 10:15:00,732 [FixedThreadPoolWithAffinityExecutor-9-0] INFO container.ContainerReportHandler: Resurrecting container #2 from DELETED to QUASI_CLOSED due to non-empty OPEN replica (keyCount=1, BCSID=4) from Container #2 (DELETED, sid=14) r0 (OPEN, bcsid=4, origin=debbb446-9562-4fa6-a5d0-6df732b9f08e, non-empty) from dn debbb446-9562-4fa6-a5d0-6df732b9f08e(ozone-datanode-2.ozone_default/172.18.0.9)
```
```
bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: 073bccac-b2e0-4464-8a50-804e5bc2dd47
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: CLOSED
Container State: QUASI_CLOSED
SequenceId: 14
Datanodes: [debbb446-9562-4fa6-a5d0-6df732b9f08e/ozone-datanode-2.ozone_default]
Replicas: [State: OPEN; ReplicaIndex: 0; SequenceId: 4; Origin: debbb446-9562-4fa6-a5d0-6df732b9f08e; Location: debbb446-9562-4fa6-a5d0-6df732b9f08e/ozone-datanode-2.ozone_default; KeyCount: 1; BytesUsed: 9;]
```
The DN2 replica transitioned from OPEN to QUASI_CLOSED with BCSID=8 and became empty. 
Replica BCSID (8) < Container BCSID (14) -> Stale replica. Container became empty again and was deleted by `EmptyContainerHandler`.
```
2026-03-18 10:15:17,391 [ReplicationMonitor] INFO health.EmptyContainerHandler: Deleting empty QUASI_CLOSED container #2 (container BCSID=14, max replica BCSID=8) with 1 replicas from originIds: [debbb446-9562-4fa6-a5d0-6df732b9f08e]. If resurrected, container will transition to QUASI_CLOSED.
```
```
bash-5.1$ ozone admin container info 2
Container id: 2
Pipeline id: 921310a1-70ae-4c98-a309-cc97f7adaa10
Write PipelineId: 06f1821c-c6f9-4723-b808-10109148804d
Write Pipeline State: CLOSED
Container State: DELETED
SequenceId: 14
Datanodes: []
Replicas: []
```