### PR TITLE
HDDS-14895. Improve DiskCheckUtil.checkReadWrite to tolerate not enough file handler

### DIFF
--- a/hadoop-hdds/container-service/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/container-service/dev-support/findbugsExcludeFile.xml
@@ -15,4 +15,8 @@
    limitations under the License.
 -->
 <FindBugsFilter>
+  <Match>
+    <Class name="org.apache.hadoop.ozone.container.common.utils.TestDiskCheckUtil"/>
+    <Bug pattern="OS_OPEN_STREAM" />
+  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
  * where the disk is mounted.
  */
 public final class DiskCheckUtil {
+  public static final String TOO_MANY_OPEN_FILES = "Too many open files";
   // For testing purposes, an alternate check implementation can be provided
   // to inject failures.
   private static DiskChecks impl = new DiskChecksImpl();
@@ -156,6 +157,14 @@ public final class DiskCheckUtil {
         logError(storageDir, String.format("Could not write file %s " +
             "for volume check.", testFile.getAbsolutePath()), ioEx);
         return false;
+      } catch (Throwable ex) {
+        String msg = ex.getMessage();
+        String causeMsg = ex.getCause() != null ? ex.getCause().getMessage() : null;
+        causeMsg = causeMsg != null ? causeMsg : "";
+        if ((msg != null && msg.contains(TOO_MANY_OPEN_FILES)) || causeMsg.contains(TOO_MANY_OPEN_FILES)) {
+          LOG.warn("Could not write file {} for volume check.", testFile.getAbsolutePath(), ex);
+          return true;
+        }
       }
 
       // Read data back from the test file.
@@ -173,9 +182,19 @@ public final class DiskCheckUtil {
             "for volume check.", testFile.getAbsolutePath()), notFoundEx);
         return false;
       } catch (IOException ioEx) {
+        String ioem = ioEx.getMessage();
+        String causeMsg = ioEx.getCause() != null ? ioEx.getCause().getMessage() : null;
+        causeMsg = causeMsg != null ? causeMsg : "";
+        if ((ioem != null && ioem.contains(TOO_MANY_OPEN_FILES)) || causeMsg.contains(TOO_MANY_OPEN_FILES)) {
+          LOG.warn("Could not read file {} for volume check.", testFile.getAbsolutePath(), ioEx);
+          return true;
+        }
         logError(storageDir, String.format("Could not read file %s " +
             "for volume check.", testFile.getAbsolutePath()), ioEx);
         return false;
+      } catch (Throwable t) {
+        logError(storageDir, String.format("Could not read file %s " +
+            "for volume check.", testFile.getAbsolutePath()), t);
       }
 
       // Check that test file has the expected content.
@@ -201,7 +220,7 @@ public final class DiskCheckUtil {
       LOG.error("Volume {} failed health check. {}", storageDir, message);
     }
 
-    private void logError(File storageDir, String message, Exception ex) {
+    private void logError(File storageDir, String message, Throwable ex) {
       LOG.error("Volume {} failed health check. {}", storageDir, message, ex);
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestDiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestDiskCheckUtil.java
@@ -20,11 +20,23 @@ package org.apache.hadoop.ozone.container.common.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 
 import java.io.File;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.ratis.util.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.MockedStatic;
 
 /**
  * Tests {@link DiskCheckUtil} does not incorrectly identify an unhealthy
@@ -32,6 +44,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Tests that it identifies an improperly configured directory mount point.
  *
  */
+@Execution(ExecutionMode.SAME_THREAD)
 public class TestDiskCheckUtil {
 
   @TempDir
@@ -79,5 +92,39 @@ public class TestDiskCheckUtil {
     File[] children = testDir.listFiles();
     assertNotNull(children);
     assertEquals(0, children.length);
+  }
+
+  @Test
+  public void testWriteFailureDueToTooManyOpenFiles() {
+    try (MockedStatic<FileUtils> mockService = mockStatic(FileUtils.class)) {
+
+      mockService.when(() -> FileUtils.newOutputStreamForceAtClose(any(File.class), any(OpenOption[].class)))
+          .thenThrow(new ExceptionInInitializerError("java.io.IOException: Too many open files"));
+
+      String path = "/Volumes/DiskFullTest/disk-check-c967569c";
+      assertThrows(ExceptionInInitializerError.class,
+          () -> FileUtils.newOutputStreamForceAtClose(new File(path), new OpenOption[2]));
+
+      // Test that checkReadWrite returns true for the too many open file case
+      boolean result = DiskCheckUtil.checkReadWrite(testDir, testDir, 1024);
+      assertTrue(result, "checkReadWrite should return true when too many open files");
+    }
+  }
+
+  @Test
+  public void testReadFailureDueToTooManyOpenFiles() {
+    try (MockedStatic<Files> mockService = mockStatic(Files.class)) {
+
+      String path = "/Volumes/DiskFullTest/disk-check-c967569c";
+      mockService.when(() -> Files.newInputStream(any(Path.class), any(OpenOption[].class)))
+          .thenThrow(new FileSystemException(path + ": Too many open files"));
+
+      assertThrows(FileSystemException.class,
+          () -> Files.newInputStream(Paths.get(path), new OpenOption[2]));
+
+      // Test that checkReadWrite returns true for the too many open file case
+      boolean result = DiskCheckUtil.checkReadWrite(testDir, testDir, 1024);
+      assertTrue(result, "checkReadWrite should return true when too many open files");
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If DiskCheckUtil.checkReadWrite failed due to no open file handlers during file write, the Error type exception is not caught by checkReadWrite, so the volume will be marked as failure immediately.

This task aims to catch the exception, and if it's too many open files case, tolerate it, and don't return false result. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14895

## How was this patch tested?
new unit tests 

real Files.newInputStream exception 

```
  java.nio.file.FileSystemException: /Volumes/DiskFullTest/disk-check-c967569c-a7a4-4924-b6c0-63e16d71eda0: Too many open files
  at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:100)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
  at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
  at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
  at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
  at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
  at java.base/java.nio.file.Files.newInputStream(Files.java:156)
```

real FileUtils.newOutputStreamForceAtClose exception

```
java.lang.ExceptionInInitializerError
  at java.base/sun.nio.ch.FileChannelImpl.<init>(FileChannelImpl.java:123)
  at java.base/sun.nio.ch.FileChannelImpl.open(FileChannelImpl.java:145)
  at java.base/sun.nio.fs.UnixChannelFactory.newFileChannel(UnixChannelFactory.java:144)
  at java.base/sun.nio.fs.UnixChannelFactory.newFileChannel(UnixChannelFactory.java:156)
  at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:180)
  at java.base/java.nio.channels.FileChannel.open(FileChannel.java:292)
  at java.base/java.nio.channels.FileChannel.open(FileChannel.java:345)
  at org.apache.ratis.util.FileUtils.lambda$newFileChannel$6(FileUtils.java:178)
  at org.apache.ratis.util.LogUtils.supplyAndLog(LogUtils.java:58)
  at org.apache.ratis.util.FileUtils.newFileChannel(FileUtils.java:177)
  at org.apache.ratis.util.FileUtils.newOutputStreamForceAtClose(FileUtils.java:165)
  at org.apache.ratis.util.FileUtils.newOutputStreamForceAtClose(FileUtils.java:169)
  at org.apache.hadoop.hdds.scm.TestHddsServerUtils.testTooManyOpenFiles(TestHddsServerUtils.java:411)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:566)
  at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
  at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
  at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
  at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
  at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:161)
  at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:152)
  at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:91)
  at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:112)
  at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:94)
  at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
  at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
  at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
  at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
  at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:93)
  at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:87)
  at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$4(TestMethodTestDescriptor.java:221)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:217)
  at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:159)
  at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:157)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147)
  at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:145)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:144)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:101)
  at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
  at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:161)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147)
  at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:145)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:144)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:101)
  at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
  at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:161)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147)
  at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:145)
  at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:144)
  at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:101)
  at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
  at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
  at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
  at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
  at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
  at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91)
  at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
  at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
  at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
  at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
  at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
  at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:66)
  at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:66)
  at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
  at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
  at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
  at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
  at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
Caused by: java.io.IOException: Too many open files
  at java.base/sun.nio.ch.FileDispatcherImpl.init(Native Method)
  at java.base/sun.nio.ch.FileDispatcherImpl.<clinit>(FileDispatcherImpl.java:38)
```