### PR TITLE
HDDS-15023. S3ErrorTable should be an enum

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AuthorizationFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AuthorizationFilter.java
@@ -71,14 +71,14 @@ public class AuthorizationFilter implements ContainerRequestFilter {
       } else {
         LOG.debug("Unsupported AWS signature version: {}",
             signatureInfo.getVersion());
-        throw S3_AUTHINFO_CREATION_ERROR;
+        throw S3ErrorTable.newError(S3_AUTHINFO_CREATION_ERROR, String.valueOf(signatureInfo.getVersion()), null);
       }
 
       String awsAccessId = signatureInfo.getAwsAccessId();
       // ONLY validate aws access id when needed.
       if (awsAccessId == null || awsAccessId.equals("")) {
         LOG.debug("Malformed s3 header. awsAccessID: {}", awsAccessId);
-        throw ACCESS_DENIED;
+        throw S3ErrorTable.newError(ACCESS_DENIED, null, null);
       }
     } catch (OS3Exception ex) {
       LOG.debug("Error during Client Creation: ", ex);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -99,8 +99,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     try {
       return handler.handleGetRequest(context, bucketName);
     } catch (OMException ex) {
-      OS3Exception code = translateException(ex);
-      throw newError(code, bucketName, ex);
+      throw newError(translateException(ex), bucketName, ex);
     }
   }
 
@@ -271,8 +270,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     try {
       return handler.handlePutRequest(context, bucketName, body);
     } catch (OMException ex) {
-      OS3Exception code = translateException(ex);
-      throw newError(code, bucketName, ex);
+      throw newError(translateException(ex), bucketName, ex);
     }
   }
 
@@ -320,8 +318,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     try {
       return handler.handleDeleteRequest(context, bucketName);
     } catch (OMException ex) {
-      OS3Exception code = translateException(ex);
-      throw newError(code, bucketName, ex);
+      throw newError(translateException(ex), bucketName, ex);
     }
   }
 
@@ -431,7 +428,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     handler = new AuditingBucketOperationHandler(chain);
   }
 
-  private static OS3Exception translateException(OMException ex) {
+  private static S3ErrorTable translateException(OMException ex) {
     switch (ex.getResult()) {
     case ACCESS_DENIED:
     case INVALID_TOKEN:

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 import java.io.IOException;
@@ -50,11 +51,13 @@ public class CompleteMultipartUploadRequestUnmarshaller
       InputStream inputStream) throws WebApplicationException {
     try {
       if (inputStream.available() == 0) {
-        throw wrapOS3Exception(INVALID_REQUEST.withMessage("You must specify at least one part"));
+        throw wrapOS3Exception(newError(INVALID_REQUEST, null, null)
+            .withMessage("You must specify at least one part"));
       }
       return super.readFrom(aClass, type, annotations, mediaType, multivaluedMap, inputStream);
     } catch (IOException e) {
-      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
+      throw wrapOS3Exception(newError(INVALID_REQUEST, null, e)
+          .withMessage(e.getMessage()));
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MessageUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MessageUnmarshaller.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
@@ -81,7 +82,7 @@ public class MessageUnmarshaller<T> implements MessageBodyReader<T> {
       filter.parse(new InputSource(inputStream));
       return cls.cast(unmarshallerHandler.getResult());
     } catch (Exception e) {
-      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
+      throw wrapOS3Exception(newError(INVALID_REQUEST, null, e).withMessage(e.getMessage()));
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/OS3Exception.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/OS3Exception.java
@@ -158,8 +158,8 @@ public class OS3Exception extends RuntimeException {
         this.getRequestId());
   }
 
-  /** Create a copy with specific message. */
   public OS3Exception withMessage(String message) {
-    return new OS3Exception(code, message, httpCode);
+    setErrorMessage(message);
+    return this;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -27,7 +27,6 @@ import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 import static org.apache.hadoop.ozone.OzoneConsts.S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_NOT_SATISFIABLE;
 
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,163 +34,174 @@ import org.slf4j.LoggerFactory;
  * This class represents errors from Ozone S3 service.
  * This class needs to be updated to add new errors when required.
  */
-public final class S3ErrorTable {
+public enum S3ErrorTable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(
-      S3ErrorTable.class);
+  INVALID_URI("InvalidURI",
+      "Couldn't parse the specified URI.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception INVALID_URI = new OS3Exception("InvalidURI",
-      "Couldn't parse the specified URI.", HTTP_BAD_REQUEST);
+  NO_SUCH_VOLUME("NoSuchVolume",
+      "The specified volume does not exist", HTTP_NOT_FOUND),
 
-  public static final OS3Exception NO_SUCH_VOLUME = new OS3Exception(
-      "NoSuchVolume", "The specified volume does not exist", HTTP_NOT_FOUND);
+  NO_SUCH_BUCKET("NoSuchBucket",
+      "The specified bucket does not exist", HTTP_NOT_FOUND),
 
-  public static final OS3Exception NO_SUCH_BUCKET = new OS3Exception(
-      "NoSuchBucket", "The specified bucket does not exist", HTTP_NOT_FOUND);
+  AUTH_PROTOCOL_NOT_SUPPORTED("AuthProtocolNotSupported",
+      "Auth protocol used for this request is not supported.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception AUTH_PROTOCOL_NOT_SUPPORTED =
-      new OS3Exception("AuthProtocolNotSupported", "Auth protocol used for" +
-          " this request is not supported.", HTTP_BAD_REQUEST);
-
-  public static final OS3Exception S3_AUTHINFO_CREATION_ERROR =
-      new OS3Exception("InvalidRequest", "Error creating s3 auth info. " +
+  S3_AUTHINFO_CREATION_ERROR("InvalidRequest", "Error creating s3 auth info. " +
           "The request may not be signed using AWS V4 signing algorithm," +
-          " or might be invalid", HTTP_FORBIDDEN);
+          " or might be invalid", HTTP_FORBIDDEN),
 
-  public static final OS3Exception BUCKET_NOT_EMPTY = new OS3Exception(
+  BUCKET_NOT_EMPTY(
       "BucketNotEmpty", "The bucket you tried to delete is not empty. " +
       "If you are using --force option to delete all objects in the bucket, " +
       "please ensure that the bucket layout is OBJECT_STORE or " +
       "that the bucket is completely empty before delete.",
-      HTTP_CONFLICT);
+      HTTP_CONFLICT),
 
-  public static final OS3Exception MALFORMED_HEADER = new OS3Exception(
+  MALFORMED_HEADER(
       "AuthorizationHeaderMalformed", "The authorization header you provided " +
-      "is invalid.", HTTP_BAD_REQUEST);
+      "is invalid.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception NO_SUCH_KEY = new OS3Exception(
-      "NoSuchKey", "The specified key does not exist", HTTP_NOT_FOUND);
+  NO_SUCH_KEY(
+      "NoSuchKey", "The specified key does not exist", HTTP_NOT_FOUND),
 
-  public static final OS3Exception INVALID_ARGUMENT = new OS3Exception(
-      "InvalidArgument", "Invalid Argument", HTTP_BAD_REQUEST);
+  INVALID_ARGUMENT(
+      "InvalidArgument", "Invalid Argument", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception INVALID_REQUEST = new OS3Exception(
-      "InvalidRequest", "Invalid Request", HTTP_BAD_REQUEST);
+  INVALID_REQUEST(
+      "InvalidRequest", "Invalid Request", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception INVALID_RANGE = new OS3Exception(
+  INVALID_RANGE(
       "InvalidRange", "The requested range is not satisfiable",
-      RANGE_NOT_SATISFIABLE);
+      RANGE_NOT_SATISFIABLE),
 
-  public static final OS3Exception NO_SUCH_UPLOAD = new OS3Exception(
+  NO_SUCH_UPLOAD(
       "NoSuchUpload", "The specified multipart upload does not exist. The " +
       "upload ID might be invalid, or the multipart upload might have " +
-      "been aborted or completed.", HTTP_NOT_FOUND);
+      "been aborted or completed.", HTTP_NOT_FOUND),
 
-  public static final OS3Exception INVALID_BUCKET_NAME = new OS3Exception(
+  INVALID_BUCKET_NAME(
       "InvalidBucketName", "The specified bucket is not valid.",
-      HTTP_BAD_REQUEST);
+      HTTP_BAD_REQUEST),
 
-  public static final OS3Exception INVALID_PART = new OS3Exception(
+  INVALID_PART(
       "InvalidPart", "One or more of the specified parts could not be found." +
       " The part might not have been uploaded, or the specified entity " +
-      "tag might not have matched the part's entity tag.", HTTP_BAD_REQUEST);
+      "tag might not have matched the part's entity tag.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception INVALID_PART_ORDER = new OS3Exception(
+  INVALID_PART_ORDER(
       "InvalidPartOrder", "The list of parts was not in ascending order. The " +
       "parts list must be specified in order by part number.",
-      HTTP_BAD_REQUEST);
+      HTTP_BAD_REQUEST),
 
-  public static final OS3Exception ENTITY_TOO_SMALL = new OS3Exception(
+  ENTITY_TOO_SMALL(
       "EntityTooSmall", "Your proposed upload is smaller than the minimum " +
       "allowed object size. Each part must be at least 5 MB in size, except " +
-      "the last part.", HTTP_BAD_REQUEST);
+      "the last part.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception INTERNAL_ERROR = new OS3Exception(
+  INTERNAL_ERROR(
       "InternalError", "We encountered an internal error. Please try again.",
-      HTTP_INTERNAL_ERROR);
+      HTTP_INTERNAL_ERROR),
 
-  public static final OS3Exception ACCESS_DENIED = new OS3Exception(
+  ACCESS_DENIED(
       "AccessDenied", "User doesn't have the right to access this " +
-      "resource.", HTTP_FORBIDDEN);
+      "resource.", HTTP_FORBIDDEN),
 
-  public static final OS3Exception PRECOND_FAILED = new OS3Exception(
+  PRECOND_FAILED(
       "PreconditionFailed", "At least one of the pre-conditions you " +
-      "specified did not hold", HTTP_PRECON_FAILED);
+      "specified did not hold", HTTP_PRECON_FAILED),
 
-  public static final OS3Exception CONDITIONAL_REQUEST_CONFLICT =
-      new OS3Exception("ConditionalRequestConflict",
+  CONDITIONAL_REQUEST_CONFLICT("ConditionalRequestConflict",
           "A conflicting conditional operation occurred. Retry the request.",
-          HTTP_CONFLICT);
+          HTTP_CONFLICT),
   
-  public static final OS3Exception NOT_IMPLEMENTED = new OS3Exception(
+  NOT_IMPLEMENTED(
       "NotImplemented", "This part of feature is not implemented yet.",
-      HTTP_NOT_IMPLEMENTED);
+      HTTP_NOT_IMPLEMENTED),
 
-  public static final OS3Exception NO_OVERWRITE = new OS3Exception(
-      "Conflict", "Cannot overwrite file with directory", HTTP_CONFLICT);
+  NO_OVERWRITE(
+      "Conflict", "Cannot overwrite file with directory", HTTP_CONFLICT),
 
-  public static final OS3Exception METADATA_TOO_LARGE = new OS3Exception(
+  METADATA_TOO_LARGE(
       "MetadataTooLarge", "Illegal user defined metadata. Combined size " +
       "exceeds the maximum allowed metadata size of " +
-      S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB + "KB", HTTP_BAD_REQUEST);
+      S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB + "KB", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception BUCKET_ALREADY_EXISTS = new OS3Exception(
+  BUCKET_ALREADY_EXISTS(
       "BucketAlreadyExists", "The requested bucket name is not available" +
-      " as it already exists.", HTTP_CONFLICT);
+      " as it already exists.", HTTP_CONFLICT),
 
-  public static final OS3Exception INVALID_TAG = new OS3Exception(
-      "InvalidTag", "Your request contains tag input that is not valid.", HTTP_BAD_REQUEST);
+  INVALID_TAG(
+      "InvalidTag", "Your request contains tag input that is not valid.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception NO_SUCH_TAG_SET = new OS3Exception(
-      "NoSuchTagSet", "The specified tag does not exist.", HTTP_NOT_FOUND);
+  NO_SUCH_TAG_SET(
+      "NoSuchTagSet", "The specified tag does not exist.", HTTP_NOT_FOUND),
 
-  public static final OS3Exception MALFORMED_XML = new OS3Exception(
+  MALFORMED_XML(
       "MalformedXML", "The XML you provided was not well-formed or did not " +
-      "validate against our published schema", HTTP_BAD_REQUEST);
+      "validate against our published schema", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception QUOTA_EXCEEDED = new OS3Exception(
+  QUOTA_EXCEEDED(
       "QuotaExceeded", "The quota has been exceeded. " +
       "Please review your disk space or namespace usage and adjust accordingly.",
       HTTP_FORBIDDEN
-  );
+  ),
 
-  public static final OS3Exception INVALID_STORAGE_CLASS = new OS3Exception(
+  INVALID_STORAGE_CLASS(
       "InvalidStorageClass", "The storage class that you specified is not valid. " +
       "Provide a supported storage class[STANDARD|REDUCED_REDUNDANCY|STANDARD_IA] or " +
       "a valid custom EC storage config for if using STANDARD_IA.",
-      HTTP_BAD_REQUEST);
+      HTTP_BAD_REQUEST),
 
-  public static final OS3Exception BUCKET_OWNER_MISMATCH = new OS3Exception(
+  BUCKET_OWNER_MISMATCH(
       "Access Denied", "User doesn't have permission to access this resource due to a " +
-      "bucket ownership mismatch.", HTTP_FORBIDDEN);
+      "bucket ownership mismatch.", HTTP_FORBIDDEN),
 
-  public static final OS3Exception X_AMZ_CONTENT_SHA256_MISMATCH = new OS3Exception(
+  X_AMZ_CONTENT_SHA256_MISMATCH(
       "XAmzContentSHA256Mismatch", "The provided 'x-amz-content-sha256' header does " +
-      "not match the computed hash.", HTTP_BAD_REQUEST);
+      "not match the computed hash.", HTTP_BAD_REQUEST),
 
-  public static final OS3Exception BAD_DIGEST = new OS3Exception(
+  BAD_DIGEST(
       "BadDigest", "The Content-MD5 or checksum value that you specified did not match what the server received.",
       HTTP_BAD_REQUEST);
 
-  private static Function<Exception, OS3Exception> generateInternalError =
-      e -> new OS3Exception("InternalError", e.getMessage(), HTTP_INTERNAL_ERROR);
+  private static final Logger LOG = LoggerFactory.getLogger(S3ErrorTable.class);
 
-  private S3ErrorTable() {
-    //No one should construct this object.
+  private final String code;
+  private final String message;
+  private final int httpCode;
+
+  S3ErrorTable(String code, String message, int httpCode) {
+    this.code = code;
+    this.message = message;
+    this.httpCode = httpCode;
   }
 
-  public static OS3Exception newError(OS3Exception e, String resource) {
+  public String getCode() {
+    return code;
+  }
+
+  public String getErrorMessage() {
+    return message;
+  }
+
+  public int getHttpCode() {
+    return httpCode;
+  }
+
+  public static OS3Exception newError(S3ErrorTable e, String resource) {
     return newError(e, resource, null);
   }
 
   /**
-   * Create a new instance of Error.
+   * Create a new {@link OS3Exception} for the given error.
    * @param e Error Template
    * @param resource Resource associated with this exception
    * @param ex the original exception, may be null
    * @return creates a new instance of error based on the template
    */
-  public static OS3Exception newError(OS3Exception e, String resource,
+  public static OS3Exception newError(S3ErrorTable e, String resource,
       Exception ex) {
     OS3Exception err =  new OS3Exception(e.getCode(), e.getErrorMessage(),
         e.getHttpCode());
@@ -202,9 +212,5 @@ public final class S3ErrorTable {
       LOG.debug(err.toXml(), ex);
     }
     return err;
-  }
-
-  public static OS3Exception getInternalError(Exception e) {
-    return generateInternalError.apply(e);
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/StringToSignProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/StringToSignProducer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.s3.signature;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.S3_AUTHINFO_CREATION_ERROR;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.UNSIGNED_PAYLOAD;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.X_AMZ_CONTENT_SHA256;
 
@@ -114,7 +115,7 @@ public final class StringToSignProducer {
     strToSign.append(signatureInfo.getAlgorithm()).append(NEWLINE);
     if (signatureInfo.getDateTime() == null) {
       LOG.error("DateTime Header not found.");
-      throw S3_AUTHINFO_CREATION_ERROR;
+      throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
     }
     strToSign.append(signatureInfo.getDateTime()).append(NEWLINE)
         .append(credentialScope).append(NEWLINE);
@@ -187,13 +188,13 @@ public final class StringToSignProducer {
           validateSignedHeader(schema, header, headerValue);
         } catch (DateTimeParseException ex) {
           LOG.error("DateTime format invalid.", ex);
-          throw S3_AUTHINFO_CREATION_ERROR;
+          throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
         }
 
       } else {
         LOG.error("Header " + header + " not present in "
             + "request but requested to be signed.");
-        throw S3_AUTHINFO_CREATION_ERROR;
+        throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
       }
     }
 
@@ -225,7 +226,7 @@ public final class StringToSignProducer {
     if (contentSignatureHeaderValue == null) {
       LOG.error("The request must include " + X_AMZ_CONTENT_SHA256
           + " header for signed payload");
-      throw S3_AUTHINFO_CREATION_ERROR;
+      throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
     }
     // Simply return the header value of x-amz-content-sha256 as the payload hash
     // These are the possible cases:
@@ -332,7 +333,7 @@ public final class StringToSignProducer {
         LOG.error("AWS date not in valid range. Request timestamp:{} should "
             + "not be older than {} seconds.",
             headerValue, PRESIGN_URL_MAX_EXPIRATION_SECONDS);
-        throw S3_AUTHINFO_CREATION_ERROR;
+        throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
       }
       break;
     case X_AMZ_CONTENT_SHA256:
@@ -361,7 +362,7 @@ public final class StringToSignProducer {
   ) throws OS3Exception {
     if (!canonicalHeaders.contains(HOST + ":")) {
       LOG.error("The SignedHeaders list must include HTTP Host header");
-      throw S3_AUTHINFO_CREATION_ERROR;
+      throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
     }
     for (String header : headers.keySet().stream()
         .filter(s -> s.startsWith("x-amz-"))
@@ -375,7 +376,7 @@ public final class StringToSignProducer {
         }
         LOG.error("The SignedHeaders list must include all "
             + "x-amz-* headers in the request");
-        throw S3_AUTHINFO_CREATION_ERROR;
+        throw newError(S3_AUTHINFO_CREATION_ERROR, null, null);
       }
     }
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/EndpointTestUtils.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/EndpointTestUtils.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.apache.http.HttpStatus;
 import org.apache.ratis.util.function.CheckedRunnable;
@@ -246,16 +247,16 @@ public final class EndpointTestUtils {
     }
   }
 
-  /** Verify error response for {@code request} matches {@code expected} {@link OS3Exception}. */
-  public static OS3Exception assertErrorResponse(OS3Exception expected, CheckedRunnable<?> request) {
+  /** Verify error response for {@code request} matches {@code expected} {@link S3ErrorTable}. */
+  public static OS3Exception assertErrorResponse(S3ErrorTable expected, CheckedRunnable<?> request) {
     OS3Exception actual = assertThrows(OS3Exception.class, request::run);
     assertEquals(expected.getCode(), actual.getCode());
     assertEquals(expected.getHttpCode(), actual.getHttpCode());
     return actual;
   }
 
-  /** Verify error response for {@code request} matches {@code expected} {@link OS3Exception}. */
-  public static OS3Exception assertErrorResponse(OS3Exception expected, CheckedSupplier<Response, ?> request) {
+  /** Verify error response for {@code request} matches {@code expected} {@link S3ErrorTable}. */
+  public static OS3Exception assertErrorResponse(S3ErrorTable expected, CheckedSupplier<Response, ?> request) {
     OS3Exception actual = assertThrows(OS3Exception.class, () -> request.get().close());
     assertEquals(expected.getCode(), actual.getCode());
     assertEquals(expected.getHttpCode(), actual.getHttpCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/exception/TestOS3Exceptions.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/exception/TestOS3Exceptions.java
@@ -29,11 +29,8 @@ public class TestOS3Exceptions {
 
   @Test
   public void testOS3Exceptions() {
-    OS3Exception ex = new OS3Exception("AccessDenied", "Access Denied",
-        403);
-    String requestId = OzoneUtils.getRequestID();
-    ex = S3ErrorTable.newError(ex, "bucket");
-    ex.setRequestId(requestId);
+    OS3Exception ex = S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, "bucket");
+    ex.setRequestId(OzoneUtils.getRequestID());
     String val = ex.toXml();
     String formatString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n" +
         "<Error>%n" +


### PR DESCRIPTION
## What changes were proposed in this pull request?

`S3ErrorTable` defines errors as instances of `OS3Exception`, leading to potential misuse:

- Stack traces of these constants reflect class initialization, not the place where the actual error is encountered.  Instead, new instance should be created (e.g. via `S3ErrorTable#newError`) for throwing, but it is easy to forget and throw directly.
- Instances are constants, but their properties are mutable.

This PR changes `S3ErrorTable` to be an `enum`, which cannot be throw directly, must be used to create the `OS3Exception`.  Type name would better be `S3ErrorCode` or similar, but is kept as is for now to reduce change.

Also remove unused `S3ErrorTable.getInternalError`.

https://issues.apache.org/jira/browse/HDDS-15023

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/24306299207