### PR TITLE
HDDS-15004. Stabilize TestReconContainerEndpoint#testContainerEndpointForOBSBucket

### DIFF
--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -86,15 +86,9 @@ public class TestReconContainerEndpoint {
   }
 
   @AfterEach
-  public void shutdown() throws IOException {
-    try {
-      IOUtils.closeQuietly(client);
-      if (cluster != null) {
-        cluster.shutdown();
-      }
-    } finally {
-      ContainerKeyMapperHelper.clearSharedContainerCountMap();
-    }
+  public void shutdown() {
+    IOUtils.closeQuietly(client, cluster);
+    ContainerKeyMapperHelper.clearSharedContainerCountMap();
   }
 
   @Test

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -36,11 +36,14 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.recon.api.ContainerEndpoint;
 import org.apache.hadoop.ozone.recon.api.types.KeyMetadata;
 import org.apache.hadoop.ozone.recon.api.types.KeysResponse;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
+import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperHelper;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskControllerImpl;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -60,6 +63,9 @@ public class TestReconContainerEndpoint {
 
   @BeforeEach
   public void init() throws Exception {
+    // ContainerKeyMapper tasks share static maps/flags across the JVM; reset so a
+    // prior test method cannot break mapper state for this cluster instance.
+    ContainerKeyMapperHelper.clearSharedContainerCountMap();
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED);
@@ -77,11 +83,15 @@ public class TestReconContainerEndpoint {
 
   @AfterEach
   public void shutdown() throws IOException {
-    if (client != null) {
-      client.close();
-    }
-    if (cluster != null) {
-      cluster.shutdown();
+    try {
+      if (client != null) {
+        client.close();
+      }
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    } finally {
+      ContainerKeyMapperHelper.clearSharedContainerCountMap();
     }
   }
 
@@ -117,6 +127,9 @@ public class TestReconContainerEndpoint {
     CompletableFuture<Void> completableFuture =
         omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
+    completableFuture.join();
+    // The buffer can be empty while tasks still finish processing a dequeued batch.
+    Thread.sleep(2000);
 
     //Search for the bucket from the bucket table and verify its FSO
     OmBucketInfo bucketInfo = cluster.getOzoneManager().getBucketInfo(volName, bucketName);
@@ -186,14 +199,17 @@ public class TestReconContainerEndpoint {
     CompletableFuture<Void> completableFuture =
         omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
+    completableFuture.join();
+    Thread.sleep(2000);
 
     // Search for the bucket from the bucket table and verify its OBS
     OmBucketInfo bucketInfo = cluster.getOzoneManager().getBucketInfo(volumeName, obsBucketName);
     assertNotNull(bucketInfo);
     assertEquals(BucketLayout.OBJECT_STORE, bucketInfo.getBucketLayout());
 
-    // Initialize the ContainerEndpoint
-    long containerId = 1L;
+    long containerId = getContainerIdForKey(volumeName, obsBucketName,
+        obsSingleFileKey);
+
     Response response = getContainerEndpointResponse(containerId);
 
     assertNotNull(response, "Response should not be null.");
@@ -224,6 +240,22 @@ public class TestReconContainerEndpoint {
             recon.getReconServer().getReconContainerMetadataManager(),
             omMetadataManagerInstance);
     return containerEndpoint.getKeysForContainer(containerId, 10, "");
+  }
+
+  private long getContainerIdForKey(String volumeName, String bucketName,
+      String keyName) throws IOException {
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .build();
+    OmKeyLocationInfo location = cluster.getOzoneManager()
+        .lookupKey(keyArgs)
+        .getKeyLocationVersions()
+        .get(0)
+        .getBlocksLatestVersionOnly()
+        .get(0);
+    return location.getContainerID();
   }
 
   private void writeTestData(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -23,9 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
@@ -42,6 +45,7 @@ import org.apache.hadoop.ozone.recon.api.ContainerEndpoint;
 import org.apache.hadoop.ozone.recon.api.types.KeyMetadata;
 import org.apache.hadoop.ozone.recon.api.types.KeysResponse;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperHelper;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskControllerImpl;
@@ -84,9 +88,7 @@ public class TestReconContainerEndpoint {
   @AfterEach
   public void shutdown() throws IOException {
     try {
-      if (client != null) {
-        client.close();
-      }
+      IOUtils.closeQuietly(client);
       if (cluster != null) {
         cluster.shutdown();
       }
@@ -128,8 +130,8 @@ public class TestReconContainerEndpoint {
         omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
     completableFuture.join();
-    // The buffer can be empty while tasks still finish processing a dequeued batch.
-    Thread.sleep(2000);
+    waitUntilReconIndexesKeysForPaths(volName, bucketName,
+        nestedDirKey, singleFileKey);
 
     //Search for the bucket from the bucket table and verify its FSO
     OmBucketInfo bucketInfo = cluster.getOzoneManager().getBucketInfo(volName, bucketName);
@@ -137,8 +139,7 @@ public class TestReconContainerEndpoint {
     assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         bucketInfo.getBucketLayout());
 
-    // Assuming a known container ID that these keys have been written into
-    long testContainerID = 1L;
+    long testContainerID = getContainerIdForKey(volName, bucketName, nestedDirKey);
 
     // Query the ContainerEndpoint for the keys in the specified container
     Response response = getContainerEndpointResponse(testContainerID);
@@ -158,7 +159,7 @@ public class TestReconContainerEndpoint {
     assertEquals("file1", keyMetadata.getKey());
     assertEquals("testvol/fsobucket/dir1/dir2/dir3/file1", keyMetadata.getCompletePath());
 
-    testContainerID = 2L;
+    testContainerID = getContainerIdForKey(volName, bucketName, singleFileKey);
     response = getContainerEndpointResponse(testContainerID);
     data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
@@ -200,7 +201,7 @@ public class TestReconContainerEndpoint {
         omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
     completableFuture.join();
-    Thread.sleep(2000);
+    waitUntilReconIndexesKeysForPaths(volumeName, obsBucketName, obsSingleFileKey);
 
     // Search for the bucket from the bucket table and verify its OBS
     OmBucketInfo bucketInfo = cluster.getOzoneManager().getBucketInfo(volumeName, obsBucketName);
@@ -240,6 +241,24 @@ public class TestReconContainerEndpoint {
             recon.getReconServer().getReconContainerMetadataManager(),
             omMetadataManagerInstance);
     return containerEndpoint.getKeysForContainer(containerId, 10, "");
+  }
+
+  /**
+   * Wait until Recon's container-key index reflects all written keys (by container id).
+   * The OM event queue can be empty while a batch is still being processed.
+   */
+  private void waitUntilReconIndexesKeysForPaths(String volumeName,
+      String bucketName, String... keyPaths)
+      throws Exception {
+    Map<Long, Integer> requiredCountByContainer = new HashMap<>();
+    for (String keyPath : keyPaths) {
+      long containerId =
+          getContainerIdForKey(volumeName, bucketName, keyPath);
+      requiredCountByContainer.merge(containerId, 1, Integer::sum);
+    }
+    ReconContainerMetadataManager mgr =
+        recon.getReconServer().getReconContainerMetadataManager();
+    TestReconOmMetaManagerUtils.waitUntilReconKeyCounts(mgr, requiredCountByContainer);
   }
 
   private long getContainerIdForKey(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconOmMetaManagerUtils.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconOmMetaManagerUtils.java
@@ -51,6 +51,10 @@ public class TestReconOmMetaManagerUtils {
    * Waits until Recon's container-key index reports at least the given number of keys
    * per container id. Use after OM sync when the event buffer can be empty while a
    * dequeued batch is still being processed.
+   * <p>
+   * IO failures from {@code mgr} reads (including temporary {@code RocksDatabaseException}
+   * while Recon applies updates) are treated as "not ready yet"; the wait repeats until the
+   * timeout if counts never converge.
    *
    * @param mgr                      Recon container metadata manager
    * @param minimumCountPerContainer map of container ID to minimum inclusive key count
@@ -67,8 +71,9 @@ public class TestReconOmMetaManagerUtils {
         }
         return true;
       } catch (IOException ex) {
-        throw new RuntimeException(ex);
+        // Retry: concurrent Recon indexing can transiently expose a closed Rocks handle.
+        return false;
       }
-    }, 500, 45000);
+    }, 1000, 90000);
   }
 }

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconOmMetaManagerUtils.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconOmMetaManagerUtils.java
@@ -17,7 +17,10 @@
 
 package org.apache.hadoop.ozone.recon;
 
+import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.apache.hadoop.ozone.recon.tasks.OMUpdateEventBuffer;
 import org.apache.ozone.test.GenericTestUtils;
 
@@ -42,5 +45,30 @@ public class TestReconOmMetaManagerUtils {
         throw new RuntimeException("Error waiting for event buffer to empty", e);
       }
     });
+  }
+
+  /**
+   * Waits until Recon's container-key index reports at least the given number of keys
+   * per container id. Use after OM sync when the event buffer can be empty while a
+   * dequeued batch is still being processed.
+   *
+   * @param mgr                      Recon container metadata manager
+   * @param minimumCountPerContainer map of container ID to minimum inclusive key count
+   * @throws Exception               if the condition is not met within the timeout or on interrupt
+   */
+  public static void waitUntilReconKeyCounts(ReconContainerMetadataManager mgr,
+      Map<Long, Integer> minimumCountPerContainer) throws Exception {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        for (Map.Entry<Long, Integer> e : minimumCountPerContainer.entrySet()) {
+          if (mgr.getKeyCountForContainer(e.getKey()) < e.getValue()) {
+            return false;
+          }
+        }
+        return true;
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    }, 500, 45000);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the intermittent failure in TestReconContainerEndpoint#testContainerEndpointForOBSBucket ([HDDS-15004](https://issues.apache.org/jira/browse/HDDS-15004)).

The test sometimes failed with expected: <1> but was: <0> on KeysResponse#getTotalCount(). That usually meant either Recon had not finished updating its containerdi-key index, or the test queried the wrong container id.

Please describe your PR in detail:
1. Use the real container id from OM

OBS: the test no longer hard-codes 1L. It uses OzoneManager#lookupKey (via getContainerIdForKey) to get the container id from the key’s block locations.
FSO: the same helper is used for each key path instead of assuming fixed container ids.

2.  Fail fast when the async “buffer empty” wait breaks

After waitForEventBufferEmpty, the test only waited until the CompletableFuture completed. If the async work failed, the future could still be “done” and the test would continue anyway.

The test now calls completableFuture.join() after GenericTestUtils.waitFor(completableFuture::isDone, …) so a failed buffer wait is not ignored.

3. Wait until Recon actually has the keys (no sleep in TestReconContainerEndpoint)

The OM event buffer can be empty while Recon is still applying that batch (events are removed from the queue before processing finishes). So “buffer empty” is not enough to assert on the container endpoint.

Instead of sleeping, the test waits until ReconContainerMetadataManager#getKeyCountForContainer shows the expected number of keys per container. That logic lives in TestReconOmMetaManagerUtils.waitUntilReconKeyCounts, which polls until counts match or a timeout is hit. 

The FSO test builds the expected counts from both written keys (so if two keys share a container, it waits for the right total).

4. Clean up static state between tests

ContainerKeyMapperHelper uses JVM-wide static flags and maps. If one test method runs before another in the same process, the second test can see stale state.


5. Safer shutdown in @AfterEach

The client is closed with IOUtils.closeQuietly(client) so a client-close error does not block cluster.shutdown().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15004

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)

https://github.com/arunsarin85/ozone/actions/runs/24855010484
https://github.com/arunsarin85/ozone/actions/runs/24855051641