### PR TITLE
HDDS-14913. Implement Scalable CSV Export for Unhealthy Containers in Recon UI.

### DIFF
--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -222,8 +222,7 @@ public class TestReconContainerEndpoint {
             null, // ContainerHealthSchemaManager - not needed for this test
             recon.getReconServer().getReconNamespaceSummaryManager(),
             recon.getReconServer().getReconContainerMetadataManager(),
-            omMetadataManagerInstance,
-            new OzoneConfiguration());
+            omMetadataManagerInstance);
     return containerEndpoint.getKeysForContainer(containerId, 10, "");
   }
 

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -222,7 +222,8 @@ public class TestReconContainerEndpoint {
             null, // ContainerHealthSchemaManager - not needed for this test
             recon.getReconServer().getReconNamespaceSummaryManager(),
             recon.getReconServer().getReconContainerMetadataManager(),
-            omMetadataManagerInstance);
+            omMetadataManagerInstance,
+            new OzoneConfiguration());
     return containerEndpoint.getKeysForContainer(containerId, 10, "");
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -253,6 +253,10 @@ public final class  ReconServerConfigKeys {
       "ozone.recon.scm.container.id.batch.size";
   public static final long OZONE_RECON_SCM_CONTAINER_ID_BATCH_SIZE_DEFAULT = 1_000_000;
 
+  public static final String OZONE_RECON_CSV_EXPORT_MAX_RECORDS_KEY =
+      "ozone.recon.csv.export.max.records";
+  public static final int OZONE_RECON_CSV_EXPORT_MAX_RECORDS_DEFAULT = 5000000;
+
   /**
    * Private constructor for utility class.
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -253,9 +253,6 @@ public final class  ReconServerConfigKeys {
       "ozone.recon.scm.container.id.batch.size";
   public static final long OZONE_RECON_SCM_CONTAINER_ID_BATCH_SIZE_DEFAULT = 1_000_000;
 
-  public static final String OZONE_RECON_CSV_EXPORT_MAX_RECORDS_KEY =
-      "ozone.recon.csv.export.max.records";
-  public static final int OZONE_RECON_CSV_EXPORT_MAX_RECORDS_DEFAULT = 5000000;
 
   /**
    * Private constructor for utility class.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -253,7 +253,6 @@ public final class  ReconServerConfigKeys {
       "ozone.recon.scm.container.id.batch.size";
   public static final long OZONE_RECON_SCM_CONTAINER_ID_BATCH_SIZE_DEFAULT = 1_000_000;
 
-
   /**
    * Private constructor for utility class.
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -254,6 +254,21 @@ public final class  ReconServerConfigKeys {
   public static final long OZONE_RECON_SCM_CONTAINER_ID_BATCH_SIZE_DEFAULT = 1_000_000;
 
   /**
+   * JDBC fetch size for streaming unhealthy container exports.
+   * Controls how many rows Derby/JDBC returns per round-trip when executing
+   * {@code /api/v1/containers/unhealthy/export}.
+   *
+   * <p>Larger values reduce round-trips but increase memory per batch.
+   * For example, {@code fetchSize=10000} → 1,000 round-trips for 10M rows;
+   * {@code fetchSize=50000} → 200 round-trips but ~5× memory per batch.
+   *
+   * <p>Default: 10,000 rows per fetch (~1 MB per batch)
+   */
+  public static final String OZONE_RECON_UNHEALTHY_CONTAINER_FETCH_SIZE =
+      "ozone.recon.unhealthy.container.fetch.size";
+  public static final int OZONE_RECON_UNHEALTHY_CONTAINER_FETCH_SIZE_DEFAULT = 10_000;
+
+  /**
    * Private constructor for utility class.
    */
   private ReconServerConfigKeys() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -26,6 +26,7 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_MAX_CONTA
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_MIN_CONTAINER_ID;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -485,21 +486,27 @@ public class ContainerEndpoint {
     final ContainerSchemaDefinition.UnHealthyContainerStates filterState = internalState;
 
     StreamingOutput stream = outputStream -> {
-      try (Cursor<UnhealthyContainersRecord> cursor =
+      try (BufferedOutputStream bos = new BufferedOutputStream(outputStream, 256 * 1024);
+           Cursor<UnhealthyContainersRecord> cursor =
                containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, limit)) {
         
-        PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(bos, StandardCharsets.UTF_8));
         
         // Write CSV header
         writer.println("container_id,container_state,in_state_since," +
             "expected_replica_count,actual_replica_count,replica_delta");
         
+        StringBuilder sb = new StringBuilder(128);
         while (cursor.hasNext()) {
           UnhealthyContainersRecord rec = cursor.fetchNext();
-          writer.printf("%d,%s,%d,%d,%d,%d%n",
-              rec.getContainerId(), rec.getContainerState(),
-              rec.getInStateSince(), rec.getExpectedReplicaCount(),
-              rec.getActualReplicaCount(), rec.getReplicaDelta());
+          sb.setLength(0);
+          sb.append(rec.getContainerId()).append(',')
+              .append(rec.getContainerState()).append(',')
+              .append(rec.getInStateSince()).append(',')
+              .append(rec.getExpectedReplicaCount()).append(',')
+              .append(rec.getActualReplicaCount()).append(',')
+              .append(rec.getReplicaDelta());
+          writer.println(sb);
         }
         writer.flush();
       } catch (Exception e) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -115,7 +115,6 @@ public class ContainerEndpoint {
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerEndpoint.class);
   private BucketLayout layout = BucketLayout.DEFAULT;
-  private final int maxCsvExportRecords;
 
   /**
    * Enumeration representing different data filters.
@@ -154,8 +153,7 @@ public class ContainerEndpoint {
                            ContainerHealthSchemaManager containerHealthSchemaManager,
                            ReconNamespaceSummaryManager reconNamespaceSummaryManager,
                            ReconContainerMetadataManager reconContainerMetadataManager,
-                           ReconOMMetadataManager omMetadataManager,
-                           OzoneConfiguration ozoneConfiguration) {
+                           ReconOMMetadataManager omMetadataManager) {
     this.containerManager =
         (ReconContainerManager) reconSCM.getContainerManager();
     this.pipelineManager = reconSCM.getPipelineManager();
@@ -164,9 +162,6 @@ public class ContainerEndpoint {
     this.reconSCM = reconSCM;
     this.reconContainerMetadataManager = reconContainerMetadataManager;
     this.omMetadataManager = omMetadataManager;
-    this.maxCsvExportRecords = ozoneConfiguration.getInt(
-        ReconServerConfigKeys.OZONE_RECON_CSV_EXPORT_MAX_RECORDS_KEY,
-        ReconServerConfigKeys.OZONE_RECON_CSV_EXPORT_MAX_RECORDS_DEFAULT);
   }
 
   /**
@@ -489,12 +484,10 @@ public class ContainerEndpoint {
 
     // Must be effectively final for use in the lambda
     final ContainerSchemaDefinition.UnHealthyContainerStates filterState = internalState;
-    final int finalLimit = (limit <= 0 || limit > maxCsvExportRecords)
-        ? maxCsvExportRecords : limit;
 
     StreamingOutput stream = outputStream -> {
       try (Cursor<UnhealthyContainersRecord> cursor =
-               containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, finalLimit)) {
+               containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, limit)) {
         
         PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
         

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -61,6 +61,8 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.ContainerDiscrepancyInfo;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
@@ -84,8 +86,14 @@ import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
 import org.apache.hadoop.ozone.util.SeekableIterator;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.apache.ozone.recon.schema.generated.tables.pojos.UnhealthyContainers;
+import org.apache.ozone.recon.schema.generated.tables.records.UnhealthyContainersRecord;
+import org.jooq.Cursor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import javax.ws.rs.core.StreamingOutput;
 
 
 /**
@@ -107,6 +115,7 @@ public class ContainerEndpoint {
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerEndpoint.class);
   private BucketLayout layout = BucketLayout.DEFAULT;
+  private final int maxCsvExportRecords;
 
   /**
    * Enumeration representing different data filters.
@@ -145,7 +154,8 @@ public class ContainerEndpoint {
                            ContainerHealthSchemaManager containerHealthSchemaManager,
                            ReconNamespaceSummaryManager reconNamespaceSummaryManager,
                            ReconContainerMetadataManager reconContainerMetadataManager,
-                           ReconOMMetadataManager omMetadataManager) {
+                           ReconOMMetadataManager omMetadataManager,
+                           OzoneConfiguration ozoneConfiguration) {
     this.containerManager =
         (ReconContainerManager) reconSCM.getContainerManager();
     this.pipelineManager = reconSCM.getPipelineManager();
@@ -154,6 +164,9 @@ public class ContainerEndpoint {
     this.reconSCM = reconSCM;
     this.reconContainerMetadataManager = reconContainerMetadataManager;
     this.omMetadataManager = omMetadataManager;
+    this.maxCsvExportRecords = ozoneConfiguration.getInt(
+        ReconServerConfigKeys.OZONE_RECON_CSV_EXPORT_MAX_RECORDS_KEY,
+        ReconServerConfigKeys.OZONE_RECON_CSV_EXPORT_MAX_RECORDS_DEFAULT);
   }
 
   /**
@@ -448,6 +461,68 @@ public class ContainerEndpoint {
       response.setSummaryCount(s.getContainerState(), s.getCount());
     }
     return Response.ok(response).build();
+  }
+
+  /**
+   * Export all unhealthy containers into a CSV file by streaming the results directly
+   * from the database without holding them in the JVM heap.
+   *
+   * @param state The container state to filter by, or null for all.
+   * @param limit The maximum number of records to return, 0 for unlimited.
+   * @return {@link Response} containing the CSV StreamingOutput.
+   */
+  @GET
+  @Path("/unhealthy/export")
+  @Produces("text/csv")
+  public Response exportUnhealthyContainers(
+      @QueryParam("state") String state,
+      @DefaultValue("0") @QueryParam(RECON_QUERY_LIMIT) int limit) {
+
+    ContainerSchemaDefinition.UnHealthyContainerStates internalState = null;
+    if (StringUtils.isNotEmpty(state)) {
+      try {
+        internalState = ContainerSchemaDefinition.UnHealthyContainerStates.valueOf(state);
+      } catch (IllegalArgumentException e) {
+        throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
+      }
+    }
+
+    // Must be effectively final for use in the lambda
+    final ContainerSchemaDefinition.UnHealthyContainerStates filterState = internalState;
+    final int finalLimit = (limit <= 0 || limit > maxCsvExportRecords)
+        ? maxCsvExportRecords : limit;
+
+    StreamingOutput stream = outputStream -> {
+      try (Cursor<UnhealthyContainersRecord> cursor =
+               containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, finalLimit)) {
+        
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
+        
+        // Write CSV header
+        writer.println("container_id,container_state,in_state_since," +
+            "expected_replica_count,actual_replica_count,replica_delta");
+        
+        while (cursor.hasNext()) {
+          UnhealthyContainersRecord rec = cursor.fetchNext();
+          writer.printf("%d,%s,%d,%d,%d,%d%n",
+              rec.getContainerId(), rec.getContainerState(),
+              rec.getInStateSince(), rec.getExpectedReplicaCount(),
+              rec.getActualReplicaCount(), rec.getReplicaDelta());
+        }
+        writer.flush();
+      } catch (Exception e) {
+        LOG.error("Error streaming unhealthy containers CSV", e);
+        throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+      }
+    };
+
+    String filename = String.format("unhealthy_containers_%s_%d.csv",
+        state != null ? state.toLowerCase() : "all",
+        System.currentTimeMillis());
+
+    return Response.ok(stream)
+        .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
+        .build();
   }
 
   private UnhealthyContainerMetadata toUnhealthyMetadata(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -482,7 +482,6 @@ public class ContainerEndpoint {
       }
     }
 
-    // Must be effectively final for use in the lambda
     final ContainerSchemaDefinition.UnHealthyContainerStates filterState = internalState;
 
     StreamingOutput stream = outputStream -> {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -27,7 +27,10 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_MIN_CONTA
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -48,7 +51,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -61,7 +66,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.ContainerDiscrepancyInfo;
@@ -90,10 +94,6 @@ import org.apache.ozone.recon.schema.generated.tables.records.UnhealthyContainer
 import org.jooq.Cursor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.PrintWriter;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import javax.ws.rs.core.StreamingOutput;
 
 
 /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_MIN_CONTA
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 
 import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -54,7 +55,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -67,7 +67,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.ContainerDiscrepancyInfo;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
@@ -465,6 +464,7 @@ public class ContainerEndpoint {
    *
    * @param state The container state to filter by, or null for all.
    * @param limit The maximum number of records to return, 0 for unlimited.
+   * @param prevKey The previous container ID to skip, for pagination.
    * @return {@link Response} containing the CSV StreamingOutput.
    */
   @GET
@@ -472,7 +472,13 @@ public class ContainerEndpoint {
   @Produces("text/csv")
   public Response exportUnhealthyContainers(
       @QueryParam("state") String state,
-      @DefaultValue("0") @QueryParam(RECON_QUERY_LIMIT) int limit) {
+      @DefaultValue("0") @QueryParam(RECON_QUERY_LIMIT) int limit,
+      @DefaultValue(PREV_CONTAINER_ID_DEFAULT_VALUE) @QueryParam(RECON_QUERY_PREVKEY) long prevKey) {
+
+    if (limit < 0) {
+      throw new WebApplicationException("The limit query parameter must be "
+          + "greater than or equal to 0.", Response.Status.BAD_REQUEST);
+    }
 
     ContainerSchemaDefinition.UnHealthyContainerStates internalState = null;
     if (StringUtils.isNotEmpty(state)) {
@@ -488,13 +494,13 @@ public class ContainerEndpoint {
     StreamingOutput stream = outputStream -> {
       try (BufferedOutputStream bos = new BufferedOutputStream(outputStream, 256 * 1024);
            Cursor<UnhealthyContainersRecord> cursor =
-               containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, limit)) {
+               containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, limit, prevKey)) {
         
-        PrintWriter writer = new PrintWriter(new OutputStreamWriter(bos, StandardCharsets.UTF_8));
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(bos, StandardCharsets.UTF_8));
         
         // Write CSV header
-        writer.println("container_id,container_state,in_state_since," +
-            "expected_replica_count,actual_replica_count,replica_delta");
+        writer.write("container_id,container_state,in_state_since," +
+            "expected_replica_count,actual_replica_count,replica_delta\n");
         
         StringBuilder sb = new StringBuilder(128);
         while (cursor.hasNext()) {
@@ -505,8 +511,8 @@ public class ContainerEndpoint {
               .append(rec.getInStateSince()).append(',')
               .append(rec.getExpectedReplicaCount()).append(',')
               .append(rec.getActualReplicaCount()).append(',')
-              .append(rec.getReplicaDelta());
-          writer.println(sb);
+              .append(rec.getReplicaDelta()).append('\n');
+          writer.write(sb.toString());
         }
         writer.flush();
       } catch (Exception e) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -30,7 +30,6 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -526,6 +525,7 @@ public class ContainerEndpoint {
         System.currentTimeMillis());
 
     return Response.ok(stream)
+        .header("Content-Type", "text/csv")
         .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
         .build();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -458,12 +458,12 @@ public class ContainerEndpoint {
   }
 
   /**
-   * Export all unhealthy containers into a CSV file by streaming the results directly
-   * from the database without holding them in the JVM heap.
+   * Export unhealthy containers for a given state into a CSV file by streaming
+   * the results directly from the database without holding them in the JVM heap.
    *
-   * @param state The container state to filter by, or null for all.
-   * @param limit The maximum number of records to return, 0 for unlimited.
-   * @param prevKey The previous container ID to skip, for pagination.
+   * @param state The container state to filter by (required).
+   * @param limit The maximum number of records to return, -1 for unlimited.
+   * @param prevKey The previous container ID to skip, for cursor-based pagination.
    * @return {@link Response} containing the CSV StreamingOutput.
    */
   @GET
@@ -471,21 +471,24 @@ public class ContainerEndpoint {
   @Produces("text/csv")
   public Response exportUnhealthyContainers(
       @QueryParam("state") String state,
-      @DefaultValue("0") @QueryParam(RECON_QUERY_LIMIT) int limit,
+      @DefaultValue("-1") @QueryParam(RECON_QUERY_LIMIT) int limit,
       @DefaultValue(PREV_CONTAINER_ID_DEFAULT_VALUE) @QueryParam(RECON_QUERY_PREVKEY) long prevKey) {
 
-    if (limit < 0) {
-      throw new WebApplicationException("The limit query parameter must be "
-          + "greater than or equal to 0.", Response.Status.BAD_REQUEST);
+    if (StringUtils.isEmpty(state)) {
+      throw new WebApplicationException("The state query parameter is required.",
+          Response.Status.BAD_REQUEST);
     }
 
-    ContainerSchemaDefinition.UnHealthyContainerStates internalState = null;
-    if (StringUtils.isNotEmpty(state)) {
-      try {
-        internalState = ContainerSchemaDefinition.UnHealthyContainerStates.valueOf(state);
-      } catch (IllegalArgumentException e) {
-        throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
-      }
+    if (limit < -1) {
+      throw new WebApplicationException("The limit query parameter must be "
+          + "greater than or equal to -1.", Response.Status.BAD_REQUEST);
+    }
+
+    ContainerSchemaDefinition.UnHealthyContainerStates internalState;
+    try {
+      internalState = ContainerSchemaDefinition.UnHealthyContainerStates.valueOf(state);
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
     }
 
     final ContainerSchemaDefinition.UnHealthyContainerStates filterState = internalState;
@@ -494,18 +497,20 @@ public class ContainerEndpoint {
       try (BufferedOutputStream bos = new BufferedOutputStream(outputStream, 256 * 1024);
            Cursor<UnhealthyContainersRecord> cursor =
                containerHealthSchemaManager.getUnhealthyContainersCursor(filterState, limit, prevKey)) {
-        
+
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(bos, StandardCharsets.UTF_8));
-        
+
         // Write CSV header
         writer.write("container_id,container_state,in_state_since," +
             "expected_replica_count,actual_replica_count,replica_delta\n");
-        
+
+        long lastContainerId = 0;
         StringBuilder sb = new StringBuilder(128);
         while (cursor.hasNext()) {
           UnhealthyContainersRecord rec = cursor.fetchNext();
+          lastContainerId = rec.getContainerId();
           sb.setLength(0);
-          sb.append(rec.getContainerId()).append(',')
+          sb.append(lastContainerId).append(',')
               .append(rec.getContainerState()).append(',')
               .append(rec.getInStateSince()).append(',')
               .append(rec.getExpectedReplicaCount()).append(',')
@@ -513,19 +518,30 @@ public class ContainerEndpoint {
               .append(rec.getReplicaDelta()).append('\n');
           writer.write(sb.toString());
         }
+
+        // Write the last container ID as a trailer comment so the client can
+        // use it as prevKey for the next paginated chunk without parsing CSV rows.
+        // Lines starting with '#' are ignored by standard CSV parsers.
+        writer.write("#last_container_id:" + lastContainerId + "\n");
         writer.flush();
+      } catch (IOException e) {
+        // Client disconnected or network error mid-stream — the 200 OK header
+        // has already been sent so we cannot change the status. Abort cleanly.
+        LOG.warn("Client disconnected during CSV export", e);
+        throw e;
       } catch (Exception e) {
+        // Unexpected DB/application error — wrap and rethrow as IOException so
+        // the JAX-RS container aborts the connection, giving the browser a
+        // failed/incomplete download signal.
         LOG.error("Error streaming unhealthy containers CSV", e);
-        throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+        throw new IOException("Internal error during CSV export", e);
       }
     };
 
     String filename = String.format("unhealthy_containers_%s_%d.csv",
-        state != null ? state.toLowerCase() : "all",
-        System.currentTimeMillis());
+        state.toLowerCase(), System.currentTimeMillis());
 
     return Response.ok(stream)
-        .header("Content-Type", "text/csv")
         .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
         .build();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -462,7 +462,7 @@ public class ContainerEndpoint {
    * the results directly from the database without holding them in the JVM heap.
    *
    * @param state The container state to filter by (required).
-   * @param limit The maximum number of records to return, -1 for unlimited.
+   * @param limit The maximum number of records to return (must be positive or -1 for unlimited).
    * @param prevKey The previous container ID to skip, for cursor-based pagination.
    * @return {@link Response} containing the CSV StreamingOutput.
    */
@@ -479,9 +479,9 @@ public class ContainerEndpoint {
           Response.Status.BAD_REQUEST);
     }
 
-    if (limit < -1) {
+    if (limit < -1 || limit == 0) {
       throw new WebApplicationException("The limit query parameter must be "
-          + "greater than or equal to -1.", Response.Status.BAD_REQUEST);
+          + "a positive integer or -1 (unlimited).", Response.Status.BAD_REQUEST);
     }
 
     ContainerSchemaDefinition.UnHealthyContainerStates internalState;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -397,12 +397,19 @@ public class ContainerHealthSchemaManager {
 
     if (state != null) {
       query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
+      // Single-state filter: ordering by container_state is redundant (every
+      // row has the same value).  ORDER BY container_id alone lets Derby walk
+      // the composite index idx_state_container_id in order and return rows
+      // immediately — no sort step, eliminating "time to first byte" delay.
+      query.addOrderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc());
+    } else {
+      // All-states query: order by state first, then container_id.  This
+      // matches the composite index order so Derby can still avoid a sort.
+      query.addOrderBy(
+          UNHEALTHY_CONTAINERS.CONTAINER_STATE.asc(),
+          UNHEALTHY_CONTAINERS.CONTAINER_ID.asc()
+      );
     }
-
-    query.addOrderBy(
-        UNHEALTHY_CONTAINERS.CONTAINER_STATE.asc(),
-        UNHEALTHY_CONTAINERS.CONTAINER_ID.asc()
-    );
 
     if (limit > 0) {
       query.addLimit(limit);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -36,6 +36,7 @@ import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
 import org.apache.ozone.recon.schema.generated.tables.records.UnhealthyContainersRecord;
 import org.jooq.Condition;
+import org.jooq.Cursor;
 import org.jooq.DSLContext;
 import org.jooq.OrderField;
 import org.jooq.Record;
@@ -379,6 +380,35 @@ public class ContainerHealthSchemaManager {
       LOG.error("Failed to query UNHEALTHY_CONTAINERS table", e);
       return new ArrayList<>();
     }
+  }
+
+  /**
+   * Returns a streaming cursor over unhealthy container records.
+   * Caller MUST close the cursor.
+   *
+   * @param state filter by state, or null for all states
+   * @param limit max records to return, 0 = unlimited
+   * @return Cursor returning UnhealthyContainersRecord
+   */
+  public Cursor<UnhealthyContainersRecord> getUnhealthyContainersCursor(
+      UnHealthyContainerStates state, int limit) {
+    DSLContext dslContext = containerSchemaDefinition.getDSLContext();
+    org.jooq.SelectQuery<UnhealthyContainersRecord> query = dslContext.selectFrom(UNHEALTHY_CONTAINERS).getQuery();
+
+    if (state != null) {
+      query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
+    }
+
+    query.addOrderBy(
+        UNHEALTHY_CONTAINERS.CONTAINER_STATE.asc(),
+        UNHEALTHY_CONTAINERS.CONTAINER_ID.asc()
+    );
+
+    if (limit > 0) {
+      query.addLimit(limit);
+    }
+
+    return query.fetchLazy();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -388,21 +388,28 @@ public class ContainerHealthSchemaManager {
    *
    * @param state filter by state, or null for all states
    * @param limit max records to return, 0 = unlimited
+   * @param prevKey previous container ID to skip, for pagination
    * @return Cursor returning UnhealthyContainersRecord
    */
   public Cursor<UnhealthyContainersRecord> getUnhealthyContainersCursor(
-      UnHealthyContainerStates state, int limit) {
+      UnHealthyContainerStates state, int limit, long prevKey) {
     DSLContext dslContext = containerSchemaDefinition.getDSLContext();
     org.jooq.SelectQuery<UnhealthyContainersRecord> query = dslContext.selectFrom(UNHEALTHY_CONTAINERS).getQuery();
 
     if (state != null) {
       query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
+      if (prevKey > 0) {
+        query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
+      }
       // Single-state filter: ordering by container_state is redundant (every
       // row has the same value).  ORDER BY container_id alone lets Derby walk
       // the composite index idx_state_container_id in order and return rows
       // immediately — no sort step, eliminating "time to first byte" delay.
       query.addOrderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc());
     } else {
+      if (prevKey > 0) {
+        query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
+      }
       // All-states query: order by state first, then container_id.  This
       // matches the composite index order so Derby can still avoid a sort.
       query.addOrderBy(
@@ -414,6 +421,10 @@ public class ContainerHealthSchemaManager {
     if (limit > 0) {
       query.addLimit(limit);
     }
+
+    // Set a fetch size to improve streaming throughput by reducing JDBC round-trips.
+    // 10,000 is a reasonable default for Derby to balance memory and network overhead.
+    query.fetchSize(10000);
 
     return query.fetchLazy();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -386,6 +386,23 @@ public class ContainerHealthSchemaManager {
    * Returns a streaming cursor over unhealthy container records.
    * Caller MUST close the cursor.
    *
+   * Final Complete Query Examples:
+   * Example 1: Export 50,000 MISSING containers, starting after container ID 12345
+   *
+   * SELECT * FROM unhealthy_containers
+   * WHERE container_state = 'MISSING'
+   *   AND container_id > 12345
+   * ORDER BY container_id ASC
+   * LIMIT 50000
+   * JDBC will fetch 10,000 rows at a time (5 batches total)
+   *
+   * Example 2: Export all 100,000 containers (all states), no pagination
+   *
+   * SELECT * FROM unhealthy_containers
+   * ORDER BY container_state ASC, container_id ASC
+   * LIMIT 100000
+   * JDBC will fetch 10,000 rows at a time (10 batches total)
+   *
    * @param state filter by state, or null for all states
    * @param limit max records to return, 0 = unlimited
    * @param prevKey previous container ID to skip, for pagination
@@ -394,24 +411,27 @@ public class ContainerHealthSchemaManager {
   public Cursor<UnhealthyContainersRecord> getUnhealthyContainersCursor(
       UnHealthyContainerStates state, int limit, long prevKey) {
     DSLContext dslContext = containerSchemaDefinition.getDSLContext();
+
+    // In plain SQL: SELECT * FROM unhealthy_containers
     org.jooq.SelectQuery<UnhealthyContainersRecord> query = dslContext.selectFrom(UNHEALTHY_CONTAINERS).getQuery();
 
     if (state != null) {
+      // Filtering by ONE specific state (e.g., state = "MISSING")
+      // WHERE container_state = 'MISSING'
       query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
       if (prevKey > 0) {
+        // AND container_id > 12345
         query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
       }
-      // Single-state filter: ordering by container_state is redundant (every
-      // row has the same value).  ORDER BY container_id alone lets Derby walk
-      // the composite index idx_state_container_id in order and return rows
-      // immediately — no sort step, eliminating "time to first byte" delay.
+      // ORDER BY container_id ASC
       query.addOrderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc());
     } else {
+      // Exporting ALL states (state = null)
       if (prevKey > 0) {
+        // WHERE container_id > 12345
         query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
       }
-      // All-states query: order by state first, then container_id.  This
-      // matches the composite index order so Derby can still avoid a sort.
+      // ORDER BY container_state ASC, container_id ASC
       query.addOrderBy(
           UNHEALTHY_CONTAINERS.CONTAINER_STATE.asc(),
           UNHEALTHY_CONTAINERS.CONTAINER_ID.asc()
@@ -422,8 +442,8 @@ public class ContainerHealthSchemaManager {
       query.addLimit(limit);
     }
 
-    // Set a fetch size to improve streaming throughput by reducing JDBC round-trips.
-    // 10,000 is a reasonable default for Derby to balance memory and network overhead.
+    // This doesn't change the SQL query.
+    // It tells JDBC: "When you fetch data, bring me 10,000 rows at a time, not one-by-one"
     query.fetchSize(10000);
 
     return query.fetchLazy();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -383,67 +383,44 @@ public class ContainerHealthSchemaManager {
   }
 
   /**
-   * Returns a streaming cursor over unhealthy container records.
+   * Returns a streaming cursor over unhealthy container records for a given state.
    * Caller MUST close the cursor.
    *
-   * Final Complete Query Examples:
-   * Example 1: Export 50,000 MISSING containers, starting after container ID 12345
+   * Generated SQL example (50,000 MISSING containers, starting after container ID 12345):
    *
    * SELECT * FROM unhealthy_containers
    * WHERE container_state = 'MISSING'
    *   AND container_id > 12345
    * ORDER BY container_id ASC
    * LIMIT 50000
-   * JDBC will fetch 10,000 rows at a time (5 batches total)
    *
-   * Example 2: Export all 100,000 containers (all states), no pagination
-   *
-   * SELECT * FROM unhealthy_containers
-   * ORDER BY container_state ASC, container_id ASC
-   * LIMIT 100000
-   * JDBC will fetch 10,000 rows at a time (10 batches total)
-   *
-   * @param state filter by state, or null for all states
-   * @param limit max records to return, 0 = unlimited
-   * @param prevKey previous container ID to skip, for pagination
+   * @param state filter by state (required)
+   * @param limit max records to return, -1 = unlimited
+   * @param prevKey previous container ID to skip, for cursor-based pagination
    * @return Cursor returning UnhealthyContainersRecord
    */
   public Cursor<UnhealthyContainersRecord> getUnhealthyContainersCursor(
       UnHealthyContainerStates state, int limit, long prevKey) {
     DSLContext dslContext = containerSchemaDefinition.getDSLContext();
-
-    // In plain SQL: SELECT * FROM unhealthy_containers
     org.jooq.SelectQuery<UnhealthyContainersRecord> query = dslContext.selectFrom(UNHEALTHY_CONTAINERS).getQuery();
 
-    if (state != null) {
-      // Filtering by ONE specific state (e.g., state = "MISSING")
-      // WHERE container_state = 'MISSING'
-      query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
-      if (prevKey > 0) {
-        // AND container_id > 12345
-        query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
-      }
-      // ORDER BY container_id ASC
-      query.addOrderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc());
-    } else {
-      // Exporting ALL states (state = null)
-      if (prevKey > 0) {
-        // WHERE container_id > 12345
-        query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
-      }
-      // ORDER BY container_state ASC, container_id ASC
-      query.addOrderBy(
-          UNHEALTHY_CONTAINERS.CONTAINER_STATE.asc(),
-          UNHEALTHY_CONTAINERS.CONTAINER_ID.asc()
-      );
+    // WHERE container_state = ?
+    query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
+
+    if (prevKey > 0) {
+      // AND container_id > ?  (cursor-based pagination)
+      query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_ID.gt(prevKey));
     }
+
+    // ORDER BY container_id ASC — matches composite index (state, container_id),
+    // so Derby walks it in order with no sort step.
+    query.addOrderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc());
 
     if (limit > 0) {
       query.addLimit(limit);
     }
 
-    // This doesn't change the SQL query.
-    // It tells JDBC: "When you fetch data, bring me 10,000 rows at a time, not one-by-one"
+    // Fetch 10,000 rows per JDBC round-trip instead of one-by-one.
     query.fetchSize(10000);
 
     return query.fetchLazy();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
 import org.apache.ozone.recon.schema.generated.tables.records.UnhealthyContainersRecord;
@@ -68,11 +70,16 @@ public class ContainerHealthSchemaManager {
   static final int MAX_DELETE_CHUNK_SIZE = 1_000;
 
   private final ContainerSchemaDefinition containerSchemaDefinition;
+  private final int jdbcFetchSize;
 
   @Inject
   public ContainerHealthSchemaManager(
-      ContainerSchemaDefinition containerSchemaDefinition) {
+      ContainerSchemaDefinition containerSchemaDefinition,
+      OzoneConfiguration conf) {
     this.containerSchemaDefinition = containerSchemaDefinition;
+    this.jdbcFetchSize = conf.getInt(
+        ReconServerConfigKeys.OZONE_RECON_UNHEALTHY_CONTAINER_FETCH_SIZE,
+        ReconServerConfigKeys.OZONE_RECON_UNHEALTHY_CONTAINER_FETCH_SIZE_DEFAULT);
   }
 
   /**
@@ -420,8 +427,9 @@ public class ContainerHealthSchemaManager {
       query.addLimit(limit);
     }
 
-    // Fetch 10,000 rows per JDBC round-trip instead of one-by-one.
-    query.fetchSize(10000);
+    // Controls how many rows Derby returns per JDBC round-trip.
+    // Configurable via ozone.recon.unhealthy.container.fetch.size (default: 10,000).
+    query.fetchSize(jdbcFetchSize);
 
     return query.fetchLazy();
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.less
@@ -32,6 +32,13 @@
       padding: 16px 8px;
       align-items: center;
     }
+
+    .table-actions-section {
+      display: flex;
+      align-items: center;
+      column-gap: 10px;
+      padding-right: 8px;
+    }
   }
 }
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,7 +19,8 @@
 
 import React, { useState, useCallback } from "react";
 import moment from "moment";
-import { Card, Row, Tabs } from "antd";
+import { Button, Card, Row, Tabs, Tooltip, message, Select } from "antd";
+import { DownloadOutlined } from "@ant-design/icons";
 import { ValueType } from "react-select/src/types";
 
 import Search from "@/v2/components/search/search";
@@ -73,6 +75,7 @@ const Containers: React.FC<{}> = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [selectedTab, setSelectedTab] = useState<string>('1');
   const [searchColumn, setSearchColumn] = useState<'containerID' | 'pipelineID'>('containerID');
+  const [exportLimit, setExportLimit] = useState<number>(10000);
 
   const debouncedSearch = useDebounce(searchTerm, 300);
 
@@ -175,6 +178,31 @@ const Containers: React.FC<{}> = () => {
     5: mismatchedReplicaContainerData
   }
 
+  // Mapping tab keys to the backend state parameter for CSV export
+  const tabToExportState: Record<string, string> = {
+    '1': 'MISSING',
+    '2': 'UNDER_REPLICATED',
+    '3': 'OVER_REPLICATED',
+    '4': 'MIS_REPLICATED',
+    '5': 'REPLICA_MISMATCH'
+  };
+
+  // Human-readable labels for the export tooltip
+  const tabToLabel: Record<string, string> = {
+    '1': 'Missing',
+    '2': 'Under-Replicated',
+    '3': 'Over-Replicated',
+    '4': 'Mis-Replicated',
+    '5': 'Mismatched Replicas'
+  };
+
+  const handleExportCsv = useCallback(() => {
+    const state = tabToExportState[selectedTab];
+    const exportUrl = `/api/v1/containers/unhealthy/export?state=${state}&limit=${exportLimit}`;
+    window.open(exportUrl, '_blank');
+    message.success(`Exporting ${tabToLabel[selectedTab]} containers as CSV (Limit: ${exportLimit})`);
+  }, [selectedTab, exportLimit]);
+
   const highlightData = (
     <div style={{
         display: 'flex',
@@ -260,18 +288,40 @@ const Containers: React.FC<{}> = () => {
                 onTagClose={() => { }}
                 columnLength={columnOptions.length} />
             </div>
-            <Search
-              disabled={dataToTabKeyMap[selectedTab]?.length < 1}
-              searchOptions={SearchableColumnOpts}
-              searchInput={searchTerm}
-              searchColumn={searchColumn}
-              onSearchChange={
-                (e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)
-              }
-              onChange={(value) => {
-                setSearchTerm('');
-                setSearchColumn(value as 'containerID' | 'pipelineID');
-              }} />
+            <div className='table-actions-section'>
+              <Search
+                disabled={dataToTabKeyMap[selectedTab]?.length < 1}
+                searchOptions={SearchableColumnOpts}
+                searchInput={searchTerm}
+                searchColumn={searchColumn}
+                onSearchChange={
+                  (e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)
+                }
+                onChange={(value) => {
+                  setSearchTerm('');
+                  setSearchColumn(value as 'containerID' | 'pipelineID');
+                }} />
+              <Select
+                value={exportLimit}
+                onChange={(value: number) => setExportLimit(value)}
+                style={{ width: 130 }}
+                options={[
+                  { value: 10000, label: '10K Records' },
+                  { value: 100000, label: '100K Records' },
+                  { value: 1000000, label: '1M Records' },
+                  { value: 5000000, label: '5M Records' }
+                ]}
+              />
+              <Tooltip title={`Export ${tabToLabel[selectedTab]} containers as CSV`}>
+                <Button
+                  type='primary'
+                  icon={<DownloadOutlined />}
+                  onClick={handleExportCsv}
+                  className='export-csv-btn'>
+                  Export CSV
+                </Button>
+              </Tooltip>
+            </div>
           </div>
           <Tabs defaultActiveKey='1'
             onChange={(activeKey: string) => setSelectedTab(activeKey)}>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
@@ -309,7 +309,7 @@ const Containers: React.FC<{}> = () => {
                   { value: 10000, label: '10K Records' },
                   { value: 100000, label: '100K Records' },
                   { value: 1000000, label: '1M Records' },
-                  { value: 5000000, label: '5M Records' }
+                  { value: 0, label: 'Complete' }
                 ]}
               />
               <Tooltip title={`Export ${tabToLabel[selectedTab]} containers as CSV`}>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
@@ -225,6 +225,12 @@ const Containers: React.FC<{}> = () => {
         const trailerMatch = text.match(/^#last_container_id:(\d+)$/m);
         const lastContainerId = trailerMatch ? parseInt(trailerMatch[1], 10) : 0;
 
+        // Count actual data rows returned (excluding header and trailer comment)
+        const actualRecords = text.split('\n')
+          .filter(l => l && !l.startsWith('#') && !l.startsWith('container_id'))
+          .length;
+        totalExported += actualRecords;
+
         // Strip the trailer comment before saving so the downloaded file is clean CSV.
         const cleanCsv = text.replace(/^#last_container_id:\d+\n?$/m, '');
         const blob = new Blob([cleanCsv], { type: 'text/csv' });
@@ -236,8 +242,6 @@ const Containers: React.FC<{}> = () => {
         a.click();
         document.body.removeChild(a);
         window.URL.revokeObjectURL(url);
-
-        totalExported += currentLimit;
 
         // lastContainerId === 0 means no rows were written — export is complete.
         if (!lastContainerId || isNaN(lastContainerId)) {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
@@ -196,11 +196,79 @@ const Containers: React.FC<{}> = () => {
     '5': 'Mismatched Replicas'
   };
 
-  const handleExportCsv = useCallback(() => {
+  const handleExportCsv = useCallback(async () => {
     const state = tabToExportState[selectedTab];
-    const exportUrl = `/api/v1/containers/unhealthy/export?state=${state}&limit=${exportLimit}`;
-    window.open(exportUrl, '_blank');
-    message.success(`Exporting ${tabToLabel[selectedTab]} containers as CSV (Limit: ${exportLimit})`);
+    const label = tabToLabel[selectedTab];
+
+    if (exportLimit > 0 && exportLimit <= 500000) {
+      const exportUrl = `/api/v1/containers/unhealthy/export?state=${state}&limit=${exportLimit}`;
+      window.open(exportUrl, '_blank');
+      message.success(`Exporting ${label} containers as CSV (Limit: ${exportLimit})`);
+      return;
+    }
+
+    const chunkSize = 500000;
+    let prevKey = 0;
+    let part = 1;
+    let totalExported = 0;
+    const hideMessage = message.loading(`Starting export of ${label} containers in chunks...`, 0);
+
+    try {
+      while (true) {
+        const currentLimit = exportLimit === 0 ? chunkSize : Math.min(chunkSize, exportLimit - totalExported);
+        if (currentLimit <= 0) break;
+
+        const exportUrl = `/api/v1/containers/unhealthy/export?state=${state}&limit=${currentLimit}&prevKey=${prevKey}`;
+        const response = await fetch(exportUrl);
+        
+        if (!response.ok) {
+          throw new Error(`Failed to fetch part ${part}`);
+        }
+
+        const text = await response.text();
+        const lines = text.trim().split('\n');
+        
+        // lines[0] is header. If only header, no data.
+        if (lines.length <= 1) {
+          break;
+        }
+
+        const blob = new Blob([text], { type: 'text/csv' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `unhealthy_containers_${state.toLowerCase()}_part${part}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+
+        const recordsInChunk = lines.length - 1;
+        totalExported += recordsInChunk;
+        
+        const lastLine = lines[lines.length - 1];
+        const lastContainerId = parseInt(lastLine.split(',')[0], 10);
+        
+        if (isNaN(lastContainerId)) {
+          throw new Error("Failed to parse container ID for pagination");
+        }
+        
+        prevKey = lastContainerId;
+        
+        if (recordsInChunk < currentLimit) {
+          break;
+        }
+        
+        part++;
+      }
+      
+      message.success(`Successfully exported ${totalExported} ${label} containers.`);
+    } catch (error: any) {
+      console.error("Export failed:", error);
+      message.error(`Export failed: ${error.message || error}`);
+    } finally {
+      hideMessage();
+    }
   }, [selectedTab, exportLimit]);
 
   const highlightData = (

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/containers/containers.tsx
@@ -200,13 +200,6 @@ const Containers: React.FC<{}> = () => {
     const state = tabToExportState[selectedTab];
     const label = tabToLabel[selectedTab];
 
-    if (exportLimit > 0 && exportLimit <= 500000) {
-      const exportUrl = `/api/v1/containers/unhealthy/export?state=${state}&limit=${exportLimit}`;
-      window.open(exportUrl, '_blank');
-      message.success(`Exporting ${label} containers as CSV (Limit: ${exportLimit})`);
-      return;
-    }
-
     const chunkSize = 500000;
     let prevKey = 0;
     let part = 1;
@@ -215,7 +208,7 @@ const Containers: React.FC<{}> = () => {
 
     try {
       while (true) {
-        const currentLimit = exportLimit === 0 ? chunkSize : Math.min(chunkSize, exportLimit - totalExported);
+        const currentLimit = exportLimit === -1 ? chunkSize : Math.min(chunkSize, exportLimit - totalExported);
         if (currentLimit <= 0) break;
 
         const exportUrl = `/api/v1/containers/unhealthy/export?state=${state}&limit=${currentLimit}&prevKey=${prevKey}`;
@@ -226,14 +219,15 @@ const Containers: React.FC<{}> = () => {
         }
 
         const text = await response.text();
-        const lines = text.trim().split('\n');
-        
-        // lines[0] is header. If only header, no data.
-        if (lines.length <= 1) {
-          break;
-        }
 
-        const blob = new Blob([text], { type: 'text/csv' });
+        // Extract #last_container_id trailer written by the backend as the final line.
+        // This avoids parsing CSV rows and is safe regardless of field content.
+        const trailerMatch = text.match(/^#last_container_id:(\d+)$/m);
+        const lastContainerId = trailerMatch ? parseInt(trailerMatch[1], 10) : 0;
+
+        // Strip the trailer comment before saving so the downloaded file is clean CSV.
+        const cleanCsv = text.replace(/^#last_container_id:\d+\n?$/m, '');
+        const blob = new Blob([cleanCsv], { type: 'text/csv' });
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
@@ -243,21 +237,14 @@ const Containers: React.FC<{}> = () => {
         document.body.removeChild(a);
         window.URL.revokeObjectURL(url);
 
-        const recordsInChunk = lines.length - 1;
-        totalExported += recordsInChunk;
-        
-        const lastLine = lines[lines.length - 1];
-        const lastContainerId = parseInt(lastLine.split(',')[0], 10);
-        
-        if (isNaN(lastContainerId)) {
-          throw new Error("Failed to parse container ID for pagination");
-        }
-        
-        prevKey = lastContainerId;
-        
-        if (recordsInChunk < currentLimit) {
+        totalExported += currentLimit;
+
+        // lastContainerId === 0 means no rows were written — export is complete.
+        if (!lastContainerId || isNaN(lastContainerId)) {
           break;
         }
+
+        prevKey = lastContainerId;
         
         part++;
       }
@@ -377,7 +364,7 @@ const Containers: React.FC<{}> = () => {
                   { value: 10000, label: '10K Records' },
                   { value: 100000, label: '100K Records' },
                   { value: 1000000, label: '1M Records' },
-                  { value: 0, label: 'Complete' }
+                  { value: -1, label: 'Complete' }
                 ]}
               />
               <Tooltip title={`Export ${tabToLabel[selectedTab]} containers as CSV`}>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -57,6 +58,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -1954,4 +1956,125 @@ public class TestContainerEndpoint {
       }
     }
   }
+
+  @Test
+  public void testExportUnhealthyContainersValidState() throws IOException, TimeoutException {
+    // Setup: Create unhealthy container records
+    putContainerInfos(15);
+    uuid1 = newDatanode("host1", "127.0.0.1");
+    uuid2 = newDatanode("host2", "127.0.0.2");
+    uuid3 = newDatanode("host3", "127.0.0.3");
+    uuid4 = newDatanode("host4", "127.0.0.4");
+    createUnhealthyRecords(5, 4, 3, 2, 1);
+
+    // Test: Call the export endpoint with valid state
+    Response response = containerEndpoint.exportUnhealthyContainers(
+        "MISSING", 100, 0);
+
+    // Verify: Response is 200 OK
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    // Verify: Content-Type is text/csv
+    assertEquals("text/csv", response.getHeaderString("Content-Type"));
+
+    // Verify: Content-Disposition header is present
+    String contentDisposition = response.getHeaderString("Content-Disposition");
+    assertNotNull(contentDisposition);
+    assertTrue(contentDisposition.contains("attachment"));
+    assertTrue(contentDisposition.contains("unhealthy_containers_missing"));
+
+    // Verify: CSV has correct header and data
+    StreamingOutput streamingOutput = (StreamingOutput) response.getEntity();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    streamingOutput.write(outputStream);
+    String csvOutput = outputStream.toString("UTF-8");
+    String[] lines = csvOutput.split("\n");
+
+    // First line should be the header
+    assertTrue(lines[0].contains("container_id"));
+    assertTrue(lines[0].contains("container_state"));
+    assertTrue(lines[0].contains("in_state_since"));
+
+    // Should have 5 MISSING containers (plus header = 6 lines)
+    assertEquals(6, lines.length);
+
+    // All data rows should contain MISSING state
+    for (int i = 1; i < lines.length; i++) {
+      assertTrue(lines[i].contains("MISSING"));
+    }
+  }
+
+  @Test
+  public void testExportUnhealthyContainersInvalidState() {
+    // Test: Call export endpoint with invalid state
+    WebApplicationException exception = assertThrows(
+        WebApplicationException.class,
+        () -> containerEndpoint.exportUnhealthyContainers(
+            "INVALID_STATE", 100, 0)
+    );
+
+    // Verify: Returns 400 Bad Request
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
+        exception.getResponse().getStatus());
+  }
+
+  @Test
+  public void testExportUnhealthyContainersLimitParameter()
+      throws IOException, TimeoutException {
+    // Setup: Create test data
+    putContainerInfos(200);
+    uuid1 = newDatanode("host1", "127.0.0.1");
+    uuid2 = newDatanode("host2", "127.0.0.2");
+    uuid3 = newDatanode("host3", "127.0.0.3");
+    uuid4 = newDatanode("host4", "127.0.0.4");
+
+    // Create 150 MISSING containers
+    for (int i = 0; i < 150; i++) {
+      createUnhealthyRecord(i + 1,
+          UnHealthyContainerStates.MISSING.toString(),
+          3, 0, 3, null, false);
+    }
+
+    // Test: Request 50 records
+    Response response = containerEndpoint.exportUnhealthyContainers(
+        "MISSING", 50, 0);
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    StreamingOutput streamingOutput = (StreamingOutput) response.getEntity();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    streamingOutput.write(outputStream);
+    String csvOutput = outputStream.toString("UTF-8");
+    String[] lines = csvOutput.split("\n");
+
+    // Should return exactly what was requested + header
+    assertEquals(51, lines.length);
+
+    // Test: Request 100 records
+    response = containerEndpoint.exportUnhealthyContainers(
+        "MISSING", 100, 0);
+
+    streamingOutput = (StreamingOutput) response.getEntity();
+    outputStream = new ByteArrayOutputStream();
+    streamingOutput.write(outputStream);
+    csvOutput = outputStream.toString("UTF-8");
+    lines = csvOutput.split("\n");
+
+    // Should return exactly 100 + header
+    assertEquals(101, lines.length);
+
+    // Test: Request 0 (all records)
+    response = containerEndpoint.exportUnhealthyContainers(
+        "MISSING", 0, 0);
+
+    streamingOutput = (StreamingOutput) response.getEntity();
+    outputStream = new ByteArrayOutputStream();
+    streamingOutput.write(outputStream);
+    csvOutput = outputStream.toString("UTF-8");
+    lines = csvOutput.split("\n");
+
+    // Should return all 150 records + header
+    assertEquals(151, lines.length);
+  }
+
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1959,7 +1959,6 @@ public class TestContainerEndpoint {
 
   @Test
   public void testExportUnhealthyContainersValidState() throws IOException, TimeoutException {
-    // Setup: Create unhealthy container records
     putContainerInfos(15);
     uuid1 = newDatanode("host1", "127.0.0.1");
     uuid2 = newDatanode("host2", "127.0.0.2");
@@ -1967,114 +1966,220 @@ public class TestContainerEndpoint {
     uuid4 = newDatanode("host4", "127.0.0.4");
     createUnhealthyRecords(5, 4, 3, 2, 1);
 
-    // Test: Call the export endpoint with valid state
     Response response = containerEndpoint.exportUnhealthyContainers(
         "MISSING", 100, 0);
 
-    // Verify: Response is 200 OK
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    // Verify: Content-Type is text/csv
-    assertEquals("text/csv", response.getHeaderString("Content-Type"));
-
-    // Verify: Content-Disposition header is present
+    // Content-Disposition must indicate attachment with correct filename prefix
     String contentDisposition = response.getHeaderString("Content-Disposition");
     assertNotNull(contentDisposition);
     assertTrue(contentDisposition.contains("attachment"));
     assertTrue(contentDisposition.contains("unhealthy_containers_missing"));
 
-    // Verify: CSV has correct header and data
     StreamingOutput streamingOutput = (StreamingOutput) response.getEntity();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     streamingOutput.write(outputStream);
     String csvOutput = outputStream.toString("UTF-8");
     String[] lines = csvOutput.split("\n");
 
-    // First line should be the header
-    assertTrue(lines[0].contains("container_id"));
-    assertTrue(lines[0].contains("container_state"));
-    assertTrue(lines[0].contains("in_state_since"));
+    // First line is the CSV header
+    assertEquals("container_id,container_state,in_state_since," +
+        "expected_replica_count,actual_replica_count,replica_delta", lines[0]);
 
-    // Should have 5 MISSING containers (plus header = 6 lines)
-    assertEquals(6, lines.length);
+    // 5 MISSING containers + 1 header row + 1 trailer comment
+    assertEquals(7, lines.length);
 
-    // All data rows should contain MISSING state
-    for (int i = 1; i < lines.length; i++) {
+    // All data rows must contain MISSING state (skip header and trailer)
+    for (int i = 1; i < lines.length - 1; i++) {
       assertTrue(lines[i].contains("MISSING"));
     }
+
+    // Trailer comment must be present and have a positive container ID
+    String trailerLine = lines[lines.length - 1];
+    assertTrue(trailerLine.startsWith("#last_container_id:"));
+    long lastId = Long.parseLong(trailerLine.split(":")[1]);
+    assertTrue(lastId > 0);
+  }
+
+  @Test
+  public void testExportUnhealthyContainersMissingStateParam() {
+    // state is required — empty/null must return 400
+    WebApplicationException ex1 = assertThrows(
+        WebApplicationException.class,
+        () -> containerEndpoint.exportUnhealthyContainers("", 100, 0)
+    );
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
+        ex1.getResponse().getStatus());
+
+    WebApplicationException ex2 = assertThrows(
+        WebApplicationException.class,
+        () -> containerEndpoint.exportUnhealthyContainers(null, 100, 0)
+    );
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
+        ex2.getResponse().getStatus());
   }
 
   @Test
   public void testExportUnhealthyContainersInvalidState() {
-    // Test: Call export endpoint with invalid state
     WebApplicationException exception = assertThrows(
         WebApplicationException.class,
         () -> containerEndpoint.exportUnhealthyContainers(
             "INVALID_STATE", 100, 0)
     );
-
-    // Verify: Returns 400 Bad Request
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
         exception.getResponse().getStatus());
   }
 
   @Test
+  public void testExportUnhealthyContainersNegativeLimitRejected() {
+    // limit < -1 must return 400; -1 (unlimited) is valid
+    WebApplicationException exception = assertThrows(
+        WebApplicationException.class,
+        () -> containerEndpoint.exportUnhealthyContainers("MISSING", -2, 0)
+    );
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
+        exception.getResponse().getStatus());
+  }
+
+  @Test
+  public void testExportUnhealthyContainersEmptyResultSet()
+      throws IOException, TimeoutException {
+    // No records inserted for OVER_REPLICATED — CSV should contain only the header
+    putContainerInfos(5);
+    uuid1 = newDatanode("host1", "127.0.0.1");
+    uuid2 = newDatanode("host2", "127.0.0.2");
+    uuid3 = newDatanode("host3", "127.0.0.3");
+    uuid4 = newDatanode("host4", "127.0.0.4");
+    createUnhealthyRecords(5, 0, 0, 0, 0);
+
+    Response response = containerEndpoint.exportUnhealthyContainers(
+        "OVER_REPLICATED", -1, 0);
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    StreamingOutput streamingOutput = (StreamingOutput) response.getEntity();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    streamingOutput.write(outputStream);
+    String csvOutput = outputStream.toString("UTF-8");
+
+    // Only header + trailer, no data rows
+    String[] lines = csvOutput.trim().split("\n");
+    assertEquals(2, lines.length); // header + #last_container_id:0
+    assertTrue(lines[0].contains("container_id"));
+    assertEquals("#last_container_id:0", lines[1]);
+  }
+
+  @Test
   public void testExportUnhealthyContainersLimitParameter()
       throws IOException, TimeoutException {
-    // Setup: Create test data
     putContainerInfos(200);
     uuid1 = newDatanode("host1", "127.0.0.1");
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
 
-    // Create 150 MISSING containers
     for (int i = 0; i < 150; i++) {
       createUnhealthyRecord(i + 1,
           UnHealthyContainerStates.MISSING.toString(),
           3, 0, 3, null, false);
     }
 
-    // Test: Request 50 records
+    // Limit 50 — should return exactly 50 data rows
     Response response = containerEndpoint.exportUnhealthyContainers(
         "MISSING", 50, 0);
-
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-
     StreamingOutput streamingOutput = (StreamingOutput) response.getEntity();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     streamingOutput.write(outputStream);
-    String csvOutput = outputStream.toString("UTF-8");
-    String[] lines = csvOutput.split("\n");
+    String[] lines = outputStream.toString("UTF-8").split("\n");
+    assertEquals(52, lines.length); // 50 data + 1 header + 1 trailer
 
-    // Should return exactly what was requested + header
-    assertEquals(51, lines.length);
-
-    // Test: Request 100 records
-    response = containerEndpoint.exportUnhealthyContainers(
-        "MISSING", 100, 0);
-
+    // Limit 100 — should return exactly 100 data rows
+    response = containerEndpoint.exportUnhealthyContainers("MISSING", 100, 0);
     streamingOutput = (StreamingOutput) response.getEntity();
     outputStream = new ByteArrayOutputStream();
     streamingOutput.write(outputStream);
-    csvOutput = outputStream.toString("UTF-8");
-    lines = csvOutput.split("\n");
+    lines = outputStream.toString("UTF-8").split("\n");
+    assertEquals(102, lines.length); // 100 data + 1 header + 1 trailer
 
-    // Should return exactly 100 + header
-    assertEquals(101, lines.length);
-
-    // Test: Request 0 (all records)
-    response = containerEndpoint.exportUnhealthyContainers(
-        "MISSING", 0, 0);
-
+    // Limit -1 (unlimited) — should return all 150 data rows
+    response = containerEndpoint.exportUnhealthyContainers("MISSING", -1, 0);
     streamingOutput = (StreamingOutput) response.getEntity();
     outputStream = new ByteArrayOutputStream();
     streamingOutput.write(outputStream);
-    csvOutput = outputStream.toString("UTF-8");
-    lines = csvOutput.split("\n");
+    lines = outputStream.toString("UTF-8").split("\n");
+    assertEquals(152, lines.length); // 150 data + 1 header + 1 trailer
+  }
 
-    // Should return all 150 records + header
-    assertEquals(151, lines.length);
+  @Test
+  public void testExportUnhealthyContainersPrevKeyPagination()
+      throws IOException, TimeoutException {
+    // Insert 10 MISSING containers with IDs 1–10
+    putContainerInfos(10);
+    uuid1 = newDatanode("host1", "127.0.0.1");
+    uuid2 = newDatanode("host2", "127.0.0.2");
+    uuid3 = newDatanode("host3", "127.0.0.3");
+    uuid4 = newDatanode("host4", "127.0.0.4");
+    for (int i = 1; i <= 10; i++) {
+      createUnhealthyRecord(i, UnHealthyContainerStates.MISSING.toString(),
+          3, 0, 3, null, false);
+    }
+
+    // Helper to extract last_container_id from trailer
+    java.util.function.Function<String, Long> extractLastId = csv -> {
+      java.util.regex.Matcher m = java.util.regex.Pattern
+          .compile("^#last_container_id:(\\d+)$", java.util.regex.Pattern.MULTILINE)
+          .matcher(csv);
+      return m.find() ? Long.parseLong(m.group(1)) : 0L;
+    };
+
+    // Fetch first 5 (prevKey = 0)
+    Response page1 = containerEndpoint.exportUnhealthyContainers("MISSING", 5, 0);
+    ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+    ((StreamingOutput) page1.getEntity()).write(out1);
+    String csv1 = out1.toString("UTF-8");
+    // data lines = total lines minus header and trailer
+    String[] page1Lines = csv1.split("\n");
+    long dataLinesPage1 = Arrays.stream(page1Lines)
+        .filter(l -> !l.startsWith("#") && !l.startsWith("container_id")).count();
+    assertEquals(5, dataLinesPage1);
+
+    long lastIdPage1 = extractLastId.apply(csv1);
+    assertEquals(5, lastIdPage1);
+
+    // Fetch next 5 using prevKey = lastIdPage1
+    Response page2 = containerEndpoint.exportUnhealthyContainers("MISSING", 5, lastIdPage1);
+    ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+    ((StreamingOutput) page2.getEntity()).write(out2);
+    String csv2 = out2.toString("UTF-8");
+    String[] page2Lines = csv2.split("\n");
+    long dataLinesPage2 = Arrays.stream(page2Lines)
+        .filter(l -> !l.startsWith("#") && !l.startsWith("container_id")).count();
+    assertEquals(5, dataLinesPage2);
+
+    long lastIdPage2 = extractLastId.apply(csv2);
+    assertEquals(10, lastIdPage2);
+
+    // Verify no overlap — all page1 container IDs must be < all page2 container IDs
+    long[] ids1 = Arrays.stream(page1Lines)
+        .filter(l -> !l.startsWith("#") && !l.startsWith("container_id"))
+        .mapToLong(l -> Long.parseLong(l.split(",")[0])).toArray();
+    long[] ids2 = Arrays.stream(page2Lines)
+        .filter(l -> !l.startsWith("#") && !l.startsWith("container_id"))
+        .mapToLong(l -> Long.parseLong(l.split(",")[0])).toArray();
+    for (long id1 : ids1) {
+      for (long id2 : ids2) {
+        assertTrue(id1 < id2, "Page 1 IDs must be strictly less than page 2 IDs");
+      }
+    }
+
+    // Fetch page 3 — no more records, trailer must show last_container_id:0
+    Response page3 = containerEndpoint.exportUnhealthyContainers("MISSING", 5, lastIdPage2);
+    ByteArrayOutputStream out3 = new ByteArrayOutputStream();
+    ((StreamingOutput) page3.getEntity()).write(out3);
+    String csv3 = out3.toString("UTF-8");
+    assertEquals(0L, (long) extractLastId.apply(csv3));
   }
 
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -2032,14 +2032,22 @@ public class TestContainerEndpoint {
   }
 
   @Test
-  public void testExportUnhealthyContainersNegativeLimitRejected() {
+  public void testExportUnhealthyContainersInvalidLimitRejected() {
     // limit < -1 must return 400; -1 (unlimited) is valid
-    WebApplicationException exception = assertThrows(
+    WebApplicationException ex1 = assertThrows(
         WebApplicationException.class,
         () -> containerEndpoint.exportUnhealthyContainers("MISSING", -2, 0)
     );
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
-        exception.getResponse().getStatus());
+        ex1.getResponse().getStatus());
+
+    // limit == 0 must return 400; 0 rows is not a valid request
+    WebApplicationException ex2 = assertThrows(
+        WebApplicationException.class,
+        () -> containerEndpoint.exportUnhealthyContainers("MISSING", 0, 0)
+    );
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(),
+        ex2.getResponse().getStatus());
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestReconReplicationManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestReconReplicationManager.java
@@ -88,7 +88,8 @@ public class TestReconReplicationManager extends AbstractReconSqlDBTest {
   public void setUp() throws Exception {
     dao = getDao(UnhealthyContainersDao.class);
     schemaManagerV2 = new ContainerHealthSchemaManager(
-        getSchemaDefinition(ContainerSchemaDefinition.class));
+        getSchemaDefinition(ContainerSchemaDefinition.class),
+        new OzoneConfiguration());
 
     containerManager = mock(ContainerManager.class);
     PlacementPolicy placementPolicy = mock(PlacementPolicy.class);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -273,7 +273,8 @@ public class TestUnhealthyContainersDerbyPerformance {
 
     dao = injector.getInstance(UnhealthyContainersDao.class);
     schemaDefinition = injector.getInstance(ContainerSchemaDefinition.class);
-    schemaManager = new ContainerHealthSchemaManager(schemaDefinition);
+    schemaManager = new ContainerHealthSchemaManager(schemaDefinition,
+        new org.apache.hadoop.hdds.conf.OzoneConfiguration());
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Problem:** 
Currently, exporting a large number of unhealthy container records (e.g., Missing, Under-Replicated, Mis-Replicated, etc.) from Recon is difficult. The UI is paginated and cannot efficiently handle downloading millions of records. Administrators often have to rely on manual, non-scalable database extraction methods (like connecting the Derby `ij` client) to analyze cluster health data. Furthermore, exporting millions of rows into a single CSV file causes issues for users opening the file in spreadsheet applications like Microsoft Excel, which have a hard limit of ~1 million rows.

**Solution:** 
This ticket implements a native, scalable, and memory-safe CSV export feature directly in the Recon UI and Backend.

**Frontend:** 
Added an "Export CSV" button to the Recon Containers page with a dropdown selector allowing administrators to quickly extract data blocks ranging from 10K up to a "Complete" export of all records for the currently active diagnostic tab. 
* **Smart Chunking:** To ensure compatibility with spreadsheet software and prevent massive single-file downloads, "Complete" exports are automatically chunked by the UI. The frontend sequentially requests and downloads the data in safe 500K-record files (e.g., `part1.csv`, `part2.csv`) until all records are exported.

**Backend:** 
Added a new REST endpoint (`/api/v1/containers/unhealthy/export`) that uses jOOQ cursors and JAX-RS `StreamingOutput` to fetch and stream records lazily. 
* **Zero Memory Pressure:** By piping data directly from the Derby database to the HTTP response using a `BufferedWriter`, the JVM heap memory is protected from OutOfMemory (OOM) errors, regardless of scale. The file is not stored anywhere on the server and is not loaded fully into memory.
* **High Throughput:** The database cursor is configured with `fetchSize(10000)` to minimize JDBC round-trips, and a composite index (`idx_state_container_id`) ensures Derby doesn't have to sort millions of rows before streaming, resulting in a Time-To-First-Byte (TTFB) of under 50ms.
* **Pagination:** The endpoint supports a `prevKey` parameter, allowing the frontend to seamlessly paginate through millions of records across multiple HTTP requests.
* **Exception Handling:** The stream correctly propagates `IOException`s (e.g., if a client disconnects mid-download) to immediately abort the database cursor and free up resources.

**Security:** 
The endpoint sits behind Recon's robust `@AdminOnly` authorization. Negative limits are explicitly rejected with a `400 Bad Request` to prevent accidental unbounded queries.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14913

## How was this patch tested?
Tested out with 5 million containers for each state.

Test Limit | TTFB (s) | Total Time (s) | Downloaded (MB) | Rows Received
-- | -- | -- | -- | --
10,000 | 0.032 | 0.038 | 0.31 | 10,000
100,000 | 0.019 | 0.220 | 3.23 | 100,000
1,000,000 | 0.019 | 3.317 | 33.27 | 1,000,000
Complete (5,000,000) | 0.020 | 9.439 | 170.60 | 5,000,000


<!-- notionvc: 4e9a0f9d-1a45-434d-bfa3-f011d5910e43 -->

<img width="1506" height="552" alt="image" src="https://github.com/user-attachments/assets/8476a474-5818-4d07-8550-72af4d13e93c" />

<img width="722" height="354" alt="image" src="https://github.com/user-attachments/assets/610f7893-497e-446a-936b-10c972f4b492" />


