### PR TITLE
HDDS-14898. Fix Latent S3 API Issue having No Acl Check for ListParts

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3942,11 +3942,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     final String realVolumeName = bucket.realVolume();
     final String realBucketName = bucket.realBucket();
 
-    if (getAclsEnabled() && isStsS3Request()) {
+    if (getAclsEnabled()) {
       omMetadataReader.checkAcls(
           ResourceType.BUCKET, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, null);
       omMetadataReader.checkAcls(
-          ResourceType.KEY, StoreType.OZONE, ACLType.LIST, realVolumeName, realBucketName, keyName);
+          ResourceType.KEY, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, keyName);
     }
 
     final Map<String, String> auditMap = bucket.audit();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3938,9 +3938,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       final String bucketName, String keyName, String uploadID,
       int partNumberMarker, int maxParts)  throws IOException {
 
-    ResolvedBucket bucket = resolveBucketLink(Pair.of(volumeName, bucketName));
+    final ResolvedBucket bucket = resolveBucketLink(Pair.of(volumeName, bucketName));
+    final String realVolumeName = bucket.realVolume();
+    final String realBucketName = bucket.realBucket();
 
-    Map<String, String> auditMap = bucket.audit();
+    if (getAclsEnabled() && isStsS3Request()) {
+      omMetadataReader.checkAcls(
+          ResourceType.BUCKET, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, null);
+      omMetadataReader.checkAcls(
+          ResourceType.KEY, StoreType.OZONE, ACLType.LIST, realVolumeName, realBucketName, keyName);
+    }
+
+    final Map<String, String> auditMap = bucket.audit();
     auditMap.put(OzoneConsts.KEY, keyName);
     auditMap.put(OzoneConsts.UPLOAD_ID, uploadID);
     auditMap.put(OzoneConsts.PART_NUMBER_MARKER,
@@ -3949,9 +3958,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     metrics.incNumListMultipartUploadParts();
     try {
-      OmMultipartUploadListParts omMultipartUploadListParts =
-          keyManager.listParts(bucket.realVolume(), bucket.realBucket(),
-              keyName, uploadID, partNumberMarker, maxParts);
+      final OmMultipartUploadListParts omMultipartUploadListParts = keyManager.listParts(
+          realVolumeName, realBucketName, keyName, uploadID, partNumberMarker, maxParts);
       AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction
           .LIST_MULTIPART_UPLOAD_PARTS, auditMap));
       return omMultipartUploadListParts;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3942,28 +3942,28 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     final String realVolumeName = bucket.realVolume();
     final String realBucketName = bucket.realBucket();
 
-    if (getAclsEnabled()) {
-      omMetadataReader.checkAcls(
-          ResourceType.BUCKET, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, null);
-      omMetadataReader.checkAcls(
-          ResourceType.KEY, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, keyName);
-    }
-
     final Map<String, String> auditMap = bucket.audit();
-    auditMap.put(OzoneConsts.KEY, keyName);
-    auditMap.put(OzoneConsts.UPLOAD_ID, uploadID);
-    auditMap.put(OzoneConsts.PART_NUMBER_MARKER,
-        Integer.toString(partNumberMarker));
-    auditMap.put(OzoneConsts.MAX_PARTS, Integer.toString(maxParts));
-
-    metrics.incNumListMultipartUploadParts();
     try {
+      auditMap.put(OzoneConsts.KEY, keyName);
+      auditMap.put(OzoneConsts.UPLOAD_ID, uploadID);
+      auditMap.put(OzoneConsts.PART_NUMBER_MARKER,
+          Integer.toString(partNumberMarker));
+      auditMap.put(OzoneConsts.MAX_PARTS, Integer.toString(maxParts));
+
+      if (getAclsEnabled()) {
+        omMetadataReader.checkAcls(
+            ResourceType.BUCKET, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, null);
+        omMetadataReader.checkAcls(
+            ResourceType.KEY, StoreType.OZONE, ACLType.READ, realVolumeName, realBucketName, keyName);
+      }
+
+      metrics.incNumListMultipartUploadParts();
       final OmMultipartUploadListParts omMultipartUploadListParts = keyManager.listParts(
           realVolumeName, realBucketName, keyName, uploadID, partNumberMarker, maxParts);
       AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction
           .LIST_MULTIPART_UPLOAD_PARTS, auditMap));
       return omMultipartUploadListParts;
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       metrics.incNumListMultipartUploadPartFails();
       AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction
           .LIST_MULTIPART_UPLOAD_PARTS, auditMap, ex));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListPartsAcls.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListPartsAcls.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.LIST;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.KEY;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.ozone.audit.AuditMessage;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
+import org.apache.hadoop.ozone.security.STSTokenIdentifier;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+
+
+/**
+ * Unit tests for STS + ACL checks on {@link OzoneManager#listParts}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestOzoneManagerListPartsAcls {
+
+  private OmTestManagers omTestManagers;
+  private OzoneManager om;
+
+  private OzoneManager omSpy;
+  private OmMetadataReader omMetadataReader;
+  private KeyManager keyManager;
+  private OMMetrics metrics;
+
+  private static final String REQUESTED_VOLUME = "requestedVolume";
+  private static final String REQUESTED_BUCKET = "requestedBucket";
+  private static final String REAL_VOLUME = "realVolume";
+  private static final String REAL_BUCKET = "realBucket";
+  private static final String KEY_NAME = "object/key";
+  private static final String UPLOAD_ID = "uploadId";
+  private static final String STS_ACCESS_ID = "ASIA7O1AJD8VV4KCEAX5";
+
+  @BeforeAll
+  void setup(@TempDir File folder) throws Exception {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    ServerUtils.setOzoneMetaDirPath(conf, folder.toString());
+    omTestManagers = new OmTestManagers(conf);
+    om = omTestManagers.getOzoneManager();
+  }
+
+  @AfterAll
+  void cleanup() {
+    if (omTestManagers != null) {
+      omTestManagers.stop();
+    }
+  }
+
+  @BeforeEach
+  void init() throws Exception {
+    omSpy = spy(om);
+    omMetadataReader = mock(OmMetadataReader.class);
+    keyManager = mock(KeyManager.class);
+    metrics = mock(OMMetrics.class);
+
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "omMetadataReader", omMetadataReader);
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "keyManager", keyManager);
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "metrics", metrics);
+
+    doReturn(new ResolvedBucket(REQUESTED_VOLUME, REQUESTED_BUCKET, REAL_VOLUME, REAL_BUCKET, "owner", null))
+        .when(omSpy).resolveBucketLink(Pair.of(REQUESTED_VOLUME, REQUESTED_BUCKET));
+
+    final AuditMessage mockAuditMessage = mock(AuditMessage.class);
+    when(mockAuditMessage.getOp()).thenReturn("LIST_MULTIPART_UPLOAD_PARTS");
+    doReturn(mockAuditMessage).when(omSpy).buildAuditMessageForSuccess(any(), anyMap());
+    doReturn(mockAuditMessage).when(omSpy).buildAuditMessageForFailure(any(), anyMap(), any(Throwable.class));
+
+    when(keyManager.listParts(anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt()))
+        .thenReturn(mock(OmMultipartUploadListParts.class));
+  }
+
+  @AfterEach
+  void tearDown() {
+    OzoneManager.setS3Auth(null);
+    OzoneManager.setStsTokenIdentifier(null);
+  }
+
+  @Test
+  void testSkipsAclChecksWhenAclsAreDisabledEvenForStsRequest() throws Exception {
+    setupStsS3Request();
+    when(omSpy.getAclsEnabled()).thenReturn(false);
+
+    omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
+
+    verify(omMetadataReader, never()).checkAcls(any(), any(), any(), any(), any(), any());
+    verify(keyManager).listParts(
+        eq(REAL_VOLUME), eq(REAL_BUCKET), eq(KEY_NAME), eq(UPLOAD_ID), eq(0), eq(10));
+  }
+
+  @Test
+  void testSkipsAclChecksWhenNotStsRequestEvenIfAclsAreEnabled() throws Exception {
+    OzoneManager.setS3Auth(null);
+    OzoneManager.setStsTokenIdentifier(null);
+    when(omSpy.getAclsEnabled()).thenReturn(true);
+
+    omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
+
+    verify(omMetadataReader, never()).checkAcls(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void testAclsEnabledAndStsRequestChecksBucketReadThenKeyListUsingResolvedNames() throws Exception {
+    setupStsS3Request();
+    when(omSpy.getAclsEnabled()).thenReturn(true);
+
+    omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
+
+    final InOrder inOrder = inOrder(omMetadataReader);
+    inOrder.verify(omMetadataReader).checkAcls(BUCKET, OZONE, READ, REAL_VOLUME, REAL_BUCKET, null);
+    inOrder.verify(omMetadataReader).checkAcls(KEY, OZONE, LIST, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
+    verify(keyManager).listParts(
+        eq(REAL_VOLUME), eq(REAL_BUCKET), eq(KEY_NAME), eq(UPLOAD_ID), eq(0), eq(10));
+    verify(metrics).incNumListMultipartUploadParts();
+    verify(metrics, never()).incNumListMultipartUploadPartFails();
+  }
+
+  @Test
+  void testReadAclAccessDeniedSkipsKeyManagerAndKeyListAclChecksAndNoMetrics() throws Exception {
+    setupStsS3Request();
+    when(omSpy.getAclsEnabled()).thenReturn(true);
+
+    doThrow(new OMException("denied", OMException.ResultCodes.PERMISSION_DENIED))
+        .when(omMetadataReader).checkAcls(BUCKET, OZONE, READ, REAL_VOLUME, REAL_BUCKET, null);
+
+    assertThrows(
+        OMException.class, () -> omSpy.listParts(
+            REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10));
+
+    verify(keyManager, never()).listParts(
+        anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt());
+    verify(metrics, never()).incNumListMultipartUploadParts();
+    verify(metrics, never()).incNumListMultipartUploadPartFails();
+    verify(omMetadataReader, never()).checkAcls(KEY, OZONE, LIST, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
+  }
+
+  @Test
+  void testKeyListAclAccessDeniedSkipsKeyManagerAndNoMetrics() throws Exception {
+    setupStsS3Request();
+    when(omSpy.getAclsEnabled()).thenReturn(true);
+
+    doNothing().when(omMetadataReader).checkAcls(BUCKET, OZONE, READ, REAL_VOLUME, REAL_BUCKET, null);
+    doThrow(new OMException("denied", OMException.ResultCodes.PERMISSION_DENIED))
+        .when(omMetadataReader).checkAcls(KEY, OZONE, LIST, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
+
+    assertThrows(
+        OMException.class, () -> omSpy.listParts(
+            REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10));
+
+    verify(keyManager, never()).listParts(
+        anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt());
+    verify(metrics, never()).incNumListMultipartUploadParts();
+    verify(metrics, never()).incNumListMultipartUploadPartFails();
+  }
+
+  @Test
+  void testNonStsRequestSkipsAclChecks() throws Exception {
+    OzoneManager.setS3Auth(S3Authentication.newBuilder().setAccessId(STS_ACCESS_ID).build());
+    OzoneManager.setStsTokenIdentifier(null);
+    when(omSpy.getAclsEnabled()).thenReturn(true);
+
+    omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
+
+    verify(omMetadataReader, never()).checkAcls(any(), any(), any(), any(), any(), any());
+  }
+
+  private void setupStsS3Request() {
+    OzoneManager.setS3Auth(S3Authentication.newBuilder().setAccessId(STS_ACCESS_ID).build());
+    OzoneManager.setStsTokenIdentifier(mock(STSTokenIdentifier.class));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListPartsAcls.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListPartsAcls.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om;
 
-import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.LIST;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.KEY;
@@ -47,7 +46,6 @@ import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
-import org.apache.hadoop.ozone.security.STSTokenIdentifier;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,7 +57,7 @@ import org.mockito.InOrder;
 
 
 /**
- * Unit tests for STS + ACL checks on {@link OzoneManager#listParts}.
+ * Unit tests for ACL checks on {@link OzoneManager#listParts}.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestOzoneManagerListPartsAcls {
@@ -78,7 +76,6 @@ public class TestOzoneManagerListPartsAcls {
   private static final String REAL_BUCKET = "realBucket";
   private static final String KEY_NAME = "object/key";
   private static final String UPLOAD_ID = "uploadId";
-  private static final String STS_ACCESS_ID = "ASIA7O1AJD8VV4KCEAX5";
 
   @BeforeAll
   void setup(@TempDir File folder) throws Exception {
@@ -121,12 +118,11 @@ public class TestOzoneManagerListPartsAcls {
   @AfterEach
   void tearDown() {
     OzoneManager.setS3Auth(null);
-    OzoneManager.setStsTokenIdentifier(null);
   }
 
   @Test
-  void testSkipsAclChecksWhenAclsAreDisabledEvenForStsRequest() throws Exception {
-    setupStsS3Request();
+  void testSkipsAclChecksWhenAclsAreDisabled() throws Exception {
+    setupS3Request();
     when(omSpy.getAclsEnabled()).thenReturn(false);
 
     omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
@@ -137,26 +133,15 @@ public class TestOzoneManagerListPartsAcls {
   }
 
   @Test
-  void testSkipsAclChecksWhenNotStsRequestEvenIfAclsAreEnabled() throws Exception {
-    OzoneManager.setS3Auth(null);
-    OzoneManager.setStsTokenIdentifier(null);
-    when(omSpy.getAclsEnabled()).thenReturn(true);
-
-    omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
-
-    verify(omMetadataReader, never()).checkAcls(any(), any(), any(), any(), any(), any());
-  }
-
-  @Test
-  void testAclsEnabledAndStsRequestChecksBucketReadThenKeyListUsingResolvedNames() throws Exception {
-    setupStsS3Request();
+  void testAclsEnabledChecksBucketReadThenKeyReadUsingResolvedNames() throws Exception {
+    setupS3Request();
     when(omSpy.getAclsEnabled()).thenReturn(true);
 
     omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
 
     final InOrder inOrder = inOrder(omMetadataReader);
     inOrder.verify(omMetadataReader).checkAcls(BUCKET, OZONE, READ, REAL_VOLUME, REAL_BUCKET, null);
-    inOrder.verify(omMetadataReader).checkAcls(KEY, OZONE, LIST, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
+    inOrder.verify(omMetadataReader).checkAcls(KEY, OZONE, READ, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
     verify(keyManager).listParts(
         eq(REAL_VOLUME), eq(REAL_BUCKET), eq(KEY_NAME), eq(UPLOAD_ID), eq(0), eq(10));
     verify(metrics).incNumListMultipartUploadParts();
@@ -164,8 +149,8 @@ public class TestOzoneManagerListPartsAcls {
   }
 
   @Test
-  void testReadAclAccessDeniedSkipsKeyManagerAndKeyListAclChecksAndNoMetrics() throws Exception {
-    setupStsS3Request();
+  void testReadAclAccessDeniedSkipsKeyManagerAndKeyReadAclChecksAndNoMetrics() throws Exception {
+    setupS3Request();
     when(omSpy.getAclsEnabled()).thenReturn(true);
 
     doThrow(new OMException("denied", OMException.ResultCodes.PERMISSION_DENIED))
@@ -179,17 +164,17 @@ public class TestOzoneManagerListPartsAcls {
         anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt());
     verify(metrics, never()).incNumListMultipartUploadParts();
     verify(metrics, never()).incNumListMultipartUploadPartFails();
-    verify(omMetadataReader, never()).checkAcls(KEY, OZONE, LIST, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
+    verify(omMetadataReader, never()).checkAcls(KEY, OZONE, READ, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
   }
 
   @Test
-  void testKeyListAclAccessDeniedSkipsKeyManagerAndNoMetrics() throws Exception {
-    setupStsS3Request();
+  void testKeyReadAclAccessDeniedSkipsKeyManagerAndNoMetrics() throws Exception {
+    setupS3Request();
     when(omSpy.getAclsEnabled()).thenReturn(true);
 
     doNothing().when(omMetadataReader).checkAcls(BUCKET, OZONE, READ, REAL_VOLUME, REAL_BUCKET, null);
     doThrow(new OMException("denied", OMException.ResultCodes.PERMISSION_DENIED))
-        .when(omMetadataReader).checkAcls(KEY, OZONE, LIST, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
+        .when(omMetadataReader).checkAcls(KEY, OZONE, READ, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
 
     assertThrows(
         OMException.class, () -> omSpy.listParts(
@@ -201,19 +186,7 @@ public class TestOzoneManagerListPartsAcls {
     verify(metrics, never()).incNumListMultipartUploadPartFails();
   }
 
-  @Test
-  void testNonStsRequestSkipsAclChecks() throws Exception {
-    OzoneManager.setS3Auth(S3Authentication.newBuilder().setAccessId(STS_ACCESS_ID).build());
-    OzoneManager.setStsTokenIdentifier(null);
-    when(omSpy.getAclsEnabled()).thenReturn(true);
-
-    omSpy.listParts(REQUESTED_VOLUME, REQUESTED_BUCKET, KEY_NAME, UPLOAD_ID, 0, 10);
-
-    verify(omMetadataReader, never()).checkAcls(any(), any(), any(), any(), any(), any());
-  }
-
-  private void setupStsS3Request() {
-    OzoneManager.setS3Auth(S3Authentication.newBuilder().setAccessId(STS_ACCESS_ID).build());
-    OzoneManager.setStsTokenIdentifier(mock(STSTokenIdentifier.class));
+  private void setupS3Request() {
+    OzoneManager.setS3Auth(S3Authentication.newBuilder().setAccessId("AKIAJWFJK62WUTKNFJJA").build());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListPartsAcls.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListPartsAcls.java
@@ -130,6 +130,8 @@ public class TestOzoneManagerListPartsAcls {
     verify(omMetadataReader, never()).checkAcls(any(), any(), any(), any(), any(), any());
     verify(keyManager).listParts(
         eq(REAL_VOLUME), eq(REAL_BUCKET), eq(KEY_NAME), eq(UPLOAD_ID), eq(0), eq(10));
+    verify(metrics).incNumListMultipartUploadParts();
+    verify(metrics, never()).incNumListMultipartUploadPartFails();
   }
 
   @Test
@@ -149,7 +151,7 @@ public class TestOzoneManagerListPartsAcls {
   }
 
   @Test
-  void testReadAclAccessDeniedSkipsKeyManagerAndKeyReadAclChecksAndNoMetrics() throws Exception {
+  void testReadAclAccessDeniedSkipsKeyManagerAndKeyReadAclChecksAndRecordsFailure() throws Exception {
     setupS3Request();
     when(omSpy.getAclsEnabled()).thenReturn(true);
 
@@ -163,12 +165,13 @@ public class TestOzoneManagerListPartsAcls {
     verify(keyManager, never()).listParts(
         anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt());
     verify(metrics, never()).incNumListMultipartUploadParts();
-    verify(metrics, never()).incNumListMultipartUploadPartFails();
+    verify(metrics).incNumListMultipartUploadPartFails();
+    verify(omSpy).buildAuditMessageForFailure(any(), anyMap(), any(Throwable.class));
     verify(omMetadataReader, never()).checkAcls(KEY, OZONE, READ, REAL_VOLUME, REAL_BUCKET, KEY_NAME);
   }
 
   @Test
-  void testKeyReadAclAccessDeniedSkipsKeyManagerAndNoMetrics() throws Exception {
+  void testKeyReadAclAccessDeniedSkipsKeyManagerAndRecordsFailure() throws Exception {
     setupS3Request();
     when(omSpy.getAclsEnabled()).thenReturn(true);
 
@@ -183,7 +186,8 @@ public class TestOzoneManagerListPartsAcls {
     verify(keyManager, never()).listParts(
         anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt());
     verify(metrics, never()).incNumListMultipartUploadParts();
-    verify(metrics, never()).incNumListMultipartUploadPartFails();
+    verify(metrics).incNumListMultipartUploadPartFails();
+    verify(omSpy).buildAuditMessageForFailure(any(), anyMap(), any(Throwable.class));
   }
 
   private void setupS3Request() {


### PR DESCRIPTION
Please describe your PR in detail:
* Currently, there are no acl checks in the S3 ListParts implementation. This ticket adds the acl checks.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14898

## How was this patch tested?
unit tests, smoke tests