### PR TITLE
HDDS-14861. [STS] Fix Latent S3 API issue when ListBuckets Missing a Required Permission

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -379,24 +379,33 @@ public abstract class EndpointBase {
       OzoneVolume volume = getVolume();
       ownerSetter.accept(volume);
       return query.apply(volume);
-    } catch (OMException e) {
-      if (e.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
-        return Collections.emptyIterator();
-      } else  if (e.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw newError(S3ErrorTable.ACCESS_DENIED,
-            "listBuckets", e);
-      } else if (isExpiredToken(e)) {
-        throw newError(S3ErrorTable.EXPIRED_TOKEN, s3Auth.getAccessID(), e);
-      } else if (e.getResult() == ResultCodes.INVALID_TOKEN) {
-        throw newError(S3ErrorTable.ACCESS_DENIED,
-            s3Auth.getAccessID(), e);
-      } else if (e.getResult() == ResultCodes.TIMEOUT ||
-          e.getResult() == ResultCodes.INTERNAL_ERROR) {
-        throw newError(S3ErrorTable.INTERNAL_ERROR,
-            "listBuckets", e);
-      } else {
-        throw e;
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof OMException) {
+        return handleOMException((OMException) e.getCause());
       }
+      throw e;
+    } catch (OMException e) {
+      return handleOMException(e);
+    }
+  }
+
+  private Iterator<OzoneBucket> handleOMException(OMException e) throws OMException {
+    if (e.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
+      return Collections.emptyIterator();
+    } else  if (e.getResult() == ResultCodes.PERMISSION_DENIED) {
+      throw newError(S3ErrorTable.ACCESS_DENIED,
+          "listBuckets", e);
+    } else if (isExpiredToken(e)) {
+      throw newError(S3ErrorTable.EXPIRED_TOKEN, s3Auth.getAccessID(), e);
+    } else if (e.getResult() == ResultCodes.INVALID_TOKEN) {
+      throw newError(S3ErrorTable.ACCESS_DENIED,
+          s3Auth.getAccessID(), e);
+    } else if (e.getResult() == ResultCodes.TIMEOUT ||
+        e.getResult() == ResultCodes.INTERNAL_ERROR) {
+      throw newError(S3ErrorTable.INTERNAL_ERROR,
+          "listBuckets", e);
+    } else {
+      throw e;
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -115,7 +115,7 @@ public final class S3ErrorTable {
       "resource.", HTTP_FORBIDDEN);
 
   public static final OS3Exception EXPIRED_TOKEN = new OS3Exception(
-      "ExpiredToken", "The provided token has expired.", HTTP_FORBIDDEN);
+      "ExpiredToken", "The provided token has expired.", HTTP_BAD_REQUEST);
 
   public static final OS3Exception PRECOND_FAILED = new OS3Exception(
       "PreconditionFailed", "At least one of the pre-conditions you " +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
@@ -24,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -31,6 +34,7 @@ import java.util.Map;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.Test;
@@ -137,4 +141,45 @@ public class TestEndpointBase {
     assertFalse(endpointBase.isExpiredToken(new OMException(ResultCodes.INVALID_TOKEN)));
   }
 
+  @Test
+  public void testListS3BucketsHandlesRuntimeExceptionWrappingOMException() throws Exception {
+    final EndpointBase endpointBase = new EndpointBase() {
+      @Override
+      public void init() { }
+
+      @Override
+      protected OzoneVolume getVolume() {
+        final OzoneVolume volume = mock(OzoneVolume.class);
+        when(volume.listBuckets(anyString())).thenThrow(
+            new RuntimeException(new OMException("Permission Denied", ResultCodes.PERMISSION_DENIED)));
+        return volume;
+      }
+    };
+
+    final OS3Exception e = assertThrows(
+        OS3Exception.class, () -> endpointBase.listS3Buckets(
+            "prefix", volume -> { }), "listS3Buckets should fail.");
+
+    // Ensure we get the correct code
+    assertEquals("AccessDenied", e.getCode());
+  }
+
+  @Test
+  public void testListS3BucketsHandlesRuntimeExceptionWrappingOMExceptionVolumeNotFound() throws Exception {
+    final EndpointBase endpointBase = new EndpointBase() {
+      @Override
+      public void init() { }
+
+      @Override
+      protected OzoneVolume getVolume() {
+        final OzoneVolume volume = mock(OzoneVolume.class);
+        when(volume.listBuckets(anyString())).thenThrow(
+            new RuntimeException(new OMException("Volume Not Found", ResultCodes.VOLUME_NOT_FOUND)));
+        return volume;
+      }
+    };
+
+    // Ensure we get an empty iterator
+    assertFalse(endpointBase.listS3Buckets("prefix", volume -> { }).hasNext());
+  }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/exception/TestOS3Exceptions.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/exception/TestOS3Exceptions.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.s3.exception;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.ozone.web.utils.OzoneUtils;
@@ -48,9 +49,19 @@ public class TestOS3Exceptions {
     assertEquals(expected, val);
   }
 
+  /**
+   * AWS S3 returns HTTP 400 Bad Request for ExpiredToken (not 403).
+   */
+  @Test
+  public void testExpiredTokenUsesBadRequestHttpStatus() {
+    assertEquals(HTTP_BAD_REQUEST, S3ErrorTable.EXPIRED_TOKEN.getHttpCode());
+    final OS3Exception fromTable = S3ErrorTable.newError(S3ErrorTable.EXPIRED_TOKEN, "resource");
+    assertEquals(HTTP_BAD_REQUEST, fromTable.getHttpCode());
+  }
+
   @Test
   public void testOS3ExceptionWithToken0() {
-    OS3Exception ex = new OS3Exception("ExpiredToken", "The provided token has expired.", 403);
+    OS3Exception ex = new OS3Exception("ExpiredToken", "The provided token has expired.", 400);
     ex = S3ErrorTable.newError(ex, "resource");
     ex.setRequestId(OzoneUtils.getRequestID());
     ex.setHostId(OzoneUtils.getRequestID());


### PR DESCRIPTION
Please describe your PR in detail:
* Currently, in latent S3 api handling, if user wants to make a list-buckets call and is missing either the READ or LIST permission on the volume, when using AWS cli, it gives an internal server error after 4 retries. Because this is a latent S3 api bug, the same thing happens with STS. This ticket fixes the underlying issue so a proper AccessDenied error is returned.
* See the Jira ticket for additional info.
* Separately, when testing against Ceph tests (and AWS), the HTTP status code must be 400 instead of 403, so update that here as well.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14861

## How was this patch tested?
unit tests, smoke test, manual testing with AWS cli
