### PR TITLE
HDDS-14939. Implement version file rewrite logic for path migration across metadata history

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -387,6 +387,7 @@ Apache License 2.0
    org.apache.hadoop:hadoop-shaded-protobuf_3_25
    org.apache.httpcomponents:httpcore
    org.apache.iceberg:iceberg-api
+   org.apache.iceberg:iceberg-bundled-guava
    org.apache.iceberg:iceberg-common
    org.apache.iceberg:iceberg-core
    org.apache.kerby:kerb-admin

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -87,6 +87,7 @@ share/ozone/lib/hppc.jar
 share/ozone/lib/httpclient.jar
 share/ozone/lib/httpcore.jar
 share/ozone/lib/iceberg-api.jar
+share/ozone/lib/iceberg-bundled-guava.jar
 share/ozone/lib/iceberg-common.jar
 share/ozone/lib/iceberg-core.jar
 share/ozone/lib/istack-commons-runtime.jar

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -37,12 +37,6 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.iceberg</groupId>
-          <artifactId>iceberg-bundled-guava</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.iceberg</groupId>
@@ -61,16 +55,24 @@
           <artifactId>httpcore5-h2</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.iceberg</groupId>
-          <artifactId>iceberg-bundled-guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.checkerframework</groupId>
           <artifactId>checker-qual</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.roaringbitmap</groupId>
           <artifactId>RoaringBitmap</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -66,6 +66,10 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -1,37 +1,60 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.hadoop.ozone.iceberg;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.RewriteTablePathUtil;
+import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.actions.ImmutableRewriteTablePath;
 import org.apache.iceberg.actions.RewriteTablePath;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.util.Pair;
 
+/**
+ * An implementation of {@link RewriteTablePath} for Apache Ozone backed Iceberg tables.
+ *
+ * <p>This action rewrites table's metadata and position delete file paths by replacing a source
+ * prefix with a target prefix. It processes table versions, snapshots, manifests and position delete files.</p>
+ *
+ * <p>The rewrite can be scoped between optional start and end metadata versions,
+ * and all rewritten files are staged in a temporary directory.</p>
+ */
 public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   private static final String RESULT_LOCATION = "file-list";
@@ -184,8 +207,105 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   }
 
   private String rebuildMetadata() {
-    //TODO need to implement rewrite of metadata files , manifest list , manifest files and position delete files.
-    return null;
+    //TODO need to implement rewrite of manifest list , manifest files and position delete files.
+    TableMetadata startMetadata = startVersionName != null
+            ? ((HasTableOperations) newStaticTable(startVersionName, table.io()))
+            .operations()
+            .current()
+            : null;
+    TableMetadata endMetadata =
+            ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
+
+    if (endMetadata.partitionStatisticsFiles() != null
+            && !endMetadata.partitionStatisticsFiles().isEmpty()) {
+      throw new IllegalArgumentException("Partition statistics files are not supported yet.");
+    }
+
+    RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
+
+    Set<Pair<String, String>> copyPlan = new HashSet<>();
+    copyPlan.addAll(rewriteVersionResult.copyPlan());
+
+    return saveFileList(copyPlan);
+  }
+
+  private String saveFileList(Set<Pair<String, String>> filesToMove) {
+    String fileListPath = stagingDir + RESULT_LOCATION;
+    OutputFile fileList = table.io().newOutputFile(fileListPath);
+    writeAsCsv(filesToMove, fileList);
+    return fileListPath;
+  }
+
+  private void writeAsCsv(Set<Pair<String, String>> rows, OutputFile outputFile) {
+    try (BufferedWriter writer = new BufferedWriter(
+            new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
+      for (Pair<String, String> pair : rows) {
+        writer.write(String.join(",", pair.first(), pair.second()));
+        writer.newLine();
+      }
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
+    }
+  }
+
+  private RewriteResult<Snapshot> rewriteVersionFiles(TableMetadata endMetadata) {
+    RewriteResult<Snapshot> result = new RewriteResult<>();
+    result.toRewrite().addAll(endMetadata.snapshots());
+    result.copyPlan().addAll(rewriteVersionFile(endMetadata, endVersionName));
+
+    List<MetadataLogEntry> versions = endMetadata.previousFiles();
+    for (int i = versions.size() - 1; i >= 0; i--) {
+      String versionFilePath = versions.get(i).file();
+      if (versionFilePath.equals(startVersionName)) {
+        break;
+      }
+
+      if (!fileExist(versionFilePath)) {
+        throw new IllegalArgumentException(String.format("Version file %s doesn't exist", versionFilePath));
+      }
+
+      TableMetadata tableMetadata = new StaticTableOperations(versionFilePath, table.io()).current();
+
+      result.toRewrite().addAll(tableMetadata.snapshots());
+      result.copyPlan().addAll(rewriteVersionFile(tableMetadata, versionFilePath));
+    }
+
+    return result;
+  }
+
+  private Set<Pair<String, String>> rewriteVersionFile(TableMetadata metadata, String versionFilePath) {
+    Set<Pair<String, String>> result = new HashSet<>();
+    String stagingPath =
+            RewriteTablePathUtil.stagingPath(versionFilePath, sourcePrefix, stagingDir);
+    System.out.println("Processing version file " + versionFilePath);
+    TableMetadata newTableMetadata = RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
+    TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
+    result.add(Pair.of(stagingPath, RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix)));
+    result.addAll(statsFileCopyPlan(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
+
+    return result;
+  }
+
+  private Set<Pair<String, String>> statsFileCopyPlan(List<StatisticsFile> beforeStats, 
+    List<StatisticsFile> afterStats) {
+    Set<Pair<String, String>> result = new HashSet<>();
+    if (beforeStats.isEmpty()) {
+      return result;
+    }
+
+    if (beforeStats.size() != afterStats.size()) {
+      throw new IllegalArgumentException("Before and after path rewrite, statistic files count should be same");
+    }
+
+    for (int i = 0; i < beforeStats.size(); i++) {
+      StatisticsFile before = beforeStats.get(i);
+      StatisticsFile after = afterStats.get(i);
+      if (before.fileSizeInBytes() != after.fileSizeInBytes()) {
+        throw new IllegalArgumentException("Before and after path rewrite, statistic files count should be same");
+      }
+      result.add(Pair.of(before.path(), after.path()));
+    }
+    return result;
   }
 
   private boolean fileExist(String path) {
@@ -215,5 +335,10 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     if (value.trim().isEmpty()) {
       throw new IllegalArgumentException(name + " is empty");
     }
+  }
+
+  private Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
   }
 }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
 import org.apache.iceberg.Snapshot;
@@ -144,8 +145,9 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
               "Source prefix cannot be the same as target prefix (%s)", sourcePrefix));
     }
 
-    validateAndSetEndVersion();
-    validateAndSetStartVersion();
+    TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+    validateAndSetEndVersion(tableMetadata);
+    validateAndSetStartVersion(tableMetadata);
 
     if (stagingDir == null) {
       stagingDir =
@@ -158,9 +160,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     }
   }
 
-  private void validateAndSetEndVersion() {
-    TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
-
+  private void validateAndSetEndVersion(TableMetadata tableMetadata) {
     if (endVersionName == null) {
       Objects.requireNonNull(
           tableMetadata.metadataFileLocation(), "Metadata file location should not be null");
@@ -170,9 +170,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     }
   }
 
-  private void validateAndSetStartVersion() {
-    TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
-
+  private void validateAndSetStartVersion(TableMetadata tableMetadata) {
     if (startVersionName != null) {
       this.startVersionName = validateVersion(tableMetadata, startVersionName);
     }
@@ -182,11 +180,12 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     String versionFile = null;
     if (versionInFilePath(tableMetadata.metadataFileLocation(), versionFileName)) {
       versionFile = tableMetadata.metadataFileLocation();
-    }
-
-    for (MetadataLogEntry log : tableMetadata.previousFiles()) {
-      if (versionInFilePath(log.file(), versionFileName)) {
-        versionFile = log.file();
+    } else {
+      for (MetadataLogEntry log : tableMetadata.previousFiles()) {
+        if (versionInFilePath(log.file(), versionFileName)) {
+          versionFile = log.file();
+          break;
+        }
       }
     }
 
@@ -209,15 +208,15 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   private String rebuildMetadata() {
     //TODO need to implement rewrite of manifest list , manifest files and position delete files.
     TableMetadata startMetadata = startVersionName != null
-            ? ((HasTableOperations) newStaticTable(startVersionName, table.io()))
-            .operations()
-            .current()
-            : null;
+        ? ((HasTableOperations) newStaticTable(startVersionName, table.io()))
+        .operations()
+        .current()
+        : null;
     TableMetadata endMetadata =
-            ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
+        ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
 
-    if (endMetadata.partitionStatisticsFiles() != null
-            && !endMetadata.partitionStatisticsFiles().isEmpty()) {
+    List<PartitionStatisticsFile> partitionStats = endMetadata.partitionStatisticsFiles();
+    if (partitionStats != null && !partitionStats.isEmpty()) {
       throw new IllegalArgumentException("Partition statistics files are not supported yet.");
     }
 
@@ -238,7 +237,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   private void writeAsCsv(Set<Pair<String, String>> rows, OutputFile outputFile) {
     try (BufferedWriter writer = new BufferedWriter(
-            new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
+        new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
       for (Pair<String, String> pair : rows) {
         writer.write(String.join(",", pair.first(), pair.second()));
         writer.newLine();
@@ -275,11 +274,12 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   private Set<Pair<String, String>> rewriteVersionFile(TableMetadata metadata, String versionFilePath) {
     Set<Pair<String, String>> result = new HashSet<>();
-    String stagingPath =
-            RewriteTablePathUtil.stagingPath(versionFilePath, sourcePrefix, stagingDir);
+    String stagingPath = RewriteTablePathUtil.stagingPath(versionFilePath, sourcePrefix, stagingDir);
+    
     System.out.println("Processing version file " + versionFilePath);
     TableMetadata newTableMetadata = RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
     TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
+    
     result.add(Pair.of(stagingPath, RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix)));
     result.addAll(statsFileCopyPlan(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
 
@@ -301,7 +301,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
       StatisticsFile before = beforeStats.get(i);
       StatisticsFile after = afterStats.get(i);
       if (before.fileSizeInBytes() != after.fileSizeInBytes()) {
-        throw new IllegalArgumentException("Before and after path rewrite, statistic files count should be same");
+        throw new IllegalArgumentException("Before and after path rewrite, statistic files size should be same");
       }
       result.add(Pair.of(before.path(), after.path()));
     }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -58,7 +58,6 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   private int parallelism;
 
   private final Table table;
-  private ExecutorService executorService;
 
   public RewriteTablePathOzoneAction(Table table) {
     this.table = table;
@@ -103,7 +102,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   @Override
   public Result execute() {
     validateInputs();
-    this.executorService = Executors.newFixedThreadPool(parallelism);
+    // TODO: should use for parallel manifest and position delete file rewriting.
+    ExecutorService executorService = Executors.newFixedThreadPool(parallelism);
     try {
       return doExecute();
     } finally {

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.ozone.iceberg;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -28,23 +25,18 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
-import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.actions.ImmutableRewriteTablePath;
 import org.apache.iceberg.actions.RewriteTablePath;
-import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Pair;
 
 /**
@@ -57,8 +49,6 @@ import org.apache.iceberg.util.Pair;
  * and all rewritten files are staged in a temporary directory.</p>
  */
 public class RewriteTablePathOzoneAction implements RewriteTablePath {
-
-  private static final String RESULT_LOCATION = "file-list";
 
   private String sourcePrefix;
   private String targetPrefix;
@@ -82,8 +72,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   @Override
   public RewriteTablePath rewriteLocationPrefix(String sPrefix, String tPrefix) {
-    checkNonNullNonEmpty(sPrefix, "Source prefix");
-    checkNonNullNonEmpty(tPrefix, "Target prefix");
+    RewriteTablePathOzoneUtils.checkNonNullNonEmpty(sPrefix, "Source prefix");
+    RewriteTablePathOzoneUtils.checkNonNullNonEmpty(tPrefix, "Target prefix");
     this.sourcePrefix = sPrefix;
     this.targetPrefix = tPrefix;
     return this;
@@ -91,21 +81,21 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   @Override
   public RewriteTablePath startVersion(String sVersion) {
-    checkNonNullNonEmpty(sVersion, "Start version");
+    RewriteTablePathOzoneUtils.checkNonNullNonEmpty(sVersion, "Start version");
     this.startVersionName = sVersion;
     return this;
   }
 
   @Override
   public RewriteTablePath endVersion(String eVersion) {
-    checkNonNullNonEmpty(eVersion, "End version");
+    RewriteTablePathOzoneUtils.checkNonNullNonEmpty(eVersion, "End version");
     this.endVersionName = eVersion;
     return this;
   }
 
   @Override
   public RewriteTablePath stagingLocation(String stagingLocation) {
-    checkNonNullNonEmpty(stagingLocation, "Staging location");
+    RewriteTablePathOzoneUtils.checkNonNullNonEmpty(stagingLocation, "Staging location");
     this.stagingDir = stagingLocation;
     return this;
   }
@@ -151,7 +141,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
     if (stagingDir == null) {
       stagingDir =
-          getMetadataLocation(table)
+              RewriteTablePathOzoneUtils.getMetadataLocation(table)
               + "copy-table-staging-"
               + UUID.randomUUID()
               + RewriteTablePathUtil.FILE_SEPARATOR;
@@ -194,7 +184,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
           String.format(
               "Cannot find provided version file %s in metadata log.", versionFileName));
     }
-    if (!fileExist(versionFile)) {
+    if (!RewriteTablePathOzoneUtils.fileExist(versionFile, table.io())) {
       throw new IllegalArgumentException(
           String.format("Version file %s does not exist.", versionFile));
     }
@@ -207,13 +197,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   private String rebuildMetadata() {
     //TODO need to implement rewrite of manifest list , manifest files and position delete files.
-    TableMetadata startMetadata = startVersionName != null
-        ? ((HasTableOperations) newStaticTable(startVersionName, table.io()))
-        .operations()
-        .current()
-        : null;
-    TableMetadata endMetadata =
-        ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
+    TableMetadata endMetadata = new StaticTableOperations(endVersionName, table.io()).current();
 
     List<PartitionStatisticsFile> partitionStats = endMetadata.partitionStatisticsFiles();
     if (partitionStats != null && !partitionStats.isEmpty()) {
@@ -225,26 +209,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     Set<Pair<String, String>> copyPlan = new HashSet<>();
     copyPlan.addAll(rewriteVersionResult.copyPlan());
 
-    return saveFileList(copyPlan);
-  }
-
-  private String saveFileList(Set<Pair<String, String>> filesToMove) {
-    String fileListPath = stagingDir + RESULT_LOCATION;
-    OutputFile fileList = table.io().newOutputFile(fileListPath);
-    writeAsCsv(filesToMove, fileList);
-    return fileListPath;
-  }
-
-  private void writeAsCsv(Set<Pair<String, String>> rows, OutputFile outputFile) {
-    try (BufferedWriter writer = new BufferedWriter(
-        new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
-      for (Pair<String, String> pair : rows) {
-        writer.write(String.join(",", pair.first(), pair.second()));
-        writer.newLine();
-      }
-    } catch (IOException e) {
-      throw new RuntimeIOException(e);
-    }
+    return RewriteTablePathOzoneUtils.saveFileList(copyPlan, stagingDir, table.io());
   }
 
   private RewriteResult<Snapshot> rewriteVersionFiles(TableMetadata endMetadata) {
@@ -259,7 +224,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
         break;
       }
 
-      if (!fileExist(versionFilePath)) {
+      if (!RewriteTablePathOzoneUtils.fileExist(versionFilePath, table.io())) {
         throw new IllegalArgumentException(String.format("Version file %s doesn't exist", versionFilePath));
       }
 
@@ -281,64 +246,9 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
     
     result.add(Pair.of(stagingPath, RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix)));
-    result.addAll(statsFileCopyPlan(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
+    result.addAll(RewriteTablePathOzoneUtils.statsFileCopyPlan(
+            metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
 
     return result;
-  }
-
-  private Set<Pair<String, String>> statsFileCopyPlan(List<StatisticsFile> beforeStats, 
-    List<StatisticsFile> afterStats) {
-    Set<Pair<String, String>> result = new HashSet<>();
-    if (beforeStats.isEmpty()) {
-      return result;
-    }
-
-    if (beforeStats.size() != afterStats.size()) {
-      throw new IllegalArgumentException("Before and after path rewrite, statistic files count should be same");
-    }
-
-    for (int i = 0; i < beforeStats.size(); i++) {
-      StatisticsFile before = beforeStats.get(i);
-      StatisticsFile after = afterStats.get(i);
-      if (before.fileSizeInBytes() != after.fileSizeInBytes()) {
-        throw new IllegalArgumentException("Before and after path rewrite, statistic files size should be same");
-      }
-      result.add(Pair.of(before.path(), after.path()));
-    }
-    return result;
-  }
-
-  private boolean fileExist(String path) {
-    if (path == null || path.trim().isEmpty()) {
-      return false;
-    }
-    return table.io().newInputFile(path).exists();
-  }
-
-  private String getMetadataLocation(Table tbl) {
-    String currentMetadataPath =
-        ((HasTableOperations) tbl).operations().current().metadataFileLocation();
-    int lastIndex = currentMetadataPath.lastIndexOf(RewriteTablePathUtil.FILE_SEPARATOR);
-    String metadataDir = "";
-    if (lastIndex != -1) {
-      metadataDir = currentMetadataPath.substring(0, lastIndex + 1);
-    }
-
-    if (metadataDir.isEmpty()) {
-      throw new IllegalArgumentException("Failed to get the metadata file root directory");
-    }
-    return metadataDir;
-  }
-
-  private static void checkNonNullNonEmpty(String value, String name) {
-    Objects.requireNonNull(value, () -> name + " is null");
-    if (value.trim().isEmpty()) {
-      throw new IllegalArgumentException(name + " is empty");
-    }
-  }
-
-  private Table newStaticTable(String metadataFileLocation, FileIO io) {
-    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
-    return new BaseTable(ops, metadataFileLocation);
   }
 }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.iceberg;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.RewriteTablePathUtil;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.util.Pair;
+
+final class RewriteTablePathOzoneUtils {
+
+  private static final String RESULT_LOCATION = "file-list";
+  
+  private RewriteTablePathOzoneUtils() {
+    // utility class
+  }
+
+  static Set<Pair<String, String>> statsFileCopyPlan(List<StatisticsFile> beforeStats,
+                                                      List<StatisticsFile> afterStats) {
+    Set<Pair<String, String>> result = new HashSet<>();
+    if (beforeStats.isEmpty()) {
+      return result;
+    }
+
+    if (beforeStats.size() != afterStats.size()) {
+      throw new IllegalArgumentException("Before and after path rewrite, statistic files count should be same");
+    }
+
+    for (int i = 0; i < beforeStats.size(); i++) {
+      StatisticsFile before = beforeStats.get(i);
+      StatisticsFile after = afterStats.get(i);
+      if (before.fileSizeInBytes() != after.fileSizeInBytes()) {
+        throw new IllegalArgumentException("Before and after path rewrite, statistic files size should be same");
+      }
+      result.add(Pair.of(before.path(), after.path()));
+    }
+    return result;
+  }
+
+  static boolean fileExist(String path, FileIO io) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return io.newInputFile(path).exists();
+  }
+
+  static String getMetadataLocation(Table tbl) {
+    String currentMetadataPath = ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+    int lastIndex = currentMetadataPath.lastIndexOf(RewriteTablePathUtil.FILE_SEPARATOR);
+    String metadataDir = "";
+    if (lastIndex != -1) {
+      metadataDir = currentMetadataPath.substring(0, lastIndex + 1);
+    }
+
+    if (metadataDir.isEmpty()) {
+      throw new IllegalArgumentException("Failed to get the metadata file root directory");
+    }
+    return metadataDir;
+  }
+
+  static void checkNonNullNonEmpty(String value, String name) {
+    Objects.requireNonNull(value, () -> name + " is null");
+    if (value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " is empty");
+    }
+  }
+
+  static String saveFileList(Set<Pair<String, String>> filesToMove, String stagingDir, FileIO io) {
+    String fileListPath = stagingDir + RESULT_LOCATION;
+    OutputFile fileList = io.newOutputFile(fileListPath);
+    writeAsCsv(filesToMove, fileList);
+    return fileListPath;
+  }
+
+  static void writeAsCsv(Set<Pair<String, String>> rows, OutputFile outputFile) {
+    try (BufferedWriter writer = new BufferedWriter(
+        new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
+      for (Pair<String, String> pair : rows) {
+        writer.append(pair.first()).append(',').append(pair.second());
+        writer.newLine();
+      }
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
+    }
+  }
+}

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
@@ -34,6 +34,10 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Pair;
 
+/**
+ * Helper methods used by {@link RewriteTablePathOzoneAction} when rewriting
+ * Iceberg table paths on Ozone-backed tables.
+ */
 final class RewriteTablePathOzoneUtils {
 
   private static final String RESULT_LOCATION = "file-list";
@@ -65,7 +69,7 @@ final class RewriteTablePathOzoneUtils {
   }
 
   static boolean fileExist(String path, FileIO io) {
-    if (path == null || path.trim().isEmpty()) {
+    if (path == null || path.isBlank()) {
       return false;
     }
     return io.newInputFile(path).exists();
@@ -87,7 +91,7 @@ final class RewriteTablePathOzoneUtils {
 
   static void checkNonNullNonEmpty(String value, String name) {
     Objects.requireNonNull(value, () -> name + " is null");
-    if (value.trim().isEmpty()) {
+    if (value.isBlank()) {
       throw new IllegalArgumentException(name + " is empty");
     }
   }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
@@ -33,6 +33,8 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper methods used by {@link RewriteTablePathOzoneAction} when rewriting
@@ -41,6 +43,7 @@ import org.apache.iceberg.util.Pair;
 final class RewriteTablePathOzoneUtils {
 
   private static final String RESULT_LOCATION = "file-list";
+  private static final Logger LOG = LoggerFactory.getLogger(RewriteTablePathOzoneUtils.class);
   
   private RewriteTablePathOzoneUtils() {
     // utility class
@@ -78,15 +81,10 @@ final class RewriteTablePathOzoneUtils {
   static String getMetadataLocation(Table tbl) {
     String currentMetadataPath = ((HasTableOperations) tbl).operations().current().metadataFileLocation();
     int lastIndex = currentMetadataPath.lastIndexOf(RewriteTablePathUtil.FILE_SEPARATOR);
-    String metadataDir = "";
-    if (lastIndex != -1) {
-      metadataDir = currentMetadataPath.substring(0, lastIndex + 1);
-    }
-
-    if (metadataDir.isEmpty()) {
+    if (lastIndex == -1) {
       throw new IllegalArgumentException("Failed to get the metadata file root directory");
     }
-    return metadataDir;
+    return currentMetadataPath.substring(0, lastIndex + 1);
   }
 
   static void checkNonNullNonEmpty(String value, String name) {
@@ -111,6 +109,7 @@ final class RewriteTablePathOzoneUtils {
         writer.newLine();
       }
     } catch (IOException e) {
+      LOG.error("Failed to write CSV to {}", outputFile.location(), e);
       throw new RuntimeIOException(e);
     }
   }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/package-info.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Apache Ozone integration with Apache Iceberg.
+ */
+package org.apache.hadoop.ozone.iceberg;

--- a/hadoop-ozone/iceberg/src/test/java/org/apache/hadoop/ozone/iceberg/TestRewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/test/java/org/apache/hadoop/ozone/iceberg/TestRewriteTablePathOzoneAction.java
@@ -62,12 +62,9 @@ class TestRewriteTablePathOzoneAction {
       Types.NestedField.required(2, "c2", Types.StringType.get()),
       Types.NestedField.optional(3, "c3", Types.StringType.get()));
 
-  private String tableLocation = null;
   private String sourcePrefix = null;
   private String targetPrefix = null;
   private Table table = null;
-
-  private final HadoopTables tables = new HadoopTables(new Configuration());
 
   @TempDir
   private java.nio.file.Path tableDir;
@@ -78,7 +75,7 @@ class TestRewriteTablePathOzoneAction {
 
   @BeforeEach
   public void setupTableLocation() {
-    this.tableLocation = tableDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
+      String tableLocation = tableDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
     this.table = createTable(tableLocation + "/");
     this.sourcePrefix = tableLocation;
     this.targetPrefix = targetDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
@@ -261,6 +258,7 @@ class TestRewriteTablePathOzoneAction {
   }
 
   private Table createTable(String location) {
+    HadoopTables tables = new HadoopTables(new Configuration());
     Table tbl = tables.create(SCHEMA, PartitionSpec.unpartitioned(), new HashMap<>(), location);
     for (int i = 0; i < COMMITS; i++) {
       String dataPath = location + "/data/batch-" + i + ".parquet";

--- a/hadoop-ozone/iceberg/src/test/java/org/apache/hadoop/ozone/iceberg/TestRewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/test/java/org/apache/hadoop/ozone/iceberg/TestRewriteTablePathOzoneAction.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.ozone.iceberg;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,7 +76,7 @@ class TestRewriteTablePathOzoneAction {
 
   @BeforeEach
   public void setupTableLocation() {
-      String tableLocation = tableDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
+    String tableLocation = tableDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
     this.table = createTable(tableLocation + "/");
     this.sourcePrefix = tableLocation;
     this.targetPrefix = targetDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
@@ -193,7 +194,7 @@ class TestRewriteTablePathOzoneAction {
    * - Every metadata-log entry path starts with target
    * - Every snapshot's manifest-list path starts with target
    * - Every statistics file path starts with target
-   * - None of the above contain the source prefix
+   * - None of the above contain the source prefix.
    */
   private void assertAllInternalPathsRewritten(Set<Pair<String, String>> csvPairs, String target) {
     for (Pair<String, String> pair : csvPairs) {

--- a/hadoop-ozone/iceberg/src/test/java/org/apache/hadoop/ozone/iceberg/TestRewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/test/java/org/apache/hadoop/ozone/iceberg/TestRewriteTablePathOzoneAction.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.iceberg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteTablePathUtil;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.actions.RewriteTablePath;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Testing path rewrite of iceberg table metadata files.
+ */
+class TestRewriteTablePathOzoneAction {
+
+  private static final int COMMITS = 4;
+  private static final String TABLE_NAME = "test_table";
+
+  private static final Schema SCHEMA = new Schema(
+      Types.NestedField.required(1, "c1", Types.IntegerType.get()),
+      Types.NestedField.required(2, "c2", Types.StringType.get()),
+      Types.NestedField.optional(3, "c3", Types.StringType.get()));
+
+  private String tableLocation = null;
+  private String sourcePrefix = null;
+  private String targetPrefix = null;
+  private Table table = null;
+
+  private final HadoopTables tables = new HadoopTables(new Configuration());
+
+  @TempDir
+  private java.nio.file.Path tableDir;
+  @TempDir
+  private java.nio.file.Path targetDir;
+  @TempDir
+  private java.nio.file.Path stagingDir;
+
+  @BeforeEach
+  public void setupTableLocation() {
+    this.tableLocation = tableDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
+    this.table = createTable(tableLocation + "/");
+    this.sourcePrefix = tableLocation;
+    this.targetPrefix = targetDir.toUri().toString().replaceFirst("^file:///", "file:/") + TABLE_NAME;
+  }
+
+  @Test
+  void fullTablePathRewrite() throws Exception {
+    RewriteTablePath.Result result = new RewriteTablePathOzoneAction(table)
+        .rewriteLocationPrefix(sourcePrefix, targetPrefix)
+        .stagingLocation(stagingDir.toString() + "/")
+        .execute();
+
+    List<String> metadataPaths = metadataLogEntryPaths(table);
+    Set<String> expectedTargets = new HashSet<>();
+    for (String path : metadataPaths) {
+      expectedTargets.add(RewriteTablePathUtil.newPath(path, sourcePrefix, targetPrefix));
+    }
+
+    Set<Pair<String, String>> csvPairs = readCsvPairs(table, result.fileListLocation());
+    assertEquals(expectedTargets, csvPairs.stream().map(Pair::second).collect(Collectors.toSet()));
+
+    // Verify all internal paths inside each staged metadata file are rewritten to target.
+    assertAllInternalPathsRewritten(csvPairs, targetPrefix);
+  }
+
+  @Test
+  void tablePathRewriteForStartAndNoEndVersionProvided() throws Exception {
+    List<String> metadataPaths = metadataLogEntryPaths(table);
+    String startName = RewriteTablePathUtil.fileName(metadataPaths.get(2));
+
+    RewriteTablePath.Result result = new RewriteTablePathOzoneAction(table)
+        .rewriteLocationPrefix(sourcePrefix, targetPrefix)
+        .stagingLocation(stagingDir.toString() + "/")
+        .startVersion(startName)
+        .execute();
+
+    List<String> expectedPaths = new ArrayList<>();
+    for (int i = metadataPaths.size() - 1; i >= 3; i--) {
+      expectedPaths.add(metadataPaths.get(i));
+    }
+
+    Set<String> expectedTargets = new HashSet<>();
+    for (String versionPath : expectedPaths) {
+      expectedTargets.add(RewriteTablePathUtil.newPath(versionPath, sourcePrefix, targetPrefix));
+    }
+
+    Set<Pair<String, String>> csvPairs = readCsvPairs(table, result.fileListLocation());
+    assertEquals(expectedTargets, csvPairs.stream().map(Pair::second).collect(Collectors.toSet()));
+
+    // Verify all internal paths inside each staged metadata file are rewritten to target
+    assertAllInternalPathsRewritten(csvPairs, targetPrefix);
+  }
+
+  @Test
+  void tablePathRewriteForOnlyEndVersionProvided() throws Exception {
+    List<String> metadataPaths = metadataLogEntryPaths(table);
+    String endName = RewriteTablePathUtil.fileName(metadataPaths.get(2));
+
+    RewriteTablePath.Result result = new RewriteTablePathOzoneAction(table)
+        .rewriteLocationPrefix(sourcePrefix, targetPrefix)
+        .stagingLocation(stagingDir.toString() + "/")
+        .endVersion(endName)
+        .execute();
+
+    List<String> expectedPaths = new ArrayList<>();
+    for (int i = 2; i >= 0; i--) {
+      expectedPaths.add(metadataPaths.get(i));
+    }
+
+    Set<String> expectedTargets = new HashSet<>();
+    for (String versionPath : expectedPaths) {
+      expectedTargets.add(RewriteTablePathUtil.newPath(versionPath, sourcePrefix, targetPrefix));
+    }
+
+    Set<Pair<String, String>> csvPairs = readCsvPairs(table, result.fileListLocation());
+    assertEquals(expectedTargets, csvPairs.stream().map(Pair::second).collect(Collectors.toSet()));
+
+    // Verify all internal paths inside each staged metadata file are rewritten to target
+    assertAllInternalPathsRewritten(csvPairs, targetPrefix);
+  }
+
+  @Test
+  void tablePathRewriteForStartAndEndVersionProvided() throws Exception {
+    List<String> metadataPaths = metadataLogEntryPaths(table);
+    String startName = RewriteTablePathUtil.fileName(metadataPaths.get(1));
+    String endName = RewriteTablePathUtil.fileName(metadataPaths.get(3));
+
+    RewriteTablePath.Result result = new RewriteTablePathOzoneAction(table)
+        .rewriteLocationPrefix(sourcePrefix, targetPrefix)
+        .stagingLocation(stagingDir.toString() + "/")
+        .startVersion(startName)
+        .endVersion(endName)
+        .execute();
+
+    List<String> expectedPaths = new ArrayList<>();
+    for (int i = 3; i >= 2; i--) {
+      expectedPaths.add(metadataPaths.get(i));
+    }
+
+    Set<String> expectedTargets = new HashSet<>();
+    for (String versionPath : expectedPaths) {
+      expectedTargets.add(RewriteTablePathUtil.newPath(versionPath, sourcePrefix, targetPrefix));
+    }
+
+    Set<Pair<String, String>> csvPairs = readCsvPairs(table, result.fileListLocation());
+    assertEquals(expectedTargets, csvPairs.stream().map(Pair::second).collect(Collectors.toSet()));
+
+    // Verify all internal paths inside each staged metadata file are rewritten to target
+    assertAllInternalPathsRewritten(csvPairs, targetPrefix);
+  }
+
+  /**
+   * For every staged metadata JSON file in the CSV, parses the file and asserts that:
+   * - The table location starts with target
+   * - Every metadata-log entry path starts with target
+   * - Every snapshot's manifest-list path starts with target
+   * - Every statistics file path starts with target
+   * - None of the above contain the source prefix
+   */
+  private void assertAllInternalPathsRewritten(Set<Pair<String, String>> csvPairs, String target) {
+    for (Pair<String, String> pair : csvPairs) {
+      String stagingPath = pair.first();
+      String targetPath = pair.second();
+
+      // Only inspect .metadata.json files, manifest/data files and snapshots are not yet rewritten
+      if (!stagingPath.endsWith(".metadata.json")) {
+        continue;
+      }
+
+      assertTrue(targetPath.startsWith(target),
+          "Target path in CSV should start with target prefix: " + targetPath);
+
+      TableMetadata rewritten = new StaticTableOperations(stagingPath, table.io()).current();
+
+      assertTrue(rewritten.location().startsWith(target),
+          "Metadata location should start with target: " + rewritten.location());
+
+      for (MetadataLogEntry entry : rewritten.previousFiles()) {
+        assertTrue(entry.file().startsWith(target),
+            "Metadata log entry should start with target: " + entry.file());
+      }
+
+      for (Snapshot snapshot : rewritten.snapshots()) {
+        String manifestList = snapshot.manifestListLocation();
+        assertTrue(manifestList.startsWith(target),
+            "Snapshot manifest-list should start with target: " + manifestList);
+      }
+    }
+  }
+
+  private static List<String> metadataLogEntryPaths(Table tbl) {
+    TableMetadata meta = ((HasTableOperations) tbl).operations().current();
+    List<String> paths = new ArrayList<>();
+    for (MetadataLogEntry e : meta.previousFiles()) {
+      paths.add(e.file());
+    }
+    paths.add(meta.metadataFileLocation());
+    return paths;
+  }
+
+  /** Returns all (stagingPath, targetPath) pairs from the CSV file list. */
+  private static Set<Pair<String, String>> readCsvPairs(Table tbl, String fileListUri)
+      throws Exception {
+    Set<Pair<String, String>> pairs = new HashSet<>();
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(tbl.io().newInputFile(fileListUri).newStream(),
+            StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        int comma = line.indexOf(',');
+        if (comma < 0) {
+          continue;
+        }
+        String first = line.substring(0, comma);
+        String second = line.substring(comma + 1);
+        pairs.add(Pair.of(first, second));
+      }
+    }
+    return pairs;
+  }
+
+  private Table createTable(String location) {
+    Table tbl = tables.create(SCHEMA, PartitionSpec.unpartitioned(), new HashMap<>(), location);
+    for (int i = 0; i < COMMITS; i++) {
+      String dataPath = location + "/data/batch-" + i + ".parquet";
+      tbl.newAppend().appendFile(dummyDataFile(dataPath)).commit();
+    }
+    return tables.load(location);
+  }
+
+  private DataFile dummyDataFile(String dataPath) {
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+        .withPath(dataPath)
+        .withFileSizeInBytes(1024)
+        .withRecordCount(1)
+        .withFormat(FileFormat.PARQUET)
+        .build();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change implements the logic to rewrite table metadata version files across the metadata history, enabling path migration from a source prefix to a target prefix.

Traversal should start from the provided endMetadata (current or specified version) and iterate backwards through previous metadata version files until reached the startVersion provided if any(if not then till beginning). We also need to collect all the snapshots from each traversed historical metadata version.

For each metadata version file we can take help of iceberg's RewriteTablePathUtil to rewrite absolute file paths in it from sourcePrefix -> targetPrefix  and then we have to add the rewritten file to the staging location.

We should also update copy plan with staging -> final path mappings for each metadata version file rewritten. 

## What is the link to the Apache JIRA

[HDDS-14939](https://issues.apache.org/jira/browse/HDDS-14939)

## How was this patch tested?
Added test cases
Green CI:
https://github.com/sreejasahithi/ozone/actions/runs/24237563462
