### PR TITLE
HDDS-8703. Integration test for SnapshotDeletingService during OM failover

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN
 import static org.apache.ozone.test.LambdaTestUtils.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -298,6 +299,145 @@ public class TestOzoneManagerHASnapshot {
     OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl) cluster.getOMLeader().getMetadataManager();
     // Verify that the snapshot chain is not corrupted even after deletions.
     assertFalse(metadataManager.getSnapshotChainManager().isSnapshotChainCorrupted());
+  }
+
+  /**
+   * Tests that SnapshotDeletingService (SDS) correctly handles an OM leader
+   * failover. The old leader's SDS is suspended (simulating SDS being blocked
+   * or mid-cleanup) when a snapshot is queued for deletion. After the leader
+   * failover, the new leader's SDS picks up the pending work and correctly
+   * purges the snapshot. (HDDS-8703)
+   */
+  @Test
+  public void testSnapshotDeletingServiceDuringOMFailover()
+      throws Exception {
+    OzoneManager oldLeader = cluster.getOMLeader();
+    String oldLeaderId = oldLeader.getOMNodeId();
+
+    // Create keys and a snapshot so there is data to clean up.
+    int numKeys = 5;
+    for (int i = 0; i < numKeys; i++) {
+      createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
+    }
+
+    String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(10);
+    createSnapshot(volumeName, bucketName, snapshotName);
+
+    // Suspend SDS on the current leader before the snapshot is deleted,
+    // simulating SDS being blocked while a cleanup is pending.
+    oldLeader.getKeyManager().getSnapshotDeletingService().suspend();
+
+    // Delete the snapshot — marks it as SNAPSHOT_DELETED in the DB.
+    store.deleteSnapshot(volumeName, bucketName, snapshotName);
+    String tableKey = SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName);
+
+    // Wait for the snapshot entry to reach SNAPSHOT_DELETED state on old leader.
+    GenericTestUtils.waitFor(() -> {
+      try {
+        SnapshotInfo info = oldLeader.getMetadataManager()
+            .getSnapshotInfoTable().get(tableKey);
+        return info != null
+            && info.getSnapshotStatus() == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 1000, 30000);
+
+    try {
+      // Trigger OM leader failover: with 3 OMs and quorum=2, the remaining
+      // two nodes elect a new leader.
+      cluster.shutdownOzoneManager(oldLeader);
+      cluster.waitForLeaderOM();
+
+      OzoneManager newLeader = cluster.getOMLeader();
+      assertNotNull(newLeader);
+      // Confirm that a genuinely different OM node became leader.
+      assertNotEquals(oldLeaderId, newLeader.getOMNodeId());
+
+      // The new leader's SDS (not suspended) must process the pending deleted
+      // snapshot and purge it from the DB, even though the old leader's SDS
+      // never ran the cleanup.
+      checkSnapshotIsPurgedFromDB(newLeader, tableKey);
+
+      // Verify the snapshot chain is not corrupted after the cleanup.
+      OmMetadataManagerImpl metadataManager =
+          (OmMetadataManagerImpl) newLeader.getMetadataManager();
+      assertFalse(metadataManager.getSnapshotChainManager().isSnapshotChainCorrupted());
+    } finally {
+      // Restore the 3-node cluster for subsequent tests.
+      cluster.restartOzoneManager(oldLeader, true);
+    }
+  }
+
+  /**
+   * Tests that SDS on the new leader correctly handles multiple snapshots
+   * queued for deletion after an OM leader failover. After the failover, all
+   * pending deletions should be completed and the snapshot chain should remain
+   * consistent. (HDDS-8703)
+   */
+  @Test
+  public void testSnapshotDeletingServiceWithMultipleSnapshotsDuringFailover()
+      throws Exception {
+    OzoneManager oldLeader = cluster.getOMLeader();
+    String oldLeaderId = oldLeader.getOMNodeId();
+
+    int numSnapshots = 3;
+    List<String> snapshotNames = new ArrayList<>();
+    List<String> tableKeys = new ArrayList<>();
+
+    // Create multiple snapshots, each capturing distinct state.
+    for (int i = 0; i < numSnapshots; i++) {
+      createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
+      String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(10);
+      createSnapshot(volumeName, bucketName, snapshotName);
+      snapshotNames.add(snapshotName);
+      tableKeys.add(SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
+    }
+
+    // Suspend SDS on the current leader so no cleanup starts yet.
+    oldLeader.getKeyManager().getSnapshotDeletingService().suspend();
+
+    // Queue all snapshots for deletion.
+    for (String snapshotName : snapshotNames) {
+      store.deleteSnapshot(volumeName, bucketName, snapshotName);
+    }
+
+    // Wait for every snapshot to be marked SNAPSHOT_DELETED on the old leader.
+    for (String tableKey : tableKeys) {
+      GenericTestUtils.waitFor(() -> {
+        try {
+          SnapshotInfo info = oldLeader.getMetadataManager()
+              .getSnapshotInfoTable().get(tableKey);
+          return info != null
+              && info.getSnapshotStatus() == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }, 1000, 30000);
+    }
+
+    try {
+      // Trigger leader failover.
+      cluster.shutdownOzoneManager(oldLeader);
+      cluster.waitForLeaderOM();
+
+      OzoneManager newLeader = cluster.getOMLeader();
+      assertNotNull(newLeader);
+      assertNotEquals(oldLeaderId, newLeader.getOMNodeId());
+
+      // The new leader's SDS must purge all deleted snapshots.
+      for (String tableKey : tableKeys) {
+        checkSnapshotIsPurgedFromDB(newLeader, tableKey);
+      }
+
+      // Verify snapshot chain integrity after all cleanups.
+      OmMetadataManagerImpl metadataManager =
+          (OmMetadataManagerImpl) newLeader.getMetadataManager();
+      assertFalse(metadataManager.getSnapshotChainManager().isSnapshotChainCorrupted());
+    } finally {
+      // Restore the 3-node cluster for subsequent tests.
+      cluster.restartOzoneManager(oldLeader, true);
+    }
   }
 
   private void createFileKey(OzoneBucket bucket, String keyName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
@@ -62,6 +62,8 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests snapshot in OM HA setup.
@@ -303,89 +305,23 @@ public class TestOzoneManagerHASnapshot {
 
   /**
    * Tests that SnapshotDeletingService (SDS) correctly handles an OM leader
-   * failover. The old leader's SDS is suspended (simulating SDS being blocked
-   * or mid-cleanup) when a snapshot is queued for deletion. After the leader
-   * failover, the new leader's SDS picks up the pending work and correctly
-   * purges the snapshot. (HDDS-8703)
-   */
-  @Test
-  public void testSnapshotDeletingServiceDuringOMFailover()
-      throws Exception {
-    OzoneManager oldLeader = cluster.getOMLeader();
-    String oldLeaderId = oldLeader.getOMNodeId();
-
-    // Create keys and a snapshot so there is data to clean up.
-    int numKeys = 5;
-    for (int i = 0; i < numKeys; i++) {
-      createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
-    }
-
-    String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(10);
-    createSnapshot(volumeName, bucketName, snapshotName);
-
-    // Suspend SDS on the current leader before the snapshot is deleted,
-    // simulating SDS being blocked while a cleanup is pending.
-    oldLeader.getKeyManager().getSnapshotDeletingService().suspend();
-
-    // Delete the snapshot — marks it as SNAPSHOT_DELETED in the DB.
-    store.deleteSnapshot(volumeName, bucketName, snapshotName);
-    String tableKey = SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName);
-
-    // Wait for the snapshot entry to reach SNAPSHOT_DELETED state on old leader.
-    GenericTestUtils.waitFor(() -> {
-      try {
-        SnapshotInfo info = oldLeader.getMetadataManager()
-            .getSnapshotInfoTable().get(tableKey);
-        return info != null
-            && info.getSnapshotStatus() == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }, 1000, 30000);
-
-    try {
-      // Trigger OM leader failover: with 3 OMs and quorum=2, the remaining
-      // two nodes elect a new leader.
-      cluster.shutdownOzoneManager(oldLeader);
-      cluster.waitForLeaderOM();
-
-      OzoneManager newLeader = cluster.getOMLeader();
-      assertNotNull(newLeader);
-      // Confirm that a genuinely different OM node became leader.
-      assertNotEquals(oldLeaderId, newLeader.getOMNodeId());
-
-      // The new leader's SDS (not suspended) must process the pending deleted
-      // snapshot and purge it from the DB, even though the old leader's SDS
-      // never ran the cleanup.
-      checkSnapshotIsPurgedFromDB(newLeader, tableKey);
-
-      // Verify the snapshot chain is not corrupted after the cleanup.
-      OmMetadataManagerImpl metadataManager =
-          (OmMetadataManagerImpl) newLeader.getMetadataManager();
-      assertFalse(metadataManager.getSnapshotChainManager().isSnapshotChainCorrupted());
-    } finally {
-      // Restore the 3-node cluster for subsequent tests.
-      cluster.restartOzoneManager(oldLeader, true);
-    }
-  }
-
-  /**
-   * Tests that SDS on the new leader correctly handles multiple snapshots
-   * queued for deletion after an OM leader failover. After the failover, all
-   * pending deletions should be completed and the snapshot chain should remain
+   * failover with {@code numSnapshots} snapshots queued for deletion. The old
+   * leader's SDS is suspended (simulating SDS being blocked or mid-cleanup)
+   * before the failover. After the failover, the new leader's SDS must pick up
+   * all pending deletions, purge them from the DB, and leave the snapshot chain
    * consistent. (HDDS-8703)
    */
-  @Test
-  public void testSnapshotDeletingServiceWithMultipleSnapshotsDuringFailover()
+  @ParameterizedTest
+  @ValueSource(ints = {1, 3})
+  public void testSnapshotDeletingServiceDuringOMFailover(int numSnapshots)
       throws Exception {
     OzoneManager oldLeader = cluster.getOMLeader();
     String oldLeaderId = oldLeader.getOMNodeId();
 
-    int numSnapshots = 3;
     List<String> snapshotNames = new ArrayList<>();
     List<String> tableKeys = new ArrayList<>();
 
-    // Create multiple snapshots, each capturing distinct state.
+    // Create numSnapshots snapshots, each capturing distinct state.
     for (int i = 0; i < numSnapshots; i++) {
       createFileKey(ozoneBucket, "key-" + RandomStringUtils.secure().nextNumeric(10));
       String snapshotName = "snap-" + RandomStringUtils.secure().nextNumeric(10);
@@ -394,7 +330,8 @@ public class TestOzoneManagerHASnapshot {
       tableKeys.add(SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
     }
 
-    // Suspend SDS on the current leader so no cleanup starts yet.
+    // Suspend SDS on the current leader before any snapshot is deleted,
+    // simulating SDS being blocked while cleanup is pending.
     oldLeader.getKeyManager().getSnapshotDeletingService().suspend();
 
     // Queue all snapshots for deletion.
@@ -402,7 +339,7 @@ public class TestOzoneManagerHASnapshot {
       store.deleteSnapshot(volumeName, bucketName, snapshotName);
     }
 
-    // Wait for every snapshot to be marked SNAPSHOT_DELETED on the old leader.
+    // Wait for every snapshot to reach SNAPSHOT_DELETED state on the old leader.
     for (String tableKey : tableKeys) {
       GenericTestUtils.waitFor(() -> {
         try {
@@ -417,20 +354,23 @@ public class TestOzoneManagerHASnapshot {
     }
 
     try {
-      // Trigger leader failover.
+      // Trigger OM leader failover: with 3 OMs and quorum=2, the remaining
+      // two nodes elect a new leader.
       cluster.shutdownOzoneManager(oldLeader);
       cluster.waitForLeaderOM();
 
       OzoneManager newLeader = cluster.getOMLeader();
       assertNotNull(newLeader);
+      // Confirm that a genuinely different OM node became leader.
       assertNotEquals(oldLeaderId, newLeader.getOMNodeId());
 
-      // The new leader's SDS must purge all deleted snapshots.
+      // The new leader's SDS (not suspended) must purge all deleted snapshots,
+      // even though the old leader's SDS never ran the cleanup.
       for (String tableKey : tableKeys) {
         checkSnapshotIsPurgedFromDB(newLeader, tableKey);
       }
 
-      // Verify snapshot chain integrity after all cleanups.
+      // Verify the snapshot chain is not corrupted after all cleanups.
       OmMetadataManagerImpl metadataManager =
           (OmMetadataManagerImpl) newLeader.getMetadataManager();
       assertFalse(metadataManager.getSnapshotChainManager().isSnapshotChainCorrupted());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added two integration tests to TestOzoneManagerHASnapshot that verify SnapshotDeletingService (SDS) behaves correctly when an OM leader failover happens while snapshot cleanup is pending.

testSnapshotDeletingServiceDuringOMFailover Simulates SDS being blocked on the old leader (via suspend()) while a snapshot is queued for deletion. Triggers a leader failover by shutting down the old leader. Verifies that the new leader's SDS independently picks up the pending SNAPSHOT_DELETED entry, purges it from the DB, and leaves the snapshot chain in a consistent state.

testSnapshotDeletingServiceWithMultipleSnapshotsDuringFailover Extends the above scenario to 3 snapshots queued for deletion simultaneously before the failover. Verifies the new leader's SDS correctly processes the full backlog and that chain integrity holds after all cleanups complete.

Please describe your PR in detail:
SnapshotDeletingService (SDS) is a background service on the OM leader responsible for cleaning up deleted snapshots.Two @Test methods are added:

1. testSnapshotDeletingServiceDuringOMFailover
- Creates 5 keys and one snapshot
- Suspends SDS on the current leader (simulates SDS blocked mid-run)
- Deletes the snapshot, waits for it to reach SNAPSHOT_DELETED state in DB
- Shuts down the old leader → forces election of a genuinely different new leader (cluster has 3 OMs, quorum=2)
- Waits for the new leader's SDS to purge the snapshot from snapshotInfoTable
- Asserts snapshot chain is not corrupted
- finally block restores the 3-node cluster by restarting the old OM

2. testSnapshotDeletingServiceWithMultipleSnapshotsDuringFailover

- Creates 3 snapshots with distinct keys captured in each
- Suspends SDS on the current leader
- Deletes all 3 snapshots, waits for all to reach SNAPSHOT_DELETED
- Shuts down the old leader, waits for new leader election
- Waits for the new leader's SDS to purge all 3 snapshots
- Asserts snapshot chain integrity

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8703

## How was this patch tested?

The two new tests were run locally against a 3-node MiniOzoneHAClusterImpl:

mvn test -pl hadoop-ozone/integration-test -am \
  -Dtest="TestOzoneManagerHASnapshot#testSnapshotDeletingServiceDuringOMFailover+testSnapshotDeletingServiceWithMultipleSnapshotsDuringFailover" \
  -DfailIfNoTests=false
Result:


Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.88 s
BUILD SUCCESS
<img width="909" height="801" alt="image" src="https://github.com/user-attachments/assets/784a6b99-894e-499f-9b5f-7a62648a7973" />

