### PR TITLE
HDDS-15076. Fix Incorrect pending deletion size for EC blocks in DN

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -649,7 +649,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       // Update pending deletion blocks count, blocks bytes and delete transaction ID in in-memory container status.
       // Persist pending bytes only if the feature is finalized.
       if (VersionedDatanodeFeatures.isFinalized(
-          HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION) && delTX.hasTotalBlockSize()) {
+          HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION) && delTX.hasTotalSizePerReplica()) {
         long pendingBytes = containerData.getBlockPendingDeletionBytes();
         pendingBytes += delTX.getTotalSizePerReplica();
         metadataTable
@@ -658,7 +658,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
                 pendingBytes);
       }
       containerData.incrPendingDeletionBlocks(newDeletionBlocks,
-          delTX.hasTotalBlockSize() ? delTX.getTotalSizePerReplica() : 0);
+          delTX.hasTotalSizePerReplica() ? delTX.getTotalSizePerReplica() : 0);
       containerData.updateDeleteTransactionId(delTX.getTxID());
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -648,17 +648,18 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
 
       // Update pending deletion blocks count, blocks bytes and delete transaction ID in in-memory container status.
       // Persist pending bytes only if the feature is finalized.
+      long perReplicaPendingBytes = delTX.getTotalSizePerReplica();
       if (VersionedDatanodeFeatures.isFinalized(
-          HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION) && delTX.hasTotalBlockSize()) {
+          HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION)) {
         long pendingBytes = containerData.getBlockPendingDeletionBytes();
-        pendingBytes += delTX.getTotalBlockSize();
+        pendingBytes += perReplicaPendingBytes;
         metadataTable
             .putWithBatch(batchOperation,
                 containerData.getPendingDeleteBlockBytesKey(),
                 pendingBytes);
       }
       containerData.incrPendingDeletionBlocks(newDeletionBlocks,
-          delTX.hasTotalBlockSize() ? delTX.getTotalBlockSize() : 0);
+          perReplicaPendingBytes);
       containerData.updateDeleteTransactionId(delTX.getTxID());
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -648,18 +648,17 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
 
       // Update pending deletion blocks count, blocks bytes and delete transaction ID in in-memory container status.
       // Persist pending bytes only if the feature is finalized.
-      long perReplicaPendingBytes = delTX.getTotalSizePerReplica();
       if (VersionedDatanodeFeatures.isFinalized(
-          HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION)) {
+          HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION) && delTX.hasTotalBlockSize()) {
         long pendingBytes = containerData.getBlockPendingDeletionBytes();
-        pendingBytes += perReplicaPendingBytes;
+        pendingBytes += delTX.getTotalSizePerReplica();
         metadataTable
             .putWithBatch(batchOperation,
                 containerData.getPendingDeleteBlockBytesKey(),
                 pendingBytes);
       }
       containerData.incrPendingDeletionBlocks(newDeletionBlocks,
-          perReplicaPendingBytes);
+          delTX.hasTotalBlockSize() ? delTX.getTotalSizePerReplica() : 0);
       containerData.updateDeleteTransactionId(delTX.getTxID());
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/BlockGroup.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/BlockGroup.java
@@ -50,6 +50,7 @@ public final class BlockGroup {
       kbb.addBlocks(deletedBlock.getBlockID().getProtobuf());
       kbb.addSize(deletedBlock.getSize());
       kbb.addReplicatedSize(deletedBlock.getReplicatedSize());
+      kbb.addSizePerReplica(deletedBlock.getSizePerReplica());
     }
     return kbb.setKey(groupID).build();
   }
@@ -62,17 +63,21 @@ public final class BlockGroup {
   public static BlockGroup getFromProto(KeyBlocks proto) {
     List<DeletedBlock> deletedBlocksList = new ArrayList<>();
     for (int i = 0; i < proto.getBlocksCount(); i++) {
-      long repSize = SIZE_NOT_AVAILABLE;
       long size = SIZE_NOT_AVAILABLE;
+      long repSize = SIZE_NOT_AVAILABLE;
+      long sizePerReplica = SIZE_NOT_AVAILABLE;
       if (proto.getSizeCount() > i) {
         size = proto.getSize(i);
       }
       if (proto.getReplicatedSizeCount() > i) {
         repSize = proto.getReplicatedSize(i);
       }
+      if (proto.getSizePerReplicaCount() > i) {
+        sizePerReplica = proto.getSizePerReplica(i);
+      }
       BlockID block = new BlockID(proto.getBlocks(i).getContainerBlockID().getContainerID(),
           proto.getBlocks(i).getContainerBlockID().getLocalID());
-      deletedBlocksList.add(new DeletedBlock(block, size, repSize));
+      deletedBlocksList.add(new DeletedBlock(block, size, repSize, sizePerReplica));
     }
     return BlockGroup.newBuilder().setKeyName(proto.getKey())
         .addAllDeletedBlocks(deletedBlocksList)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/DeletedBlock.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/DeletedBlock.java
@@ -27,11 +27,13 @@ public class DeletedBlock {
   private BlockID blockID;
   private long size;
   private long replicatedSize;
+  private long sizePerReplica;
 
-  public DeletedBlock(BlockID blockID, long size, long replicatedSize) {
+  public DeletedBlock(BlockID blockID, long size, long replicatedSize, long sizePerReplica) {
     this.blockID = blockID;
     this.size = size;
     this.replicatedSize = replicatedSize;
+    this.sizePerReplica = sizePerReplica;
   }
 
   public BlockID getBlockID() {
@@ -46,13 +48,18 @@ public class DeletedBlock {
     return this.replicatedSize;
   }
 
+  public long getSizePerReplica() {
+    return this.sizePerReplica;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder(64);
     sb.append(" localID: ").append(blockID.getContainerBlockID().getLocalID())
         .append(" containerID: ").append(blockID.getContainerBlockID().getContainerID())
         .append(" size: ").append(size)
-        .append(" replicatedSize: ").append(replicatedSize);
+        .append(" replicatedSize: ").append(replicatedSize)
+        .append(" sizePerReplica: ").append(sizePerReplica);
     return sb.toString();
   }
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -377,6 +377,7 @@ message DeletedBlocksTransaction {
   optional int32 count = 4 [deprecated=true];
   optional uint64 totalBlockSize = 5;
   optional uint64 totalBlockReplicatedSize = 6;
+  optional uint64 totalSizePerReplica = 7;
 }
 
 // ACK message datanode sent to SCM, contains the result of

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -183,6 +183,7 @@ message KeyBlocks {
   repeated BlockID blocks = 2;
   repeated uint64 size = 3;
   repeated uint64 replicatedSize = 4;
+  repeated uint64 sizePerReplica = 5;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -171,6 +171,11 @@ public class DeletedBlockLogImpl
         builder.setTotalBlockReplicatedSize(replicatedSize);
         builder.setTotalBlockSize(blocks.stream().mapToLong(DeletedBlock::getSize).sum());
       }
+
+      long sizePerReplica = blocks.stream().mapToLong(DeletedBlock::getSizePerReplica).sum();
+      if (sizePerReplica >= 0) {
+        builder.setTotalSizePerReplica(sizePerReplica);
+      }
     }
     return builder.build();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -231,7 +231,8 @@ public class TestDeletedBlockLog {
       updateContainerMetadata(containerID, state);
       for (int j = 0; j < BLOCKS_PER_TXN; j++)  {
         long localID = localIDBase + j;
-        blocks.add(new DeletedBlock(new BlockID(containerID, localID), blockSize + j, blockSize + j));
+        blocks.add(new DeletedBlock(new BlockID(containerID, localID),
+            blockSize + j, blockSize + j, blockSize + j));
       }
       blockMap.put(containerID, blocks);
     }
@@ -733,7 +734,8 @@ public class TestDeletedBlockLog {
     Map<Long, List<DeletedBlock>> deletedBlocksMap = new HashMap<>();
     long localId = RandomUtils.secure().randomLong();
     List<DeletedBlock> blockIDList = new ArrayList<>();
-    blockIDList.add(new DeletedBlock(new BlockID(containerID, localId), SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
+    blockIDList.add(new DeletedBlock(new BlockID(containerID, localId),
+        SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
     deletedBlocksMap.put(containerID, blockIDList);
     addTransactions(deletedBlocksMap, true);
     blocks = getTransactions(txNum * BLOCKS_PER_TXN * ONE);
@@ -808,7 +810,8 @@ public class TestDeletedBlockLog {
     long containerID = 1000000;
     List<DeletedBlock> blocks = new ArrayList<>();
     for (int i = 0; i < blockCount; i++) {
-      blocks.add(new DeletedBlock(new BlockID(containerID, 100000000 + i), 128 * 1024 * 1024, 128 * 1024 * 1024));
+      blocks.add(new DeletedBlock(new BlockID(containerID, 100000000 + i),
+          128 * 1024 * 1024, 128 * 1024 * 1024, 128 * 1024 * 1024));
     }
     List<Long> localIdList = blocks.stream().map(b -> b.getBlockID().getLocalID()).collect(Collectors.toList());
     DeletedBlocksTransaction tx1 = DeletedBlocksTransaction.newBuilder()
@@ -818,6 +821,7 @@ public class TestDeletedBlockLog {
         .setCount(0)
         .setTotalBlockSize(blocks.stream().mapToLong(DeletedBlock::getSize).sum())
         .setTotalBlockReplicatedSize(blocks.stream().mapToLong(DeletedBlock::getReplicatedSize).sum())
+        .setTotalSizePerReplica(blocks.stream().mapToLong(DeletedBlock::getSizePerReplica).sum())
         .build();
     DeletedBlocksTransaction tx2 = DeletedBlocksTransaction.newBuilder()
         .setTxID(txID)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/QuotaUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/QuotaUtil.java
@@ -67,6 +67,24 @@ public final class QuotaUtil {
   }
 
   /**
+   * Calculate the physical bytes stored on a single DataNode for one block.
+   * For RATIS each DN holds a full copy, so the per-replica size equals the
+   * logical block size. For EC each DN holds one chunk per stripe, so the
+   * per-replica size is {@code replicatedSize / requiredNodes}.
+   *
+   * @param dataSize  logical (unreplicated) block size in bytes
+   * @param repConfig replication configuration
+   * @return bytes stored on a single DN for this block
+   */
+  public static long getSizePerReplica(long dataSize, ReplicationConfig repConfig) {
+    int requiredNodes = repConfig.getRequiredNodes();
+    if (requiredNodes <= 0) {
+      return dataSize;
+    }
+    return getReplicatedSize(dataSize, repConfig) / requiredNodes;
+  }
+
+  /**
    * Get an estimated data size (before replication) from the replicated size.
    * An (inaccurate) reverse of getReplicatedSize().
    * @param replicatedSize size after replication.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/QuotaUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/QuotaUtil.java
@@ -77,6 +77,9 @@ public final class QuotaUtil {
    * @return bytes stored on a single DN for this block
    */
   public static long getSizePerReplica(long dataSize, ReplicationConfig repConfig) {
+    if (repConfig.getReplicationType() == RATIS) {
+      return dataSize;
+    }
     int requiredNodes = repConfig.getRequiredNodes();
     if (requiredNodes <= 0) {
       return dataSize;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestQuotaUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestQuotaUtil.java
@@ -97,4 +97,28 @@ public class TestQuotaUtil {
     assertEquals(dataSize + ONE_MB * 2, replicatedSize);
   }
 
+  @Test
+  public void testGetSizePerReplicaRatisThree() {
+    ReplicationConfig repConfig = RatisReplicationConfig.getInstance(THREE);
+    // Each of the 3 DNs holds the full block, so per-replica == logical size.
+    assertEquals(123 * ONE_MB, QuotaUtil.getSizePerReplica(123 * ONE_MB, repConfig));
+  }
+
+  @Test
+  public void testGetSizePerReplicaRatisOne() {
+    ReplicationConfig repConfig = RatisReplicationConfig.getInstance(ONE);
+    assertEquals(123 * ONE_MB, QuotaUtil.getSizePerReplica(123 * ONE_MB, repConfig));
+  }
+
+  @Test
+  public void testGetSizePerReplicaEC() {
+    // EC(3,2): 5 nodes total. replicatedSize = dataSize + parity overhead.
+    // Per-replica = replicatedSize / 5.
+    ECReplicationConfig repConfig = new ECReplicationConfig(3, 2, RS, ONE_MB);
+    long dataSize = ONE_MB * 3 * 10; // 10 full stripes
+    long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
+    long expected = replicatedSize / repConfig.getRequiredNodes(); // / 5
+    assertEquals(expected, QuotaUtil.getSizePerReplica(dataSize, repConfig));
+  }
+
 }

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractTestStorageDistributionEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractTestStorageDistributionEndpoint.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.ozone.recon;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
-import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
-import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_GAP;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
@@ -36,18 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -57,25 +50,17 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
-import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
-import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.recon.api.DataNodeMetricsService;
@@ -84,27 +69,22 @@ import org.apache.hadoop.ozone.recon.api.types.DatanodeStorageReport;
 import org.apache.hadoop.ozone.recon.api.types.ScmPendingDeletion;
 import org.apache.hadoop.ozone.recon.api.types.StorageCapacityDistributionResponse;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
-import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ratis.util.function.CheckedConsumer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test class for the Storage Distribution REST endpoint in the
- * Recon service. This class is responsible for setting up the
- * testing environment, performing operations on an Ozone cluster,
- * and validating the response of the storage distribution endpoint.
+ * Abstract base class for Storage Distribution endpoint integration tests.
+ * Provides shared cluster lifecycle management, helper methods, and common
+ * verification logic. Subclasses supply the replication-type-specific
+ * configuration (number of datanodes, replication config) and the concrete
+ * {@code @Test} method.
  */
-public class TestStorageDistributionEndpoint {
+public abstract class AbstractTestStorageDistributionEndpoint {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestStorageDistributionEndpoint.class);
+  protected static final Logger LOG =
+      LoggerFactory.getLogger(AbstractTestStorageDistributionEndpoint.class);
 
   private static OzoneConfiguration conf;
   private static MiniOzoneCluster cluster;
@@ -113,19 +93,55 @@ public class TestStorageDistributionEndpoint {
   private static OzoneClient client;
   private static ReconService recon;
   private FileSystem fs;
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  protected static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private static final String STORAGE_DIST_ENDPOINT = "/api/v1/storageDistribution";
-  private static final String PENDING_DELETION_ENDPOINT = "/api/v1/pendingDeletion";
+  protected static final String STORAGE_DIST_ENDPOINT = "/api/v1/storageDistribution";
+  protected static final String PENDING_DELETION_ENDPOINT = "/api/v1/pendingDeletion";
 
-  static List<Arguments> replicationConfigs() {
-    return Collections.singletonList(
-        Arguments.of(ReplicationConfig.fromTypeAndFactor(RATIS, THREE))
-    );
+  protected static OzoneConfiguration getConf() {
+    return conf;
   }
 
-  @BeforeAll
-  public static void setup() throws Exception {
+  protected static MiniOzoneCluster getCluster() {
+    return cluster;
+  }
+
+  protected static OzoneManager getOm() {
+    return om;
+  }
+
+  protected static StorageContainerManager getScm() {
+    return scm;
+  }
+
+  protected static OzoneClient getClient() {
+    return client;
+  }
+
+  protected static ReconService getRecon() {
+    return recon;
+  }
+
+  protected FileSystem getFs() {
+    return fs;
+  }
+
+  protected void setFs(FileSystem fileSystem) {
+    this.fs = fileSystem;
+  }
+
+  /**
+   * Returns the number of datanodes to start in the mini cluster.
+   * Subclasses return a value appropriate for their replication type.
+   */
+  protected abstract int getNumDatanodes();
+
+  /**
+   * Initialises the {@link OzoneConfiguration}, builds a {@link MiniOzoneCluster}
+   * with {@code numDatanodes} datanodes, and waits for the cluster to be ready.
+   * Subclasses call this from their own {@code @BeforeAll} static method.
+   */
+  protected static void initializeCluster(int numDatanodes) throws Exception {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
@@ -136,20 +152,18 @@ public class TestStorageDistributionEndpoint {
     conf.setTimeDuration(OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL, 500, TimeUnit.MILLISECONDS);
     conf.set(ReconServerConfigKeys.OZONE_RECON_DN_METRICS_COLLECTION_MINIMUM_API_DELAY, "5s");
 
-    // Enhanced SCM configuration for faster block deletion processing
     ScmConfig scmConfig = conf.getObject(ScmConfig.class);
     scmConfig.setBlockDeletionInterval(Duration.ofMillis(100));
     conf.setFromObject(scmConfig);
     conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
 
-    // Enhanced DataNode configuration to move pending deletion from SCM to DN faster
     DatanodeConfiguration dnConf = conf.getObject(DatanodeConfiguration.class);
     dnConf.setBlockDeletionInterval(Duration.ofMillis(30000));
     conf.setFromObject(dnConf);
 
     recon = new ReconService(conf);
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(3)
+        .setNumDatanodes(numDatanodes)
         .addService(recon)
         .build();
     cluster.waitForClusterToBeReady();
@@ -158,60 +172,20 @@ public class TestStorageDistributionEndpoint {
     client = cluster.newClient();
   }
 
-  @ParameterizedTest
-  @MethodSource("replicationConfigs")
-  public void testStorageDistributionEndpoint(ReplicationConfig replicationConfig) throws Exception {
+  protected OzoneBucket createVolumeAndBucket(ReplicationConfig replicationConfig)
+      throws Exception {
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume("vol1");
     BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED)
         .setDefaultReplicationConfig(new DefaultReplicationConfig(replicationConfig))
         .build();
-
     OzoneVolume volume = objectStore.getVolume("vol1");
     volume.createBucket("bucket1", bucketArgs);
-    OzoneBucket bucket = volume.getBucket("bucket1");
-
-    createOpenKeysAndMultipartKeys(volume.getName(), bucket.getName(), replicationConfig);
-
-    String rootPath = String.format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucket.getName(),
-        bucket.getVolumeName());
-
-    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
-    fs = FileSystem.get(conf);
-
-    Path dir1 = new Path("/dir1");
-    fs.mkdirs(dir1);
-    for (int i = 1; i <= 10; i++) {
-      Path path1 = new Path(dir1, "testKey" + i);
-      try (FSDataOutputStream stream = fs.create(path1)) {
-        stream.write(1);
-      }
-    }
-    Path dir2 = new Path("/dir2");
-    fs.mkdirs(dir2);
-    for (int i = 1; i <= 10; i++) {
-      Path path1 = new Path(dir2, "testKey" + i);
-      try (FSDataOutputStream stream = fs.create(path1)) {
-        stream.write(1);
-      }
-    }
-    waitForKeysCreated(replicationConfig);
-    GenericTestUtils.waitFor(this::verifyStorageDistributionAfterKeyCreation, 1000, 30000);
-    closeAllContainers();
-    fs.delete(dir1, true);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOm, 1000, 30000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 2000, 30000);
-    GenericTestUtils.waitFor(() ->
-            Objects.requireNonNull(scm.getClientProtocolServer().getDeletedBlockSummary()).getTotalBlockCount() == 0,
-        1000, 30000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 2000, 60000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 2000, 60000);
-    cluster.getHddsDatanodes().get(0).stop();
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOnDnFailure, 2000, 60000);
+    return volume.getBucket("bucket1");
   }
 
-  private void createOpenKeysAndMultipartKeys(String volumeName,
+  protected void createOpenKeysAndMultipartKeys(String volumeName,
       String bucketName, ReplicationConfig config) throws Exception {
     ObjectStore objectStore = client.getObjectStore();
     OzoneManagerProtocol ozoneManagerClient =
@@ -222,24 +196,23 @@ public class TestStorageDistributionEndpoint {
         .setBucketName(bucketName)
         .setKeyName("openkey1")
         .setReplicationConfig(config)
-        .setDataSize(10)// this sets unreplicated size; replicated = 10 * 3 = 30
+        .setDataSize(100) // unreplicated size; replicated = 10 * 3 = 30
         .setAcls(new ArrayList<>())
         .setOwnerName("ownerName")
         .build();
     ozoneManagerClient.openKey(openKey);
-    //Create a Multipart open key
+
     OmMultipartInfo multipartInfo = objectStore.getClientProxy()
         .initiateMultipartUpload(volumeName, bucketName, "mpukey1",
             config, new HashMap<>());
-
     OzoneOutputStream partStream = objectStore.getClientProxy()
         .createMultipartKey(volumeName, bucketName, "mpukey1",
-            10L, 1, multipartInfo.getUploadID());
-    partStream.write(new byte[10]);
+            100L, 1, multipartInfo.getUploadID());
+    partStream.write(new byte[100]);
     partStream.close();
   }
 
-  private boolean verifyStorageDistributionAfterKeyCreation() {
+  protected boolean verifyStorageDistributionAfterKeyCreation() {
     try {
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(STORAGE_DIST_ENDPOINT);
@@ -248,15 +221,16 @@ public class TestStorageDistributionEndpoint {
           MAPPER.readValue(response, StorageCapacityDistributionResponse.class);
 
       assertEquals(20, storageResponse.getGlobalNamespace().getTotalKeys());
-      assertEquals(120, storageResponse.getGlobalNamespace().getTotalUsedSpace());
-      assertEquals(60, storageResponse.getUsedSpaceBreakDown().getOpenKeyBytes().getTotalOpenKeyBytes());
-      assertEquals(30, storageResponse.getUsedSpaceBreakDown().getOpenKeyBytes().getMultipartOpenKeyBytes());
-      assertEquals(30, storageResponse.getUsedSpaceBreakDown().getOpenKeyBytes().getOpenKeyAndFileBytes());
-      assertEquals(60, storageResponse.getUsedSpaceBreakDown().getFinalizedKeyBytes());
-      assertEquals(3, storageResponse.getDataNodeUsage().size());
+      assertEquals(1200, storageResponse.getGlobalNamespace().getTotalUsedSpace());
+      assertEquals(600, storageResponse.getUsedSpaceBreakDown().getOpenKeyBytes().getTotalOpenKeyBytes());
+      assertEquals(300, storageResponse.getUsedSpaceBreakDown().getOpenKeyBytes().getMultipartOpenKeyBytes());
+      assertEquals(300, storageResponse.getUsedSpaceBreakDown().getOpenKeyBytes().getOpenKeyAndFileBytes());
+      assertEquals(600, storageResponse.getUsedSpaceBreakDown().getFinalizedKeyBytes());
+      assertEquals(getNumDatanodes(), storageResponse.getDataNodeUsage().size());
+
       List<DatanodeStorageReport> reports = storageResponse.getDataNodeUsage();
       List<HddsProtos.DatanodeUsageInfoProto> scmReports =
-          scm.getClientProtocolServer().getDatanodeUsageInfo(true, 3, 1);
+          scm.getClientProtocolServer().getDatanodeUsageInfo(true, getNumDatanodes(), 1);
 
       long totalReserved = 0;
       long totalMinFreeSpace = 0;
@@ -295,21 +269,21 @@ public class TestStorageDistributionEndpoint {
       assertEquals(totalFileSystemCapacity, storageResponse.getGlobalStorage().getTotalFileSystemCapacity());
       assertEquals(totalRemaining, storageResponse.getGlobalStorage().getTotalOzoneFreeSpace());
       return true;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOG.debug("Waiting for storage distribution assertions to pass", e);
       return false;
     }
   }
 
-  private boolean verifyPendingDeletionAfterKeyDeletionOm() {
+  protected boolean verifyPendingDeletionAfterKeyDeletionOm() {
     try {
       syncDataFromOM();
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(PENDING_DELETION_ENDPOINT).append("?component=om");
       String response = TestReconEndpointUtil.makeHttpCall(conf, urlBuilder);
       Map<String, Number> pendingDeletionMap = MAPPER.readValue(response, Map.class);
-      assertEquals(30L, pendingDeletionMap.get("totalSize").longValue());
-      assertEquals(30L, pendingDeletionMap.get("pendingDirectorySize").longValue() +
+      assertEquals(300L, pendingDeletionMap.get("totalSize").longValue());
+      assertEquals(300L, pendingDeletionMap.get("pendingDirectorySize").longValue() +
           pendingDeletionMap.get("pendingKeySize").longValue());
       return true;
     } catch (Exception e) {
@@ -318,14 +292,14 @@ public class TestStorageDistributionEndpoint {
     }
   }
 
-  private boolean verifyPendingDeletionAfterKeyDeletionScm() {
+  protected boolean verifyPendingDeletionAfterKeyDeletionScm() {
     try {
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(PENDING_DELETION_ENDPOINT).append("?component=scm");
       String response = TestReconEndpointUtil.makeHttpCall(conf, urlBuilder);
       ScmPendingDeletion pendingDeletion = MAPPER.readValue(response, ScmPendingDeletion.class);
-      assertEquals(30, pendingDeletion.getTotalReplicatedBlockSize());
-      assertEquals(10, pendingDeletion.getTotalBlocksize());
+      assertEquals(300, pendingDeletion.getTotalReplicatedBlockSize());
+      assertEquals(100, pendingDeletion.getTotalBlocksize());
       assertEquals(10, pendingDeletion.getTotalBlocksCount());
       return true;
     } catch (Throwable e) {
@@ -334,21 +308,22 @@ public class TestStorageDistributionEndpoint {
     }
   }
 
-  private boolean verifyPendingDeletionAfterKeyDeletionDn() {
+  protected boolean verifyPendingDeletionAfterKeyDeletionDn() {
     try {
       scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(PENDING_DELETION_ENDPOINT).append("?component=dn");
       String response = TestReconEndpointUtil.makeHttpCall(conf, urlBuilder);
-      DataNodeMetricsServiceResponse pendingDeletion = MAPPER.readValue(response, DataNodeMetricsServiceResponse.class);
+      DataNodeMetricsServiceResponse pendingDeletion =
+          MAPPER.readValue(response, DataNodeMetricsServiceResponse.class);
       assertNotNull(pendingDeletion);
-      assertEquals(30, pendingDeletion.getTotalPendingDeletionSize());
+      assertEquals(300, pendingDeletion.getTotalPendingDeletionSize());
       assertEquals(DataNodeMetricsService.MetricCollectionStatus.FINISHED, pendingDeletion.getStatus());
-      assertEquals(pendingDeletion.getTotalNodesQueried(), pendingDeletion.getPendingDeletionPerDataNode().size());
+      assertEquals(pendingDeletion.getTotalNodesQueried(),
+          pendingDeletion.getPendingDeletionPerDataNode().size());
       assertEquals(0, pendingDeletion.getTotalNodeQueryFailures());
-      pendingDeletion.getPendingDeletionPerDataNode().forEach(dn -> {
-        assertEquals(10, dn.getPendingBlockSize());
-      });
+      pendingDeletion.getPendingDeletionPerDataNode().forEach(dn ->
+          assertEquals(300 / getNumDatanodes(), dn.getPendingBlockSize()));
       return true;
     } catch (Throwable e) {
       LOG.debug("Waiting for storage distribution assertions to pass", e);
@@ -356,21 +331,22 @@ public class TestStorageDistributionEndpoint {
     }
   }
 
-  private boolean verifyPendingDeletionClearsAtDn() {
+  protected boolean verifyPendingDeletionClearsAtDn() {
     try {
       scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(PENDING_DELETION_ENDPOINT).append("?component=dn");
       String response = TestReconEndpointUtil.makeHttpCall(conf, urlBuilder);
-      DataNodeMetricsServiceResponse pendingDeletion = MAPPER.readValue(response, DataNodeMetricsServiceResponse.class);
+      DataNodeMetricsServiceResponse pendingDeletion =
+          MAPPER.readValue(response, DataNodeMetricsServiceResponse.class);
       assertNotNull(pendingDeletion);
       assertEquals(0, pendingDeletion.getTotalPendingDeletionSize());
       assertEquals(DataNodeMetricsService.MetricCollectionStatus.FINISHED, pendingDeletion.getStatus());
-      assertEquals(pendingDeletion.getTotalNodesQueried(), pendingDeletion.getPendingDeletionPerDataNode().size());
+      assertEquals(pendingDeletion.getTotalNodesQueried(),
+          pendingDeletion.getPendingDeletionPerDataNode().size());
       assertEquals(0, pendingDeletion.getTotalNodeQueryFailures());
-      pendingDeletion.getPendingDeletionPerDataNode().forEach(dn -> {
-        assertEquals(0, dn.getPendingBlockSize());
-      });
+      pendingDeletion.getPendingDeletionPerDataNode().forEach(dn ->
+          assertEquals(0, dn.getPendingBlockSize()));
       return true;
     } catch (Throwable e) {
       LOG.debug("Waiting for storage distribution assertions to pass", e);
@@ -378,12 +354,13 @@ public class TestStorageDistributionEndpoint {
     }
   }
 
-  private boolean verifyPendingDeletionAfterKeyDeletionOnDnFailure() {
+  protected boolean verifyPendingDeletionAfterKeyDeletionOnDnFailure() {
     try {
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(PENDING_DELETION_ENDPOINT).append("?component=dn");
       String response = TestReconEndpointUtil.makeHttpCall(conf, urlBuilder);
-      DataNodeMetricsServiceResponse pendingDeletion = MAPPER.readValue(response, DataNodeMetricsServiceResponse.class);
+      DataNodeMetricsServiceResponse pendingDeletion =
+          MAPPER.readValue(response, DataNodeMetricsServiceResponse.class);
       assertNotNull(pendingDeletion);
       assertEquals(1, pendingDeletion.getTotalNodeQueryFailures());
       assertTrue(pendingDeletion.getPendingDeletionPerDataNode()
@@ -395,64 +372,15 @@ public class TestStorageDistributionEndpoint {
     }
   }
 
-  private void verifyBlocksCreated(
-      List<OmKeyLocationInfoGroup> omKeyLocationInfoGroups) throws Exception {
-    for (HddsDatanodeService datanode : cluster.getHddsDatanodes()) {
-      ContainerSet dnContainerSet =
-          datanode.getDatanodeStateMachine().getContainer().getContainerSet();
-      performOperationOnKeyContainers((blockID) -> {
-        KeyValueContainerData cData = (KeyValueContainerData) dnContainerSet
-            .getContainer(blockID.getContainerID()).getContainerData();
-        try (DBHandle db = BlockUtils.getDB(cData, conf)) {
-          assertNotNull(db.getStore().getBlockDataTable()
-              .get(cData.getBlockKey(blockID.getLocalID())));
-        }
-      }, omKeyLocationInfoGroups);
-    }
-  }
-
-  private static void syncDataFromOM() {
+  protected static void syncDataFromOM() {
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
         recon.getReconServer().getOzoneManagerServiceProvider();
     impl.syncDataFromOM();
   }
 
-  private void waitForKeysCreated(ReplicationConfig replicationConfig) throws Exception {
-    for (int i = 1; i <= 10; i++) {
-      OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName("vol1")
-          .setBucketName("bucket1").setKeyName("dir1/testKey" + i).setDataSize(0)
-          .setReplicationConfig(replicationConfig)
-          .build();
-      List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList =
-          om.lookupKey(keyArgs).getKeyLocationVersions();
-
-      // verify key blocks were created in DN.
-      GenericTestUtils.waitFor(() -> {
-        try {
-          scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
-          verifyBlocksCreated(omKeyLocationInfoGroupList);
-          syncDataFromOM();
-          return true;
-        } catch (Throwable t) {
-          LOG.warn("Verify blocks creation failed", t);
-          return false;
-        }
-      }, 1000, 10000);
-    }
-  }
-
-  private static void performOperationOnKeyContainers(
-      CheckedConsumer<BlockID, Exception> consumer,
-      List<OmKeyLocationInfoGroup> omKeyLocationInfoGroups) throws Exception {
-
-    for (OmKeyLocationInfoGroup omKeyLocationInfoGroup :
-        omKeyLocationInfoGroups) {
-      List<OmKeyLocationInfo> omKeyLocationInfos =
-          omKeyLocationInfoGroup.getLocationList();
-      for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfos) {
-        BlockID blockID = omKeyLocationInfo.getBlockID();
-        consumer.accept(blockID);
-      }
+  protected static void closeAllContainers() {
+    for (ContainerInfo container : scm.getContainerManager().getContainers()) {
+      scm.getEventQueue().fireEvent(SCMEvents.CLOSE_CONTAINER, container.containerID());
     }
   }
 
@@ -474,14 +402,6 @@ public class TestStorageDistributionEndpoint {
   public static void tear() {
     if (cluster != null) {
       cluster.shutdown();
-    }
-  }
-
-  private static void closeAllContainers() {
-    for (ContainerInfo container :
-        scm.getContainerManager().getContainers()) {
-      scm.getEventQueue().fireEvent(SCMEvents.CLOSE_CONTAINER,
-          container.containerID());
     }
   }
 }

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointEC.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointEC.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon;
+
+import java.util.Objects;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the Storage Distribution REST endpoint using
+ * EC (Erasure Coding) replication. The cluster is started with 5 datanodes
+ * to satisfy the EC (3,2) placement requirements.
+ *
+ * <p>Common infrastructure and verification helpers are provided by
+ * {@link AbstractTestStorageDistributionEndpoint}.
+ */
+public class TestStorageDistributionEndpointEC extends AbstractTestStorageDistributionEndpoint {
+
+  private static final int NUM_DATANODES = 5;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    initializeCluster(NUM_DATANODES);
+  }
+
+  @Override
+  protected int getNumDatanodes() {
+    return NUM_DATANODES;
+  }
+
+  @Test
+  public void testStorageDistributionEndpoint() throws Exception {
+    ReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
+
+    OzoneBucket bucket = createVolumeAndBucket(replicationConfig);
+    createOpenKeysAndMultipartKeys(bucket.getVolumeName(), bucket.getName(), replicationConfig);
+
+    String rootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+    getConf().set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    setFs(FileSystem.get(getConf()));
+
+    Path dir1 = new Path("/dir1");
+    getFs().mkdirs(dir1);
+    for (int i = 1; i <= 10; i++) {
+      try (FSDataOutputStream stream = getFs().create(new Path(dir1, "testKey" + i))) {
+        stream.write(new byte[10]);
+      }
+    }
+    Path dir2 = new Path("/dir2");
+    getFs().mkdirs(dir2);
+    for (int i = 1; i <= 10; i++) {
+      try (FSDataOutputStream stream = getFs().create(new Path(dir2, "testKey" + i))) {
+        stream.write(new byte[10]);
+      }
+    }
+
+    GenericTestUtils.waitFor(this::verifyStorageDistributionAfterKeyCreation, 1000, 60000);
+    closeAllContainers();
+    getFs().delete(dir1, true);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOm, 1000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 2000, 30000);
+    GenericTestUtils.waitFor(() -> Objects.requireNonNull(
+            getScm().getClientProtocolServer().getDeletedBlockSummary()).getTotalBlockCount() == 0,
+        1000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 2000, 60000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 2000, 60000);
+  }
+}

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointRatis.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointRatis.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon;
+
+import java.util.Objects;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the Storage Distribution REST endpoint using
+ * Ratis THREE replication. The cluster is started with 3 datanodes.
+ *
+ * <p>In addition to the common verification flow, this test also stops
+ * one datanode to verify that the pending-deletion endpoint correctly
+ * reports a query failure for the stopped node.
+ *
+ * <p>Common infrastructure and verification helpers are provided by
+ * {@link AbstractTestStorageDistributionEndpoint}.
+ */
+public class TestStorageDistributionEndpointRatis extends AbstractTestStorageDistributionEndpoint {
+
+  private static final int NUM_DATANODES = 3;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    initializeCluster(NUM_DATANODES);
+  }
+
+  @Override
+  protected int getNumDatanodes() {
+    return NUM_DATANODES;
+  }
+
+  @Test
+  public void testStorageDistributionEndpoint() throws Exception {
+    ReplicationConfig replicationConfig =
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
+
+    OzoneBucket bucket = createVolumeAndBucket(replicationConfig);
+    createOpenKeysAndMultipartKeys(bucket.getVolumeName(), bucket.getName(), replicationConfig);
+
+    String rootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+    getConf().set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    setFs(FileSystem.get(getConf()));
+
+    Path dir1 = new Path("/dir1");
+    getFs().mkdirs(dir1);
+    for (int i = 1; i <= 10; i++) {
+      try (FSDataOutputStream stream = getFs().create(new Path(dir1, "testKey" + i))) {
+        stream.write(new byte[10]);
+      }
+    }
+    Path dir2 = new Path("/dir2");
+    getFs().mkdirs(dir2);
+    for (int i = 1; i <= 10; i++) {
+      try (FSDataOutputStream stream = getFs().create(new Path(dir2, "testKey" + i))) {
+        stream.write(new byte[10]);
+      }
+    }
+
+    GenericTestUtils.waitFor(this::verifyStorageDistributionAfterKeyCreation, 1000, 60000);
+    closeAllContainers();
+    getFs().delete(dir1, true);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOm, 1000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 2000, 30000);
+    GenericTestUtils.waitFor(() -> Objects.requireNonNull(
+            getScm().getClientProtocolServer().getDeletedBlockSummary()).getTotalBlockCount() == 0,
+        1000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 2000, 60000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 2000, 60000);
+    getCluster().getHddsDatanodes().get(0).stop();
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOnDnFailure, 2000, 60000);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -293,9 +293,9 @@ public class TestStorageContainerManager {
       Map<Long, List<DeletedBlock>> deletedBlocks = new HashMap<>();
       List<DeletedBlock> blocks = new ArrayList<>();
       blocks.add(new DeletedBlock(new BlockID(containerID, RandomUtils.secure().randomLong()),
-          SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
+          SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
       blocks.add(new DeletedBlock(new BlockID(containerID, RandomUtils.secure().randomLong()),
-          SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
+          SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
       deletedBlocks.put(containerID, blocks);
       addTransactions(cluster.getStorageContainerManager(), delLog,
           deletedBlocks);
@@ -502,11 +502,12 @@ public class TestStorageContainerManager {
           info.getLatestVersionLocations().getLocationList();
       list.forEach(location -> {
         if (containerBlocks.containsKey(location.getContainerID())) {
-          containerBlocks.get(location.getContainerID())
-              .add(new DeletedBlock(location.getBlockID(), SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
+          containerBlocks.get(location.getContainerID()).add(new DeletedBlock(location.getBlockID(),
+              SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
         } else {
           List<DeletedBlock> blks = Lists.newArrayList();
-          blks.add(new DeletedBlock(location.getBlockID(), SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
+          blks.add(new DeletedBlock(location.getBlockID(),
+              SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
           containerBlocks.put(location.getContainerID(), blks);
         }
       });

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmDataDistributionFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmDataDistributionFinalization.java
@@ -414,9 +414,11 @@ public class TestScmDataDistributionFinalization {
       for (int j = 0; j < BLOCKS_PER_TX; j++)  {
         long localID = localIDBase + j;
         if (withSize) {
-          blocks.add(new DeletedBlock(new BlockID(containerID, localID), BLOCK_SIZE, BLOCK_SIZE * 3));
+          blocks.add(new DeletedBlock(new BlockID(containerID, localID),
+              BLOCK_SIZE, BLOCK_SIZE * 3, BLOCK_SIZE));
         } else {
-          blocks.add(new DeletedBlock(new BlockID(containerID, localID), SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
+          blocks.add(new DeletedBlock(new BlockID(containerID, localID),
+              SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE, SIZE_NOT_AVAILABLE));
         }
       }
       blockMap.put(containerID, blocks);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
@@ -125,7 +125,8 @@ public class TestDeletedBlocksTxnShell {
       List<DeletedBlock> blocks = new ArrayList<>();
       for (int j = 0; j < BLOCKS_PER_TX; j++)  {
         long localID = localIDBase + j;
-        blocks.add(new DeletedBlock(new BlockID(containerID, localID), BLOCK_SIZE, BLOCK_REPLICATED_SIZE));
+        blocks.add(new DeletedBlock(new BlockID(containerID, localID),
+            BLOCK_SIZE, BLOCK_REPLICATED_SIZE, BLOCK_SIZE));
       }
       blockMap.put(containerID, blocks);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -851,10 +851,10 @@ public class KeyManagerImpl implements KeyManager {
               List<DeletedBlock> deletedBlocks = info.getKeyLocationVersions().stream()
                   .flatMap(versionLocations -> versionLocations.getLocationList().stream()
                       .map(b -> new DeletedBlock(
-                          new BlockID(b.getContainerID(),
-                            b.getLocalID()),
-                            b.getLength(),
-                            QuotaUtil.getReplicatedSize(b.getLength(), info.getReplicationConfig())
+                          new BlockID(b.getContainerID(), b.getLocalID()),
+                          b.getLength(),
+                          QuotaUtil.getReplicatedSize(b.getLength(), info.getReplicationConfig()),
+                          QuotaUtil.getSizePerReplica(b.getLength(), info.getReplicationConfig())
                       ))).collect(Collectors.toList());
               String blockGroupName = kv.getKey() + "/" + reclaimableKeyCount++;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1856,11 +1856,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
           info.getKeyLocationVersions()) {
         List<DeletedBlock> item = keyLocations.getLocationList().stream()
             .map(b -> new DeletedBlock(
-                new BlockID(b.getContainerID(),
-                      b.getLocalID()),
-                      b.getLength(),
-                      QuotaUtil.getReplicatedSize(b.getLength(),
-                      info.getReplicationConfig())))
+                new BlockID(b.getContainerID(), b.getLocalID()),
+                b.getLength(),
+                QuotaUtil.getReplicatedSize(b.getLength(), info.getReplicationConfig()),
+                QuotaUtil.getSizePerReplica(b.getLength(), info.getReplicationConfig())))
             .collect(Collectors.toList());
         BlockGroup keyBlocks = BlockGroup.newBuilder()
             .setKeyName(deletedKey)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -286,7 +286,8 @@ class TestKeyDeletingService extends OzoneTestBase {
       BlockGroup blockGroup1 = BlockGroup.newBuilder().setKeyName("key1/1")
           .addAllDeletedBlocks(new ArrayList<>()).build();
       //Create a BlockGroup with non-empty deleted blocks
-      List<DeletedBlock> deletedBlocks = Collections.singletonList(new DeletedBlock(new BlockID(1, 1), 1, 3));
+      List<DeletedBlock> deletedBlocks = Collections.singletonList(new DeletedBlock(new BlockID(1, 1),
+          1, 3, 1));
       BlockGroup blockGroup2 = BlockGroup.newBuilder().setKeyName("key2/2")
           .addAllDeletedBlocks(deletedBlocks).build();
       Map<String, PurgedKey> blockGroups = new HashMap<>();
@@ -892,7 +893,7 @@ class TestKeyDeletingService extends OzoneTestBase {
             });
         BlockGroup blockGroup = BlockGroup.newBuilder().setKeyName("key1/1")
             .addAllDeletedBlocks(Collections.singletonList(new DeletedBlock(
-                new BlockID(1, 1), 1, 3))).build();
+                new BlockID(1, 1), 1, 3, 1))).build();
         Map<String, PurgedKey> blockGroups = Collections.singletonMap(blockGroup.getGroupID(), new PurgedKey("vol",
             "buck", 1, blockGroup, "key1", 30, true));
         List<String> renameEntriesToBeDeleted = Collections.singletonList("key2");


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem**
For EC blocks, each DataNode holds only one shard but each DN was crediting itself with the full logical block size as its pending-deletion contribution. This inflated cluster-wide pending deletion metrics by a factor of roughly (k+m)/m (e.g. 3× for EC(3,2) or EC(6,3)).

**Why this approximation is acceptable**
Dividing the total replicated size evenly across all nodes is not byte-perfect, the last partial stripe means some data shards are smaller than others.
However the cluster-wide sum across all DNs still equals totalReplicatedSize, so aggregate metrics are correct.
The per-DN error is at most ±1 ecChunkSize per block and this is negligible at container scale.

## What is the link to the Apache JIRA

HDDS-15076

## How was this patch tested?
Tested using existing testcases and additional unit testcase.
