### PR TITLE
HDDS-14897. Add multiple S3 gateways to the rolling-upgrade suite

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/s3-haproxy.cfg
+++ b/hadoop-ozone/dist/src/main/compose/common/s3-haproxy.cfg
@@ -33,9 +33,13 @@ frontend http-in
 
 backend servers
     balance roundrobin
-    server server1 s3g1:9878 maxconn 32
-    server server2 s3g2:9878 maxconn 32
-    server server3 s3g3:9878 maxconn 32
+    option httpchk GET /
+    http-check expect ! rstatus ^5
+    server server1 s3g1:9878 maxconn 32 check
+    server server2 s3g2:9878 maxconn 32 check
+    server server3 s3g3:9878 maxconn 32 check
+    retries 3
+    option redispatch
 
 frontend webadmin
     bind *:19878
@@ -43,6 +47,10 @@ frontend webadmin
 
 backend webadmin-servers
     balance roundrobin
-    server server1 s3g1:19878 maxconn 32
-    server server2 s3g2:19878 maxconn 32
-    server server3 s3g3:19878 maxconn 32
+    option httpchk GET /
+    http-check expect ! rstatus ^5
+    server server1 s3g1:19878 maxconn 32 check 
+    server server2 s3g2:19878 maxconn 32 check
+    server server3 s3g3:19878 maxconn 32 check
+    retries 3
+    option redispatch

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -278,7 +278,7 @@ reorder_om_nodes() {
         "if [[ -f /etc/hadoop/ozone-site.xml ]]; then \
           sed -i -e 's/om1,om2,om3/${new_order}/' /etc/hadoop/ozone-site.xml; \
           echo 'Replaced OM order with ${new_order} in ${c}'; \
-        fi"
+        fi" || true
     done
   fi
 }

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -273,12 +273,12 @@ reorder_om_nodes() {
   local new_order="$1"
 
   if [[ -n "${new_order}" ]] && [[ "${new_order}" != "om1,om2,om3" ]]; then
-    for c in $(docker-compose ps | cut -f1 -d' ' | grep -v -e '^NAME$' -e '^om'); do
+    for c in $(docker-compose ps | cut -f1 -d' ' | grep -v -e '^NAME$' -e '^om' -e 's3g-haproxy'); do
       docker exec "${c}" bash -c \
         "if [[ -f /etc/hadoop/ozone-site.xml ]]; then \
           sed -i -e 's/om1,om2,om3/${new_order}/' /etc/hadoop/ozone-site.xml; \
           echo 'Replaced OM order with ${new_order} in ${c}'; \
-        fi" || true
+        fi
     done
   fi
 }

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -278,7 +278,7 @@ reorder_om_nodes() {
         "if [[ -f /etc/hadoop/ozone-site.xml ]]; then \
           sed -i -e 's/om1,om2,om3/${new_order}/' /etc/hadoop/ozone-site.xml; \
           echo 'Replaced OM order with ${new_order} in ${c}'; \
-        fi
+        fi"
     done
   fi
 }

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
@@ -274,7 +274,7 @@ services:
       - *krb5conf
       - *ozone-dir
       - *transformation
-  s3g:
+  s3g-haproxy:
     image: haproxy:lts-alpine
     hostname: s3g
     networks:

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
@@ -72,6 +72,16 @@ x-volumes:
     - &ozone-dir ../../../..:${OZONE_DIR}
     - &transformation ../../../../libexec/transformation.py:/opt/hadoop/libexec/transformation.py
 
+x-s3-worker:
+  &s3-worker
+  command: ["ozone","s3g"]
+  <<: *common-config
+  environment:
+    <<: *environment
+  ports:
+    - 9878
+    - 19878
+
 services:
   kdc:
     command: ["/opt/hadoop/compose/common/init-kdc.sh"]
@@ -265,18 +275,49 @@ services:
       - *ozone-dir
       - *transformation
   s3g:
-    command: ["ozone","s3g"]
-    <<: *common-config
-    environment:
-      <<: *environment
+    image: haproxy:lts-alpine
     hostname: s3g
     networks:
       net:
         ipv4_address: 10.9.0.23
     ports:
       - 9878:9878
+      - 19878:19878
     volumes:
-      - ${OZONE_VOLUME}/s3g:/data
+      - ../../../common/s3-haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
+    command: ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+  s3g1:
+    <<: *s3-worker
+    hostname: s3g1
+    networks:
+      net:
+        ipv4_address: 10.9.0.24
+    volumes:
+      - ${OZONE_VOLUME}/s3g1:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+      - *transformation
+  s3g2:
+    <<: *s3-worker
+    hostname: s3g2
+    networks:
+      net:
+        ipv4_address: 10.9.0.25
+    volumes:
+      - ${OZONE_VOLUME}/s3g2:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+      - *transformation
+  s3g3:
+    <<: *s3-worker
+    hostname: s3g3
+    networks:
+      net:
+        ipv4_address: 10.9.0.26
+    volumes:
+      - ${OZONE_VOLUME}/s3g3:/data
       - *keytabs
       - *krb5conf
       - *ozone-dir

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/load.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/load.sh
@@ -27,6 +27,6 @@ export COMPOSE_FILE="$TEST_DIR/compose/ha/docker-compose.yaml"
 export OM_SERVICE_ID=omservice
 export SECURITY_ENABLED="true"
 
-create_data_dirs dn{1..5} kms om{1..3} recon s3g scm{1..3}
+create_data_dirs dn{1..5} kms om{1..3} recon s3g s3g{1..3} scm{1..3}
 
 echo "Using docker cluster defined in $COMPOSE_FILE"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/load.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/load.sh
@@ -27,6 +27,6 @@ export COMPOSE_FILE="$TEST_DIR/compose/ha/docker-compose.yaml"
 export OM_SERVICE_ID=omservice
 export SECURITY_ENABLED="true"
 
-create_data_dirs dn{1..5} kms om{1..3} recon s3g s3g{1..3} scm{1..3}
+create_data_dirs dn{1..5} kms om{1..3} recon s3g{1..3} scm{1..3}
 
 echo "Using docker cluster defined in $COMPOSE_FILE"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,7 +33,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-# run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
+run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 #run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 #run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
@@ -43,7 +43,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 # run_test om-ha non-rolling-upgrade 1.1.0 "$OZONE_CURRENT_VERSION"
 
 # Rolling upgrade test, commented out for now
-run_test ha     rolling-upgrade "$OZONE_CURRENT_VERSION" "$OZONE_CURRENT_VERSION"
+# run_test ha     rolling-upgrade "$OZONE_CURRENT_VERSION" "$OZONE_CURRENT_VERSION"
 
 generate_report "upgrade" "$ALL_RESULT_DIR"
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,7 +33,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
+# run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 #run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 #run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
@@ -43,7 +43,7 @@ run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
 # run_test om-ha non-rolling-upgrade 1.1.0 "$OZONE_CURRENT_VERSION"
 
 # Rolling upgrade test, commented out for now
-# run_test ha     rolling-upgrade "$OZONE_CURRENT_VERSION" "$OZONE_CURRENT_VERSION"
+ run_test ha     rolling-upgrade "$OZONE_CURRENT_VERSION" "$OZONE_CURRENT_VERSION"
 
 generate_report "upgrade" "$ALL_RESULT_DIR"
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,7 +33,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
+# run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 #run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 #run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
@@ -43,7 +43,7 @@ run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
 # run_test om-ha non-rolling-upgrade 1.1.0 "$OZONE_CURRENT_VERSION"
 
 # Rolling upgrade test, commented out for now
-# run_test ha     rolling-upgrade "$OZONE_CURRENT_VERSION" "$OZONE_CURRENT_VERSION"
+run_test ha     rolling-upgrade "$OZONE_CURRENT_VERSION" "$OZONE_CURRENT_VERSION"
 
 generate_report "upgrade" "$ALL_RESULT_DIR"
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/rolling-upgrade/driver.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/rolling-upgrade/driver.sh
@@ -74,6 +74,9 @@ rolling_restart_service() {
     dn*)
       wait_for_port "${SERVICE}" 9882 120
       ;;
+    s3g*)
+      wait_for_port "${SERVICE}" 9878 120
+      ;;
   esac
 }
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/rolling-upgrade/driver.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/rolling-upgrade/driver.sh
@@ -54,20 +54,13 @@ rolling_restart_service() {
     fi
   fi
 
-  # The data generation/validation is doing S3 API tests, so skip it in case the S3 gateway is updated
-  # TODO find a better solution
-  if [[ ${SERVICE} != "s3g" ]]; then
-    callback before_service_restart
-  fi
+  callback before_service_restart
 
   # Restart service with new image.
   prepare_for_image "${OZONE_UPGRADE_TO}"
   create_containers "${SERVICE}"
 
-  # The data generation/validation is doing S3 API tests, so skip it in case the S3 gateway is updated
-  if [[ ${SERVICE} != "s3g" ]]; then
-    callback after_service_restart
-  fi
+  callback after_service_restart
 
   # Service-specific readiness checks.
   case "${SERVICE}" in
@@ -112,14 +105,17 @@ for s in dn1 dn2 dn3 dn4 dn5; do
   rolling_restart_service "$s" "$OZONE_UPGRADE_TO"
 done
 
+# OMs
 for s in om1 om2 om3; do
   OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-2-${s}"
   rolling_restart_service "$s" "$OZONE_UPGRADE_TO"
 done
 
-# S3 Gateway
-OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-2-s3g"
-rolling_restart_service "s3g" "$OZONE_UPGRADE_TO"
+# S3 Gateways (s3g is HAProxy and does not need to be upgraded)
+for s in s3g1 s3g2 s3g3; do
+  OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-2-${s}"
+  rolling_restart_service "$s" "$OZONE_UPGRADE_TO"
+done
 
 # TODO Add downgrade scenario
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use HA Proxy to load balance multiple S3 gateways. I did the necessary changes in `docker-compose.yaml` and adjusted the shell scripts for that. I didn't use the existing `s3-haproxy.yaml`, as the one in common was not working out of the box with the Ozone HA setup (also found [HDDS-14956](https://issues.apache.org/jira/browse/HDDS-14956)). As this suite always need to have multiple S3 gateways I think it's okay to have it in the `docker-compose.yaml`. 

One outstanding change is in the `hadoop-ozone/dist/src/main/compose/testlib.sh`. Without that change I faced this error:
```
OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH
```
 Cursor help: "This is from reorder_om_nodes in testlib.sh. It iterates over ALL containers and runs docker exec ... bash -c "...". The HAProxy container (ha-s3g-1) uses haproxy:lts-alpine — Alpine Linux — which only has sh, not bash." 
 
 This is new, as Ozone HA suite never used S3 HAProxy setup before and if it's not Ozone HA we are not calling `reorder_om_nodes`. This fix will simply skip it and as the ha proxy container doesn't need `ozone-site.xml`, it's safe to do this. The downside is it would also silently swallow genuine bash failures. Another solution is to use `sh` instead of `bash`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14897

## How was this patch tested?

CI with the rolling upgrade test suite: https://github.com/dombizita/ozone/actions/runs/23846523428
With commenting out (current state on HDDS-14496-zdu): https://github.com/dombizita/ozone/actions/runs/23846562903

```
--- RESTARTING s3g1 WITH IMAGE 2.2.0 ---
Using Docker Compose v2
==============================================================================
2.2.0-2.2.0-2-s3g1-generate-generate-s3g1 :: Generate data                    
==============================================================================
Create a volume and bucket                                            | PASS |
------------------------------------------------------------------------------
Create key                                                            | PASS |
------------------------------------------------------------------------------
Create a bucket in s3v volume                                         | PASS |
------------------------------------------------------------------------------
Create key in the bucket in s3v volume                                | PASS |
------------------------------------------------------------------------------
Try to create a bucket using S3 API                                   | PASS |
------------------------------------------------------------------------------
Create key using S3 API                                               | PASS |
------------------------------------------------------------------------------
2.2.0-2.2.0-2-s3g1-generate-generate-s3g1 :: Generate data            | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/upgrade/result/robot-2.2.0-2.2.0-2-s3g1-001.xml
Using Docker Compose v2
==============================================================================
2.2.0-2.2.0-2-s3g1-validate-generate-s3g1 :: Smoketest ozone cluster startup  
==============================================================================
Read data from previously created key                                 | PASS |
------------------------------------------------------------------------------
Read key created with Ozone Shell using S3 API                        | PASS |
------------------------------------------------------------------------------
Read key created with S3 API using S3 API                             | PASS |
------------------------------------------------------------------------------
2.2.0-2.2.0-2-s3g1-validate-generate-s3g1 :: Smoketest ozone clust... | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/upgrade/result/robot-2.2.0-2.2.0-2-s3g1-002.xml
--- RESTARTING s3g2 WITH IMAGE 2.2.0 ---
Using Docker Compose v2
==============================================================================
2.2.0-2.2.0-2-s3g2-generate-generate-s3g2 :: Generate data                    
==============================================================================
Create a volume and bucket                                            | PASS |
------------------------------------------------------------------------------
Create key                                                            | PASS |
------------------------------------------------------------------------------
Create a bucket in s3v volume                                         | PASS |
------------------------------------------------------------------------------
Create key in the bucket in s3v volume                                | PASS |
------------------------------------------------------------------------------
Try to create a bucket using S3 API                                   | PASS |
------------------------------------------------------------------------------
Create key using S3 API                                               | PASS |
------------------------------------------------------------------------------
2.2.0-2.2.0-2-s3g2-generate-generate-s3g2 :: Generate data            | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/upgrade/result/robot-2.2.0-2.2.0-2-s3g2-001.xml
Using Docker Compose v2
==============================================================================
2.2.0-2.2.0-2-s3g2-validate-generate-s3g2 :: Smoketest ozone cluster startup  
==============================================================================
Read data from previously created key                                 | PASS |
------------------------------------------------------------------------------
Read key created with Ozone Shell using S3 API                        | PASS |
------------------------------------------------------------------------------
Read key created with S3 API using S3 API                             | PASS |
------------------------------------------------------------------------------
2.2.0-2.2.0-2-s3g2-validate-generate-s3g2 :: Smoketest ozone clust... | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/upgrade/result/robot-2.2.0-2.2.0-2-s3g2-002.xml
--- RESTARTING s3g3 WITH IMAGE 2.2.0 ---
Using Docker Compose v2
==============================================================================
2.2.0-2.2.0-2-s3g3-generate-generate-s3g3 :: Generate data                    
==============================================================================
Create a volume and bucket                                            | PASS |
------------------------------------------------------------------------------
Create key                                                            | PASS |
------------------------------------------------------------------------------
Create a bucket in s3v volume                                         | PASS |
------------------------------------------------------------------------------
Create key in the bucket in s3v volume                                | PASS |
------------------------------------------------------------------------------
Try to create a bucket using S3 API                                   | PASS |
------------------------------------------------------------------------------
Create key using S3 API                                               | PASS |
------------------------------------------------------------------------------
2.2.0-2.2.0-2-s3g3-generate-generate-s3g3 :: Generate data            | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/upgrade/result/robot-2.2.0-2.2.0-2-s3g3-001.xml
Using Docker Compose v2
==============================================================================
2.2.0-2.2.0-2-s3g3-validate-generate-s3g3 :: Smoketest ozone cluster startup  
==============================================================================
Read data from previously created key                                 | PASS |
------------------------------------------------------------------------------
Read key created with Ozone Shell using S3 API                        | PASS |
------------------------------------------------------------------------------
Read key created with S3 API using S3 API                             | PASS |
------------------------------------------------------------------------------
2.2.0-2.2.0-2-s3g3-validate-generate-s3g3 :: Smoketest ozone clust... | PASS |
3 tests, 3 passed, 0 failed
```
