### PR TITLE
HDDS-14874. Make Ratis append-entries.compose.enabled false by default.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -579,7 +579,7 @@ public final class ScmConfigKeys {
   public static final int OZONE_SCM_HA_RAFT_LOG_PURGE_GAP_DEFAULT = 1000000;
 
   public static final String OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED =
-          "ozone.scm.ha.ratis.log.append-entries.compose.enabled";
+          "ozone.scm.ha.ratis.raft.server.log.append-entries.compose.enabled";
   public static final boolean
       OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED_DEFAULT = false;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -578,6 +578,11 @@ public final class ScmConfigKeys {
           "ozone.scm.ha.ratis.log.purge.gap";
   public static final int OZONE_SCM_HA_RAFT_LOG_PURGE_GAP_DEFAULT = 1000000;
 
+  public static final String OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED =
+          "ozone.scm.ha.ratis.log.append-entries.compose.enabled";
+  public static final boolean
+      OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED_DEFAULT = false;
+
   /**
    * the config will transfer value to ratis config
    * raft.server.snapshot.auto.trigger.threshold.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -352,6 +352,10 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_LOG_PURGE_GAP_DEFAULT);
     RaftServerConfigKeys.Log.setPurgeGap(properties, purgeGap);
 
+    properties.setBoolean(
+        "raft.server.log.append-entries.compose.enabled",
+        ratisServerConfig.isAppendEntriesComposeEnabled());
+
     //Set the number of Snapshots Retained.
     RatisServerConfiguration ratisServerConfiguration =
         conf.getObject(RatisServerConfiguration.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -34,6 +34,7 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
@@ -267,11 +268,16 @@ public class TestDatanodeConfiguration {
         DatanodeRatisServerConfig.class);
     assertEquals(0, ratisConf.getLogAppenderWaitTimeMin(),
         "getLogAppenderWaitTimeMin");
+    assertFalse(ratisConf.isAppendEntriesComposeEnabled(),
+        "isAppendEntriesComposeEnabled");
 
     assertWaitTimeMin(TimeDuration.ZERO, conf);
+    assertAppendEntriesComposeEnabled(false, conf);
     ratisConf.setLogAppenderWaitTimeMin(1);
+    ratisConf.setAppendEntriesComposeEnabled(true);
     conf.setFromObject(ratisConf);
     assertWaitTimeMin(TimeDuration.ONE_MILLISECOND, conf);
+    assertAppendEntriesComposeEnabled(true, conf);
   }
 
   static void assertWaitTimeMin(TimeDuration expected,
@@ -282,5 +288,14 @@ public class TestDatanodeConfiguration {
     final TimeDuration t = RaftServerConfigKeys.Log.Appender.waitTimeMin(p);
     assertEquals(expected, t,
         RaftServerConfigKeys.Log.Appender.WAIT_TIME_MIN_KEY);
+  }
+
+  static void assertAppendEntriesComposeEnabled(boolean expected,
+      OzoneConfiguration conf) throws Exception {
+    final DatanodeDetails dn = MockPipeline.createPipeline(1).getFirstNode();
+    final RaftProperties p = ContainerTestUtils.newXceiverServerRatis(dn, conf)
+        .newRaftProperties();
+    final String key = "raft.server.log.append-entries.compose.enabled";
+    assertEquals(expected, p.getBoolean(key, null), key);
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -132,6 +132,15 @@ public class DatanodeRatisServerConfig {
   )
   private long logAppenderWaitTimeMin;
 
+  @Config(key = "hdds.ratis.raft.server.log.append-entries.compose.enabled",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      tags = {OZONE, DATANODE, RATIS, PERFORMANCE},
+      description = "Enable/disable composing appendEntries requests on the " +
+          "Ratis server log appender path."
+  )
+  private boolean appendEntriesComposeEnabled;
+
   public long getRequestTimeOut() {
     return requestTimeOut;
   }
@@ -210,5 +219,14 @@ public class DatanodeRatisServerConfig {
 
   public void setLogAppenderWaitTimeMin(long logAppenderWaitTimeMin) {
     this.logAppenderWaitTimeMin = logAppenderWaitTimeMin;
+  }
+
+  public boolean isAppendEntriesComposeEnabled() {
+    return appendEntriesComposeEnabled;
+  }
+
+  public void setAppendEntriesComposeEnabled(
+      boolean appendEntriesComposeEnabled) {
+    this.appendEntriesComposeEnabled = appendEntriesComposeEnabled;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -196,6 +196,12 @@ public final class RatisUtil {
             ozoneConf.getInt(ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_PURGE_GAP,
                     ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_PURGE_GAP_DEFAULT));
     Log.setSegmentCacheNumMax(properties, 2);
+    properties.setBoolean(
+        "raft.server.log.append-entries.compose.enabled",
+        ozoneConf.getBoolean(
+            ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED,
+            ScmConfigKeys.
+                OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED_DEFAULT));
 
     return logAppenderQueueByteLimit;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -206,6 +206,10 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_LOG_PURGE_GAP =
       "ozone.om.ratis.log.purge.gap";
   public static final int OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT = 1000000;
+  public static final String OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED =
+      "ozone.om.ratis.log.append-entries.compose.enabled";
+  public static final boolean
+      OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED_DEFAULT = false;
   public static final String OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX
       = "ozone.om.ratis.log.purge.upto.snapshot.index";
   public static final boolean

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -207,7 +207,7 @@ public final class OMConfigKeys {
       "ozone.om.ratis.log.purge.gap";
   public static final int OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT = 1000000;
   public static final String OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED =
-      "ozone.om.ratis.log.append-entries.compose.enabled";
+      "ozone.om.ratis.raft.server.log.append-entries.compose.enabled";
   public static final boolean
       OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED_DEFAULT = false;
   public static final String OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -127,6 +127,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OMConfigKeys.OZONE_THREAD_NUMBER_KEY_DELETION,
         ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY,
         ScmConfigKeys.OZONE_SCM_HA_PREFIX,
+        ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPEND_ENTRIES_COMPOSE_ENABLED,
+        OMConfigKeys.OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED,
         S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED,
         DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
         OzoneConfigKeys.HDDS_SCM_CLIENT_RPC_TIME_OUT,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -817,6 +817,12 @@ public final class OzoneManagerRatisServer {
         OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP,
         OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT));
 
+    properties.setBoolean(
+        "raft.server.log.append-entries.compose.enabled",
+        conf.getBoolean(
+            OMConfigKeys.OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED,
+            OMConfigKeys.OZONE_OM_RATIS_LOG_APPEND_ENTRIES_COMPOSE_ENABLED_DEFAULT));
+
     // This avoids writing commit metadata to Raft Log, which can be used to recover the
     // commit index even if a majority of servers are dead. We don't need this for OzoneManager,
     // disabling this will avoid the additional disk IO.


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-14874. Make Ratis append-entries.compose.enabled false by default.

Please describe your PR in detail:
[RATIS-2235](https://issues.apache.org/jira/browse/RATIS-2235) has introduced performance degradation in Ozone. That was addressed in [RATIS-2387](https://issues.apache.org/jira/browse/RATIS-2387), which made the previous logic optional.  We should explicitly set append-entries.compose.enabled to false to restore the old behavior. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14874

## How was this patch tested?
UTs.
Performance comparison of large file writes on 3 container-based nodes:
40GB file upload.
Before patch:
  Run 1: Upload:   189.79s ( 215.81 MB/s)
  Run 2: Upload:   178.98s ( 228.84 MB/s)
  Run 3: Upload:   173.18s ( 236.51 MB/s)
After patch:
  Run 1: Upload:   121.48s ( 337.16 MB/s) 
  Run 2: Upload:   122.66s ( 333.93 MB/s) 
  Run 3: Upload:   106.20s ( 385.67 MB/s) 
