### PR TITLE
HDDS-15102. Avoid ArchiveOutputStream.createArchiveEntry due to libnss issue

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
@@ -82,8 +82,22 @@ public final class Archiver {
 
   private static TarArchiveEntry createBasicTarArchiveEntry(File file, String entryName)
       throws IOException {
-    TarArchiveEntry entry = new TarArchiveEntry(entryName);
-    entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+    final Path path = file.toPath();
+
+    final TarArchiveEntry entry;
+    if (Files.isDirectory(path)) {
+      final int nameLength = entryName.length();
+      final String dirName = nameLength == 0 || entryName.charAt(nameLength - 1) != '/'
+          ? entryName + "/"
+          : entryName;
+      entry = new TarArchiveEntry(dirName);
+      entry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
+    } else {
+      entry = new TarArchiveEntry(entryName);
+      entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+      entry.setSize(Files.size(path));
+    }
+
     try {
       BasicFileAttributes attrs = Files.readAttributes(
           file.toPath(), BasicFileAttributes.class);
@@ -93,7 +107,6 @@ public final class Archiver {
     } catch (IOException e) {
       entry.setModTime(file.lastModified()); // fallback
     }
-    entry.setSize(file.length());
     return entry;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -105,7 +106,20 @@ public final class Archiver {
   public static long includeFile(File file, String entryName,
       ArchiveOutputStream<TarArchiveEntry> archiveOutput) throws IOException {
     final long bytes;
-    TarArchiveEntry entry = archiveOutput.createArchiveEntry(file, entryName);
+
+    TarArchiveEntry entry = new TarArchiveEntry(entryName);
+    entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+    try {
+      BasicFileAttributes attrs = Files.readAttributes(
+          file.toPath(), BasicFileAttributes.class);
+      entry.setLastModifiedTime(attrs.lastModifiedTime());
+      entry.setLastAccessTime(attrs.lastAccessTime());
+      entry.setCreationTime(attrs.creationTime());
+    } catch (IOException e) {
+      entry.setModTime(file.lastModified()); // fallback
+    }
+    entry.setSize(file.length());
+
     archiveOutput.putArchiveEntry(entry);
     try (InputStream input = Files.newInputStream(file.toPath())) {
       bytes = IOUtils.copy(input, archiveOutput, getBufferSize(file.length()));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
@@ -36,6 +36,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -90,7 +91,7 @@ public final class Archiver {
       final String dirName = nameLength == 0 || entryName.charAt(nameLength - 1) != '/'
           ? entryName + "/"
           : entryName;
-      entry = new TarArchiveEntry(dirName);
+      entry = new TarArchiveEntry(dirName, TarConstants.LF_DIR);
       entry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
     } else {
       entry = new TarArchiveEntry(entryName);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
@@ -80,12 +80,29 @@ public final class Archiver {
     return output.toByteArray();
   }
 
+  private static TarArchiveEntry createBasicTarArchiveEntry(File file, String entryName)
+      throws IOException {
+    TarArchiveEntry entry = new TarArchiveEntry(entryName);
+    entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+    try {
+      BasicFileAttributes attrs = Files.readAttributes(
+          file.toPath(), BasicFileAttributes.class);
+      entry.setLastModifiedTime(attrs.lastModifiedTime());
+      entry.setLastAccessTime(attrs.lastAccessTime());
+      entry.setCreationTime(attrs.creationTime());
+    } catch (IOException e) {
+      entry.setModTime(file.lastModified()); // fallback
+    }
+    entry.setSize(file.length());
+    return entry;
+  }
+
   public static void includePath(Path dir, String subdir,
       ArchiveOutputStream<TarArchiveEntry> archiveOutput) throws IOException {
 
     // Add a directory entry before adding files, in case the directory is
     // empty.
-    TarArchiveEntry entry = archiveOutput.createArchiveEntry(dir.toFile(), subdir);
+    TarArchiveEntry entry = createBasicTarArchiveEntry(dir.toFile(), subdir);
     archiveOutput.putArchiveEntry(entry);
     archiveOutput.closeArchiveEntry();
 
@@ -106,20 +123,7 @@ public final class Archiver {
   public static long includeFile(File file, String entryName,
       ArchiveOutputStream<TarArchiveEntry> archiveOutput) throws IOException {
     final long bytes;
-
-    TarArchiveEntry entry = new TarArchiveEntry(entryName);
-    entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
-    try {
-      BasicFileAttributes attrs = Files.readAttributes(
-          file.toPath(), BasicFileAttributes.class);
-      entry.setLastModifiedTime(attrs.lastModifiedTime());
-      entry.setLastAccessTime(attrs.lastAccessTime());
-      entry.setCreationTime(attrs.creationTime());
-    } catch (IOException e) {
-      entry.setModTime(file.lastModified()); // fallback
-    }
-    entry.setSize(file.length());
-
+    TarArchiveEntry entry = createBasicTarArchiveEntry(file, entryName);
     archiveOutput.putArchiveEntry(entry);
     try (InputStream input = Files.newInputStream(file.toPath())) {
       bytes = IOUtils.copy(input, archiveOutput, getBufferSize(file.length()));
@@ -152,7 +156,7 @@ public final class Archiver {
     long bytes = 0;
     try {
       Files.createLink(link.toPath(), file.toPath());
-      TarArchiveEntry entry = archiveOutput.createArchiveEntry(link, entryName);
+      TarArchiveEntry entry = createBasicTarArchiveEntry(link, entryName);
       archiveOutput.putArchiveEntry(entry);
       try (InputStream input = Files.newInputStream(link.toPath())) {
         bytes = IOUtils.copyLarge(input, archiveOutput);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestArchiver.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestArchiver.java
@@ -42,6 +42,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 /** Test {@link Archiver}. */
@@ -76,22 +77,19 @@ class TestArchiver {
     Files.write(tempFile.toPath(), "Test Content".getBytes(StandardCharsets.UTF_8));
 
     TarArchiveOutputStream mockArchiveOutput = mock(TarArchiveOutputStream.class);
-    TarArchiveEntry mockEntry = new TarArchiveEntry(entryName);
-    AtomicBoolean isHardLinkCreated = new AtomicBoolean(false);
-    when(mockArchiveOutput.createArchiveEntry(any(File.class), eq(entryName)))
-        .thenAnswer(invocation -> {
-          File linkFile = invocation.getArgument(0);
-          isHardLinkCreated.set(Files.isSameFile(tempFile.toPath(), linkFile.toPath()));
-          return mockEntry;
-        });
 
     // Call method under test
     long bytesCopied = Archiver.linkAndIncludeFile(tempFile, entryName, mockArchiveOutput, tmpDir);
     assertEquals(Files.size(tempFile.toPath()), bytesCopied);
     // Verify archive interactions
-    verify(mockArchiveOutput, times(1)).putArchiveEntry(mockEntry);
+    ArgumentCaptor<TarArchiveEntry> entryCaptor = ArgumentCaptor.forClass(TarArchiveEntry.class);
+    verify(mockArchiveOutput, times(1)).putArchiveEntry(entryCaptor.capture());
     verify(mockArchiveOutput, times(1)).closeArchiveEntry();
-    assertTrue(isHardLinkCreated.get());
+
+    TarArchiveEntry capturedEntry = entryCaptor.getValue();
+    assertEquals(entryName, capturedEntry.getName());
+    assertEquals(Files.size(tempFile.toPath()), capturedEntry.getSize());
+
     assertFalse(Files.exists(tmpDir.resolve(entryName)));
     // Cleanup
     assertTrue(tempFile.delete());


### PR DESCRIPTION
## What changes were proposed in this pull request?

We encountered DN randomly crash in our cluster, should be related to sssd bugs. Some detailed error logs can be found below.

 

This ticket is a workaround for this issue, so that sssd won't be used to trigger the crash of Datanode.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f2bb5f5dd2b, pid=2252464, tid=2472131
#
# JRE version: OpenJDK Runtime Environment (21.0.9) (build 21.0.9-internal-adhoc.root.jdk)
# Java VM: OpenJDK 64-Bit Server VM (21.0.9-internal-adhoc.root.jdk, mixed mode, sharing, tiered, compressed class ptrs, z gc, linux-amd64)
# Problematic frame:
# C  [libnss_sss.so.2+0x6d2b]  _nss_sss_endnetent+0x4b 
```

```
Stack: [0x00007f26e0bf6000,0x00007f26e0cf7000],  sp=0x00007f26e0cf4f10,  free space=1019k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libnss_sss.so.2+0x6d2b]  _nss_sss_endnetent+0x4b
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 35103  sun.nio.fs.UnixNativeDispatcher.getpwuid(I)[B java.base@21.0.9-internal (0 bytes) @ 0x00007f2ba229ae19 [0x00007f2ba229adc0+0x0000000000000059]
J 47972 c2 org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.includeFile(Ljava/io/File;Ljava/lang/String;Lorg/apache/commons/compress/archivers/ArchiveOutputStream;)V (80 bytes) @ 0x00007f2ba1401160 [0x00007f2ba14004c0+0x0000000000000ca0]
J 48138 c1 org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.pack(Lorg/apache/hadoop/ozone/container/common/interfaces/Container;Ljava/io/OutputStream;)V (105 bytes) @ 0x00007f2b98c6a3ac [0x00007f2b98c69e80+0x000000000000052c]
J 48133 c1 org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer.packContainerToDestination(Ljava/io/OutputStream;Lorg/apache/hadoop/ozone/container/common/interfaces/ContainerPacker;)V (63 bytes) @ 0x00007f2b998a1aa4 [0x00007f2b998a17c0+0x00000000000002e4]
J 48131 c1 org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer.exportContainerData(Ljava/io/OutputStream;Lorg/apache/hadoop/ozone/container/common/interfaces/ContainerPacker;)V (166 bytes) @ 0x00007f2b989993ec [0x00007f2b98998b60+0x000000000000088c]
J 48128 c1 org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource.copyData(JLjava/io/OutputStream;Lorg/apache/hadoop/ozone/container/replication/CopyContainerCompression;)V (58 bytes) @ 0x00007f2b98e71d04 [0x00007f2b98e70ea0+0x0000000000000e64]
J 48118 c1 org.apache.hadoop.ozone.container.replication.GrpcReplicationService.download(Lorg/apache/hadoop/hdds/protocol/datanode/proto/ContainerProtos$CopyContainerRequestProto;Lorg/apache/ratis/thirdparty/io/grpc/stub/StreamObserver;)V (296 bytes) @ 0x00007f2b999c4d14 [0x00007f2b999c4360+0x00000000000009b4]
J 48117 c1 org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc$MethodHandlers.invoke(Ljava/lang/Object;Lorg/apache/ratis/thirdparty/io/grpc/stub/StreamObserver;)V (50 bytes) @ 0x00007f2b99314bcc [0x00007f2b993149e0+0x00000000000001ec]
J 35258 c2 org.apache.ratis.thirdparty.io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext()V (81 bytes) @ 0x00007f2ba0f58f18 [0x00007f2ba0f58d60+0x00000000000001b8]
J 16850 c2 org.apache.ratis.thirdparty.io.grpc.internal.ContextRunnable.run()V (35 bytes) @ 0x00007f2ba135e5c0 [0x00007f2ba135e220+0x00000000000003a0]
J 51312 c2 org.apache.ratis.thirdparty.io.grpc.internal.SerializingExecutor.run()V (114 bytes) @ 0x00007f2ba123dab4 [0x00007f2ba123d9a0+0x0000000000000114]
J 27132 c2 java.util.concurrent.ThreadPoolExecutor$Worker.run()V java.base@21.0.9-internal (9 bytes) @ 0x00007f2ba0fa2f24 [0x00007f2ba0fa2c80+0x00000000000002a4]
J 25894 c2 java.lang.Thread.run()V java.base@21.0.9-internal (23 bytes) @ 0x00007f2ba125b5cc [0x00007f2ba125b520+0x00000000000000ac]
v  ~StubRoutines::call_stub 0x00007f2b9fc52cbf 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15102

## How was this patch tested?

This is a replacement of TarArchiveEntry initialization, existing unit test will be enough.
