### PR TITLE
HDDS-14795. Allow non-S3-compliant bucket name length if strict S3 is disabled

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -76,9 +76,9 @@ public final class HddsClientUtils {
       throw new IllegalArgumentException(resType + " name is null");
     }
 
-    boolean enforceLength = !resType.equals("bucket") || isStrictS3;
+    boolean applyS3LengthConstraint = !resType.equals("bucket") || isStrictS3;
 
-    if (enforceLength) {
+    if (applyS3LengthConstraint) {
       if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH) {
         throw new IllegalArgumentException(resType +
             " name '" + resName + "' is too short, " +

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -71,31 +71,33 @@ public final class HddsClientUtils {
   private HddsClientUtils() {
   }
 
-  private static void doNameChecks(String resName, String resType) {
+  private static void doNameChecks(String resName, String resType, boolean isStrictS3) {
     if (resName == null) {
       throw new IllegalArgumentException(resType + " name is null");
     }
 
-    if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH) {
-      throw new IllegalArgumentException(resType +
-          " name '" + resName + "' is too short, " +
-          VALID_LENGTH_MESSAGE);
-    }
-
-    if (resName.length() > OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH) {
-      String nameToReport;
-
-      if (resName.length() > MAX_BUCKET_NAME_LENGTH_IN_LOG) {
-        nameToReport = String.format(
-            "%s...",
-            resName.substring(0, MAX_BUCKET_NAME_LENGTH_IN_LOG));
-      } else {
-        nameToReport = resName;
+    if (isStrictS3) {
+      if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH) {
+        throw new IllegalArgumentException(resType +
+            " name '" + resName + "' is too short, " +
+            VALID_LENGTH_MESSAGE);
       }
 
-      throw new IllegalArgumentException(resType +
-          " name '" + nameToReport + "' is too long, " +
-          VALID_LENGTH_MESSAGE);
+      if (resName.length() > OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH) {
+        String nameToReport;
+
+        if (resName.length() > MAX_BUCKET_NAME_LENGTH_IN_LOG) {
+          nameToReport = String.format(
+              "%s...",
+              resName.substring(0, MAX_BUCKET_NAME_LENGTH_IN_LOG));
+        } else {
+          nameToReport = resName;
+        }
+
+        throw new IllegalArgumentException(resType +
+            " name '" + nameToReport + "' is too long, " +
+            VALID_LENGTH_MESSAGE);
+      }
     }
 
     if (resName.charAt(0) == '.' || resName.charAt(0) == '-') {
@@ -191,7 +193,7 @@ public final class HddsClientUtils {
           " name cannot be an IPv4 address or all numeric");
     }
 
-    doNameChecks(resName, resType);
+    doNameChecks(resName, resType, isStrictS3);
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -76,7 +76,9 @@ public final class HddsClientUtils {
       throw new IllegalArgumentException(resType + " name is null");
     }
 
-    if (isStrictS3) {
+    boolean enforceLength = !resType.equals("bucket") || isStrictS3;
+
+    if (enforceLength) {
       if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH) {
         throw new IllegalArgumentException(resType +
             " name '" + resName + "' is too short, " +

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -68,13 +68,22 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
   }
 
   @Test
-  public void preExecuteRejectsInvalidBucketName() {
-    // Verify invalid bucket name throws exception
+  public void preExecuteRejectsShortBucketNameWhenStrictS3Enabled() {
+    when(ozoneManager.isStrictS3()).thenReturn(true);
+
     OMException omException = assertThrows(OMException.class,
         () -> doPreExecute("volume1", "b1"));
     assertEquals(
         "bucket name 'b1' is too short, valid length is 3-63 characters",
         omException.getMessage());
+  }
+
+  @Test
+  public void preExecuteAllowsShortBucketNameWhenStrictS3Disabled()
+      throws Exception {
+    when(ozoneManager.isStrictS3()).thenReturn(false);
+
+    doPreExecute("volume1", "b1");
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.request.bucket;
 
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -67,23 +68,34 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     doPreExecute(volumeName, bucketName);
   }
 
-  @Test
-  public void preExecuteRejectsShortBucketNameWhenStrictS3Enabled() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "b1",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  })
+  public void preExecuteRejectsInvalidBucketNameLengthWhenStrictS3Enabled(
+      String bucketName) {
     when(ozoneManager.isStrictS3()).thenReturn(true);
 
     OMException omException = assertThrows(OMException.class,
-        () -> doPreExecute("volume1", "b1"));
-    assertEquals(
-        "bucket name 'b1' is too short, valid length is 3-63 characters",
-        omException.getMessage());
+        () -> doPreExecute("volume1", bucketName));
+
+    assertThat(omException.getMessage())
+        .contains("bucket name")
+        .contains("valid length is 3-63 characters");
   }
 
-  @Test
-  public void preExecuteAllowsShortBucketNameWhenStrictS3Disabled()
-      throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "b1",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  })
+  public void preExecuteAllowsInvalidLengthBucketNameWhenStrictS3Disabled(
+      String bucketName) throws Exception {
+
     when(ozoneManager.isStrictS3()).thenReturn(false);
 
-    doPreExecute("volume1", "b1");
+    doPreExecute("volume1", bucketName);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
* Apply S3 bucket name length (3–63) validation only when strict S3 naming is enabled
* Allow non-S3-compliant bucket names when strict S3 is disabled
* Keep existing length validation unchanged for volume name

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14795
## How was this patch tested?
- Updated and added unit tests for strict and non-strict bucket naming
- All CI checks passed
   - https://github.com/Russole/ozone/actions/runs/23796758818 
