### PR TITLE
HDDS-14966. OM UI shows wrong Leader Readiness values

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -1079,7 +1079,7 @@ public final class OmUtils {
   }
   
   public static List<List<String>> format(
-          List<ServiceInfo> nodes, int port, String leaderId, String leaderReadiness) {
+          List<ServiceInfo> nodes, int port, String leaderId) {
     List<List<String>> omInfoList = new ArrayList<>();
     // Ensuring OM's are printed in correct order
     List<ServiceInfo> omNodes = nodes.stream()
@@ -1089,8 +1089,10 @@ public final class OmUtils {
     for (ServiceInfo info : omNodes) {
       // Printing only the OM's running
       if (info.getNodeType() == HddsProtos.NodeType.OM) {
-        String role = info.getOmRoleInfo().getNodeId().equals(leaderId)
-                      ? "LEADER" : "FOLLOWER";
+        String nodeId = info.getOmRoleInfo().getNodeId();
+        String role = nodeId.equals(leaderId) ? "LEADER" : "FOLLOWER";
+        String leaderReadiness = nodeId.equals(leaderId)
+            ? "LEADER_AND_READY" : "NOT_LEADER";
         List<String> omInfo = new ArrayList<>();
         omInfo.add(info.getHostname());
         omInfo.add(info.getOmRoleInfo().getNodeId());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -39,8 +39,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_PORT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ReadConsistencyProto.READ_CONSISTENCY_UNSPECIFIED;
-import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.FOLLOWER;
-import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.LEADER;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -1079,9 +1079,10 @@ public final class OmUtils {
   public static boolean isBucketSnapshotIndicator(String key) {
     return key.startsWith(OM_SNAPSHOT_INDICATOR) && key.split("/").length == 2;
   }
-  
+
   public static List<List<String>> format(
-          List<ServiceInfo> nodes, int port, String leaderId) {
+      List<ServiceInfo> nodes, int port, String leaderId,
+      String localNodeId, String localLeaderStatus) {
     List<List<String>> omInfoList = new ArrayList<>();
     // Ensuring OM's are printed in correct order
     List<ServiceInfo> omNodes = nodes.stream()
@@ -1089,21 +1090,25 @@ public final class OmUtils {
         .sorted(Comparator.comparing(ServiceInfo::getHostname))
         .collect(Collectors.toList());
     for (ServiceInfo info : omNodes) {
-      // Printing only the OM's running
-      if (info.getNodeType() == HddsProtos.NodeType.OM) {
-        String nodeId = info.getOmRoleInfo().getNodeId();
-        String role = nodeId.equals(leaderId) ?
-            LEADER.name() : FOLLOWER.name();
-        String leaderReadiness = nodeId.equals(leaderId)
-            ? "LEADER_AND_READY" : "NOT_LEADER";
-        List<String> omInfo = new ArrayList<>();
-        omInfo.add(info.getHostname());
-        omInfo.add(info.getOmRoleInfo().getNodeId());
-        omInfo.add(String.valueOf(port));
-        omInfo.add(role);
-        omInfo.add(leaderReadiness);
-        omInfoList.add(omInfo);
+      String nodeId = info.getOmRoleInfo().getNodeId();
+      boolean isLeaderNode = nodeId.equals(leaderId);
+      boolean isLocalNode = nodeId.equals(localNodeId);
+      String role = info.getOmRoleInfo().getServerRole();
+
+      String displayValue;
+      if (isLeaderNode && isLocalNode) {
+        displayValue = localLeaderStatus;
+      } else {
+        displayValue = role;
       }
+
+      List<String> omInfo = new ArrayList<>();
+      omInfo.add(info.getHostname());
+      omInfo.add(nodeId);
+      omInfo.add(String.valueOf(port));
+      omInfo.add(role);
+      omInfo.add(displayValue);
+      omInfoList.add(omInfo);
     }
     return omInfoList;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -39,6 +39,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_PORT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ReadConsistencyProto.READ_CONSISTENCY_UNSPECIFIED;
+import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.FOLLOWER;
+import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.LEADER;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -1090,7 +1092,8 @@ public final class OmUtils {
       // Printing only the OM's running
       if (info.getNodeType() == HddsProtos.NodeType.OM) {
         String nodeId = info.getOmRoleInfo().getNodeId();
-        String role = nodeId.equals(leaderId) ? "LEADER" : "FOLLOWER";
+        String role = nodeId.equals(leaderId) ?
+            LEADER.name() : FOLLOWER.name();
         String leaderReadiness = nodeId.equals(leaderId)
             ? "LEADER_AND_READY" : "NOT_LEADER";
         List<String> omInfo = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3218,6 +3218,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return getRatisRolesException("Server is shutting down");
     }
 
+    String localLeaderStatus = omRatisServer.getLeaderStatus().name();
+    String localNodeId = omNodeDetails.getNodeId();
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
       LOG.error(NO_LEADER_ERROR_MESSAGE);
@@ -3231,7 +3233,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.error("Failed to getServiceList", e);
       return getRatisRolesException("IO-Exception Occurred, " + e.getMessage());
     }
-    return OmUtils.format(serviceList, port, leaderId.toString());
+    return OmUtils.format(serviceList, port, leaderId.toString(),
+        localNodeId, localLeaderStatus);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3217,7 +3217,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (null == omRatisServer) {
       return getRatisRolesException("Server is shutting down");
     }
-    String leaderReadiness = omRatisServer.getLeaderStatus().name();
+
     final RaftPeerId leaderId = omRatisServer.getLeaderId();
     if (leaderId == null) {
       LOG.error(NO_LEADER_ERROR_MESSAGE);
@@ -3231,7 +3231,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.error("Failed to getServiceList", e);
       return getRatisRolesException("IO-Exception Occurred, " + e.getMessage());
     }
-    return OmUtils.format(serviceList, port, leaderId.toString(), leaderReadiness);
+    return OmUtils.format(serviceList, port, leaderId.toString());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Fix incorrect Leader Readiness display in OM HA UI by computing the value per node instead of using the local OM status.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14966
## How was this patch tested?
- Verified the fix by running a 3-OM HA cluster and checking the OM Web UI. The Leader Readiness column now shows correct    per-node values.
- OM Leader
<img width="1855" height="218" alt="Om_1" src="https://github.com/user-attachments/assets/1e5ce0ef-cdc0-468a-8e25-a14bd31fe9b8" />

- OM Follwer 1
<img width="1851" height="210" alt="Om_2" src="https://github.com/user-attachments/assets/160e5574-1364-4f5e-8854-e304dc728b2f" />

- OM Follwer 2
<img width="1865" height="215" alt="Om_3" src="https://github.com/user-attachments/assets/76592a20-ed14-4bda-992f-67a0208f403a" />



