### PR TITLE
HDDS-14591. Cache HBASE_SUPPORT finalization status for putBlock

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -21,11 +21,13 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.ozone.OzoneConsts.INCREMENTAL_CHUNK_LIST;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -63,6 +65,7 @@ public class BlockManagerImpl implements BlockManager {
   private final int readMappedBufferThreshold;
   private final int readMappedBufferMaxCount;
   private final boolean readNettyChunkedNioFile;
+  private final AtomicBoolean hbaseSupportFinalized;
 
   /**
    * Constructs a Block Manager.
@@ -84,6 +87,8 @@ public class BlockManagerImpl implements BlockManager {
     this.readNettyChunkedNioFile = config.getBoolean(
         ScmConfigKeys.OZONE_CHUNK_READ_NETTY_CHUNKED_NIO_FILE_KEY,
         ScmConfigKeys.OZONE_CHUNK_READ_NETTY_CHUNKED_NIO_FILE_DEFAULT);
+    this.hbaseSupportFinalized = new AtomicBoolean(
+        VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.HBASE_SUPPORT));
   }
 
   @Override
@@ -227,13 +232,12 @@ public class BlockManagerImpl implements BlockManager {
           }
         }
 
-        boolean incrementalEnabled = true;
-        if (!VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.HBASE_SUPPORT)) {
+        boolean incrementalEnabled = isIncrementalChunkListFeatureFinalized();
+        if (!incrementalEnabled) {
           if (isPartialChunkList(data)) {
             throw new StorageContainerException("DataNode has not finalized " +
                 "upgrading to a version that supports incremental chunk list.", UNSUPPORTED_REQUEST);
           }
-          incrementalEnabled = false;
         }
         db.getStore().putBlockByID(batch, incrementalEnabled, localID, data,
             containerData, endOfBlock);
@@ -459,6 +463,22 @@ public class BlockManagerImpl implements BlockManager {
       KeyValueContainerData containerData) throws IOException {
     String blockKey = containerData.getBlockKey(blockID.getLocalID());
     return db.getStore().getBlockByID(blockID, blockKey);
+  }
+
+  @VisibleForTesting
+  boolean isIncrementalChunkListFeatureFinalized() {
+    if (hbaseSupportFinalized.get()) {
+      return true;
+    }
+    if (VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.HBASE_SUPPORT)) {
+      if (hbaseSupportFinalized.compareAndSet(false, true)) {
+        LOG.info("Layout feature {} is finalized. Skipping finalization checks "
+                + "for incremental chunk list on subsequent putBlock requests.",
+            HDDSLayoutFeature.HBASE_SUPPORT);
+      }
+      return true;
+    }
+    return false;
   }
 
   private static boolean isPartialChunkList(BlockData data) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -22,11 +22,15 @@ import static org.apache.hadoop.ozone.OzoneConsts.INCREMENTAL_CHUNK_LIST;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl.FULL_CHUNK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -39,6 +43,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -53,9 +58,12 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 
 /**
  * This class is used to test key related operations on the container.
@@ -141,6 +149,25 @@ public class TestBlockManagerImpl {
   @AfterEach
   public void cleanup() {
     BlockUtils.shutdownCache(config);
+  }
+
+  @Test
+  public void testFinalizationStatusCachedForIncrementalChunkListChecks() {
+    config = new OzoneConfiguration();
+    try (MockedStatic<VersionedDatanodeFeatures> mockedFeatures =
+             mockStatic(VersionedDatanodeFeatures.class)) {
+      mockedFeatures.when(() -> VersionedDatanodeFeatures.isFinalized(
+              HDDSLayoutFeature.HBASE_SUPPORT))
+          .thenReturn(false, false, true);
+
+      BlockManagerImpl manager = new BlockManagerImpl(config);
+      assertFalse(manager.isIncrementalChunkListFeatureFinalized());
+      assertTrue(manager.isIncrementalChunkListFeatureFinalized());
+      assertTrue(manager.isIncrementalChunkListFeatureFinalized());
+
+      mockedFeatures.verify(() -> VersionedDatanodeFeatures.isFinalized(
+          HDDSLayoutFeature.HBASE_SUPPORT), times(3));
+    }
   }
 
   @ContainerTestVersionInfo.ContainerTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
Avoid checking VersionedDatanodeFeatures.isFinalized(HBASE_SUPPORT) on every putBlock request. Cache the finalized state in BlockManagerImpl, and once finalization is observed, reuse the cached value for subsequent requests.


- Keep existing behavior before finalization: partial chunk list requests are rejected with UNSUPPORTED_REQUEST.
- Add a unit test to verify the finalization status is cached after it is first detected as finalized.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14591

## How was this patch tested?
unit tests
