### PR TITLE
HDDS-15003. Inline EndpointBase#createS3Bucket/deleteS3Bucket

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
@@ -88,7 +88,7 @@ public class BucketAclHandler extends BucketOperationHandler {
     context.setAction(S3GAction.GET_ACL);
 
     try {
-      OzoneBucket bucket = getBucket(bucketName);
+      OzoneBucket bucket = context.getVolume().getBucket(bucketName);
       S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
       S3Owner owner = S3Owner.of(bucket.getOwner());
 
@@ -139,9 +139,9 @@ public class BucketAclHandler extends BucketOperationHandler {
     String grantFull = getHeaders().getHeaderString(S3Acl.GRANT_FULL_CONTROL);
 
     try {
-      OzoneBucket bucket = getBucket(bucketName);
+      OzoneVolume volume = context.getVolume();
+      OzoneBucket bucket = volume.getBucket(bucketName);
       S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
-      OzoneVolume volume = getVolume();
 
       List<OzoneAcl> ozoneAclListOnBucket = new ArrayList<>();
       List<OzoneAcl> ozoneAclListOnVolume = new ArrayList<>();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 
 import java.io.IOException;
 import java.io.InputStream;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -62,10 +63,16 @@ public class BucketCrudHandler extends BucketOperationHandler {
 
     context.setAction(S3GAction.CREATE_BUCKET);
 
-    String location = createS3Bucket(bucketName);
-    getMetrics().updateCreateBucketSuccessStats(context.getStartNanos());
-    return Response.status(HttpStatus.SC_OK).header("Location", location)
-        .build();
+    try {
+      getClient().getObjectStore().createS3Bucket(bucketName);
+      getMetrics().updateCreateBucketSuccessStats(context.getStartNanos());
+      return Response.status(HttpStatus.SC_OK)
+          .header(HttpHeaders.LOCATION, "/" + bucketName)
+          .build();
+    } catch (Exception e) {
+      getMetrics().updateCreateBucketFailureStats(context.getStartNanos());
+      throw e;
+    }
   }
 
   /**
@@ -83,10 +90,10 @@ public class BucketCrudHandler extends BucketOperationHandler {
 
     try {
       if (S3Owner.hasBucketOwnershipVerificationConditions(getHeaders())) {
-        OzoneBucket bucket = getBucket(bucketName);
+        OzoneBucket bucket = context.getVolume().getBucket(bucketName);
         S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
       }
-      deleteS3Bucket(bucketName);
+      context.getVolume().deleteBucket(bucketName);
     } catch (Exception ex) {
       getMetrics().updateDeleteBucketFailureStats(context.getStartNanos());
       throw ex;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -136,7 +136,7 @@ public class BucketEndpoint extends BucketOperationHandler {
       boolean shallow = listKeysShallowEnabled
           && OZONE_URI_DELIMITER.equals(delimiter);
 
-      bucket = getBucket(bucketName);
+      bucket = context.getVolume().getBucket(bucketName);
       S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
 
       ozoneKeyIterator = bucket.listKeys(prefix, prevKey, shallow);
@@ -293,11 +293,14 @@ public class BucketEndpoint extends BucketOperationHandler {
     long startNanos = Time.monotonicNowNanos();
     S3GAction s3GAction = S3GAction.HEAD_BUCKET;
     try {
-      OzoneBucket bucket = getBucket(bucketName);
+      OzoneBucket bucket = getVolume().getBucket(bucketName);
       S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
       auditReadSuccess(s3GAction);
       getMetrics().updateHeadBucketSuccessStats(startNanos);
       return Response.ok().build();
+    } catch (OMException e) {
+      auditReadFailure(s3GAction, e);
+      throw newError(translateException(e), bucketName, e);
     } catch (Exception e) {
       auditReadFailure(s3GAction, e);
       throw e;
@@ -342,7 +345,7 @@ public class BucketEndpoint extends BucketOperationHandler {
   ) throws OS3Exception, IOException {
     S3GAction s3GAction = S3GAction.MULTI_DELETE;
 
-    OzoneBucket bucket = getBucket(bucketName);
+    OzoneBucket bucket = getVolume().getBucket(bucketName);
     MultiDeleteResponse result = new MultiDeleteResponse();
     List<String> deleteKeys = new ArrayList<>();
 
@@ -429,15 +432,21 @@ public class BucketEndpoint extends BucketOperationHandler {
   }
 
   private static OS3Exception translateException(OMException ex) {
-    if (isAccessDenied(ex)) {
+    switch (ex.getResult()) {
+    case ACCESS_DENIED:
+    case INVALID_TOKEN:
+    case PERMISSION_DENIED:
       return S3ErrorTable.ACCESS_DENIED;
-    } else if (ex.getResult() == ResultCodes.BUCKET_NOT_EMPTY) {
+    case BUCKET_ALREADY_EXISTS:
+      return S3ErrorTable.BUCKET_ALREADY_EXISTS;
+    case BUCKET_NOT_EMPTY:
       return S3ErrorTable.BUCKET_NOT_EMPTY;
-    } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
+    case BUCKET_NOT_FOUND:
+    case VOLUME_NOT_FOUND:
       return S3ErrorTable.NO_SUCH_BUCKET;
-    } else if (ex.getResult() == ResultCodes.INVALID_BUCKET_NAME) {
+    case INVALID_BUCKET_NAME:
       return S3ErrorTable.INVALID_BUCKET_NAME;
-    } else {
+    default:
       return INTERNAL_ERROR;
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -108,7 +108,6 @@ import org.apache.hadoop.ozone.s3.signature.SignatureInfo;
 import org.apache.hadoop.ozone.s3.util.AuditUtils;
 import org.apache.hadoop.ozone.s3.util.S3Utils;
 import org.apache.hadoop.ozone.web.utils.OzoneUtils;
-import org.apache.hadoop.util.Time;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.slf4j.Logger;
@@ -186,27 +185,6 @@ public abstract class EndpointBase {
     return queryParams;
   }
 
-  protected OzoneBucket getBucket(OzoneVolume volume, String bucketName)
-      throws OS3Exception, IOException {
-    OzoneBucket bucket;
-    try {
-      bucket = volume.getBucket(bucketName);
-    } catch (OMException ex) {
-      if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
-      } else if (ex.getResult() == ResultCodes.INVALID_TOKEN) {
-        throw newError(S3ErrorTable.ACCESS_DENIED,
-            s3Auth.getAccessID(), ex);
-      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
-          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
-        throw newError(S3ErrorTable.INTERNAL_ERROR, bucketName, ex);
-      } else {
-        throw ex;
-      }
-    }
-    return bucket;
-  }
-
   /**
    * Initializes the object post construction. Calls init() from any
    * child classes to work around the issue of only one method can be annotated.
@@ -272,62 +250,6 @@ public abstract class EndpointBase {
 
   protected OzoneVolume getVolume() throws IOException {
     return client.getObjectStore().getS3Volume();
-  }
-
-  /**
-   * Create an S3Bucket, and also it creates mapping needed to access via
-   * ozone and S3.
-   * @param bucketName
-   * @return location of the S3Bucket.
-   * @throws IOException
-   */
-  protected String createS3Bucket(String bucketName) throws
-      IOException, OS3Exception {
-    long startNanos = Time.monotonicNowNanos();
-    try {
-      client.getObjectStore().createS3Bucket(bucketName);
-    } catch (OMException ex) {
-      getMetrics().updateCreateBucketFailureStats(startNanos);
-      if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
-      } else if (ex.getResult() == ResultCodes.INVALID_TOKEN) {
-        throw newError(S3ErrorTable.ACCESS_DENIED,
-            s3Auth.getAccessID(), ex);
-      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
-          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
-        throw newError(S3ErrorTable.INTERNAL_ERROR, bucketName, ex);
-      } else if (ex.getResult() == ResultCodes.BUCKET_ALREADY_EXISTS) {
-        throw newError(S3ErrorTable.BUCKET_ALREADY_EXISTS, bucketName, ex);
-      } else {
-        throw ex;
-      }
-    }
-    return "/" + bucketName;
-  }
-
-  /**
-   * Deletes an s3 bucket and removes mapping of Ozone volume/bucket.
-   * @param s3BucketName - S3 Bucket Name.
-   * @throws  IOException in case the bucket cannot be deleted.
-   */
-  protected void deleteS3Bucket(String s3BucketName)
-      throws IOException, OS3Exception {
-    try {
-      client.getObjectStore().deleteS3Bucket(s3BucketName);
-    } catch (OMException ex) {
-      if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw newError(S3ErrorTable.ACCESS_DENIED,
-            s3BucketName, ex);
-      } else if (ex.getResult() == ResultCodes.INVALID_TOKEN) {
-        throw newError(S3ErrorTable.ACCESS_DENIED,
-            s3Auth.getAccessID(), ex);
-      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
-          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
-        throw newError(S3ErrorTable.INTERNAL_ERROR, s3BucketName, ex);
-      } else {
-        throw ex;
-      }
-    }
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListMultipartUploadsHandler.java
@@ -56,7 +56,7 @@ class ListMultipartUploadsHandler extends BucketOperationHandler {
 
     long startNanos = context.getStartNanos();
 
-    OzoneBucket bucket = getBucket(bucketName);
+    OzoneBucket bucket = context.getVolume().getBucket(bucketName);
 
     try {
       S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -17,9 +17,6 @@
 
 package org.apache.hadoop.ozone.client;
 
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_ALREADY_EXISTS;
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_EMPTY;
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.mockito.Mockito.mock;
 
@@ -40,20 +37,20 @@ import org.apache.hadoop.util.Time;
  */
 public class ObjectStoreStub extends ObjectStore {
 
-  private static OzoneConfiguration conf = new OzoneConfiguration();
-  private Map<String, OzoneVolumeStub> volumes = new HashMap<>();
-  private Map<String, Boolean> bucketEmptyStatus = new HashMap<>();
+  private final Map<String, OzoneVolumeStub> volumes = new HashMap<>();
+  private final String s3VolumeName;
 
   public ObjectStoreStub() {
-    super(conf, mock(ClientProtocol.class));
+    this(new OzoneConfiguration(), mock(ClientProtocol.class));
   }
 
   public ObjectStoreStub(ConfigurationSource conf, ClientProtocol proxy) {
     super(conf, proxy);
+    s3VolumeName = HddsClientUtils.getDefaultS3VolumeName(conf);
   }
 
   @Override
-  public void createVolume(String volumeName) throws IOException {
+  public void createVolume(String volumeName) {
     createVolume(volumeName,
         VolumeArgs.newBuilder()
             .setAdmin("root")
@@ -86,8 +83,7 @@ public class ObjectStoreStub extends ObjectStore {
   }
 
   @Override
-  public Iterator<? extends OzoneVolume> listVolumes(String volumePrefix)
-      throws IOException {
+  public Iterator<? extends OzoneVolume> listVolumes(String volumePrefix) {
     return volumes.values()
         .stream()
         .filter(volume -> volume.getName().startsWith(volumePrefix))
@@ -98,7 +94,7 @@ public class ObjectStoreStub extends ObjectStore {
 
   @Override
   public Iterator<? extends OzoneVolume> listVolumes(String volumePrefix,
-      String prevVolume) throws IOException {
+      String prevVolume) {
     return volumes.values()
         .stream()
         .filter(volume -> volume.getName().compareTo(prevVolume) > 0)
@@ -109,7 +105,7 @@ public class ObjectStoreStub extends ObjectStore {
 
   @Override
   public Iterator<? extends OzoneVolume> listVolumesByUser(String user,
-      String volumePrefix, String prevVolume) throws IOException {
+      String volumePrefix, String prevVolume) {
     return volumes.values()
         .stream()
         .filter(volume -> volume.getOwner().equals(user))
@@ -120,7 +116,7 @@ public class ObjectStoreStub extends ObjectStore {
   }
 
   @Override
-  public void deleteVolume(String volumeName) throws IOException {
+  public void deleteVolume(String volumeName) {
     volumes.remove(volumeName);
   }
 
@@ -128,41 +124,25 @@ public class ObjectStoreStub extends ObjectStore {
   public OzoneVolume getS3Volume() throws IOException {
     // Always return default S3 volume. This class will not be used for
     // multitenant testing.
-    String volumeName = HddsClientUtils.getDefaultS3VolumeName(conf);
-    return getVolume(volumeName);
+    return getVolume(s3VolumeName);
   }
 
   @Override
   public void createS3Bucket(String s3BucketName) throws
       IOException {
-    if (!bucketEmptyStatus.containsKey(s3BucketName)) {
-      String volumeName = HddsClientUtils.getDefaultS3VolumeName(conf);
-      bucketEmptyStatus.put(s3BucketName, true);
-      if (!volumes.containsKey(volumeName)) {
-        createVolume(volumeName);
-      }
-      volumes.get(volumeName).createBucket(s3BucketName);
-    } else {
-      throw new OMException("", BUCKET_ALREADY_EXISTS);
+    if (!volumes.containsKey(s3VolumeName)) {
+      createVolume(s3VolumeName);
     }
+    volumes.get(s3VolumeName).createBucket(s3BucketName);
   }
 
   @Override
   public void deleteS3Bucket(String s3BucketName) throws
       IOException {
-    if (bucketEmptyStatus.containsKey(s3BucketName)) {
-      if (bucketEmptyStatus.get(s3BucketName)) {
-        bucketEmptyStatus.remove(s3BucketName);
-      } else {
-        throw new OMException("", BUCKET_NOT_EMPTY);
-      }
-    } else {
-      throw new OMException("", BUCKET_NOT_FOUND);
+    OzoneVolume volume = getS3Volume();
+    if (volume == null) {
+      throw new OMException("", VOLUME_NOT_FOUND);
     }
+    volume.deleteBucket(s3BucketName);
   }
-
-  public void setBucketEmptyStatus(String bucketName, boolean status) {
-    bucketEmptyStatus.computeIfPresent(bucketName, (k, v) -> status);
-  }
-
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -105,6 +105,10 @@ public final class OzoneBucketStub extends OzoneBucket {
     }
   }
 
+  boolean isEmpty() {
+    return keyDetails.isEmpty();
+  }
+
   @Override
   public OzoneOutputStream createKey(String key, long size) throws IOException {
     return createKey(key, size,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
@@ -106,7 +106,7 @@ public final class OzoneVolumeStub extends OzoneVolume {
   }
 
   @Override
-  public void createBucket(String bucketName) {
+  public void createBucket(String bucketName) throws OMException {
     createBucket(bucketName, new BucketArgs.Builder()
         .setStorageType(StorageType.DEFAULT)
         .setVersioning(false)
@@ -114,7 +114,11 @@ public final class OzoneVolumeStub extends OzoneVolume {
   }
 
   @Override
-  public void createBucket(String bucketName, BucketArgs bucketArgs) {
+  public void createBucket(String bucketName, BucketArgs bucketArgs) throws OMException {
+    if (buckets.containsKey(bucketName)) {
+      throw new OMException("", OMException.ResultCodes.BUCKET_ALREADY_EXISTS);
+    }
+
     buckets.put(bucketName, OzoneBucketStub.newBuilder()
         .setVolumeName(getName())
         .setName(bucketName)
@@ -166,10 +170,14 @@ public final class OzoneVolumeStub extends OzoneVolume {
 
   @Override
   public void deleteBucket(String bucketName) throws IOException {
-    if (buckets.containsKey(bucketName)) {
+    if (!buckets.containsKey(bucketName)) {
+      throw new OMException("", OMException.ResultCodes.BUCKET_NOT_FOUND);
+    }
+    OzoneBucketStub bucket = (OzoneBucketStub) buckets.get(bucketName);
+    if (bucket.isEmpty()) {
       buckets.remove(bucketName);
     } else {
-      throw new OMException("", OMException.ResultCodes.BUCKET_NOT_FOUND);
+      throw new OMException("", OMException.ResultCodes.BUCKET_NOT_EMPTY);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAclHandler.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAclHandler.java
@@ -37,6 +37,8 @@ import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,7 +153,7 @@ public class TestBucketAclHandler {
     when(headers.getHeaderString(S3Acl.GRANT_READ))
         .thenReturn("id=\"testuser\"");
 
-    assertThrows(OS3Exception.class,
+    assertThrows(OMException.class,
         () -> aclHandler.handlePutRequest(mockContext(), "nonexistent-bucket", null),
         "Should throw OS3Exception for non-existent bucket");
   }
@@ -236,7 +238,7 @@ public class TestBucketAclHandler {
 
   @Test
   public void testHandleGetRequestBucketNotFound() {
-    assertThrows(OS3Exception.class,
+    assertThrows(OMException.class,
         () -> aclHandler.handleGetRequest(mockContext(), "nonexistent-bucket"),
         "Should throw OS3Exception for non-existent bucket");
   }
@@ -258,7 +260,14 @@ public class TestBucketAclHandler {
     assertNotNull(result.getAclList().getGrantList());
   }
 
-  private static S3RequestContext mockContext() {
-    return new S3RequestContext(mock(BucketEndpoint.class), null);
+  private S3RequestContext mockContext() throws IOException {
+    BucketEndpoint endpoint = mock(BucketEndpoint.class);
+    OzoneVolume volume = mock(OzoneVolume.class);
+    when(endpoint.getVolume()).thenReturn(volume);
+    when(volume.getBucket(BUCKET_NAME))
+        .thenAnswer(any -> client.getObjectStore().getS3Bucket(BUCKET_NAME));
+    when(volume.getBucket("nonexistent-bucket"))
+        .thenThrow(new OMException("", OMException.ResultCodes.BUCKET_NOT_FOUND));
+    return new S3RequestContext(endpoint, null);
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
-import org.apache.hadoop.ozone.client.ObjectStoreStub;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
@@ -79,8 +78,7 @@ public class TestBucketDelete {
   @Test
   public void testDeleteWithBucketNotEmpty() throws Exception {
     try {
-      ObjectStoreStub stub = (ObjectStoreStub) objectStoreStub;
-      stub.setBucketEmptyStatus(bucketName, false);
+      objectStoreStub.getS3Bucket(bucketName).createDirectory("dir");
       bucketEndpoint.delete(bucketName);
     } catch (OS3Exception ex) {
       assertEquals(S3ErrorTable.BUCKET_NOT_EMPTY.getCode(), ex.getCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -118,7 +118,8 @@ public class TestPermissionCheck {
    */
   @Test
   public void testGetBucket() throws IOException {
-    doThrow(exception).when(objectStore).getS3Bucket(anyString());
+    doThrow(exception).when(volume).getBucket(anyString());
+    when(objectStore.getS3Volume()).thenReturn(volume);
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
         .build();
@@ -129,6 +130,7 @@ public class TestPermissionCheck {
 
   @Test
   public void testCreateBucket() throws IOException {
+    when(objectStore.getS3Volume()).thenReturn(volume);
     when(objectStore.getVolume(anyString())).thenReturn(volume);
     doThrow(exception).when(objectStore).createS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
@@ -141,8 +143,9 @@ public class TestPermissionCheck {
 
   @Test
   public void testDeleteBucket() throws IOException {
-    doThrow(exception).when(objectStore).deleteS3Bucket(anyString());
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    doThrow(exception).when(volume).deleteBucket(anyString());
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
         .build();
@@ -153,7 +156,8 @@ public class TestPermissionCheck {
 
   @Test
   public void testListMultiUpload() throws IOException {
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).listMultipartUploads(any(), any(), any(), anyInt());
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
@@ -166,7 +170,8 @@ public class TestPermissionCheck {
   @Test
   public void testListKey() throws IOException {
     when(objectStore.getVolume(anyString())).thenReturn(volume);
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).listKeys(anyString(), isNull(),
         anyBoolean());
     BucketEndpoint bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
@@ -179,7 +184,8 @@ public class TestPermissionCheck {
   @Test
   public void testDeleteKeys() throws IOException, OS3Exception {
     when(objectStore.getVolume(anyString())).thenReturn(volume);
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     Map<String, ErrorInfo> deleteErrors = new HashMap<>();
     deleteErrors.put("deleteKeyName", new ErrorInfo("ACCESS_DENIED", "ACL check failed"));
     when(bucket.deleteKeys(any(), anyBoolean())).thenReturn(deleteErrors);
@@ -202,7 +208,7 @@ public class TestPermissionCheck {
   @Test
   public void testGetAcl() throws Exception {
     when(objectStore.getS3Volume()).thenReturn(volume);
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).getAcls();
 
     when(headers.getHeaderString(S3Acl.GRANT_READ))
@@ -219,7 +225,7 @@ public class TestPermissionCheck {
   @Test
   public void testSetAcl() throws Exception {
     when(objectStore.getS3Volume()).thenReturn(volume);
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).setAcl(any());
 
     when(headers.getHeaderString(S3Acl.GRANT_READ))
@@ -241,7 +247,6 @@ public class TestPermissionCheck {
     when(client.getProxy()).thenReturn(clientProtocol);
     when(objectStore.getS3Volume()).thenReturn(volume);
     when(volume.getBucket(anyString())).thenReturn(bucket);
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(clientProtocol)
         .getS3KeyDetails(anyString(), anyString());
     ObjectEndpoint objectEndpoint = EndpointBuilder.newObjectEndpointBuilder()
@@ -285,7 +290,9 @@ public class TestPermissionCheck {
 
   @Test
   public void testMultiUploadKey() throws IOException {
+    when(objectStore.getS3Volume()).thenReturn(volume);
     when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).initiateMultipartUpload(anyString(), any(), anyMap(), anyMap());
     ObjectEndpoint objectEndpoint = EndpointBuilder.newObjectEndpointBuilder()
         .setClient(client)
@@ -301,7 +308,6 @@ public class TestPermissionCheck {
   public void testObjectTagging() throws Exception {
     when(objectStore.getVolume(anyString())).thenReturn(volume);
     when(objectStore.getS3Volume()).thenReturn(volume);
-    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     when(volume.getBucket("bucketName")).thenReturn(bucket);
     when(bucket.getObjectTagging(anyString())).thenThrow(exception);
     doThrow(exception).when(bucket).putObjectTagging(anyString(), anyMap());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -193,20 +193,21 @@ public class TestS3GatewayMetrics {
   public void testDeleteBucketSuccess() throws Exception {
     long oriMetric = metrics.getDeleteBucketSuccess();
 
-    bucketEndpoint.delete(bucketName);
+    String newBucket = "new-bucket";
+    clientStub.getObjectStore().createS3Bucket(newBucket);
+    bucketEndpoint.delete(newBucket);
 
     long curMetric = metrics.getDeleteBucketSuccess();
     assertEquals(1L, curMetric - oriMetric);
   }
 
   @Test
-  public void testDeleteBucketFailure() throws Exception {
+  public void testDeleteBucketFailure() {
     long oriMetric = metrics.getDeleteBucketFailure();
-    bucketEndpoint.delete(bucketName);
 
     // Deleting a bucket that does not exist will result in delete failure
     OS3Exception e = assertThrows(OS3Exception.class, () ->
-        bucketEndpoint.delete(bucketName));
+        bucketEndpoint.delete("no-such-bucket"));
     assertEquals(S3ErrorTable.NO_SUCH_BUCKET.getCode(), e.getCode());
     assertEquals(S3ErrorTable.NO_SUCH_BUCKET.getErrorMessage(),
         e.getErrorMessage());


### PR DESCRIPTION
## What changes were proposed in this pull request?

`BucketEndpoint` is responsible for converting `OMException` to `OS3Exception`, but bucket management methods inherited from `EndpointBase` also do it for some result codes.  These are called from inner handler methods (within audited block).  This causes audit log to show the wrong exception (`OS3Exception`) in some cases.  This change is the first step towards fixing that, follow-up will handle remaining `getBucket` usage.

- Merge `EndpointBase#createS3Bucket` and `#deleteS3Bucket` into `BucketCrudHandler`
- Remove unused `EndpointBase#getBucket(OzoneVolume, String)`
- Reduce usage of `EndpointBase#getBucket(String)`
- Create `OzoneBucketStub#isEmpty` to reduce extra logic related to "emptiness" in `ObjectStoreStub` (both of these objects are used only in unit tests).  Previous logic allowed `TestS3GatewayMetrics#testDeleteBucketSuccess` to delete a non-empty bucket because "non-empty" flag was not set.

https://issues.apache.org/jira/browse/HDDS-15003

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/24191772810