### PR TITLE
HDDS-14829. Split snapshot diff job into separate rpc calls for submitting job and getting the report.

### DIFF
--- a/hadoop-hdds/docs/content/feature/Snapshot.md
+++ b/hadoop-hdds/docs/content/feature/Snapshot.md
@@ -93,9 +93,14 @@ Manage snapshots using `ozone sh` or `ozone fs` (Hadoop-compatible) commands:
     ```
     Requires read privileges on the bucket.
 
-*   **Snapshot Diff:** Shows changes between two snapshots or a snapshot and the live bucket.
+*   **Submit Snapshot Diff:** Submit job to find diff between two snapshots or a snapshot and the live bucket.
     ```shell
     ozone sh snapshot diff /vol1/bucket1 <snap1> <snap2_or_live_bucket>
+    ```
+  
+*   **Get Snapshot Diff Report:** Shows changes between two snapshots or a snapshot and the live bucket.
+    ```shell
+    ozone sh snapshot diff --get-report /vol1/bucket1 <snap1> <snap2_or_live_bucket>
     ```
     Output prefixes: `+` (add), `-` (delete), `M` (modify), `R` (rename). Use `-p`, `-t` for pagination.
     Manage diff jobs: `ozone sh snapshot listDiff /vol1/bucket1`, `ozone sh snapshot cancelDiff <jobId>`.

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -131,8 +131,17 @@ public class SnapshotDiffHandler extends Handler {
       response = store.submitSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
           forceFullDiff, diffDisableNativeLibs);
     } catch (OMException ex) {
+      // submit snapshot diff falls back to legacy snapshotDiff is server does not support it.
       if (ex.getResult() == OMException.ResultCodes.NOT_SUPPORTED_OPERATION) {
-        getSnapshotDiff(store, volumeName, bucketName);
+        SnapshotDiffResponse diffResponse = store.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+            token, pageSize, forceFullDiff, diffDisableNativeLibs);
+        try (PrintWriter writer = out()) {
+          if (json) {
+            writer.println(toJsonStringWithDefaultPrettyPrinter(getJsonObject(diffResponse)));
+          } else {
+            writer.println(diffResponse);
+          }
+        }
       }
       return;
     }

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -142,8 +142,9 @@ public class SnapshotDiffHandler extends Handler {
             writer.println(diffResponse);
           }
         }
+        return;
       }
-      return;
+      throw ex;
     }
     try (PrintWriter writer = out()) {
       writer.println(response);

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -83,7 +83,7 @@ public class SnapshotDiffHandler extends Handler {
   private boolean cancel;
 
   @CommandLine.Option(names = {"-r", "--get-report"},
-      description = "Get the snapshot diff report is available; " +
+      description = "Get the snapshot diff report if available; " +
           "does not submit a diff job if there is no job in progress.",
       defaultValue = "false")
   private boolean getReport;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -31,11 +31,13 @@ import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.shell.Handler;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import picocli.CommandLine;
 
 /**
@@ -124,9 +126,18 @@ public class SnapshotDiffHandler extends Handler {
 
   private void submitSnapshotDiff(ObjectStore store, String volumeName,
                                String bucketName) throws IOException {
+    SubmitSnapshotDiffResponse response;
+    try {
+      response = store.submitSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+          forceFullDiff, diffDisableNativeLibs);
+    } catch (OMException ex) {
+      if (ex.getResult() == OMException.ResultCodes.NOT_SUPPORTED_OPERATION) {
+        getSnapshotDiff(store, volumeName, bucketName);
+      }
+      return;
+    }
     try (PrintWriter writer = out()) {
-      writer.println(store.submitSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
-          forceFullDiff, diffDisableNativeLibs));
+      writer.println(response);
     }
   }
 

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -82,6 +82,12 @@ public class SnapshotDiffHandler extends Handler {
       defaultValue = "false")
   private boolean cancel;
 
+  @CommandLine.Option(names = {"-r", "--get-report"},
+      description = "Get the snapshot diff report is available; " +
+          "does not submit a diff job if there is no job in progress.",
+      defaultValue = "false")
+  private boolean getReport;
+
   @CommandLine.Option(names = {"--dnld", "--disable-native-libs-diff"},
       description = "perform diff of snapshot without using" +
           " native libs (optional)",
@@ -109,15 +115,25 @@ public class SnapshotDiffHandler extends Handler {
 
     if (cancel) {
       cancelSnapshotDiff(client.getObjectStore(), volumeName, bucketName);
-    } else {
+    } else if (getReport) {
       getSnapshotDiff(client.getObjectStore(), volumeName, bucketName);
+    } else {
+      submitSnapshotDiff(client.getObjectStore(), volumeName, bucketName);
+    }
+  }
+
+  private void submitSnapshotDiff(ObjectStore store, String volumeName,
+                               String bucketName) throws IOException {
+    try (PrintWriter writer = out()) {
+      writer.println(store.submitSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+          forceFullDiff, diffDisableNativeLibs));
     }
   }
 
   private void getSnapshotDiff(ObjectStore store, String volumeName,
                                String bucketName) throws IOException {
     SnapshotDiffResponse diffResponse = store.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
-        token, pageSize, forceFullDiff, diffDisableNativeLibs);
+        token, pageSize);
     try (PrintWriter writer = out()) {
       if (json) {
         writer.println(toJsonStringWithDefaultPrettyPrinter(getJsonObject(diffResponse)));

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
@@ -698,6 +699,7 @@ public class ObjectStore {
    * @throws IOException in case of any exception while generating snapshot diff
    */
   @SuppressWarnings("parameternumber")
+  @Deprecated()
   public SnapshotDiffResponse snapshotDiff(String volumeName,
                                            String bucketName,
                                            String fromSnapshot,
@@ -709,6 +711,50 @@ public class ObjectStore {
       throws IOException {
     return proxy.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
         token, pageSize, forceFullDiff, disableNativeDiff);
+  }
+
+  /**
+   * Get the differences between two snapshots.
+   * @param volumeName Name of the volume to which the snapshot bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param token to get the index to return diff report from.
+   * @param pageSize maximum entries returned to the report.
+   * @return the difference report between two snapshots
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize)
+      throws IOException {
+    return proxy.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+        token, pageSize);
+  }
+
+  /**
+   * Submit snapshot diff job.
+   * @param volumeName Name of the volume to which the snapshot bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param disableNativeDiff request to force diff to perform diffs without native lib
+   * @return the result of submitting snapshot diff job.
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  public SubmitSnapshotDiffResponse submitSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       boolean forceFullDiff,
+                                                       boolean disableNativeDiff)
+      throws IOException {
+    return proxy.submitSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+        forceFullDiff, disableNativeDiff);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import jakarta.annotation.Nullable;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
@@ -71,6 +72,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.Token;
 
@@ -1325,14 +1327,49 @@ public interface ClientProtocol {
    * @param pageSize maximum entries returned to the report.
    * @param forceFullDiff request to force full diff, skipping DAG optimization
    * @return the difference report between two snapshots
+   * @deprecated Use {@link #snapshotDiff(String, String, String, String, String, int, boolean, boolean, boolean)}
+   * instead to submit a new snapshot diff job or just return the existing job result.
    * @throws IOException in case of any exception while generating snapshot diff
    */
+  @Deprecated
   @SuppressWarnings("parameternumber")
   SnapshotDiffResponse snapshotDiff(String volumeName, String bucketName,
                                     String fromSnapshot, String toSnapshot,
                                     String token, int pageSize,
                                     boolean forceFullDiff,
                                     boolean disableNativeDiff)
+      throws IOException;
+
+  /**
+   * Get the differences between two snapshots.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param token to get the index to return diff report from.
+   * @param pageSize maximum entries returned to the report.
+   * @return the difference report between two snapshots
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  SnapshotDiffResponse snapshotDiff(String volumeName, String bucketName,
+                                    String fromSnapshot, String toSnapshot,
+                                    String token, int pageSize)
+      throws IOException;
+
+  /**
+   * Submit snapshot diff job.
+   * @param volumeName Name of the volume to which the snapshot bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param disableNativeDiff request to force diff to perform diffs without native lib
+   * @return the result of submitting snapshot diff job.
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  SubmitSnapshotDiffResponse submitSnapshotDiff(String volumeName, String bucketName,
+                                                String fromSnapshot, String toSnapshot,
+                                                boolean forceFullDiff, boolean disableNativeDiff)
       throws IOException;
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import jakarta.annotation.Nullable;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1325,8 +1325,9 @@ public interface ClientProtocol {
    * @param token to get the index to return diff report from.
    * @param pageSize maximum entries returned to the report.
    * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param disableNativeDiff request to force diff to perform diffs without native lib
    * @return the difference report between two snapshots
-   * @deprecated Use {@link #snapshotDiff(String, String, String, String, String, int, boolean, boolean, boolean)}
+   * @deprecated Use {@link #snapshotDiff(String, String, String, String, String, int)}
    * instead to submit a new snapshot diff job or just return the existing job result.
    * @throws IOException in case of any exception while generating snapshot diff
    */

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -177,6 +177,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
@@ -1035,6 +1036,7 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  @Deprecated
   public SnapshotDiffResponse snapshotDiff(String volumeName,
                                            String bucketName,
                                            String fromSnapshot,
@@ -1051,6 +1053,38 @@ public class RpcClient implements ClientProtocol {
     return ozoneManagerClient.snapshotDiff(volumeName, bucketName,
         fromSnapshot, toSnapshot, token, pageSize, forceFullDiff,
         disableNativeDiff);
+  }
+
+  @Override
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize)
+      throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    return ozoneManagerClient.snapshotDiff(volumeName, bucketName,
+        fromSnapshot, toSnapshot, token, pageSize);
+  }
+
+  @Override
+  public SubmitSnapshotDiffResponse submitSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       boolean forceFullDiff,
+                                                       boolean disableNativeDiff)
+      throws IOException {
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    return ozoneManagerClient.submitSnapshotDiff(volumeName, bucketName,
+        fromSnapshot, toSnapshot, forceFullDiff, disableNativeDiff);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -251,6 +251,7 @@ public final class OmUtils {
     case SnapshotDiff:
     case CancelSnapshotDiff:
     case ListSnapshotDiffJobs:
+    case SubmitSnapshotDiff:
     case TransferLeadership:
     case SetSafeMode:
     case PrintCompactionLogDag:
@@ -441,6 +442,7 @@ public final class OmUtils {
     case SnapshotDiff:
     case CancelSnapshotDiff:
     case ListSnapshotDiffJobs:
+    case SubmitSnapshotDiff:
     case PrintCompactionLogDag:
       // Snapshot diff is a local to a single OM node so we should not send it arbitrarily
       // to any OM nodes

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
@@ -291,6 +291,9 @@ public class SnapshotDiffJob {
     if (largestEntryKey != null) {
       builder.setLargestEntryKey(largestEntryKey);
     }
+    if (StringUtils.isNotEmpty(reason)) {
+      builder.setMessage(reason);
+    }
 
     return builder.build();
   }
@@ -302,7 +305,7 @@ public class SnapshotDiffJob {
     SubStatus subStatus = (diffJobProto.hasSubStatus()) ?
         SubStatus.fromProtoBuf(diffJobProto.getSubStatus()) : null;
     String largestEntryKey = diffJobProto.hasLargestEntryKey() ? diffJobProto.getLargestEntryKey() : null;
-    return new SnapshotDiffJob(
+    SnapshotDiffJob job = new SnapshotDiffJob(
         diffJobProto.getCreationTime(),
         diffJobProto.getJobId(),
         status,
@@ -316,6 +319,10 @@ public class SnapshotDiffJob {
         subStatus,
         diffJobProto.getKeysProcessedPct(),
         largestEntryKey);
+    if (diffJobProto.hasMessage()) {
+      job.setReason(diffJobProto.getMessage());
+    }
+    return job;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import jakarta.annotation.Nullable;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -73,6 +74,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.TokenInfo;
@@ -793,8 +795,11 @@ public interface OzoneManagerProtocol
    * @param pageSize maximum entries returned to the report.
    * @param forceFullDiff request to force full diff, skipping DAG optimization
    * @return the difference report between two snapshots
+   * @deprecated Use {@link #snapshotDiff(String, String, String, String, String, int, boolean, boolean, Boolean)}
+   * instead
    * @throws IOException in case of any exception while generating snapshot diff
    */
+  @Deprecated
   @SuppressWarnings("parameternumber")
   default SnapshotDiffResponse snapshotDiff(String volumeName,
                                             String bucketName,
@@ -804,6 +809,51 @@ public interface OzoneManagerProtocol
                                             int pageSize,
                                             boolean forceFullDiff,
                                             boolean disableNativeDiff)
+      throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
+   * Get the differences between two snapshots.
+   * @param volumeName Name of the volume to which the snapshotted bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param token to get the index to return diff report from.
+   * @param pageSize maximum entries returned to the report.
+   * @return the difference report between two snapshots
+   * instead
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  default SnapshotDiffResponse snapshotDiff(String volumeName,
+                                            String bucketName,
+                                            String fromSnapshot,
+                                            String toSnapshot,
+                                            String token,
+                                            int pageSize)
+      throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
+   * Submit snapshot diff job.
+   * @param volumeName Name of the volume to which the snapshot bucket belong
+   * @param bucketName Name of the bucket to which the snapshots belong
+   * @param fromSnapshot The name of the starting snapshot
+   * @param toSnapshot The name of the ending snapshot
+   * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param disableNativeDiff request to force diff to perform diffs without native lib
+   * @return the result of submitting snapshot diff job.
+   * @throws IOException in case of any exception while generating snapshot diff
+   */
+  default SubmitSnapshotDiffResponse submitSnapshotDiff(String volumeName,
+                                                String bucketName,
+                                                String fromSnapshot,
+                                                String toSnapshot,
+                                                boolean forceFullDiff,
+                                                boolean disableNativeDiff)
       throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented");

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -793,8 +793,9 @@ public interface OzoneManagerProtocol
    * @param token to get the index to return diff report from.
    * @param pageSize maximum entries returned to the report.
    * @param forceFullDiff request to force full diff, skipping DAG optimization
+   * @param disableNativeDiff request to force diff to perform diffs without native lib
    * @return the difference report between two snapshots
-   * @deprecated Use {@link #snapshotDiff(String, String, String, String, String, int, boolean, boolean, Boolean)}
+   * @deprecated Use {@link #snapshotDiff(String, String, String, String, String, int)}
    * instead
    * @throws IOException in case of any exception while generating snapshot diff
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import jakarta.annotation.Nullable;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.ozone.OzoneAcl;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -245,6 +245,7 @@ import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.ozone.util.ProtobufUtils;
@@ -1382,6 +1383,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * {@inheritDoc}
    */
   @Override
+  @Deprecated
   public SnapshotDiffResponse snapshotDiff(String volumeName,
                                            String bucketName,
                                            String fromSnapshot,
@@ -1391,6 +1393,35 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                            boolean forceFullDiff,
                                            boolean disableNativeDiff)
       throws IOException {
+    return snapshotDiffInternal(volumeName, bucketName, fromSnapshot, toSnapshot, token,
+        pageSize, forceFullDiff, disableNativeDiff);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize)
+      throws IOException {
+    return snapshotDiffInternal(volumeName, bucketName, fromSnapshot, toSnapshot, token,
+        pageSize, null, null);
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private SnapshotDiffResponse snapshotDiffInternal(String volumeName,
+                                                    String bucketName,
+                                                    String fromSnapshot,
+                                                    String toSnapshot,
+                                                    String token,
+                                                    int pageSize,
+                                                    Boolean forceFullDiff,
+                                                    Boolean disableNativeDiff)
+      throws IOException {
     final OzoneManagerProtocolProtos.SnapshotDiffRequest.Builder
         requestBuilder =
         OzoneManagerProtocolProtos.SnapshotDiffRequest.newBuilder()
@@ -1398,9 +1429,15 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .setBucketName(bucketName)
             .setFromSnapshot(fromSnapshot)
             .setToSnapshot(toSnapshot)
-            .setPageSize(pageSize)
-            .setForceFullDiff(forceFullDiff)
-            .setDisableNativeDiff(disableNativeDiff);
+            .setPageSize(pageSize);
+
+    if (forceFullDiff != null) {
+      requestBuilder.setForceFullDiff(forceFullDiff);
+    }
+
+    if (disableNativeDiff != null) {
+      requestBuilder.setDisableNativeDiff(disableNativeDiff);
+    }
 
     if (!StringUtils.isBlank(token)) {
       requestBuilder.setToken(token);
@@ -1419,6 +1456,38 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         JobStatus.fromProtobuf(diffResponse.getJobStatus()),
         diffResponse.getWaitTimeInMs(),
         diffResponse.getReason());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SubmitSnapshotDiffResponse submitSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       boolean forceFullDiff,
+                                                       boolean disableNativeDiff)
+      throws IOException {
+    final OzoneManagerProtocolProtos.SubmitSnapshotDiffRequest.Builder
+        requestBuilder =
+        OzoneManagerProtocolProtos.SubmitSnapshotDiffRequest.newBuilder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setFromSnapshot(fromSnapshot)
+            .setToSnapshot(toSnapshot)
+            .setForceFullDiff(forceFullDiff)
+            .setDisableNativeDiff(disableNativeDiff);
+
+    final OMRequest omRequest = createOMRequest(Type.SubmitSnapshotDiff)
+        .setSubmitSnapshotDiffRequest(requestBuilder)
+        .build();
+    final OMResponse omResponse = submitRequest(omRequest);
+    handleError(omResponse);
+    OzoneManagerProtocolProtos.SubmitSnapshotDiffResponse submitDiffResponse =
+        omResponse.getSubmitSnapshotDiffResponse();
+
+    return new SubmitSnapshotDiffResponse(submitDiffResponse.getResponse());
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.UnsafeByteOperations;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
@@ -52,6 +53,7 @@ import org.apache.hadoop.hdds.tracing.SkipTracing;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc_.CallerContext;
+import org.apache.hadoop.ipc_.RemoteException;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -1482,11 +1484,19 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final OMRequest omRequest = createOMRequest(Type.SubmitSnapshotDiff)
         .setSubmitSnapshotDiffRequest(requestBuilder)
         .build();
-    final OMResponse omResponse = submitRequest(omRequest);
-    handleError(omResponse);
+    final OMResponse omResponse;
+    try {
+      omResponse = submitRequest(omRequest);
+      handleError(omResponse);
+    } catch (IOException ex) {
+      if ((ex instanceof RemoteException) &&
+          (InvalidProtocolBufferException.class.getName().equals(((RemoteException) ex).getClassName()))) {
+        throw new OMException("Server does not support SubmitSnapshotDiff API", ResultCodes.NOT_SUPPORTED_OPERATION);
+      }
+      throw ex;
+    }
     OzoneManagerProtocolProtos.SubmitSnapshotDiffResponse submitDiffResponse =
         omResponse.getSubmitSnapshotDiffResponse();
-
     return new SubmitSnapshotDiffResponse(submitDiffResponse.getResponse());
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1396,7 +1396,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                            boolean disableNativeDiff)
       throws IOException {
     return snapshotDiffInternal(volumeName, bucketName, fromSnapshot, toSnapshot, token,
-        pageSize, forceFullDiff, disableNativeDiff);
+        pageSize, forceFullDiff, disableNativeDiff, false);
   }
 
   /**
@@ -1411,7 +1411,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                            int pageSize)
       throws IOException {
     return snapshotDiffInternal(volumeName, bucketName, fromSnapshot, toSnapshot, token,
-        pageSize, null, null);
+        pageSize, null, null, true);
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -1422,7 +1422,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                                     String token,
                                                     int pageSize,
                                                     Boolean forceFullDiff,
-                                                    Boolean disableNativeDiff)
+                                                    Boolean disableNativeDiff,
+                                                    boolean reportOnly)
       throws IOException {
     final OzoneManagerProtocolProtos.SnapshotDiffRequest.Builder
         requestBuilder =
@@ -1457,7 +1458,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         diffResponse.getSnapshotDiffReport()),
         JobStatus.fromProtobuf(diffResponse.getJobStatus()),
         diffResponse.getWaitTimeInMs(),
-        diffResponse.getReason());
+        diffResponse.getReason(),
+        reportOnly);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffResponse.java
@@ -32,6 +32,15 @@ public class SnapshotDiffResponse {
   private final String reason;
   private SubStatus subStatus;
   private double progressPercent = 0.0;
+  private boolean isReportOnly = false;
+
+  public SnapshotDiffResponse(final SnapshotDiffReportOzone snapshotDiffReport,
+                              final JobStatus jobStatus,
+                              final long waitTimeInMs,
+                              boolean isReportOnly) {
+    this(snapshotDiffReport, jobStatus, waitTimeInMs);
+    this.isReportOnly = isReportOnly;
+  }
 
   public SnapshotDiffResponse(final SnapshotDiffReportOzone snapshotDiffReport,
                               final JobStatus jobStatus,
@@ -40,6 +49,15 @@ public class SnapshotDiffResponse {
     this.jobStatus = jobStatus;
     this.waitTimeInMs = waitTimeInMs;
     this.reason = StringUtils.EMPTY;
+  }
+
+  public SnapshotDiffResponse(final SnapshotDiffReportOzone snapshotDiffReport,
+                              final JobStatus jobStatus,
+                              final long waitTimeInMs,
+                              final String reason,
+                              boolean isReportOnly) {
+    this(snapshotDiffReport, jobStatus, waitTimeInMs, reason);
+    this.isReportOnly = isReportOnly;
   }
 
   public SnapshotDiffResponse(final SnapshotDiffReportOzone snapshotDiffReport,
@@ -90,19 +108,34 @@ public class SnapshotDiffResponse {
       } else {
         str.append("Unknown reason.");
       }
-      str.append("'. Please retry after ")
-          .append(waitTimeInMs)
-          .append(" ms.\n");
+
+      if (isReportOnly) {
+        str.append("'.\n Please resubmit the job without using the --get-report option.\n");
+      } else {
+        str.append("'. Please retry after ").append(waitTimeInMs).append(" ms.\n");
+      }
       break;
-    case CANCELLED:
-      str.append("Snapshot diff job has been CANCELLED.");
+    case REJECTED:
+      str.append("Snapshot diff job is REJECTED.\n");
+      if (isReportOnly) {
+        str.append(" Please resubmit the job without using the --get-report option.");
+      } else {
+        str.append(" Please retry after ").append(waitTimeInMs).append(" ms.\n");
+      }
+      break;
+    case NOT_FOUND:
+      str.append("No snapshot diff job found. Job may not have been submitted or was removed during cleanup.\n" +
+          "Submit a new snapshot diff job without using the --get-report option.\n");
       break;
     default:
       str.append("Snapshot diff job is ")
-          .append(jobStatus)
-          .append(". Please retry after ")
-          .append(waitTimeInMs)
-          .append(" ms.\n");
+          .append(jobStatus);
+      if (waitTimeInMs > 0L) {
+        str.append(". Please retry after ")
+            .append(waitTimeInMs)
+            .append(" ms");
+      }
+      str.append(".\n");
       if (subStatus != null) {
         str.append("SubStatus : ")
             .append(subStatus);
@@ -125,7 +158,8 @@ public class SnapshotDiffResponse {
     DONE,
     REJECTED,
     FAILED,
-    CANCELLED;
+    CANCELLED,
+    NOT_FOUND;
 
     public JobStatusProto toProtobuf() {
       return JobStatusProto.valueOf(this.name());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffResponse.java
@@ -124,8 +124,13 @@ public class SnapshotDiffResponse {
       }
       break;
     case NOT_FOUND:
-      str.append("No snapshot diff job found. Job may not have been submitted or was removed during cleanup.\n" +
-          "Submit a new snapshot diff job without using the --get-report option.\n");
+      if (isReportOnly) {
+        str.append("No snapshot diff job found. Job may not have been submitted or was removed during cleanup.\n" +
+            "Submit a new snapshot diff job without using the --get-report option.\n");
+
+      } else {
+        str.append("Invalid state for submit snapshot diff call");
+      }
       break;
     default:
       str.append("Snapshot diff job is ")

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SubmitSnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SubmitSnapshotDiffResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.snapshot;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * POJO for Submit Snapshot Diff Response.
+ */
+public class SubmitSnapshotDiffResponse {
+  private final String response;
+
+  public SubmitSnapshotDiffResponse(long waitTimeInMs, SnapshotDiffResponse.JobStatus prevStatus, String prevReason) {
+    StringBuilder msgBuilder = new StringBuilder();
+    if (prevStatus != null) {
+      msgBuilder.append("Previous snapshot diff attempt found. Status: ")
+          .append(prevStatus);
+      if (StringUtils.isNotEmpty(prevReason)) {
+        msgBuilder.append(", reason: ").append(prevReason);
+      }
+      msgBuilder.append(".\n");
+    }
+    if (prevStatus == SnapshotDiffResponse.JobStatus.DONE || prevStatus == SnapshotDiffResponse.JobStatus.IN_PROGRESS) {
+      msgBuilder.append("Please get the report using --get-report option");
+      if (prevStatus == SnapshotDiffResponse.JobStatus.IN_PROGRESS) {
+        msgBuilder.append(" in ").append(waitTimeInMs).append(" ms");
+      }
+      msgBuilder.append(".\n");
+    } else {
+      msgBuilder.append("Submitting a new job. Please retry after ")
+          .append(waitTimeInMs)
+          .append(" ms using --get-report option to get the report.\n");
+    }
+
+    this.response = msgBuilder.toString();
+  }
+
+  public SubmitSnapshotDiffResponse(String response) {
+    this.response = response;
+  }
+
+  public String getResponse() {
+    return response;
+  }
+
+  @Override
+  public String toString() {
+    return response;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SubmitSnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SubmitSnapshotDiffResponse.java
@@ -27,7 +27,7 @@ public class SubmitSnapshotDiffResponse {
 
   public SubmitSnapshotDiffResponse(long waitTimeInMs, SnapshotDiffResponse.JobStatus prevStatus, String prevReason) {
     StringBuilder msgBuilder = new StringBuilder();
-    if (prevStatus != null) {
+    if (prevStatus != null && prevStatus != SnapshotDiffResponse.JobStatus.QUEUED) {
       msgBuilder.append("Previous snapshot diff attempt found. Status: ")
           .append(prevStatus);
       if (StringUtils.isNotEmpty(prevReason)) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/snapshot/TestSnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/snapshot/TestSnapshotDiffResponse.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus;
+import org.junit.jupiter.api.Test;
+
+class TestSnapshotDiffResponse {
+
+  @Test
+  void testReportOnlyNotFoundMessage() {
+    SnapshotDiffResponse response = new SnapshotDiffResponse(createReport(),
+        JobStatus.NOT_FOUND, 1000L, true);
+
+    String message = response.toString();
+    assertTrue(message.contains("No snapshot diff job found"));
+    assertTrue(message.contains("--get-report"));
+  }
+
+  @Test
+  void testReportOnlyRejectedMessage() {
+    SnapshotDiffResponse response = new SnapshotDiffResponse(createReport(),
+        JobStatus.REJECTED, 1000L, true);
+
+    String message = response.toString();
+    assertTrue(message.contains("REJECTED"));
+    assertTrue(message.contains("resubmit the job without using the --get-report option"));
+  }
+
+  @Test
+  void testReportOnlyFailedMessageIncludesReason() {
+    SnapshotDiffResponse response = new SnapshotDiffResponse(createReport(),
+        JobStatus.FAILED, 1000L, "some failure", true);
+
+    String message = response.toString();
+    assertTrue(message.contains("FAILED"));
+    assertTrue(message.contains("some failure"));
+    assertTrue(message.contains("resubmit the job without using the --get-report option"));
+  }
+
+  @Test
+  void testReportOnlyInProgressIncludesSubStatusAndProgress() {
+    SnapshotDiffResponse response = new SnapshotDiffResponse(createReport(),
+        JobStatus.IN_PROGRESS, 1000L, true);
+    response.setSubStatus(SubStatus.OBJECT_ID_MAP_GEN_OBS);
+    response.setProgressPercent(55.5);
+
+    String message = response.toString();
+    assertTrue(message.contains("IN_PROGRESS"));
+    assertTrue(message.contains("OBJECT_ID_MAP_GEN_OBS"));
+    assertTrue(message.contains("Keys Processed Estimated Percentage"));
+    assertTrue(message.contains("55.5"));
+  }
+
+  private SnapshotDiffReportOzone createReport() {
+    return new SnapshotDiffReportOzone("snapshotRoot", "vol", "bucket", "fromSnap",
+        "toSnap", Collections.emptyList(), null);
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/snapshot/TestSubmitSnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/snapshot/TestSubmitSnapshotDiffResponse.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
+import org.junit.jupiter.api.Test;
+
+class TestSubmitSnapshotDiffResponse {
+
+  @Test
+  void testSubmitResponseForQueuedJob() {
+    SubmitSnapshotDiffResponse response =
+        new SubmitSnapshotDiffResponse(1000L, JobStatus.QUEUED, null);
+
+    String message = response.getResponse();
+    assertTrue(message.contains("Submitting a new job"));
+    assertTrue(message.contains("--get-report"));
+  }
+
+  @Test
+  void testSubmitResponseForInProgressJob() {
+    SubmitSnapshotDiffResponse response =
+        new SubmitSnapshotDiffResponse(1000L, JobStatus.IN_PROGRESS, null);
+
+    String message = response.getResponse();
+    assertTrue(message.contains("Previous snapshot diff attempt found"));
+    assertTrue(message.contains("IN_PROGRESS"));
+    assertTrue(message.contains("--get-report"));
+  }
+
+  @Test
+  void testSubmitResponseForDoneJob() {
+    SubmitSnapshotDiffResponse response =
+        new SubmitSnapshotDiffResponse(1000L, JobStatus.DONE, null);
+
+    String message = response.getResponse();
+    assertTrue(message.contains("Previous snapshot diff attempt found"));
+    assertTrue(message.contains("DONE"));
+    assertTrue(message.contains("--get-report"));
+  }
+
+  @Test
+  void testSubmitResponseForFailedJobIncludesReason() {
+    SubmitSnapshotDiffResponse response =
+        new SubmitSnapshotDiffResponse(1000L, JobStatus.FAILED, "previous failure");
+
+    String message = response.getResponse();
+    assertTrue(message.contains("Previous snapshot diff attempt found"));
+    assertTrue(message.contains("FAILED"));
+    assertTrue(message.contains("previous failure"));
+    assertTrue(message.contains("Submitting a new job"));
+    assertTrue(message.contains("--get-report"));
+  }
+
+  @Test
+  void testSubmitResponseForRejectedJobIncludesReason() {
+    SubmitSnapshotDiffResponse response =
+        new SubmitSnapshotDiffResponse(1000L, JobStatus.REJECTED, "previously rejected");
+
+    String message = response.getResponse();
+    assertTrue(message.contains("Previous snapshot diff attempt found"));
+    assertTrue(message.contains("REJECTED"));
+    assertTrue(message.contains("previously rejected"));
+    assertTrue(message.contains("Submitting a new job"));
+    assertTrue(message.contains("--get-report"));
+  }
+
+  @Test
+  void testSubmitResponseForCancelledJobIncludesReason() {
+    SubmitSnapshotDiffResponse response =
+        new SubmitSnapshotDiffResponse(1000L, JobStatus.CANCELLED, "previously cancelled");
+
+    String message = response.getResponse();
+    assertTrue(message.contains("Previous snapshot diff attempt found"));
+    assertTrue(message.contains("CANCELLED"));
+    assertTrue(message.contains("previously cancelled"));
+    assertTrue(message.contains("Submitting a new job"));
+    assertTrue(message.contains("--get-report"));
+  }
+}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
@@ -19,7 +19,8 @@ Library             OperatingSystem
 Resource            ../ozone-lib/shell.robot
 
 *** Variables ***
-${EC_VERSION}     1.3.0
-${FSO_VERSION}    1.3.0
-${HSYNC_VERSION}  2.0.0
-${TESTFILE}       ${TEST_DATA_DIR}/small
+${EC_VERSION}         1.3.0
+${FSO_VERSION}        1.3.0
+${SNAPSHOT_VERSION}   1.4.0
+${HSYNC_VERSION}      2.0.0
+${TESTFILE}           ${TEST_DATA_DIR}/small

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -81,12 +81,9 @@ HSync Can Be Used To Create Keys
     Freon DFSG      sync=HSYNC    n=1    path=${pfspath}
 
 Snapshot Diff RPC Is Compatible
-    # Snapshot diff requires snapshot support + FSO buckets in these tests.
-    Pass Execution If    '${CLIENT_VERSION}' < '${FSO_VERSION}'    Client does not support FSO
-    Pass Execution If    '${CLUSTER_VERSION}' < '${FSO_VERSION}'   Cluster does not support FSO
-
-    ${status}    ${help} =    Run Keyword And Ignore Error    Execute    ozone sh snapshot --help
-    Run Keyword If    '${status}' == 'FAIL'    Pass Execution    Snapshot CLI not supported by this client
+    # Snapshot diff requires snapshot support in these tests.
+    Pass Execution If    '${CLIENT_VERSION}' < '${SNAPSHOT_VERSION}'    Snapshot CLI not supported by this client
+    Pass Execution If    '${CLUSTER_VERSION}' < '${SNAPSHOT_VERSION}'   Snapshot CLI not supported by this client
 
     ${bucket} =      Set Variable    snapdiff-${CLIENT_VERSION}
     ${fromSnap} =    Set Variable    snapdiff-from-${CLIENT_VERSION}
@@ -113,16 +110,28 @@ Snapshot Diff Report Should Contain Created Keys
     ${status}    ${output} =    Run Keyword And Ignore Error
     ...    Execute    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
 
+    # new client
     IF    '${status}' == 'PASS'
         # On newer servers, --get-report does not submit jobs. If the job is not
         # found, submit it first (this keeps new-client/new-server behavior).
         ${notFound} =    Run Keyword And Return Status
         ...    Should Contain    ${output}    No snapshot diff job found
         IF    ${notFound}
-            Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+            ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+                           Should Contain    ${output}    Submitting a new job
+        ELSE
+        # On older servers, --get-report falls back to the legacy snapshot diff command,
+        # which submits the job if it doesn't exist. In this case, both snapshot diff and  --get-report
+        # should return the report.
+            ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+                           Should Contain    ${output}    Difference between snapshot: ${fromSnap} and snapshot: ${toSnap}
+                           Should Contain    ${output}    ${key1}
+                           Should Contain    ${output}    ${key2}
         END
         ${output} =    Execute    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
     ELSE
+        # old client, which does not support --get-report.
+        # The snapshot diff command should return the report, submitting a job if necessary.
         ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
     END
 

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -98,8 +98,7 @@ Snapshot Diff RPC Is Compatible
     Execute          ozone sh key put /vol1/${bucket}/${key2} ${TESTFILE}
     Execute          ozone sh snapshot create /vol1/${bucket} ${toSnap}
 
-    # Wait until report generation is complete and validate output includes the created keys.
-    Wait Until Keyword Succeeds    2min    5sec    Snapshot Diff Report Should Contain Created Keys
+    Snapshot Diff Report Should Contain Created Keys
     ...    /vol1/${bucket}    ${fromSnap}    ${toSnap}    ${key1}    ${key2}
 
 *** Keywords ***
@@ -110,7 +109,6 @@ Snapshot Diff Report Should Contain Created Keys
     ${status}    ${output} =    Run Keyword And Ignore Error
     ...    Execute    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
 
-    # new client
     IF    '${status}' == 'PASS'
         # On newer servers, --get-report does not submit jobs. If the job is not
         # found, submit it first (this keeps new-client/new-server behavior).
@@ -120,21 +118,29 @@ Snapshot Diff Report Should Contain Created Keys
             ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
                            Should Contain    ${output}    Submitting a new job
         ELSE
-        # On older servers, --get-report falls back to the legacy snapshot diff command,
-        # which submits the job if it doesn't exist. In this case, both snapshot diff and  --get-report
-        # should return the report.
-            ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
-                           Should Contain    ${output}    Difference between snapshot: ${fromSnap} and snapshot: ${toSnap}
-                           Should Contain    ${output}    ${key1}
-                           Should Contain    ${output}    ${key2}
+        # On older servers, --get-report falls back to the legacy snapshot diff command.
+        # Ensure the submit path succeeds without failing the test.
+            ${submitStatus}    ${submitOutput} =    Run Keyword And Ignore Error
+            ...    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+            Run Keyword If    '${submitStatus}' == 'FAIL'
+            ...    Fail    Snapshot diff submit failed: ${submitOutput}
         END
-        ${output} =    Execute    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
+        Wait Until Keyword Succeeds    2min    5sec
+        ...    Snapshot Diff Command Should Contain Created Keys
+        ...    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
+        ...    ${fromSnap}    ${toSnap}    ${key1}    ${key2}
     ELSE
         # old client, which does not support --get-report.
         # The snapshot diff command should return the report, submitting a job if necessary.
-        ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+        Wait Until Keyword Succeeds    2min    5sec
+        ...    Snapshot Diff Command Should Contain Created Keys
+        ...    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+        ...    ${fromSnap}    ${toSnap}    ${key1}    ${key2}
     END
 
+Snapshot Diff Command Should Contain Created Keys
+    [Arguments]    ${command}    ${fromSnap}    ${toSnap}    ${key1}    ${key2}
+    ${output} =    Execute    ${command}
     Should Contain    ${output}    Difference between snapshot: ${fromSnap} and snapshot: ${toSnap}
     Should Contain    ${output}    ${key1}
     Should Contain    ${output}    ${key2}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -79,3 +79,53 @@ HSync Can Be Used To Create Keys
     Freon DFSG      sync=HSYNC    n=1    path=${o3fspath}
     ${pfspath} =    Format FS URL         ofs      $vol1    bucket1
     Freon DFSG      sync=HSYNC    n=1    path=${pfspath}
+
+Snapshot Diff RPC Is Compatible
+    # Snapshot diff requires snapshot support + FSO buckets in these tests.
+    Pass Execution If    '${CLIENT_VERSION}' < '${FSO_VERSION}'    Client does not support FSO
+    Pass Execution If    '${CLUSTER_VERSION}' < '${FSO_VERSION}'   Cluster does not support FSO
+
+    ${status}    ${help} =    Run Keyword And Ignore Error    Execute    ozone sh snapshot --help
+    Run Keyword If    '${status}' == 'FAIL'    Pass Execution    Snapshot CLI not supported by this client
+
+    ${bucket} =      Set Variable    snapdiff-${CLIENT_VERSION}
+    ${fromSnap} =    Set Variable    snapdiff-from-${CLIENT_VERSION}
+    ${toSnap} =      Set Variable    snapdiff-to-${CLIENT_VERSION}
+    ${key1} =        Set Variable    snapdiff-key1-${CLIENT_VERSION}
+    ${key2} =        Set Variable    snapdiff-key2-${CLIENT_VERSION}
+
+    Execute          ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /vol1/${bucket}
+    Execute          ozone sh key put /vol1/${bucket}/base ${TESTFILE}
+    Execute          ozone sh snapshot create /vol1/${bucket} ${fromSnap}
+    Execute          ozone sh key put /vol1/${bucket}/${key1} ${TESTFILE}
+    Execute          ozone sh key put /vol1/${bucket}/${key2} ${TESTFILE}
+    Execute          ozone sh snapshot create /vol1/${bucket} ${toSnap}
+
+    # Wait until report generation is complete and validate output includes the created keys.
+    Wait Until Keyword Succeeds    2min    5sec    Snapshot Diff Report Should Contain Created Keys
+    ...    /vol1/${bucket}    ${fromSnap}    ${toSnap}    ${key1}    ${key2}
+
+*** Keywords ***
+Snapshot Diff Report Should Contain Created Keys
+    [Arguments]    ${bucketPath}    ${fromSnap}    ${toSnap}    ${key1}    ${key2}
+
+    # New clients support --get-report. Old clients don't; fall back to the legacy call.
+    ${status}    ${output} =    Run Keyword And Ignore Error
+    ...    Execute    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
+
+    IF    '${status}' == 'PASS'
+        # On newer servers, --get-report does not submit jobs. If the job is not
+        # found, submit it first (this keeps new-client/new-server behavior).
+        ${notFound} =    Run Keyword And Return Status
+        ...    Should Contain    ${output}    No snapshot diff job found
+        IF    ${notFound}
+            Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+        END
+        ${output} =    Execute    ozone sh snapshot diff --get-report ${bucketPath} ${fromSnap} ${toSnap}
+    ELSE
+        ${output} =    Execute    ozone sh snapshot diff ${bucketPath} ${fromSnap} ${toSnap}
+    END
+
+    Should Contain    ${output}    Difference between snapshot: ${fromSnap} and snapshot: ${toSnap}
+    Should Contain    ${output}    ${key1}
+    Should Contain    ${output}    ${key2}

--- a/hadoop-ozone/dist/src/main/smoketest/omha/data-validation-after-om-bootstrap.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/data-validation-after-om-bootstrap.robot
@@ -62,20 +62,27 @@ Check snapshots on OM
     ${snap2_res} =      Execute                 echo "${snap_list}" | grep ${snap_2}
                         Should contain          ${snap2_res}        ${snap_2}
 
-Run snap diff and get response
+Get snap diff response
     [arguments]         ${volume}           ${bucket}           ${snap_1}       ${snap_2}
-    ${diff_res} =       Execute             ozone sh snapshot diff /${volume}/${bucket} ${snap_1} ${snap_2}
+    ${diff_res} =       Execute             ozone sh snapshot diff --get-report /${volume}/${bucket} ${snap_1} ${snap_2}
                         [return]            ${diff_res}
+
+Submit snap diff job
+    [arguments]         ${volume}           ${bucket}           ${snap_1}       ${snap_2}
+    ${submit_res} =     Execute             ozone sh snapshot diff /${volume}/${bucket} ${snap_1} ${snap_2}
+                        Should contain      ${submit_res}       --get-report option
+    [return]            ${submit_res}
 
 Snap diff finished
     [arguments]         ${volume}           ${bucket}           ${snap_1}       ${snap_2}
-    ${diff_res} =       Run snap diff and get response          ${volume}       ${bucket}       ${snap_1}       ${snap_2}
+    ${diff_res} =       Get snap diff response          ${volume}       ${bucket}       ${snap_1}       ${snap_2}
                         Should contain      ${diff_res}         Difference between snapshot: ${snap_1} and snapshot: ${snap_2}
 
 Run snap diff and validate results
     [arguments]         ${volume}           ${bucket}           ${snap_1}       ${snap_2}       ${key_1}        ${key_2}
+    Submit snap diff job                            ${volume}           ${bucket}       ${snap_1}       ${snap_2}
     Wait Until Keyword Succeeds             2min                3sec            Snap diff finished              ${volume}           ${bucket}       ${snap_1}       ${snap_2}
-    ${diff_res} =       Run snap diff and get response          ${volume}       ${bucket}       ${snap_1}       ${snap_2}
+    ${diff_res} =       Get snap diff response          ${volume}       ${bucket}       ${snap_1}       ${snap_2}
     ${key_num} =        Execute             echo "${diff_res}" | grep 'key' | wc -l
                         Should be true      ${key_num} == 2
     ${diff_key1} =      Execute             echo "${diff_res}" | grep ${key_1} | wc -l

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
@@ -51,12 +51,14 @@ Snapshot Diff
     ${snapshot_three} =     Create snapshot     ${VOLUME}       ${BUCKET}
     Set Suite Variable      ${SNAPSHOT_THREE}     ${snapshot_three}
     ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
-                    Should contain      ${result}       Snapshot diff job is IN_PROGRESS
+                    Should contain      ${result}       Submitting a new job
+                    Should contain      ${result}       --get-report option
     ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_THREE}
-                    Should contain      ${result}       Snapshot diff job is IN_PROGRESS
+                    Should contain      ${result}       Submitting a new job
+                    Should contain      ${result}       --get-report option
 
 Snapshot Diff as JSON
-    ${result} =     Execute             ozone sh snapshot diff --json /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+    ${result} =     Execute             ozone sh snapshot diff --get-report --json /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
                     Should contain      echo '${result}' | jq '.jobStatus'   DONE
                     Should contain      echo '${result}' | jq '.snapshotDiffReport.volumeName'    ${VOLUME}
                     Should contain      echo '${result}' | jq '.snapshotDiffReport.bucketName'    ${BUCKET}
@@ -64,7 +66,7 @@ Snapshot Diff as JSON
                     Should contain      echo '${result}' | jq '.snapshotDiffReport.toSnapshot'    ${SNAPSHOT_TWO}
                     Should contain      echo '${result}' | jq '.snapshotDiffReport.diffList | .[].sourcePath'    ${KEY_TWO}
                     Should contain      echo '${result}' | jq '.snapshotDiffReport.diffList | .[].sourcePath'    ${KEY_THREE}
-    ${result} =     Execute             ozone sh snapshot diff --json /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+    ${result} =     Execute             ozone sh snapshot diff --get-report --json /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_THREE}
                     Should contain      echo '${result}' | jq '.jobStatus'   DONE
 
 List Snapshot Diff Jobs

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -2048,8 +2048,8 @@ message SnapshotDiffRequest {
   optional string toSnapshot = 4;
   optional string token = 5;
   optional uint32 pageSize = 6;
-  optional bool forceFullDiff = 7;
-  optional bool disableNativeDiff = 8;
+  optional bool forceFullDiff = 7 [deprecated = true];
+  optional bool disableNativeDiff = 8 [deprecated = true];
 }
 
 message SubmitSnapshotDiffRequest {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -156,6 +156,7 @@ enum Type {
   PutObjectTagging = 140;
   GetObjectTagging = 141;
   DeleteObjectTagging = 142;
+  SubmitSnapshotDiff = 143;
 }
 
 enum SafeMode {
@@ -306,6 +307,8 @@ message OMRequest {
   optional PutObjectTaggingRequest          putObjectTaggingRequest        = 141;
   optional DeleteObjectTaggingRequest       deleteObjectTaggingRequest     = 142;
   repeated SetSnapshotPropertyRequest       SetSnapshotPropertyRequests    = 143;
+
+  optional SubmitSnapshotDiffRequest        submitSnapshotDiffRequest       = 144;
 }
 
 message OMResponse {
@@ -439,6 +442,8 @@ message OMResponse {
   optional GetObjectTaggingResponse          getObjectTaggingResponse      = 140;
   optional PutObjectTaggingResponse          putObjectTaggingResponse      = 141;
   optional DeleteObjectTaggingResponse       deleteObjectTaggingResponse   = 142;
+
+  optional SubmitSnapshotDiffResponse        submitSnapshotDiffResponse    = 143;
 }
 
 enum Status {
@@ -2047,6 +2052,15 @@ message SnapshotDiffRequest {
   optional bool disableNativeDiff = 8;
 }
 
+message SubmitSnapshotDiffRequest {
+  optional string volumeName = 1;
+  optional string bucketName = 2;
+  optional string fromSnapshot = 3;
+  optional string toSnapshot = 4;
+  optional bool forceFullDiff = 7;
+  optional bool disableNativeDiff = 8;
+}
+
 message CancelSnapshotDiffRequest {
   optional string volumeName = 1;
   optional string bucketName = 2;
@@ -2182,6 +2196,7 @@ message SnapshotDiffResponse {
     REJECTED = 4;
     FAILED = 5;
     CANCELLED = 6;
+    NOT_FOUND = 7;
   }
 
   enum SubStatus {
@@ -2197,6 +2212,10 @@ message SnapshotDiffResponse {
   optional int64 waitTimeInMs = 3;
   optional string reason = 4;
   optional SubStatus subStatus = 5;
+}
+
+message SubmitSnapshotDiffResponse {
+  optional string response = 1;
 }
 
 message CancelSnapshotDiffResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -117,7 +117,8 @@ public enum OMAction implements AuditAction {
 
   GET_SNAPSHOT_DIFF_REPORT,
   LIST_SNAPSHOT_DIFF_JOBS,
-  CANCEL_SNAPSHOT_DIFF_JOBS;
+  CANCEL_SNAPSHOT_DIFF_JOBS,
+  SUBMIT_SNAPSHOT_DIFF_JOB;
 
   @Override
   public String getAction() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -110,6 +110,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 import org.apache.ratis.util.function.CheckedFunction;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
@@ -825,6 +826,7 @@ public final class OmSnapshotManager implements AutoCloseable {
   }
 
   @SuppressWarnings("parameternumber")
+  @Deprecated
   public SnapshotDiffResponse getSnapshotDiffReport(final String volume,
                                                     final String bucket,
                                                     final String fromSnapshot,
@@ -855,15 +857,54 @@ public final class OmSnapshotManager implements AutoCloseable {
             fromSnapshot, toSnapshot, index, pageSize, forceFullDiff,
             disableNativeDiff);
 
-    // Check again to make sure that from and to snapshots are still active and
-    // were not deleted in between response generation.
-    // Ideally, snapshot diff and snapshot deletion should take an explicit lock
-    // to achieve the synchronization, but it would be complex and expensive.
-    // To avoid the complexity, we just check that snapshots are active
-    // before returning the response. It is like an optimistic lock to achieve
-    // similar behaviour and make sure client gets consistent response.
     validateSnapshotsExistAndActive(volume, bucket, fromSnapshot, toSnapshot);
     return snapshotDiffReport;
+  }
+
+  public SnapshotDiffResponse getSnapshotDiffResponse(final String volume,
+                                                      final String bucket,
+                                                      final String fromSnapshot,
+                                                      final String toSnapshot,
+                                                      final String token,
+                                                      int pageSize)
+      throws IOException {
+    // Check if fromSnapshot and toSnapshot are equal.
+    if (Objects.equals(fromSnapshot, toSnapshot)) {
+      SnapshotDiffReportOzone diffReport = new SnapshotDiffReportOzone(
+          getSnapshotRootPath(volume, bucket).toString(), volume, bucket,
+          fromSnapshot, toSnapshot, Collections.emptyList(), null);
+      return new SnapshotDiffResponse(diffReport, DONE, 0L);
+    }
+
+    String index = validateToken(token);
+    if (pageSize <= 0 || pageSize > maxPageSize) {
+      pageSize = maxPageSize;
+    }
+
+    return snapshotDiffManager.getSnapshotDiffReport(volume, bucket,
+            fromSnapshot, toSnapshot, index, pageSize);
+  }
+
+  public SubmitSnapshotDiffResponse submitSnapshotDiff(final String volume,
+                                                       final String bucket,
+                                                       final String fromSnapshot,
+                                                       final String toSnapshot,
+                                                       boolean forceFullDiff,
+                                                       boolean disableNativeDiff)
+      throws IOException {
+    validateSnapshotsExistAndActive(volume, bucket, fromSnapshot, toSnapshot);
+
+    // Check if fromSnapshot and toSnapshot are equal.
+    if (Objects.equals(fromSnapshot, toSnapshot)) {
+      return new SubmitSnapshotDiffResponse("Cannot submit diff between same snapshots.");
+    }
+
+    SubmitSnapshotDiffResponse snapshotDiffResponse =
+        snapshotDiffManager.submitSnapshotDiff(volume, bucket,
+            fromSnapshot, toSnapshot, forceFullDiff, disableNativeDiff);
+
+    validateSnapshotsExistAndActive(volume, bucket, fromSnapshot, toSnapshot);
+    return snapshotDiffResponse;
   }
 
   public ListSnapshotDiffJobResponse getSnapshotDiffList(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -868,6 +868,8 @@ public final class OmSnapshotManager implements AutoCloseable {
                                                       final String token,
                                                       int pageSize)
       throws IOException {
+    validateSnapshotsExistAndActive(volume, bucket, fromSnapshot, toSnapshot);
+
     // Check if fromSnapshot and toSnapshot are equal.
     if (Objects.equals(fromSnapshot, toSnapshot)) {
       SnapshotDiffReportOzone diffReport = new SnapshotDiffReportOzone(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -253,7 +253,7 @@ public final class OmSnapshotManager implements AutoCloseable {
         cacheCleanupServiceInterval, compactNonSnapshotDiffTables, ozoneManager.getMetadataManager().getLock());
 
     this.snapshotDiffManager = new SnapshotDiffManager(snapshotDiffDb,
-        ozoneManager, snapDiffJobCf, snapDiffReportCf,
+        ozoneManager, snapDiffJobCf, snapDiffReportCf, snapDiffPurgedJobCf,
         columnFamilyOptions, codecRegistry);
 
     diffCleanupServiceInterval = ozoneManager.getConfiguration()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -157,6 +157,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.management.ObjectName;
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
@@ -328,6 +329,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
@@ -5277,6 +5279,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
+  @Deprecated
   @SuppressWarnings("parameternumber")
   public SnapshotDiffResponse snapshotDiff(String volume,
                                            String bucket,
@@ -5318,6 +5321,90 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } finally {
       if (auditSuccess) {
         AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.GET_SNAPSHOT_DIFF_REPORT,
+            auditMap));
+      }
+    }
+  }
+
+  @Override
+  public SnapshotDiffResponse snapshotDiff(String volume,
+                                           String bucket,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize)
+      throws IOException {
+    boolean auditSuccess = true;
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    auditMap.put(OzoneConsts.VOLUME, volume);
+    auditMap.put(OzoneConsts.BUCKET, bucket);
+    auditMap.put(OzoneConsts.FROM_SNAPSHOT, fromSnapshot);
+    auditMap.put(OzoneConsts.TO_SNAPSHOT, toSnapshot);
+    auditMap.put(OzoneConsts.TOKEN, token);
+    auditMap.put(OzoneConsts.PAGE_SIZE, String.valueOf(pageSize));
+
+    try {
+      // Updating the volumeName & bucketName in case the bucket is a linked bucket. We need to do this before a
+      // permission check, since linked bucket permissions and source bucket permissions could be different.
+      ResolvedBucket resolvedBucket = resolveBucketLink(Pair.of(volume, bucket), false);
+      if (getAclsEnabled()) {
+        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+            ACLType.READ, resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
+      }
+      // do not increment snapshot diff job metrics here, since it is not
+      // a job, but a request.
+      return omSnapshotManager.getSnapshotDiffResponse(resolvedBucket.realVolume(), resolvedBucket.realBucket(),
+              fromSnapshot, toSnapshot, token, pageSize);
+    } catch (Exception ex) {
+      auditSuccess = false;
+      AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction.GET_SNAPSHOT_DIFF_REPORT,
+          auditMap, ex));
+      throw ex;
+    } finally {
+      if (auditSuccess) {
+        AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.GET_SNAPSHOT_DIFF_REPORT,
+            auditMap));
+      }
+    }
+  }
+
+  @Override
+  public SubmitSnapshotDiffResponse submitSnapshotDiff(String volume,
+                                                       String bucket,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       boolean forceFullDiff,
+                                                       boolean disableNativeDiff)
+      throws IOException {
+    boolean auditSuccess = true;
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    auditMap.put(OzoneConsts.VOLUME, volume);
+    auditMap.put(OzoneConsts.BUCKET, bucket);
+    auditMap.put(OzoneConsts.FROM_SNAPSHOT, fromSnapshot);
+    auditMap.put(OzoneConsts.TO_SNAPSHOT, toSnapshot);
+    auditMap.put(OzoneConsts.FORCE_FULL_DIFF, String.valueOf(forceFullDiff));
+    auditMap.put(OzoneConsts.DISABLE_NATIVE_DIFF, String.valueOf(disableNativeDiff));
+
+    try {
+      // Updating the volumeName & bucketName in case the bucket is a linked bucket. We need to do this before a
+      // permission check, since linked bucket permissions and source bucket permissions could be different.
+      ResolvedBucket resolvedBucket = resolveBucketLink(Pair.of(volume, bucket), false);
+      if (getAclsEnabled()) {
+        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+            ACLType.READ, resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
+      }
+      // do not increment snapshot diff job metrics here, since it is not
+      // a job, but a request.
+      return omSnapshotManager.submitSnapshotDiff(resolvedBucket.realVolume(), resolvedBucket.realBucket(),
+          fromSnapshot, toSnapshot, forceFullDiff, disableNativeDiff);
+    } catch (Exception ex) {
+      auditSuccess = false;
+      AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction.SUBMIT_SNAPSHOT_DIFF_JOB,
+          auditMap, ex));
+      throw ex;
+    } finally {
+      if (auditSuccess) {
+        AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.SUBMIT_SNAPSHOT_DIFF_JOB,
             auditMap));
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -157,7 +157,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.management.ObjectName;
-import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.leftPad;
 import static org.apache.hadoop.hdds.StringUtils.getLexicographicallyHigherString;
 import static org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffType.CREATE;
@@ -646,7 +647,8 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
         forceFullDiff, disableNativeDiff);
 
     JobStatus prevStatus = snapDiffJob.getStatus();
-    String prevReason = snapDiffJob.getReason();
+    String prevReason = isEmpty(snapDiffJob.getReason()) ? null : snapDiffJob.getReason();
+    String jobId = prevStatus == QUEUED ? snapDiffJob.getJobId() : UUID.randomUUID().toString();
 
     switch (prevStatus) {
     case QUEUED:
@@ -658,14 +660,10 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
           volumeName, bucketName, fromSnapshotName, toSnapshotName);
       try {
         updateJobStatus(snapDiffJobKey, prevStatus, IN_PROGRESS);
-        snapDiffExecutor.execute(() -> generateSnapshotDiffReport(snapDiffJobKey, snapDiffJob.getJobId(),
+        snapDiffExecutor.execute(() -> generateSnapshotDiffReport(snapDiffJobKey, jobId,
             volumeName, bucketName, fromSnapshotName, toSnapshotName,
             forceFullDiff, disableNativeDiff));
-        if (prevStatus == QUEUED) {
-          return new SubmitSnapshotDiffResponse(defaultWaitTime, null, null);
-        } else {
-          return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, prevReason);
-        }
+        return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, prevReason);
       } catch (RejectedExecutionException exception) {
         updateJobStatus(snapDiffJobKey, IN_PROGRESS, REJECTED);
         LOG.warn("Exceeded the snapDiff parallel requests processing " +
@@ -679,7 +677,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
       }
     case IN_PROGRESS:
     case DONE:
-      return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, null);
+      return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, prevReason);
     default:
       throw new IllegalStateException("Unknown snapshot job status: " + snapDiffJob.getStatus());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -166,6 +166,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
   private final OMMetadataManager activeOmMetadataManager;
   private final CodecRegistry codecRegistry;
   private final ManagedColumnFamilyOptions familyOptions;
+  private final ColumnFamilyHandle snapDiffPurgedJobCfh;
   // TODO: [SNAPSHOT] Use different wait time based of job status.
   private final long defaultWaitTime;
   private final long maxAllowedKeyChangesForASnapDiff;
@@ -212,6 +213,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
                              OzoneManager ozoneManager,
                              ColumnFamilyHandle snapDiffJobCfh,
                              ColumnFamilyHandle snapDiffReportCfh,
+                             ColumnFamilyHandle snapDiffPurgedJobCfh,
                              ManagedColumnFamilyOptions familyOptions,
                              CodecRegistry codecRegistry) {
     this.db = db;
@@ -219,6 +221,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
     this.activeOmMetadataManager = ozoneManager.getMetadataManager();
     this.familyOptions = familyOptions;
     this.codecRegistry = codecRegistry;
+    this.snapDiffPurgedJobCfh = snapDiffPurgedJobCfh;
     this.defaultWaitTime = ozoneManager.getConfiguration().getTimeDuration(
         OZONE_OM_SNAPSHOT_DIFF_JOB_DEFAULT_WAIT_TIME,
         OZONE_OM_SNAPSHOT_DIFF_JOB_DEFAULT_WAIT_TIME_DEFAULT,
@@ -592,12 +595,12 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
           new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName,
               bucketName, fromSnapshotName, toSnapshotName, new ArrayList<>(),
               null),
-          snapDiffJob.getStatus(), defaultWaitTime, true);
+          snapDiffJob.getStatus(), defaultWaitTime);
     case IN_PROGRESS:
       SnapshotDiffResponse response = new SnapshotDiffResponse(
           new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName, bucketName,
               fromSnapshotName, toSnapshotName,
-              new ArrayList<>(), null), IN_PROGRESS, defaultWaitTime, true);
+              new ArrayList<>(), null), IN_PROGRESS, defaultWaitTime);
       response.setSubStatus(snapDiffJob.getSubStatus());
       response.setProgressPercent(snapDiffJob.getKeysProcessedPct());
       return response;
@@ -609,18 +612,18 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
           // waitTime is equal to clean up internal. After that job will be
           // removed and client can retry.
           ozoneManager.getOmSnapshotManager().getDiffCleanupServiceInterval(),
-          snapDiffJob.getReason(), true);
+          snapDiffJob.getReason());
     case DONE:
       SnapshotDiffReportOzone report = createPageResponse(snapDiffJob,
           volumeName, bucketName, fromSnapshotName, toSnapshotName, index,
           pageSize);
-      return new SnapshotDiffResponse(report, DONE, 0L, true);
+      return new SnapshotDiffResponse(report, DONE, 0L);
     case CANCELLED:
       return new SnapshotDiffResponse(
           new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName,
               bucketName, fromSnapshotName, toSnapshotName, new ArrayList<>(),
               null),
-          CANCELLED, 0L, true);
+          CANCELLED, 0L);
     default:
       throw new IllegalStateException("Unknown snapshot job status: " +
           snapDiffJob.getStatus());
@@ -648,7 +651,12 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
 
     JobStatus prevStatus = snapDiffJob.getStatus();
     String prevReason = isEmpty(snapDiffJob.getReason()) ? null : snapDiffJob.getReason();
-    String jobId = prevStatus == QUEUED ? snapDiffJob.getJobId() : UUID.randomUUID().toString();
+    String jobId = snapDiffJob.getJobId();
+    if (prevStatus == FAILED || prevStatus == REJECTED || prevStatus == CANCELLED) {
+      jobId = createSnapDiffJob(snapDiffJobKey, volumeName, bucketName, fromSnapshotName,
+          toSnapshotName, forceFullDiff, disableNativeDiff, prevStatus, snapDiffJob);
+    }
+    final String submitJobId = jobId;
 
     switch (prevStatus) {
     case QUEUED:
@@ -660,7 +668,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
           volumeName, bucketName, fromSnapshotName, toSnapshotName);
       try {
         updateJobStatus(snapDiffJobKey, prevStatus, IN_PROGRESS);
-        snapDiffExecutor.execute(() -> generateSnapshotDiffReport(snapDiffJobKey, jobId,
+        snapDiffExecutor.execute(() -> generateSnapshotDiffReport(snapDiffJobKey, submitJobId,
             volumeName, bucketName, fromSnapshotName, toSnapshotName,
             forceFullDiff, disableNativeDiff));
         return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, prevReason);
@@ -916,14 +924,48 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
     SnapshotDiffJob snapDiffJob = snapDiffJobTable.get(jobKey);
 
     if (snapDiffJob == null) {
-      String jobId = UUID.randomUUID().toString();
-      snapDiffJob = new SnapshotDiffJob(System.currentTimeMillis(), jobId,
-          QUEUED, volumeName, bucketName, fromSnapshotName, toSnapshotName, forceFullDiff,
-          disableNativeDiff, 0L, null, 0.0, null);
-      snapDiffJobTable.put(jobKey, snapDiffJob);
+      createSnapDiffJob(jobKey, volumeName, bucketName, fromSnapshotName, toSnapshotName,
+          forceFullDiff, disableNativeDiff, QUEUED, null);
+      snapDiffJob = snapDiffJobTable.get(jobKey);
     }
 
     return snapDiffJob;
+  }
+
+  @SuppressWarnings("parameternumber")
+  private synchronized String createSnapDiffJob(String jobKey,
+                                                String volumeName,
+                                                String bucketName,
+                                                String fromSnapshotName,
+                                                String toSnapshotName,
+                                                boolean forceFullDiff,
+                                                boolean disableNativeDiff,
+                                                JobStatus jobStatus,
+                                                SnapshotDiffJob previousJob) {
+    if (previousJob != null) {
+      enqueueSnapshotDiffReportCleanup(previousJob);
+    }
+    String jobId = UUID.randomUUID().toString();
+    SnapshotDiffJob snapDiffJob = new SnapshotDiffJob(System.currentTimeMillis(), jobId,
+        jobStatus, volumeName, bucketName, fromSnapshotName, toSnapshotName, forceFullDiff,
+        disableNativeDiff, 0L, null, 0.0, null);
+    snapDiffJobTable.put(jobKey, snapDiffJob);
+    return jobId;
+  }
+
+  private void enqueueSnapshotDiffReportCleanup(SnapshotDiffJob previousJob) {
+    String jobId = previousJob.getJobId();
+    if (isEmpty(jobId)) {
+      return;
+    }
+    try {
+      db.get().put(snapDiffPurgedJobCfh,
+          codecRegistry.asRawData(jobId),
+          codecRegistry.asRawData(previousJob.getTotalDiffEntries()));
+    } catch (IOException | RocksDBException exception) {
+      LOG.warn("Failed to enqueue snapshot diff report cleanup for jobId: {}.",
+          jobId, exception);
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -51,7 +51,13 @@ import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.Cancel
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_NON_CANCELLABLE;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_SUCCEEDED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone.getDiffReportEntry;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.*;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.CANCELLED;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.FAILED;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.NOT_FOUND;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.QUEUED;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.REJECTED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus.DIFF_REPORT_GEN;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus.OBJECT_ID_MAP_GEN_FSO;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus.OBJECT_ID_MAP_GEN_OBS;
@@ -673,7 +679,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
       }
     case IN_PROGRESS:
     case DONE:
-      return new SubmitSnapshotDiffResponse(defaultWaitTime, IN_PROGRESS, null);
+      return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, null);
     default:
       throw new IllegalStateException("Unknown snapshot job status: " + snapDiffJob.getStatus());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -51,12 +51,7 @@ import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.Cancel
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_NON_CANCELLABLE;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_SUCCEEDED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone.getDiffReportEntry;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.CANCELLED;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.FAILED;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.QUEUED;
-import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.REJECTED;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.*;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus.DIFF_REPORT_GEN;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus.OBJECT_ID_MAP_GEN_FSO;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus.OBJECT_ID_MAP_GEN_OBS;
@@ -137,6 +132,7 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.SubStatus;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.util.ClosableIterator;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.ozone.rocksdb.util.SstFileInfo;
@@ -486,6 +482,7 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
   }
 
   @SuppressWarnings("parameternumber")
+  @Deprecated
   public SnapshotDiffResponse getSnapshotDiffReport(
       final String volumeName,
       final String bucketName,
@@ -553,6 +550,132 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
     default:
       throw new IllegalStateException("Unknown snapshot job status: " +
           snapDiffJob.getStatus());
+    }
+  }
+
+  public SnapshotDiffResponse getSnapshotDiffReport(
+      final String volumeName,
+      final String bucketName,
+      final String fromSnapshotName,
+      final String toSnapshotName,
+      final String index,
+      final int pageSize
+  ) throws IOException {
+
+    SnapshotInfo fsInfo = getSnapshotInfo(ozoneManager,
+        volumeName, bucketName, fromSnapshotName);
+    SnapshotInfo tsInfo = getSnapshotInfo(ozoneManager,
+        volumeName, bucketName, toSnapshotName);
+
+    String snapDiffJobKey = generateSnapDiffJobKey.apply(fsInfo, tsInfo);
+    SnapshotDiffJob snapDiffJob = snapDiffJobTable.get(snapDiffJobKey);
+    OFSPath snapshotRoot = getSnapshotRootPath(volumeName, bucketName);
+
+    if (snapDiffJob == null) {
+      return new SnapshotDiffResponse(
+          new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName, bucketName,
+              fromSnapshotName, toSnapshotName,
+              new ArrayList<>(), null), NOT_FOUND, defaultWaitTime);
+    }
+
+    switch (snapDiffJob.getStatus()) {
+    case QUEUED:
+    case REJECTED:
+      return new SnapshotDiffResponse(
+          new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName,
+              bucketName, fromSnapshotName, toSnapshotName, new ArrayList<>(),
+              null),
+          snapDiffJob.getStatus(), defaultWaitTime, true);
+    case IN_PROGRESS:
+      SnapshotDiffResponse response = new SnapshotDiffResponse(
+          new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName, bucketName,
+              fromSnapshotName, toSnapshotName,
+              new ArrayList<>(), null), IN_PROGRESS, defaultWaitTime, true);
+      response.setSubStatus(snapDiffJob.getSubStatus());
+      response.setProgressPercent(snapDiffJob.getKeysProcessedPct());
+      return response;
+    case FAILED:
+      return new SnapshotDiffResponse(
+          new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName,
+              bucketName, fromSnapshotName, toSnapshotName, new ArrayList<>(),
+              null), FAILED,
+          // waitTime is equal to clean up internal. After that job will be
+          // removed and client can retry.
+          ozoneManager.getOmSnapshotManager().getDiffCleanupServiceInterval(),
+          snapDiffJob.getReason(), true);
+    case DONE:
+      SnapshotDiffReportOzone report = createPageResponse(snapDiffJob,
+          volumeName, bucketName, fromSnapshotName, toSnapshotName, index,
+          pageSize);
+      return new SnapshotDiffResponse(report, DONE, 0L, true);
+    case CANCELLED:
+      return new SnapshotDiffResponse(
+          new SnapshotDiffReportOzone(snapshotRoot.toString(), volumeName,
+              bucketName, fromSnapshotName, toSnapshotName, new ArrayList<>(),
+              null),
+          CANCELLED, 0L, true);
+    default:
+      throw new IllegalStateException("Unknown snapshot job status: " +
+          snapDiffJob.getStatus());
+    }
+  }
+
+  public synchronized SubmitSnapshotDiffResponse submitSnapshotDiff(
+      final String volumeName,
+      final String bucketName,
+      final String fromSnapshotName,
+      final String toSnapshotName,
+      final boolean forceFullDiff,
+      final boolean disableNativeDiff
+  ) throws IOException {
+    SnapshotInfo fsInfo = getSnapshotInfo(ozoneManager,
+        volumeName, bucketName, fromSnapshotName);
+    SnapshotInfo tsInfo = getSnapshotInfo(ozoneManager,
+        volumeName, bucketName, toSnapshotName);
+
+    String snapDiffJobKey = generateSnapDiffJobKey.apply(fsInfo, tsInfo);
+
+    SnapshotDiffJob snapDiffJob = getSnapDiffReportStatus(snapDiffJobKey,
+        volumeName, bucketName, fromSnapshotName, toSnapshotName,
+        forceFullDiff, disableNativeDiff);
+
+    JobStatus prevStatus = snapDiffJob.getStatus();
+    String prevReason = snapDiffJob.getReason();
+
+    switch (prevStatus) {
+    case QUEUED:
+    case FAILED:
+    case REJECTED:
+    case CANCELLED:
+      LOG.info("Submitting snapshot diff generation request for" +
+              " volume: {}, bucket: {}, fromSnapshot: {} and toSnapshot: {}",
+          volumeName, bucketName, fromSnapshotName, toSnapshotName);
+      try {
+        updateJobStatus(snapDiffJobKey, prevStatus, IN_PROGRESS);
+        snapDiffExecutor.execute(() -> generateSnapshotDiffReport(snapDiffJobKey, snapDiffJob.getJobId(),
+            volumeName, bucketName, fromSnapshotName, toSnapshotName,
+            forceFullDiff, disableNativeDiff));
+        if (prevStatus == QUEUED) {
+          return new SubmitSnapshotDiffResponse(defaultWaitTime, null, null);
+        } else {
+          return new SubmitSnapshotDiffResponse(defaultWaitTime, prevStatus, prevReason);
+        }
+      } catch (RejectedExecutionException exception) {
+        updateJobStatus(snapDiffJobKey, IN_PROGRESS, REJECTED);
+        LOG.warn("Exceeded the snapDiff parallel requests processing " +
+                "limit. Rejecting the snapDiff job: {}.", snapDiffJobKey);
+        return new SubmitSnapshotDiffResponse("Snapshot diff job was rejected because parallel processing of " +
+            "snap diff jobs exceeded the limit. Please try again in " + defaultWaitTime + " ms.");
+      } catch (Exception exception) {
+        updateJobStatusToFailed(snapDiffJobKey, exception.getMessage());
+        LOG.error("Snapshot diff job: {} failed.", snapDiffJobKey, exception);
+        return new SubmitSnapshotDiffResponse("Snapshot diff job submission failed. Reason: " + exception.getMessage());
+      }
+    case IN_PROGRESS:
+    case DONE:
+      return new SubmitSnapshotDiffResponse(defaultWaitTime, IN_PROGRESS, null);
+    default:
+      throw new IllegalStateException("Unknown snapshot job status: " + snapDiffJob.getStatus());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -163,6 +163,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.request.validation.RequestProcessingPhase;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.util.ProtobufUtils;
@@ -347,6 +348,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         ListSnapshotDiffJobResponse listSnapDiffResponse =
             listSnapshotDiffJobs(request.getListSnapshotDiffJobRequest());
         responseBuilder.setListSnapshotDiffJobResponse(listSnapDiffResponse);
+        break;
+      case SubmitSnapshotDiff:
+        SubmitSnapshotDiffResponse submitSnapshotDiff = submitSnapshotDiff(
+            request.getSubmitSnapshotDiffRequest());
+        responseBuilder.setSubmitSnapshotDiffResponse(submitSnapshotDiff);
         break;
       case EchoRPC:
         EchoRPCResponse echoRPCResponse =
@@ -1387,16 +1393,28 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   @DisallowedUntilLayoutVersion(FILESYSTEM_SNAPSHOT)
   private SnapshotDiffResponse snapshotDiff(
       SnapshotDiffRequest snapshotDiffRequest) throws IOException {
-    org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse response =
-        impl.snapshotDiff(
-            snapshotDiffRequest.getVolumeName(),
-            snapshotDiffRequest.getBucketName(),
-            snapshotDiffRequest.getFromSnapshot(),
-            snapshotDiffRequest.getToSnapshot(),
-            snapshotDiffRequest.getToken(),
-            snapshotDiffRequest.getPageSize(),
-            snapshotDiffRequest.getForceFullDiff(),
-            snapshotDiffRequest.getDisableNativeDiff());
+    org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse response;
+
+    if (snapshotDiffRequest.hasForceFullDiff() && snapshotDiffRequest.hasDisableNativeDiff()) {
+      response = impl.snapshotDiff(
+          snapshotDiffRequest.getVolumeName(),
+          snapshotDiffRequest.getBucketName(),
+          snapshotDiffRequest.getFromSnapshot(),
+          snapshotDiffRequest.getToSnapshot(),
+          snapshotDiffRequest.getToken(),
+          snapshotDiffRequest.getPageSize(),
+          snapshotDiffRequest.getForceFullDiff(),
+          snapshotDiffRequest.getDisableNativeDiff());
+    } else {
+      response = impl.snapshotDiff(
+          snapshotDiffRequest.getVolumeName(),
+          snapshotDiffRequest.getBucketName(),
+          snapshotDiffRequest.getFromSnapshot(),
+          snapshotDiffRequest.getToSnapshot(),
+          snapshotDiffRequest.getToken(),
+          snapshotDiffRequest.getPageSize());
+    }
+
 
     SnapshotDiffResponse.Builder builder = SnapshotDiffResponse.newBuilder()
         .setJobStatus(response.getJobStatus().toProtobuf())
@@ -1408,6 +1426,29 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     if (response.getSnapshotDiffReport() != null) {
       builder.setSnapshotDiffReport(
           response.getSnapshotDiffReport().toProtobuf());
+    }
+
+    return builder.build();
+  }
+
+  @DisallowedUntilLayoutVersion(FILESYSTEM_SNAPSHOT)
+  private SubmitSnapshotDiffResponse submitSnapshotDiff(
+      SubmitSnapshotDiffRequest submitSnapshotDiffRequest) throws IOException {
+
+    org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse response =
+        impl.submitSnapshotDiff(
+            submitSnapshotDiffRequest.getVolumeName(),
+            submitSnapshotDiffRequest.getBucketName(),
+            submitSnapshotDiffRequest.getFromSnapshot(),
+            submitSnapshotDiffRequest.getToSnapshot(),
+            submitSnapshotDiffRequest.getForceFullDiff(),
+            submitSnapshotDiffRequest.getDisableNativeDiff());
+
+    SubmitSnapshotDiffResponse.Builder builder = SubmitSnapshotDiffResponse
+        .newBuilder();
+
+    if (StringUtils.isNotEmpty(response.getResponse())) {
+      builder.setResponse(response.getResponse());
     }
 
     return builder.build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -155,6 +155,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetSafe
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotDiffRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SubmitSnapshotDiffRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantGetUserInfoRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantGetUserInfoResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantListUserRequest;
@@ -163,7 +165,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.request.validation.RequestProcessingPhase;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
-import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.util.ProtobufUtils;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -37,6 +37,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.helpers.BucketLayout.LEGACY;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.getTableKey;
 import static org.apache.hadoop.ozone.om.snapshot.db.SnapshotDiffDBDefinition.SNAP_DIFF_JOB_TABLE_NAME;
+import static org.apache.hadoop.ozone.om.snapshot.db.SnapshotDiffDBDefinition.SNAP_DIFF_PURGED_JOB_TABLE_NAME;
 import static org.apache.hadoop.ozone.om.snapshot.db.SnapshotDiffDBDefinition.SNAP_DIFF_REPORT_TABLE_NAME;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_ALREADY_CANCELLED_JOB;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_ALREADY_DONE_JOB;
@@ -49,6 +50,7 @@ import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.CA
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.FAILED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.NOT_FOUND;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.QUEUED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.REJECTED;
 import static org.apache.ratis.util.JavaUtils.attempt;
@@ -184,6 +186,7 @@ public class TestSnapshotDiffManager {
   private List<ColumnFamilyHandle> columnFamilyHandles;
   private ColumnFamilyHandle snapDiffJobTable;
   private ColumnFamilyHandle snapDiffReportTable;
+  private ColumnFamilyHandle snapDiffPurgedJobTable;
   private SnapshotDiffManager snapshotDiffManager;
   private final List<JobStatus> jobStatuses = Arrays.asList(QUEUED, IN_PROGRESS,
       DONE, REJECTED, FAILED);
@@ -255,9 +258,14 @@ public class TestSnapshotDiffManager {
         new ColumnFamilyDescriptor(
             StringUtils.string2Bytes(SNAP_DIFF_REPORT_TABLE_NAME),
             columnFamilyOptions));
+    snapDiffPurgedJobTable = db.get().createColumnFamily(
+        new ColumnFamilyDescriptor(
+            StringUtils.string2Bytes(SNAP_DIFF_PURGED_JOB_TABLE_NAME),
+            columnFamilyOptions));
 
     columnFamilyHandles.add(snapDiffJobTable);
     columnFamilyHandles.add(snapDiffReportTable);
+    columnFamilyHandles.add(snapDiffPurgedJobTable);
 
     String snapshotNamePrefix = "snap-";
     String snapshotPath = "snapshotPath";
@@ -359,7 +367,8 @@ public class TestSnapshotDiffManager {
         });
     when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
     snapshotDiffManager = new SnapshotDiffManager(db, ozoneManager,
-        snapDiffJobTable, snapDiffReportTable, columnFamilyOptions, codecRegistry);
+        snapDiffJobTable, snapDiffReportTable, snapDiffPurgedJobTable,
+        columnFamilyOptions, codecRegistry);
     when(omSnapshotManager.getDiffCleanupServiceInterval()).thenReturn(0L);
   }
 
@@ -1439,10 +1448,7 @@ public class TestSnapshotDiffManager {
 
     SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
         ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
-
-    assertThat(response.getResponse())
-        .contains("Submitting a new job")
-        .contains("--get-report");
+    assertNotNull(response);
 
     SnapshotDiffJob job = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
     assertNotNull(job);
@@ -1466,11 +1472,7 @@ public class TestSnapshotDiffManager {
     SnapshotDiffManager spy = spy(snapshotDiffManager);
     SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
         ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
-
-    assertThat(response.getResponse())
-        .contains("Previous snapshot diff attempt found")
-        .contains("IN_PROGRESS")
-        .contains("--get-report");
+    assertNotNull(response);
 
     verify(spy, never()).generateSnapshotDiffReport(anyString(), anyString(),
         anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyBoolean());
@@ -1488,11 +1490,7 @@ public class TestSnapshotDiffManager {
     SnapshotDiffManager spy = spy(snapshotDiffManager);
     SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
         ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
-
-    assertThat(response.getResponse())
-        .contains("Previous snapshot diff attempt found")
-        .contains("DONE")
-        .contains("--get-report");
+    assertNotNull(response);
 
     verify(spy, never()).generateSnapshotDiffReport(anyString(), anyString(),
         anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyBoolean());
@@ -1515,13 +1513,7 @@ public class TestSnapshotDiffManager {
 
     SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
         ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
-
-    assertThat(response.getResponse())
-        .contains("Previous snapshot diff attempt found")
-        .contains("FAILED")
-        .contains("previous failure")
-        .contains("Submitting a new job")
-        .contains("--get-report");
+    assertNotNull(response);
 
     SnapshotDiffJob updated = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
     assertNotNull(updated);
@@ -1545,13 +1537,7 @@ public class TestSnapshotDiffManager {
 
     SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
         ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
-
-    assertThat(response.getResponse())
-        .contains("Previous snapshot diff attempt found")
-        .contains("CANCELLED")
-        .contains("previously cancelled")
-        .contains("Submitting a new job")
-        .contains("--get-report");
+    assertNotNull(response);
 
     SnapshotDiffJob updated = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
     assertNotNull(updated);
@@ -1575,13 +1561,7 @@ public class TestSnapshotDiffManager {
 
     SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
         ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
-
-    assertThat(response.getResponse())
-        .contains("Previous snapshot diff attempt found")
-        .contains("REJECTED")
-        .contains("previously rejected")
-        .contains("Submitting a new job")
-        .contains("--get-report");
+    assertNotNull(response);
 
     SnapshotDiffJob updated = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
     assertNotNull(updated);
@@ -1595,10 +1575,7 @@ public class TestSnapshotDiffManager {
 
     SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
         ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
-
-    assertThat(response.toString())
-        .contains("No snapshot diff job found")
-        .contains("--get-report");
+    assertEquals(NOT_FOUND, response.getJobStatus());
   }
 
   @Test
@@ -1612,10 +1589,7 @@ public class TestSnapshotDiffManager {
 
     SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
         ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
-
-    assertThat(response.toString())
-        .contains("REJECTED")
-        .contains("resubmit the job without using the --get-report option");
+    assertEquals(REJECTED, response.getJobStatus());
   }
 
   @Test
@@ -1630,11 +1604,8 @@ public class TestSnapshotDiffManager {
 
     SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
         ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
-
-    assertThat(response.toString())
-        .contains("FAILED")
-        .contains("some failure")
-        .contains("resubmit the job without using the --get-report option");
+    assertEquals(FAILED, response.getJobStatus());
+    assertEquals("some failure", response.getReason());
   }
 
   @Test
@@ -1702,11 +1673,6 @@ public class TestSnapshotDiffManager {
 
     SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
         ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
-
-    assertThat(response.toString())
-        .contains("IN_PROGRESS")
-        .contains("OBJECT_ID_MAP_GEN_OBS")
-        .contains("Keys Processed Estimated Percentage")
-        .contains("55.5");
+    assertEquals(IN_PROGRESS, response.getJobStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -45,6 +45,7 @@ import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.Cancel
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_NON_CANCELLABLE;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_SUCCEEDED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone.getDiffReportEntryCodec;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.CANCELLED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.FAILED;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
@@ -58,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
@@ -67,6 +69,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -141,6 +144,7 @@ import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.util.ClosableIterator;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ExitUtil;
@@ -1268,6 +1272,47 @@ public class TestSnapshotDiffManager {
     }
   }
 
+  private static final class SnapDiffTestContext {
+    private final String volumeName;
+    private final String bucketName;
+    private final String fromSnapshotName;
+    private final String toSnapshotName;
+    private final String diffJobKey;
+
+    private SnapDiffTestContext(
+        String volumeName,
+        String bucketName,
+        String fromSnapshotName,
+        String toSnapshotName,
+        String diffJobKey
+    ) {
+      this.volumeName = volumeName;
+      this.bucketName = bucketName;
+      this.fromSnapshotName = fromSnapshotName;
+      this.toSnapshotName = toSnapshotName;
+      this.diffJobKey = diffJobKey;
+    }
+  }
+
+  private SnapDiffTestContext setupRandomSnapDiffTestContext() throws IOException {
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    String bucketName = "bucket-" + RandomStringUtils.secure().nextNumeric(5);
+
+    String fromSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+    String toSnapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(5);
+
+    UUID fromSnapshotUUID = UUID.randomUUID();
+    UUID toSnapshotUUID = UUID.randomUUID();
+
+    setupMocksForRunningASnapDiff(volumeName, bucketName);
+    setUpSnapshots(volumeName, bucketName, fromSnapshotName, toSnapshotName,
+        fromSnapshotUUID, toSnapshotUUID);
+
+    String diffJobKey = fromSnapshotUUID + DELIMITER + toSnapshotUUID;
+    return new SnapDiffTestContext(volumeName, bucketName, fromSnapshotName,
+        toSnapshotName, diffJobKey);
+  }
+
   private void setUpSnapshots(String volumeName, String bucketName,
                               String fromSnapshotName, String toSnapshotName,
                               UUID fromSnapshotUUID, UUID toSnapshotUUID)
@@ -1381,5 +1426,287 @@ public class TestSnapshotDiffManager {
     assertEquals(1, jobs.size());
     assertEquals(snapshotNames.get(0), jobs.get(0).getFromSnapshot());
     assertEquals(snapshotNames.get(1), jobs.get(0).getToSnapshot());
+  }
+
+  @Test
+  public void testSubmitSnapshotDiffNewJobSubmitsAndReturnsMessage()
+      throws Exception {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    doNothing().when(spy).generateSnapshotDiffReport(eq(ctx.diffJobKey), anyString(),
+        eq(ctx.volumeName), eq(ctx.bucketName), eq(ctx.fromSnapshotName), eq(ctx.toSnapshotName),
+        eq(false), eq(false));
+
+    SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
+
+    assertThat(response.getResponse())
+        .contains("Submitting a new job")
+        .contains("--get-report");
+
+    SnapshotDiffJob job = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
+    assertNotNull(job);
+    assertEquals(IN_PROGRESS, job.getStatus());
+
+    attempt(() -> verify(spy, atLeast(1)).generateSnapshotDiffReport(eq(ctx.diffJobKey),
+            anyString(), eq(ctx.volumeName), eq(ctx.bucketName), eq(ctx.fromSnapshotName),
+            eq(ctx.toSnapshotName), eq(false), eq(false)),
+        10, TimeDuration.ONE_SECOND, null, null);
+  }
+
+  @Test
+  public void testSubmitSnapshotDiffInProgressShortCircuits()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        IN_PROGRESS, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        false, false, 0L, null, 0.0, null);
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
+
+    assertThat(response.getResponse())
+        .contains("Previous snapshot diff attempt found")
+        .contains("IN_PROGRESS")
+        .contains("--get-report");
+
+    verify(spy, never()).generateSnapshotDiffReport(anyString(), anyString(),
+        anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  public void testSubmitSnapshotDiffDoneShortCircuits()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        DONE, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        false, false, 1L, null, 0.0, null);
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
+
+    assertThat(response.getResponse())
+        .contains("Previous snapshot diff attempt found")
+        .contains("DONE")
+        .contains("--get-report");
+
+    verify(spy, never()).generateSnapshotDiffReport(anyString(), anyString(),
+        anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  public void testSubmitSnapshotDiffResubmitsWhenPreviouslyFailed()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        FAILED, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        false, false, 0L, null, 0.0, null);
+    existing.setReason("previous failure");
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    doNothing().when(spy).generateSnapshotDiffReport(eq(ctx.diffJobKey), anyString(),
+        eq(ctx.volumeName), eq(ctx.bucketName), eq(ctx.fromSnapshotName), eq(ctx.toSnapshotName),
+        eq(false), eq(false));
+
+    SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
+
+    assertThat(response.getResponse())
+        .contains("Previous snapshot diff attempt found")
+        .contains("FAILED")
+        .contains("previous failure")
+        .contains("Submitting a new job")
+        .contains("--get-report");
+
+    SnapshotDiffJob updated = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
+    assertNotNull(updated);
+    assertEquals(IN_PROGRESS, updated.getStatus());
+  }
+
+  @Test
+  public void testSubmitSnapshotDiffResubmitsWhenPreviouslyCancelled()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        CANCELLED, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName,
+        ctx.toSnapshotName, false, false, 0L, null, 0.0, null);
+    existing.setReason("previously cancelled");
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    doNothing().when(spy).generateSnapshotDiffReport(eq(ctx.diffJobKey), anyString(),
+        eq(ctx.volumeName), eq(ctx.bucketName), eq(ctx.fromSnapshotName),
+        eq(ctx.toSnapshotName), eq(false), eq(false));
+
+    SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
+
+    assertThat(response.getResponse())
+        .contains("Previous snapshot diff attempt found")
+        .contains("CANCELLED")
+        .contains("previously cancelled")
+        .contains("Submitting a new job")
+        .contains("--get-report");
+
+    SnapshotDiffJob updated = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
+    assertNotNull(updated);
+    assertEquals(IN_PROGRESS, updated.getStatus());
+  }
+
+  @Test
+  public void testSubmitSnapshotDiffResubmitsWhenPreviouslyRejected()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        REJECTED, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName,
+        ctx.toSnapshotName, false, false, 0L, null, 0.0, null);
+    existing.setReason("previously rejected");
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    doNothing().when(spy).generateSnapshotDiffReport(eq(ctx.diffJobKey), anyString(),
+        eq(ctx.volumeName), eq(ctx.bucketName), eq(ctx.fromSnapshotName),
+        eq(ctx.toSnapshotName), eq(false), eq(false));
+
+    SubmitSnapshotDiffResponse response = spy.submitSnapshotDiff(ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false);
+
+    assertThat(response.getResponse())
+        .contains("Previous snapshot diff attempt found")
+        .contains("REJECTED")
+        .contains("previously rejected")
+        .contains("Submitting a new job")
+        .contains("--get-report");
+
+    SnapshotDiffJob updated = spy.getSnapDiffJobTable().get(ctx.diffJobKey);
+    assertNotNull(updated);
+    assertEquals(IN_PROGRESS, updated.getStatus());
+  }
+
+  @Test
+  public void testGetSnapshotDiffReportReportOnlyReturnsNotFoundWhenNoJob()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+
+    SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
+
+    assertThat(response.toString())
+        .contains("No snapshot diff job found")
+        .contains("--get-report");
+  }
+
+  @Test
+  public void testGetSnapshotDiffReportReportOnlyRejectedSuggestsResubmit()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        REJECTED, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        false, false, 0L, null, 0.0, null);
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
+
+    assertThat(response.toString())
+        .contains("REJECTED")
+        .contains("resubmit the job without using the --get-report option");
+  }
+
+  @Test
+  public void testGetSnapshotDiffReportReportOnlyFailedSuggestsResubmit()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        FAILED, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        false, false, 0L, null, 0.0, null);
+    existing.setReason("some failure");
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
+
+    assertThat(response.toString())
+        .contains("FAILED")
+        .contains("some failure")
+        .contains("resubmit the job without using the --get-report option");
+  }
+
+  @Test
+  public void testGetSnapshotDiffReportReportOnlyCancelledReturnsCancelledStatus()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        CANCELLED, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName,
+        ctx.toSnapshotName, false, false, 0L, null, 0.0, null);
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
+
+    assertThat(response.toString())
+        .contains("CANCELLED");
+  }
+
+  @Test
+  public void testGetSnapshotDiffReportWhenDone() throws Exception {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+
+    String jobId = UUID.randomUUID().toString();
+    int totalNumberOfRecords = 2;
+    List<DiffReportEntry> expectedEntries = new ArrayList<>();
+
+    for (int idx = 0; idx < totalNumberOfRecords; idx++) {
+      DiffReportEntry entry = new DiffReportEntry(SnapshotDiffReport.DiffType.MODIFY,
+          codecRegistry.asRawData(jobId + DELIMITER + idx));
+      expectedEntries.add(entry);
+    }
+
+    SnapshotDiffManager spy = spy(snapshotDiffManager);
+    SnapshotDiffReportOzone dummyReport = new SnapshotDiffReportOzone(
+        SnapshotDiffManager.getSnapshotRootPath(ctx.volumeName, ctx.bucketName).toString(),
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        expectedEntries, null);
+    doReturn(dummyReport).when(spy).createPageResponse(any(SnapshotDiffJob.class),
+        eq(ctx.volumeName), eq(ctx.bucketName), eq(ctx.fromSnapshotName),
+        eq(ctx.toSnapshotName), eq(""), eq(1000));
+
+    SnapshotDiffJob doneJob = new SnapshotDiffJob(0L, jobId, DONE, ctx.volumeName,
+        ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, false, false,
+        totalNumberOfRecords, null, 0.0, null);
+    spy.getSnapDiffJobTable().put(ctx.diffJobKey, doneJob);
+
+    SnapshotDiffResponse response = spy.getSnapshotDiffReport(
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
+
+    assertEquals(DONE, response.getJobStatus());
+    assertNotNull(response.getSnapshotDiffReport());
+    assertThat(response.getSnapshotDiffReport()).isSameAs(dummyReport);
+    assertThat(response.getSnapshotDiffReport().getDiffList())
+        .containsExactlyElementsOf(expectedEntries);
+  }
+
+  @Test
+  public void testGetSnapshotDiffReportReportOnlyInProgressIncludesProgressDetails()
+      throws IOException {
+    SnapDiffTestContext ctx = setupRandomSnapDiffTestContext();
+    SnapshotDiffJob existing = new SnapshotDiffJob(0L, UUID.randomUUID().toString(),
+        IN_PROGRESS, ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName,
+        false, false, 0L, SnapshotDiffResponse.SubStatus.OBJECT_ID_MAP_GEN_OBS, 55.5, null);
+    snapshotDiffManager.getSnapDiffJobTable().put(ctx.diffJobKey, existing);
+
+    SnapshotDiffResponse response = snapshotDiffManager.getSnapshotDiffReport(
+        ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
+
+    assertThat(response.toString())
+        .contains("IN_PROGRESS")
+        .contains("OBJECT_ID_MAP_GEN_OBS")
+        .contains("Keys Processed Estimated Percentage")
+        .contains("55.5");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -186,7 +186,6 @@ public class TestSnapshotDiffManager {
   private List<ColumnFamilyHandle> columnFamilyHandles;
   private ColumnFamilyHandle snapDiffJobTable;
   private ColumnFamilyHandle snapDiffReportTable;
-  private ColumnFamilyHandle snapDiffPurgedJobTable;
   private SnapshotDiffManager snapshotDiffManager;
   private final List<JobStatus> jobStatuses = Arrays.asList(QUEUED, IN_PROGRESS,
       DONE, REJECTED, FAILED);
@@ -258,7 +257,7 @@ public class TestSnapshotDiffManager {
         new ColumnFamilyDescriptor(
             StringUtils.string2Bytes(SNAP_DIFF_REPORT_TABLE_NAME),
             columnFamilyOptions));
-    snapDiffPurgedJobTable = db.get().createColumnFamily(
+    ColumnFamilyHandle snapDiffPurgedJobTable = db.get().createColumnFamily(
         new ColumnFamilyDescriptor(
             StringUtils.string2Bytes(SNAP_DIFF_PURGED_JOB_TABLE_NAME),
             columnFamilyOptions));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManagerMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManagerMXBean.java
@@ -88,6 +88,9 @@ public class TestSnapshotDiffManagerMXBean {
     ColumnFamilyHandle reportCFH = db.get().createColumnFamily(
         new ColumnFamilyDescriptor("reportTable".getBytes(StandardCharsets.UTF_8),
             columnFamilyOptions));
+    ColumnFamilyHandle purgedJobCFH = db.get().createColumnFamily(
+        new ColumnFamilyDescriptor("purgedJobTable".getBytes(StandardCharsets.UTF_8),
+            columnFamilyOptions));
 
     snapDiffJobTable = new RocksDbPersistentMap<>(db, jobCFH,
         codecRegistry, String.class, SnapshotDiffJob.class);
@@ -105,7 +108,7 @@ public class TestSnapshotDiffManagerMXBean {
     when(ozoneManager.getOmSnapshotManager()).thenReturn(mock(OmSnapshotManager.class));
 
     snapshotDiffManager = new SnapshotDiffManager(db, ozoneManager,
-        jobCFH, reportCFH, columnFamilyOptions, codecRegistry);
+        jobCFH, reportCFH, purgedJobCFH, columnFamilyOptions, codecRegistry);
 
     mbs = ManagementFactory.getPlatformMBeanServer();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
@@ -43,7 +43,9 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.jupiter.api.Assertions;
@@ -310,5 +312,90 @@ public class TestOzoneManagerRequestHandler {
         "Audit message should contain Transaction 10, got: " + formatted);
     Assertions.assertTrue(formatted.contains("Command") && formatted.contains("CreateVolume"),
         "Audit message should contain Command CreateVolume, got: " + formatted);
+  }
+
+  @Test
+  public void testSnapshotDiffRoutingUsesCorrectServerMethodBasedOnOptionalFlags()
+      throws IOException {
+    OzoneManagerRequestHandler handler = getRequestHandler(10);
+    OzoneManager ozoneManager = handler.getOzoneManager();
+
+    OMLayoutVersionManager lvm = Mockito.mock(OMLayoutVersionManager.class);
+    Mockito.when(lvm.isAllowed(Mockito.anyString())).thenReturn(true);
+    Mockito.when(ozoneManager.getVersionManager()).thenReturn(lvm);
+
+    Mockito.when(ozoneManager.snapshotDiff(Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyInt(), Mockito.anyBoolean(), Mockito.anyBoolean()))
+        .thenReturn(new SnapshotDiffResponse(null, SnapshotDiffResponse.JobStatus.IN_PROGRESS, 123L));
+
+    Mockito.when(ozoneManager.snapshotDiff(Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyInt()))
+        .thenReturn(new SnapshotDiffResponse(null, SnapshotDiffResponse.JobStatus.NOT_FOUND, 0L));
+
+    OzoneManagerProtocolProtos.SnapshotDiffRequest.Builder commonReqBuilder =
+        OzoneManagerProtocolProtos.SnapshotDiffRequest.newBuilder()
+            .setVolumeName("vol")
+            .setBucketName("buck")
+            .setFromSnapshot("s1")
+            .setToSnapshot("s2")
+            .setToken("t")
+            .setPageSize(10);
+
+    // Legacy request: presence of these fields is the backwards-compat signal.
+    OzoneManagerProtocolProtos.SnapshotDiffRequest legacySnapshotDiffRequest =
+        commonReqBuilder.clone()
+            .setForceFullDiff(false)
+            .setDisableNativeDiff(false)
+            .build();
+
+    OzoneManagerProtocolProtos.OMRequest request =
+        OzoneManagerProtocolProtos.OMRequest.newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.SnapshotDiff)
+            .setClientId("client")
+            .setSnapshotDiffRequest(legacySnapshotDiffRequest)
+            .build();
+
+    OzoneManagerProtocolProtos.OMResponse response =
+        handler.handleReadRequest(request);
+
+    Mockito.verify(ozoneManager).snapshotDiff("vol", "buck", "s1", "s2", "t",
+        10, false, false);
+    Mockito.verify(ozoneManager, Mockito.never()).snapshotDiff(Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyInt());
+
+    Assertions.assertTrue(response.hasSnapshotDiffResponse());
+    Assertions.assertEquals(
+        OzoneManagerProtocolProtos.SnapshotDiffResponse.JobStatusProto.IN_PROGRESS,
+        response.getSnapshotDiffResponse().getJobStatus());
+    Assertions.assertEquals(123L, response.getSnapshotDiffResponse().getWaitTimeInMs());
+
+    Mockito.clearInvocations(ozoneManager);
+
+    // Report-only request: do NOT set forceFullDiff/disableNativeDiff.
+    OzoneManagerProtocolProtos.SnapshotDiffRequest reportOnlySnapshotDiffRequest =
+        commonReqBuilder.clone().build();
+    OzoneManagerProtocolProtos.OMRequest reportOnlyRequest =
+        OzoneManagerProtocolProtos.OMRequest.newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.SnapshotDiff)
+            .setClientId("client")
+            .setSnapshotDiffRequest(reportOnlySnapshotDiffRequest)
+            .build();
+
+    OzoneManagerProtocolProtos.OMResponse reportOnlyResponse =
+        handler.handleReadRequest(reportOnlyRequest);
+
+    Mockito.verify(ozoneManager).snapshotDiff("vol", "buck", "s1", "s2", "t", 10);
+    Mockito.verify(ozoneManager, Mockito.never()).snapshotDiff(Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean(), Mockito.anyBoolean());
+
+    Assertions.assertTrue(reportOnlyResponse.hasSnapshotDiffResponse());
+    Assertions.assertEquals(
+        OzoneManagerProtocolProtos.SnapshotDiffResponse.JobStatusProto.NOT_FOUND,
+        reportOnlyResponse.getSnapshotDiffResponse().getJobStatus());
+    Assertions.assertEquals(0L, reportOnlyResponse.getSnapshotDiffResponse().getWaitTimeInMs());
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import jakarta.annotation.Nullable;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
@@ -62,6 +63,7 @@ import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.token.Token;
 
 /**
@@ -778,6 +780,7 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  @Deprecated
   public SnapshotDiffResponse snapshotDiff(String volumeName,
                                            String bucketName,
                                            String fromSnapshot,
@@ -786,6 +789,28 @@ public class ClientProtocolStub implements ClientProtocol {
                                            int pageSize,
                                            boolean forceFullDiff,
                                            boolean disableNativeDiff)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public SnapshotDiffResponse snapshotDiff(String volumeName,
+                                           String bucketName,
+                                           String fromSnapshot,
+                                           String toSnapshot,
+                                           String token,
+                                           int pageSize)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public SubmitSnapshotDiffResponse submitSnapshotDiff(String volumeName,
+                                                       String bucketName,
+                                                       String fromSnapshot,
+                                                       String toSnapshot,
+                                                       boolean forceFullDiff,
+                                                       boolean disableNativeDiff)
       throws IOException {
     return null;
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import jakarta.annotation.Nullable;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the snapshot diff process ties snapshot diff job cleanup with re-submission i.e., new snapshot diff cannot be submitted until old snapshot diff job is cleaned up from the DB as there is a single rpc call used for submitting snap diff and gettng the report. Hence, the cleanup has to be inline with the default wait time  (1m) because, 
 - CLI requests are asked to wait default wait time to retrieve the report/status of the job.
 - If cleanup runs at T0, T1 and so on... snapshot diff job that is submitted at T0.5 which fails immediately is cleaned up from the DB at T1.
  --  When the user tries to get the report/status at T1.5 they do not know about the failure and just resubmit. 
  -- This will continue to go on at T2.5 and so on...
 ```
 T0: Replication job submits a snapshot diff job and is asked to check back in 1min for the report. 
T0.2: The job fails immediately and the status of the job is updated as FAILED in the DB
T0.5: But immediately after that cleanup runs and removes the job from the DB
T1: After a minute the user runs the snapshot diff with get-report again as instructed in Step 1 but since the job disappears from the DB it will output "No snapshot diff job found. Job may not have been submitted or was removed during cleanup"
```

The proposal is to refactor the snapshot diff workflow by splitting the process into two distinct RPC calls and removing the dependency between cleanup and submission:
 - Submit Job: Initiates the snapshot diff job and returns immediately with a status.
 - Get Report: A separate call to retrieve the results once the job is complete.
 
**RPC Layer:** Updated the Ozone Manager protocol to support separate submitSnapshotDiff and getSnapshotDiffReport requests.
**Client Side:** Updated the ozone sh snapshot diff command to handle the new asynchronous flow. It now submits the job and provides instructions to the user on how to poll for the report using the --get-report option.
**Response Handling:** Introduced SubmitSnapshotDiffResponse to provide clear feedback to the user regarding the job status (e.g., if a job is already in progress, completed, or newly submitted).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14829

## How was this patch tested?

Acceptance tests and Unit tests.
