### PR TITLE
HDDS-15024. Track pending containers in SCM to prevent Datanode over-allocation

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.node;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -123,17 +124,23 @@ public class PendingContainerTracker {
     /**
      * Add container to current window.
      */
-    synchronized boolean add(ContainerID containerID) {
-      return currentWindow.add(containerID);
+    synchronized boolean add(ContainerID containerID, DatanodeID dnID) {
+      boolean added = currentWindow.add(containerID);
+      LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
+          containerID, dnID, added, getCount());
+      return added;
     }
 
     /**
      * Remove container from both windows.
      */
-    synchronized boolean remove(ContainerID containerID) {
+    synchronized boolean remove(ContainerID containerID, DatanodeID dnID) {
       boolean removedFromCurrent = currentWindow.remove(containerID);
       boolean removedFromPrevious = previousWindow.remove(containerID);
-      return removedFromCurrent || removedFromPrevious;
+      boolean removed = removedFromCurrent || removedFromPrevious;
+      LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
+          containerID, dnID, removed, getCount());
+      return removed;
     }
 
     /**
@@ -162,15 +169,9 @@ public class PendingContainerTracker {
     }
 
     TwoWindowBucket get(DatanodeDetails dn) {
-      if (dn == null) {
-        return null;
-      }
+      Objects.requireNonNull(dn, "dn == null");
       return get(dn.getID());
     }
-  }
-
-  public PendingContainerTracker(long maxContainerSize) {
-    this(maxContainerSize, 5 * 60 * 1000, null); // Default 5 minutes
   }
 
   public PendingContainerTracker(long maxContainerSize, long rollIntervalMs,
@@ -188,9 +189,7 @@ public class PendingContainerTracker {
    * allocations or container reports touching this tracker.
    */
   public void rollWindowsIfNeeded(DatanodeDetails node) {
-    if (node == null) {
-      return;
-    }
+    Objects.requireNonNull(node, "node == null");
     datanodeBuckets.get(node.getID());
   }
 
@@ -205,7 +204,9 @@ public class PendingContainerTracker {
    */
   public boolean hasEffectiveAllocatableSpaceForNewContainer(
       DatanodeDetails node, DatanodeInfo datanodeInfo, long containerSize) {
-    if (node == null || datanodeInfo == null || containerSize <= 0) {
+    Objects.requireNonNull(node, "node == null");
+    Objects.requireNonNull(datanodeInfo, "datanodeInfo == null");
+    if (containerSize <= 0) {
       return false;
     }
     long pendingBytes = getPendingAllocationSize(node);
@@ -238,10 +239,8 @@ public class PendingContainerTracker {
    * @param containerID The container being allocated
    */
   public void recordPendingAllocation(Pipeline pipeline, ContainerID containerID) {
-    if (pipeline == null || containerID == null) {
-      LOG.warn("Ignoring null pipeline or containerID");
-      return;
-    }
+    Objects.requireNonNull(pipeline, "pipeline == null");
+    Objects.requireNonNull(containerID, "containerID == null");
 
     for (DatanodeDetails node : pipeline.getNodes()) {
       recordPendingAllocationForDatanode(node, containerID);
@@ -256,10 +255,8 @@ public class PendingContainerTracker {
    * @param containerID The container being allocated/replicated
    */
   public void recordPendingAllocationForDatanode(DatanodeDetails node, ContainerID containerID) {
-    if (node == null || containerID == null) {
-      LOG.warn("Ignoring null node or containerID");
-      return;
-    }
+    Objects.requireNonNull(node, "node == null");
+    Objects.requireNonNull(containerID, "containerID == null");
 
     DatanodeID dnID = node.getID();
     boolean added = addContainerToBucket(containerID, dnID);
@@ -270,13 +267,7 @@ public class PendingContainerTracker {
   }
 
   private boolean addContainerToBucket(ContainerID containerID, DatanodeID dnID) {
-    TwoWindowBucket bucket = datanodeBuckets.get(dnID);
-    synchronized (bucket) {
-      boolean added = bucket.add(containerID);
-      LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
-          containerID, dnID, added, bucket.getCount());
-      return added;
-    }
+    return datanodeBuckets.get(dnID).add(containerID, dnID);
   }
 
   /**
@@ -288,9 +279,8 @@ public class PendingContainerTracker {
    * @param containerID The container to remove from pending
    */
   public void removePendingAllocation(DatanodeDetails node, ContainerID containerID) {
-    if (node == null || containerID == null) {
-      return;
-    }
+    Objects.requireNonNull(node, "node == null");
+    Objects.requireNonNull(containerID, "containerID == null");
 
     DatanodeID dnID = node.getID();
     boolean removed = removeContainerFromBucket(containerID, dnID);
@@ -301,13 +291,7 @@ public class PendingContainerTracker {
   }
 
   private boolean removeContainerFromBucket(ContainerID containerID, DatanodeID dnID) {
-    TwoWindowBucket bucket = datanodeBuckets.get(dnID);
-    synchronized (bucket) {
-      boolean removed = bucket.remove(containerID);
-      LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
-          containerID, dnID, removed, bucket.getCount());
-      return removed;
-    }
+    return datanodeBuckets.get(dnID).remove(containerID, dnID);
   }
 
   /**
@@ -320,9 +304,7 @@ public class PendingContainerTracker {
    * @return Total bytes of pending container allocations
    */
   public long getPendingAllocationSize(DatanodeDetails node) {
-    if (node == null) {
-      return 0;
-    }
+    Objects.requireNonNull(node, "node == null");
     return getPendingContainerCount(node) * maxContainerSize;
   }
 
@@ -334,13 +316,8 @@ public class PendingContainerTracker {
    * @return Pending container count
    */
   public long getPendingContainerCount(DatanodeDetails node) {
-    if (node == null) {
-      return 0;
-    }
-    TwoWindowBucket bucket = datanodeBuckets.get(node);
-    synchronized (bucket) {
-      return bucket.getCount();
-    }
+    Objects.requireNonNull(node, "node == null");
+    return datanodeBuckets.get(node).getCount();
   }
 
   /**
@@ -348,13 +325,9 @@ public class PendingContainerTracker {
    */
   @VisibleForTesting
   public boolean containsPendingContainer(DatanodeDetails node, ContainerID containerID) {
-    if (node == null || containerID == null) {
-      return false;
-    }
-    TwoWindowBucket bucket = datanodeBuckets.get(node);
-    synchronized (bucket) {
-      return bucket.contains(containerID);
-    }
+    Objects.requireNonNull(node, "node == null");
+    Objects.requireNonNull(containerID, "containerID == null");
+    return datanodeBuckets.get(node).contains(containerID);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -216,7 +216,8 @@ public class PendingContainerTracker {
   private boolean hasAllocatableSpaceAfterPending(
       DatanodeInfo datanodeInfo, long containerSize, long pendingAllocationBytes) {
     List<StorageReportProto> storageReports = datanodeInfo.getStorageReports();
-    if (storageReports == null || storageReports.isEmpty()) {
+    Objects.requireNonNull(storageReports, "storageReports == null");
+    if (storageReports.isEmpty()) {
       return false;
     }
     for (StorageReportProto report : storageReports) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -107,13 +107,16 @@ public class PendingContainerTracker {
         previousWindow.clear();
         currentWindow.clear();
         lastRollTime = now;
+        LOG.debug("Double roll interval elapsed: ({}ms) dropped: {} pending containers from both windows",
+            elapsed, getCount());
       } else if (elapsed >= rollIntervalMs) {
         previousWindow.clear();
         final Set<ContainerID> tmp = previousWindow;
         previousWindow = currentWindow;
         currentWindow = tmp;
         lastRollTime = now;
-        LOG.debug("Rolled window. Previous window size: {}, Current window reset to empty", previousWindow.size());
+        LOG.debug("Rolled window. Previous window size: {} elapsed: ({}ms), Current window reset to empty",
+            previousWindow.size(), elapsed);
       }
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -1,0 +1,424 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.node;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.container.common.volume.VolumeUsage;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks per-datanode pending container allocations at SCM using a Two Window Tumbling Bucket
+ * pattern (similar to HDFS HADOOP-3707).
+ *
+ * Two Window Tumbling Bucket for automatic aging and cleanup.
+ *
+ * How It Works:
+ *   <li>Each DataNode has two sets: <b>currentWindow</b> and <b>previousWindow</b></li>
+ *   <li>New allocations go into <b>currentWindow</b></li>
+ *   <li>Every <b>ROLL_INTERVAL</b> (default 5 minutes):
+ *     <ul>
+ *       <li>previousWindow = currentWindow (shift)</li>
+ *       <li>currentWindow = new empty set (reset)</li>
+ *       <li>Old previousWindow is discarded (automatic aging)</li>
+ *     </ul>
+ *   </li>
+ *   <li>When checking pending: return <b>union</b> of currentWindow + previousWindow</li>
+ *
+ *
+ * Example Timeline:
+ * <pre>
+ * Time  | Action                    | CurrentWindow | PreviousWindow | Total Pending
+ * ------+---------------------------+---------------+----------------+--------------
+ * 00:00 | Allocate Container-1      | {C1}          | {}             | {C1}
+ * 00:02 | Allocate Container-2      | {C1, C2}      | {}             | {C1, C2}
+ * 00:05 | [ROLL] Window tumbles     | {}            | {C1, C2}       | {C1, C2}
+ * 00:07 | Allocate Container-3      | {C3}          | {C1, C2}       | {C1, C2, C3}
+ * 00:08 | Report confirms C1        | {C3}          | {C2}           | {C2, C3}
+ * 00:10 | [ROLL] Window tumbles     | {}            | {C3}           | {C3}
+ *       | (C2 aged out if not reported)
+ * </pre>
+ *
+ */
+public class PendingContainerTracker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PendingContainerTracker.class);
+
+  /**
+   * Roll interval in milliseconds.
+   * Configurable via hdds.scm.container.pending.allocation.roll.interval.
+   * Default: 5 minutes.
+   * Containers automatically age out after 2 × rollIntervalMs.
+   */
+  private final long rollIntervalMs;
+
+  /**
+   * Map of DataNode ID to TwoWindowBucket.
+   */
+  private final ConcurrentHashMap<DatanodeID, TwoWindowBucket> datanodeBuckets;
+
+  /**
+   * Maximum container size in bytes.
+   */
+  private final long maxContainerSize;
+
+  /**
+   * Metrics for tracking pending containers (same instance as {@link SCMNodeManager}'s node metrics).
+   */
+  private final SCMNodeMetrics metrics;
+
+  /**
+   * Two-window bucket for a single DataNode.
+   * Contains current and previous window sets, plus last roll timestamp.
+   */
+  private static class TwoWindowBucket {
+    private Set<ContainerID> currentWindow = new HashSet<>();
+    private Set<ContainerID> previousWindow = new HashSet<>();
+    private long lastRollTime = Time.monotonicNow();
+    private final long rollIntervalMs;
+
+    TwoWindowBucket(long rollIntervalMs) {
+      this.rollIntervalMs = rollIntervalMs;
+    }
+
+    /**
+     * Roll one or both windows based on elapsed time.
+     */
+    synchronized void rollIfNeeded() {
+      long now = Time.monotonicNow();
+      long elapsed = now - lastRollTime;
+
+      if (elapsed >= 2 * rollIntervalMs) {
+        previousWindow.clear();
+        currentWindow.clear();
+        lastRollTime = now;
+      } else if (elapsed >= rollIntervalMs) {
+        previousWindow = currentWindow;
+        currentWindow = new HashSet<>();
+        lastRollTime = now;
+        LOG.debug("Rolled window. Previous window size: {}, Current window reset to empty", previousWindow.size());
+      }
+    }
+
+    /**
+     * Get union of both windows (all pending containers).
+     */
+    synchronized Set<ContainerID> getAllPending() {
+      Set<ContainerID> all = new HashSet<>();
+      all.addAll(currentWindow);
+      all.addAll(previousWindow);
+      return all;
+    }
+
+    /**
+     * Add container to current window.
+     */
+    synchronized boolean add(ContainerID containerID) {
+      return currentWindow.add(containerID);
+    }
+
+    /**
+     * Remove container from both windows.
+     */
+    synchronized boolean remove(ContainerID containerID) {
+      boolean removedFromCurrent = currentWindow.remove(containerID);
+      boolean removedFromPrevious = previousWindow.remove(containerID);
+      return removedFromCurrent || removedFromPrevious;
+    }
+
+    /**
+     * Check if either window is non-empty.
+     */
+    synchronized boolean isEmpty() {
+      return currentWindow.isEmpty() && previousWindow.isEmpty();
+    }
+
+    /**
+     * Count of pending containers in both windows.
+     */
+    synchronized int getCount() {
+      return currentWindow.size() + previousWindow.size();
+    }
+  }
+
+  public PendingContainerTracker(long maxContainerSize) {
+    this(maxContainerSize, 10 * 60 * 1000, null); // Default 10 minutes
+  }
+
+  public PendingContainerTracker(long maxContainerSize, long rollIntervalMs,
+      SCMNodeMetrics metrics) {
+    this.datanodeBuckets = new ConcurrentHashMap<>();
+    this.maxContainerSize = maxContainerSize;
+    this.rollIntervalMs = rollIntervalMs;
+    this.metrics = metrics;
+    LOG.info("PendingContainerTracker initialized with maxContainerSize={}B, rollInterval={}ms",
+        maxContainerSize, rollIntervalMs);
+  }
+
+  /**
+   * Advances the two-window tumbling bucket for this datanode when the roll interval has elapsed.
+   * Call on periodic paths (e.g. node report) so windows age even when there are no new
+   * allocations or container reports touching this tracker.
+   */
+  public void rollWindowsIfNeeded(DatanodeDetails node) {
+    if (node == null) {
+      return;
+    }
+    DatanodeID dnID = node.getID();
+    datanodeBuckets.computeIfPresent(dnID, (k, bucket) -> {
+      synchronized (bucket) {
+        bucket.rollIfNeeded();
+        // Remove bucket if empty after roll
+        return bucket.isEmpty() ? null : bucket;
+      }
+    });
+  }
+
+  /**
+   * Whether the datanode can fit another container of {@code containerSize} after accounting for
+   * SCM pending allocations for {@code node} (this tracker) and usable space on {@code datanodeInfo}.
+   * Combines {@link #getPendingAllocationSize} with the per-disk slot check in one call.
+   *
+   * @param node identity used to look up pending allocations (same DN as {@code datanodeInfo})
+   * @param datanodeInfo storage reports for the datanode
+   * @param containerSize required container size in bytes (typically SCM max container size)
+   */
+  public boolean hasEffectiveAllocatableSpaceForNewContainer(
+      DatanodeDetails node, DatanodeInfo datanodeInfo, long containerSize) {
+    if (node == null || datanodeInfo == null || containerSize <= 0) {
+      return false;
+    }
+    long pendingBytes = getPendingAllocationSize(node);
+    return hasAllocatableSpaceAfterPending(datanodeInfo, containerSize, pendingBytes);
+  }
+
+  private boolean hasAllocatableSpaceAfterPending(
+      DatanodeInfo datanodeInfo, long containerSize, long pendingAllocationBytes) {
+    List<StorageReportProto> storageReports = datanodeInfo.getStorageReports();
+    if (storageReports == null || storageReports.isEmpty()) {
+      return false;
+    }
+    long effectiveAllocatableSpace = 0L;
+    for (StorageReportProto report : storageReports) {
+      long usableSpace = VolumeUsage.getUsableSpace(report);
+      long containersOnThisDisk = usableSpace / containerSize;
+      effectiveAllocatableSpace += containersOnThisDisk * containerSize;
+      if (effectiveAllocatableSpace - pendingAllocationBytes >= containerSize) {
+        return true;
+      }
+    }
+    if (metrics != null) {
+      metrics.incNumSkippedFullNodeContainerAllocation();
+    }
+    return false;
+  }
+
+  /**
+   * Drops all pending allocation state for a datanode (e.g. stale/dead cleanup).
+   */
+  public void clearPendingForDatanode(DatanodeDetails node) {
+    if (node == null) {
+      return;
+    }
+    DatanodeID dnID = node.getID();
+    datanodeBuckets.remove(dnID);
+    LOG.debug("Cleared pending container allocations for datanode {}", dnID);
+  }
+
+  /**
+   * Record a pending container allocation for all DataNodes in the pipeline.
+   * Container is added to the current window.
+   *
+   * @param pipeline The pipeline where container is allocated
+   * @param containerID The container being allocated
+   */
+  public void recordPendingAllocation(Pipeline pipeline, ContainerID containerID) {
+    if (pipeline == null || containerID == null) {
+      LOG.warn("Ignoring null pipeline or containerID");
+      return;
+    }
+
+    for (DatanodeDetails node : pipeline.getNodes()) {
+      recordPendingAllocationForDatanode(node, containerID);
+    }
+  }
+
+  /**
+   * Record a pending container allocation for a single DataNode.
+   * Container is added to the current window.
+   *
+   * @param node The DataNode where container is being allocated/replicated
+   * @param containerID The container being allocated/replicated
+   */
+  public void recordPendingAllocationForDatanode(DatanodeDetails node, ContainerID containerID) {
+    if (node == null || containerID == null) {
+      LOG.warn("Ignoring null node or containerID");
+      return;
+    }
+
+    DatanodeID dnID = node.getID();
+    AtomicBoolean added = addContainerToBucket(containerID, dnID);
+
+    if (added.get() && metrics != null) {
+      metrics.incNumPendingContainersAdded();
+    }
+  }
+
+  private AtomicBoolean addContainerToBucket(ContainerID containerID, DatanodeID dnID) {
+    AtomicBoolean added = new AtomicBoolean(false);
+
+    datanodeBuckets.compute(dnID, (k, existing) -> {
+      TwoWindowBucket bucket = (existing != null) ? existing : new TwoWindowBucket(rollIntervalMs);
+      synchronized (bucket) {
+        bucket.rollIfNeeded();
+        added.set(bucket.add(containerID));
+        LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
+            containerID, dnID, added.get(), bucket.getCount());
+        return bucket;
+      }
+    });
+    return added;
+  }
+
+  /**
+   * Remove a pending container allocation from a specific DataNode.
+   * Removes from both current and previous windows.
+   * Called when container is confirmed.
+   *
+   * @param node The DataNode
+   * @param containerID The container to remove from pending
+   */
+  public void removePendingAllocation(DatanodeDetails node, ContainerID containerID) {
+    if (node == null || containerID == null) {
+      return;
+    }
+
+    DatanodeID dnID = node.getID();
+    AtomicBoolean removed = removeContainerFromBucket(containerID, dnID);
+
+    if (removed.get() && metrics != null) {
+      metrics.incNumPendingContainersRemoved();
+    }
+  }
+
+  private AtomicBoolean removeContainerFromBucket(ContainerID containerID, DatanodeID dnID) {
+    AtomicBoolean removed = new AtomicBoolean(false);
+
+    datanodeBuckets.computeIfPresent(dnID, (k, bucket) -> {
+      synchronized (bucket) {
+        bucket.rollIfNeeded();
+        removed.set(bucket.remove(containerID));
+        LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
+            containerID, dnID, removed.get(), bucket.getCount());
+        return bucket.isEmpty() ? null : bucket;
+      }
+    });
+    return removed;
+  }
+
+  /**
+   * Bytes of SCM-side pending container allocations for this datanode (count × configured max
+   * container size). For whether a new container can be placed, prefer
+   * {@link #hasEffectiveAllocatableSpaceForNewContainer}.
+   * <p>Note: this call may advance the internal tumbling window if the roll interval has elapsed,
+   * ensuring the returned value reflects the most up-to-date pending state.</p>
+   *
+   * @param node The DataNode
+   * @return Total bytes of pending container allocations
+   */
+  public long getPendingAllocationSize(DatanodeDetails node) {
+    if (node == null) {
+      return 0;
+    }
+
+    TwoWindowBucket bucket = datanodeBuckets.get(node.getID());
+    if (bucket == null) {
+      return 0;
+    }
+
+    synchronized (bucket) {
+      bucket.rollIfNeeded();
+      return (long) bucket.getCount() * maxContainerSize;
+    }
+  }
+
+  /**
+   * Get the set of pending container IDs for a DataNode.
+   * Returns union of current and previous windows.
+   * Useful for debugging and monitoring.
+   * <p>Note: this call may advance the internal tumbling window if the roll interval has elapsed,
+   * ensuring the returned set reflects the most up-to-date pending state.</p>
+   *
+   * @param node The DataNode
+   * @return Set of pending container IDs
+   */
+  public Set<ContainerID> getPendingContainers(DatanodeDetails node) {
+    if (node == null) {
+      return Collections.emptySet();
+    }
+
+    TwoWindowBucket bucket = datanodeBuckets.get(node.getID());
+    if (bucket == null) {
+      return Collections.emptySet();
+    }
+
+    synchronized (bucket) {
+      bucket.rollIfNeeded();
+      return bucket.getAllPending();
+    }
+  }
+
+  /**
+   * Get total number of DataNodes with pending allocations.
+   *
+   * @return Count of DataNodes
+   */
+  public int getDataNodeCount() {
+    return datanodeBuckets.size();
+  }
+
+  /**
+   * Get total number of pending containers across all DataNodes.
+   * Note: Same container on multiple DataNodes is counted once per DataNode.
+   * The count may include containers from the previous window (up to 10 minutes old).
+   *
+   * @return Total pending container count
+   */
+  public long getTotalPendingCount() {
+    return datanodeBuckets.values().stream()
+        .mapToLong(TwoWindowBucket::getCount)
+        .sum();
+  }
+
+  @VisibleForTesting
+  public SCMNodeMetrics getMetrics() {
+    return metrics;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -18,12 +18,10 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
@@ -71,18 +69,7 @@ public class PendingContainerTracker {
 
   private static final Logger LOG = LoggerFactory.getLogger(PendingContainerTracker.class);
 
-  /**
-   * Roll interval in milliseconds.
-   * Configurable via hdds.scm.container.pending.allocation.roll.interval.
-   * Default: 5 minutes.
-   * Containers automatically age out after 2 × rollIntervalMs.
-   */
-  private final long rollIntervalMs;
-
-  /**
-   * Map of DataNode ID to TwoWindowBucket.
-   */
-  private final ConcurrentHashMap<DatanodeID, TwoWindowBucket> datanodeBuckets;
+  private final DatanodeBuckets datanodeBuckets;
 
   /**
    * Maximum container size in bytes.
@@ -120,21 +107,17 @@ public class PendingContainerTracker {
         currentWindow.clear();
         lastRollTime = now;
       } else if (elapsed >= rollIntervalMs) {
+        previousWindow.clear();
+        final Set<ContainerID> tmp = previousWindow;
         previousWindow = currentWindow;
-        currentWindow = new HashSet<>();
+        currentWindow = tmp;
         lastRollTime = now;
         LOG.debug("Rolled window. Previous window size: {}, Current window reset to empty", previousWindow.size());
       }
     }
 
-    /**
-     * Get union of both windows (all pending containers).
-     */
-    synchronized Set<ContainerID> getAllPending() {
-      Set<ContainerID> all = new HashSet<>();
-      all.addAll(currentWindow);
-      all.addAll(previousWindow);
-      return all;
+    synchronized boolean contains(ContainerID containerID) {
+      return currentWindow.contains(containerID) || previousWindow.contains(containerID);
     }
 
     /**
@@ -154,13 +137,6 @@ public class PendingContainerTracker {
     }
 
     /**
-     * Check if either window is non-empty.
-     */
-    synchronized boolean isEmpty() {
-      return currentWindow.isEmpty() && previousWindow.isEmpty();
-    }
-
-    /**
      * Count of pending containers in both windows.
      */
     synchronized int getCount() {
@@ -168,15 +144,39 @@ public class PendingContainerTracker {
     }
   }
 
+  /**
+   * Per-datanode two-window buckets.
+   */
+  private static class DatanodeBuckets {
+    private final ConcurrentHashMap<DatanodeID, TwoWindowBucket> map = new ConcurrentHashMap<>();
+    private final long rollIntervalMs;
+
+    DatanodeBuckets(long rollIntervalMs) {
+      this.rollIntervalMs = rollIntervalMs;
+    }
+
+    TwoWindowBucket get(DatanodeID id) {
+      final TwoWindowBucket bucket = map.compute(id, (k, b) -> b != null ? b : new TwoWindowBucket(rollIntervalMs));
+      bucket.rollIfNeeded();
+      return bucket;
+    }
+
+    TwoWindowBucket get(DatanodeDetails dn) {
+      if (dn == null) {
+        return null;
+      }
+      return get(dn.getID());
+    }
+  }
+
   public PendingContainerTracker(long maxContainerSize) {
-    this(maxContainerSize, 10 * 60 * 1000, null); // Default 10 minutes
+    this(maxContainerSize, 5 * 60 * 1000, null); // Default 5 minutes
   }
 
   public PendingContainerTracker(long maxContainerSize, long rollIntervalMs,
       SCMNodeMetrics metrics) {
-    this.datanodeBuckets = new ConcurrentHashMap<>();
+    this.datanodeBuckets = new DatanodeBuckets(rollIntervalMs);
     this.maxContainerSize = maxContainerSize;
-    this.rollIntervalMs = rollIntervalMs;
     this.metrics = metrics;
     LOG.info("PendingContainerTracker initialized with maxContainerSize={}B, rollInterval={}ms",
         maxContainerSize, rollIntervalMs);
@@ -184,21 +184,14 @@ public class PendingContainerTracker {
 
   /**
    * Advances the two-window tumbling bucket for this datanode when the roll interval has elapsed.
-   * Call on periodic paths (e.g. node report) so windows age even when there are no new
+   * Call on periodic paths (node report) so windows age even when there are no new
    * allocations or container reports touching this tracker.
    */
   public void rollWindowsIfNeeded(DatanodeDetails node) {
     if (node == null) {
       return;
     }
-    DatanodeID dnID = node.getID();
-    datanodeBuckets.computeIfPresent(dnID, (k, bucket) -> {
-      synchronized (bucket) {
-        bucket.rollIfNeeded();
-        // Remove bucket if empty after roll
-        return bucket.isEmpty() ? null : bucket;
-      }
-    });
+    datanodeBuckets.get(node.getID());
   }
 
   /**
@@ -225,12 +218,9 @@ public class PendingContainerTracker {
     if (storageReports == null || storageReports.isEmpty()) {
       return false;
     }
-    long effectiveAllocatableSpace = 0L;
     for (StorageReportProto report : storageReports) {
       long usableSpace = VolumeUsage.getUsableSpace(report);
-      long containersOnThisDisk = usableSpace / containerSize;
-      effectiveAllocatableSpace += containersOnThisDisk * containerSize;
-      if (effectiveAllocatableSpace - pendingAllocationBytes >= containerSize) {
+      if (usableSpace - pendingAllocationBytes >= containerSize) {
         return true;
       }
     }
@@ -238,18 +228,6 @@ public class PendingContainerTracker {
       metrics.incNumSkippedFullNodeContainerAllocation();
     }
     return false;
-  }
-
-  /**
-   * Drops all pending allocation state for a datanode (e.g. stale/dead cleanup).
-   */
-  public void clearPendingForDatanode(DatanodeDetails node) {
-    if (node == null) {
-      return;
-    }
-    DatanodeID dnID = node.getID();
-    datanodeBuckets.remove(dnID);
-    LOG.debug("Cleared pending container allocations for datanode {}", dnID);
   }
 
   /**
@@ -284,27 +262,21 @@ public class PendingContainerTracker {
     }
 
     DatanodeID dnID = node.getID();
-    AtomicBoolean added = addContainerToBucket(containerID, dnID);
+    boolean added = addContainerToBucket(containerID, dnID);
 
-    if (added.get() && metrics != null) {
+    if (added && metrics != null) {
       metrics.incNumPendingContainersAdded();
     }
   }
 
-  private AtomicBoolean addContainerToBucket(ContainerID containerID, DatanodeID dnID) {
-    AtomicBoolean added = new AtomicBoolean(false);
-
-    datanodeBuckets.compute(dnID, (k, existing) -> {
-      TwoWindowBucket bucket = (existing != null) ? existing : new TwoWindowBucket(rollIntervalMs);
-      synchronized (bucket) {
-        bucket.rollIfNeeded();
-        added.set(bucket.add(containerID));
-        LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
-            containerID, dnID, added.get(), bucket.getCount());
-        return bucket;
-      }
-    });
-    return added;
+  private boolean addContainerToBucket(ContainerID containerID, DatanodeID dnID) {
+    TwoWindowBucket bucket = datanodeBuckets.get(dnID);
+    synchronized (bucket) {
+      boolean added = bucket.add(containerID);
+      LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
+          containerID, dnID, added, bucket.getCount());
+      return added;
+    }
   }
 
   /**
@@ -321,32 +293,26 @@ public class PendingContainerTracker {
     }
 
     DatanodeID dnID = node.getID();
-    AtomicBoolean removed = removeContainerFromBucket(containerID, dnID);
+    boolean removed = removeContainerFromBucket(containerID, dnID);
 
-    if (removed.get() && metrics != null) {
+    if (removed && metrics != null) {
       metrics.incNumPendingContainersRemoved();
     }
   }
 
-  private AtomicBoolean removeContainerFromBucket(ContainerID containerID, DatanodeID dnID) {
-    AtomicBoolean removed = new AtomicBoolean(false);
-
-    datanodeBuckets.computeIfPresent(dnID, (k, bucket) -> {
-      synchronized (bucket) {
-        bucket.rollIfNeeded();
-        removed.set(bucket.remove(containerID));
-        LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
-            containerID, dnID, removed.get(), bucket.getCount());
-        return bucket.isEmpty() ? null : bucket;
-      }
-    });
-    return removed;
+  private boolean removeContainerFromBucket(ContainerID containerID, DatanodeID dnID) {
+    TwoWindowBucket bucket = datanodeBuckets.get(dnID);
+    synchronized (bucket) {
+      boolean removed = bucket.remove(containerID);
+      LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
+          containerID, dnID, removed, bucket.getCount());
+      return removed;
+    }
   }
 
   /**
    * Bytes of SCM-side pending container allocations for this datanode (count × configured max
-   * container size). For whether a new container can be placed, prefer
-   * {@link #hasEffectiveAllocatableSpaceForNewContainer}.
+   * container size).
    * <p>Note: this call may advance the internal tumbling window if the roll interval has elapsed,
    * ensuring the returned value reflects the most up-to-date pending state.</p>
    *
@@ -357,64 +323,38 @@ public class PendingContainerTracker {
     if (node == null) {
       return 0;
     }
-
-    TwoWindowBucket bucket = datanodeBuckets.get(node.getID());
-    if (bucket == null) {
-      return 0;
-    }
-
-    synchronized (bucket) {
-      bucket.rollIfNeeded();
-      return (long) bucket.getCount() * maxContainerSize;
-    }
+    return getPendingContainerCount(node) * maxContainerSize;
   }
 
   /**
-   * Get the set of pending container IDs for a DataNode.
-   * Returns union of current and previous windows.
-   * Useful for debugging and monitoring.
-   * <p>Note: this call may advance the internal tumbling window if the roll interval has elapsed,
-   * ensuring the returned set reflects the most up-to-date pending state.</p>
+   * Number of pending container allocations for this datanode (union of current and previous
+   * windows). This call may advance the internal tumbling window if the roll interval has elapsed.
    *
    * @param node The DataNode
-   * @return Set of pending container IDs
+   * @return Pending container count
    */
-  public Set<ContainerID> getPendingContainers(DatanodeDetails node) {
+  public long getPendingContainerCount(DatanodeDetails node) {
     if (node == null) {
-      return Collections.emptySet();
+      return 0;
     }
-
-    TwoWindowBucket bucket = datanodeBuckets.get(node.getID());
-    if (bucket == null) {
-      return Collections.emptySet();
-    }
-
+    TwoWindowBucket bucket = datanodeBuckets.get(node);
     synchronized (bucket) {
-      bucket.rollIfNeeded();
-      return bucket.getAllPending();
+      return bucket.getCount();
     }
   }
 
   /**
-   * Get total number of DataNodes with pending allocations.
-   *
-   * @return Count of DataNodes
+   * Whether container is in the current or previous window for this datanode.
    */
-  public int getDataNodeCount() {
-    return datanodeBuckets.size();
-  }
-
-  /**
-   * Get total number of pending containers across all DataNodes.
-   * Note: Same container on multiple DataNodes is counted once per DataNode.
-   * The count may include containers from the previous window (up to 10 minutes old).
-   *
-   * @return Total pending container count
-   */
-  public long getTotalPendingCount() {
-    return datanodeBuckets.values().stream()
-        .mapToLong(TwoWindowBucket::getCount)
-        .sum();
+  @VisibleForTesting
+  public boolean containsPendingContainer(DatanodeDetails node, ContainerID containerID) {
+    if (node == null || containerID == null) {
+      return false;
+    }
+    TwoWindowBucket bucket = datanodeBuckets.get(node);
+    synchronized (bucket) {
+      return bucket.contains(containerID);
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -104,11 +104,11 @@ public class PendingContainerTracker {
       long elapsed = now - lastRollTime;
 
       if (elapsed >= 2 * rollIntervalMs) {
+        int dropped = getCount();
         previousWindow.clear();
         currentWindow.clear();
         lastRollTime = now;
-        LOG.debug("Double roll interval elapsed: ({}ms) dropped: {} pending containers from both windows",
-            elapsed, getCount());
+        LOG.debug("Double roll interval elapsed ({}ms): dropped {} pending containers", elapsed, dropped);
       } else if (elapsed >= rollIntervalMs) {
         previousWindow.clear();
         final Set<ContainerID> tmp = previousWindow;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -223,9 +223,12 @@ public class PendingContainerTracker {
     if (storageReports.isEmpty()) {
       return false;
     }
+    long effectiveAllocatableSpace = 0L;
     for (StorageReportProto report : storageReports) {
       long usableSpace = VolumeUsage.getUsableSpace(report);
-      if (usableSpace - pendingAllocationBytes >= containerSize) {
+      long containersOnThisDisk = usableSpace / containerSize;
+      effectiveAllocatableSpace += containersOnThisDisk * containerSize;
+      if (effectiveAllocatableSpace - pendingAllocationBytes >= containerSize) {
         return true;
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -197,27 +197,20 @@ public class PendingContainerTracker {
   }
 
   /**
-   * Whether the datanode can fit another container of {@code containerSize} after accounting for
-   * SCM pending allocations for {@code node} (this tracker) and usable space on {@code datanodeInfo}.
-   * Combines {@link #getPendingAllocationSize} with the per-disk slot check in one call.
+   * Whether the datanode can fit another container of {@link #maxContainerSize} after accounting for
+   * SCM pending allocations for {@code node} (this tracker) and usable space across volumes on
+   * {@code datanodeInfo}. Pending bytes are {@link #getPendingContainerCount} × {@code maxContainerSize};
+   * effective allocatable space sums full-container slots per storage report.
    *
    * @param node identity used to look up pending allocations (same DN as {@code datanodeInfo})
    * @param datanodeInfo storage reports for the datanode
-   * @param containerSize required container size in bytes (typically SCM max container size)
    */
   public boolean hasEffectiveAllocatableSpaceForNewContainer(
-      DatanodeDetails node, DatanodeInfo datanodeInfo, long containerSize) {
+      DatanodeDetails node, DatanodeInfo datanodeInfo) {
     Objects.requireNonNull(node, "node == null");
     Objects.requireNonNull(datanodeInfo, "datanodeInfo == null");
-    if (containerSize <= 0) {
-      return false;
-    }
-    long pendingBytes = getPendingAllocationSize(node);
-    return hasAllocatableSpaceAfterPending(datanodeInfo, containerSize, pendingBytes);
-  }
 
-  private boolean hasAllocatableSpaceAfterPending(
-      DatanodeInfo datanodeInfo, long containerSize, long pendingAllocationBytes) {
+    long pendingAllocationSize = getPendingContainerCount(node) * maxContainerSize;
     List<StorageReportProto> storageReports = datanodeInfo.getStorageReports();
     Objects.requireNonNull(storageReports, "storageReports == null");
     if (storageReports.isEmpty()) {
@@ -226,9 +219,9 @@ public class PendingContainerTracker {
     long effectiveAllocatableSpace = 0L;
     for (StorageReportProto report : storageReports) {
       long usableSpace = VolumeUsage.getUsableSpace(report);
-      long containersOnThisDisk = usableSpace / containerSize;
-      effectiveAllocatableSpace += containersOnThisDisk * containerSize;
-      if (effectiveAllocatableSpace - pendingAllocationBytes >= containerSize) {
+      long containersOnThisDisk = usableSpace / maxContainerSize;
+      effectiveAllocatableSpace += containersOnThisDisk * maxContainerSize;
+      if (effectiveAllocatableSpace - pendingAllocationSize >= maxContainerSize) {
         return true;
       }
     }
@@ -299,20 +292,6 @@ public class PendingContainerTracker {
 
   private boolean removeContainerFromBucket(ContainerID containerID, DatanodeID dnID) {
     return datanodeBuckets.get(dnID).remove(containerID, dnID);
-  }
-
-  /**
-   * Bytes of SCM-side pending container allocations for this datanode (count × configured max
-   * container size).
-   * <p>Note: this call may advance the internal tumbling window if the roll interval has elapsed,
-   * ensuring the returned value reflects the most up-to-date pending state.</p>
-   *
-   * @param node The DataNode
-   * @return Total bytes of pending container allocations
-   */
-  public long getPendingAllocationSize(DatanodeDetails node) {
-    Objects.requireNonNull(node, "node == null");
-    return getPendingContainerCount(node) * maxContainerSize;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
@@ -50,6 +50,10 @@ public final class SCMNodeMetrics implements MetricsSource {
   private @Metric MutableCounterLong numNodeCommandQueueReportProcessed;
   private @Metric MutableCounterLong numNodeCommandQueueReportProcessingFailed;
   private @Metric String textMetric;
+  // Pending container allocations at SCM (per-DN tracker), not yet on datanodes.
+  private @Metric MutableCounterLong numPendingContainersAdded;
+  private @Metric MutableCounterLong numPendingContainersRemoved;
+  private @Metric MutableCounterLong numSkippedFullNodeContainerAllocation;
 
   private final MetricsRegistry registry;
   private final NodeManagerMXBean managerMXBean;
@@ -122,6 +126,18 @@ public final class SCMNodeMetrics implements MetricsSource {
    */
   void incNumNodeCommandQueueReportProcessingFailed() {
     numNodeCommandQueueReportProcessingFailed.incr();
+  }
+
+  void incNumPendingContainersAdded() {
+    numPendingContainersAdded.incr();
+  }
+
+  void incNumPendingContainersRemoved() {
+    numPendingContainersRemoved.incr();
+  }
+
+  void incNumSkippedFullNodeContainerAllocation() {
+    numSkippedFullNodeContainerAllocation.incr();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Timeout;
 public class TestPendingContainerTracker {
 
   private static final long MAX_CONTAINER_SIZE = 5L * 1024 * 1024 * 1024; // 5GB
-
+  private static final long DEFAULT_ROLL_INTERVAL_MS = 5 * 60 * 1000;
   private static final int NUM_DATANODES = 1000;
   private static final int NUM_PIPELINES = 1000;
   private static final int NUM_CONTAINERS = 10_000;
@@ -59,7 +59,7 @@ public class TestPendingContainerTracker {
 
   @BeforeEach
   public void setUp() throws IOException {
-    tracker = new PendingContainerTracker(MAX_CONTAINER_SIZE);
+    tracker = new PendingContainerTracker(MAX_CONTAINER_SIZE, DEFAULT_ROLL_INTERVAL_MS, null);
 
     datanodes = new ArrayList<>(NUM_DATANODES);
     for (int i = 0; i < NUM_DATANODES; i++) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -17,12 +17,14 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -39,73 +41,88 @@ public class TestPendingContainerTracker {
 
   private static final long MAX_CONTAINER_SIZE = 5L * 1024 * 1024 * 1024; // 5GB
 
+  private static final int NUM_DATANODES = 1000;
+  private static final int NUM_PIPELINES = 1000;
+  private static final int NUM_CONTAINERS = 10_000;
+  private List<DatanodeDetails> datanodes;
+  private List<Pipeline> pipelines;
+  private List<ContainerID> containers;
+
   private PendingContainerTracker tracker;
   private Pipeline pipeline;
   private DatanodeDetails dn1;
   private DatanodeDetails dn2;
-  private DatanodeDetails dn3;
+
+  /** First three container IDs. */
   private ContainerID container1;
   private ContainerID container2;
-  private ContainerID container3;
 
   @BeforeEach
   public void setUp() throws IOException {
     tracker = new PendingContainerTracker(MAX_CONTAINER_SIZE);
 
-    // Create a 3-node Ratis pipeline
-    pipeline = MockPipeline.createPipeline(3);
-    dn1 = pipeline.getNodes().get(0);
-    dn2 = pipeline.getNodes().get(1);
-    dn3 = pipeline.getNodes().get(2);
+    datanodes = new ArrayList<>(NUM_DATANODES);
+    for (int i = 0; i < NUM_DATANODES; i++) {
+      datanodes.add(MockDatanodeDetails.randomLocalDatanodeDetails());
+    }
 
-    container1 = ContainerID.valueOf(1L);
-    container2 = ContainerID.valueOf(2L);
-    container3 = ContainerID.valueOf(3L);
+    pipelines = new ArrayList<>(NUM_PIPELINES);
+    for (int i = 0; i < NUM_PIPELINES; i++) {
+      pipelines.add(MockPipeline.createPipeline(Collections.singletonList(datanodes.get(i))));
+    }
+
+    containers = new ArrayList<>(NUM_CONTAINERS);
+    for (long id = 1; id <= NUM_CONTAINERS; id++) {
+      containers.add(ContainerID.valueOf(id));
+    }
+
+    pipeline = MockPipeline.createPipeline(datanodes.subList(0, 3));
+    dn1 = datanodes.get(0);
+    dn2 = datanodes.get(1);
+
+    container1 = containers.get(0);
+    container2 = containers.get(1);
   }
 
   @Test
   public void testRecordPendingAllocation() {
-    // Initially no pending containers
-    assertEquals(0, tracker.getPendingContainers(dn1).size());
-    assertEquals(0, tracker.getPendingAllocationSize(dn1));
+    // Allocate first 100 containers across first 100 pipelines (1 DN each)
+    for (int i = 0; i < 100; i++) {
+      tracker.recordPendingAllocation(pipelines.get(i), containers.get(i));
+    }
 
-    // Record a pending allocation
-    tracker.recordPendingAllocation(pipeline, container1);
+    // Each of the first 100 DNs should have 1 pending container
+    for (int i = 0; i < 100; i++) {
+      assertEquals(1, tracker.getPendingContainerCount(datanodes.get(i)));
+      assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(datanodes.get(i)));
+    }
 
-    // All 3 DNs should have the container pending
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
-    assertEquals(1, tracker.getPendingContainers(dn2).size());
-    assertEquals(1, tracker.getPendingContainers(dn3).size());
-
-    // Size should be MAX_CONTAINER_SIZE for each DN
-    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
-    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn2));
-    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn3));
+    // DNs beyond index 100 should have 0 pending
+    assertEquals(0, tracker.getPendingContainerCount(datanodes.get(500)));
+    assertEquals(0, tracker.getPendingContainerCount(datanodes.get(999)));
   }
 
   @Test
-  public void testRecordMultiplePendingAllocations() {
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container2);
-    tracker.recordPendingAllocation(pipeline, container3);
+  public void testRemovePendingAllocation() {
+    // Allocate containers 0-99 to first 100 pipelines
+    for (int i = 0; i < 100; i++) {
+      tracker.recordPendingAllocation(pipelines.get(i), containers.get(i));
+    }
 
-    // Each DN should have 3 pending containers
-    assertEquals(3, tracker.getPendingContainers(dn1).size());
-    assertEquals(3, tracker.getPendingContainers(dn2).size());
-    assertEquals(3, tracker.getPendingContainers(dn3).size());
+    // Remove from first 50 DNs
+    for (int i = 0; i < 50; i++) {
+      tracker.removePendingAllocation(datanodes.get(i), containers.get(i));
+    }
 
-    // Size should be 3 × MAX_CONTAINER_SIZE
-    assertEquals(3 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
-  }
+    // First 50 DNs should have 0 pending
+    for (int i = 0; i < 50; i++) {
+      assertEquals(0, tracker.getPendingContainerCount(datanodes.get(i)));
+    }
 
-  @Test
-  public void testIdempotentRecording() {
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container1); // Duplicate
-
-    // Should still be 1 container (Set deduplication)
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
-    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+    // DNs 50-99 should still have 1 pending
+    for (int i = 50; i < 100; i++) {
+      assertEquals(1, tracker.getPendingContainerCount(datanodes.get(i)));
+    }
   }
 
   /**
@@ -121,56 +138,20 @@ public class TestPendingContainerTracker {
         new PendingContainerTracker(MAX_CONTAINER_SIZE, rollMs, null);
 
     shortRollTracker.recordPendingAllocationForDatanode(dn1, container1);
-    Set<ContainerID> pendingDn1 = shortRollTracker.getPendingContainers(dn1);
-    assertEquals(1, pendingDn1.size());
-    assertThat(pendingDn1).containsExactly(container1);
+    assertEquals(1, shortRollTracker.getPendingContainerCount(dn1));
+    assertTrue(shortRollTracker.containsPendingContainer(dn1, container1));
 
     // First roll: C1 moves from currentWindow to previousWindow; union still includes C1
     Thread.sleep(rollMs + 80);
     shortRollTracker.rollWindowsIfNeeded(dn1);
-    pendingDn1 = shortRollTracker.getPendingContainers(dn1);
-    assertEquals(1, pendingDn1.size());
-    assertThat(pendingDn1).containsExactly(container1);
+    assertEquals(1, shortRollTracker.getPendingContainerCount(dn1));
+    assertTrue(shortRollTracker.containsPendingContainer(dn1, container1));
 
     // Second roll: prior previousWindow (holding C1) is dropped; C1 is no longer pending
     Thread.sleep(rollMs + 80);
     shortRollTracker.rollWindowsIfNeeded(dn1);
-    assertEquals(0, shortRollTracker.getPendingContainers(dn1).size());
+    assertEquals(0, shortRollTracker.getPendingContainerCount(dn1));
     assertEquals(0L, shortRollTracker.getPendingAllocationSize(dn1));
-  }
-
-  @Test
-  public void testRemovePendingAllocation() {
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container2);
-
-    assertEquals(2, tracker.getPendingContainers(dn1).size());
-
-    // Remove one container from DN1
-    tracker.removePendingAllocation(dn1, container1);
-
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
-    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
-
-    // DN2 and DN3 should still have both containers
-    assertEquals(2, tracker.getPendingContainers(dn2).size());
-    assertEquals(2, tracker.getPendingContainers(dn3).size());
-  }
-
-  @Test
-  public void testRemovePendingAllocationFromPipeline() {
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container2);
-
-    // Remove container1 from all nodes in pipeline
-    for (DatanodeDetails dn : pipeline.getNodes()) {
-      tracker.removePendingAllocation(dn, container1);
-    }
-
-    // All DNs should have only container2 remaining
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
-    assertEquals(1, tracker.getPendingContainers(dn2).size());
-    assertEquals(1, tracker.getPendingContainers(dn3).size());
   }
 
   @Test
@@ -181,53 +162,13 @@ public class TestPendingContainerTracker {
     tracker.removePendingAllocation(dn1, container2);
 
     // DN1 should still have container1
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    assertEquals(1, tracker.getPendingContainerCount(dn1));
   }
 
   @Test
-  public void testGetPendingContainers() {
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container2);
-
-    Set<ContainerID> pending = tracker.getPendingContainers(dn1);
-
-    assertEquals(2, pending.size());
-    assertThat(pending).contains(container1);
-    assertThat(pending).contains(container2);
-
-    // Returned set should be a copy - modifying it shouldn't affect tracker
-    pending.add(container3);
-    assertEquals(2, tracker.getPendingContainers(dn1).size()); // Should still be 2
-  }
-
-  @Test
-  public void testGetPendingContainersForNonExistentDN() {
+  public void testUnknownDatanodeHasZeroPendingCount() {
     DatanodeDetails unknownDN = MockDatanodeDetails.randomDatanodeDetails();
-
-    Set<ContainerID> pending = tracker.getPendingContainers(unknownDN);
-
-    assertThat(pending).isEmpty();
-  }
-
-  @Test
-  public void testGetTotalPendingCount() {
-    assertEquals(0, tracker.getTotalPendingCount());
-
-    tracker.recordPendingAllocation(pipeline, container1);
-
-    // 1 container × 3 DNs = 3 total pending
-    assertEquals(3, tracker.getTotalPendingCount());
-
-    tracker.recordPendingAllocation(pipeline, container2);
-
-    // 2 containers × 3 DNs = 6 total pending
-    assertEquals(6, tracker.getTotalPendingCount());
-
-    // Remove from one DN
-    tracker.removePendingAllocation(dn1, container1);
-
-    // (2 containers × 2 DNs) + (1 container × 1 DN) = 5 total
-    assertEquals(5, tracker.getTotalPendingCount());
+    assertEquals(0, tracker.getPendingContainerCount(unknownDN));
   }
 
   @Test
@@ -261,62 +202,23 @@ public class TestPendingContainerTracker {
     for (Thread thread : threads) {
       thread.join();
     }
-
-    // Verify no exceptions occurred and counts are reasonable
-    assertThat(tracker.getTotalPendingCount()).isGreaterThanOrEqualTo(0);
-    assertThat(tracker.getDataNodeCount()).isLessThanOrEqualTo(3);
   }
 
   @Test
-  public void testMemoryCleanupOnEmptySet() {
+  public void testBucketsRetainedWhenEmpty() {
     tracker.recordPendingAllocation(pipeline, container1);
 
-    assertEquals(3, tracker.getDataNodeCount());
+    assertEquals(1, tracker.getPendingContainerCount(dn1));
 
     // Remove the only pending container from DN1
     tracker.removePendingAllocation(dn1, container1);
 
-    // DN1 should be removed from the map (memory cleanup)
-    assertEquals(2, tracker.getDataNodeCount());
-  }
+    assertEquals(0, tracker.getPendingContainerCount(dn1));
+    assertEquals(1, tracker.getPendingContainerCount(dn2));
 
-  @Test
-  public void testPendingContainer() {
-    // Simulate allocation and confirmation flow
-
-    // Allocate 3 containers
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container2);
-    tracker.recordPendingAllocation(pipeline, container3);
-
-    // Each DN should have 3 pending, 15GB total
-    assertEquals(3, tracker.getPendingContainers(dn1).size());
-    assertEquals(3 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
-
-    // DN1 confirms container1 via container report
-    tracker.removePendingAllocation(dn1, container1);
-
-    // DN1 now has 2 pending, 10GB
-    assertEquals(2, tracker.getPendingContainers(dn1).size());
-    assertEquals(2 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
-
-    // DN2 and DN3 still have 3 pending
-    assertEquals(3, tracker.getPendingContainers(dn2).size());
-    assertEquals(3, tracker.getPendingContainers(dn3).size());
-
-    // All DNs eventually confirm all containers
-    for (DatanodeDetails dn : pipeline.getNodes()) {
-      tracker.removePendingAllocation(dn, container1);
-      tracker.removePendingAllocation(dn, container2);
-      tracker.removePendingAllocation(dn, container3);
-    }
-
-    // All DNs should have 0 pending
-    assertEquals(0, tracker.getPendingContainers(dn1).size());
-    assertEquals(0, tracker.getPendingContainers(dn2).size());
-    assertEquals(0, tracker.getPendingContainers(dn3).size());
-    assertEquals(0, tracker.getTotalPendingCount());
-    assertEquals(0, tracker.getDataNodeCount());
+    // Empty bucket for DN1 is still usable for new allocations
+    tracker.recordPendingAllocationForDatanode(dn1, container2);
+    assertEquals(1, tracker.getPendingContainerCount(dn1));
   }
 
   @Test
@@ -328,81 +230,92 @@ public class TestPendingContainerTracker {
     tracker.recordPendingAllocation(pipeline, container1);
     tracker.recordPendingAllocation(pipeline, container2);
 
-    assertEquals(2, tracker.getPendingContainers(dn1).size());
+    assertEquals(2, tracker.getPendingContainerCount(dn1));
 
     // Remove container1 - should work regardless of which window it's in
     tracker.removePendingAllocation(dn1, container1);
 
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    assertEquals(1, tracker.getPendingContainerCount(dn1));
 
-    Set<ContainerID> pending = tracker.getPendingContainers(dn1);
-    assertFalse(pending.contains(container1));
-    assertThat(pending).contains(container2);
+    assertFalse(tracker.containsPendingContainer(dn1, container1));
+    assertTrue(tracker.containsPendingContainer(dn1, container2));
   }
 
   @Test
-  public void testUnionOfBothWindows() {
-    // This test verifies the two-window concept:
-    // getPendingContainers should return union of current + previous windows
+  public void testManyContainersOnSingleDatanode() {
+    // Allocate first 1000 containers to the first datanode
+    DatanodeDetails dn = datanodes.get(0);
+    for (int i = 0; i < 1000; i++) {
+      tracker.recordPendingAllocationForDatanode(dn, containers.get(i));
+    }
 
-    // Add container1
-    tracker.recordPendingAllocation(pipeline, container1);
+    assertEquals(1000, tracker.getPendingContainerCount(dn));
+    assertEquals(1000 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn));
 
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
-    Set<ContainerID> pending1 = tracker.getPendingContainers(dn1);
-    assertThat(pending1).contains(container1);
+    // Verify specific containers are present
+    assertTrue(tracker.containsPendingContainer(dn, containers.get(0)));
+    assertTrue(tracker.containsPendingContainer(dn, containers.get(500)));
+    assertTrue(tracker.containsPendingContainer(dn, containers.get(999)));
 
-    // Add container2 - should be in same window initially
-    tracker.recordPendingAllocation(pipeline, container2);
+    // Remove half of them
+    for (int i = 0; i < 500; i++) {
+      tracker.removePendingAllocation(dn, containers.get(i));
+    }
 
-    assertEquals(2, tracker.getPendingContainers(dn1).size());
-    Set<ContainerID> pending2 = tracker.getPendingContainers(dn1);
-    assertThat(pending2).contains(container1);
-    assertThat(pending2).contains(container2);
-
-    // Both containers should be in the union
-    assertEquals(2, pending2.size());
+    assertEquals(500, tracker.getPendingContainerCount(dn));
+    assertFalse(tracker.containsPendingContainer(dn, containers.get(0)));
+    assertTrue(tracker.containsPendingContainer(dn, containers.get(999)));
   }
 
   @Test
-  public void testIdempotencyAcrossWindows() {
-    // Recording same container multiple times should only count it once
-    // This should work even if it spans windows
+  public void testAllDatanodesWithMultipleContainers() {
+    // Allocate 10 containers to each of the 1000 datanodes
+    for (int dnIdx = 0; dnIdx < NUM_DATANODES; dnIdx++) {
+      DatanodeDetails dn = datanodes.get(dnIdx);
+      for (int cIdx = 0; cIdx < 10; cIdx++) {
+        int containerIdx = dnIdx * 10 + cIdx;
+        tracker.recordPendingAllocationForDatanode(dn, containers.get(containerIdx));
+      }
+    }
 
-    tracker.recordPendingAllocation(pipeline, container1);
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    // Each DN should have 10 pending containers
+    for (int i = 0; i < NUM_DATANODES; i++) {
+      assertEquals(10, tracker.getPendingContainerCount(datanodes.get(i)));
+      assertEquals(10 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(datanodes.get(i)));
+    }
 
-    // Record again - should still be 1 (idempotency via Set)
-    tracker.recordPendingAllocation(pipeline, container1);
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    // Remove all containers from every 10th DN
+    for (int dnIdx = 0; dnIdx < NUM_DATANODES; dnIdx += 10) {
+      DatanodeDetails dn = datanodes.get(dnIdx);
+      for (int cIdx = 0; cIdx < 10; cIdx++) {
+        int containerIdx = dnIdx * 10 + cIdx;
+        tracker.removePendingAllocation(dn, containers.get(containerIdx));
+      }
+    }
 
-    // Add different container
-    tracker.recordPendingAllocation(pipeline, container2);
-    assertEquals(2, tracker.getPendingContainers(dn1).size());
+    // Every 10th DN should have 0 pending
+    for (int i = 0; i < NUM_DATANODES; i += 10) {
+      assertEquals(0, tracker.getPendingContainerCount(datanodes.get(i)));
+    }
 
-    // Record container1 again
-    tracker.recordPendingAllocation(pipeline, container1);
-    assertEquals(2, tracker.getPendingContainers(dn1).size());
+    // Other DNs should still have 10 pending
+    assertEquals(10, tracker.getPendingContainerCount(datanodes.get(1)));
+    assertEquals(10, tracker.getPendingContainerCount(datanodes.get(15)));
+    assertEquals(10, tracker.getPendingContainerCount(datanodes.get(999)));
   }
 
   @Test
-  public void testExplicitRemoval() {
+  public void testIdempotentRecording() {
+    // Allocate same 100 containers multiple times to first 100 DNs
+    DatanodeDetails dn = datanodes.get(0);
 
-    tracker.recordPendingAllocation(pipeline, container1);
-    tracker.recordPendingAllocation(pipeline, container2);
-    tracker.recordPendingAllocation(pipeline, container3);
+    for (int round = 0; round < 5; round++) {
+      for (int i = 0; i < 100; i++) {
+        tracker.recordPendingAllocationForDatanode(dn, containers.get(i));
+      }
+    }
 
-    assertEquals(3, tracker.getPendingContainers(dn1).size());
-
-    // Simulate container report confirms container1 and container2
-    tracker.removePendingAllocation(dn1, container1);
-    tracker.removePendingAllocation(dn1, container2);
-
-    // Immediately reflects the removal (doesn't wait for aging)
-    assertEquals(1, tracker.getPendingContainers(dn1).size());
-
-    Set<ContainerID> pending = tracker.getPendingContainers(dn1);
-    assertEquals(1, pending.size());
-    assertThat(pending).contains(container3);
+    // Should still only have 100 containers
+    assertEquals(100, tracker.getPendingContainerCount(dn));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -96,7 +96,8 @@ public class TestPendingContainerTracker {
     // Each of the first 100 DNs should have 1 pending container
     for (int i = 0; i < 100; i++) {
       assertEquals(1, tracker.getPendingContainerCount(datanodes.get(i)));
-      assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(datanodes.get(i)));
+      assertEquals(MAX_CONTAINER_SIZE,
+          tracker.getPendingContainerCount(datanodes.get(i)) * MAX_CONTAINER_SIZE);
     }
 
     // DNs beyond index 100 should have 0 pending
@@ -153,7 +154,7 @@ public class TestPendingContainerTracker {
     Thread.sleep(rollMs + 80);
     shortRollTracker.rollWindowsIfNeeded(dn1);
     assertEquals(0, shortRollTracker.getPendingContainerCount(dn1));
-    assertEquals(0L, shortRollTracker.getPendingAllocationSize(dn1));
+    assertEquals(0L, shortRollTracker.getPendingContainerCount(dn1) * MAX_CONTAINER_SIZE);
   }
 
   @Test
@@ -252,7 +253,7 @@ public class TestPendingContainerTracker {
     }
 
     assertEquals(1000, tracker.getPendingContainerCount(dn));
-    assertEquals(1000 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn));
+    assertEquals(1000 * MAX_CONTAINER_SIZE, tracker.getPendingContainerCount(dn) * MAX_CONTAINER_SIZE);
 
     // Verify specific containers are present
     assertTrue(tracker.containsPendingContainer(dn, containers.get(0)));
@@ -283,7 +284,8 @@ public class TestPendingContainerTracker {
     // Each DN should have 10 pending containers
     for (int i = 0; i < NUM_DATANODES; i++) {
       assertEquals(10, tracker.getPendingContainerCount(datanodes.get(i)));
-      assertEquals(10 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(datanodes.get(i)));
+      assertEquals(10 * MAX_CONTAINER_SIZE,
+          tracker.getPendingContainerCount(datanodes.get(i)) * MAX_CONTAINER_SIZE);
     }
 
     // Remove all containers from every 10th DN
@@ -333,7 +335,7 @@ public class TestPendingContainerTracker {
     DatanodeInfo dnInfo = new DatanodeInfo(dn, NodeStatus.inServiceHealthy(), null);
     dnInfo.updateStorageReports(reports);
 
-    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo));
   }
 
   @Test
@@ -353,11 +355,11 @@ public class TestPendingContainerTracker {
     dnInfo.updateStorageReports(reports);
     // Remaining space available for 1 container across all the volume after 2 container allocation
 
-    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo));
 
     tracker.recordPendingAllocationForDatanode(dn, containers.get(2));
     // Remaining space available for 0 container across all the volume
-    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo));
   }
 
   @Test
@@ -372,11 +374,11 @@ public class TestPendingContainerTracker {
     dnInfo.updateStorageReports(reports);
     // Remaining space available for 1 container across all the volume considering committed bytes
 
-    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo));
     tracker.recordPendingAllocationForDatanode(dn, containers.get(0));
     // Remaining space available for 0 container across all the volume considering
     // committed bytes and container allocation
-    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo));
   }
 
   private StorageReportProto createStorageReport(DatanodeDetails dn, long capacity, long remaining, long committed) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.node;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.util.Set;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests for PendingContainerTracker.
+ */
+public class TestPendingContainerTracker {
+
+  private static final long MAX_CONTAINER_SIZE = 5L * 1024 * 1024 * 1024; // 5GB
+
+  private PendingContainerTracker tracker;
+  private Pipeline pipeline;
+  private DatanodeDetails dn1;
+  private DatanodeDetails dn2;
+  private DatanodeDetails dn3;
+  private ContainerID container1;
+  private ContainerID container2;
+  private ContainerID container3;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    tracker = new PendingContainerTracker(MAX_CONTAINER_SIZE);
+
+    // Create a 3-node Ratis pipeline
+    pipeline = MockPipeline.createPipeline(3);
+    dn1 = pipeline.getNodes().get(0);
+    dn2 = pipeline.getNodes().get(1);
+    dn3 = pipeline.getNodes().get(2);
+
+    container1 = ContainerID.valueOf(1L);
+    container2 = ContainerID.valueOf(2L);
+    container3 = ContainerID.valueOf(3L);
+  }
+
+  @Test
+  public void testRecordPendingAllocation() {
+    // Initially no pending containers
+    assertEquals(0, tracker.getPendingContainers(dn1).size());
+    assertEquals(0, tracker.getPendingAllocationSize(dn1));
+
+    // Record a pending allocation
+    tracker.recordPendingAllocation(pipeline, container1);
+
+    // All 3 DNs should have the container pending
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    assertEquals(1, tracker.getPendingContainers(dn2).size());
+    assertEquals(1, tracker.getPendingContainers(dn3).size());
+
+    // Size should be MAX_CONTAINER_SIZE for each DN
+    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn2));
+    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn3));
+  }
+
+  @Test
+  public void testRecordMultiplePendingAllocations() {
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+    tracker.recordPendingAllocation(pipeline, container3);
+
+    // Each DN should have 3 pending containers
+    assertEquals(3, tracker.getPendingContainers(dn1).size());
+    assertEquals(3, tracker.getPendingContainers(dn2).size());
+    assertEquals(3, tracker.getPendingContainers(dn3).size());
+
+    // Size should be 3 × MAX_CONTAINER_SIZE
+    assertEquals(3 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+  }
+
+  @Test
+  public void testIdempotentRecording() {
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container1); // Duplicate
+
+    // Should still be 1 container (Set deduplication)
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+  }
+
+  /**
+   * After one roll interval, pending entries move from currentWindow to previousWindow and remain
+   * visible. After a second roll (2× interval total), the old previousWindow is discarded and the
+   * container ages out if not confirmed.
+   */
+  @Test
+  @Timeout(30)
+  public void testTwoWindowRollAgesOutContainerAfterTwoIntervals() throws InterruptedException {
+    long rollMs = 200L;
+    PendingContainerTracker shortRollTracker =
+        new PendingContainerTracker(MAX_CONTAINER_SIZE, rollMs, null);
+
+    shortRollTracker.recordPendingAllocationForDatanode(dn1, container1);
+    Set<ContainerID> pendingDn1 = shortRollTracker.getPendingContainers(dn1);
+    assertEquals(1, pendingDn1.size());
+    assertThat(pendingDn1).containsExactly(container1);
+
+    // First roll: C1 moves from currentWindow to previousWindow; union still includes C1
+    Thread.sleep(rollMs + 80);
+    shortRollTracker.rollWindowsIfNeeded(dn1);
+    pendingDn1 = shortRollTracker.getPendingContainers(dn1);
+    assertEquals(1, pendingDn1.size());
+    assertThat(pendingDn1).containsExactly(container1);
+
+    // Second roll: prior previousWindow (holding C1) is dropped; C1 is no longer pending
+    Thread.sleep(rollMs + 80);
+    shortRollTracker.rollWindowsIfNeeded(dn1);
+    assertEquals(0, shortRollTracker.getPendingContainers(dn1).size());
+    assertEquals(0L, shortRollTracker.getPendingAllocationSize(dn1));
+  }
+
+  @Test
+  public void testRemovePendingAllocation() {
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+
+    assertEquals(2, tracker.getPendingContainers(dn1).size());
+
+    // Remove one container from DN1
+    tracker.removePendingAllocation(dn1, container1);
+
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    assertEquals(MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+
+    // DN2 and DN3 should still have both containers
+    assertEquals(2, tracker.getPendingContainers(dn2).size());
+    assertEquals(2, tracker.getPendingContainers(dn3).size());
+  }
+
+  @Test
+  public void testRemovePendingAllocationFromPipeline() {
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+
+    // Remove container1 from all nodes in pipeline
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      tracker.removePendingAllocation(dn, container1);
+    }
+
+    // All DNs should have only container2 remaining
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    assertEquals(1, tracker.getPendingContainers(dn2).size());
+    assertEquals(1, tracker.getPendingContainers(dn3).size());
+  }
+
+  @Test
+  public void testRemoveNonExistentContainer() {
+    tracker.recordPendingAllocation(pipeline, container1);
+
+    // Remove a container that was never added - should not throw exception
+    tracker.removePendingAllocation(dn1, container2);
+
+    // DN1 should still have container1
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+  }
+
+  @Test
+  public void testGetPendingContainers() {
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+
+    Set<ContainerID> pending = tracker.getPendingContainers(dn1);
+
+    assertEquals(2, pending.size());
+    assertThat(pending).contains(container1);
+    assertThat(pending).contains(container2);
+
+    // Returned set should be a copy - modifying it shouldn't affect tracker
+    pending.add(container3);
+    assertEquals(2, tracker.getPendingContainers(dn1).size()); // Should still be 2
+  }
+
+  @Test
+  public void testGetPendingContainersForNonExistentDN() {
+    DatanodeDetails unknownDN = MockDatanodeDetails.randomDatanodeDetails();
+
+    Set<ContainerID> pending = tracker.getPendingContainers(unknownDN);
+
+    assertThat(pending).isEmpty();
+  }
+
+  @Test
+  public void testGetTotalPendingCount() {
+    assertEquals(0, tracker.getTotalPendingCount());
+
+    tracker.recordPendingAllocation(pipeline, container1);
+
+    // 1 container × 3 DNs = 3 total pending
+    assertEquals(3, tracker.getTotalPendingCount());
+
+    tracker.recordPendingAllocation(pipeline, container2);
+
+    // 2 containers × 3 DNs = 6 total pending
+    assertEquals(6, tracker.getTotalPendingCount());
+
+    // Remove from one DN
+    tracker.removePendingAllocation(dn1, container1);
+
+    // (2 containers × 2 DNs) + (1 container × 1 DN) = 5 total
+    assertEquals(5, tracker.getTotalPendingCount());
+  }
+
+  @Test
+  public void testConcurrentModification() throws InterruptedException {
+    // Test thread-safety by having multiple threads add/remove containers
+    final int numThreads = 10;
+    final int operationsPerThread = 100;
+
+    Thread[] threads = new Thread[numThreads];
+
+    for (int i = 0; i < numThreads; i++) {
+      final int threadId = i;
+      threads[i] = new Thread(() -> {
+        for (int j = 0; j < operationsPerThread; j++) {
+          ContainerID cid = ContainerID.valueOf(threadId * 1000L + j);
+          tracker.recordPendingAllocation(pipeline, cid);
+
+          if (j % 2 == 0) {
+            tracker.removePendingAllocation(dn1, cid);
+          }
+        }
+      });
+    }
+
+    // Start all threads
+    for (Thread thread : threads) {
+      thread.start();
+    }
+
+    // Wait for all to finish
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // Verify no exceptions occurred and counts are reasonable
+    assertThat(tracker.getTotalPendingCount()).isGreaterThanOrEqualTo(0);
+    assertThat(tracker.getDataNodeCount()).isLessThanOrEqualTo(3);
+  }
+
+  @Test
+  public void testMemoryCleanupOnEmptySet() {
+    tracker.recordPendingAllocation(pipeline, container1);
+
+    assertEquals(3, tracker.getDataNodeCount());
+
+    // Remove the only pending container from DN1
+    tracker.removePendingAllocation(dn1, container1);
+
+    // DN1 should be removed from the map (memory cleanup)
+    assertEquals(2, tracker.getDataNodeCount());
+  }
+
+  @Test
+  public void testPendingContainer() {
+    // Simulate allocation and confirmation flow
+
+    // Allocate 3 containers
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+    tracker.recordPendingAllocation(pipeline, container3);
+
+    // Each DN should have 3 pending, 15GB total
+    assertEquals(3, tracker.getPendingContainers(dn1).size());
+    assertEquals(3 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+
+    // DN1 confirms container1 via container report
+    tracker.removePendingAllocation(dn1, container1);
+
+    // DN1 now has 2 pending, 10GB
+    assertEquals(2, tracker.getPendingContainers(dn1).size());
+    assertEquals(2 * MAX_CONTAINER_SIZE, tracker.getPendingAllocationSize(dn1));
+
+    // DN2 and DN3 still have 3 pending
+    assertEquals(3, tracker.getPendingContainers(dn2).size());
+    assertEquals(3, tracker.getPendingContainers(dn3).size());
+
+    // All DNs eventually confirm all containers
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      tracker.removePendingAllocation(dn, container1);
+      tracker.removePendingAllocation(dn, container2);
+      tracker.removePendingAllocation(dn, container3);
+    }
+
+    // All DNs should have 0 pending
+    assertEquals(0, tracker.getPendingContainers(dn1).size());
+    assertEquals(0, tracker.getPendingContainers(dn2).size());
+    assertEquals(0, tracker.getPendingContainers(dn3).size());
+    assertEquals(0, tracker.getTotalPendingCount());
+    assertEquals(0, tracker.getDataNodeCount());
+  }
+
+  @Test
+  public void testRemoveFromBothWindows() {
+    // This test verifies that removal works from both current and previous windows
+    // In general, a container could be in previous window after a roll
+
+    // Add containers
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+
+    assertEquals(2, tracker.getPendingContainers(dn1).size());
+
+    // Remove container1 - should work regardless of which window it's in
+    tracker.removePendingAllocation(dn1, container1);
+
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+
+    Set<ContainerID> pending = tracker.getPendingContainers(dn1);
+    assertFalse(pending.contains(container1));
+    assertThat(pending).contains(container2);
+  }
+
+  @Test
+  public void testUnionOfBothWindows() {
+    // This test verifies the two-window concept:
+    // getPendingContainers should return union of current + previous windows
+
+    // Add container1
+    tracker.recordPendingAllocation(pipeline, container1);
+
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+    Set<ContainerID> pending1 = tracker.getPendingContainers(dn1);
+    assertThat(pending1).contains(container1);
+
+    // Add container2 - should be in same window initially
+    tracker.recordPendingAllocation(pipeline, container2);
+
+    assertEquals(2, tracker.getPendingContainers(dn1).size());
+    Set<ContainerID> pending2 = tracker.getPendingContainers(dn1);
+    assertThat(pending2).contains(container1);
+    assertThat(pending2).contains(container2);
+
+    // Both containers should be in the union
+    assertEquals(2, pending2.size());
+  }
+
+  @Test
+  public void testIdempotencyAcrossWindows() {
+    // Recording same container multiple times should only count it once
+    // This should work even if it spans windows
+
+    tracker.recordPendingAllocation(pipeline, container1);
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+
+    // Record again - should still be 1 (idempotency via Set)
+    tracker.recordPendingAllocation(pipeline, container1);
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+
+    // Add different container
+    tracker.recordPendingAllocation(pipeline, container2);
+    assertEquals(2, tracker.getPendingContainers(dn1).size());
+
+    // Record container1 again
+    tracker.recordPendingAllocation(pipeline, container1);
+    assertEquals(2, tracker.getPendingContainers(dn1).size());
+  }
+
+  @Test
+  public void testExplicitRemoval() {
+
+    tracker.recordPendingAllocation(pipeline, container1);
+    tracker.recordPendingAllocation(pipeline, container2);
+    tracker.recordPendingAllocation(pipeline, container3);
+
+    assertEquals(3, tracker.getPendingContainers(dn1).size());
+
+    // Simulate container report confirms container1 and container2
+    tracker.removePendingAllocation(dn1, container1);
+    tracker.removePendingAllocation(dn1, container2);
+
+    // Immediately reflects the removal (doesn't wait for aging)
+    assertEquals(1, tracker.getPendingContainers(dn1).size());
+
+    Set<ContainerID> pending = tracker.getPendingContainers(dn1);
+    assertEquals(1, pending.size());
+    assertThat(pending).contains(container3);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -317,5 +319,67 @@ public class TestPendingContainerTracker {
 
     // Should still only have 100 containers
     assertEquals(100, tracker.getPendingContainerCount(dn));
+  }
+
+  @Test
+  public void testMultiVolumeAccumulatedSpaceIsNotEnough() {
+    DatanodeDetails dn = datanodes.get(0);
+    long containerSize = MAX_CONTAINER_SIZE;
+    
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dn, 100 * containerSize, containerSize / 4, 0));
+    reports.add(createStorageReport(dn, 100 * containerSize, containerSize / 4, 0));
+    reports.add(createStorageReport(dn, 100 * containerSize, containerSize / 2, 0));
+    DatanodeInfo dnInfo = new DatanodeInfo(dn, NodeStatus.inServiceHealthy(), null);
+    dnInfo.updateStorageReports(reports);
+
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+  }
+
+  @Test
+  public void testMultiVolumeWithPendingAllocation() {
+    DatanodeDetails dn = datanodes.get(0);
+    long containerSize = MAX_CONTAINER_SIZE;
+
+    // Remaining space available for 3 containers across all the volumes
+    tracker.recordPendingAllocationForDatanode(dn, containers.get(0));
+    tracker.recordPendingAllocationForDatanode(dn, containers.get(1));
+
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dn, 100 * containerSize, containerSize, 0));
+    reports.add(createStorageReport(dn, 50 * containerSize, containerSize, 0));
+    reports.add(createStorageReport(dn, 100 * containerSize, containerSize, 0));
+    DatanodeInfo dnInfo = new DatanodeInfo(dn, NodeStatus.inServiceHealthy(), null);
+    dnInfo.updateStorageReports(reports);
+    // Remaining space available for 1 container across all the volume after 2 container allocation
+
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+
+    tracker.recordPendingAllocationForDatanode(dn, containers.get(2));
+    // Remaining space available for 0 container across all the volume
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+  }
+
+  @Test
+  public void testMultiVolumeWithCommittedBytes() {
+    DatanodeDetails dn = datanodes.get(0);
+    long containerSize = MAX_CONTAINER_SIZE;
+    
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dn, 100 * containerSize, 6 * containerSize, 5 * containerSize));
+    reports.add(createStorageReport(dn, 50 * containerSize, 3 * containerSize, 3 * containerSize));
+    DatanodeInfo dnInfo = new DatanodeInfo(dn, NodeStatus.inServiceHealthy(), null);
+    dnInfo.updateStorageReports(reports);
+    // Remaining space available for 1 container across all the volume considering committed bytes
+
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+    tracker.recordPendingAllocationForDatanode(dn, containers.get(0));
+    // Remaining space available for 0 container across all the volume considering
+    // committed bytes and container allocation
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dn, dnInfo, containerSize));
+  }
+
+  private StorageReportProto createStorageReport(DatanodeDetails dn, long capacity, long remaining, long committed) {
+    return HddsTestUtils.createStorageReports(dn.getID(), capacity, remaining, committed).get(0);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce PendingContainerTracker in SCM to track container allocations that are issued but not yet fully realized on DataNodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15024

## How was this patch tested?

Unit test
