### PR TITLE
HDDS-15042. Run basic checks with Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     uses: ./.github/workflows/check.yml
     with:
       checkout-fetch-depth: ${{ matrix.check != 'bats' && 1 || 0 }}
-      java-version: 8 # HDDS-10150
+      java-version: ${{ matrix.check == 'findbugs' && '8' || needs.build-info.outputs.java-version }} # HDDS-10150
       needs-maven-cache: ${{ !contains('author,bats', matrix.check) }}
       ratis-args: ${{ inputs.ratis_args }}
       script: ${{ matrix.check }}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Basic checks are currently run with Java 8, but only findbugs needs Java 8.
This patch updates others to use Java 21.

## What is the link to the Apache JIRA

[HDDS-15042](https://issues.apache.org/jira/browse/HDDS-15042)

## How was this patch tested?

Green CI : https://github.com/sreejasahithi/ozone/actions/runs/24659659550
