### PR TITLE
HDDS-15080. DirectoryDeletingService is using single thread

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -159,7 +159,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   private final SnapshotChainManager snapshotChainManager;
   private final boolean deepCleanSnapshots;
   private ExecutorService deletionThreadPool;
-  private final int numberOfParallelThreadsPerStore;
+  private volatile int numberOfParallelThreadsPerStore;
   private final AtomicLong deletedDirsCount;
   private final AtomicLong movedDirsCount;
   private final AtomicLong movedFilesCount;
@@ -175,8 +175,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
         StorageUnit.BYTES);
     this.numberOfParallelThreadsPerStore = dirDeletingServiceCorePoolSize;
-    this.deletionThreadPool = new ThreadPoolExecutor(0, numberOfParallelThreadsPerStore,
-        interval, unit, new LinkedBlockingDeque<>(Integer.MAX_VALUE));
+    this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
     // always go to 90% of max limit for request as other header will be added
     this.ratisByteLimit = (int) (limit * 0.9);
     registerReconfigCallbacks(ozoneManager.getReconfigurationHandler());
@@ -209,6 +208,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     shutdown();
     setInterval(newInterval, TimeUnit.SECONDS);
     setPoolSize(newCorePoolSize);
+    this.numberOfParallelThreadsPerStore = newCorePoolSize;
     start();
   }
 
@@ -251,10 +251,17 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   @Override
   public synchronized void start() {
     if (deletionThreadPool == null || deletionThreadPool.isShutdown() || deletionThreadPool.isTerminated()) {
-      this.deletionThreadPool = new ThreadPoolExecutor(0, numberOfParallelThreadsPerStore,
-          super.getIntervalMillis(), TimeUnit.MILLISECONDS, new LinkedBlockingDeque<>(Integer.MAX_VALUE));
+      this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
     }
     super.start();
+  }
+
+  private ThreadPoolExecutor createDeletionThreadPool(int threadCount) {
+    ThreadPoolExecutor pool =
+        new ThreadPoolExecutor(threadCount, threadCount, super.getIntervalMillis(), TimeUnit.MILLISECONDS,
+            new LinkedBlockingDeque<>());
+    pool.allowCoreThreadTimeOut(true);
+    return pool;
   }
 
   private boolean isThreadPoolActive(ExecutorService threadPoolExecutor) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -159,7 +159,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   private final SnapshotChainManager snapshotChainManager;
   private final boolean deepCleanSnapshots;
   private ExecutorService deletionThreadPool;
-  private int numberOfParallelThreadsPerStore;
+  private final AtomicInteger numberOfParallelThreadsPerStore;
   private final AtomicLong deletedDirsCount;
   private final AtomicLong movedDirsCount;
   private final AtomicLong movedFilesCount;
@@ -174,8 +174,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
         StorageUnit.BYTES);
-    this.numberOfParallelThreadsPerStore = dirDeletingServiceCorePoolSize;
-    this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
+    this.numberOfParallelThreadsPerStore = new AtomicInteger(dirDeletingServiceCorePoolSize);
+    this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore.get());
     // always go to 90% of max limit for request as other header will be added
     this.ratisByteLimit = (int) (limit * 0.9);
     registerReconfigCallbacks(ozoneManager.getReconfigurationHandler());
@@ -208,7 +208,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     shutdown();
     setInterval(newInterval, TimeUnit.SECONDS);
     setPoolSize(newCorePoolSize);
-    this.numberOfParallelThreadsPerStore = newCorePoolSize;
+    this.numberOfParallelThreadsPerStore.set(newCorePoolSize);
     start();
   }
 
@@ -251,7 +251,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   @Override
   public synchronized void start() {
     if (deletionThreadPool == null || deletionThreadPool.isShutdown() || deletionThreadPool.isTerminated()) {
-      this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
+      this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore.get());
     }
     super.start();
   }
@@ -269,10 +269,6 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
 
   private boolean isThreadPoolActive(ExecutorService threadPoolExecutor) {
     return threadPoolExecutor != null && !threadPoolExecutor.isShutdown() && !threadPoolExecutor.isTerminated();
-  }
-
-  private synchronized int getNumberOfParallelThreadsPerStore() {
-    return numberOfParallelThreadsPerStore;
   }
 
   @VisibleForTesting
@@ -621,7 +617,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         Map<UUID, Pair<Long, Long>> exclusiveSizeMap = Maps.newConcurrentMap();
 
         CompletableFuture<Boolean> processedAllDeletedDirs = CompletableFuture.completedFuture(true);
-        final int parallelThreads = getNumberOfParallelThreadsPerStore();
+        final int parallelThreads = numberOfParallelThreadsPerStore.get();
         for (int i = 0; i < parallelThreads; i++) {
           CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
             try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -275,6 +275,11 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     return numberOfParallelThreadsPerStore;
   }
 
+  @VisibleForTesting
+  ThreadPoolExecutor getDeletionThreadPool() {
+    return (ThreadPoolExecutor) deletionThreadPool;
+  }
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   void optimizeDirDeletesAndSubmitRequest(
       long dirNum, long subDirNum, long subFileNum,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -175,9 +175,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
         StorageUnit.BYTES);
     this.numberOfParallelThreadsPerStore = dirDeletingServiceCorePoolSize;
-    this.deletionThreadPool = new ThreadPoolExecutor(
-        numberOfParallelThreadsPerStore, numberOfParallelThreadsPerStore,
-        interval, unit, new LinkedBlockingDeque<>(Integer.MAX_VALUE));
+    this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
     // always go to 90% of max limit for request as other header will be added
     this.ratisByteLimit = (int) (limit * 0.9);
     registerReconfigCallbacks(ozoneManager.getReconfigurationHandler());
@@ -253,16 +251,28 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   @Override
   public synchronized void start() {
     if (deletionThreadPool == null || deletionThreadPool.isShutdown() || deletionThreadPool.isTerminated()) {
-      this.deletionThreadPool = new ThreadPoolExecutor(
-          numberOfParallelThreadsPerStore, numberOfParallelThreadsPerStore,
-          super.getIntervalMillis(), TimeUnit.MILLISECONDS,
-          new LinkedBlockingDeque<>(Integer.MAX_VALUE));
+      this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
     }
     super.start();
   }
 
+  private ThreadPoolExecutor createDeletionThreadPool(int threadCount) {
+    long intervalMillis = super.getIntervalMillis();
+    ThreadPoolExecutor pool = new ThreadPoolExecutor(
+        threadCount, threadCount, intervalMillis,
+        TimeUnit.MILLISECONDS, new LinkedBlockingDeque<>(Integer.MAX_VALUE));
+    if (intervalMillis > 0) {
+      pool.allowCoreThreadTimeOut(true);
+    }
+    return pool;
+  }
+
   private boolean isThreadPoolActive(ExecutorService threadPoolExecutor) {
     return threadPoolExecutor != null && !threadPoolExecutor.isShutdown() && !threadPoolExecutor.isTerminated();
+  }
+
+  private synchronized int getNumberOfParallelThreadsPerStore() {
+    return numberOfParallelThreadsPerStore;
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -606,7 +616,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         Map<UUID, Pair<Long, Long>> exclusiveSizeMap = Maps.newConcurrentMap();
 
         CompletableFuture<Boolean> processedAllDeletedDirs = CompletableFuture.completedFuture(true);
-        for (int i = 0; i < numberOfParallelThreadsPerStore; i++) {
+        final int parallelThreads = getNumberOfParallelThreadsPerStore();
+        for (int i = 0; i < parallelThreads; i++) {
           CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
             try {
               return processDeletedDirectories(currentSnapshotInfo, keyManager, dirSupplier,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -159,7 +159,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   private final SnapshotChainManager snapshotChainManager;
   private final boolean deepCleanSnapshots;
   private ExecutorService deletionThreadPool;
-  private final int numberOfParallelThreadsPerStore;
+  private int numberOfParallelThreadsPerStore;
   private final AtomicLong deletedDirsCount;
   private final AtomicLong movedDirsCount;
   private final AtomicLong movedFilesCount;
@@ -210,6 +210,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     shutdown();
     setInterval(newInterval, TimeUnit.SECONDS);
     setPoolSize(newCorePoolSize);
+    this.numberOfParallelThreadsPerStore = newCorePoolSize;
     start();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -159,7 +159,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   private final SnapshotChainManager snapshotChainManager;
   private final boolean deepCleanSnapshots;
   private ExecutorService deletionThreadPool;
-  private volatile int numberOfParallelThreadsPerStore;
+  private final int numberOfParallelThreadsPerStore;
   private final AtomicLong deletedDirsCount;
   private final AtomicLong movedDirsCount;
   private final AtomicLong movedFilesCount;
@@ -175,7 +175,9 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
         StorageUnit.BYTES);
     this.numberOfParallelThreadsPerStore = dirDeletingServiceCorePoolSize;
-    this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
+    this.deletionThreadPool = new ThreadPoolExecutor(
+        numberOfParallelThreadsPerStore, numberOfParallelThreadsPerStore,
+        interval, unit, new LinkedBlockingDeque<>(Integer.MAX_VALUE));
     // always go to 90% of max limit for request as other header will be added
     this.ratisByteLimit = (int) (limit * 0.9);
     registerReconfigCallbacks(ozoneManager.getReconfigurationHandler());
@@ -208,7 +210,6 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     shutdown();
     setInterval(newInterval, TimeUnit.SECONDS);
     setPoolSize(newCorePoolSize);
-    this.numberOfParallelThreadsPerStore = newCorePoolSize;
     start();
   }
 
@@ -251,17 +252,12 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   @Override
   public synchronized void start() {
     if (deletionThreadPool == null || deletionThreadPool.isShutdown() || deletionThreadPool.isTerminated()) {
-      this.deletionThreadPool = createDeletionThreadPool(numberOfParallelThreadsPerStore);
+      this.deletionThreadPool = new ThreadPoolExecutor(
+          numberOfParallelThreadsPerStore, numberOfParallelThreadsPerStore,
+          super.getIntervalMillis(), TimeUnit.MILLISECONDS,
+          new LinkedBlockingDeque<>(Integer.MAX_VALUE));
     }
     super.start();
-  }
-
-  private ThreadPoolExecutor createDeletionThreadPool(int threadCount) {
-    ThreadPoolExecutor pool =
-        new ThreadPoolExecutor(threadCount, threadCount, super.getIntervalMillis(), TimeUnit.MILLISECONDS,
-            new LinkedBlockingDeque<>());
-    pool.allowCoreThreadTimeOut(true);
-    return pool;
   }
 
   private boolean isThreadPoolActive(ExecutorService threadPoolExecutor) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -22,13 +22,9 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mockStatic;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -42,10 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -72,7 +65,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,68 +190,13 @@ public class TestDirectoryDeletingService {
     OmTestManagers omTestManagers
         = new OmTestManagers(conf);
     OzoneManager ozoneManager = omTestManagers.getOzoneManager();
-    AtomicBoolean isRunning = new AtomicBoolean(true);
-    try (MockedStatic mockedStatic = mockStatic(CompletableFuture.class, CALLS_REAL_METHODS)) {
-      List<Pair<Supplier, CompletableFuture>> futureList = new ArrayList<>();
-      Thread deletionThread = new Thread(() -> {
-        while (futureList.size() < threadCount) {
-          try {
-            Thread.sleep(100);
-          } catch (InterruptedException e) {
-            LOG.error("Error while sleeping", e);
-          }
-        }
-        for (int i = futureList.size() - 1; i >= 0; i--) {
-          Pair<Supplier, CompletableFuture> pair = futureList.get(i);
-          pair.getLeft().get();
-          assertTrue(isRunning.get());
-          pair.getRight().complete(false);
-          try {
-            Thread.sleep(500);
-          } catch (InterruptedException e) {
-            LOG.error("Error while sleeping", e);
-          }
-        }
-      });
-      deletionThread.start();
-
-      mockedStatic
-          .when(() -> CompletableFuture.supplyAsync(any(), any()))
-          .thenAnswer(invocation -> {
-            Supplier<Boolean> supplier = invocation.getArgument(0);
-            CompletableFuture<Boolean> future = new CompletableFuture<>();
-            futureList.add(Pair.of(supplier, future));
-            return future;
-          });
-      ozoneManager.getKeyManager().getDirDeletingService().suspend();
-      DirectoryDeletingService.DirDeletingTask dirDeletingTask =
-          ozoneManager.getKeyManager().getDirDeletingService().new DirDeletingTask(null);
-
-      dirDeletingTask.processDeletedDirsForStore(null, ozoneManager.getKeyManager(), 1, 6000);
-      assertThat(futureList).hasSize(threadCount);
-      for (Pair<Supplier, CompletableFuture> pair : futureList) {
-        assertTrue(pair.getRight().isDone());
-      }
-      isRunning.set(false);
-    } finally {
-      ozoneManager.stop();
-    }
-  }
-
-  @Test
-  @DisplayName("DirectoryDeletingService uses configured number of worker threads")
-  public void testDirectoryDeletionWorkerPoolUsesConfiguredThreadCount() throws Exception {
-    int threadCount = 10;
-    OzoneConfiguration conf = createConfAndInitValues(threadCount);
-    OmTestManagers omTestManagers = new OmTestManagers(conf);
-    OzoneManager ozoneManager = omTestManagers.getOzoneManager();
     try {
       DirectoryDeletingService service =
           (DirectoryDeletingService) ozoneManager.getKeyManager().getDirDeletingService();
-      ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) getPrivateField(service, "deletionThreadPool");
-
-      assertThat(threadPoolExecutor.getCorePoolSize()).as(
-          "core pool size should match configured directory deletion threads").isEqualTo(threadCount);
+      ThreadPoolExecutor threadPoolExecutor = service.getDeletionThreadPool();
+      assertThat(threadPoolExecutor.getCorePoolSize())
+          .as("core pool size should match configured directory deletion threads")
+          .isEqualTo(threadCount);
 
       CountDownLatch tasksStarted = new CountDownLatch(threadCount);
       CountDownLatch releaseTasks = new CountDownLatch(1);
@@ -279,21 +216,18 @@ public class TestDirectoryDeletingService {
         }, threadPoolExecutor));
       }
 
-      assertTrue(tasksStarted.await(10, TimeUnit.SECONDS), "Expected all submitted tasks to start");
-      assertThat(workerThreads).as("Expected tasks to run in parallel using configured workers").hasSize(threadCount);
+      assertTrue(tasksStarted.await(10, TimeUnit.SECONDS),
+          "Expected all submitted tasks to start");
+      assertThat(workerThreads)
+          .as("Expected tasks to run in parallel using configured workers")
+          .hasSize(threadCount);
 
       releaseTasks.countDown();
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(10, TimeUnit.SECONDS);
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+          .get(10, TimeUnit.SECONDS);
     } finally {
       ozoneManager.stop();
     }
-  }
-
-  private static Object getPrivateField(Object target, String fieldName)
-      throws NoSuchFieldException, IllegalAccessException {
-    Field field = target.getClass().getDeclaredField(fieldName);
-    field.setAccessible(true);
-    return field.get(target);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -66,15 +66,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test Directory Deleting Service.
  */
 public class TestDirectoryDeletingService {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestDirectoryDeletingService.class);
 
   @TempDir
   private Path folder;
@@ -187,16 +183,14 @@ public class TestDirectoryDeletingService {
   public void testMultithreadedDirectoryDeletion() throws Exception {
     int threadCount = 10;
     OzoneConfiguration conf = createConfAndInitValues(threadCount);
-    OmTestManagers omTestManagers
-        = new OmTestManagers(conf);
+    OmTestManagers omTestManagers = new OmTestManagers(conf);
     OzoneManager ozoneManager = omTestManagers.getOzoneManager();
     try {
       DirectoryDeletingService service =
           (DirectoryDeletingService) ozoneManager.getKeyManager().getDirDeletingService();
       ThreadPoolExecutor threadPoolExecutor = service.getDeletionThreadPool();
-      assertThat(threadPoolExecutor.getCorePoolSize())
-          .as("core pool size should match configured directory deletion threads")
-          .isEqualTo(threadCount);
+      assertThat(threadPoolExecutor.getCorePoolSize()).as(
+          "core pool size should match configured directory deletion threads").isEqualTo(threadCount);
 
       CountDownLatch tasksStarted = new CountDownLatch(threadCount);
       CountDownLatch releaseTasks = new CountDownLatch(1);
@@ -216,26 +210,21 @@ public class TestDirectoryDeletingService {
         }, threadPoolExecutor));
       }
 
-      assertTrue(tasksStarted.await(10, TimeUnit.SECONDS),
-          "Expected all submitted tasks to start");
-      assertThat(workerThreads)
-          .as("Expected tasks to run in parallel using configured workers")
-          .hasSize(threadCount);
+      assertTrue(tasksStarted.await(10, TimeUnit.SECONDS), "Expected all submitted tasks to start");
+      assertThat(workerThreads).as("Expected tasks to run in parallel using configured workers").hasSize(threadCount);
 
       releaseTasks.countDown();
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-          .get(10, TimeUnit.SECONDS);
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(10, TimeUnit.SECONDS);
 
       // Also exercise the actual DirectoryDeletingService task path.
       service.suspend();
-      DirectoryDeletingService.DirDeletingTask dirDeletingTask =
-          service.new DirDeletingTask(null);
+      DirectoryDeletingService.DirDeletingTask dirDeletingTask = service.new DirDeletingTask(null);
+      assertThat(threadPoolExecutor.isShutdown()).as(
+          "deletion thread pool should be active when processing deleted dirs").isFalse();
       long completedTaskCountBefore = threadPoolExecutor.getCompletedTaskCount();
-      dirDeletingTask.processDeletedDirsForStore(
-          null, ozoneManager.getKeyManager(), 1, 1);
-      assertThat(threadPoolExecutor.getCompletedTaskCount())
-          .as("processDeletedDirsForStore should execute tasks on deletion thread pool")
-          .isGreaterThan(completedTaskCountBefore);
+      dirDeletingTask.processDeletedDirsForStore(null, ozoneManager.getKeyManager(), 1, 1);
+      GenericTestUtils.waitFor(
+          () -> threadPoolExecutor.getCompletedTaskCount() >= completedTaskCountBefore + threadCount, 100, 5000);
     } finally {
       ozoneManager.stop();
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -28,13 +28,19 @@ import static org.mockito.Mockito.mockStatic;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -238,6 +244,56 @@ public class TestDirectoryDeletingService {
     } finally {
       ozoneManager.stop();
     }
+  }
+
+  @Test
+  @DisplayName("DirectoryDeletingService uses configured number of worker threads")
+  public void testDirectoryDeletionWorkerPoolUsesConfiguredThreadCount() throws Exception {
+    int threadCount = 10;
+    OzoneConfiguration conf = createConfAndInitValues(threadCount);
+    OmTestManagers omTestManagers = new OmTestManagers(conf);
+    OzoneManager ozoneManager = omTestManagers.getOzoneManager();
+    try {
+      DirectoryDeletingService service =
+          (DirectoryDeletingService) ozoneManager.getKeyManager().getDirDeletingService();
+      ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) getPrivateField(service, "deletionThreadPool");
+
+      assertThat(threadPoolExecutor.getCorePoolSize()).as(
+          "core pool size should match configured directory deletion threads").isEqualTo(threadCount);
+
+      CountDownLatch tasksStarted = new CountDownLatch(threadCount);
+      CountDownLatch releaseTasks = new CountDownLatch(1);
+      Set<String> workerThreads = Collections.synchronizedSet(new HashSet<>());
+      List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+      for (int i = 0; i < threadCount; i++) {
+        futures.add(CompletableFuture.runAsync(() -> {
+          workerThreads.add(Thread.currentThread().getName());
+          tasksStarted.countDown();
+          try {
+            assertTrue(releaseTasks.await(10, TimeUnit.SECONDS));
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for release latch", e);
+          }
+        }, threadPoolExecutor));
+      }
+
+      assertTrue(tasksStarted.await(10, TimeUnit.SECONDS), "Expected all submitted tasks to start");
+      assertThat(workerThreads).as("Expected tasks to run in parallel using configured workers").hasSize(threadCount);
+
+      releaseTasks.countDown();
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(10, TimeUnit.SECONDS);
+    } finally {
+      ozoneManager.stop();
+    }
+  }
+
+  private static Object getPrivateField(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(target);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -225,6 +225,17 @@ public class TestDirectoryDeletingService {
       releaseTasks.countDown();
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
           .get(10, TimeUnit.SECONDS);
+
+      // Also exercise the actual DirectoryDeletingService task path.
+      service.suspend();
+      DirectoryDeletingService.DirDeletingTask dirDeletingTask =
+          service.new DirDeletingTask(null);
+      long completedTaskCountBefore = threadPoolExecutor.getCompletedTaskCount();
+      dirDeletingTask.processDeletedDirsForStore(
+          null, ozoneManager.getKeyManager(), 1, 1);
+      assertThat(threadPoolExecutor.getCompletedTaskCount())
+          .as("processDeletedDirsForStore should execute tasks on deletion thread pool")
+          .isGreaterThan(completedTaskCountBefore);
     } finally {
       ozoneManager.stop();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Switched DirectoryDeletingService to consistently use a fixed-size parallel deletion pool instead of the previous core-0 setup.
Unified pool creation so constructor/start/restart all follow the same path and behave the same after reconfiguration.
Also fixed thread-count reconfig handling so updated values are actually used by worker creation and pool recreation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15080

## How was this patch tested?

Tested Manually on a cluster.
```
2026-04-22 21:05:50,910 [pool-37-thread-2] INFO org.apache.hadoop.ozone.om.service.DirectoryDeletingService: Number of dirs deleted: 224, Number of sub-dir deleted: 0, Number of sub-files moved: 447 to DeletedTable, Number of sub-dirs moved 110 to DeletedDirectoryTable, iteration elapsed: 445ms,  totalRunCount: 1
2026-04-22 21:05:50,921 [pool-37-thread-8] INFO org.apache.hadoop.ozone.om.service.DirectoryDeletingService: Number of dirs deleted: 159, Number of sub-dir deleted: 0, Number of sub-files moved: 568 to DeletedTable, Number of sub-dirs moved 89 to DeletedDirectoryTable, iteration elapsed: 456ms,  totalRunCount: 1
2026-04-22 21:05:50,929 [pool-37-thread-7] INFO org.apache.hadoop.ozone.om.service.DirectoryDeletingService: Number of dirs deleted: 262, Number of sub-dir deleted: 0, Number of sub-files moved: 339 to DeletedTable, Number of sub-dirs moved 135 to DeletedDirectoryTable, iteration elapsed: 465ms,  totalRunCount: 1
2026-04-22 21:05:50,940 [pool-37-thread-6] INFO org.apache.hadoop.ozone.om.service.DirectoryDeletingService: Number of dirs deleted: 211, Number of sub-dir deleted: 0, Number of sub-files moved: 437 to DeletedTable, Number of sub-dirs moved 133 to DeletedDirectoryTable, iteration elapsed: 475ms,  totalRunCount: 1
2026-04-22 21:05:50,951 [pool-37-thread-9] INFO org.apache.hadoop.ozone.om.service.DirectoryDeletingService: Number of dirs deleted: 221, Number of sub-dir deleted: 0, Number of sub-files moved: 474 to DeletedTable, Number of sub-dirs moved 116 to DeletedDirectoryTable, iteration elapsed: 487ms,  totalRunCount: 1
```