### PR TITLE
HDDS-15094. Add protocol and cipher config to gRPC TLS config

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -292,6 +292,9 @@ public final class HddsConfigKeys {
       ".test.cert";
   public static final boolean HDDS_GRPC_TLS_TEST_CERT_DEFAULT = false;
 
+  public static final String HDDS_GRPC_TLS_PROTOCOLS = "hdds.grpc.tls.protocols";
+  public static final String HDDS_GRPC_TLS_CIPHERS = "hdds.grpc.tls.ciphers";
+
   // Comma separated acls (users, groups) allowing clients accessing
   // datanode container protocol
   // when hadoop.security.authorization is true, this needs to be set in

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
@@ -24,8 +24,10 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_KEY_ALGORITHM;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_KEY_LEN;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_SECURITY_PROVIDER;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_CIPHERS;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROTOCOLS;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROVIDER;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROVIDER_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_TEST_CERT;
@@ -83,10 +85,14 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
@@ -144,6 +150,8 @@ public class SecurityConfig {
       Pattern.compile("\\d{2}:\\d{2}:\\d{2}");
   private final Duration caAckTimeout;
   private final SslProvider grpcSSLProvider;
+  private final String[] grpcTlsProtocols;
+  private final List<String> grpcTlsCiphers;
   private final Duration rootCaCertificatePollingInterval;
   private final boolean autoCARotationEnabled;
   private final Duration expiredCertificateCheckInterval;
@@ -282,6 +290,18 @@ public class SecurityConfig {
     this.grpcSSLProvider = SslProvider.valueOf(
         configuration.get(HDDS_GRPC_TLS_PROVIDER,
             HDDS_GRPC_TLS_PROVIDER_DEFAULT));
+
+    String protocolsValue = configuration.get(HDDS_GRPC_TLS_PROTOCOLS);
+    this.grpcTlsProtocols =
+        StringUtils.isBlank(protocolsValue)
+        ? null
+        : configuration.getTrimmedStrings(HDDS_GRPC_TLS_PROTOCOLS);
+
+    String ciphersValue = configuration.get(HDDS_GRPC_TLS_CIPHERS);
+    this.grpcTlsCiphers =
+        StringUtils.isBlank(ciphersValue)
+        ? null
+        : Collections.unmodifiableList(Arrays.asList(configuration.getTrimmedStrings(HDDS_GRPC_TLS_CIPHERS)));
   }
 
   public static synchronized void initSecurityProvider(ConfigurationSource configuration) {
@@ -570,6 +590,22 @@ public class SecurityConfig {
    */
   public SslProvider getGrpcSslProvider() {
     return grpcSSLProvider;
+  }
+
+  /**
+   * Returns TLS protocol versions for gRPC servers,
+   * or null for provider defaults.
+   */
+  public String[] getGrpcTlsProtocols() {
+    return grpcTlsProtocols == null ? null : Arrays.copyOf(grpcTlsProtocols, grpcTlsProtocols.length);
+  }
+
+  /**
+   * Returns TLS cipher suites for gRPC servers,
+   * or null for provider defaults.
+   */
+  public List<String> getGrpcTlsCiphers() {
+    return grpcTlsCiphers;
   }
 
   public boolean useExternalCACertificate(String component) {

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2547,6 +2547,24 @@
     <description>If HDDS GRPC server TLS is enabled.</description>
   </property>
   <property>
+    <name>hdds.grpc.tls.protocols</name>
+    <value></value>
+    <tag>OZONE, HDDS, SECURITY, TLS, CRYPTO_COMPLIANCE</tag>
+    <description>Comma-separated list of TLS protocol versions for gRPC
+      server endpoints (e.g. "TLSv1.3" or "TLSv1.2,TLSv1.3"). When empty,
+      the TLS provider's defaults are used. Applies to server endpoints
+      only; clients are not restricted.</description>
+  </property>
+  <property>
+    <name>hdds.grpc.tls.ciphers</name>
+    <value></value>
+    <tag>OZONE, HDDS, SECURITY, TLS, CRYPTO_COMPLIANCE</tag>
+    <description>Comma-separated list of TLS cipher suites for gRPC server
+      endpoints (e.g. "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256").
+      When empty, the TLS provider's defaults are used. Applies to server
+      endpoints only; clients are not restricted.</description>
+  </property>
+  <property>
     <name>hdds.x509.default.duration</name>
     <value>P365D</value>
     <tag>OZONE, HDDS, SECURITY</tag>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/TestSecurityConfigTlsSettings.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/TestSecurityConfigTlsSettings.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.security;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_CIPHERS;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROTOCOLS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Arrays;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for SecurityConfig TLS protocol and cipher suite parsing.
+ */
+public class TestSecurityConfigTlsSettings {
+
+  @Test
+  public void testProtocolsDefault() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertNull(secConf.getGrpcTlsProtocols());
+  }
+
+  @Test
+  public void testProtocolsSingle() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_GRPC_TLS_PROTOCOLS, "TLSv1.3");
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertArrayEquals(new String[]{"TLSv1.3"}, secConf.getGrpcTlsProtocols());
+  }
+
+  @Test
+  public void testProtocolsMultiple() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_GRPC_TLS_PROTOCOLS, "TLSv1.2,TLSv1.3");
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertArrayEquals(new String[]{"TLSv1.2", "TLSv1.3"}, secConf.getGrpcTlsProtocols());
+  }
+
+  @Test
+  public void testProtocolsWhitespaceTrimmed() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_GRPC_TLS_PROTOCOLS, " TLSv1.3 , TLSv1.2 ");
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertArrayEquals(new String[]{"TLSv1.3", "TLSv1.2"}, secConf.getGrpcTlsProtocols());
+  }
+
+  @Test
+  public void testProtocolsEmptyValue() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_GRPC_TLS_PROTOCOLS, "");
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertNull(secConf.getGrpcTlsProtocols());
+  }
+
+  @Test
+  public void testCiphersDefault() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertNull(secConf.getGrpcTlsCiphers());
+  }
+
+  @Test
+  public void testCiphersMultiple() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_GRPC_TLS_CIPHERS, "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256");
+    SecurityConfig secConf = new SecurityConfig(conf);
+    assertEquals(
+        Arrays.asList("TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"),
+        secConf.getGrpcTlsCiphers());
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -145,6 +145,8 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
             caClient.getKeyManager());
         SslContextBuilder sslContextBuilder = GrpcSslContexts.configure(
             sslClientContextBuilder, secConf.getGrpcSslProvider());
+        sslContextBuilder.protocols(secConf.getGrpcTlsProtocols());
+        sslContextBuilder.ciphers(secConf.getGrpcTlsCiphers());
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure datanode GRPC endpoint.", ex);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -120,6 +120,8 @@ public class ReplicationServer {
 
         sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
         sslContextBuilder.trustManager(caClient.getTrustManager());
+        sslContextBuilder.protocols(secConf.getGrpcTlsProtocols());
+        sslContextBuilder.ciphers(secConf.getGrpcTlsCiphers());
 
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (IOException ex) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestGrpcTlsConfig.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestGrpcTlsConfig.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.security.ssl;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROVIDER;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.XceiverClientProtocolServiceGrpc;
+import org.apache.hadoop.hdds.protocol.datanode.proto.XceiverClientProtocolServiceGrpc.XceiverClientProtocolServiceImplBase;
+import org.apache.hadoop.hdds.protocol.datanode.proto.XceiverClientProtocolServiceGrpc.XceiverClientProtocolServiceStub;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
+import org.apache.hadoop.ozone.container.ContainerTestHelper;
+import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
+import org.apache.ratis.thirdparty.io.grpc.Server;
+import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests TLS protocol version and cipher suite enforcement on gRPC endpoints.
+ */
+public class TestGrpcTlsConfig {
+  private CertificateClientTestImpl caClient;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_GRPC_TLS_PROVIDER, "JDK");
+    caClient = new CertificateClientTestImpl(conf);
+  }
+
+  @Test
+  public void testTls13ServerAcceptsTls13Client() throws Exception {
+    Server server = null;
+    ManagedChannel channel = null;
+    try {
+      server = setupServer(new String[]{"TLSv1.3"}, null);
+      server.start();
+      channel = setupClient(server.getPort(), new String[]{"TLSv1.3"}, null);
+      XceiverClientProtocolServiceStub asyncStub = XceiverClientProtocolServiceGrpc.newStub(channel);
+      ContainerCommandResponseProto response = sendRequest(asyncStub);
+      assertEquals(SUCCESS, response.getResult());
+    } finally {
+      shutdown(channel, server);
+    }
+  }
+
+  @Test
+  public void testTls13ServerRejectsTls12Client() throws Exception {
+    Server server = null;
+    ManagedChannel channel = null;
+    try {
+      server = setupServer(new String[]{"TLSv1.3"}, null);
+      server.start();
+      channel = setupClient(server.getPort(),  new String[]{"TLSv1.2"}, null);
+      XceiverClientProtocolServiceStub asyncStub =  XceiverClientProtocolServiceGrpc.newStub(channel);
+      assertThrows(ExecutionException.class, () -> sendRequest(asyncStub));
+    } finally {
+      shutdown(channel, server);
+    }
+  }
+
+  @Test
+  public void testCipherMatchSucceeds() throws Exception {
+    Server server = null;
+    ManagedChannel channel = null;
+    try {
+      String[] ciphers = {"TLS_AES_256_GCM_SHA384"};
+      server = setupServer(new String[]{"TLSv1.3"}, ciphers);
+      server.start();
+      channel = setupClient(server.getPort(), new String[]{"TLSv1.3"}, ciphers);
+      XceiverClientProtocolServiceStub asyncStub = XceiverClientProtocolServiceGrpc.newStub(channel);
+      ContainerCommandResponseProto response = sendRequest(asyncStub);
+      assertEquals(SUCCESS, response.getResult());
+    } finally {
+      shutdown(channel, server);
+    }
+  }
+
+  @Test
+  public void testCipherMismatchFails() throws Exception {
+    Server server = null;
+    ManagedChannel channel = null;
+    try {
+      server = setupServer(new String[]{"TLSv1.3"}, new String[]{"TLS_AES_256_GCM_SHA384"});
+      server.start();
+      channel = setupClient(server.getPort(), new String[]{"TLSv1.3"}, new String[]{"TLS_AES_128_GCM_SHA256"});
+      XceiverClientProtocolServiceStub asyncStub = XceiverClientProtocolServiceGrpc.newStub(channel);
+      assertThrows(ExecutionException.class, () -> sendRequest(asyncStub));
+    } finally {
+      shutdown(channel, server);
+    }
+  }
+
+  @Test
+  public void testDefaultConfigAcceptsConnection() throws Exception {
+    Server server = null;
+    ManagedChannel channel = null;
+    try {
+      server = setupServer(null, null);
+      server.start();
+      channel = setupClient(server.getPort(), null, null);
+      XceiverClientProtocolServiceStub asyncStub = XceiverClientProtocolServiceGrpc.newStub(channel);
+      ContainerCommandResponseProto response = sendRequest(asyncStub);
+      assertEquals(SUCCESS, response.getResult());
+    } finally {
+      shutdown(channel, server);
+    }
+  }
+
+  private Server setupServer(String[] protocols, String[] ciphers)
+      throws Exception {
+    NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(0).addService(new GrpcService());
+    SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(caClient.getKeyManager());
+    sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
+    sslContextBuilder.trustManager(caClient.getTrustManager());
+    sslContextBuilder = GrpcSslContexts.configure(sslContextBuilder, SslProvider.JDK);
+    if (protocols != null) {
+      sslContextBuilder.protocols(protocols);
+    }
+    if (ciphers != null) {
+      sslContextBuilder.ciphers(Arrays.asList(ciphers));
+    }
+    nettyServerBuilder.sslContext(sslContextBuilder.build());
+    return nettyServerBuilder.build();
+  }
+
+  private ManagedChannel setupClient(int port, String[] protocols, String[] ciphers) throws Exception {
+    NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress("localhost", port);
+    SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
+    sslContextBuilder.trustManager(caClient.getTrustManager());
+    sslContextBuilder.keyManager(caClient.getKeyManager());
+    sslContextBuilder = GrpcSslContexts.configure(sslContextBuilder, SslProvider.JDK);
+    if (protocols != null) {
+      sslContextBuilder.protocols(protocols);
+    }
+    if (ciphers != null) {
+      sslContextBuilder.ciphers(Arrays.asList(ciphers));
+    }
+    channelBuilder.useTransportSecurity().sslContext(sslContextBuilder.build());
+    return channelBuilder.build();
+  }
+
+  private ContainerCommandResponseProto sendRequest(
+      XceiverClientProtocolServiceStub stub) throws Exception {
+    DatanodeDetails dn = DatanodeDetails.newBuilder().setUuid(UUID.randomUUID()).build();
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    nodes.add(dn);
+    Pipeline pipeline = Pipeline.newBuilder().setId(PipelineID.randomId())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE))
+        .setState(Pipeline.PipelineState.OPEN)
+        .setNodes(nodes).build();
+
+    ContainerCommandRequestProto request = ContainerTestHelper.getCreateContainerRequest(0, pipeline);
+    final CompletableFuture<ContainerCommandResponseProto> replyFuture = new CompletableFuture<>();
+    final StreamObserver<ContainerCommandRequestProto> requestObserver =
+        stub.send(new StreamObserver<ContainerCommandResponseProto>() {
+          @Override
+          public void onNext(ContainerCommandResponseProto value) {
+            replyFuture.complete(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            replyFuture.completeExceptionally(t);
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        });
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+    return replyFuture.get();
+  }
+
+  private void shutdown(ManagedChannel channel, Server server) {
+    if (channel != null) {
+      channel.shutdownNow();
+    }
+    if (server != null) {
+      server.shutdownNow();
+    }
+  }
+
+  private static class GrpcService
+      extends XceiverClientProtocolServiceImplBase {
+
+    @Override
+    public StreamObserver<ContainerCommandRequestProto> send(
+        StreamObserver<ContainerCommandResponseProto> responseObserver) {
+      return new StreamObserver<ContainerCommandRequestProto>() {
+
+        @Override
+        public void onNext(ContainerCommandRequestProto request) {
+          ContainerCommandResponseProto resp =
+              ContainerCommandResponseProto.newBuilder()
+                  .setCmdType(ContainerProtos.Type.CreateContainer)
+                  .setResult(SUCCESS)
+                  .build();
+          responseObserver.onNext(resp);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+        }
+
+        @Override
+        public void onCompleted() {
+          responseObserver.onCompleted();
+        }
+      };
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcProtocolService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcProtocolService.java
@@ -74,6 +74,8 @@ public class InterSCMGrpcProtocolService {
         SslContextBuilder sslContextBuilder = GrpcSslContexts.configure(
             sslServerContextBuilder, securityConfig.getGrpcSslProvider());
         sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
+        sslContextBuilder.protocols(securityConfig.getGrpcTlsProtocols());
+        sslContextBuilder.ciphers(securityConfig.getGrpcTlsCiphers());
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
@@ -164,6 +164,8 @@ public class GrpcOzoneManagerServer {
             sslClientContextBuilder,
             SslProvider.valueOf(omServerConfig.get(HDDS_GRPC_TLS_PROVIDER,
                 HDDS_GRPC_TLS_PROVIDER_DEFAULT)));
+        sslContextBuilder.protocols(secConf.getGrpcTlsProtocols());
+        sslContextBuilder.ciphers(secConf.getGrpcTlsCiphers());
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure Om S3g GRPC channel.", ex);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add protocol and cipher config to gRPC TLS config

Please describe your PR in detail:
This change enables Ozone administrators to restrict TLS protocol versions and cipher suites on all gRPC server endpoints (OzoneManager, XceiverServer, ReplicationServer, InterSCMGrpcProtocolService) via two new configuration keys: hdds.grpc.tls.protocols (e.g. "TLSv1.3") and hdds.grpc.tls.ciphers
(e.g. "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256").
When unset, provider defaults are preserved for full backward compatibility. The configuration is parsed in SecurityConfig and applied server-side only — clients are intentionally unrestricted since the server controls TLS handshake negotiation. 
The PR is generated by: Claude - Opus 4.6

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15094

## How was this patch tested?
New tests verify both config parsing (7 cases in TestSecurityConfigTlsSettings) and actual TLS handshake enforcement including protocol version rejection and cipher mismatch failure (5 cases in TestGrpcTlsConfig).
