### PR TITLE
HDDS-13803. Client aware tracing

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -414,7 +414,7 @@ public class OzoneConfiguration extends Configuration implements MutableConfigur
         new DeprecationDelta("hdds.recon.heartbeat.interval",
             HddsConfigKeys.HDDS_RECON_HEARTBEAT_INTERVAL),
         new DeprecationDelta("hdds.tracing.enabled",
-            "ozone.tracing.enabled"),
+            "ozone.tracing.mode"),
     });
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
@@ -79,6 +79,22 @@ public class TracingConfig extends ReconfigurableConfig {
   )
   private String spanSampling;
 
+  @Config(
+      key = "ozone.tracing.client.application-aware",
+      defaultValue = "true",
+      type = ConfigType.BOOLEAN,
+      reconfigurable = true,
+      tags = { ConfigTag.OZONE, ConfigTag.HDDS },
+      description = "When true and Ozone's own tracing is disabled, the client may still "
+          + "emit child spans using the application's OpenTelemetry (GlobalOpenTelemetry) "
+          + "when an active span exists in Context."
+  )
+  private boolean clientApplicationAware;
+
+  public boolean isClientApplicationAware() {
+    return clientApplicationAware;
+  }
+
   public boolean isTracingEnabled() {
     return tracingEnabled;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
@@ -39,25 +39,6 @@ public class TracingConfig extends ReconfigurableConfig {
   private static final String OTEL_TRACES_SAMPLER_ARG = "OTEL_TRACES_SAMPLER_ARG";
   private static final String OTEL_SPAN_SAMPLING_ARG = "OTEL_SPAN_SAMPLING_ARG";
 
-  /**
-   * Tracing configuration in ozone.
-   */
-  public enum TracingMode {
-    /** No Ozone tracer; do not create spans from application context. */
-    TRACING_OFF,
-    /** No Ozone tracer; may create child spans under an application trace. */
-    TRACING_CLIENT,
-    /** Ozone initializes its OTLP tracer and exports spans (subject to sampling). */
-    TRACING_OZONE;
-
-    static TracingMode fromConfig(String raw) {
-      if (raw == null || raw.isEmpty()) {
-        return TRACING_CLIENT;
-      }
-      return valueOf(raw.trim().toUpperCase(java.util.Locale.ROOT));
-    }
-  }
-
   @Config(
       key = "ozone.tracing.mode",
       defaultValue = "TRACING_CLIENT",
@@ -102,6 +83,25 @@ public class TracingConfig extends ReconfigurableConfig {
       description = "Optional per-span sampling: comma-separated spanName:rate entries."
   )
   private String spanSampling;
+
+  /**
+   * Tracing configuration in ozone.
+   */
+  public enum TracingMode {
+    /** No Ozone tracer; do not create spans from application context. */
+    TRACING_OFF,
+    /** No Ozone tracer; may create child spans under an application trace. */
+    TRACING_CLIENT,
+    /** Ozone initializes its OTLP tracer and exports spans (subject to sampling). */
+    TRACING_OZONE;
+
+    static TracingMode fromConfig(String raw) {
+      if (raw == null || raw.isEmpty()) {
+        return TRACING_CLIENT;
+      }
+      return valueOf(raw.trim().toUpperCase(java.util.Locale.ROOT));
+    }
+  }
 
   public boolean isClientApplicationAware() {
     return tracingMode != TracingMode.TRACING_OFF;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
@@ -39,17 +39,39 @@ public class TracingConfig extends ReconfigurableConfig {
   private static final String OTEL_TRACES_SAMPLER_ARG = "OTEL_TRACES_SAMPLER_ARG";
   private static final String OTEL_SPAN_SAMPLING_ARG = "OTEL_SPAN_SAMPLING_ARG";
 
+  /**
+   * Tracing configuration in ozone.
+   */
+  public enum TracingMode {
+    /** No Ozone tracer; do not create spans from application context. */
+    TRACING_OFF,
+    /** No Ozone tracer; may create child spans under an application trace. */
+    TRACING_CLIENT,
+    /** Ozone initializes its OTLP tracer and exports spans (subject to sampling). */
+    TRACING_OZONE;
+
+    static TracingMode fromConfig(String raw) {
+      if (raw == null || raw.isEmpty()) {
+        return TRACING_CLIENT;
+      }
+      return valueOf(raw.trim().toUpperCase(java.util.Locale.ROOT));
+    }
+  }
+
   @Config(
-      key = "ozone.tracing.enabled",
-      defaultValue = "false",
-      type = ConfigType.BOOLEAN,
+      key = "ozone.tracing.mode",
+      defaultValue = "TRACING_CLIENT",
+      type = ConfigType.STRING,
       reconfigurable = true,
       tags = { ConfigTag.OZONE, ConfigTag.HDDS },
-      description = "If true, Ozone initializes its own tracer and exports spans (subject to sampling). "
-          + "If false, the Ozone client does not use that tracer; optional child spans under an "
-          + "application trace are controlled by ozone.tracing.client.application-aware."
+      description = "Tracing modes: " +
+          "TRACING_OZONE: Ozone's internal tracer is used to export spans to OTLP. " +
+          "TRACING_CLIENT: If context is present then The application's tracer is used to create child spans. " +
+          "TRACING_OFF: no tracing."
   )
-  private boolean tracingEnabled;
+  private String tracingModeRaw;
+
+  private TracingMode tracingMode = TracingMode.TRACING_CLIENT;
 
   @Config(
       key = "ozone.tracing.endpoint",
@@ -81,30 +103,34 @@ public class TracingConfig extends ReconfigurableConfig {
   )
   private String spanSampling;
 
-  @Config(
-      key = "ozone.tracing.client.application-aware",
-      defaultValue = "true",
-      type = ConfigType.BOOLEAN,
-      reconfigurable = true,
-      tags = { ConfigTag.OZONE, ConfigTag.HDDS },
-      description = "This is used when ozone.tracing.enabled is false. If true and "
-      + "an active span exists in the current OpenTelemetry Context (application "
-      + "GlobalOpenTelemetry), the client may create child spans under that trace. If no "
-      + "active span exists, no spans are created. If false, no spans are created regardless "
-      + "of application context."
-  )
-  private boolean clientApplicationAware;
-
   public boolean isClientApplicationAware() {
-    return clientApplicationAware;
+    return tracingMode != TracingMode.TRACING_OFF;
   }
 
   public boolean isTracingEnabled() {
-    return tracingEnabled;
+    return tracingMode == TracingMode.TRACING_OZONE;
+  }
+
+  private static TracingMode resolveTracingMode(String value) {
+    if (value == null || value.isEmpty()) {
+      return TracingMode.TRACING_CLIENT;
+    }
+    if (TracingMode.TRACING_OFF.name().equals(value)) {
+      return TracingMode.TRACING_OFF;
+    }
+    if (TracingMode.TRACING_CLIENT.name().equals(value)) {
+      return TracingMode.TRACING_CLIENT;
+    }
+    if (TracingMode.TRACING_OZONE.name().equals(value)) {
+      return TracingMode.TRACING_OZONE;
+    }
+    return TracingMode.TRACING_CLIENT;
   }
 
   @PostConstruct
   public void validate() {
+    tracingMode = resolveTracingMode(tracingModeRaw);
+
     if (tracingEndpoint.isEmpty()) {
       tracingEndpoint = System.getenv(OTEL_EXPORTER_OTLP_ENDPOINT);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
@@ -45,7 +45,9 @@ public class TracingConfig extends ReconfigurableConfig {
       type = ConfigType.BOOLEAN,
       reconfigurable = true,
       tags = { ConfigTag.OZONE, ConfigTag.HDDS },
-      description = "If true, tracing is initialized and spans may be exported (subject to sampling)."
+      description = "If true, Ozone initializes its own tracer and exports spans (subject to sampling). "
+          + "If false, the Ozone client does not use that tracer; optional child spans under an "
+          + "application trace are controlled by ozone.tracing.client.application-aware."
   )
   private boolean tracingEnabled;
 
@@ -85,9 +87,11 @@ public class TracingConfig extends ReconfigurableConfig {
       type = ConfigType.BOOLEAN,
       reconfigurable = true,
       tags = { ConfigTag.OZONE, ConfigTag.HDDS },
-      description = "When true and Ozone's own tracing is disabled, the client may still "
-          + "emit child spans using the application's OpenTelemetry (GlobalOpenTelemetry) "
-          + "when an active span exists in Context."
+      description = "This is used when ozone.tracing.enabled is false. If true and "
+      + "an active span exists in the current OpenTelemetry Context (application "
+      + "GlobalOpenTelemetry), the client may create child spans under that trace. If no "
+      + "active span exists, no spans are created. If false, no spans are created regardless "
+      + "of application context."
   )
   private boolean clientApplicationAware;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.tracing;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -48,10 +49,12 @@ import org.slf4j.LoggerFactory;
 public final class TracingUtil {
   private static final Logger LOG = LoggerFactory.getLogger(TracingUtil.class);
   private static final String NULL_SPAN_AS_STRING = "";
+  private static final String OZONE_CLIENT_TRACER_SCOPE = "org.apache.hadoop.ozone.client";
 
   private static volatile boolean isInit = false;
   private static Tracer tracer = OpenTelemetry.noop().getTracer("noop");
   private static SdkTracerProvider sdkTracerProvider;
+  private static volatile TracingConfig clientTracingConfig;
 
   private TracingUtil() {
   }
@@ -61,6 +64,7 @@ public final class TracingUtil {
    */
   public static synchronized void initTracing(
       String serviceName, TracingConfig tracingConfig) {
+    clientTracingConfig = tracingConfig;
     if (!tracingConfig.isTracingEnabled() || isInit) {
       return;
     }
@@ -72,6 +76,38 @@ public final class TracingUtil {
     } catch (Exception e) {
       LOG.error("Failed to initialize tracing", e);
     }
+  }
+
+  /**
+   * When ozone tracing is off , client tracing is off and no context exist thn
+   * span creation should be skipped.
+   */
+  private static boolean shouldByPassSpanCreation() {
+    if (clientTracingConfig == null) {
+      return false;
+    }
+    //if ozone tracing is true then resolve tracer as usual and create span
+    if (clientTracingConfig.isTracingEnabled()) {
+      return false;
+    }
+    boolean hasValidContext = Span.current().getSpanContext().isValid();
+    boolean clientApplicationTracing = clientTracingConfig.isClientApplicationAware();
+
+    //if ozone tracing is false but context exists and client tracing is true then create span.
+    return !(hasValidContext && clientApplicationTracing);
+  }
+
+  /**
+   * When Ozone OTLP tracing is off but the app has an active span, use the app SDK via GlobalOpenTelemetry.
+   */
+  private static Tracer resolveTracerForNewSpan(Span parentSpan) {
+    if (clientTracingConfig != null
+        && !clientTracingConfig.isTracingEnabled()
+        && clientTracingConfig.isClientApplicationAware()
+        && parentSpan.getSpanContext().isValid()) {
+      return GlobalOpenTelemetry.get().getTracer(OZONE_CLIENT_TRACER_SCOPE);
+    }
+    return tracer;
   }
 
   /**
@@ -253,16 +289,20 @@ public final class TracingUtil {
    * If a parent span exists in the current context, this becomes a child span.
    */
   public static <E extends Exception> void executeInNewSpan(String spanName,
-      CheckedRunnable<E> runnable) throws E {
+                                                            CheckedRunnable<E> runnable) throws E {
+    if (shouldByPassSpanCreation()) {
+      runnable.run();
+      return;
+    }
     Span span = buildSpan(spanName);
     executeInSpan(span, runnable);
   }
 
-  /**
-   * Execute {@code supplier} inside an activated new span.
-   */
   public static <R, E extends Exception> R executeInNewSpan(String spanName,
-      CheckedSupplier<R, E> supplier) throws E {
+                                                            CheckedSupplier<R, E> supplier) throws E {
+    if (shouldByPassSpanCreation()) {
+      return supplier.get();
+    }
     Span span = buildSpan(spanName);
     return executeInSpan(span, supplier);
   }
@@ -317,6 +357,9 @@ public final class TracingUtil {
    * in case of Exceptions.
    */
   public static TraceCloseable createActivatedSpan(String spanName) {
+    if (shouldByPassSpanCreation()) {
+      return () -> { };
+    }
     Span span = buildSpan(spanName);
     Scope scope = span.makeCurrent();
     return () -> {
@@ -380,11 +423,11 @@ public final class TracingUtil {
   private static Span buildSpan(String spanName) {
     Context currentContext = Context.current();
     Span parentSpan = Span.fromContext(currentContext);
+    Tracer spanTracer = resolveTracerForNewSpan(parentSpan);
 
     if (parentSpan.getSpanContext().isValid()) {
-      return tracer.spanBuilder(spanName).setParent(currentContext).startSpan();
-    } else {
-      return tracer.spanBuilder(spanName).setNoParent().startSpan();
+      return spanTracer.spanBuilder(spanName).setParent(currentContext).startSpan();
     }
+    return spanTracer.spanBuilder(spanName).setNoParent().startSpan();
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -289,7 +289,7 @@ public final class TracingUtil {
    * If a parent span exists in the current context, this becomes a child span.
    */
   public static <E extends Exception> void executeInNewSpan(String spanName,
-                                                            CheckedRunnable<E> runnable) throws E {
+      CheckedRunnable<E> runnable) throws E {
     if (shouldByPassSpanCreation()) {
       runnable.run();
       return;
@@ -299,7 +299,7 @@ public final class TracingUtil {
   }
 
   public static <R, E extends Exception> R executeInNewSpan(String spanName,
-                                                            CheckedSupplier<R, E> supplier) throws E {
+      CheckedSupplier<R, E> supplier) throws E {
     if (shouldByPassSpanCreation()) {
       return supplier.get();
     }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtil.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtil.java
@@ -57,7 +57,7 @@ public class TestTracingUtil {
 
   private static MutableConfigurationSource tracingEnabled() {
     MutableConfigurationSource config = new InMemoryConfigurationForTesting();
-    config.setBoolean("ozone.tracing.enabled", true);
+    config.set("ozone.tracing.mode", TracingConfig.TracingMode.TRACING_OZONE.name());
     return config;
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtilClientApplicationAware.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtilClientApplicationAware.java
@@ -133,6 +133,7 @@ public class TestTracingUtilClientApplicationAware {
 
     Tracer appTracer = GlobalOpenTelemetry.get().getTracer("test-app");
     Span parent = appTracer.spanBuilder("parent").startSpan();
+    final String parentSpanId = parent.getSpanContext().getSpanId();
     try (Scope ignored = parent.makeCurrent()) {
       TracingUtil.executeInNewSpan("child-from-global", () ->
           assertThat(Span.current().getSpanContext().isValid()).isTrue());
@@ -146,11 +147,19 @@ public class TestTracingUtilClientApplicationAware {
             + "the child must be created with GlobalOpenTelemetry.")
         .isTrue();
 
+    // Child span must use the Ozone client scope on GlobalOpenTelemetry (not the test-app parent scope).
     assertThat(exportedSpans)
         .filteredOn(s -> "child-from-global".equals(s.getName()))
         .singleElement()
         .extracting(s -> s.getInstrumentationScopeInfo().getName())
         .isEqualTo(OZONE_CLIENT_TRACER_SCOPE);
+
+    // Child must link to the application parent span in the same trace.
+    assertThat(exportedSpans)
+        .filteredOn(s -> "child-from-global".equals(s.getName()))
+        .singleElement()
+        .extracting(SpanData::getParentSpanId)
+        .isEqualTo(parentSpanId);
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtilClientApplicationAware.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtilClientApplicationAware.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.hadoop.hdds.conf.InMemoryConfigurationForTesting;
+import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests client application-aware tracing: when Ozone OTLP tracing is off but an
+ * active span exists, spans use {@link GlobalOpenTelemetry}; otherwise the
+ * static Ozone {@link TracingUtil} tracer is used, or span creation is skipped.
+ */
+public class TestTracingUtilClientApplicationAware {
+
+  private static final String OZONE_CLIENT_TRACER_SCOPE = "org.apache.hadoop.ozone.client";
+
+  private final List<SpanData> exportedSpans = new CopyOnWriteArrayList<>();
+  private SdkTracerProvider testSdkTracerProvider;
+
+  @BeforeEach
+  public void setUp() {
+    GlobalOpenTelemetry.resetForTest();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(false, true));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (testSdkTracerProvider != null) {
+      testSdkTracerProvider.shutdown();
+      testSdkTracerProvider = null;
+    }
+    GlobalOpenTelemetry.resetForTest();
+    exportedSpans.clear();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(false, true));
+  }
+
+  private static TracingConfig clientTracingConfig(boolean tracingEnabled,
+                                                   boolean clientApplicationAware) {
+    MutableConfigurationSource conf = new InMemoryConfigurationForTesting();
+    conf.setBoolean("ozone.tracing.enabled", tracingEnabled);
+    conf.setBoolean("ozone.tracing.client.application-aware", clientApplicationAware);
+    return conf.getObject(TracingConfig.class);
+  }
+
+  /**
+   * Registers a global SDK that records ended spans into {@link #exportedSpans}.
+   */
+  private void registerGlobalTestSdk() {
+    SpanExporter exporter = new SpanExporter() {
+      @Override
+      public CompletableResultCode export(Collection<SpanData> spans) {
+        exportedSpans.addAll(spans);
+        return CompletableResultCode.ofSuccess();
+      }
+
+      @Override
+      public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+      }
+
+      @Override
+      public CompletableResultCode shutdown() {
+        return CompletableResultCode.ofSuccess();
+      }
+    };
+    testSdkTracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build();
+    GlobalOpenTelemetry.set(
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(testSdkTracerProvider)
+            .build());
+  }
+
+  private boolean hasExportedSpanNamed(String name) {
+    return exportedSpans.stream().anyMatch(s -> name.equals(s.getName()));
+  }
+
+  @Test
+  public void testOzoneTracingOnUsesStaticTracerNotGlobalOpenTelemetry() throws Exception {
+    registerGlobalTestSdk();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(true, true));
+
+    TracingUtil.executeInNewSpan("ozone-client-span", () -> {
+      assertThat(Span.current().getSpanContext().isValid()).isTrue();
+    });
+
+    assertThat(hasExportedSpanNamed("ozone-client-span"))
+        .withFailMessage("When Ozone client tracing is on, spans must use the Ozone SDK tracer, "
+            + "not GlobalOpenTelemetry, so the test global exporter must not see them.")
+        .isFalse();
+  }
+
+  @Test
+  public void testOzoneTracingOffWithAppAwareAndParentUsesGlobalTracer() throws Exception {
+    registerGlobalTestSdk();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(false, true));
+
+    Tracer appTracer = GlobalOpenTelemetry.get().getTracer("test-app");
+    Span parent = appTracer.spanBuilder("parent").startSpan();
+    try (Scope ignored = parent.makeCurrent()) {
+      TracingUtil.executeInNewSpan("child-from-global", () ->
+          assertThat(Span.current().getSpanContext().isValid()).isTrue());
+    } finally {
+      parent.end();
+    }
+    testSdkTracerProvider.forceFlush();
+
+    assertThat(hasExportedSpanNamed("child-from-global"))
+        .withFailMessage("With Ozone tracing off, client application-aware on, and a valid parent span, "
+            + "the child must be created with GlobalOpenTelemetry.")
+        .isTrue();
+
+    assertThat(exportedSpans)
+        .filteredOn(s -> "child-from-global".equals(s.getName()))
+        .singleElement()
+        .extracting(s -> s.getInstrumentationScopeInfo().getName())
+        .isEqualTo(OZONE_CLIENT_TRACER_SCOPE);
+  }
+
+  @Test
+  public void testOzoneTracingOffApplicationAwareFalseSkipsSpan() throws Exception {
+    registerGlobalTestSdk();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(false, false));
+
+    Tracer appTracer = GlobalOpenTelemetry.get().getTracer("test-app");
+    Span parent = appTracer.spanBuilder("parent").startSpan();
+    try (Scope ignored = parent.makeCurrent()) {
+      TracingUtil.executeInNewSpan("should-not-exist", () -> {
+        assertEquals(
+            parent.getSpanContext(),
+            Span.current().getSpanContext(),
+            "When application-aware is false, TracingUtil should not create a child span; "
+                + "the active span should remain the application parent.");
+      });
+    } finally {
+      parent.end();
+    }
+    testSdkTracerProvider.forceFlush();
+
+    assertThat(hasExportedSpanNamed("should-not-exist")).isFalse();
+  }
+
+  @Test
+  public void testOzoneTracingOffNoParentContextSkipsSpan() throws Exception {
+    registerGlobalTestSdk();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(false, true));
+
+    TracingUtil.executeInNewSpan("no-parent-bypass", () ->
+        assertThat(Span.current().getSpanContext().isValid())
+            .withFailMessage("Without a valid parent, span creation should be bypassed.")
+            .isFalse());
+    testSdkTracerProvider.forceFlush();
+
+    assertThat(hasExportedSpanNamed("no-parent-bypass")).isFalse();
+  }
+
+  @Test
+  public void testCreateActivatedSpanBypassWhenConditionsNotMet() throws Exception {
+    registerGlobalTestSdk();
+    TracingUtil.reconfigureTracing("client", clientTracingConfig(false, false));
+
+    try (TracingUtil.TraceCloseable closeable =
+             TracingUtil.createActivatedSpan("activated-bypass")) {
+      assertNotNull(closeable);
+    }
+    if (testSdkTracerProvider != null) {
+      testSdkTracerProvider.forceFlush();
+    }
+    assertThat(hasExportedSpanNamed("activated-bypass")).isFalse();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtilClientApplicationAware.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtilClientApplicationAware.java
@@ -71,9 +71,17 @@ public class TestTracingUtilClientApplicationAware {
 
   private static TracingConfig clientTracingConfig(boolean tracingEnabled,
                                                    boolean clientApplicationAware) {
+    TracingConfig.TracingMode mode;
+    if (tracingEnabled) {
+      mode = TracingConfig.TracingMode.TRACING_OZONE;
+    } else if (clientApplicationAware) {
+      mode = TracingConfig.TracingMode.TRACING_CLIENT;
+    } else {
+      mode = TracingConfig.TracingMode.TRACING_OFF;
+    }
+
     MutableConfigurationSource conf = new InMemoryConfigurationForTesting();
-    conf.setBoolean("ozone.tracing.enabled", tracingEnabled);
-    conf.setBoolean("ozone.tracing.client.application-aware", clientApplicationAware);
+    conf.set("ozone.tracing.mode", mode.name());
     return conf.getObject(TracingConfig.class);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Ozone client needs the flexibility to either initiate a new span or continue an existing application-level trace by creating a child span. Currently, if ozone.tracing.enabled is false, all tracing is suppressed. A specific scenario arises when the Ozone client should only trace if it's explicitly enabled to continue an application's existing trace.

* **When `ozone.tracing.enabled` is True:**
    * The client uses the standard Ozone-initialized tracer (existing behavior).
* **When `ozone.tracing.enabled` is False:**
    * **If `application-aware` is True and an active span exists:** The client will create child spans using the application’s `GlobalOpenTelemetry` context. This allows Ozone operations to appear as children of the application's spans.
    * **If no active span exists:** No spans are created (standalone tracing remains off).
    * **If `application-aware` is False:** No spans are created regardless of the application context.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13803

## How was this patch tested?
Written unit tests and existing tests.