### PR TITLE
HDDS-10819. Respect ssl.server.include.cipher.list and ssl.enabled.protocols in HttpServer2

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -557,6 +557,7 @@ public final class OzoneConfigKeys {
       "ozone.http.policy";
   public static final String OZONE_HTTP_POLICY_DEFAULT =
       HttpConfig.Policy.HTTP_ONLY.name();
+  public static final String  OZONE_SSL_ENABLED_PROTOCOLS = "ozone.ssl.enabled.protocols";
   public static final String  OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY =
       "ozone.https.server.keystore.resource";
   public static final String  OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3748,6 +3748,15 @@
     </description>
   </property>
   <property>
+    <name>ozone.ssl.enabled.protocols</name>
+    <tag>OZONE,SECURITY,CRYPTO_COMPLIANCE</tag>
+    <value/>
+    <description>
+      The supported SSL protocols used to restrict connections towards the WebUI of different components,
+      and the S3 GateWay.
+    </description>
+  </property>
+  <property>
     <name>ssl.server.keystore.location</name>
     <tag>OZONE, SECURITY, MANAGEMENT</tag>
     <value/>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
+import org.apache.hadoop.security.ssl.SSLFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -370,25 +371,28 @@ public abstract class BaseHttpServer implements AutoCloseable {
     }
   }
 
-  public static HttpServer2.Builder loadSslConfToHttpServerBuilder(
-      HttpServer2.Builder builder, ConfigurationSource sslConf) {
-    return builder
+  public static void loadSslConfToHttpServerBuilder(HttpServer2.Builder builder, ConfigurationSource sslConf) {
+    builder
         .needsClientAuth(
             sslConf.getBoolean(OZONE_CLIENT_HTTPS_NEED_AUTH_KEY,
                 OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT))
         .keyPassword(getPassword(sslConf, OZONE_SERVER_HTTPS_KEYPASSWORD_KEY))
-        .keyStore(sslConf.get("ssl.server.keystore.location"),
+        .keyStore(
+            sslConf.get(SSLFactory.SSL_SERVER_KEYSTORE_LOCATION),
             getPassword(sslConf, OZONE_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY),
-            sslConf.get(HddsConfigKeys.HDDS_HTTP_SERVER_KEYSTORE_TYPE,
-                HddsConfigKeys.HDDS_HTTP_SERVER_KEYSTORE_TYPE_DEFAULT))
-        .trustStore(sslConf.get("ssl.server.truststore.location"),
+            sslConf.get(
+                HddsConfigKeys.HDDS_HTTP_SERVER_KEYSTORE_TYPE,
+                HddsConfigKeys.HDDS_HTTP_SERVER_KEYSTORE_TYPE_DEFAULT)
+        )
+        .trustStore(
+            sslConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_LOCATION),
             getPassword(sslConf, OZONE_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY),
-            sslConf.get(HddsConfigKeys.HDDS_HTTP_SERVER_TRUSTSTORE_TYPE,
-                HddsConfigKeys.HDDS_HTTP_SERVER_TRUSTSTORE_TYPE_DEFAULT))
-        .excludeCiphers(
-            sslConf.get("ssl.server.exclude.cipher.list"))
-        .includeCiphers(
-            sslConf.get("ssl.server.include.cipher.list"));
+            sslConf.get(
+                HddsConfigKeys.HDDS_HTTP_SERVER_TRUSTSTORE_TYPE,
+                HddsConfigKeys.HDDS_HTTP_SERVER_TRUSTSTORE_TYPE_DEFAULT)
+        )
+        .includeCiphers(sslConf.get(SSLFactory.SSL_SERVER_INCLUDE_CIPHER_LIST))
+        .excludeCiphers(sslConf.get(SSLFactory.SSL_SERVER_EXCLUDE_CIPHER_LIST));
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -386,7 +386,9 @@ public abstract class BaseHttpServer implements AutoCloseable {
             sslConf.get(HddsConfigKeys.HDDS_HTTP_SERVER_TRUSTSTORE_TYPE,
                 HddsConfigKeys.HDDS_HTTP_SERVER_TRUSTSTORE_TYPE_DEFAULT))
         .excludeCiphers(
-            sslConf.get("ssl.server.exclude.cipher.list"));
+            sslConf.get("ssl.server.exclude.cipher.list"))
+        .includeCiphers(
+            sslConf.get("ssl.server.include.cipher.list"));
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -593,35 +593,18 @@ public final class HttpServer2 implements FilterContainer {
       return conn;
     }
 
-    private void setEnabledProtocols(
-        SslContextFactory sslContextFactory) {
-      String enabledProtocols = conf.get(
-          SSLFactory.SSL_ENABLED_PROTOCOLS_KEY,
-          SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
-      if (!enabledProtocols.equals(
-          SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT)) {
-        String[] jettyExcludedProtocols =
-            sslContextFactory.getExcludeProtocols();
-        String[] enabledProtocolsArray =
-            StringUtils.getTrimmedStrings(enabledProtocols);
-        List<String> enabledProtocolsList =
-            Arrays.asList(enabledProtocolsArray);
+    private void setEnabledProtocols(SslContextFactory sslContextFactory) {
+      String enabledProtocols =
+          conf.get(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+      if (!enabledProtocols.equals(SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT)) {
+        List<String> originalExcludedProtocols = Arrays.asList(sslContextFactory.getExcludeProtocols());
+        String[] enabledProtocolsArray = StringUtils.getTrimmedStrings(enabledProtocols);
 
-        List<String> resetExcludedProtocols = new ArrayList<>();
-        for (String jettyExcludedProtocol : jettyExcludedProtocols) {
-          if (!enabledProtocolsList.contains(jettyExcludedProtocol)) {
-            resetExcludedProtocols.add(jettyExcludedProtocol);
-          } else {
-            LOG.debug("Removed {} from exclude protocol list",
-                jettyExcludedProtocol);
-          }
-        }
+        List<String> finalExcludedProtocols = new ArrayList<>(originalExcludedProtocols);
+        finalExcludedProtocols.removeAll(Arrays.asList(enabledProtocolsArray));
 
-        sslContextFactory.setExcludeProtocols(
-            resetExcludedProtocols.toArray(new String[0]));
-        LOG.info("Reset exclude protocol list: {}",
-            resetExcludedProtocols);
-
+        sslContextFactory.setExcludeProtocols(finalExcludedProtocols.toArray(new String[0]));
+        LOG.info("Disabled protocols: {}", finalExcludedProtocols);
         sslContextFactory.setIncludeProtocols(enabledProtocolsArray);
         LOG.info("Enabled protocols: {}", enabledProtocols);
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -250,6 +251,7 @@ public final class HttpServer2 implements FilterContainer {
     private String authFilterConfigurationPrefix =
         "hadoop.http.authentication.";
     private String excludeCiphers;
+    private String includeCiphers;
 
     private boolean xFrameEnabled;
     private XFrameOption xFrameOption = XFrameOption.SAMEORIGIN;
@@ -377,6 +379,11 @@ public final class HttpServer2 implements FilterContainer {
       return this;
     }
 
+    public Builder includeCiphers(String pIncludeCiphers) {
+      this.includeCiphers = pIncludeCiphers;
+      return this;
+    }
+
     /**
      * Adds the ability to control X_FRAME_OPTIONS on HttpServer2.
      * @param enabled - True enables X_FRAME_OPTIONS false disables it.
@@ -448,6 +455,7 @@ public final class HttpServer2 implements FilterContainer {
       trustStoreType = sslConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_TYPE,
           SSLFactory.SSL_SERVER_TRUSTSTORE_TYPE_DEFAULT);
       excludeCiphers = sslConf.get(SSLFactory.SSL_SERVER_EXCLUDE_CIPHER_LIST);
+      includeCiphers = sslConf.get(SSLFactory.SSL_SERVER_INCLUDE_CIPHER_LIST);
     }
 
     public Builder withoutDefaultApps() {
@@ -565,16 +573,58 @@ public final class HttpServer2 implements FilterContainer {
           sslContextFactory.setTrustStorePassword(trustStorePassword);
         }
       }
-      if (null != excludeCiphers && !excludeCiphers.isEmpty()) {
+      if (excludeCiphers != null && !excludeCiphers.isEmpty()) {
         sslContextFactory.setExcludeCipherSuites(
             StringUtils.getTrimmedStrings(excludeCiphers));
         LOG.info("Excluded Cipher List: {}", excludeCiphers);
       }
 
+      if (includeCiphers != null && !includeCiphers.isEmpty()) {
+        sslContextFactory.setIncludeCipherSuites(
+            StringUtils.getTrimmedStrings(includeCiphers));
+        LOG.info("Included Cipher List: {}", includeCiphers);
+      }
+
+      setEnabledProtocols(sslContextFactory);
+
       conn.addFirstConnectionFactory(new SslConnectionFactory(sslContextFactory,
           HttpVersion.HTTP_1_1.asString()));
 
       return conn;
+    }
+
+    private void setEnabledProtocols(
+        SslContextFactory sslContextFactory) {
+      String enabledProtocols = conf.get(
+          SSLFactory.SSL_ENABLED_PROTOCOLS_KEY,
+          SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+      if (!enabledProtocols.equals(
+          SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT)) {
+        String[] jettyExcludedProtocols =
+            sslContextFactory.getExcludeProtocols();
+        String[] enabledProtocolsArray =
+            StringUtils.getTrimmedStrings(enabledProtocols);
+        List<String> enabledProtocolsList =
+            Arrays.asList(enabledProtocolsArray);
+
+        List<String> resetExcludedProtocols = new ArrayList<>();
+        for (String jettyExcludedProtocol : jettyExcludedProtocols) {
+          if (!enabledProtocolsList.contains(jettyExcludedProtocol)) {
+            resetExcludedProtocols.add(jettyExcludedProtocol);
+          } else {
+            LOG.debug("Removed {} from exclude protocol list",
+                jettyExcludedProtocol);
+          }
+        }
+
+        sslContextFactory.setExcludeProtocols(
+            resetExcludedProtocols.toArray(new String[0]));
+        LOG.info("Reset exclude protocol list: {}",
+            resetExcludedProtocols);
+
+        sslContextFactory.setIncludeProtocols(enabledProtocolsArray);
+        LOG.info("Enabled protocols: {}", enabledProtocols);
+      }
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -594,8 +594,8 @@ public final class HttpServer2 implements FilterContainer {
     }
 
     private void setEnabledProtocols(SslContextFactory sslContextFactory) {
-      String enabledProtocols =
-          conf.get(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+      String enabledProtocols = conf.get(OzoneConfigKeys.OZONE_SSL_ENABLED_PROTOCOLS,
+          conf.get(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT));
       if (!enabledProtocols.equals(SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT)) {
         List<String> originalExcludedProtocols = Arrays.asList(sslContextFactory.getExcludeProtocols());
         String[] enabledProtocolsArray = StringUtils.getTrimmedStrings(enabledProtocols);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2SSL.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2SSL.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.server.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URL;
+import java.security.KeyStore;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.apache.hadoop.security.ssl.SSLFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for HttpServer2 SSL/TLS configuration: cipher suite filtering
+ * and protocol version enforcement.
+ */
+public class TestHttpServer2SSL {
+
+  @TempDir
+  private static File baseDir;
+  private static String keystoresDir;
+  private static String sslConfDir;
+  private static OzoneConfiguration conf;
+  private static Configuration sslServerConf;
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    conf = new OzoneConfiguration();
+    keystoresDir = baseDir.getAbsolutePath();
+    sslConfDir = KeyStoreTestUtil.getClasspathDir(TestHttpServer2SSL.class);
+    KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfDir, conf, false);
+
+    // Read back the generated keystore/truststore properties
+    sslServerConf = new Configuration(false);
+    sslServerConf.addResource(KeyStoreTestUtil.getServerSSLConfigFileName());
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
+  }
+
+  @Test
+  public void testExcludedCiphers() throws Exception {
+    // Pick a cipher that's normally available and exclude it
+    String excludedCipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+    HttpServer2 server = buildServer(excludedCipher, null, null);
+    server.start();
+    try {
+      InetSocketAddress addr = server.getConnectorAddress(0);
+      // Connect with only the excluded cipher — should fail
+      SSLSocketFactory factory = createSocketFactory(new String[]{excludedCipher}, null);
+      assertThrows(SSLHandshakeException.class, () -> connectWithFactory(factory, addr));
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testIncludedCiphers() throws Exception {
+    // Include only one specific cipher
+    String includedCipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+    HttpServer2 server = buildServer(null, includedCipher, null);
+    server.start();
+    try {
+      InetSocketAddress addr = server.getConnectorAddress(0);
+      // Connect with the included cipher — should succeed
+      SSLSocketFactory factory = createSocketFactory(new String[]{includedCipher}, null);
+      int responseCode = connectWithFactory(factory, addr);
+      assertEquals(HttpURLConnection.HTTP_OK, responseCode);
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testIncludedCiphersRejectsOther() throws Exception {
+    // Include only one cipher; try connecting with a different one
+    String includedCipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+    String otherCipher = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384";
+    HttpServer2 server = buildServer(null, includedCipher, null);
+    server.start();
+    try {
+      InetSocketAddress addr = server.getConnectorAddress(0);
+      SSLSocketFactory factory = createSocketFactory(new String[]{otherCipher}, null);
+      assertThrows(SSLHandshakeException.class, () -> connectWithFactory(factory, addr));
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testEnabledProtocolsTls12() throws Exception {
+    HttpServer2 server = buildServer(null, null, "TLSv1.2");
+    server.start();
+    try {
+      InetSocketAddress addr = server.getConnectorAddress(0);
+      // Connect with TLSv1.2 — should succeed
+      SSLSocketFactory factory = createSocketFactory(null, new String[]{"TLSv1.2"});
+      int responseCode = connectWithFactory(factory, addr);
+      assertEquals(HttpURLConnection.HTTP_OK, responseCode);
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testEnabledProtocolsRejectsOther() throws Exception {
+    // Configure server to accept only TLSv1.2, try connecting with TLSv1.1
+    HttpServer2 server = buildServer(null, null, "TLSv1.2");
+    server.start();
+    try {
+      InetSocketAddress addr = server.getConnectorAddress(0);
+      SSLSocketFactory factory = createSocketFactory(null, new String[]{"TLSv1.1"});
+      assertThrows(Exception.class, () -> connectWithFactory(factory, addr));
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testDefaultConfigAcceptsConnection() throws Exception {
+    // No cipher/protocol restrictions — connection should succeed
+    HttpServer2 server = buildServer(null, null, null);
+    server.start();
+    try {
+      InetSocketAddress addr = server.getConnectorAddress(0);
+      SSLSocketFactory factory = createSocketFactory(null, null);
+      int responseCode = connectWithFactory(factory, addr);
+      assertEquals(HttpURLConnection.HTTP_OK, responseCode);
+    } finally {
+      server.stop();
+    }
+  }
+
+  private HttpServer2 buildServer(String excludeCiphers, String includeCiphers, String enabledProtocols)
+      throws Exception {
+    OzoneConfiguration serverConf = new OzoneConfiguration(conf);
+    if (enabledProtocols != null) {
+      serverConf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, enabledProtocols);
+    }
+    HttpServer2.Builder builder = new HttpServer2.Builder()
+        .setName("test")
+        .addEndpoint(new URI("https://localhost:0"))
+        .setConf(serverConf)
+        .keyStore(
+            sslServerConf.get(SSLFactory.SSL_SERVER_KEYSTORE_LOCATION),
+            sslServerConf.get(SSLFactory.SSL_SERVER_KEYSTORE_PASSWORD),
+            sslServerConf.get(SSLFactory.SSL_SERVER_KEYSTORE_TYPE, SSLFactory.SSL_SERVER_KEYSTORE_TYPE_DEFAULT))
+        .trustStore(
+            sslServerConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_LOCATION),
+            sslServerConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_PASSWORD),
+            sslServerConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_TYPE, SSLFactory.SSL_SERVER_TRUSTSTORE_TYPE_DEFAULT))
+        .keyPassword(
+            sslServerConf.get(SSLFactory.SSL_SERVER_KEYSTORE_KEYPASSWORD));
+    if (excludeCiphers != null) {
+      builder.excludeCiphers(excludeCiphers);
+    }
+    if (includeCiphers != null) {
+      builder.includeCiphers(includeCiphers);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Creates an SSLSocketFactory that wraps the test trust store
+   * and can force specific ciphers and/or protocols on created sockets.
+   */
+  private SSLSocketFactory createSocketFactory(String[] ciphers, String[] protocols) throws Exception {
+    // Trust store was created by KeyStoreTestUtil.setupSSLConfig
+    String tsLocation = sslServerConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_LOCATION);
+    String tsPassword = sslServerConf.get(SSLFactory.SSL_SERVER_TRUSTSTORE_PASSWORD);
+    KeyStore ts = KeyStore.getInstance("jks");
+    try (InputStream in = java.nio.file.Files.newInputStream(java.nio.file.Paths.get(tsLocation))) {
+      ts.load(in, tsPassword != null ? tsPassword.toCharArray() : null);
+    }
+    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    tmf.init(ts);
+    TrustManager[] trustManagers = tmf.getTrustManagers();
+
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, trustManagers, null);
+    SSLSocketFactory baseFactory = sslContext.getSocketFactory();
+
+    if (ciphers == null && protocols == null) {
+      return baseFactory;
+    }
+    return new ConstrainedSSLSocketFactory(baseFactory, ciphers, protocols);
+  }
+
+  /**
+   * Connects to the HTTPS server using the given SSLSocketFactory
+   * and returns the HTTP response code.
+   */
+  private int connectWithFactory(SSLSocketFactory factory, InetSocketAddress addr) throws IOException {
+    URL url = new URL("https://localhost:" + addr.getPort() + "/jmx");
+    HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+    conn.setSSLSocketFactory(factory);
+    conn.setHostnameVerifier((hostname, session) -> true);
+    conn.setConnectTimeout(5000);
+    conn.setReadTimeout(5000);
+    return conn.getResponseCode();
+  }
+
+  /**
+   * An SSLSocketFactory wrapper that constrains the cipher suites
+   * and/or protocols on created sockets.
+   */
+  private static class ConstrainedSSLSocketFactory extends SSLSocketFactory {
+    private final SSLSocketFactory delegate;
+    private final String[] ciphers;
+    private final String[] protocols;
+
+    ConstrainedSSLSocketFactory(SSLSocketFactory delegate, String[] ciphers, String[] protocols) {
+      this.delegate = delegate;
+      this.ciphers = ciphers;
+      this.protocols = protocols;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+      return ciphers != null ? ciphers : delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+      return ciphers != null ? ciphers : delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+      return constrain((SSLSocket) delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+      return constrain((SSLSocket) delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, java.net.InetAddress localHost, int localPort)
+        throws IOException {
+      return constrain((SSLSocket) delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(java.net.InetAddress host, int port) throws IOException {
+      return constrain((SSLSocket) delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(java.net.InetAddress address, int port, java.net.InetAddress localAddress, int localPort)
+        throws IOException {
+      return constrain((SSLSocket) delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private SSLSocket constrain(SSLSocket socket) {
+      SSLParameters params = socket.getSSLParameters();
+      if (ciphers != null) {
+        params.setCipherSuites(ciphers);
+      }
+      if (protocols != null) {
+        params.setProtocols(protocols);
+      }
+      socket.setSSLParameters(params);
+      return socket;
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add ssl.server.include.cipher.list and ssl.enabled.protocols to HttpServer2 setup.

Please describe your PR in detail:
Port TLS protocol version control and cipher suite inclusion support from Hadoop's HttpServer2 to Ozone's forked copy, aligning with upstream changes from HADOOP-15169 and HADOOP-19546. Currently, Ozone's web endpoints (OM, SCM, Datanode, S3Gateway, Recon, HttpFS, Freon) only support excluding cipher suites via ssl.server.exclude.cipher.list and have no mechanism to restrict TLS protocol versions — both features that Hadoop's HttpServer2 already provides. This change adds the includeCiphers builder field and method to HttpServer2, ports the setEnabledProtocols() method that honors the hadoop.ssl.enabled.protocols configuration key, wires the new ssl.server.include.cipher.list config through BaseHttpServer.loadSslConfToHttpServerBuilder(), and adds comprehensive SSL tests verifying that cipher exclusion/inclusion and protocol restrictions are actually enforced at the TLS handshake level — a test coverage gap that exists today. All required constants (SSLFactory.SSL_SERVER_INCLUDE_CIPHER_LIST, SSLFactory.SSL_ENABLED_PROTOCOLS_KEY) are already available in Ozone's existing Hadoop 3.4.3 dependency, so no version bump is needed.

The changeset is generated by Claude - Opus 4.6

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10819

## How was this patch tested?

JUnit tests are added.
