### PR TITLE
HDDS-15041. Fix some typos

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ipc_/AlignmentContext.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ipc_/AlignmentContext.java
@@ -42,7 +42,7 @@ public interface AlignmentContext {
   void updateResponseState(RpcResponseHeaderProto.Builder header);
 
   /**
-   * This is the intended client method call to implement to recieve state info
+   * This is the intended client method call to implement to receive state info
    * during RPC response processing.
    *
    * @param header The RPC response header.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ipc_/Server.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ipc_/Server.java
@@ -2914,7 +2914,7 @@ public abstract class Server {
         long startTimeNanos = 0;
         // True iff the connection for this call has been dropped.
         // Set to true by default and update to false later if the connection
-        // can be succesfully read.
+        // can be successfully read.
         boolean connDropped = true;
 
         try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractRDBStore.java
@@ -91,7 +91,7 @@ public abstract class AbstractRDBStore<DEF extends DBDefinition> implements DBSt
     try {
       options = DBConfigFromFile.readDBOptionsFromFile(optionsPath);
     } catch (RocksDBException e) {
-      throw new RocksDatabaseException("Error occured when reading RocksDBOptions from: " + optionsPath, e);
+      throw new RocksDatabaseException("Error occurred when reading RocksDBOptions from: " + optionsPath, e);
     }
     return options;
   }
@@ -105,7 +105,7 @@ public abstract class AbstractRDBStore<DEF extends DBDefinition> implements DBSt
     try {
       cfoptionsFromFile = DBConfigFromFile.readCFOptionsFromFile(optionsPath, DEFAULT_COLUMN_FAMILY_NAME);
     } catch (RocksDBException ex) {
-      throw new RocksDatabaseException("Error occured when reading CFOptions from: " + optionsPath, ex);
+      throw new RocksDatabaseException("Error occurred when reading CFOptions from: " + optionsPath, ex);
     }
     usedCfOptions = cfoptionsFromFile != null ? cfoptionsFromFile :
         dbProfile.getColumnFamilyOptions(config);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -537,7 +537,7 @@ public final class SCMContainerPlacementRackAware
   /**
    * Choose a batch of datanodes on different rack than excludedNodes or
    * chosenNodes.
-   * TODO HDDS-7226: Update Implementation to accomodate for already used
+   * TODO HDDS-7226: Update Implementation to accommodate for already used
    * nodes to conform to existing placement policy.
    *
    * @param excludedNodes - list of the datanodes to excluded. Can be null.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -537,8 +537,6 @@ public final class SCMContainerPlacementRackAware
   /**
    * Choose a batch of datanodes on different rack than excludedNodes or
    * chosenNodes.
-   * TODO HDDS-7226: Update Implementation to accommodate for already used
-   * nodes to conform to existing placement policy.
    *
    * @param excludedNodes - list of the datanodes to excluded. Can be null.
    * @param chosenNodes - list of nodes already chosen. These nodes should also

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -235,8 +235,6 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
 
   /**
    * Pipeline placement choose datanodes to join the pipeline.
-   * TODO: HDDS-7227: Update Implementation to accommodate for already used
-   * nodes in pipeline to conform to existing placement policy.
    * @param usedNodes - list of the datanodes to already chosen in the
    *                      pipeline.
    * @param excludedNodes - excluded nodes

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -235,7 +235,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
 
   /**
    * Pipeline placement choose datanodes to join the pipeline.
-   * TODO: HDDS-7227: Update Implementation to accomodate for already used
+   * TODO: HDDS-7227: Update Implementation to accommodate for already used
    * nodes in pipeline to conform to existing placement policy.
    * @param usedNodes - list of the datanodes to already chosen in the
    *                      pipeline.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis_snapshot/OmRatisSnapshotProvider.java
@@ -236,7 +236,7 @@ public class OmRatisSnapshotProvider extends RDBSnapshotProvider {
    * value1</pre>
    * @param connection HTTP URL connection which output stream is used.
    * @param sstFiles SST files for exclusion.
-   * @throws IOException if an exception occured during writing to output
+   * @throws IOException if an exception occurred during writing to output
    * stream.
    */
   public static void writeFormData(HttpURLConnection connection,

--- a/tools/fault-injection-service/FileSystem/failure_injector_fs.cc
+++ b/tools/fault-injection-service/FileSystem/failure_injector_fs.cc
@@ -126,7 +126,7 @@ void *FailureInjectorFs::fifs_init(
     cfg->attr_timeout = 0;
     cfg->negative_timeout = 0;
     
-    /* Create a seperate GRPC server thread to accept failure injection. */
+    /* Create a separate GRPC server thread to accept failure injection. */
     std::thread th(&RunGrpcService::RunServer, mGrpcSever);
     th.detach();
 


### PR DESCRIPTION
Trivial typo fixes in comments, javadoc, and a couple of error/log messages. No behavior changes.

- `failure_injector_fs.cc`: `seperate GRPC` -> `separate GRPC`
- `SCMContainerPlacementRackAware.java`, `PipelinePlacementPolicy.java`: `accomodate` -> `accommodate`
- `AbstractRDBStore.java` (2x): `Error occured when reading` -> `Error occurred when reading`
- `OmRatisSnapshotProvider.java`: `exception occured` -> `exception occurred`
- `AlignmentContext.java`: `to recieve state info` -> `to receive state info`
- `Server.java`: `can be succesfully read` -> `can be successfully read`