### PR TITLE
HDDS-15078. Reduce duplication in BucketAclHandler

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
@@ -158,33 +158,33 @@ public class BucketAclHandler extends BucketOperationHandler {
         // Handle grants in headers
         if (grantReads != null) {
           ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantReads,
-              S3Acl.ACLType.READ.getValue()));
+              S3Acl.ACLType.READ));
           ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantReads,
-              S3Acl.ACLType.READ.getValue()));
+              S3Acl.ACLType.READ));
         }
         if (grantWrites != null) {
           ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantWrites,
-              S3Acl.ACLType.WRITE.getValue()));
+              S3Acl.ACLType.WRITE));
           ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantWrites,
-              S3Acl.ACLType.WRITE.getValue()));
+              S3Acl.ACLType.WRITE));
         }
         if (grantReadACP != null) {
           ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantReadACP,
-              S3Acl.ACLType.READ_ACP.getValue()));
+              S3Acl.ACLType.READ_ACP));
           ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantReadACP,
-              S3Acl.ACLType.READ_ACP.getValue()));
+              S3Acl.ACLType.READ_ACP));
         }
         if (grantWriteACP != null) {
           ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantWriteACP,
-              S3Acl.ACLType.WRITE_ACP.getValue()));
+              S3Acl.ACLType.WRITE_ACP));
           ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantWriteACP,
-              S3Acl.ACLType.WRITE_ACP.getValue()));
+              S3Acl.ACLType.WRITE_ACP));
         }
         if (grantFull != null) {
           ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantFull,
-              S3Acl.ACLType.FULL_CONTROL.getValue()));
+              S3Acl.ACLType.FULL_CONTROL));
           ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantFull,
-              S3Acl.ACLType.FULL_CONTROL.getValue()));
+              S3Acl.ACLType.FULL_CONTROL));
         }
       }
 
@@ -229,7 +229,7 @@ public class BucketAclHandler extends BucketOperationHandler {
    * Example: x-amz-grant-write: id="111122223333", id="555566667777"
    */
   private List<OzoneAcl> getAndConvertAclOnBucket(
-      String value, String permission) throws OS3Exception {
+      String value, S3Acl.ACLType permission) throws OS3Exception {
     return parseAndConvertAcl(value, permission, true);
   }
 
@@ -237,7 +237,7 @@ public class BucketAclHandler extends BucketOperationHandler {
    * Convert ACL string to Ozone ACL on volume.
    */
   private List<OzoneAcl> getAndConvertAclOnVolume(
-      String value, String permission) throws OS3Exception {
+      String value, S3Acl.ACLType permission) throws OS3Exception {
     return parseAndConvertAcl(value, permission, false);
   }
 
@@ -254,7 +254,7 @@ public class BucketAclHandler extends BucketOperationHandler {
    * @throws OS3Exception if parsing fails or grantee type is not supported
    */
   private List<OzoneAcl> parseAndConvertAcl(
-      String value, String permission, boolean isBucket) throws OS3Exception {
+      String value, S3Acl.ACLType permission, boolean isBucket) throws OS3Exception {
     List<OzoneAcl> ozoneAclList = new ArrayList<>();
     if (StringUtils.isEmpty(value)) {
       return ozoneAclList;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
@@ -149,10 +149,7 @@ public class BucketAclHandler extends BucketOperationHandler {
           && grantWriteACP == null && grantFull == null) {
         // Handle grants in body
         S3BucketAcl putBucketAclRequest = UNMARSHALLER.get().readFrom(body);
-        ozoneAclListOnBucket.addAll(
-            S3Acl.s3AclToOzoneNativeAclOnBucket(putBucketAclRequest));
-        ozoneAclListOnVolume.addAll(
-            S3Acl.s3AclToOzoneNativeAclOnVolume(putBucketAclRequest));
+        S3Acl.s3AclToOzoneNativeAcl(putBucketAclRequest, ozoneAclListOnVolume, ozoneAclListOnBucket);
       } else {
         // Handle grants in headers
         if (grantReads != null) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
@@ -26,7 +26,6 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentity
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -224,6 +223,9 @@ public class BucketAclHandler extends BucketOperationHandler {
       return;
     }
 
+    Set<IAccessAuthorizer.ACLType> aclsOnBucket = S3Acl.getOzoneAclOnBucketFromS3Permission(permission);
+    Set<IAccessAuthorizer.ACLType> aclsOnVolume = S3Acl.getOzoneAclOnVolumeFromS3Permission(permission);
+
     String[] subValues = value.split(",");
     for (String acl : subValues) {
       String[] part = acl.split("=");
@@ -240,15 +242,8 @@ public class BucketAclHandler extends BucketOperationHandler {
 
       String userId = part[1];
 
-      // Build ACL on Bucket
-      EnumSet<IAccessAuthorizer.ACLType> aclsOnBucket =
-          S3Acl.getOzoneAclOnBucketFromS3Permission(permission);
       bucketAclList.add(OzoneAcl.of(USER, userId, DEFAULT, aclsOnBucket));
       bucketAclList.add(OzoneAcl.of(USER, userId, ACCESS, aclsOnBucket));
-
-      // Build ACL on Volume
-      EnumSet<IAccessAuthorizer.ACLType> aclsOnVolume =
-          S3Acl.getOzoneAclOnVolumeFromS3Permission(permission);
       volumeAclList.add(OzoneAcl.of(USER, userId, ACCESS, aclsOnVolume));
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketAclHandler.java
@@ -157,34 +157,19 @@ public class BucketAclHandler extends BucketOperationHandler {
       } else {
         // Handle grants in headers
         if (grantReads != null) {
-          ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantReads,
-              S3Acl.ACLType.READ));
-          ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantReads,
-              S3Acl.ACLType.READ));
+          parseAndConvertAcl(grantReads, S3Acl.ACLType.READ, ozoneAclListOnVolume, ozoneAclListOnBucket);
         }
         if (grantWrites != null) {
-          ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantWrites,
-              S3Acl.ACLType.WRITE));
-          ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantWrites,
-              S3Acl.ACLType.WRITE));
+          parseAndConvertAcl(grantWrites, S3Acl.ACLType.WRITE, ozoneAclListOnVolume, ozoneAclListOnBucket);
         }
         if (grantReadACP != null) {
-          ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantReadACP,
-              S3Acl.ACLType.READ_ACP));
-          ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantReadACP,
-              S3Acl.ACLType.READ_ACP));
+          parseAndConvertAcl(grantReadACP, S3Acl.ACLType.READ_ACP, ozoneAclListOnVolume, ozoneAclListOnBucket);
         }
         if (grantWriteACP != null) {
-          ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantWriteACP,
-              S3Acl.ACLType.WRITE_ACP));
-          ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantWriteACP,
-              S3Acl.ACLType.WRITE_ACP));
+          parseAndConvertAcl(grantWriteACP, S3Acl.ACLType.WRITE_ACP, ozoneAclListOnVolume, ozoneAclListOnBucket);
         }
         if (grantFull != null) {
-          ozoneAclListOnBucket.addAll(getAndConvertAclOnBucket(grantFull,
-              S3Acl.ACLType.FULL_CONTROL));
-          ozoneAclListOnVolume.addAll(getAndConvertAclOnVolume(grantFull,
-              S3Acl.ACLType.FULL_CONTROL));
+          parseAndConvertAcl(grantFull, S3Acl.ACLType.FULL_CONTROL, ozoneAclListOnVolume, ozoneAclListOnBucket);
         }
       }
 
@@ -224,40 +209,19 @@ public class BucketAclHandler extends BucketOperationHandler {
   }
 
   /**
-   * Convert ACL string to Ozone ACL on bucket.
-   *
-   * Example: x-amz-grant-write: id="111122223333", id="555566667777"
-   */
-  private List<OzoneAcl> getAndConvertAclOnBucket(
-      String value, S3Acl.ACLType permission) throws OS3Exception {
-    return parseAndConvertAcl(value, permission, true);
-  }
-
-  /**
-   * Convert ACL string to Ozone ACL on volume.
-   */
-  private List<OzoneAcl> getAndConvertAclOnVolume(
-      String value, S3Acl.ACLType permission) throws OS3Exception {
-    return parseAndConvertAcl(value, permission, false);
-  }
-
-  /**
    * Parse ACL string and convert to Ozone ACLs.
-   *
-   * This is a common method extracted from getAndConvertAclOnBucket and
-   * getAndConvertAclOnVolume to reduce code duplication.
    *
    * @param value the ACL header value (e.g., "id=\"user1\",id=\"user2\"")
    * @param permission the S3 permission type (READ, WRITE, etc.)
-   * @param isBucket true for bucket ACL, false for volume ACL
-   * @return list of OzoneAcl objects
+   * @param volumeAclList the list of volume ACLs to append to
+   * @param bucketAclList the list of bucket ACLs to append to
    * @throws OS3Exception if parsing fails or grantee type is not supported
    */
-  private List<OzoneAcl> parseAndConvertAcl(
-      String value, S3Acl.ACLType permission, boolean isBucket) throws OS3Exception {
-    List<OzoneAcl> ozoneAclList = new ArrayList<>();
+  private void parseAndConvertAcl(
+      String value, S3Acl.ACLType permission, List<OzoneAcl> volumeAclList, List<OzoneAcl> bucketAclList
+  ) throws OS3Exception {
     if (StringUtils.isEmpty(value)) {
-      return ozoneAclList;
+      return;
     }
 
     String[] subValues = value.split(",");
@@ -276,20 +240,16 @@ public class BucketAclHandler extends BucketOperationHandler {
 
       String userId = part[1];
 
-      if (isBucket) {
-        // Build ACL on Bucket
-        EnumSet<IAccessAuthorizer.ACLType> aclsOnBucket =
-            S3Acl.getOzoneAclOnBucketFromS3Permission(permission);
-        ozoneAclList.add(OzoneAcl.of(USER, userId, DEFAULT, aclsOnBucket));
-        ozoneAclList.add(OzoneAcl.of(USER, userId, ACCESS, aclsOnBucket));
-      } else {
-        // Build ACL on Volume
-        EnumSet<IAccessAuthorizer.ACLType> aclsOnVolume =
-            S3Acl.getOzoneAclOnVolumeFromS3Permission(permission);
-        ozoneAclList.add(OzoneAcl.of(USER, userId, ACCESS, aclsOnVolume));
-      }
-    }
+      // Build ACL on Bucket
+      EnumSet<IAccessAuthorizer.ACLType> aclsOnBucket =
+          S3Acl.getOzoneAclOnBucketFromS3Permission(permission);
+      bucketAclList.add(OzoneAcl.of(USER, userId, DEFAULT, aclsOnBucket));
+      bucketAclList.add(OzoneAcl.of(USER, userId, ACCESS, aclsOnBucket));
 
-    return ozoneAclList;
+      // Build ACL on Volume
+      EnumSet<IAccessAuthorizer.ACLType> aclsOnVolume =
+          S3Acl.getOzoneAclOnVolumeFromS3Permission(permission);
+      volumeAclList.add(OzoneAcl.of(USER, userId, ACCESS, aclsOnVolume));
+    }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NOT_IMPLEMENTED;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.s3.endpoint.S3BucketAcl.Grant;
 import org.apache.hadoop.ozone.s3.endpoint.S3BucketAcl.Grantee;
@@ -227,7 +228,7 @@ public final class S3Acl {
         );
         ozoneAclListOnVolume.add(volumeAcl);
 
-        EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnBucketFromS3Permission(permissionType);
+        Set<IAccessAuthorizer.ACLType> acls = getOzoneAclOnBucketFromS3Permission(permissionType);
         OzoneAcl defaultOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.DEFAULT, acls
@@ -247,9 +248,9 @@ public final class S3Acl {
     }
   }
 
-  static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnBucketFromS3Permission(ACLType permissionType)
+  static Set<IAccessAuthorizer.ACLType> getOzoneAclOnBucketFromS3Permission(ACLType permissionType)
       throws OS3Exception {
-    EnumSet<IAccessAuthorizer.ACLType> acls = EnumSet.noneOf(IAccessAuthorizer.ACLType.class);
+    Set<IAccessAuthorizer.ACLType> acls = EnumSet.noneOf(IAccessAuthorizer.ACLType.class);
     switch (permissionType) {
     case FULL_CONTROL:
       acls.add(IAccessAuthorizer.ACLType.ALL);
@@ -277,9 +278,9 @@ public final class S3Acl {
   }
 
   // User privilege on volume follows the "lest privilege" principle.
-  static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnVolumeFromS3Permission(ACLType permissionType)
+  static Set<IAccessAuthorizer.ACLType> getOzoneAclOnVolumeFromS3Permission(ACLType permissionType)
       throws OS3Exception {
-    EnumSet<IAccessAuthorizer.ACLType> acls = EnumSet.noneOf(IAccessAuthorizer.ACLType.class);
+    Set<IAccessAuthorizer.ACLType> acls = EnumSet.noneOf(IAccessAuthorizer.ACLType.class);
     switch (permissionType) {
     case FULL_CONTROL:
       acls.add(IAccessAuthorizer.ACLType.READ);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
@@ -225,7 +225,11 @@ public final class S3Acl {
           grant.getGrantee().getXsiType());
       if (identityType != null && identityType.isSupported()) {
         String permission = grant.getPermission();
-        EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnBucketFromS3Permission(permission);
+        ACLType permissionType = ACLType.getType(permission);
+        if (permissionType == null) {
+          throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, permission);
+        }
+        EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnBucketFromS3Permission(permissionType);
         OzoneAcl defaultOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.DEFAULT, acls
@@ -246,12 +250,8 @@ public final class S3Acl {
     return ozoneAclList;
   }
 
-  public static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnBucketFromS3Permission(String permission)
+  static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnBucketFromS3Permission(ACLType permissionType)
       throws OS3Exception {
-    ACLType permissionType = ACLType.getType(permission);
-    if (permissionType == null) {
-      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, permission);
-    }
     EnumSet<IAccessAuthorizer.ACLType> acls = EnumSet.noneOf(IAccessAuthorizer.ACLType.class);
     switch (permissionType) {
     case FULL_CONTROL:
@@ -273,8 +273,8 @@ public final class S3Acl {
       acls.add(IAccessAuthorizer.ACLType.LIST);
       break;
     default:
-      LOG.error("Failed to recognize S3 permission {}", permission);
-      throw S3ErrorTable.newError(INVALID_ARGUMENT, permission);
+      LOG.error("Failed to recognize S3 permission {}", permissionType);
+      throw S3ErrorTable.newError(INVALID_ARGUMENT, permissionType.name());
     }
     return acls;
   }
@@ -289,7 +289,11 @@ public final class S3Acl {
           grant.getGrantee().getXsiType());
       if (identityType != null && identityType.isSupported()) {
         String permission = grant.getPermission();
-        EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnVolumeFromS3Permission(permission);
+        ACLType permissionType = ACLType.getType(permission);
+        if (permissionType == null) {
+          throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, permission);
+        }
+        EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnVolumeFromS3Permission(permissionType);
         OzoneAcl accessOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.ACCESS, acls
@@ -306,13 +310,9 @@ public final class S3Acl {
   }
 
   // User privilege on volume follows the "lest privilege" principle.
-  public static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnVolumeFromS3Permission(String permission)
+  static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnVolumeFromS3Permission(ACLType permissionType)
       throws OS3Exception {
     EnumSet<IAccessAuthorizer.ACLType> acls = EnumSet.noneOf(IAccessAuthorizer.ACLType.class);
-    ACLType permissionType = ACLType.getType(permission);
-    if (permissionType == null) {
-      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, permission);
-    }
     switch (permissionType) {
     case FULL_CONTROL:
       acls.add(IAccessAuthorizer.ACLType.READ);
@@ -337,8 +337,8 @@ public final class S3Acl {
       acls.add(IAccessAuthorizer.ACLType.READ);
       break;
     default:
-      LOG.error("Failed to recognize S3 permission {}", permission);
-      throw S3ErrorTable.newError(INVALID_ARGUMENT, permission);
+      LOG.error("Failed to recognize S3 permission {}", permissionType);
+      throw S3ErrorTable.newError(INVALID_ARGUMENT, permissionType.name());
     }
     return acls;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
@@ -157,16 +157,6 @@ public final class S3Acl {
   private S3Acl() {
   }
 
-  public static boolean isGranteeTypeSupported(String typeStr) {
-    ACLIdentityType type =  ACLIdentityType.getTypeFromGranteeType(typeStr);
-    return type == null ? false : type.isSupported();
-  }
-
-  public static boolean isHeaderTypeSupported(String typeStr) {
-    ACLIdentityType type =  ACLIdentityType.getTypeFromHeaderType(typeStr);
-    return type == null ? false : type.isSupported();
-  }
-
   public static List<Grant> ozoneNativeAclToS3Acl(OzoneAcl ozoneAcl) {
     // Since currently only "CanonicalUser" is supported, which maps to Ozone
     // "USER"

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Acl.java
@@ -205,9 +205,9 @@ public final class S3Acl {
     return grantList;
   }
 
-  public static List<OzoneAcl> s3AclToOzoneNativeAclOnBucket(
-      S3BucketAcl bucketAcl) throws OS3Exception {
-    List<OzoneAcl> ozoneAclList = new ArrayList<>();
+  static void s3AclToOzoneNativeAcl(
+      S3BucketAcl bucketAcl, List<OzoneAcl> ozoneAclListOnVolume, List<OzoneAcl> ozoneAclListOnBucket
+  ) throws OS3Exception {
     List<Grant> grantList = bucketAcl.getAclList().getGrantList();
     for (Grant grant : grantList) {
       //  Only "CanonicalUser" is supported, which maps to Ozone "USER"
@@ -219,6 +219,14 @@ public final class S3Acl {
         if (permissionType == null) {
           throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, permission);
         }
+
+        OzoneAcl volumeAcl = OzoneAcl.of(
+            IAccessAuthorizer.ACLIdentityType.USER,
+            grant.getGrantee().getId(), OzoneAcl.AclScope.ACCESS,
+            getOzoneAclOnVolumeFromS3Permission(permissionType)
+        );
+        ozoneAclListOnVolume.add(volumeAcl);
+
         EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnBucketFromS3Permission(permissionType);
         OzoneAcl defaultOzoneAcl = OzoneAcl.of(
             IAccessAuthorizer.ACLIdentityType.USER,
@@ -228,8 +236,8 @@ public final class S3Acl {
             IAccessAuthorizer.ACLIdentityType.USER,
             grant.getGrantee().getId(), OzoneAcl.AclScope.ACCESS, acls
         );
-        ozoneAclList.add(defaultOzoneAcl);
-        ozoneAclList.add(accessOzoneAcl);
+        ozoneAclListOnBucket.add(defaultOzoneAcl);
+        ozoneAclListOnBucket.add(accessOzoneAcl);
       } else {
         LOG.error("Grantee type {} is not supported",
             grant.getGrantee().getXsiType());
@@ -237,7 +245,6 @@ public final class S3Acl {
             grant.getGrantee().getXsiType());
       }
     }
-    return ozoneAclList;
   }
 
   static EnumSet<IAccessAuthorizer.ACLType> getOzoneAclOnBucketFromS3Permission(ACLType permissionType)
@@ -267,36 +274,6 @@ public final class S3Acl {
       throw S3ErrorTable.newError(INVALID_ARGUMENT, permissionType.name());
     }
     return acls;
-  }
-
-  public static List<OzoneAcl> s3AclToOzoneNativeAclOnVolume(
-      S3BucketAcl bucketAcl) throws OS3Exception {
-    List<OzoneAcl> ozoneAclList = new ArrayList<>();
-    List<Grant> grantList = bucketAcl.getAclList().getGrantList();
-    for (Grant grant : grantList) {
-      //  Only "CanonicalUser" is supported, which maps to Ozone "USER"
-      ACLIdentityType identityType = ACLIdentityType.getTypeFromGranteeType(
-          grant.getGrantee().getXsiType());
-      if (identityType != null && identityType.isSupported()) {
-        String permission = grant.getPermission();
-        ACLType permissionType = ACLType.getType(permission);
-        if (permissionType == null) {
-          throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, permission);
-        }
-        EnumSet<IAccessAuthorizer.ACLType> acls = getOzoneAclOnVolumeFromS3Permission(permissionType);
-        OzoneAcl accessOzoneAcl = OzoneAcl.of(
-            IAccessAuthorizer.ACLIdentityType.USER,
-            grant.getGrantee().getId(), OzoneAcl.AclScope.ACCESS, acls
-        );
-        ozoneAclList.add(accessOzoneAcl);
-      } else {
-        LOG.error("Grantee type {} is not supported",
-            grant.getGrantee().getXsiType());
-        throw S3ErrorTable.newError(NOT_IMPLEMENTED,
-            grant.getGrantee().getXsiType());
-      }
-    }
-    return ozoneAclList;
   }
 
   // User privilege on volume follows the "lest privilege" principle.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve `BucketAclHandler` and `S3Acl`:
- parse ACL headers only once and use for both volume and bucket ACLs
- pass `permission` as `ACLType`, not `String`
- reduce code duplication

https://issues.apache.org/jira/browse/HDDS-15078

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/24766402729