### PR TITLE
HDDS-14920. Check actions with zizmor

### DIFF
--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -65,19 +65,19 @@ jobs:
       thirdparty-version: ${{ steps.versions.outputs.thirdparty }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.ref }}
       - name: Cache for maven dependencies
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository
             !~/.m2/repository/org/apache/ratis
           key: ratis-dependencies-${{ hashFiles('**/pom.xml') }}
       - name: Setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: 8
@@ -95,7 +95,7 @@ jobs:
           mvn -B --no-transfer-progress -Dscan=false versions:set -DnewVersion=${{ steps.versions.outputs.ratis }}
           dev-support/checks/build.sh
       - name: Store Maven repo for tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ratis-jars
           path: |
@@ -112,7 +112,7 @@ jobs:
       protobuf-version: ${{ steps.versions.outputs.protobuf }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: apache/ratis-thirdparty
           ref: ${{ needs.ratis.outputs.thirdparty-version }}

--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -90,9 +90,10 @@ jobs:
           ratis_sha=$(git rev-parse --short HEAD)
           ratis_version="$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=project.version | sed -e "s/-SNAPSHOT/-${ratis_sha}-SNAPSHOT/")"
           echo "ratis=${ratis_version}" >> $GITHUB_OUTPUT
+          echo "ratis_version=${ratis_version}" >> $GITHUB_ENV
       - name: Run a full build
         run: |
-          mvn -B --no-transfer-progress -Dscan=false versions:set -DnewVersion=${{ steps.versions.outputs.ratis }}
+          mvn -B --no-transfer-progress -Dscan=false versions:set -DnewVersion="$ratis_version"
           dev-support/checks/build.sh
       - name: Store Maven repo for tests
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -130,8 +131,14 @@ jobs:
     steps:
       - name: Print versions
         run: |
-          echo ${{ needs.ratis.outputs.ratis-version }}
-          echo ${{ needs.ratis.outputs.thirdparty-version }}
-          echo ${{ needs.ratis-thirdparty.outputs.grpc-version }}
-          echo ${{ needs.ratis-thirdparty.outputs.netty-version }}
-          echo ${{ needs.ratis-thirdparty.outputs.protobuf-version }}
+          echo "Ratis: $ratis_version"
+          echo "Thirdparty: $ratis_thirdparty_version"
+          echo "Grpc: $grpc_version"
+          echo "Netty: $netty_version"
+          echo "Protobuf: $protobuf_version"
+        env:
+          ratis_version: ${{ needs.ratis.outputs.ratis-version }}
+          ratis_thirdparty_version: ${{ needs.ratis.outputs.thirdparty-version }}
+          grpc_version: ${{ needs.ratis-thirdparty.outputs.grpc-version }}
+          netty_version: ${{ needs.ratis-thirdparty.outputs.netty-version }}
+          protobuf_version: ${{ needs.ratis-thirdparty.outputs.protobuf-version }}

--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.ref }}
       - name: Cache for maven dependencies
@@ -115,6 +116,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: apache/ratis-thirdparty
           ref: ${{ needs.ratis.outputs.thirdparty-version }}
       - name: Get component versions

--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -56,6 +56,7 @@ on:
         value: ${{ jobs.ratis-thirdparty.outputs.protobuf-version }}
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+permissions: { }
 jobs:
   ratis:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -146,14 +146,14 @@ jobs:
     steps:
       - name: Checkout project
         if: ${{ !inputs.needs-ozone-source-tarball }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.sha }}
           fetch-depth: ${{ inputs.checkout-fetch-depth }}
 
       - name: Download Ozone source tarball
         if: ${{ inputs.needs-ozone-source-tarball }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ozone-src
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: Cache for NPM dependencies
         if: ${{ inputs.needs-npm-cache }}
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.pnpm-store
@@ -174,7 +174,7 @@ jobs:
 
       - name: Cache for Maven dependencies
         if: ${{ inputs.needs-maven-cache }}
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -186,7 +186,7 @@ jobs:
       - name: Download Ozone repo
         id: download-ozone-repo
         if: ${{ inputs.needs-ozone-repo }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ozone-repo
           path: |
@@ -194,7 +194,7 @@ jobs:
 
       - name: Download Ratis repo
         if: ${{ inputs.ratis-args != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ratis-jars
           path: |
@@ -202,7 +202,7 @@ jobs:
 
       - name: Download Ozone binary tarball
         if: ${{ inputs.needs-ozone-binary-tarball }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ozone-bin
 
@@ -215,7 +215,7 @@ jobs:
 
       - name: Setup java ${{ inputs.java-version }}
         if: ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java-version }}
@@ -259,7 +259,7 @@ jobs:
 
       - name: Archive build results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ (inputs.split && format('{0}-{1}', inputs.script, inputs.split)) || inputs.script }}
           # please keep path as a single item; move to that directory all files needed in the artifact
@@ -270,7 +270,7 @@ jobs:
       # to avoid the need for 3 more inputs.
       - name: Store binaries for tests
         if: ${{ inputs.script == 'build' && !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ozone-bin
           path: |
@@ -280,7 +280,7 @@ jobs:
 
       - name: Store source tarball for compilation
         if: ${{ inputs.script == 'build' && !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ozone-src
           path: |
@@ -289,7 +289,7 @@ jobs:
 
       - name: Store Maven repo for tests
         if: ${{ inputs.script == 'build' && !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ozone-repo
           path: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -138,6 +138,8 @@ env:
   OZONE_VOLUME_OWNER: 1000
   SCRIPT: ${{ inputs.script }}
 
+permissions: { }
+
 jobs:
   check:
     name: ${{ (inputs.split && format('{0} ({1})', inputs.script, inputs.split)) || inputs.script }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -129,6 +129,11 @@ on:
         default: true
         required: false
 
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        description: 'Token for submitting build scan to Develocity'
+        required: false
+
 env:
   HADOOP_IMAGE: ghcr.io/apache/hadoop
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -148,6 +148,7 @@ jobs:
         if: ${{ !inputs.needs-ozone-source-tarball }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.sha }}
           fetch-depth: ${{ inputs.checkout-fetch-depth }}
 

--- a/.github/workflows/ci-with-ratis.yml
+++ b/.github/workflows/ci-with-ratis.yml
@@ -52,6 +52,7 @@ jobs:
       contents: read
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
     with:
       ratis_args: "-Dratis.version=${{ needs.ratis.outputs.ratis-version }} -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }} -Dratis-thirdparty.grpc.version=${{ needs.ratis.outputs.grpc-version }} -Dratis-thirdparty.netty.version=${{ needs.ratis.outputs.netty-version }} -Dratis-thirdparty.protobuf.version=${{ needs.ratis.outputs.protobuf-version }}"
       ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/ci-with-ratis.yml
+++ b/.github/workflows/ci-with-ratis.yml
@@ -48,6 +48,8 @@ jobs:
     needs:
       - ratis
     uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:

--- a/.github/workflows/ci-with-ratis.yml
+++ b/.github/workflows/ci-with-ratis.yml
@@ -49,5 +49,5 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
     with:
-      ratis_args: "-Dratis.version=${{ needs.ratis.outputs.ratis-version }} -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }} -Dio.grpc.version=${{ needs.ratis.outputs.grpc-version }} -Dnetty.version=${{ needs.ratis.outputs.netty-version }} -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
+      ratis_args: "-Dratis.version=${{ needs.ratis.outputs.ratis-version }} -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }} -Dratis-thirdparty.grpc.version=${{ needs.ratis.outputs.grpc-version }} -Dratis-thirdparty.netty.version=${{ needs.ratis.outputs.netty-version }} -Dratis-thirdparty.protobuf.version=${{ needs.ratis.outputs.protobuf-version }}"
       ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/ci-with-ratis.yml
+++ b/.github/workflows/ci-with-ratis.yml
@@ -48,7 +48,8 @@ jobs:
     needs:
       - ratis
     uses: ./.github/workflows/ci.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       ratis_args: "-Dratis.version=${{ needs.ratis.outputs.ratis-version }} -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }} -Dratis-thirdparty.grpc.version=${{ needs.ratis.outputs.grpc-version }} -Dratis-thirdparty.netty.version=${{ needs.ratis.outputs.netty-version }} -Dratis-thirdparty.protobuf.version=${{ needs.ratis.outputs.protobuf-version }}"
       ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/ci-with-ratis.yml
+++ b/.github/workflows/ci-with-ratis.yml
@@ -37,6 +37,7 @@ on:
         default: 'master'
         required: true
 run-name: Test Ozone ${{ inputs.ref }} with Ratis ${{ inputs.ratis-repo }} @ ${{ inputs.ratis-ref }}
+permissions: { }
 jobs:
   ratis:
     uses: ./.github/workflows/build-ratis.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,19 +56,19 @@ jobs:
       with-coverage: ${{ env.OZONE_WITH_COVERAGE }}
     steps:
       - name: "Checkout ${{ github.ref }} / ${{ github.sha }} (push)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
         if: github.event_name  == 'push'
       - name: "Checkout ${{ github.sha }} with its parent (pull request)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
           fetch-depth: 2
           persist-credentials: false
         if: github.event_name  == 'pull_request'
       - name: "Checkout ${{ inputs.ref }} given in workflow input (manual dispatch)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
@@ -333,12 +333,12 @@ jobs:
       - integration
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ needs.build-info.outputs.sha }}
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -347,7 +347,7 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: target/artifacts
       - name: Untar binaries
@@ -355,7 +355,7 @@ jobs:
           mkdir -p hadoop-ozone/dist/target
           tar xzvf target/artifacts/ozone-bin/ozone*.tar.gz -C hadoop-ozone/dist/target
       - name: Setup java ${{ env.TEST_JAVA_VERSION }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ env.TEST_JAVA_VERSION }}
@@ -369,7 +369,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Archive build results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage
           path: target/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ needs.build-info.outputs.sha }}
       - name: Cache for maven dependencies
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}
 
+permissions: { }
+
 jobs:
   build-info:
     runs-on: ubuntu-slim
@@ -144,6 +146,8 @@ jobs:
       github.ref_name == 'master'
     uses: ./.github/workflows/update-ozone-site-config-doc.yml
     secrets: inherit
+    permissions:
+      contents: read
 
   compile:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ on:
         description: Ozone ref (branch, tag or commit SHA)
         default: ''
         required: false
+    secrets:
+      DEVELOCITY_ACCESS_KEY:
+        description: 'Token for submitting build scan to Develocity'
+        required: false
+      SONARCLOUD_TOKEN:
+        description: 'Token for submitting coverage data to SonarCloud'
+        required: false
+
 env:
   BUILD_ARGS: "-Pdist -Psrc -Dmaven.javadoc.skip=true -Drocks_tools_native"
   TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
@@ -123,7 +131,8 @@ jobs:
       sha: ${{ needs.build-info.outputs.sha }}
       timeout-minutes: 60
       with-coverage: ${{ fromJSON(needs.build-info.outputs.with-coverage) }}
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   generate-config-doc:
     needs:
@@ -145,7 +154,6 @@ jobs:
       github.repository == 'apache/ozone' &&
       github.ref_name == 'master'
     uses: ./.github/workflows/update-ozone-site-config-doc.yml
-    secrets: inherit
     permissions:
       contents: read
 
@@ -177,7 +185,8 @@ jobs:
       split: ${{ matrix.java }}
       timeout-minutes: 45
       with-coverage: false
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   basic:
     needs:
@@ -192,7 +201,8 @@ jobs:
       script: ${{ matrix.check }}
       sha: ${{ needs.build-info.outputs.sha }}
       timeout-minutes: 30
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     strategy:
       matrix:
         check: ${{ fromJson(needs.build-info.outputs.basic-checks) }}
@@ -203,7 +213,8 @@ jobs:
       - build-info
       - build
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}
       needs-ozone-binary-tarball: true
@@ -216,7 +227,8 @@ jobs:
       - build-info
       - build
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}
       needs-ozone-repo: true
@@ -231,7 +243,8 @@ jobs:
       - basic
     if: needs.build-info.outputs.needs-compile == 'true'
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}
       needs-ozone-repo: true
@@ -247,7 +260,8 @@ jobs:
       - dependency
       - license
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}
       needs-ozone-repo: true
@@ -268,7 +282,8 @@ jobs:
       - license
     if: needs.build-info.outputs.needs-compose-tests == 'true'
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: 11 # Hadoop may not work with newer Java
       needs-ozone-binary-tarball: true
@@ -293,7 +308,8 @@ jobs:
       - license
     if: needs.build-info.outputs.needs-kubernetes-tests == 'true'
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       needs-ozone-binary-tarball: true
       ratis-args: ${{ inputs.ratis_args }}
@@ -311,7 +327,8 @@ jobs:
       - license
     if: needs.build-info.outputs.needs-integration-tests == 'true'
     uses: ./.github/workflows/check.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: ${{ needs.build-info.outputs.java-version }}
       pre-script: sudo hostname localhost

--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -18,6 +18,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: { }
+
 jobs:
   close-stale-prs:
     permissions:

--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Close Stale PRs
-        uses: actions/stale@v10
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-pr-label: 'stale'
           exempt-draft-pr: false

--- a/.github/workflows/generate-config-doc.yml
+++ b/.github/workflows/generate-config-doc.yml
@@ -21,6 +21,8 @@ on:
         type: string
         required: true
 
+permissions: { }
+
 jobs:
   generate-config-doc:
     runs-on: ubuntu-slim

--- a/.github/workflows/generate-config-doc.yml
+++ b/.github/workflows/generate-config-doc.yml
@@ -26,17 +26,17 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.sha }}
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       
       - name: Download ozone-bin artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ozone-bin
           path: ozone-bin
@@ -51,7 +51,7 @@ jobs:
           python3 dev-support/ci/xml_to_md.py ozone-bin/extracted Configurations.md
       
       - name: Upload generated documentation
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: config-documentation
           path: Configurations.md

--- a/.github/workflows/generate-config-doc.yml
+++ b/.github/workflows/generate-config-doc.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.sha }}
       
       - name: Set up Python

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -79,6 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       - id: generate
         name: Generate test matrix
@@ -107,6 +108,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for maven dependencies
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -171,6 +173,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for maven dependencies
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -133,16 +133,22 @@ jobs:
         run: |
           args="-DskipRecon -DskipShade -Dmaven.javadoc.skip=true -Drocks_tools_native"
           if [[ "$RATIS_VERSION" != "" ]]; then
-            args="$args -Dratis.version=${{ needs.ratis.outputs.ratis-version }}"
-            args="$args -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }}"
-            args="$args -Dio.grpc.version=${{ needs.ratis.outputs.grpc-version }}"
-            args="$args -Dnetty.version=${{ needs.ratis.outputs.netty-version }}"
-            args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
+            args="$args -Dratis.version=$ratis_version"
+            args="$args -Dratis.thirdparty.version=$ratis_thirdparty_version"
+            args="$args -Dratis-thirdparty.grpc.version=$grpc_version"
+            args="$args -Dratis-thirdparty.netty.version=$netty_version"
+            args="$args -Dratis-thirdparty.protobuf.version=$protobuf_version"
           fi
 
           args="$args -am -pl :$SUBMODULE"
 
           hadoop-ozone/dev-support/checks/build.sh $args
+        env:
+          ratis_version: ${{ needs.ratis.outputs.ratis-version }}
+          ratis_thirdparty_version: ${{ needs.ratis.outputs.thirdparty-version }}
+          grpc_version: ${{ needs.ratis.outputs.grpc-version }}
+          netty_version: ${{ needs.ratis.outputs.netty-version }}
+          protobuf_version: ${{ needs.ratis.outputs.protobuf-version }}
       - name: Store Maven repo for tests
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -197,17 +203,17 @@ jobs:
           java-version: ${{ github.event.inputs.java-version }}
       - name: Execute tests
         run: |
-          if [[ -e "${{ steps.download-ozone-repo.outputs.download-path }}" ]]; then
+          if [[ -e "$repo_path" ]]; then
             export OZONE_REPO_CACHED=true
           fi
 
           args="-DexcludedGroups=slow|unhealthy -DskipShade -Drocks_tools_native"
           if [[ "$RATIS_VERSION" != "" ]]; then
-            args="$args -Dratis.version=${{ needs.ratis.outputs.ratis-version }}"
-            args="$args -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }}"
-            args="$args -Dio.grpc.version=${{ needs.ratis.outputs.grpc-version }}"
-            args="$args -Dnetty.version=${{ needs.ratis.outputs.netty-version }}"
-            args="$args -Dgrpc.protobuf-compile.version=${{ needs.ratis.outputs.protobuf-version }}"
+            args="$args -Dratis.version=$ratis_version"
+            args="$args -Dratis.thirdparty.version=$ratis_thirdparty_version"
+            args="$args -Dratis-thirdparty.grpc.version=$grpc_version"
+            args="$args -Dratis-thirdparty.netty.version=$netty_version"
+            args="$args -Dratis-thirdparty.protobuf.version=$protobuf_version"
           fi
 
           args="$args -pl :$SUBMODULE"
@@ -224,6 +230,12 @@ jobs:
         continue-on-error: true
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          repo_path: ${{ steps.download-ozone-repo.outputs.download-path }}
+          ratis_version: ${{ needs.ratis.outputs.ratis-version }}
+          ratis_thirdparty_version: ${{ needs.ratis.outputs.thirdparty-version }}
+          grpc_version: ${{ needs.ratis.outputs.grpc-version }}
+          netty_version: ${{ needs.ratis.outputs.netty-version }}
+          protobuf_version: ${{ needs.ratis.outputs.protobuf-version }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/unit/summary.txt
         if: ${{ !cancelled() }}

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -71,6 +71,7 @@ env:
   # SUREFIRE-1722, SUREFIRE-1815
   SUREFIRE_VERSION: 3.0.0-M4
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}-java{5}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations, inputs.java-version) || '' }}
+permissions: { }
 jobs:
   prepare-job:
     runs-on: ubuntu-slim

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -77,7 +77,7 @@ jobs:
     outputs:
       matrix: ${{steps.generate.outputs.matrix}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
       - id: generate
@@ -105,11 +105,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -119,13 +119,13 @@ jobs:
             maven-repo-
       - name: Download Ratis repo
         if: ${{ github.event.inputs.ratis-ref != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
       - name: Setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ github.event.inputs.java-version }}
@@ -144,7 +144,7 @@ jobs:
 
           hadoop-ozone/dev-support/checks/build.sh $args
       - name: Store Maven repo for tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ozone-repo
           path: |
@@ -163,11 +163,11 @@ jobs:
         split: ${{fromJson(needs.prepare-job.outputs.matrix)}}  # Define  splits
       fail-fast: ${{ fromJson(github.event.inputs.fail-fast) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -177,21 +177,21 @@ jobs:
             maven-repo-
       - name: Download Ratis repo
         if: ${{ github.event.inputs.ratis-ref != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
       - name: Download Ozone repo
         id: download-ozone-repo
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ozone-repo
           path: |
             ~/.m2/repository/org/apache/ozone
         continue-on-error: true
       - name: Setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ github.event.inputs.java-version }}
@@ -228,7 +228,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/unit/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ failure() }}
         with:
           name: result-${{ github.run_number }}-${{ github.run_id }}-split-${{ matrix.split }}
@@ -239,7 +239,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Download build results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Count failures
         run: |
           failures=$(find . -name 'summary.txt' | grep --text -v 'iteration' | xargs grep --text -v 'exit code: 0' | wc -l)

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout project" # required for `gh` CLI
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore cache for Maven dependencies
         id: restore-cache
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -47,7 +47,7 @@ jobs:
 
       - name: Setup Java
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: 8
@@ -60,7 +60,7 @@ jobs:
       - name: Restore NodeJS tarballs
         id: restore-nodejs
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository/com/github/eirslett/node
           key: nodejs-${{ steps.nodejs-version.outputs.nodejs-version }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Save cache for Maven dependencies
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5.0.5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -29,6 +29,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: { }
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Restore cache for Maven dependencies
         id: restore-cache

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -20,6 +20,8 @@ on:
 concurrency:
   group: ci-${{ github.event.pull_request.number || case(github.repository == 'apache/ozone', github.sha, github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'apache/ozone' }}
+permissions:
+  contents: read
 jobs:
   CI:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -28,4 +28,6 @@ jobs:
       || (github.repository == 'apache/ozone' && !startsWith(github.ref_name, 'dependabot'))
       || (github.repository != 'apache/ozone' && github.ref_name != 'master')
     uses: ./.github/workflows/ci.yml
-    secrets: inherit
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check pull request title
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check pull request title
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,6 +23,8 @@ on:
       - edited
       - synchronize
 
+permissions: { }
+
 jobs:
   title:
     runs-on: ubuntu-slim

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       - name: Verify Test Filter
         run: |
@@ -83,6 +84,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for npm dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -133,6 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -50,6 +50,7 @@ env:
   JAVA_VERSION: 8
   SPLITS: ${{ github.event.inputs.splits }}
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}[{1}]-{2}', inputs.test-suite || inputs.test-filter, inputs.ref, inputs.splits) || '' }}
+permissions: { }
 jobs:
   prepare-job:
     runs-on: ubuntu-slim

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -56,7 +56,7 @@ jobs:
     outputs:
       matrix: ${{steps.generate.outputs.matrix}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Verify Test Filter
@@ -81,11 +81,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for npm dependencies
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.pnpm-store
@@ -94,7 +94,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -104,7 +104,7 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -113,7 +113,7 @@ jobs:
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Store binaries for tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ozone-bin
           path: |
@@ -131,11 +131,11 @@ jobs:
         split: ${{ fromJson(needs.prepare-job.outputs.matrix) }}
       fail-fast: ${{ fromJson(github.event.inputs.fail-fast) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ozone-bin
       - name: Untar binaries
@@ -154,7 +154,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: acceptance-${{ matrix.split }}

--- a/.github/workflows/schedule-label-pr.yml
+++ b/.github/workflows/schedule-label-pr.yml
@@ -27,4 +27,3 @@ permissions: { }
 jobs:
   label:
     uses: ./.github/workflows/label-pr.yml
-    secrets: inherit

--- a/.github/workflows/schedule-label-pr.yml
+++ b/.github/workflows/schedule-label-pr.yml
@@ -22,6 +22,8 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
+permissions: { }
+
 jobs:
   label:
     uses: ./.github/workflows/label-pr.yml

--- a/.github/workflows/scheduled-cache-update.yml
+++ b/.github/workflows/scheduled-cache-update.yml
@@ -26,4 +26,3 @@ permissions: { }
 jobs:
   update:
     uses: ./.github/workflows/populate-cache.yml
-    secrets: inherit

--- a/.github/workflows/scheduled-cache-update.yml
+++ b/.github/workflows/scheduled-cache-update.yml
@@ -21,6 +21,8 @@ on:
   schedule:
     - cron: '20 3 * * *'
 
+permissions: { }
+
 jobs:
   update:
     uses: ./.github/workflows/populate-cache.yml

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -98,6 +98,7 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           path: ozone-repo
       

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -19,6 +19,8 @@ on:
 
 env:
   BRANCH_NAME: automated-config-doc-update
+  REPO_OWNER: "${{ github.repository_owner }}"
+  SHA: ${{ github.sha }}
 
 jobs:
   update-ozone-site-config-doc:
@@ -41,7 +43,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: "${{ github.repository_owner }}"
       
       - name: Checkout ozone-site repository
         if: steps.check-site-repo.outputs.exists == 'true'
@@ -50,7 +51,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           
-          git clone --depth=1 --branch=master https://github.com/${{ github.repository_owner }}/ozone-site.git ozone-site
+          git clone --depth=1 --branch=master https://github.com/$REPO_OWNER/ozone-site.git ozone-site
           
           # Check if $BRANCH_NAME branch exists remotely
           cd ozone-site
@@ -86,7 +87,7 @@ jobs:
           # Check if file changed using git status
           if git status --porcelain "$TARGET_FILE" | grep -q .; then
             echo "changed=true" >> $GITHUB_OUTPUT
-            echo "target_file=$TARGET_FILE" >> $GITHUB_OUTPUT
+            echo "TARGET_FILE=$TARGET_FILE" >> $GITHUB_ENV
             echo "Configurations.md has changed in ozone-site"
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -105,16 +106,15 @@ jobs:
         id: extract-jira
         run: |
           cd ozone-repo
-          COMMIT_MSG=$(git log -1 --format='%s' ${{ github.sha }})
+          COMMIT_MSG=$(git log -1 --format='%s' $SHA)
           echo "Commit message: $COMMIT_MSG"
           
           JIRA_ID=$(echo "$COMMIT_MSG" | grep -oE '(HDDS|OZONE)-[0-9]+' | head -1 || echo "")
           
+          echo "JIRA_ID=$JIRA_ID" >> $GITHUB_ENV
           if [ -n "$JIRA_ID" ]; then
-            echo "jira_id=$JIRA_ID" >> $GITHUB_OUTPUT
             echo "Using JIRA ID: $JIRA_ID"
           else
-            echo "jira_id=" >> $GITHUB_OUTPUT
             echo "No JIRA ID found"
           fi
       
@@ -130,12 +130,10 @@ jobs:
           git checkout -B "$BRANCH_NAME"
           echo "Created/reset branch $BRANCH_NAME at current commit"
           
-          TARGET_FILE="${{ steps.check-changes.outputs.target_file }}"
           git add "$TARGET_FILE"
           
           # Build commit message with JIRA ID if available
-          JIRA_ID="${{ steps.extract-jira.outputs.jira_id }}"
-          COMMIT_MSG="[Auto] Update configuration documentation from ozone ${{ github.sha }}"
+          COMMIT_MSG="[Auto] Update configuration documentation from ozone $SHA"
           if [ -n "$JIRA_ID" ]; then
             COMMIT_MSG="$JIRA_ID. $COMMIT_MSG"
           fi
@@ -149,34 +147,31 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true' && github.repository == 'apache/ozone'
         env:
           GH_TOKEN: ${{ secrets.OZONE_WEBSITE_BUILD }}
-          JIRA_ID: ${{ steps.extract-jira.outputs.jira_id }}
+          REF_NAME: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
         run: |
           cd ozone-site
           
           # Generate PR body
           ../ozone-repo/dev-support/ci/pr_body_config_doc.sh \
-            "$REPO" \
-            "${{ github.workflow }}" \
-            "${{ github.run_id }}" \
-            "${{ github.ref_name }}" \
-            "${{ github.sha }}" \
-            "$JIRA_ID" > pr_body.txt
+            "$REPO" "$WORKFLOW" "$RUN_ID" "$REF_NAME" "$SHA" "$JIRA_ID" > pr_body.txt
           
           # Check if PR already exists
-          EXISTING_PR=$(gh pr list --repo "${{ github.repository_owner }}/ozone-site" \
+          EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
             --head "$BRANCH_NAME" --base master --json number --jq '.[0].number' || echo "")
           
           if [ -n "$EXISTING_PR" ]; then
             echo "Updating existing PR #$EXISTING_PR with a comment"
-            gh pr comment "$EXISTING_PR" --repo "${{ github.repository_owner }}/ozone-site" --body-file pr_body.txt
+            gh pr comment "$EXISTING_PR" --repo "$REPO_OWNER/ozone-site" --body-file pr_body.txt
           else
             echo "Creating new PR"
             TITLE="[Auto] Update configuration documentation"
             if [ -n "$JIRA_ID" ]; then
               TITLE="$JIRA_ID. $TITLE"
             fi
-            gh pr create --repo "${{ github.repository_owner }}/ozone-site" \
+            gh pr create --repo "$REPO_OWNER/ozone-site" \
               --base master --head "$BRANCH_NAME" \
               --title "$TITLE" \
               --body-file pr_body.txt

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Download generated documentation
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: config-documentation
           path: .
@@ -95,7 +95,7 @@ jobs:
       
       - name: Checkout ozone repository for script access
         if: steps.check-changes.outputs.changed == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
           path: ozone-repo

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -22,6 +22,9 @@ env:
   REPO_OWNER: "${{ github.repository_owner }}"
   SHA: ${{ github.sha }}
 
+permissions:
+  contents: read
+
 jobs:
   update-ozone-site-config-doc:
     runs-on: ubuntu-slim

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: zizmor
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
+  pull_request:
+
+permissions: { }
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Check GitHub workflows with [zizmor](https://docs.zizmor.sh/integrations/#github-actions).
- Fix violations:
  - avoid template injection by using intermediate variables (see [GitHub doc](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable))
  - do not persist credentials
  - limit workflow permissions
  - pass specific secrets to reusable workflows
  - pin actions by SHA

Also fixes leftover Ratis property names (changed in `pom.xml` by HDDS-5410) in `ci-with-ratis` and `flaky-test-check`.

https://issues.apache.org/jira/browse/HDDS-14920

## How was this patch tested?

- zizmor: https://github.com/adoroszlai/ozone/actions/runs/24710653994/job/72274232340#step:3:115
- CI: https://github.com/adoroszlai/ozone/actions/runs/24710654042
- populate-cache: https://github.com/adoroszlai/ozone/actions/runs/24714879033
- ci-with-ratis: https://github.com/adoroszlai/ozone/actions/runs/24714788670
- flaky-test-check: https://github.com/adoroszlai/ozone/actions/runs/24711716604
- repeat-acceptance-test: https://github.com/adoroszlai/ozone/actions/runs/24711755399
- label-pull-requests: https://github.com/adoroszlai/ozone/actions/runs/24714901087