### PR TITLE
HDDS-13532. Refactor BucketEndpoint.get()

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -18,22 +18,18 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIST_MAX_KEYS_LIMIT;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIST_MAX_KEYS_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
-import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
@@ -45,7 +41,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.audit.S3GAction;
@@ -61,7 +56,6 @@ import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteResponse.DeletedObject;
 import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteResponse.Error;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
-import org.apache.hadoop.ozone.s3.util.ContinueToken;
 import org.apache.hadoop.ozone.s3.util.S3Consts.QueryParams;
 import org.apache.hadoop.ozone.s3.util.S3StorageType;
 import org.apache.hadoop.util.Time;
@@ -103,157 +97,15 @@ public class BucketEndpoint extends BucketOperationHandler {
   }
 
   @Override
-  Response handleGetRequest(S3RequestContext context, String bucketName) throws IOException, OS3Exception {
-    final String continueToken = queryParams().get(QueryParams.CONTINUATION_TOKEN);
-    final String delimiter = queryParams().get(QueryParams.DELIMITER);
-    final String encodingType = queryParams().get(QueryParams.ENCODING_TYPE);
-    final String marker = queryParams().get(QueryParams.MARKER);
-    int maxKeys = queryParams().getInt(QueryParams.MAX_KEYS, 1000);
-    String prefix = queryParams().get(QueryParams.PREFIX, "");
-    String startAfter = queryParams().get(QueryParams.START_AFTER);
-
-    Iterator<? extends OzoneKey> ozoneKeyIterator = null;
-    ContinueToken decodedToken = ContinueToken.decodeFromString(continueToken);
-    OzoneBucket bucket = null;
-
+  Response handleGetRequest(S3RequestContext context, String bucketName)
+      throws IOException, OS3Exception {
     try {
-      maxKeys = validateMaxKeys(maxKeys);
-
-      // Assign marker to startAfter. for the compatibility of aws api v1
-      if (startAfter == null && marker != null) {
-        startAfter = marker;
-      }
-
-      // If continuation token and start after both are provided, then we
-      // ignore start After
-      String prevKey = continueToken != null ? decodedToken.getLastKey()
-          : startAfter;
-
-      // If shallow is true, only list immediate children
-      // delimited by OZONE_URI_DELIMITER
-      boolean shallow = listKeysShallowEnabled
-          && OZONE_URI_DELIMITER.equals(delimiter);
-
-      bucket = context.getVolume().getBucket(bucketName);
-      S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
-
-      ozoneKeyIterator = bucket.listKeys(prefix, prevKey, shallow);
-
-    } catch (OMException ex) {
-      getMetrics().updateGetBucketFailureStats(context.getStartNanos());
-      if (ex.getResult() == ResultCodes.FILE_NOT_FOUND) {
-        // File not found, continue and send normal response with 0 keyCount
-        LOG.debug("Key Not found prefix: {}", prefix);
-      } else {
-        throw ex;
-      }
+      return BucketListing.fromQueryParams(context, this, bucketName)
+          .buildResponse();
     } catch (Exception ex) {
       getMetrics().updateGetBucketFailureStats(context.getStartNanos());
       throw ex;
     }
-
-    // The valid encodingType Values is "url"
-    if (encodingType != null && !encodingType.equals(ENCODING_TYPE)) {
-      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, encodingType);
-    }
-
-    // If you specify the encoding-type request parameter,should return
-    // encoded key name values in the following response elements:
-    //   Delimiter, Prefix, Key, and StartAfter.
-    //
-    // For detail refer:
-    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-EncodingType
-    ListObjectResponse response = new ListObjectResponse();
-    response.setDelimiter(EncodingTypeObject.createNullable(delimiter, encodingType));
-    response.setName(bucketName);
-    response.setPrefix(EncodingTypeObject.createNullable(prefix, encodingType));
-    response.setMarker(marker == null ? "" : marker);
-    response.setMaxKeys(maxKeys);
-    response.setEncodingType(encodingType);
-    response.setTruncated(false);
-    response.setContinueToken(continueToken);
-    response.setStartAfter(EncodingTypeObject.createNullable(startAfter, encodingType));
-
-    String prevDir = continueToken != null ? decodedToken.getLastDir() : null;
-    String lastKey = null;
-    int count = 0;
-    if (maxKeys > 0) {
-      while (ozoneKeyIterator != null && ozoneKeyIterator.hasNext()) {
-        OzoneKey next = ozoneKeyIterator.next();
-        if (StringUtils.isNotEmpty(prefix) && !next.getName().startsWith(prefix)) {
-          continue;
-        }
-        if (startAfter != null && count == 0 && Objects.equals(startAfter, next.getName())) {
-          continue;
-        }
-        String relativeKeyName = next.getName().substring(prefix.length());
-
-        int depth = StringUtils.countMatches(relativeKeyName, delimiter);
-        if (!StringUtils.isEmpty(delimiter)) {
-          if (depth > 0) {
-            // means key has multiple delimiters in its value.
-            // ex: dir/dir1/dir2, where delimiter is "/" and prefix is dir/
-            String dirName = relativeKeyName.substring(0, relativeKeyName
-                .indexOf(delimiter));
-            if (!dirName.equals(prevDir)) {
-              response.addPrefix(EncodingTypeObject.createNullable(
-                  prefix + dirName + delimiter, encodingType));
-              prevDir = dirName;
-              count++;
-            }
-          } else if (relativeKeyName.endsWith(delimiter)) {
-            // means or key is same as prefix with delimiter at end and ends with
-            // delimiter. ex: dir/, where prefix is dir and delimiter is /
-            response.addPrefix(
-                EncodingTypeObject.createNullable(relativeKeyName, encodingType));
-            count++;
-          } else {
-            // means our key is matched with prefix if prefix is given and it
-            // does not have any common prefix.
-            addKey(response, next);
-            count++;
-          }
-        } else {
-          addKey(response, next);
-          count++;
-        }
-
-        if (count == maxKeys) {
-          lastKey = next.getName();
-          break;
-        }
-      }
-    }
-
-    response.setKeyCount(count);
-
-    if (count < maxKeys) {
-      response.setTruncated(false);
-    } else if (ozoneKeyIterator.hasNext() && lastKey != null) {
-      response.setTruncated(true);
-      ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
-      response.setNextToken(nextToken.encodeToString());
-      // Set nextMarker to be lastKey. for the compatibility of aws api v1
-      response.setNextMarker(lastKey);
-    } else {
-      response.setTruncated(false);
-    }
-
-    int keyCount = response.getCommonPrefixes().size() + response.getContents().size();
-    long opLatencyNs = getMetrics().updateGetBucketSuccessStats(context.getStartNanos());
-    getMetrics().incListKeyCount(keyCount);
-    context.getPerf().appendCount(keyCount);
-    context.getPerf().appendOpLatencyNanos(opLatencyNs);
-    response.setKeyCount(keyCount);
-    return Response.ok(response).build();
-  }
-
-  private int validateMaxKeys(int maxKeys) throws OS3Exception {
-    if (maxKeys < 0) {
-      throw newError(S3ErrorTable.INVALID_ARGUMENT, "maxKeys must be >= 0");
-    }
-
-    return Math.min(maxKeys, maxKeysLimit);
   }
 
   @PUT
@@ -422,5 +274,17 @@ public class BucketEndpoint extends BucketOperationHandler {
         .add(this)
         .build();
     handler = new AuditingBucketOperationHandler(chain);
+  }
+
+  int getMaxKeysLimit() {
+    return maxKeysLimit;
+  }
+
+  boolean isListKeysShallowEnabled() {
+    return listKeysShallowEnabled;
+  }
+
+  void addKeyMetadata(ListObjectResponse response, OzoneKey next) {
+    addKey(response, next);
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketListing.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketListing.java
@@ -38,6 +38,11 @@ import org.apache.hadoop.ozone.s3.util.S3Consts.QueryParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Handles the S3 {@code GET Bucket (List Objects)} operation: reads the listing
+ * parameters from the request's query parameters, validates them, lists the
+ * bucket's keys and builds the {@link ListObjectResponse}.
+ */
 final class BucketListing {
 
   private static final Logger LOG = LoggerFactory.getLogger(BucketListing.class);
@@ -201,7 +206,7 @@ final class BucketListing {
 
     if (count < maxKeys) {
       response.setTruncated(false);
-    } else if (ozoneKeyIterator.hasNext() && lastKey != null) {
+    } else if (ozoneKeyIterator != null && ozoneKeyIterator.hasNext() && lastKey != null) {
       response.setTruncated(true);
       ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
       response.setNextToken(nextToken.encodeToString());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketListing.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketListing.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.s3.commontypes.EncodingTypeObject;
+import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.hadoop.ozone.s3.util.ContinueToken;
+import org.apache.hadoop.ozone.s3.util.S3Consts.QueryParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class BucketListing {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BucketListing.class);
+
+  private final S3RequestContext context;
+  private final BucketEndpoint endpoint;
+  private final String bucketName;
+  private final String delimiter;
+  private final String encodingType;
+  private final String marker;
+  private final String continueToken;
+  private String prefix;
+  private String startAfter;
+  private int maxKeys;
+  private OzoneBucket bucket;
+  private Iterator<? extends OzoneKey> ozoneKeyIterator;
+  private ContinueToken decodedToken;
+
+  private BucketListing(S3RequestContext context, BucketEndpoint endpoint, String bucketName) {
+    this.context = context;
+    this.endpoint = endpoint;
+    this.bucketName = bucketName;
+    this.delimiter = endpoint.queryParams().get(QueryParams.DELIMITER);
+    this.encodingType = endpoint.queryParams().get(QueryParams.ENCODING_TYPE);
+    this.marker = endpoint.queryParams().get(QueryParams.MARKER);
+    this.maxKeys = endpoint.queryParams().getInt(QueryParams.MAX_KEYS, 1000);
+    this.prefix = endpoint.queryParams().get(QueryParams.PREFIX);
+    this.continueToken = endpoint.queryParams().get(QueryParams.CONTINUATION_TOKEN);
+    this.startAfter = endpoint.queryParams().get(QueryParams.START_AFTER);
+  }
+
+  static BucketListing fromQueryParams(S3RequestContext context, BucketEndpoint endpoint,
+      String bucketName) throws IOException, OS3Exception {
+    BucketListing listing = new BucketListing(context, endpoint, bucketName);
+    listing.validateAndPrepare();
+    return listing;
+  }
+
+  Response buildResponse() {
+    ListObjectResponse response = initializeListObjectResponse();
+    processKeyListing(response);
+    return buildFinalResponse(response);
+  }
+
+  int getMaxKeys() {
+    return maxKeys;
+  }
+
+  String getPrefix() {
+    return prefix;
+  }
+
+  private void validateAndPrepare() throws OS3Exception, IOException {
+    validateEncodingType();
+    maxKeys = validateMaxKeys(maxKeys);
+
+    if (prefix == null) {
+      prefix = "";
+    }
+
+    if (startAfter == null && marker != null) {
+      startAfter = marker;
+    }
+
+    decodedToken = ContinueToken.decodeFromString(continueToken);
+    String prevKey = continueToken != null ? decodedToken.getLastKey() : startAfter;
+    boolean shallow = endpoint.isListKeysShallowEnabled()
+        && OZONE_URI_DELIMITER.equals(delimiter);
+
+    bucket = context.getVolume().getBucket(bucketName);
+    S3Owner.verifyBucketOwnerCondition(endpoint.getHeaders(), bucketName, bucket.getOwner());
+    try {
+      ozoneKeyIterator = bucket.listKeys(prefix, prevKey, shallow);
+    } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.FILE_NOT_FOUND) {
+        LOG.debug("Key not found for prefix: {}", prefix);
+        ozoneKeyIterator = null;
+      } else {
+        throw ex;
+      }
+    }
+  }
+
+  private void validateEncodingType() throws OS3Exception {
+    if (encodingType != null && !encodingType.equals(ENCODING_TYPE)) {
+      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, encodingType);
+    }
+  }
+
+  private int validateMaxKeys(int value) throws OS3Exception {
+    if (value < 0) {
+      throw newError(S3ErrorTable.INVALID_ARGUMENT, "maxKeys must be >= 0");
+    }
+
+    return Math.min(value, endpoint.getMaxKeysLimit());
+  }
+
+  private ListObjectResponse initializeListObjectResponse() {
+    ListObjectResponse response = new ListObjectResponse();
+    response.setDelimiter(EncodingTypeObject.createNullable(delimiter, encodingType));
+    response.setName(bucketName);
+    response.setPrefix(EncodingTypeObject.createNullable(prefix, encodingType));
+    response.setMarker(marker == null ? "" : marker);
+    response.setMaxKeys(maxKeys);
+    response.setEncodingType(encodingType);
+    response.setTruncated(false);
+    response.setContinueToken(continueToken);
+    response.setStartAfter(EncodingTypeObject.createNullable(startAfter, encodingType));
+    return response;
+  }
+
+  private void processKeyListing(ListObjectResponse response) {
+    String prevDir = continueToken != null ? decodedToken.getLastDir() : null;
+    String lastKey = null;
+    int count = 0;
+
+    if (maxKeys > 0) {
+      while (ozoneKeyIterator != null && ozoneKeyIterator.hasNext()) {
+        OzoneKey next = ozoneKeyIterator.next();
+
+        if (StringUtils.isNotEmpty(prefix) && !next.getName().startsWith(prefix)) {
+          continue;
+        }
+
+        if (startAfter != null && count == 0 && Objects.equals(startAfter, next.getName())) {
+          continue;
+        }
+
+        String relativeKeyName = next.getName().substring(prefix.length());
+        int depth = StringUtils.countMatches(relativeKeyName, delimiter);
+
+        if (!StringUtils.isEmpty(delimiter)) {
+          if (depth > 0) {
+            String dirName = relativeKeyName.substring(0, relativeKeyName.indexOf(delimiter));
+            if (!dirName.equals(prevDir)) {
+              response.addPrefix(EncodingTypeObject.createNullable(
+                  prefix + dirName + delimiter, encodingType));
+              prevDir = dirName;
+              count++;
+            }
+          } else if (relativeKeyName.endsWith(delimiter)) {
+            response.addPrefix(EncodingTypeObject.createNullable(relativeKeyName, encodingType));
+            count++;
+          } else {
+            endpoint.addKeyMetadata(response, next);
+            count++;
+          }
+        } else {
+          endpoint.addKeyMetadata(response, next);
+          count++;
+        }
+
+        if (count == maxKeys) {
+          lastKey = next.getName();
+          break;
+        }
+      }
+    }
+
+    response.setKeyCount(count);
+
+    if (count < maxKeys) {
+      response.setTruncated(false);
+    } else if (ozoneKeyIterator.hasNext() && lastKey != null) {
+      response.setTruncated(true);
+      ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
+      response.setNextToken(nextToken.encodeToString());
+      response.setNextMarker(lastKey);
+    } else {
+      response.setTruncated(false);
+    }
+  }
+
+  private Response buildFinalResponse(ListObjectResponse response) {
+    int keyCount = response.getCommonPrefixes().size() + response.getContents().size();
+    long opLatencyNs = endpoint.getMetrics().updateGetBucketSuccessStats(context.getStartNanos());
+    endpoint.getMetrics().incListKeyCount(keyCount);
+    context.getPerf().appendCount(keyCount);
+    context.getPerf().appendOpLatencyNanos(opLatencyNs);
+    response.setKeyCount(keyCount);
+    return Response.ok(response).build();
+  }
+}

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketListing.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketListing.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import javax.ws.rs.core.Response;
+import org.apache.hadoop.ozone.audit.S3GAction;
+import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.hadoop.ozone.s3.util.S3Consts.QueryParams;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestBucketListing {
+
+  private static final String TEST_BUCKET_NAME = "test-bucket";
+
+  private BucketEndpoint bucketEndpoint;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    OzoneClientStub client = new OzoneClientStub();
+    bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+    client.getObjectStore().createS3Bucket(TEST_BUCKET_NAME);
+  }
+
+  private S3RequestContext newContext() {
+    return new S3RequestContext(bucketEndpoint, S3GAction.GET_BUCKET);
+  }
+
+  @Test
+  void testFromQueryParams() throws Exception {
+    bucketEndpoint.queryParamsForTest().set(QueryParams.DELIMITER, "/");
+    bucketEndpoint.queryParamsForTest().setInt(QueryParams.MAX_KEYS, 100);
+    bucketEndpoint.queryParamsForTest().set(QueryParams.PREFIX, "test/");
+
+    BucketListing listing = BucketListing.fromQueryParams(newContext(), bucketEndpoint,
+        TEST_BUCKET_NAME);
+
+    assertEquals(100, listing.getMaxKeys());
+    assertEquals("test/", listing.getPrefix());
+  }
+
+  @Test
+  void testBuildResponseUsesCappedMaxKeys() throws Exception {
+    bucketEndpoint.queryParamsForTest().setInt(QueryParams.MAX_KEYS, 5000);
+
+    BucketListing listing = BucketListing.fromQueryParams(newContext(), bucketEndpoint,
+        TEST_BUCKET_NAME);
+
+    try (Response response = listing.buildResponse()) {
+      ListObjectResponse entity = (ListObjectResponse) response.getEntity();
+      assertEquals(1000, entity.getMaxKeys());
+      assertEquals(0, entity.getKeyCount());
+    }
+  }
+
+  @Test
+  void testFromQueryParamsWithInvalidEncodingType() {
+    bucketEndpoint.queryParamsForTest().set(QueryParams.ENCODING_TYPE, "invalid");
+
+    OS3Exception exception = assertThrows(OS3Exception.class,
+        () -> BucketListing.fromQueryParams(newContext(), bucketEndpoint, TEST_BUCKET_NAME));
+
+    assertEquals(S3ErrorTable.INVALID_ARGUMENT.getCode(), exception.getCode());
+  }
+
+  @Test
+  void testFromQueryParamsWithNonexistentBucket() {
+    OMException exception = assertThrows(OMException.class,
+        () -> BucketListing.fromQueryParams(newContext(), bucketEndpoint, "nonexistent-bucket"));
+
+    assertEquals(OMException.ResultCodes.BUCKET_NOT_FOUND, exception.getResult());
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?
Reopen: https://github.com/apache/ozone/pull/9110
This pull request refactors the massively monolithic `BucketEndpoint.get()` method (ListObjects API implementation) to vastly improve codebase maintainability, readability, and unit-testability.

The original `get()` method was nearly 200 lines long. It tightly coupled logic across multiple domains—from parameter string deserialization, context variable instantiation, iterative key-prefix filtering logic, to S3 metrics/audit log emissions. This structure made it inherently risky to extend and nearly impossible to write isolated unit tests for individual components of the logic.

**Key Refactoring Improvements in this PR:**
* **Context Encapsulation (`BucketListingContext`)**: Introduced a dedicated package-private class to securely encapsulate listing state (such as `bucketName`, `prefix`, `encodingType`, `maxKeys`, `decodedToken`, `ozoneKeyIterator`, etc.). This successfully prevented "parameter-creep" and minimized variable clutter across the execution flow.
* **Method Extraction & Separation of Concerns**: We systematically decomposed the unmaintainable block into multiple single-responsibility helper methods:
  * `validateAndPrepareParameters()`: Sanitizes configuration limits, handles token decodings, verifies encoding types, and enforces S3 Bucket owner conditions.
  * `initializeListObjectResponse()`: Generates the bare-bones boilerplate response structures.
  * `processKeyListing()`: Owns the complex computational burden (the `while (ozoneKeyIterator.hasNext())` mechanism), resolving token depth matches, delimited deep structures, and `CommonPrefixes` allocations safely.
  * `buildFinalResponse()`: Isolates the responsibility of executing `PerformanceStringBuilder` increments and consistent `auditReadSuccess` publishing.
* **Seamless Upstream Synchronization**: During refactoring, this branch was comprehensively synced and merged with `master`'s recent additions (`S3RequestContext`, `PerformanceStringBuilder`, and the `BucketOperationHandler` Chain-of-Responsibility pattern). The refactor cleanly embraces these integrations while achieving optimal flow footprint. 

###  What is the link to the Apache JIRA?
https://issues.apache.org/jira/browse/HDDS-13532

###  How was this patch tested?
https://github.com/rich7420/ozone/actions/runs/23993539910