### PR TITLE
HDDS-14963. Retry attempt to pull docker images

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -59,7 +59,7 @@ for HADOOP_TEST_IMAGE in $HADOOP_TEST_IMAGES; do
   hadoop_version=$(docker run --rm "${HADOOP_TEST_IMAGE}" bash -c "hadoop version | grep -m1 '^Hadoop' | cut -f2 -d' '")
   export HADOOP_MAJOR_VERSION=${hadoop_version%%.*}
 
-  retry docker-compose --ansi never --profile hadoop --progress quiet pull nm rm
+  retry docker-compose --ansi never --profile hadoop pull nm rm
   docker-compose --ansi never --profile hadoop up -d nm rm
 
   execute_command_in_container rm hadoop version

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -59,6 +59,7 @@ for HADOOP_TEST_IMAGE in $HADOOP_TEST_IMAGES; do
   hadoop_version=$(docker run --rm "${HADOOP_TEST_IMAGE}" bash -c "hadoop version | grep -m1 '^Hadoop' | cut -f2 -d' '")
   export HADOOP_MAJOR_VERSION=${hadoop_version%%.*}
 
+  retry docker-compose --ansi never --profile hadoop --progress quiet pull nm rm
   docker-compose --ansi never --profile hadoop up -d nm rm
 
   execute_command_in_container rm hadoop version

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -179,6 +179,8 @@ start_docker_env(){
 
   docker-compose --ansi never down --remove-orphans
 
+  retry docker-compose --ansi never --progress quiet pull
+
   opts=""
   if has_scalable_datanode; then
     opts="--scale datanode=${datanode_count}"
@@ -357,6 +359,30 @@ save_container_logs() {
   done
 }
 
+retry() {
+  local -i n=0
+  local -i attempts=${RETRY_ATTEMPTS:-3}
+  local -i rc=0
+
+  set +e
+  while [[ $n -lt $attempts ]]; do
+    if "$@"; then
+      rc=0
+      break
+    fi
+    let n++
+
+    if [[ $n -eq $attempts ]]; then
+      echo "ERROR: $n attempts failed to: $@"
+      rc=1
+    else
+      sleep ${RETRY_SLEEP:-3}
+    fi
+  done
+  set -e
+
+  return ${rc}
+}
 
 ## @description wait until the port is available on the given host
 ## @param The host to check for the port

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -179,7 +179,7 @@ start_docker_env(){
 
   docker-compose --ansi never down --remove-orphans
 
-  retry docker-compose --ansi never --progress quiet pull
+  retry docker-compose --ansi never pull
 
   opts=""
   if has_scalable_datanode; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Try to reduce intermittent error in acceptance tests:

```
Error response from daemon: Head "https://ghcr.io/v2/apache/ozone-runner/manifests/20260206-2-jdk21": Get "https://ghcr.io/token?scope=repository%3Aapache%2Fozone-runner%3Apull&service=ghcr.io": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

by attempting to pull images a few times.  (Currently images are pulled internally during `docker compose up`.)

https://issues.apache.org/jira/browse/HDDS-14963

## How was this patch tested?

Tried to reproduce with `repeat-acceptance-test`, but the problem didn't happen...

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/23892541736