### PR TITLE
HDDS-15112. Handle negative space usage values gracefully in CachingSpaceUsageSource

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -120,7 +120,11 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
     if (usedSpace == 0) {
       return;
     }
-    Preconditions.assertTrue(usedSpace > 0, () -> usedSpace + " < 0");
+    if (usedSpace < 0) {
+      LOG.warn("Ignoring negative incrementUsedSpace({}) for {}", usedSpace, source);
+      return;
+    }
+
     final long current, change;
     try (AutoCloseableLock ignored = lock.writeLock(null, null)) {
       current = cachedAvailable;
@@ -140,7 +144,11 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
     if (reclaimedSpace == 0) {
       return;
     }
-    Preconditions.assertTrue(reclaimedSpace > 0, () -> reclaimedSpace + " < 0");
+    if (reclaimedSpace < 0) {
+      LOG.warn("Ignoring negative reclaimedSpace({}) for {}", reclaimedSpace, source);
+      return;
+    }
+
     final long current, change;
     try (AutoCloseableLock ignored = lock.writeLock(null, null)) {
       current = cachedUsedSpace;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -182,6 +182,41 @@ class TestCachingSpaceUsageSource {
     assertSnapshotIsUpToDate(subject);
   }
 
+  // If negative values are passed, check that the state is unchanged
+  @Test
+  void incrementUsedSpaceIgnoresNegativeValue() {
+    SpaceUsageCheckParams params = paramsBuilder(new AtomicLong(50))
+        .withRefresh(Duration.ZERO)
+        .build();
+    CachingSpaceUsageSource subject = new CachingSpaceUsageSource(params);
+    SpaceUsageSource original = subject.snapshot();
+
+    subject.incrementUsedSpace(-1L);
+
+    // negative value should be ignored, leaving cached state unchanged
+    assertEquals(original.getUsedSpace(), subject.getUsedSpace());
+    assertEquals(original.getAvailable(), subject.getAvailable());
+    assertEquals(original.getCapacity(), subject.getCapacity());
+    assertSnapshotIsUpToDate(subject);
+  }
+
+  @Test
+  void decrementUsedSpaceIgnoresNegativeValue() {
+    SpaceUsageCheckParams params = paramsBuilder(new AtomicLong(50))
+        .withRefresh(Duration.ZERO)
+        .build();
+    CachingSpaceUsageSource subject = new CachingSpaceUsageSource(params);
+    SpaceUsageSource original = subject.snapshot();
+
+    subject.decrementUsedSpace(-1L);
+
+    // negative value should be ignored, leaving cached state unchanged
+    assertEquals(original.getUsedSpace(), subject.getUsedSpace());
+    assertEquals(original.getAvailable(), subject.getAvailable());
+    assertEquals(original.getCapacity(), subject.getCapacity());
+    assertSnapshotIsUpToDate(subject);
+  }
+
   private static void assertSnapshotIsUpToDate(SpaceUsageSource subject) {
     SpaceUsageSource snapshot = subject.snapshot();
     assertEquals(subject.getCapacity(), snapshot.getCapacity());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, container sizes <= 0 in CachingSpaceUsageSource prevent a few operations from proceeding. 
We should update the validations to be handled gracefully instead of blocking operations.



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15112


## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/24917153879