### PR TITLE
HDDS-14974. Change SCMStateMachine to use ScmInvoker

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -169,6 +170,9 @@ public final class SCMHAManagerStub implements SCMHAManager {
     private Map<RequestType, Object> handlers =
         new EnumMap<>(RequestType.class);
 
+    private Map<RequestType, ScmInvoker<?>> invokers =
+        new EnumMap<>(RequestType.class);
+
     private RaftPeerId leaderId = RaftPeerId.valueOf(UUID.randomUUID().toString());
 
     @Override
@@ -178,7 +182,11 @@ public final class SCMHAManagerStub implements SCMHAManager {
     @Override
     public void registerStateMachineHandler(final RequestType handlerType,
         final Object handler) {
-      handlers.put(handlerType, handler);
+      if (handler instanceof ScmInvoker) {
+        invokers.put(handlerType, (ScmInvoker<?>) handler);
+      } else {
+        handlers.put(handlerType, handler);
+      }
     }
 
     @Override
@@ -216,6 +224,10 @@ public final class SCMHAManagerStub implements SCMHAManager {
     }
 
     private Message process(final SCMRatisRequest request) throws Exception {
+      final ScmInvoker<?> invoker = invokers.get(request.getType());
+      if (invoker != null) {
+        return invoker.invokeLocal(request.getOperation(), request.getArguments());
+      }
       return SCMStateMachine.process(request, handlers.get(request.getType()));
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
@@ -73,7 +73,7 @@ public interface SCMRatisServer {
   RaftPeerId getLeaderId();
 
   default <T extends SCMHandler> T getProxyHandler(ScmInvoker<T> invoker) {
-    registerStateMachineHandler(invoker.getType(), invoker.getImpl());
+    registerStateMachineHandler(invoker.getType(), invoker);
     return invoker.getProxy();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -226,8 +226,9 @@ public class SCMRatisServerImpl implements SCMRatisServer {
                                           final Object handler) {
     if (handler instanceof ScmInvoker) {
       stateMachine.registerInvoker(handlerType, (ScmInvoker) handler);
+    } else {
+      stateMachine.registerHandler(handlerType, handler);
     }
-    stateMachine.registerHandler(handlerType, handler);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvoker;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -223,6 +224,9 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   @Override
   public void registerStateMachineHandler(final RequestType handlerType,
                                           final Object handler) {
+    if (handler instanceof ScmInvoker) {
+      stateMachine.registerInvoker(handlerType, (ScmInvoker) handler);
+    }
     stateMachine.registerHandler(handlerType, handler);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvoker;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
@@ -77,6 +78,7 @@ public class SCMStateMachine extends BaseStateMachine {
 
   private StorageContainerManager scm;
   private Map<RequestType, Object> handlers;
+  private Map<RequestType,  ScmInvoker<?>> invokers;
   private SCMHADBTransactionBuffer transactionBuffer;
   private final SimpleStateMachineStorage storage =
       new SimpleStateMachineStorage();
@@ -93,6 +95,7 @@ public class SCMStateMachine extends BaseStateMachine {
       SCMHADBTransactionBuffer buffer) {
     this.scm = scm;
     this.handlers = new EnumMap<>(RequestType.class);
+    this.invokers = new EnumMap<>(RequestType.class);
     this.transactionBuffer = buffer;
     TransactionInfo latestTrxInfo = this.transactionBuffer.getLatestTrxInfo();
     if (!latestTrxInfo.isDefault()) {
@@ -115,6 +118,11 @@ public class SCMStateMachine extends BaseStateMachine {
 
   public void registerHandler(RequestType type, Object handler) {
     handlers.put(type, handler);
+  }
+
+  public void registerStateMachineInvoker(RequestType type,
+      ScmInvoker<?> invoker) {
+    invokers.put(type, invoker);
   }
 
   @Override
@@ -179,6 +187,10 @@ public class SCMStateMachine extends BaseStateMachine {
   }
 
   private Message process(final SCMRatisRequest request) throws Exception {
+    final ScmInvoker<?> invoker = invokers.get(request.getType());
+    if (invoker != null) {
+      return process(request, invoker);
+    }
     return process(request, handlers.get(request.getType()));
   }
 
@@ -198,6 +210,25 @@ public class SCMStateMachine extends BaseStateMachine {
       final Exception targetEx = (Exception) e.getTargetException();
       throw targetEx != null ? targetEx : e;
     }
+  }
+
+  public static Message process(final SCMRatisRequest request,
+      final ScmInvoker<?> invoker) throws Exception {
+
+    if (invoker == null) {
+      throw new IOException("No invoker found for request type "
+          + request.getType());
+    }
+
+    final Object result = invoker.invoke(
+        request.getOperation(),
+        request.getArguments());
+
+    final Class<?> returnType = invoker.getApi()
+        .getMethod(request.getOperation(), request.getParameterTypes())
+        .getReturnType();
+
+    return SCMRatisResponse.encode(result, returnType);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -225,7 +225,7 @@ public class SCMStateMachine extends BaseStateMachine {
         request.getArguments());
 
     final Class<?> returnType =
-        invoker.getReturnType(request.getOperation(), request.getArguments().length);
+        invoker.getReturnType(request.getOperation(), request.getParameterTypes());
 
     return SCMRatisResponse.encode(result, returnType);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -78,7 +78,7 @@ public class SCMStateMachine extends BaseStateMachine {
 
   private StorageContainerManager scm;
   private Map<RequestType, Object> handlers;
-  private Map<RequestType,  ScmInvoker<?>> invokers;
+  private Map<RequestType, ScmInvoker<?>> invokers;
   private SCMHADBTransactionBuffer transactionBuffer;
   private final SimpleStateMachineStorage storage =
       new SimpleStateMachineStorage();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -224,9 +224,8 @@ public class SCMStateMachine extends BaseStateMachine {
         request.getOperation(),
         request.getArguments());
 
-    final Class<?> returnType = invoker.getApi()
-        .getMethod(request.getOperation(), request.getParameterTypes())
-        .getReturnType();
+    final Class<?> returnType =
+        invoker.getReturnType(request.getOperation(), request.getArguments().length);
 
     return SCMRatisResponse.encode(result, returnType);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -120,7 +120,7 @@ public class SCMStateMachine extends BaseStateMachine {
     handlers.put(type, handler);
   }
 
-  public void registerStateMachineInvoker(RequestType type,
+  public void registerInvoker(RequestType type,
       ScmInvoker<?> invoker) {
     invokers.put(type, invoker);
   }
@@ -189,7 +189,7 @@ public class SCMStateMachine extends BaseStateMachine {
   private Message process(final SCMRatisRequest request) throws Exception {
     final ScmInvoker<?> invoker = invokers.get(request.getType());
     if (invoker != null) {
-      return process(request, invoker);
+      return invoker.invokeLocal(request.getOperation(), request.getArguments());
     }
     return process(request, handlers.get(request.getType()));
   }
@@ -210,24 +210,6 @@ public class SCMStateMachine extends BaseStateMachine {
       final Exception targetEx = (Exception) e.getTargetException();
       throw targetEx != null ? targetEx : e;
     }
-  }
-
-  public static Message process(final SCMRatisRequest request,
-      final ScmInvoker<?> invoker) throws Exception {
-
-    if (invoker == null) {
-      throw new IOException("No invoker found for request type "
-          + request.getType());
-    }
-
-    final Object result = invoker.invoke(
-        request.getOperation(),
-        request.getArguments());
-
-    final Class<?> returnType =
-        invoker.getReturnType(request.getOperation(), request.getParameterTypes());
-
-    return SCMRatisResponse.encode(result, returnType);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -116,7 +116,7 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       final ArrayList arg0 = p.length > 0 ? (ArrayList) p[0] : null;
       final DeletedBlocksTransactionSummary arg1 = p.length > 1 ? (DeletedBlocksTransactionSummary) p[1] : null;
       getImpl().addTransactionsToDB(arg0, arg1);
-      return null;
+      return Message.EMPTY;
 
     case "getReadOnlyIterator":
       returnType = Table.KeyValueIterator.class;
@@ -125,19 +125,19 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
 
     case "onFlush":
       getImpl().onFlush();
-      return null;
+      return Message.EMPTY;
 
     case "reinitialize":
       final Table arg2 = p.length > 0 ? (Table) p[0] : null;
       final Table arg3 = p.length > 1 ? (Table) p[1] : null;
       getImpl().reinitialize(arg2, arg3);
-      return null;
+      return Message.EMPTY;
 
     case "removeTransactionsFromDB":
       final ArrayList arg4 = p.length > 0 ? (ArrayList) p[0] : null;
       final DeletedBlocksTransactionSummary arg5 = p.length > 1 ? (DeletedBlocksTransactionSummary) p[1] : null;
       getImpl().removeTransactionsFromDB(arg4, arg5);
-      return null;
+      return Message.EMPTY;
 
     default:
       throw new IllegalArgumentException("Method not found: " + methodName + " in DeletedBlockLogStateManager");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -139,21 +139,61 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
   }
 
   @Override
-  public Class<?> getReturnType(String methodName, int numArgs) {
+  public Class<?> getReturnType(String methodName, Class<?>[] parameterTypes) {
     switch (methodName) {
     case "addTransactionsToDB":
-      return void.class;
+      if (java.util.Arrays.equals(parameterTypes,
+          new Class<?>[]{java.util.ArrayList.class})) {
+        return void.class;
+      }
+      if (java.util.Arrays.equals(parameterTypes,
+          new Class<?>[]{
+              java.util.ArrayList.class,
+              org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary.class
+          })) {
+        return void.class;
+      }
+      break;
+
     case "getReadOnlyIterator":
-      return Table.KeyValueIterator.class;
+      if (parameterTypes == null || parameterTypes.length == 0) {
+        return org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator.class;
+      }
+      break;
+
     case "onFlush":
-      return void.class;
+      if (parameterTypes == null || parameterTypes.length == 0) {
+        return void.class;
+      }
+      break;
+
     case "reinitialize":
-      return void.class;
+      if (java.util.Arrays.equals(parameterTypes,
+          new Class<?>[]{
+              org.apache.hadoop.hdds.utils.db.Table.class,
+              org.apache.hadoop.hdds.utils.db.Table.class
+          })) {
+        return void.class;
+      }
+      break;
+
     case "removeTransactionsFromDB":
-      return void.class;
-    default:
-      throw new IllegalArgumentException(
-          "Method not found: " + methodName + " in DeletedBlockLogStateManager");
+      if (java.util.Arrays.equals(parameterTypes,
+          new Class<?>[]{java.util.ArrayList.class})) {
+        return void.class;
+      }
+      if (java.util.Arrays.equals(parameterTypes,
+          new Class<?>[]{
+              java.util.ArrayList.class,
+              org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary.class
+          })) {
+        return void.class;
+      }
+      break;
     }
+
+    throw new IllegalArgumentException(
+        "Method not found: " + methodName
+            + " with parameterTypes in DeletedBlockLogStateManager");
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -137,4 +137,23 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       throw new IllegalArgumentException("Method not found: " + methodName + " in DeletedBlockLogStateManager");
     }
   }
+
+  @Override
+  public Class<?> getReturnType(String methodName, int numArgs) {
+    switch (methodName) {
+    case "addTransactionsToDB":
+      return void.class;
+    case "getReadOnlyIterator":
+      return Table.KeyValueIterator.class;
+    case "onFlush":
+      return void.class;
+    case "reinitialize":
+      return void.class;
+    case "removeTransactionsFromDB":
+      return void.class;
+    default:
+      throw new IllegalArgumentException(
+          "Method not found: " + methodName + " in DeletedBlockLogStateManager");
+    }
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -143,10 +143,12 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
   public Class<?> getReturnType(String methodName, Class<?>[] parameterTypes) {
     switch (methodName) {
     case "addTransactionsToDB":
-      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class})) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class})) {
         return void.class;
       }
-      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
         return void.class;
       }
       break;
@@ -164,16 +166,19 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       break;
 
     case "reinitialize":
-      if (Arrays.equals(parameterTypes, new Class<?>[]{Table.class, Table.class})) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{Table.class, Table.class})) {
         return void.class;
       }
       break;
 
     case "removeTransactionsFromDB":
-      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class})) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class})) {
         return void.class;
       }
-      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
         return void.class;
       }
       break;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.ha.invoker;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogStateManager;
@@ -145,58 +144,5 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
     }
 
     return SCMRatisResponse.encode(returnValue, returnType);
-  }
-
-  @Override
-  public Class<?> getReturnType(String methodName, Class<?>[] parameterTypes) {
-    switch (methodName) {
-    case "addTransactionsToDB":
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class})) {
-        return void.class;
-      }
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
-        return void.class;
-      }
-      break;
-
-    case "getReadOnlyIterator":
-      if (parameterTypes == null || parameterTypes.length == 0) {
-        return Table.KeyValueIterator.class;
-      }
-      break;
-
-    case "onFlush":
-      if (parameterTypes == null || parameterTypes.length == 0) {
-        return void.class;
-      }
-      break;
-
-    case "reinitialize":
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{Table.class, Table.class})) {
-        return void.class;
-      }
-      break;
-
-    case "removeTransactionsFromDB":
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class})) {
-        return void.class;
-      }
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
-        return void.class;
-      }
-      break;
-
-    default:
-      break;
-    }
-
-    throw new IllegalArgumentException(
-        "Method not found: " + methodName
-            + " with parameterTypes in DeletedBlockLogStateManager");
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -23,8 +23,10 @@ import java.util.Arrays;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogStateManager;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.ratis.protocol.Message;
 
 /** Code generated for {@link DeletedBlockLogStateManager}.  Do not modify. */
 public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockLogStateManager> {
@@ -107,7 +109,9 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
 
   @SuppressWarnings("unchecked")
   @Override
-  public Object invokeLocal(String methodName, Object[] p) throws Exception {
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
     switch (methodName) {
     case "addTransactionsToDB":
       final ArrayList arg0 = p.length > 0 ? (ArrayList) p[0] : null;
@@ -116,7 +120,9 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       return null;
 
     case "getReadOnlyIterator":
-      return getImpl().getReadOnlyIterator();
+      returnType = Table.KeyValueIterator.class;
+      returnValue = getImpl().getReadOnlyIterator();
+      break;
 
     case "onFlush":
       getImpl().onFlush();
@@ -137,6 +143,8 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
     default:
       throw new IllegalArgumentException("Method not found: " + methodName + " in DeletedBlockLogStateManager");
     }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha.invoker;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogStateManager;
@@ -142,23 +143,18 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
   public Class<?> getReturnType(String methodName, Class<?>[] parameterTypes) {
     switch (methodName) {
     case "addTransactionsToDB":
-      if (java.util.Arrays.equals(parameterTypes,
-          new Class<?>[]{java.util.ArrayList.class})) {
+      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class})) {
         return void.class;
       }
-      if (java.util.Arrays.equals(parameterTypes,
-          new Class<?>[]{
-              java.util.ArrayList.class,
-              org.apache.hadoop.hdds.protocol.proto.HddsProtos
-                  .DeletedBlocksTransactionSummary.class
-          })) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
         return void.class;
       }
       break;
 
     case "getReadOnlyIterator":
       if (parameterTypes == null || parameterTypes.length == 0) {
-        return org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator.class;
+        return Table.KeyValueIterator.class;
       }
       break;
 
@@ -169,26 +165,19 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       break;
 
     case "reinitialize":
-      if (java.util.Arrays.equals(parameterTypes,
-          new Class<?>[]{
-              org.apache.hadoop.hdds.utils.db.Table.class,
-              org.apache.hadoop.hdds.utils.db.Table.class
-          })) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{Table.class, Table.class})) {
         return void.class;
       }
       break;
 
     case "removeTransactionsFromDB":
-      if (java.util.Arrays.equals(parameterTypes,
-          new Class<?>[]{java.util.ArrayList.class})) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class})) {
         return void.class;
       }
-      if (java.util.Arrays.equals(parameterTypes,
-          new Class<?>[]{
-              java.util.ArrayList.class,
-              org.apache.hadoop.hdds.protocol.proto.HddsProtos
-                  .DeletedBlocksTransactionSummary.class
-          })) {
+      if (Arrays.equals(parameterTypes,
+          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
         return void.class;
       }
       break;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -146,8 +146,7 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class})) {
         return void.class;
       }
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
+      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
         return void.class;
       }
       break;
@@ -165,19 +164,16 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       break;
 
     case "reinitialize":
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{Table.class, Table.class})) {
+      if (Arrays.equals(parameterTypes, new Class<?>[]{Table.class, Table.class})) {
         return void.class;
       }
       break;
 
     case "removeTransactionsFromDB":
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class})) {
+      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class})) {
         return void.class;
       }
-      if (Arrays.equals(parameterTypes,
-          new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
+      if (Arrays.equals(parameterTypes, new Class<?>[]{ArrayList.class, DeletedBlocksTransactionSummary.class})) {
         return void.class;
       }
       break;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/DeletedBlockLogStateManagerInvoker.java
@@ -149,7 +149,8 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       if (java.util.Arrays.equals(parameterTypes,
           new Class<?>[]{
               java.util.ArrayList.class,
-              org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary.class
+              org.apache.hadoop.hdds.protocol.proto.HddsProtos
+                  .DeletedBlocksTransactionSummary.class
           })) {
         return void.class;
       }
@@ -185,10 +186,14 @@ public class DeletedBlockLogStateManagerInvoker extends ScmInvoker<DeletedBlockL
       if (java.util.Arrays.equals(parameterTypes,
           new Class<?>[]{
               java.util.ArrayList.class,
-              org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary.class
+              org.apache.hadoop.hdds.protocol.proto.HddsProtos
+                  .DeletedBlocksTransactionSummary.class
           })) {
         return void.class;
       }
+      break;
+
+    default:
       break;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
@@ -60,8 +60,6 @@ public abstract class ScmInvoker<T extends SCMHandler> {
     return invokeLocal(methodName, args);
   }
 
-  public abstract Class<?> getReturnType(String methodName, Class<?>[] parameterTypes);
-
   /** For non-@Replicate methods. */
   public abstract Message invokeLocal(String methodName, Object[] args) throws Exception;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisRequest;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.ratis.protocol.Message;
 
 /**
  * Invokes methods without using reflection.
@@ -62,7 +63,7 @@ public abstract class ScmInvoker<T extends SCMHandler> {
   public abstract Class<?> getReturnType(String methodName, Class<?>[] parameterTypes);
 
   /** For non-@Replicate methods. */
-  abstract Object invokeLocal(String methodName, Object[] args) throws Exception;
+  public abstract Message invokeLocal(String methodName, Object[] args) throws Exception;
 
   /** For @Replicate DIRECT methods. */
   final Object invokeReplicateDirect(NameAndParameterTypes method, Object[] args) throws SCMException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
@@ -55,6 +55,10 @@ public abstract class ScmInvoker<T extends SCMHandler> {
     return proxy;
   }
 
+  public final Object invoke(String methodName, Object[] args) throws Exception {
+    return invokeLocal(methodName, args);
+  }
+
   /** For non-@Replicate methods. */
   abstract Object invokeLocal(String methodName, Object[] args) throws Exception;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
@@ -56,10 +56,6 @@ public abstract class ScmInvoker<T extends SCMHandler> {
     return proxy;
   }
 
-  public final Object invoke(String methodName, Object[] args) throws Exception {
-    return invokeLocal(methodName, args);
-  }
-
   /** For non-@Replicate methods. */
   public abstract Message invokeLocal(String methodName, Object[] args) throws Exception;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
@@ -59,7 +59,7 @@ public abstract class ScmInvoker<T extends SCMHandler> {
     return invokeLocal(methodName, args);
   }
 
-  public abstract Class<?> getReturnType(String methodName, int numArgs);
+  public abstract Class<?> getReturnType(String methodName, Class<?>[] parameterTypes);
 
   /** For non-@Replicate methods. */
   abstract Object invokeLocal(String methodName, Object[] args) throws Exception;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvoker.java
@@ -59,6 +59,8 @@ public abstract class ScmInvoker<T extends SCMHandler> {
     return invokeLocal(methodName, args);
   }
 
+  public abstract Class<?> getReturnType(String methodName, int numArgs);
+
   /** For non-@Replicate methods. */
   abstract Object invokeLocal(String methodName, Object[] args) throws Exception;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -72,12 +72,6 @@ public final class ScmInvokerCodeGenerator {
       Object.class,
       new Class<?>[]{Exception.class});
 
-  static final DeclaredMethod GET_RETURN_TYPE = new DeclaredMethod("getReturnType",
-      new Class[]{String.class, Class[].class},
-      new String[]{"methodName", "parameterTypes"},
-      Class.class,
-      new Class<?>[]{});
-
   private final Class<?> api;
   private final String apiName;
   private final String invokerClassName;
@@ -448,73 +442,6 @@ public final class ScmInvokerCodeGenerator {
     }
   }
 
-  void printReturnTypeMethod() {
-    println();
-    println("@Override");
-    printf("public Class<?> getReturnType(String methodName, Class<?>[] parameterTypes)");
-    try (UncheckedAutoCloseable ignored = printScope()) {
-      printReturnTypeSwitch();
-    }
-  }
-
-  void printReturnTypeSwitch() {
-    printf("switch (methodName)");
-    try (UncheckedAutoCloseable ignored = printScope(true, 0)) {
-      final List<Method> apiMethods = getReturnTypeMethods();
-
-      final List<String> methodNames = apiMethods.stream()
-          .map(Method::getName)
-          .distinct()
-          .sorted()
-          .collect(Collectors.toList());
-
-      for (String methodName : methodNames) {
-        final List<Method> overrides = apiMethods.stream()
-            .filter(m -> m.getName().equals(methodName))
-            .sorted(Comparator.comparing(Method::getParameterCount))
-            .collect(Collectors.toList());
-
-        printf("case \"%s\":", methodName);
-        try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
-          for (Method m : overrides) {
-            printReturnTypeIf(m);
-          }
-          println("break;");
-        }
-        println();
-      }
-
-      printf("default:");
-      try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
-        println("break;");
-      }
-    }
-
-    println();
-    println("throw new IllegalArgumentException(");
-    println("    \"Method not found: \" + methodName");
-    println("        + \" with parameterTypes in %s\");", apiName);
-  }
-
-  void printReturnTypeIf(Method method) {
-    final Class<?>[] paramTypes = method.getParameterTypes();
-    final String params = classesToString(paramTypes, ".class");
-
-    if (paramTypes.length == 0) {
-      printf("if (parameterTypes == null || parameterTypes.length == 0)");
-      try (UncheckedAutoCloseable ignore = printScope()) {
-        println("return %s.class;", getClassname(method.getReturnType()));
-      }
-      return;
-    }
-
-    println("if (Arrays.equals(parameterTypes,");
-    printf(true, "    new Class<?>[]{%s}))", params);
-    try (UncheckedAutoCloseable ignore = printScope()) {
-      println("return %s.class;", getClassname(method.getReturnType()));
-    }
-  }
-
   public String generateClass() {
     println("/** Code generated for {@link %s}.  Do not modify. */", apiName);
     printf("public class %s extends ScmInvoker<%s>", invokerClassName, apiName);
@@ -523,19 +450,8 @@ public final class ScmInvokerCodeGenerator {
       printHeaderMethods();
       printProxyMethod();
       printInvokeMethod(INVOKE_LOCAL);
-      printReturnTypeMethod();
     }
     return out.toString();
-  }
-
-  List<Method> getReturnTypeMethods() {
-    return Arrays.stream(api.getMethods())
-        .filter(m -> !Modifier.isStatic(m.getModifiers()))
-        .filter(m -> m.getAnnotation(Deprecated.class) == null)
-        .filter(m -> !m.isDefault() || m.getAnnotation(Replicate.class) != null)
-        .sorted(Comparator.comparing(Method::getName)
-            .thenComparing(Method::getParameterCount))
-        .collect(Collectors.toList());
   }
 
   File updateFile(String classString) throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -508,22 +508,10 @@ public final class ScmInvokerCodeGenerator {
       return;
     }
 
-    final String condition =
-        String.format("Arrays.equals(parameterTypes, new Class<?>[]{%s})", params);
-
-    if ((indentation + "if (" + condition + ")").length() <= LINE_LENGTH) {
-      printf("if (%s)", condition);
-      try (UncheckedAutoCloseable ignore = printScope()) {
-        println("return %s.class;", getClassname(method.getReturnType()));
-      }
-    } else {
-      println("if (Arrays.equals(parameterTypes,");
-      try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
-        println("new Class<?>[]{%s}))", params);
-      }
-      try (UncheckedAutoCloseable ignore = printScope()) {
-        println("return %s.class;", getClassname(method.getReturnType()));
-      }
+    println("if (Arrays.equals(parameterTypes,");
+    printf(true, "    new Class<?>[]{%s}))", params);
+    try (UncheckedAutoCloseable ignore = printScope()) {
+      println("return %s.class;", getClassname(method.getReturnType()));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -72,6 +72,12 @@ public final class ScmInvokerCodeGenerator {
       Object.class,
       new Class<?>[]{Exception.class});
 
+  static final DeclaredMethod GET_RETURN_TYPE = new DeclaredMethod("getReturnType",
+      new Class[]{String.class, Class[].class},
+      new String[]{"methodName", "parameterTypes"},
+      Class.class,
+      new Class<?>[]{});
+
   private final Class<?> api;
   private final String apiName;
   private final String invokerClassName;
@@ -442,6 +448,85 @@ public final class ScmInvokerCodeGenerator {
     }
   }
 
+  void printReturnTypeMethod() {
+    println();
+    println("@Override");
+    printf("public Class<?> getReturnType(String methodName, Class<?>[] parameterTypes)");
+    try (UncheckedAutoCloseable ignored = printScope()) {
+      printReturnTypeSwitch();
+    }
+  }
+
+  void printReturnTypeSwitch() {
+    printf("switch (methodName)");
+    try (UncheckedAutoCloseable ignored = printScope(true, 0)) {
+      final List<Method> apiMethods = getReturnTypeMethods();
+
+      final List<String> methodNames = apiMethods.stream()
+          .map(Method::getName)
+          .distinct()
+          .sorted()
+          .collect(Collectors.toList());
+
+      for (String methodName : methodNames) {
+        final List<Method> overrides = apiMethods.stream()
+            .filter(m -> m.getName().equals(methodName))
+            .sorted(Comparator.comparing(Method::getParameterCount))
+            .collect(Collectors.toList());
+
+        printf("case \"%s\":", methodName);
+        try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
+          for (Method m : overrides) {
+            printReturnTypeIf(m);
+          }
+          println("break;");
+        }
+        println();
+      }
+
+      printf("default:");
+      try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
+        println("break;");
+      }
+    }
+
+    println();
+    println("throw new IllegalArgumentException(");
+    println("    \"Method not found: \" + methodName");
+    println("        + \" with parameterTypes in %s\");", apiName);
+  }
+
+  void printReturnTypeIf(Method method) {
+    final Class<?>[] paramTypes = method.getParameterTypes();
+    final String params = classesToString(paramTypes, ".class");
+
+    if (paramTypes.length == 0) {
+      printf("if (parameterTypes == null || parameterTypes.length == 0)");
+      try (UncheckedAutoCloseable ignore = printScope()) {
+        println("return %s.class;", getClassname(method.getReturnType()));
+      }
+      return;
+    }
+
+    final String condition =
+        String.format("Arrays.equals(parameterTypes, new Class<?>[]{%s})", params);
+
+    if ((indentation + "if (" + condition + ")").length() <= LINE_LENGTH) {
+      printf("if (%s)", condition);
+      try (UncheckedAutoCloseable ignore = printScope()) {
+        println("return %s.class;", getClassname(method.getReturnType()));
+      }
+    } else {
+      println("if (Arrays.equals(parameterTypes,");
+      try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
+        println("new Class<?>[]{%s}))", params);
+      }
+      try (UncheckedAutoCloseable ignore = printScope()) {
+        println("return %s.class;", getClassname(method.getReturnType()));
+      }
+    }
+  }
+
   public String generateClass() {
     println("/** Code generated for {@link %s}.  Do not modify. */", apiName);
     printf("public class %s extends ScmInvoker<%s>", invokerClassName, apiName);
@@ -450,8 +535,19 @@ public final class ScmInvokerCodeGenerator {
       printHeaderMethods();
       printProxyMethod();
       printInvokeMethod(INVOKE_LOCAL);
+      printReturnTypeMethod();
     }
     return out.toString();
+  }
+
+  List<Method> getReturnTypeMethods() {
+    return Arrays.stream(api.getMethods())
+        .filter(m -> !Modifier.isStatic(m.getModifiers()))
+        .filter(m -> m.getAnnotation(Deprecated.class) == null)
+        .filter(m -> !m.isDefault() || m.getAnnotation(Replicate.class) != null)
+        .sorted(Comparator.comparing(Method::getName)
+            .thenComparing(Method::getParameterCount))
+        .collect(Collectors.toList());
   }
 
   File updateFile(String classString) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Add a new `invokers` map in `SCMStateMachine` to use `ScmInvoker` for method dispatch
* Replace reflection-based invocation with direct invocation via `ScmInvoker`
* Add `getReturnType()` in `ScmInvoker` to avoid reflection when applying local state machine operations
* Extend `ScmInvokerCodeGenerator` to generate the `getReturnType()` method for each invoker
* Prevent checkstyle failures caused by generated invoker classes


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14974
## How was this patch tested?
- All CI checks passed
   - https://github.com/Russole/ozone/actions/runs/24354244039
- Verified that code generated by `ScmInvokerCodeGenerator` is functionally equivalent to the existing `DeletedBlockLogStateManagerInvoker`
