### PR TITLE
HDDS-14998. Use line.separator in option descriptions

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
@@ -42,14 +42,14 @@ import picocli.CommandLine.Command;
  */
 @Command(
     name = "usageinfo",
-    description = "List usage information of a datanode by IP address, hostname or UUID.\n\n" +
-        "Legend (bytes):\n" +
-        "  Filesystem Capacity/Used/Available: raw filesystem stats for the Datanode, aggregated across volumes.\n" +
+    description = "List usage information of a datanode by IP address, hostname or UUID.%n%n" +
+        "Legend (bytes):%n" +
+        "  Filesystem Capacity/Used/Available: raw filesystem stats for the Datanode, aggregated across volumes.%n" +
         "  Ozone Capacity/Used/Available: Ozone-usable stats after reserved-space adjustment, aggregated across " +
-        "  volumes (see hdds.datanode.dir.du.reserved / hdds.datanode.dir.du.reserved.percent).\n" +
-        "  Reserved: hdds.datanode.dir.du.reserved: configured reserved space for non-Ozone usage.\n" +
-        "  Committed: space pre-allocated for containers.\n" +
-        "  Free Space To Spare: minimum free space to keep before closing containers.\n",
+        "  volumes (see hdds.datanode.dir.du.reserved / hdds.datanode.dir.du.reserved.percent).%n" +
+        "  Reserved: hdds.datanode.dir.du.reserved: configured reserved space for non-Ozone usage.%n" +
+        "  Committed: space pre-allocated for containers.%n" +
+        "  Free Space To Spare: minimum free space to keep before closing containers.%n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class UsageInfoSubcommand extends ScmSubcommand {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -47,14 +47,14 @@ import picocli.CommandLine;
         "-hostname=<decommission-om-node-address> [options]",
     description = "Decommission an OzoneManager. Ensure that the node being " +
         "decommissioned is shutdown first." +
-        "\nNote - Add the node to be decommissioned to " +
+        "%nNote - Add the node to be decommissioned to " +
         OZONE_OM_DECOMMISSIONED_NODES_KEY + "config in ozone-site.xml of all " +
         "OzoneManagers before proceeding with decommission." +
-        "\nNote - DECOMMISSIONING AN OM MIGHT RENDER THE CLUSTER TO LOSE " +
+        "%nNote - DECOMMISSIONING AN OM MIGHT RENDER THE CLUSTER TO LOSE " +
         "HIGH AVAILABILITY." +
-        "\nNote - When there are only two OzoneManagers, do not stop the " +
+        "%nNote - When there are only two OzoneManagers, do not stop the " +
         "OzoneManager before decommissioning as both OzoneManagers are " +
-        "required to reach quorum." + "\n" +
+        "required to reach quorum." + "%n" +
         "It is recommended to add another OzoneManager(s) before " +
         "decommissioning one to maintain HA.",
     mixinStandardHelpOptions = true,

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/FinalizeUpgradeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/FinalizeUpgradeSubCommand.java
@@ -47,7 +47,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "finalizeupgrade",
     description = "Finalizes Ozone Manager's metadata changes and enables new "
-        + "features after a software upgrade.\n"
+        + "features after a software upgrade.%n"
         + "It is possible to specify the service ID for an HA environment, "
         + "or the Ozone manager host in a non-HA environment, if none provided "
         + "the default from configuration is being used if not ambiguous.",

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -84,7 +84,7 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
 
   @CommandLine.Option(
       names = {"-s", "--start"},
-      description = "The item to start the listing from.\n" +
+      description = "The item to start the listing from.%n" +
           "i.e. continuation token. " +
           "This will be excluded from the result.",
       defaultValue = ""

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/AuditParser.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/AuditParser.java
@@ -45,8 +45,8 @@ public class AuditParser implements DebugSubcommand {
   <.db file path> template <template name>
   <.db file path> query <custom sql>
    */
-  @Parameters(arity = "1..1", description = "Existing or new .db file.\n" +
-      "The database contains only one table called audit defined as:\n" +
+  @Parameters(arity = "1..1", description = "Existing or new .db file.%n" +
+      "The database contains only one table called audit defined as:%n" +
       "audit (datetime text, level varchar(7), logger varchar(7), " +
       "user text, ip text, op text, params text, result varchar(7), " +
       "exception text, " +

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/handler/LoadCommandHandler.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/handler/LoadCommandHandler.java
@@ -30,9 +30,9 @@ import picocli.CommandLine.ParentCommand;
  */
 @Command(name = "load",
     aliases = "l",
-    description = "Load ozone audit log files.\n\n" +
-        "To load an audit log to database:\n" +
-        "ozone debug auditparser <path to db file> load <logs>\n",
+    description = "Load ozone audit log files.%n%n" +
+        "To load an audit log to database:%n" +
+        "ozone debug auditparser <path to db file> load <logs>%n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class LoadCommandHandler implements Callable<Void> {

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/handler/QueryCommandHandler.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/handler/QueryCommandHandler.java
@@ -32,9 +32,9 @@ import picocli.CommandLine.ParentCommand;
  */
 @Command(name = "query",
     aliases = "q",
-    description = "Execute custom query.\n\n" +
-        "To run a custom read-only query on the audit logs loaded to the database:\n" +
-        "ozone debug auditparser <path to db file> query <query>\n",
+    description = "Execute custom query.%n%n" +
+        "To run a custom read-only query on the audit logs loaded to the database:%n" +
+        "ozone debug auditparser <path to db file> query <query>%n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class QueryCommandHandler implements Callable<Void> {

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/handler/TemplateCommandHandler.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/audit/parser/handler/TemplateCommandHandler.java
@@ -31,14 +31,14 @@ import picocli.CommandLine.ParentCommand;
  */
 @Command(name = "template",
     aliases = "t",
-    description = "Execute template query.\n\n" +
-        "To run a template query on the audit logs loaded to the database:\n" +
-        "ozone debug auditparser <path to db file> template <template>\n\n" +
-        "Following templates are available:\n" +
-        "(Template)              (Description)\n" +
-        "top5users              : Top 5 users.\n" +
-        "top5cmds               : Top 5 commands.\n" +
-        "top5activetimebyseconds: Top 5 active times, grouped by seconds.\n",
+    description = "Execute template query.%n%n" +
+        "To run a template query on the audit logs loaded to the database:%n" +
+        "ozone debug auditparser <path to db file> template <template>%n%n" +
+        "Following templates are available:%n" +
+        "(Template)              (Description)%n" +
+        "top5users              : Top 5 users.%n" +
+        "top5cmds               : Top 5 commands.%n" +
+        "top5activetimebyseconds: Top 5 active times, grouped by seconds.%n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class TemplateCommandHandler implements Callable<Void> {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/ListPaginationOptions.java
@@ -26,7 +26,7 @@ public class ListPaginationOptions {
   private ListLimitOptions limitOptions;
 
   @CommandLine.Option(names = {"--start", "-s"},
-      description = "The item to start the listing from.\n" +
+      description = "The item to start the listing from.%n" +
           "This will be excluded from the result.")
   private String startItem;
 

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -34,21 +34,21 @@ import picocli.shell.jline3.PicocliCommands.PicocliCommandsFactory;
 public abstract class Shell extends GenericCli {
 
   public static final String OZONE_URI_DESCRIPTION =
-      "Ozone URI could either be a full URI or short URI.\n" +
-          "Full URI should start with o3://, in case of non-HA\nclusters it " +
-          "should be followed by the host name and\noptionally the port " +
-          "number. In case of HA clusters\nthe service id should be used. " +
-          "Service id provides a\nlogical name for multiple hosts and it is " +
-          "defined\nin the property ozone.om.service.ids.\n" +
-          "Example of a full URI with host name and port number\nfor a key:" +
-          "\no3://omhostname:9862/vol1/bucket1/key1\n" +
+      "Ozone URI could either be a full URI or short URI.%n" +
+          "Full URI should start with o3://, in case of non-HA%nclusters it " +
+          "should be followed by the host name and%noptionally the port " +
+          "number. In case of HA clusters%nthe service id should be used. " +
+          "Service id provides a%nlogical name for multiple hosts and it is " +
+          "defined%nin the property ozone.om.service.ids.%n" +
+          "Example of a full URI with host name and port number%nfor a key:" +
+          "%no3://omhostname:9862/vol1/bucket1/key1%n" +
           "With a service id for a volume:" +
-          "\no3://omserviceid/vol1/\n" +
+          "%no3://omserviceid/vol1/%n" +
           "Short URI should start from the volume." +
-          "\nExample of a short URI for a bucket:" +
-          "\nvol1/bucket1\n" +
-          "Any unspecified information will be identified from\n" +
-          "the config files.\n";
+          "%nExample of a short URI for a bucket:" +
+          "%nvol1/bucket1%n" +
+          "Any unspecified information will be identified from%n" +
+          "the config files.%n";
 
   private String name;
 

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
@@ -34,8 +34,8 @@ public class AclOption implements CommandLine.ITypeConverter<OzoneAcl> {
   @CommandLine.Option(names = {"--acls", "--acl", "-al", "-a"}, split = ",",
       required = true,
       converter = AclOption.class,
-      description = "Comma separated ACL list:\n" +
-          "Example: user:user2:a OR user:user1:rw,group:hadoop:a\n" +
+      description = "Comma separated ACL list:%n" +
+          "Example: user:user2:a OR user:user1:rw,group:hadoop:a%n" +
           "r = READ, " +
           "w = WRITE, " +
           "c = CREATE, " +

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class BucketUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_BUCKET_URI_DESCRIPTION =
-      "URI of the bucket (format: volume/bucket).\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the bucket (format: volume/bucket).%n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_BUCKET_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/DeleteBucketHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/bucket/DeleteBucketHandler.java
@@ -70,9 +70,9 @@ public class DeleteBucketHandler extends BucketHandler {
       if (!yes) {
         // Ask for user confirmation
         out().print("This command will delete bucket recursively." +
-            "\nThere is no recovery option after using this command, " +
+            "%nThere is no recovery option after using this command, " +
             "and deleted keys won't move to trash." +
-            "\nEnter 'yes' to proceed': ");
+            "%nEnter 'yes' to proceed': ");
         out().flush();
         Scanner scanner = new Scanner(new InputStreamReader(
             System.in, StandardCharsets.UTF_8));

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/common/VolumeBucketUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/common/VolumeBucketUri.java
@@ -29,7 +29,7 @@ public class VolumeBucketUri
     implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_VOLUME_BUCKET_URI_DESCRIPTION =
-      "URI of the volume (format: volume) or bucket (format: volume/bucket).\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the volume (format: volume) or bucket (format: volume/bucket).%n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_VOLUME_BUCKET_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class KeyUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_KEY_URI_DESCRIPTION =
-      "URI of the key (format: volume/bucket/key).\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the key (format: volume/bucket/key).%n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_KEY_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class PrefixUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_PREFIX_URI_DESCRIPTION =
-      "URI of the prefix (format: volume/bucket/prefix).\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the prefix (format: volume/bucket/prefix).%n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_PREFIX_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotDiffHandler.java
@@ -39,7 +39,7 @@ public class ListSnapshotDiffHandler extends Handler {
   private BucketUri snapshotPath;
 
   @CommandLine.Option(names = {"--job-status"},
-      description = "List jobs based on status.\n" +
+      description = "List jobs based on status.%n" +
       "Accepted values are: queued, in_progress, done, failed, rejected",
       defaultValue = "in_progress")
   private String jobStatus;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -63,7 +63,7 @@ public class SnapshotDiffHandler extends Handler {
   @CommandLine.Option(names = {"-p", "--page-size"},
       description = "number of diff entries to be returned in the response. " +
           "Note the effective page size will also be bound by " +
-          "the server-side page size limit, see config:\n" +
+          "the server-side page size limit, see config:%n" +
           "  ozone.om.snapshot.diff.max.page.size",
       defaultValue = "1000",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotUri.java
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 public class SnapshotUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_SNAPSHOT_URI_DESCRIPTION =
-      "URI of the snapshot (format: volume/bucket/snapshot).\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the snapshot (format: volume/bucket/snapshot).%n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_SNAPSHOT_URI_DESCRIPTION,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantDeleteHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantDeleteHandler.java
@@ -51,7 +51,7 @@ public class TenantDeleteHandler extends TenantHandler {
         "But the associated volume '" + volumeName + "' is not removed. ";
     if (volumeRefCount == 0L) {
       err().println(extraPrompt + "To delete it, run"
-          + "\n    ozone sh volume delete " + volumeName + "\n");
+          + "%n    ozone sh volume delete " + volumeName + "%n");
     } else {
       err().println(extraPrompt + "And it is still referenced by some "
           + "other Ozone features (refCount is " + volumeRefCount + ").");

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
@@ -81,10 +81,10 @@ public class DeleteVolumeHandler extends VolumeHandler {
         if (!yes) {
           // Ask for user confirmation
           out().print("This command will delete volume recursively." +
-              "\nThere is no recovery option after using this command, " +
+              "%nThere is no recovery option after using this command, " +
               "and no trash for FSO buckets." +
-              "\nDelay is expected running this command." +
-              "\nEnter 'yes' to proceed': ");
+              "%nDelay is expected running this command." +
+              "%nEnter 'yes' to proceed': ");
           out().flush();
           Scanner scanner = new Scanner(new InputStreamReader(
               System.in, StandardCharsets.UTF_8));

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeUri.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeUri.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 public class VolumeUri implements CommandLine.ITypeConverter<OzoneAddress> {
 
   private static final String OZONE_VOLUME_URI_DESCRIPTION =
-      "URI of the volume.\n" + Shell.OZONE_URI_DESCRIPTION;
+      "URI of the volume.%n" + Shell.OZONE_URI_DESCRIPTION;
 
   @CommandLine.Parameters(index = "0", arity = "1..1",
       description = OZONE_VOLUME_URI_DESCRIPTION,

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3BucketGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3BucketGenerator.java
@@ -38,7 +38,7 @@ import picocli.CommandLine.Command;
  */
 @Command(name = "s3bg",
     aliases = "s3-bucket-generator",
-    description = "Create buckets via the s3 interface.\n" +
+    description = "Create buckets via the s3 interface.%n" +
         "Command requires AWS authentication environment " +
         "variables set, AWS_ACCESS_KEY_ID and " +
         "AWS_SECRET_ACCESS_KEY",

--- a/hadoop-ozone/vapor/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/vapor/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -72,11 +72,11 @@ import picocli.CommandLine.Option;
 @Command(name = "cgdn",
     description = "Offline container metadata generator for Ozone Datanodes.",
     optionListHeading =
-        "\nExecute this command with different parameters for each datanodes. "
+        "%nExecute this command with different parameters for each datanodes. "
             + "For example if you have 10 datanodes, use "
             + "'ozone vapor cgdn --index=1 --datanodes=10', 'ozone vapor"
             + " cgdn --index=2 --datanodes=10', 'ozone vapor cgdn "
-            + "--index=3 --datanodes=10', ...\n\n",
+            + "--index=3 --datanodes=10', ...%n%n",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true,
     showDefaultValues = true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use platform-specific line separator in CLI command/option descriptions instead of hard-coded `\n`.

https://picocli.info/#_format_specifiers

https://issues.apache.org/jira/browse/HDDS-14998

## How was this patch tested?

Verified help is formatted OK (same as before) for few commands:

```
$ ozone sh volume create --help
...
      <value>              URI of the volume.
                           Ozone URI could either be a full URI or short URI.
                           Full URI should start with o3://, in case of non-HA
                           clusters it should be followed by the host name and
                           optionally the port number. In case of HA clusters
                           the service id should be used. Service id provides a
                           logical name for multiple hosts and it is defined
                           in the property ozone.om.service.ids.
                           Example of a full URI with host name and port number
                           for a key:
                           o3://omhostname:9862/vol1/bucket1/key1
                           With a service id for a volume:
                           o3://omserviceid/vol1/
                           Short URI should start from the volume.
                           Example of a short URI for a bucket:
                           vol1/bucket1
                           Any unspecified information will be identified from
                           the config files.
...

$ ozone sh bucket setacl --help
...
  -a, -al, --acl, --acls=<values>[,<values>...]
                        Comma separated ACL list:
                        Example: user:user2:a OR user:user1:rw,group:hadoop:a
                        r = READ, w = WRITE, c = CREATE, d = DELETE, l = LIST,
                          a = ALL, n = NONE, x = READ_ACL, y = WRITE_ACL.
...

$ ozone debug auditparser --help
...
Commands:
  load, l      Load ozone audit log files.

               To load an audit log to database:
               ozone debug auditparser <path to db file> load <logs>

  template, t  Execute template query.

               To run a template query on the audit logs loaded to the database:
               ozone debug auditparser <path to db file> template <template>

               Following templates are available:
               (Template)              (Description)
               top5users              : Top 5 users.
               top5cmds               : Top 5 commands.
               top5activetimebyseconds: Top 5 active times, grouped by seconds.

  query, q     Execute custom query.

               To run a custom read-only query on the audit logs loaded to the
                 database:
               ozone debug auditparser <path to db file> query <query>
```

https://github.com/adoroszlai/ozone/actions/runs/24202134040