### PR TITLE
HDDS-14969. Bump Ratis to 3.2.2

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -77,7 +77,10 @@ public abstract class TestOzoneManagerHA {
   private static OzoneConfiguration conf;
   private static String omServiceId;
   private static int numOfOMs = 3;
-  private static final int LOG_PURGE_GAP = 50;
+  // Large enough that 100-volume tests do not cross the purge boundary,
+  // preventing unintended snapshot-install cycles in HA tests. Only
+  // testOMRestart deliberately creates enough entries to exceed this.
+  private static final int LOG_PURGE_GAP = 500;
   /* Reduce max number of retries to speed up unit test. */
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;

--- a/pom.xml
+++ b/pom.xml
@@ -186,11 +186,11 @@
     <protobuf.version>3.25.8</protobuf.version>
     <ranger.version>2.8.0</ranger.version>
     <!-- versions included in ratis-thirdparty, update in sync -->
-    <ratis-thirdparty.grpc.version>1.75.0</ratis-thirdparty.grpc.version>
-    <ratis-thirdparty.netty.version>4.1.127.Final</ratis-thirdparty.netty.version>
+    <ratis-thirdparty.grpc.version>1.77.1</ratis-thirdparty.grpc.version>
+    <ratis-thirdparty.netty.version>4.1.130.Final</ratis-thirdparty.netty.version>
     <ratis-thirdparty.protobuf.version>3.25.8</ratis-thirdparty.protobuf.version>
-    <ratis.thirdparty.version>1.0.10</ratis.thirdparty.version>
-    <ratis.version>3.2.1</ratis.version>
+    <ratis.thirdparty.version>1.0.11</ratis.thirdparty.version>
+    <ratis.version>3.2.2</ratis.version>
     <re2j.version>1.7</re2j.version>
     <reflections.version>0.10.2</reflections.version>
     <reload4j.version>1.2.26</reload4j.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Following version are changed in the PR
ratis-thirdparty.grpc - 1.77.1
ratis-thirdparty.netty - 4.1.130.Final
ratis-thirdparty.protobuf. - 3.25.8
 ratis.thirdparty - 1.0.11
ratis.version 3.2.2

Also incremented log purge gap to fix test case failures. 

## What is the link to the Apache JIRA

HDDS-14969

## How was this patch tested?

Forked CI - https://github.com/priyeshkaratha/ozone/actions/runs/24846331405