### PR TITLE
HDDS-14938. Implement Iceberg's RewriteTablePath action with input validation

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -256,6 +256,19 @@
   </build>
   <profiles>
     <profile>
+      <id>jdk11-with-iceberg</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-iceberg</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>build-with-ozonefs</id>
       <activation>
         <property>

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -280,6 +280,7 @@ Apache License 2.0
    com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider
    com.fasterxml.jackson.module:jackson-module-jaxb-annotations
    com.fasterxml.woodstox:woodstox-core
+   com.github.ben-manes.caffeine:caffeine
    com.github.jnr:jnr-a64asm
    com.github.jnr:jnr-constants
    com.github.jnr:jnr-ffi
@@ -366,6 +367,7 @@ Apache License 2.0
    log4j:apache-log4j-extras
    net.java.dev.jna:jna
    net.java.dev.jna:jna-platform
+   org.apache.avro:avro
    org.apache.commons:commons-compress
    org.apache.commons:commons-configuration2
    org.apache.commons:commons-collections4
@@ -384,6 +386,9 @@ Apache License 2.0
    org.apache.hadoop:hadoop-shaded-guava
    org.apache.hadoop:hadoop-shaded-protobuf_3_25
    org.apache.httpcomponents:httpcore
+   org.apache.iceberg:iceberg-api
+   org.apache.iceberg:iceberg-common
+   org.apache.iceberg:iceberg-core
    org.apache.kerby:kerb-admin
    org.apache.kerby:kerb-client
    org.apache.kerby:kerb-common

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -11,6 +11,7 @@ share/ozone/lib/asm.jar
 share/ozone/lib/asm-tree.jar
 share/ozone/lib/asm-util.jar
 share/ozone/lib/aspectjrt.jar
+share/ozone/lib/avro.jar
 share/ozone/lib/aws-java-sdk-core.jar
 share/ozone/lib/aws-java-sdk-kms.jar
 share/ozone/lib/aws-java-sdk-s3.jar
@@ -18,6 +19,7 @@ share/ozone/lib/bcpkix-jdk18on.jar
 share/ozone/lib/bcprov-jdk18on.jar
 share/ozone/lib/bcutil-jdk18on.jar
 share/ozone/lib/bonecp.RELEASE.jar
+share/ozone/lib/caffeine.jar
 share/ozone/lib/cdi-api.SP1.jar
 share/ozone/lib/commons-beanutils.jar
 share/ozone/lib/commons-cli.jar
@@ -84,6 +86,9 @@ share/ozone/lib/hk2-utils.jar
 share/ozone/lib/hppc.jar
 share/ozone/lib/httpclient.jar
 share/ozone/lib/httpcore.jar
+share/ozone/lib/iceberg-api.jar
+share/ozone/lib/iceberg-common.jar
+share/ozone/lib/iceberg-core.jar
 share/ozone/lib/istack-commons-runtime.jar
 share/ozone/lib/j2objc-annotations.jar
 share/ozone/lib/jackson-annotations.jar
@@ -223,6 +228,7 @@ share/ozone/lib/ozone-filesystem-hadoop3.jar
 share/ozone/lib/ozone-filesystem.jar
 share/ozone/lib/ozone-freon.jar
 share/ozone/lib/ozone-httpfsgateway.jar
+share/ozone/lib/ozone-iceberg.jar
 share/ozone/lib/ozone-insight.jar
 share/ozone/lib/ozone-interface-client.jar
 share/ozone/lib/ozone-interface-storage.jar

--- a/hadoop-ozone/iceberg/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/iceberg/dev-support/findbugsExcludeFile.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<FindBugsFilter>
+</FindBugsFilter>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.ozone</groupId>
+    <artifactId>ozone</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>ozone-iceberg</artifactId>
+  <version>2.2.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Apache Ozone Iceberg Integration</name>
+  <description>Apache Ozone Iceberg Integration</description>
+
+  <properties>
+    <classpath.skip>false</classpath.skip>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+
+    <!-- Common utilities -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <!-- Iceberg dependencies -->
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-api</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-core</artifactId>
+      <version>${iceberg.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Iceberg 1.10+ API is Java 11 bytecode, override parent Java 8 default. -->
+          <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
+          <fork>true</fork>
+          <maxHeap>2048</maxHeap>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -27,27 +27,46 @@
 
   <properties>
     <classpath.skip>false</classpath.skip>
+    <!-- Iceberg 1.10+ API is Java 11 bytecode, override parent Java 8 default. -->
     <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
 
-    <!-- Common utilities -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
     <!-- Iceberg dependencies -->
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
-      <version>${iceberg.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-core</artifactId>
-      <version>${iceberg.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents.client5</groupId>
+          <artifactId>httpclient5</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents.core5</groupId>
+          <artifactId>httpcore5</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents.core5</groupId>
+          <artifactId>httpcore5-h2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-bundled-guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.roaringbitmap</groupId>
+          <artifactId>RoaringBitmap</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -57,8 +76,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <!-- Iceberg 1.10+ API is Java 11 bytecode, override parent Java 8 default. -->
-          <release>11</release>
+          <proc>none</proc>
         </configuration>
       </plugin>
       <plugin>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -37,6 +37,12 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-bundled-guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.iceberg</groupId>

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hadoop.ozone.iceberg;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import com.google.common.base.Preconditions;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.RewriteTablePathUtil;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.actions.ImmutableRewriteTablePath;
+import org.apache.iceberg.actions.RewriteTablePath;
+
+public class RewriteTablePathOzoneAction implements RewriteTablePath {
+
+  private static final String RESULT_LOCATION = "file-list";
+
+  private String sourcePrefix;
+  private String targetPrefix;
+  private String startVersionName;
+  private String endVersionName;
+  private String stagingDir;
+  private int parallelism = Runtime.getRuntime().availableProcessors();
+
+  private final Table table;
+  private ExecutorService executorService;
+
+  public RewriteTablePathOzoneAction(Table table) {
+    this.table = table;
+  }
+
+  public RewriteTablePathOzoneAction(Table table, int parallelism) {
+    this.table = table;
+    this.parallelism = parallelism;
+  }
+
+  @Override
+  public RewriteTablePath rewriteLocationPrefix(String sPrefix, String tPrefix) {
+    Preconditions.checkArgument(
+        sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
+    this.sourcePrefix = sPrefix;
+    this.targetPrefix = tPrefix;
+    return this;
+  }
+
+  @Override
+  public RewriteTablePath startVersion(String sVersion) {
+    Preconditions.checkArgument(
+        sVersion != null && !sVersion.trim().isEmpty(),
+        "Start version('%s') cannot be empty.",
+        sVersion);
+    this.startVersionName = sVersion;
+    return this;
+  }
+
+  @Override
+  public RewriteTablePath endVersion(String eVersion) {
+    Preconditions.checkArgument(
+        eVersion != null && !eVersion.trim().isEmpty(),
+        "End version('%s') cannot be empty.",
+        eVersion);
+    this.endVersionName = eVersion;
+    return this;
+  }
+
+  @Override
+  public RewriteTablePath stagingLocation(String stagingLocation) {
+    Preconditions.checkArgument(
+        stagingLocation != null && !stagingLocation.isEmpty(),
+        "Staging location('%s') cannot be empty.",
+        stagingLocation);
+    this.stagingDir = stagingLocation;
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    validateInputs();
+    this.executorService = Executors.newFixedThreadPool(parallelism);
+    try {
+      return doExecute();
+    } finally {
+      executorService.shutdown();
+    }
+  }
+
+  private Result doExecute() {
+    String resultLocation = rebuildMetadata();
+    return ImmutableRewriteTablePath.Result.builder()
+        .stagingLocation(stagingDir)
+        .fileListLocation(resultLocation)
+        .latestVersion(RewriteTablePathUtil.fileName(endVersionName))
+        .build();
+  }
+
+  private void validateInputs() {
+    Preconditions.checkArgument(
+        sourcePrefix != null && !sourcePrefix.isEmpty(),
+        "Source prefix('%s') cannot be empty.",
+        sourcePrefix);
+    Preconditions.checkArgument(
+        targetPrefix != null && !targetPrefix.isEmpty(),
+        "Target prefix('%s') cannot be empty.",
+        targetPrefix);
+    Preconditions.checkArgument(
+        !sourcePrefix.equals(targetPrefix),
+        "Source prefix cannot be the same as target prefix (%s)",
+        sourcePrefix);
+
+    validateAndSetEndVersion();
+    validateAndSetStartVersion();
+
+    if (stagingDir == null) {
+      stagingDir =
+          getMetadataLocation(table)
+              + "copy-table-staging-"
+              + UUID.randomUUID()
+              + RewriteTablePathUtil.FILE_SEPARATOR;
+    } else {
+      stagingDir = RewriteTablePathUtil.maybeAppendFileSeparator(stagingDir);
+    }
+  }
+
+  private void validateAndSetEndVersion() {
+    TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+
+    if (endVersionName == null) {
+      Preconditions.checkNotNull(
+          tableMetadata.metadataFileLocation(), "Metadata file location should not be null");
+      this.endVersionName = tableMetadata.metadataFileLocation();
+    } else {
+      this.endVersionName = validateVersion(tableMetadata, endVersionName);
+    }
+  }
+
+  private void validateAndSetStartVersion() {
+    TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+
+    if (startVersionName != null) {
+      this.startVersionName = validateVersion(tableMetadata, startVersionName);
+    }
+  }
+
+  private String validateVersion(TableMetadata tableMetadata, String versionFileName) {
+    String versionFile = null;
+    if (versionInFilePath(tableMetadata.metadataFileLocation(), versionFileName)) {
+      versionFile = tableMetadata.metadataFileLocation();
+    }
+
+    for (MetadataLogEntry log : tableMetadata.previousFiles()) {
+      if (versionInFilePath(log.file(), versionFileName)) {
+        versionFile = log.file();
+      }
+    }
+
+    Preconditions.checkArgument(
+        versionFile != null,
+        "Cannot find provided version file %s in metadata log.",
+        versionFileName);
+    Preconditions.checkArgument(
+        fileExist(versionFile), "Version file %s does not exist.", versionFile);
+    return versionFile;
+  }
+
+  private boolean versionInFilePath(String path, String version) {
+    return RewriteTablePathUtil.fileName(path).equals(version);
+  }
+
+  private String rebuildMetadata() {
+    //TODO need to implement rewrite of metadata files , manifest list , manifest files and position delete files.
+    return null;
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+
+  private String getMetadataLocation(Table tbl) {
+    String currentMetadataPath =
+        ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+    int lastIndex = currentMetadataPath.lastIndexOf(RewriteTablePathUtil.FILE_SEPARATOR);
+    String metadataDir = "";
+    if (lastIndex != -1) {
+      metadataDir = currentMetadataPath.substring(0, lastIndex + 1);
+    }
+
+    Preconditions.checkArgument(
+        !metadataDir.isEmpty(), "Failed to get the metadata file root directory");
+    return metadataDir;
+  }
+}

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -18,10 +18,10 @@
  */
 package org.apache.hadoop.ozone.iceberg;
 
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import com.google.common.base.Preconditions;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.Table;
@@ -39,13 +39,14 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   private String startVersionName;
   private String endVersionName;
   private String stagingDir;
-  private int parallelism = Runtime.getRuntime().availableProcessors();
+  private int parallelism;
 
   private final Table table;
   private ExecutorService executorService;
 
   public RewriteTablePathOzoneAction(Table table) {
     this.table = table;
+    this.parallelism = Runtime.getRuntime().availableProcessors();
   }
 
   public RewriteTablePathOzoneAction(Table table, int parallelism) {
@@ -55,8 +56,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   @Override
   public RewriteTablePath rewriteLocationPrefix(String sPrefix, String tPrefix) {
-    Preconditions.checkArgument(
-        sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
+    checkNonNullNonEmpty(sPrefix, "Source prefix('%s') cannot be empty.");
+    checkNonNullNonEmpty(tPrefix, "Target prefix('%s') cannot be empty.");
     this.sourcePrefix = sPrefix;
     this.targetPrefix = tPrefix;
     return this;
@@ -64,30 +65,21 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   @Override
   public RewriteTablePath startVersion(String sVersion) {
-    Preconditions.checkArgument(
-        sVersion != null && !sVersion.trim().isEmpty(),
-        "Start version('%s') cannot be empty.",
-        sVersion);
+    checkNonNullNonEmpty(sVersion, "Start version('%s') cannot be empty.");
     this.startVersionName = sVersion;
     return this;
   }
 
   @Override
   public RewriteTablePath endVersion(String eVersion) {
-    Preconditions.checkArgument(
-        eVersion != null && !eVersion.trim().isEmpty(),
-        "End version('%s') cannot be empty.",
-        eVersion);
+    checkNonNullNonEmpty(eVersion, "End version('%s') cannot be empty.");
     this.endVersionName = eVersion;
     return this;
   }
 
   @Override
   public RewriteTablePath stagingLocation(String stagingLocation) {
-    Preconditions.checkArgument(
-        stagingLocation != null && !stagingLocation.isEmpty(),
-        "Staging location('%s') cannot be empty.",
-        stagingLocation);
+    checkNonNullNonEmpty(stagingLocation, "Staging location('%s') cannot be empty.");
     this.stagingDir = stagingLocation;
     return this;
   }
@@ -113,18 +105,11 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   }
 
   private void validateInputs() {
-    Preconditions.checkArgument(
-        sourcePrefix != null && !sourcePrefix.isEmpty(),
-        "Source prefix('%s') cannot be empty.",
-        sourcePrefix);
-    Preconditions.checkArgument(
-        targetPrefix != null && !targetPrefix.isEmpty(),
-        "Target prefix('%s') cannot be empty.",
-        targetPrefix);
-    Preconditions.checkArgument(
-        !sourcePrefix.equals(targetPrefix),
-        "Source prefix cannot be the same as target prefix (%s)",
-        sourcePrefix);
+    if (sourcePrefix.equals(targetPrefix)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Source prefix cannot be the same as target prefix (%s)", sourcePrefix));
+    }
 
     validateAndSetEndVersion();
     validateAndSetStartVersion();
@@ -144,7 +129,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
 
     if (endVersionName == null) {
-      Preconditions.checkNotNull(
+      Objects.requireNonNull(
           tableMetadata.metadataFileLocation(), "Metadata file location should not be null");
       this.endVersionName = tableMetadata.metadataFileLocation();
     } else {
@@ -172,12 +157,15 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
       }
     }
 
-    Preconditions.checkArgument(
-        versionFile != null,
-        "Cannot find provided version file %s in metadata log.",
-        versionFileName);
-    Preconditions.checkArgument(
-        fileExist(versionFile), "Version file %s does not exist.", versionFile);
+    if (versionFile == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot find provided version file %s in metadata log.", versionFileName));
+    }
+    if (!fileExist(versionFile)) {
+      throw new IllegalArgumentException(
+          String.format("Version file %s does not exist.", versionFile));
+    }
     return versionFile;
   }
 
@@ -206,8 +194,17 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
       metadataDir = currentMetadataPath.substring(0, lastIndex + 1);
     }
 
-    Preconditions.checkArgument(
-        !metadataDir.isEmpty(), "Failed to get the metadata file root directory");
+    if (metadataDir.isEmpty()) {
+      throw new IllegalArgumentException("Failed to get the metadata file root directory");
+    }
     return metadataDir;
+  }
+
+  private static void checkNonNullNonEmpty(String value, String messageFormat) {
+    String message = String.format(messageFormat, value);
+    Objects.requireNonNull(value, message);
+    if (value.trim().isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
   }
 }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -56,8 +56,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   @Override
   public RewriteTablePath rewriteLocationPrefix(String sPrefix, String tPrefix) {
-    checkNonNullNonEmpty(sPrefix, "Source prefix('%s') cannot be empty.");
-    checkNonNullNonEmpty(tPrefix, "Target prefix('%s') cannot be empty.");
+    checkNonNullNonEmpty(sPrefix, "Source prefix");
+    checkNonNullNonEmpty(tPrefix, "Target prefix");
     this.sourcePrefix = sPrefix;
     this.targetPrefix = tPrefix;
     return this;
@@ -65,21 +65,21 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   @Override
   public RewriteTablePath startVersion(String sVersion) {
-    checkNonNullNonEmpty(sVersion, "Start version('%s') cannot be empty.");
+    checkNonNullNonEmpty(sVersion, "Start version");
     this.startVersionName = sVersion;
     return this;
   }
 
   @Override
   public RewriteTablePath endVersion(String eVersion) {
-    checkNonNullNonEmpty(eVersion, "End version('%s') cannot be empty.");
+    checkNonNullNonEmpty(eVersion, "End version");
     this.endVersionName = eVersion;
     return this;
   }
 
   @Override
   public RewriteTablePath stagingLocation(String stagingLocation) {
-    checkNonNullNonEmpty(stagingLocation, "Staging location('%s') cannot be empty.");
+    checkNonNullNonEmpty(stagingLocation, "Staging location");
     this.stagingDir = stagingLocation;
     return this;
   }
@@ -200,11 +200,10 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     return metadataDir;
   }
 
-  private static void checkNonNullNonEmpty(String value, String messageFormat) {
-    String message = String.format(messageFormat, value);
-    Objects.requireNonNull(value, message);
+  private static void checkNonNullNonEmpty(String value, String name) {
+    Objects.requireNonNull(value, () -> name + " is null");
     if (value.trim().isEmpty()) {
-      throw new IllegalArgumentException(message);
+      throw new IllegalArgumentException(name + " is empty");
     }
   }
 }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.Table;
@@ -92,6 +94,14 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
       return doExecute();
     } finally {
       executorService.shutdown();
+      try {
+        if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+          executorService.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        executorService.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -107,6 +107,15 @@
 
   <profiles>
     <profile>
+      <id>jdk11-with-iceberg</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>iceberg</module>
+      </modules>
+    </profile>
+    <profile>
       <id>build-with-ozonefs</id>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <hk2.version>2.6.1</hk2.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.16</httpcore.version>
-    <iceberg.version>1.10.0</iceberg.version>
+    <iceberg.version>1.10.1</iceberg.version>
     <io.grpc.version>1.77.1</io.grpc.version>
     <jackson2-bom.version>2.21.1</jackson2-bom.version>
     <jackson2.version>2.21.2</jackson2.version>
@@ -261,6 +261,13 @@
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
         <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.iceberg</groupId>
+        <artifactId>iceberg-bom</artifactId>
+        <version>${iceberg.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
     <hk2.version>2.6.1</hk2.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.16</httpcore.version>
+    <iceberg.version>1.10.0</iceberg.version>
     <io.grpc.version>1.77.1</io.grpc.version>
     <jackson2-bom.version>2.21.1</jackson2-bom.version>
     <jackson2.version>2.21.2</jackson2.version>
@@ -1322,6 +1323,11 @@
       <dependency>
         <groupId>org.apache.ozone</groupId>
         <artifactId>ozone-httpfsgateway</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-iceberg</artifactId>
         <version>${ozone.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch implements Iceberg's [RewriteTablePath](https://github.com/apache/iceberg/blob/1.10.x/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java)  action and validates the inputs provided for the path rewrite.

Prefix Rewrite Configuration
Allow specifying:
  - sourcePrefix (existing path prefix)
  - targetPrefix (replacement prefix)
  - Ensure source and target prefixes are non-empty and not identical

Optional startVersion and endVersion inputs.
  - Validate that provided version exist in table.
  - Defaults:
    - endVersion → current metadata version if not provided
    - startVersion → if not set, rewrite applies up to end version from beginning version.
    
Staging Location Handling
- Supports user-defined staging directory.
- If not provided, automatically generates a staging path within the tables's metadata directory.

This change is required for upcoming patches in the epic: : [HDDS-14937](https://issues.apache.org/jira/browse/HDDS-14937)

## What is the link to the Apache JIRA
[HDDS-14938](https://issues.apache.org/jira/browse/HDDS-14938)

## How was this patch tested?

Green CI : https://github.com/sreejasahithi/ozone/actions/runs/24018893628
