### PR TITLE
HDDS-14999. Use line.separator in cli-admin

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
@@ -81,7 +81,8 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
             .findFirst()
             .orElse(null);
         if (currentIterationStatistic == null) {
-          System.out.println("-\n");
+          System.out.println("-");
+          System.out.println();
         } else {
           System.out.println(
               getPrettyIterationStatusInfo(currentIterationStatistic)
@@ -96,7 +97,7 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
                   .stream()
                   .filter(it -> !it.getIterationResult().isEmpty())
                   .map(this::getPrettyIterationStatusInfo)
-                  .collect(Collectors.joining("\n"))
+                  .collect(Collectors.joining(System.lineSeparator()))
           );
         }
       }
@@ -165,16 +166,18 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
     long containerMovesFailed = iterationStatusInfo.getContainerMovesFailed();
     long containerMovesTimeout = iterationStatusInfo.getContainerMovesTimeout();
     String enteringDataNodeList = iterationStatusInfo.getSizeEnteringNodesList()
-            .stream().map(nodeInfo -> nodeInfo.getUuid() + " <- " + byteDesc(nodeInfo.getDataVolume()) + "\n")
-            .collect(Collectors.joining());
+        .stream()
+        .map(nodeInfo -> nodeInfo.getUuid() + " <- " + byteDesc(nodeInfo.getDataVolume()) + System.lineSeparator())
+        .collect(Collectors.joining());
     if (enteringDataNodeList.isEmpty()) {
-      enteringDataNodeList = " -\n";
+      enteringDataNodeList = " -" + System.lineSeparator();
     }
     String leavingDataNodeList = iterationStatusInfo.getSizeLeavingNodesList()
-            .stream().map(nodeInfo -> nodeInfo.getUuid() + " -> " + byteDesc(nodeInfo.getDataVolume()) + "\n")
-            .collect(Collectors.joining());
+        .stream()
+        .map(nodeInfo -> nodeInfo.getUuid() + " -> " + byteDesc(nodeInfo.getDataVolume()) + System.lineSeparator())
+        .collect(Collectors.joining());
     if (leavingDataNodeList.isEmpty()) {
-      leavingDataNodeList = " -\n";
+      leavingDataNodeList = " -" + System.lineSeparator();
     }
     return String.format(
             "%-50s %s%n" +

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -166,7 +166,7 @@ public class InfoSubcommand extends ScmSubcommand {
       // Print pipeline of an existing container.
       String machinesStr = container.getPipeline().getNodes().stream().map(
               InfoSubcommand::buildDatanodeDetails)
-          .collect(Collectors.joining(",\n"));
+          .collect(Collectors.joining("," + System.lineSeparator()));
       System.out.printf("Datanodes: [%s]%n", machinesStr);
 
       // Print the replica details if available
@@ -174,7 +174,7 @@ public class InfoSubcommand extends ScmSubcommand {
         String replicaStr = replicas.stream()
             .sorted(Comparator.comparing(ContainerReplicaInfo::getReplicaIndex))
             .map(InfoSubcommand::buildReplicaDetails)
-            .collect(Collectors.joining(",\n"));
+            .collect(Collectors.joining("," + System.lineSeparator()));
         System.out.printf("Replicas: [%s]%n", replicaStr);
       }
     }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
@@ -99,11 +99,13 @@ public class ReconcileSubcommand extends ScmSubcommand {
       ContainerInfo containerInfo = scmClient.getContainer(containerID);
       if (containerInfo.isOpen()) {
         errorBuilder.append("Cannot get status of container ").append(containerID)
-            .append(". Reconciliation is not supported for open containers\n");
+            .append(". Reconciliation is not supported for open containers")
+            .append(System.lineSeparator());
         return false;
       } else if (containerInfo.getReplicationType() != HddsProtos.ReplicationType.RATIS) {
         errorBuilder.append("Cannot get status of container ").append(containerID)
-            .append(". Reconciliation is only supported for Ratis replicated containers\n");
+            .append(". Reconciliation is only supported for Ratis replicated containers")
+            .append(System.lineSeparator());
         return false;
       }
       List<ContainerReplicaInfo> replicas = scmClient.getContainerReplicas(containerID);
@@ -111,7 +113,7 @@ public class ReconcileSubcommand extends ScmSubcommand {
       arrayWriter.flush();
     } catch (Exception ex) {
       errorBuilder.append("Failed to get reconciliation status of container ")
-          .append(containerID).append(": ").append(getExceptionMessage(ex)).append('\n');
+          .append(containerID).append(": ").append(getExceptionMessage(ex)).append(System.lineSeparator());
       return false;
     }
     return true;
@@ -133,7 +135,8 @@ public class ReconcileSubcommand extends ScmSubcommand {
     }
 
     if (successCount > 0) {
-      System.out.println("\nUse \"ozone admin container reconcile --status\" to see the checksums of each container " +
+      System.out.println();
+      System.out.println("Use \"ozone admin container reconcile --status\" to see the checksums of each container " +
           "replica");
     }
     if (failureCount > 0) {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
@@ -98,7 +98,8 @@ public class ReportSubcommand extends ScmSubcommand {
 
     int numOfSuccess = containerIDs.size() - failures;
     if (numOfSuccess > 0) {
-      out().println("\n" + (suppress ? "Suppressed " : "Unsuppressed ") + numOfSuccess + " container(s) successfully.");
+      blankLine();
+      out().println((suppress ? "Suppressed " : "Unsuppressed ") + numOfSuccess + " container(s) successfully.");
       out().println("Container report will be updated after the next Replication Manager cycle.");
     }
 
@@ -111,7 +112,8 @@ public class ReportSubcommand extends ScmSubcommand {
     ReplicationManagerReport report = scmClient.getReplicationManagerReport();
     if (report.getReportTimeStamp() == 0) {
       System.err.println("The Container Report is not available until Replication Manager completes" +
-          " its first run after startup or fail over. All values will be zero until that time.\n");
+          " its first run after startup or fail over. All values will be zero until that time.");
+      System.err.println();
     }
 
     if (json) {
@@ -172,7 +174,7 @@ public class ReportSubcommand extends ScmSubcommand {
   }
 
   private void blankLine() {
-    System.out.print("\n");
+    System.out.println();
   }
 
   private void output(String s) {
@@ -184,6 +186,6 @@ public class ReportSubcommand extends ScmSubcommand {
     for (int i = 0; i < s.length(); i++) {
       System.out.print("=");
     }
-    System.out.print("\n");
+    System.out.println();
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -86,7 +86,8 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
       }
     } else {
       if (!json) {
-        System.out.println("\nDecommission Status: DECOMMISSIONING - " +
+        System.out.println();
+        System.out.println("Decommission Status: DECOMMISSIONING - " +
             decommissioningNodes.size() + " node(s)");
       }
     }
@@ -134,7 +135,8 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
   }
 
   private void printDetails(DatanodeDetails datanode) {
-    System.out.println("\nDatanode: " + datanode.getUuid().toString() +
+    System.out.println();
+    System.out.println("Datanode: " + datanode.getUuid().toString() +
         " (" + datanode.getNetworkLocation() + "/" + datanode.getIpAddress()
         + "/" + datanode.getHostName() + ")");
   }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
@@ -48,8 +48,8 @@ public class DecommissionSubCommand extends ScmSubcommand {
   public void execute(ScmClient scmClient) throws IOException {
     List<String> hosts = hostNameParams.getHostNames();
     List<DatanodeAdminError> errors = scmClient.decommissionNodes(hosts, force);
-    System.out.println("Started decommissioning datanode(s):\n" +
-        String.join("\n", hosts));
+    System.out.println("Started decommissioning datanode(s):");
+    hosts.forEach(System.out::println);
     showErrors(errors, "Some nodes could not enter the decommission workflow");
   }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -100,9 +100,9 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
       String dn = DiskBalancerSubCommandUtil.getDatanodeHostAndIp(p.getNode());
 
       StringBuilder header = new StringBuilder();
-      header.append("Datanode: ").append(dn).append('\n')
+      header.append("Datanode: ").append(dn).append(System.lineSeparator())
           .append("Aggregate VolumeDataDensity: ").append(p.getCurrentVolumeDensitySum())
-          .append('\n');
+          .append(System.lineSeparator());
 
       if (p.hasIdealUsage() && p.hasDiskBalancerConf()
           && p.getDiskBalancerConf().hasThreshold()) {
@@ -113,8 +113,10 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
         header.append("IdealUsage: ").append(String.format("%.8f", idealUsage))
             .append(" | Threshold: ").append(threshold).append('%')
             .append(" | ThresholdRange: (").append(String.format("%.8f", lt))
-            .append(", ").append(String.format("%.8f", ut)).append(')').append('\n').append('\n')
-            .append("Volume Details:").append('\n');
+            .append(", ").append(String.format("%.8f", ut)).append(')')
+            .append(System.lineSeparator())
+            .append(System.lineSeparator())
+            .append("Volume Details:").append(System.lineSeparator());
       }
       formatBuilder.append("%s%n");
       contentList.add(header.toString());

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -200,8 +200,8 @@ public class ListInfoSubcommand extends ScmSubcommand {
       List<Pipeline> relatedPipelines = pipelines.stream().filter(
           p -> p.getNodes().contains(datanode)).collect(Collectors.toList());
       if (relatedPipelines.isEmpty()) {
-        pipelineListInfo.append("No related pipelines" +
-            " or the node is not in Healthy state.\n");
+        pipelineListInfo.append("No related pipelines or the node is not in Healthy state.")
+            .append(System.lineSeparator());
       } else {
         relatedPipelineNum = relatedPipelines.size();
         relatedPipelines.forEach(
@@ -211,12 +211,12 @@ public class ListInfoSubcommand extends ScmSubcommand {
                 .append('/').append(p.getPipelineState().toString()).append('/')
                 .append(datanode.getID().equals(p.getLeaderId()) ?
                     "Leader" : "Follower")
-                .append('\n'));
+                .append(System.lineSeparator()));
       }
     } else {
       pipelineListInfo
           .append("No pipelines in cluster.")
-          .append('\n');
+          .append(System.lineSeparator());
     }
     System.out.println("Datanode: " + datanode.getUuid().toString() +
         " (" + datanode.getNetworkLocation() + "/" + datanode.getIpAddress()
@@ -225,8 +225,8 @@ public class ListInfoSubcommand extends ScmSubcommand {
     System.out.println("Operational State: " + dn.getOpState());
     System.out.println("Health State: " + dn.getHealthState());
     if (dn.getTotalVolumeCount() != null && dn.getHealthyVolumeCount() != null) {
-      System.out.println("Total volume count: " + dn.getTotalVolumeCount() + "\n" +
-          "Healthy volume count: " + dn.getHealthyVolumeCount());
+      System.out.println("Total volume count: " + dn.getTotalVolumeCount());
+      System.out.println("Healthy volume count: " + dn.getHealthyVolumeCount());
     }
     if (dn.getFailedVolumes() != null && !dn.getFailedVolumes().isEmpty()) {
       System.out.println("Failed volumes:");
@@ -234,7 +234,8 @@ public class ListInfoSubcommand extends ScmSubcommand {
         System.out.println("  " + vol);
       }
     }
-    System.out.println("Related pipelines:\n" + pipelineListInfo);
+    System.out.println("Related pipelines:");
+    System.out.println(pipelineListInfo);
 
     if (dn.getUsed() != null && dn.getCapacity() != null && dn.getUsed() >= 0 && dn.getCapacity() > 0) {
       System.out.println("Capacity: " + dn.getCapacity());

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -56,8 +56,8 @@ public class MaintenanceSubCommand extends ScmSubcommand {
     List<String> hosts = hostNameParams.getHostNames();
     List<DatanodeAdminError> errors =
         scmClient.startMaintenanceNodes(hosts, endInHours, force);
-    System.out.println("Entering maintenance mode on datanode(s):\n" +
-        String.join("\n", hosts));
+    System.out.println("Entering maintenance mode on datanode(s):");
+    hosts.forEach(System.out::println);
     showErrors(errors, "Some nodes could not start the maintenance workflow");
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
@@ -46,8 +46,8 @@ public class RecommissionSubCommand extends ScmSubcommand {
   public void execute(ScmClient scmClient) throws IOException {
     List<String> hosts = hostNameParams.getHostNames();
     List<DatanodeAdminError> errors = scmClient.recommissionNodes(hosts);
-    System.out.println("Started recommissioning datanode(s):\n" +
-        String.join("\n", hosts));
+    System.out.println("Started recommissioning datanode(s):");
+    hosts.forEach(System.out::println);
     showErrors(errors, "Some nodes could be recommissioned");
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -136,8 +136,8 @@ public class DiskUsageSubCommand implements Callable {
       if (duResponse.path("subPathCount").asInt(-1) == 0) {
         if (totalSize == 0) {
           // the object is empty
-          System.out.println("The object is empty.\n" +
-              "Put more files into it to visualize DU");
+          System.out.println("The object is empty.");
+          System.out.println("Put more files into it to visualize DU");
         } else {
           System.out.println("There's no immediate " +
               "sub-path under this object.");

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -85,8 +85,8 @@ public class FileSizeDistSubCommand implements Callable {
       }
       if (sum == 0) {
         printSpaces(2);
-        System.out.println("The object is empty.\n" +
-            "Put more files into it to visualize file size distribution");
+        System.out.println("The object is empty.");
+        System.out.println("Put more files into it to visualize file size distribution");
         printNewLines(1);
         return null;
       }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -112,18 +112,19 @@ public final class NSSummaryCLIUtils {
   }
 
   public static void printEmptyPathRequest() {
-    System.err.println("The path parameter is empty.\n" +
-        "If you mean the root path, use / instead.");
+    System.err.println("The path parameter is empty.");
+    System.err.println("If you mean the root path, use / instead.");
   }
 
   public static void printPathNotFound() {
-    System.err.println("Path not found in the system.\n" +
-        "Did you remove any protocol prefix before the path?");
+    System.err.println("Path not found in the system.");
+    System.err.println("Did you remove any protocol prefix before the path?");
   }
 
   public static void printTypeNA(String requestType) {
     String markUp = "@|underline " + requestType + "|@";
-    System.err.println("Path found in the system.\nBut the entity type " +
+    System.err.println("Path found in the system.");
+    System.err.println("But the entity type " +
         "is not applicable to the " + Ansi.AUTO.string(markUp) + " request");
   }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -180,14 +180,16 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
       System.out.println(line);
     }
 
+    System.out.println();
+
     // Compose next batch's command
     if (res.hasMore()) {
       String nextBatchCmd = getCmdForNextBatch(res.getContinuationToken());
 
-      System.out.println("\n" +
-          "To get the next batch of open keys, run:\n  " + nextBatchCmd);
+      System.out.println("To get the next batch of open keys, run:");
+      System.out.println("  " + nextBatchCmd);
     } else {
-      System.out.println("\nReached the end of the list.");
+      System.out.println("Reached the end of the list.");
     }
   }
 
@@ -201,13 +203,20 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
         .append(openFileList.size())
         .append(" open files (limit ")
         .append(limit)
-        .append(") under path prefix:\n  ")
+        .append(") under path prefix:")
+        .append(System.lineSeparator())
+        .append("  ")
         .append(pathPrefix);
     if (startItem != null && !startItem.isEmpty()) {
-      sb.append("\nafter continuation token:\n  ")
+      sb.append(System.lineSeparator())
+          .append("after continuation token:")
+          .append(System.lineSeparator())
+          .append("  ")
           .append(startItem);
     }
-    sb.append("\n\nClient ID\t\t\tCreation time\t\tHsync'ed\t");
+    sb.append(System.lineSeparator())
+        .append(System.lineSeparator())
+        .append("Client ID\t\t\tCreation time\t\tHsync'ed\t");
     if (showDeleted) {
       sb.append("Deleted\t");
     }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -32,8 +32,6 @@ import org.apache.hadoop.ozone.admin.OzoneAdmin;
 import org.apache.hadoop.ozone.admin.om.lease.LeaseSubCommand;
 import org.apache.hadoop.ozone.admin.om.snapshot.SnapshotSubCommand;
 import org.apache.hadoop.ozone.client.OzoneClientException;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
@@ -75,20 +73,6 @@ public class OMAdmin implements AdminSubcommand {
     return parent;
   }
 
-  public ClientProtocol createClient(String omServiceId) throws Exception {
-    OzoneConfiguration conf = parent.getOzoneConf();
-    if (OmUtils.isOmHAServiceId(conf, omServiceId)) {
-      return OzoneClientFactory.getRpcClient(omServiceId, conf).getObjectStore()
-        .getClientProxy();
-    } else {
-      throw new OzoneClientException("This command works only on OzoneManager" +
-            " HA cluster. Service ID specified does not match" +
-            " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
-            "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
-            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + "\n");
-    }
-  }
-
   public OzoneManagerProtocolClientSideTranslatorPB createOmClient(
       String omServiceID,
       String omHost,
@@ -123,7 +107,7 @@ public class OMAdmin implements AdminSubcommand {
             " HA cluster. Service ID specified does not match" +
             " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
             "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
-            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + "\n");
+            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + System.lineSeparator());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `\n` with OS-specific line separator in `ozone-cli-admin` module.

https://issues.apache.org/jira/browse/HDDS-14999

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/24775125995