### PR TITLE
HDDS-15033. Link SCM allocate-block calls to client trace.

### DIFF
--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -101,6 +101,10 @@
       <artifactId>opentelemetry-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-context</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -233,6 +233,13 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
       blocks.add(builder.build());
     }
 
+    if (!blocks.isEmpty()) {
+      String blockIds = blocks.stream()
+          .map(b -> b.getBlockID().toString())
+          .collect(Collectors.joining(", "));
+      TracingUtil.getActiveSpan().addEvent("SCM allocated block(s): " + blockIds);
+    }
+
     return blocks;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProt
 import com.google.common.base.Preconditions;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
+import io.opentelemetry.api.trace.Span;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -225,19 +226,19 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
         wrappedResponse.getAllocateScmBlockResponse();
 
     List<AllocatedBlock> blocks = new ArrayList<>(response.getBlocksCount());
+    Span traceSpan = TracingUtil.getActiveSpan();
+    int blockIndex = 0;
     for (AllocateBlockResponse resp : response.getBlocksList()) {
+      if (traceSpan.isRecording()) {
+        traceSpan.setAttribute("blockAllocated" + blockIndex,
+            resp.getContainerBlockID().toString());
+      }
+      blockIndex++;
       AllocatedBlock.Builder builder = new AllocatedBlock.Builder()
           .setContainerBlockID(
               ContainerBlockID.getFromProtobuf(resp.getContainerBlockID()))
           .setPipeline(Pipeline.getFromProtobuf(resp.getPipeline()));
       blocks.add(builder.build());
-    }
-
-    if (!blocks.isEmpty()) {
-      String blockIds = blocks.stream()
-          .map(b -> b.getBlockID().toString())
-          .collect(Collectors.joining(", "));
-      TracingUtil.getActiveSpan().addEvent("SCM allocated block(s): " + blockIds);
     }
 
     return blocks;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -72,7 +72,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE extends Enum
       TYPE type,
       String traceId) throws ServiceException {
     Span span = TracingUtil.importAndCreateSpan(type.toString(), traceId);
-    try (Scope currentscope = span.makeCurrent()) {
+    try (Scope currentScope = span.makeCurrent()) {
       if (logger.isTraceEnabled()) {
         logger.trace(
             "[service={}] [type={}] request is received: <json>{}</json>",

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.server;
 
 import com.google.protobuf.ServiceException;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import java.util.function.Function;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
@@ -71,7 +72,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE extends Enum
       TYPE type,
       String traceId) throws ServiceException {
     Span span = TracingUtil.importAndCreateSpan(type.toString(), traceId);
-    try {
+    try (Scope currentscope = span.makeCurrent()) {
       if (logger.isTraceEnabled()) {
         logger.trace(
             "[service={}] [type={}] request is received: <json>{}</json>",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Link block allocation calls to SCM by providing proper context. This ensures SCM calls are recorded as child spans under the original client-to-OM trace hierarchy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15033

## How was this patch tested?

Manual Testing through Jaeger UI.

### put key command : 
```
ozone sh key put vol1/bucket1/key1 /etc/hostname
```
<img width="1550" height="842" alt="image" src="https://github.com/user-attachments/assets/e66c6dc1-55f7-478d-b9e8-00d86eda6e2e" />


### freon ockg command :

```
ozone freon ockg -v vol1 -b bucket1 -t 1 -n 5 -s 1KB
```
<img width="1550" height="500" alt="image" src="https://github.com/user-attachments/assets/455b3790-38c4-4554-ad4a-ef708c2827b6" />

### freon rk command : 
```
ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1
```
<img width="1554" height="500" alt="image" src="https://github.com/user-attachments/assets/9a68e4f1-638b-4124-995e-720058c7719f" />

#### block info in event information:
<img width="3244" height="490" alt="image" src="https://github.com/user-attachments/assets/a5d4158a-acb2-4cea-bb62-49c3fc50d619" />

