### PR TITLE
HDDS-15051. Incorrect DN replica reporting for unhealthy and QUASI CLOSED stuck containers in Recon.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -49,6 +49,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -79,8 +80,10 @@ import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHistory;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.scm.ReconContainerManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
+import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.util.SeekableIterator;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.apache.ozone.recon.schema.generated.tables.pojos.UnhealthyContainers;
@@ -104,6 +107,7 @@ public class ContainerEndpoint {
   private final ContainerHealthSchemaManager containerHealthSchemaManager;
   private final ReconNamespaceSummaryManager reconNamespaceSummaryManager;
   private final OzoneStorageContainerManager reconSCM;
+  private final StorageContainerServiceProvider scmServiceProvider;
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerEndpoint.class);
   private BucketLayout layout = BucketLayout.DEFAULT;
@@ -152,6 +156,9 @@ public class ContainerEndpoint {
     this.containerHealthSchemaManager = containerHealthSchemaManager;
     this.reconNamespaceSummaryManager = reconNamespaceSummaryManager;
     this.reconSCM = reconSCM;
+    this.scmServiceProvider = reconSCM instanceof ReconStorageContainerManagerFacade
+        ? ((ReconStorageContainerManagerFacade) reconSCM).getScmServiceProvider()
+        : null;
     this.reconContainerMetadataManager = reconContainerMetadataManager;
     this.omMetadataManager = omMetadataManager;
   }
@@ -458,9 +465,8 @@ public class ContainerEndpoint {
           containerManager.getContainer(ContainerID.valueOf(containerID));
       long keyCount = containerInfo.getNumberOfKeys();
       UUID pipelineID = containerInfo.getPipelineID().getId();
-      List<ContainerHistory> datanodes =
-          containerManager.getLatestContainerHistory(containerID,
-              containerInfo.getReplicationConfig().getRequiredNodes());
+      List<ContainerHistory> datanodes = getReplicaDetailsForUnhealthyContainer(
+          containerID, containerInfo.getReplicationConfig().getRequiredNodes());
       UnhealthyContainers unhealthyContainers = new UnhealthyContainers(
           record.getContainerId(),
           record.getContainerState(),
@@ -474,6 +480,74 @@ public class ContainerEndpoint {
     } catch (IOException ioEx) {
       throw new UncheckedIOException(ioEx);
     }
+  }
+
+  /**
+   * For unhealthy containers, use SCM replica details only. If SCM replica
+   * lookup is unavailable, return no replicas instead of falling back to
+   * Recon-local state or history, which may diverge from SCM.
+   */
+  private List<ContainerHistory> getReplicaDetailsForUnhealthyContainer(
+      long containerID, int historyLimit) throws IOException {
+    List<ContainerHistory> scmReplicas = getScmReplicaDetails(containerID);
+    if (!scmReplicas.isEmpty()) {
+      return scmReplicas;
+    }
+    return new ArrayList<>();
+  }
+
+  private List<ContainerHistory> getScmReplicaDetails(long containerID)
+      throws IOException {
+    if (scmServiceProvider == null) {
+      return new ArrayList<>();
+    }
+
+    Map<String, ContainerHistory> historyByDn = new HashMap<>();
+    for (ContainerHistory history :
+        containerManager.getAllContainerHistory(containerID)) {
+      historyByDn.put(history.getDatanodeUuid(), history);
+    }
+
+    try {
+      List<HddsProtos.SCMContainerReplicaProto> scmReplicas =
+          scmServiceProvider.getContainerReplicas(containerID);
+      if (scmReplicas == null) {
+        return new ArrayList<>();
+      }
+
+      return scmReplicas.stream()
+          .map(replica -> toContainerHistory(containerID, replica,
+              historyByDn.get(getDatanodeUuid(replica))))
+          .sorted(Comparator.comparing(ContainerHistory::getDatanodeHost)
+              .thenComparing(ContainerHistory::getDatanodeUuid))
+          .collect(Collectors.toList());
+    } catch (IOException ex) {
+      LOG.warn("Unable to fetch SCM replica details for container {}.",
+          containerID, ex);
+      return new ArrayList<>();
+    }
+  }
+
+  private ContainerHistory toContainerHistory(long containerID,
+      HddsProtos.SCMContainerReplicaProto replica, ContainerHistory history) {
+    DatanodeDetails dn = DatanodeDetails.getFromProtoBuf(
+        replica.getDatanodeDetails());
+    long firstSeenTime = history != null ? history.getFirstSeenTime() : 0L;
+    long lastSeenTime = history != null ? history.getLastSeenTime() : 0L;
+    return new ContainerHistory(
+        containerID,
+        dn.getUuidString(),
+        dn.getHostName(),
+        firstSeenTime,
+        lastSeenTime,
+        replica.getSequenceID(),
+        replica.getState(),
+        replica.getDataChecksum());
+  }
+
+  private String getDatanodeUuid(HddsProtos.SCMContainerReplicaProto replica) {
+    return DatanodeDetails.getFromProtoBuf(replica.getDatanodeDetails())
+        .getUuidString();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -465,8 +465,8 @@ public class ContainerEndpoint {
           containerManager.getContainer(ContainerID.valueOf(containerID));
       long keyCount = containerInfo.getNumberOfKeys();
       UUID pipelineID = containerInfo.getPipelineID().getId();
-      List<ContainerHistory> datanodes = getReplicaDetailsForUnhealthyContainer(
-          containerID, containerInfo.getReplicationConfig().getRequiredNodes());
+      List<ContainerHistory> datanodes =
+          getReplicaDetailsForUnhealthyContainer(containerID);
       UnhealthyContainers unhealthyContainers = new UnhealthyContainers(
           record.getContainerId(),
           record.getContainerState(),
@@ -488,7 +488,7 @@ public class ContainerEndpoint {
    * Recon-local state or history, which may diverge from SCM.
    */
   private List<ContainerHistory> getReplicaDetailsForUnhealthyContainer(
-      long containerID, int historyLimit) throws IOException {
+      long containerID) throws IOException {
     List<ContainerHistory> scmReplicas = getScmReplicaDetails(containerID);
     if (!scmReplicas.isEmpty()) {
       return scmReplicas;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconReplicationManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconReplicationManager.java
@@ -322,7 +322,7 @@ public class ReconReplicationManager extends ReplicationManager {
         processedCount++;
 
         if (processedCount % logEvery == 0 || processedCount == containers.size()) {
-          LOG.info("Processed {}/{} containers", processedCount, containers.size());
+          LOG.debug("Processed {}/{} containers", processedCount, containers.size());
         }
       } catch (ContainerNotFoundException e) {
         LOG.error("Container {} not found", container.getContainerID(), e);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
@@ -98,4 +98,14 @@ public interface StorageContainerServiceProvider {
    * @return Total number of containers in SCM.
    */
   long getContainerCount(HddsProtos.LifeCycleState state) throws IOException;
+
+  /**
+   * Requests SCM for the current replica set of a container.
+   *
+   * @param containerId containerId
+   * @return the current SCM replica set for the container
+   * @throws IOException in case of any exception
+   */
+  List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
+      long containerId) throws IOException;
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -128,6 +128,13 @@ public class StorageContainerServiceProviderImpl
   }
 
   @Override
+  public List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
+      long containerId) throws IOException {
+    return scmClient.getContainerReplicas(containerId,
+        ClientVersion.CURRENT_VERSION);
+  }
+
+  @Override
   public DBCheckpoint getSCMDBSnapshot() {
     String snapshotFileName = RECON_SCM_SNAPSHOT_DB + "_" +
         System.currentTimeMillis();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -145,6 +146,7 @@ public class TestContainerEndpoint {
   private ContainerHealthSchemaManager containerHealthSchemaManager;
   private ReconOMMetadataManager reconOMMetadataManager;
   private OzoneConfiguration omConfiguration;
+  private StorageContainerServiceProvider scmServiceProvider;
 
   private ContainerID containerID = ContainerID.valueOf(1L);
   private Pipeline pipeline;
@@ -214,6 +216,8 @@ public class TestContainerEndpoint {
     containerEndpoint = reconTestInjector.getInstance(ContainerEndpoint.class);
     containerHealthSchemaManager =
         reconTestInjector.getInstance(ContainerHealthSchemaManager.class);
+    scmServiceProvider =
+        reconTestInjector.getInstance(StorageContainerServiceProvider.class);
     this.reconNamespaceSummaryManager =
         reconTestInjector.getInstance(ReconNamespaceSummaryManager.class);
 
@@ -240,6 +244,7 @@ public class TestContainerEndpoint {
     }
 
     omConfiguration = new OzoneConfiguration();
+    reset(scmServiceProvider);
 
     List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();
     BlockID blockID1 = new BlockID(1, 101);
@@ -880,15 +885,8 @@ public class TestContainerEndpoint {
     assertEquals(1L, missing.get(0).getContainerID());
     assertEquals(keyCount, missing.get(0).getKeys());
     assertEquals(pipelineID.getId(), missing.get(0).getPipelineID());
-    assertEquals(3, missing.get(0).getReplicas().size());
+    assertEquals(0, missing.get(0).getReplicas().size());
     assertNull(missing.get(0).getReason());
-
-    Set<String> datanodes = Collections.unmodifiableSet(
-        new HashSet<>(Arrays.asList("host2", "host3", "host4")));
-    List<ContainerHistory> containerReplicas = missing.get(0).getReplicas();
-    containerReplicas.forEach(history -> {
-      assertThat(datanodes).contains(history.getDatanodeHost());
-    });
 
     List<UnhealthyContainerMetadata> overRep = records
         .stream()
@@ -1007,9 +1005,7 @@ public class TestContainerEndpoint {
 
     Collection<UnhealthyContainerMetadata> records = responseObject.getContainers();
     assertTrue(records.stream()
-        .flatMap(containerMetadata -> containerMetadata.getReplicas().stream()
-            .map(ContainerHistory::getState))
-        .allMatch(s -> s.equals("UNHEALTHY")));
+        .allMatch(containerMetadata -> containerMetadata.getReplicas().isEmpty()));
 
     // Verify only missing containers are returned
     assertEquals(5, records.size());
@@ -1195,14 +1191,17 @@ public class TestContainerEndpoint {
     addCurrentReplicas(cID, actual, dataChecksumMismatch);
   }
 
-  private void addCurrentReplicas(long containerID, int actual,
+  private void addCurrentReplicas(long containerId, int actual,
       boolean dataChecksumMismatch) throws IOException {
+    when(scmServiceProvider.getContainerReplicas(containerId))
+        .thenReturn(buildScmReplicaProtos(actual, dataChecksumMismatch));
+
     List<UUID> uuids = Arrays.asList(uuid1, uuid2, uuid3, uuid4, uuid5);
     for (int i = 0; i < actual; i++) {
       long checksum = (dataChecksumMismatch && i == 0) ? 2345L : 1234L;
-      reconContainerManager.updateContainerReplica(ContainerID.valueOf(containerID),
+      reconContainerManager.updateContainerReplica(ContainerID.valueOf(containerId),
           ContainerReplica.newBuilder()
-              .setContainerID(ContainerID.valueOf(containerID))
+              .setContainerID(ContainerID.valueOf(containerId))
               .setContainerState(ContainerReplicaProto.State.CLOSED)
               .setDatanodeDetails(reconContainerManager.getNodeDB()
                   .get(DatanodeID.of(uuids.get(i))))
@@ -1215,6 +1214,25 @@ public class TestContainerEndpoint {
               .setChecksums(ContainerChecksums.of(checksum, 0L))
               .build());
     }
+  }
+
+  private List<HddsProtos.SCMContainerReplicaProto> buildScmReplicaProtos(
+      int actual, boolean dataChecksumMismatch) throws IOException {
+    List<UUID> uuids = Arrays.asList(uuid1, uuid2, uuid3, uuid4, uuid5);
+    List<HddsProtos.SCMContainerReplicaProto> replicas = new ArrayList<>();
+    for (int i = 0; i < actual; i++) {
+      UUID uuid = uuids.get(i);
+      long checksum = (dataChecksumMismatch && i == 0) ? 2345L : 1234L;
+      DatanodeDetails datanodeDetails = reconContainerManager.getNodeDB()
+          .get(DatanodeID.of(uuid));
+      replicas.add(HddsProtos.SCMContainerReplicaProto.newBuilder()
+          .setSequenceID(1L)
+          .setState(ContainerReplicaProto.State.CLOSED.toString())
+          .setDatanodeDetails(datanodeDetails.getProtoBufMessage())
+          .setDataChecksum(checksum)
+          .build());
+    }
+    return replicas;
   }
 
   protected ContainerWithPipeline getTestContainer(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -66,9 +66,11 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerChecksums;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -177,6 +179,7 @@ public class TestContainerEndpoint {
   private UUID uuid2;
   private UUID uuid3;
   private UUID uuid4;
+  private UUID uuid5;
 
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
@@ -850,6 +853,7 @@ public class TestContainerEndpoint {
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
+    uuid5 = newDatanode("host5", "127.0.0.5");
     createUnhealthyRecords(5, 4, 3, 2, 1);
 
     response = containerEndpoint.getUnhealthyContainers(1000, 0, 0);
@@ -863,10 +867,6 @@ public class TestContainerEndpoint {
 
     Collection<UnhealthyContainerMetadata> records
         = responseObject.getContainers();
-    assertTrue(records.stream()
-        .flatMap(containerMetadata -> containerMetadata.getReplicas().stream()
-            .map(ContainerHistory::getState))
-        .allMatch(s -> s.equals("UNHEALTHY")));
     List<UnhealthyContainerMetadata> missing = records
         .stream()
         .filter(r -> r.getContainerState()
@@ -902,6 +902,15 @@ public class TestContainerEndpoint {
     assertEquals(12345L, overRep.get(0).getUnhealthySince());
     assertEquals(6L, overRep.get(0).getContainerID());
     assertNull(overRep.get(0).getReason());
+    assertEquals(5, overRep.get(0).getReplicas().size());
+    assertTrue(overRep.get(0).getReplicas().stream()
+        .map(ContainerHistory::getState)
+        .allMatch(s -> s.equals(ContainerReplicaProto.State.CLOSED.toString())));
+    assertTrue(overRep.get(0).getReplicas().stream()
+        .map(ContainerHistory::getDatanodeHost)
+        .collect(Collectors.toSet())
+        .containsAll(Arrays.asList("host1", "host2", "host3", "host4",
+            "host5")));
 
     List<UnhealthyContainerMetadata> underRep = records
         .stream()
@@ -915,6 +924,9 @@ public class TestContainerEndpoint {
     assertEquals(12345L, underRep.get(0).getUnhealthySince());
     assertEquals(10L, underRep.get(0).getContainerID());
     assertNull(underRep.get(0).getReason());
+    assertEquals(1, underRep.get(0).getReplicas().size());
+    assertEquals(ContainerReplicaProto.State.CLOSED.toString(),
+        underRep.get(0).getReplicas().get(0).getState());
 
     List<UnhealthyContainerMetadata> misRep = records
         .stream()
@@ -928,6 +940,9 @@ public class TestContainerEndpoint {
     assertEquals(12345L, misRep.get(0).getUnhealthySince());
     assertEquals(13L, misRep.get(0).getContainerID());
     assertEquals("some reason", misRep.get(0).getReason());
+    assertEquals(1, misRep.get(0).getReplicas().size());
+    assertEquals(ContainerReplicaProto.State.CLOSED.toString(),
+        misRep.get(0).getReplicas().get(0).getState());
 
     List<UnhealthyContainerMetadata> replicaMismatch = records
         .stream()
@@ -941,6 +956,10 @@ public class TestContainerEndpoint {
     assertEquals(12345L, replicaMismatch.get(0).getUnhealthySince());
     assertEquals(15L, replicaMismatch.get(0).getContainerID());
     List<ContainerHistory> replicas = replicaMismatch.get(0).getReplicas();
+    assertEquals(3, replicas.size());
+    assertTrue(replicas.stream()
+        .map(ContainerHistory::getState)
+        .allMatch(s -> s.equals(ContainerReplicaProto.State.CLOSED.toString())));
     assertTrue(replicas.stream().anyMatch(checksum -> checksum.getDataChecksum() == 1234L));
     assertTrue(replicas.stream().anyMatch(checksum -> checksum.getDataChecksum() == 2345L));
   }
@@ -971,6 +990,7 @@ public class TestContainerEndpoint {
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
+    uuid5 = newDatanode("host5", "127.0.0.5");
     createUnhealthyRecords(5, 4, 3, 2, 1);
 
     // Check for unhealthy containers
@@ -1033,17 +1053,13 @@ public class TestContainerEndpoint {
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
+    uuid5 = newDatanode("host5", "127.0.0.5");
     createUnhealthyRecords(5, 4, 3, 2, 0);
 
     // Get first batch with no pagination (prevStartKey=0, prevLastKey=0)
     UnhealthyContainersResponse firstBatch =
         (UnhealthyContainersResponse) containerEndpoint.getUnhealthyContainers(
             3, 0, 0).getEntity();
-    assertTrue(firstBatch.getContainers().stream()
-        .flatMap(containerMetadata -> containerMetadata.getReplicas().stream()
-            .map(ContainerHistory::getState))
-        .allMatch(s -> s.equals("UNHEALTHY")));
-
     // For pagination, use the last container ID from the first batch as prevLastKey
     long lastContainerIdFromFirstBatch = firstBatch.getContainers().stream()
         .map(i -> i.getContainerID()).max(Long::compareTo).get();
@@ -1126,7 +1142,8 @@ public class TestContainerEndpoint {
   }
 
   private void createUnhealthyRecords(int missing, int overRep, int underRep,
-                                      int misRep, int dataChecksum) {
+                                      int misRep, int dataChecksum)
+      throws IOException {
     int cid = 0;
     for (int i = 0; i < missing; i++) {
       createUnhealthyRecord(++cid, UnHealthyContainerStates.MISSING.toString(),
@@ -1155,7 +1172,8 @@ public class TestContainerEndpoint {
   }
 
   private void createUnhealthyRecord(int id, String state, int expected,
-                                     int actual, int delta, String reason, boolean dataChecksumMismatch) {
+                                     int actual, int delta, String reason,
+                                     boolean dataChecksumMismatch) throws IOException {
     long cID = Integer.toUnsignedLong(id);
     ArrayList<ContainerHealthSchemaManager.UnhealthyContainerRecord> records =
         new ArrayList<>();
@@ -1173,6 +1191,30 @@ public class TestContainerEndpoint {
         "UNHEALTHY", ContainerChecksums.of(1234L, 0L));
     reconContainerManager.upsertContainerHistory(cID, uuid4, 4L, 1L,
         "UNHEALTHY", ContainerChecksums.of(1234L, 0L));
+
+    addCurrentReplicas(cID, actual, dataChecksumMismatch);
+  }
+
+  private void addCurrentReplicas(long containerID, int actual,
+      boolean dataChecksumMismatch) throws IOException {
+    List<UUID> uuids = Arrays.asList(uuid1, uuid2, uuid3, uuid4, uuid5);
+    for (int i = 0; i < actual; i++) {
+      long checksum = (dataChecksumMismatch && i == 0) ? 2345L : 1234L;
+      reconContainerManager.updateContainerReplica(ContainerID.valueOf(containerID),
+          ContainerReplica.newBuilder()
+              .setContainerID(ContainerID.valueOf(containerID))
+              .setContainerState(ContainerReplicaProto.State.CLOSED)
+              .setDatanodeDetails(reconContainerManager.getNodeDB()
+                  .get(DatanodeID.of(uuids.get(i))))
+              .setOriginNodeId(DatanodeID.of(uuids.get(i)))
+              .setSequenceId(1L)
+              .setReplicaIndex(0)
+              .setKeyCount(0L)
+              .setBytesUsed(0L)
+              .setEmpty(false)
+              .setChecksums(ContainerChecksums.of(checksum, 0L))
+              .build());
+    }
   }
 
   protected ContainerWithPipeline getTestContainer(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -982,8 +982,9 @@ public class TestContainerEndpoint {
     assertEquals(0, responseObject.getMisReplicatedCount());
     assertEquals(Collections.EMPTY_LIST, responseObject.getContainers());
 
-    // Add unhealthy records
-    putContainerInfos(5);
+    // Add unhealthy records for all container IDs created by
+    // createUnhealthyRecords(5, 4, 3, 2, 1), which uses IDs 1..15.
+    putContainerInfos(15);
     uuid1 = newDatanode("host1", "127.0.0.1");
     uuid2 = newDatanode("host2", "127.0.0.2");
     uuid3 = newDatanode("host3", "127.0.0.3");

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1194,7 +1194,8 @@ public class TestContainerEndpoint {
   private void addCurrentReplicas(long containerId, int actual,
       boolean dataChecksumMismatch) throws IOException {
     when(scmServiceProvider.getContainerReplicas(containerId))
-        .thenReturn(buildScmReplicaProtos(actual, dataChecksumMismatch));
+        .thenReturn(buildScmReplicaProtos(containerId, actual,
+            dataChecksumMismatch));
 
     List<UUID> uuids = Arrays.asList(uuid1, uuid2, uuid3, uuid4, uuid5);
     for (int i = 0; i < actual; i++) {
@@ -1217,7 +1218,8 @@ public class TestContainerEndpoint {
   }
 
   private List<HddsProtos.SCMContainerReplicaProto> buildScmReplicaProtos(
-      int actual, boolean dataChecksumMismatch) throws IOException {
+      long containerId, int actual, boolean dataChecksumMismatch)
+      throws IOException {
     List<UUID> uuids = Arrays.asList(uuid1, uuid2, uuid3, uuid4, uuid5);
     List<HddsProtos.SCMContainerReplicaProto> replicas = new ArrayList<>();
     for (int i = 0; i < actual; i++) {
@@ -1226,9 +1228,13 @@ public class TestContainerEndpoint {
       DatanodeDetails datanodeDetails = reconContainerManager.getNodeDB()
           .get(DatanodeID.of(uuid));
       replicas.add(HddsProtos.SCMContainerReplicaProto.newBuilder()
+          .setContainerID(containerId)
           .setSequenceID(1L)
           .setState(ContainerReplicaProto.State.CLOSED.toString())
           .setDatanodeDetails(datanodeDetails.getProtoBufMessage())
+          .setBytesUsed(0L)
+          .setPlaceOfBirth(DatanodeID.of(uuid).toString())
+          .setKeyCount(0L)
           .setDataChecksum(checksum)
           .build());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes incorrect datanode replica details returned by Recon for unhealthy containers by switching the unhealthy-container `replicas[] `response from Recon’s truncated replica history to SCM’s  current replica set. The response still enriches SCM replicas with Recon history metadata like first-seen and last-seen timestamps when available, but SCM is now the source of truth for replica membership.

 The change adds a new S`torageContainerServiceProvider.getContainerReplicas(...)` API, updates `ContainerEndpoint` to use it for unhealthy containers, and rewrites the affected Recon endpoint tests to validate SCM-backed behavior.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15051

## How was this patch tested?
 - Updated `TestContainerEndpoint` to validate the new unhealthy-container behavior against SCM-backed replica responses instead of Recon-local replica history.
  - Added/adjusted assertions to cover:
      - over-replicated containers returning all current SCM replicas
      - under-replicated and mis-replicated containers returning SCM replica state/details
      - replica-mismatch containers preserving checksum validation with SCM-backed replicas
      - missing containers in /containers/unhealthy returning empty replicas[] when SCM has no current replicas

<img width="2492" height="1176" alt="image" src="https://github.com/user-attachments/assets/71189fbf-1499-4552-84b3-719845bde507" />

```
bash-5.1$ ozone admin container info 1
Container id: 1
Pipeline id: d09949f4-d6f1-43c6-8fed-c0f028c3f689
Write PipelineId: 8b888300-6957-4616-ac9b-22d00da202e6
Write Pipeline State: CLOSED
Container State: QUASI_CLOSED
SequenceId: 236
Datanodes: [bc882bae-79f8-4aa4-bd53-8b4e4c082128/ozone-datanode-4.ozone_default,
734a2fae-ade6-4be1-a82a-dcf2741f62af/ozone-datanode-3.ozone_default]
Replicas: [State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 236; Origin: bc882bae-79f8-4aa4-bd53-8b4e4c082128; Location: bc882bae-79f8-4aa4-bd53-8b4e4c082128/ozone-datanode-4.ozone_default,
State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 236; Origin: bc882bae-79f8-4aa4-bd53-8b4e4c082128; Location: 734a2fae-ade6-4be1-a82a-dcf2741f62af/ozone-datanode-3.ozone_default]
```

<img width="2450" height="1284" alt="image" src="https://github.com/user-attachments/assets/512e37f9-5f99-48c7-a457-b5e6897fa75d" />

```
bash-5.1$ ozone admin container info 1
Container id: 1
Pipeline id: fb776384-9508-4a2c-90c4-a2b16b85ec5e
Write PipelineId: 8b888300-6957-4616-ac9b-22d00da202e6
Write Pipeline State: CLOSED
Container State: QUASI_CLOSED
SequenceId: 236
Datanodes: [bc882bae-79f8-4aa4-bd53-8b4e4c082128/ozone-datanode-4.ozone_default,
734a2fae-ade6-4be1-a82a-dcf2741f62af/ozone-datanode-3.ozone_default,
915cc957-eb1e-498d-982e-298cba67a332/ozone-datanode-1.ozone_default,
d0230185-6167-4e6a-97a6-092603a335d9/ozone-datanode-2.ozone_default]
Replicas: [State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 236; Origin: bc882bae-79f8-4aa4-bd53-8b4e4c082128; Location: bc882bae-79f8-4aa4-bd53-8b4e4c082128/ozone-datanode-4.ozone_default,
State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 236; Origin: bc882bae-79f8-4aa4-bd53-8b4e4c082128; Location: 734a2fae-ade6-4be1-a82a-dcf2741f62af/ozone-datanode-3.ozone_default,
State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 236; Origin: d0230185-6167-4e6a-97a6-092603a335d9; Location: 915cc957-eb1e-498d-982e-298cba67a332/ozone-datanode-1.ozone_default,
State: QUASI_CLOSED; ReplicaIndex: 0; SequenceId: 236; Origin: d0230185-6167-4e6a-97a6-092603a335d9; Location: d0230185-6167-4e6a-97a6-092603a335d9/ozone-datanode-2.ozone_default]
```