### PR TITLE
HDDS-15123. Change NumberOfKeys to NumberOfBlocks in Recon Unhealthy Container API.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -190,7 +190,7 @@ public class ContainerEndpoint {
             .map(container -> {
               ContainerMetadata containerMetadata =
                   new ContainerMetadata(container.getContainerID());
-              containerMetadata.setNumberOfKeys(container.getNumberOfKeys());
+              containerMetadata.setNumberOfBlocks(container.getNumberOfKeys());
               return containerMetadata;
             })
             .collect(Collectors.toList());
@@ -546,7 +546,7 @@ public class ContainerEndpoint {
         DeletedContainerInfo deletedContainerInfo = new DeletedContainerInfo();
         deletedContainerInfo.setContainerID(containerInfo.getContainerID());
         deletedContainerInfo.setPipelineID(containerInfo.getPipelineID());
-        deletedContainerInfo.setNumberOfKeys(containerInfo.getNumberOfKeys());
+        deletedContainerInfo.setNumberOfBlocks(containerInfo.getNumberOfKeys());
         deletedContainerInfo.setContainerState(containerInfo.getState().name());
         deletedContainerInfo.setStateEnterTime(
             containerInfo.getStateEnterTime().toEpochMilli());
@@ -657,8 +657,8 @@ public class ContainerEndpoint {
           ContainerDiscrepancyInfo containerDiscrepancyInfo =
               new ContainerDiscrepancyInfo();
           containerDiscrepancyInfo.setContainerID(nonSCMContainer.getContainerID());
-          containerDiscrepancyInfo.setNumberOfKeys(
-              nonSCMContainer.getNumberOfKeys());
+          containerDiscrepancyInfo.setNumberOfBlocks(
+              nonSCMContainer.getNumberOfBlocks());
           containerDiscrepancyInfo.setPipelines(
               nonSCMContainer.getPipelines());
           containerDiscrepancyInfo.setExistsAt("OM");
@@ -688,7 +688,7 @@ public class ContainerEndpoint {
         nonOMContainers.forEach(containerInfo -> {
           ContainerDiscrepancyInfo containerDiscrepancyInfo = new ContainerDiscrepancyInfo();
           containerDiscrepancyInfo.setContainerID(containerInfo.getContainerID());
-          containerDiscrepancyInfo.setNumberOfKeys(0);
+          containerDiscrepancyInfo.setNumberOfBlocks(0);
           List<Pipeline> pipelines = new ArrayList<>();
           PipelineID pipelineID = null;
           try {
@@ -742,7 +742,7 @@ public class ContainerEndpoint {
    * [
    *   {
    *     "containerId": 2,
-   *     "numberOfKeys": 2,
+   *     "numberOfBlocks": 2,
    *     "pipelines": []
    *   }
    * ]
@@ -792,7 +792,7 @@ public class ContainerEndpoint {
       containerDiscrepancyInfoList = omContainersDeletedInSCM.stream().map(containerMetadataEntry -> {
         ContainerDiscrepancyInfo containerDiscrepancyInfo = new ContainerDiscrepancyInfo();
         containerDiscrepancyInfo.setContainerID(containerMetadataEntry.getContainerID());
-        containerDiscrepancyInfo.setNumberOfKeys(containerMetadataEntry.getNumberOfKeys());
+        containerDiscrepancyInfo.setNumberOfBlocks(containerMetadataEntry.getNumberOfBlocks());
         containerDiscrepancyInfo.setPipelines(containerMetadataEntry.getPipelines());
         return containerDiscrepancyInfo;
       }).collect(Collectors.toList());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerDiscrepancyInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerDiscrepancyInfo.java
@@ -30,8 +30,8 @@ public class ContainerDiscrepancyInfo {
   @JsonProperty("containerId")
   private long containerID;
 
-  @JsonProperty("numberOfKeys")
-  private long numberOfKeys;
+  @JsonProperty("numberOfBlocks")
+  private long numberOfBlocks;
 
   @JsonProperty("pipelines")
   private List<Pipeline> pipelines;
@@ -52,12 +52,12 @@ public class ContainerDiscrepancyInfo {
     this.containerID = containerID;
   }
 
-  public long getNumberOfKeys() {
-    return numberOfKeys;
+  public long getNumberOfBlocks() {
+    return numberOfBlocks;
   }
 
-  public void setNumberOfKeys(long numberOfKeys) {
-    this.numberOfKeys = numberOfKeys;
+  public void setNumberOfBlocks(long numberOfBlocks) {
+    this.numberOfBlocks = numberOfBlocks;
   }
 
   public List<Pipeline> getPipelines() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerMetadata.java
@@ -33,8 +33,8 @@ public class ContainerMetadata {
   @XmlElement(name = "ContainerID")
   private long containerID;
 
-  @XmlElement(name = "NumberOfKeys")
-  private long numberOfKeys;
+  @XmlElement(name = "NumberOfBlocks")
+  private long numberOfBlocks;
 
   @JsonProperty("pipelines")
   private List<Pipeline> pipelines;
@@ -51,12 +51,12 @@ public class ContainerMetadata {
     this.containerID = containerID;
   }
 
-  public long getNumberOfKeys() {
-    return numberOfKeys;
+  public long getNumberOfBlocks() {
+    return numberOfBlocks;
   }
 
-  public void setNumberOfKeys(long numberOfKeys) {
-    this.numberOfKeys = numberOfKeys;
+  public void setNumberOfBlocks(long numberOfBlocks) {
+    this.numberOfBlocks = numberOfBlocks;
   }
 
   public List<Pipeline> getPipelines() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DeletedContainerInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DeletedContainerInfo.java
@@ -35,9 +35,9 @@ public class DeletedContainerInfo {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private PipelineID pipelineID;
 
-  @JsonProperty("numberOfKeys")
+  @JsonProperty("numberOfBlocks")
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  private long numberOfKeys;
+  private long numberOfBlocks;
 
   @JsonProperty("containerState")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -83,12 +83,12 @@ public class DeletedContainerInfo {
     this.pipelineID = pipelineID;
   }
 
-  public long getNumberOfKeys() {
-    return numberOfKeys;
+  public long getNumberOfBlocks() {
+    return numberOfBlocks;
   }
 
-  public void setNumberOfKeys(long numberOfKeys) {
-    this.numberOfKeys = numberOfKeys;
+  public void setNumberOfBlocks(long numberOfBlocks) {
+    this.numberOfBlocks = numberOfBlocks;
   }
 
   public String getContainerState() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -479,7 +479,7 @@ public class ReconContainerMetadataManagerImpl
         ContainerMetadata containerMetadata = new ContainerMetadata(currentKey.getKey().getContainerId());
         do {
           ContainerKeyPrefix containerKeyPrefix = this.currentKey.getKey();
-          containerMetadata.setNumberOfKeys(containerMetadata.getNumberOfKeys() + 1);
+          containerMetadata.setNumberOfBlocks(containerMetadata.getNumberOfBlocks() + 1);
           getPipelines(containerKeyPrefix).forEach(pipeline -> {
             pipelines.putIfAbsent(pipeline.getId(), pipeline);
           });

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -3810,7 +3810,7 @@
     "containerDiscrepancyInfo": [
       {
         "containerId": 1,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -3839,7 +3839,7 @@
       },
       {
         "containerId": 2,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -3857,7 +3857,7 @@
       },
       {
         "containerId": 3,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -3875,7 +3875,7 @@
       },
       {
         "containerId": 4,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -3893,7 +3893,7 @@
       },
       {
         "containerId": 5,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -3911,7 +3911,7 @@
       },
       {
         "containerId": 6,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -3929,7 +3929,7 @@
       },
       {
         "containerId": 7,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -3947,7 +3947,7 @@
       },
       {
         "containerId": 8,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -3965,7 +3965,7 @@
       },
       {
         "containerId": 9,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -3983,7 +3983,7 @@
       },
       {
         "containerId": 10,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -4001,7 +4001,7 @@
       },
       {
         "containerId": 11,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -4030,7 +4030,7 @@
       },
       {
         "containerId": 12,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -4048,7 +4048,7 @@
       },
       {
         "containerId": 13,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -4066,7 +4066,7 @@
       },
       {
         "containerId": 14,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -4084,7 +4084,7 @@
       },
       {
         "containerId": 15,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -4102,7 +4102,7 @@
       },
       {
         "containerId": 16,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -4120,7 +4120,7 @@
       },
       {
         "containerId": 17,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -4138,7 +4138,7 @@
       },
       {
         "containerId": 18,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -4156,7 +4156,7 @@
       },
       {
         "containerId": 19,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -4174,7 +4174,7 @@
       },
       {
         "containerId": 20,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -4192,7 +4192,7 @@
       },
       {
         "containerId": 21,
-        "numberOfKeys": 11,
+        "numberOfBlocks": 11,
         "pipelines": [
           {
             "id": {
@@ -4210,7 +4210,7 @@
       },
       {
         "containerId": 22,
-        "numberOfKeys": 12,
+        "numberOfBlocks": 12,
         "pipelines": [
           {
             "id": {
@@ -4232,7 +4232,7 @@
     "containerDiscrepancyInfo": [
       {
         "containerId": 1,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -4261,7 +4261,7 @@
       },
       {
         "containerId": 2,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -4279,7 +4279,7 @@
       },
       {
         "containerId": 3,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -4297,7 +4297,7 @@
       },
       {
         "containerId": 4,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -4315,7 +4315,7 @@
       },
       {
         "containerId": 5,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -4333,7 +4333,7 @@
       },
       {
         "containerId": 6,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -4351,7 +4351,7 @@
       },
       {
         "containerId": 7,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -4369,7 +4369,7 @@
       },
       {
         "containerId": 8,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -4387,7 +4387,7 @@
       },
       {
         "containerId": 9,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -4405,7 +4405,7 @@
       },
       {
         "containerId": 10,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -4423,7 +4423,7 @@
       },
       {
         "containerId": 11,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -4452,7 +4452,7 @@
       },
       {
         "containerId": 12,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -4470,7 +4470,7 @@
       },
       {
         "containerId": 13,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -4488,7 +4488,7 @@
       },
       {
         "containerId": 14,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -4506,7 +4506,7 @@
       },
       {
         "containerId": 15,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -4524,7 +4524,7 @@
       },
       {
         "containerId": 16,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -4542,7 +4542,7 @@
       },
       {
         "containerId": 17,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -4560,7 +4560,7 @@
       },
       {
         "containerId": 18,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -4578,7 +4578,7 @@
       },
       {
         "containerId": 19,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -4596,7 +4596,7 @@
       },
       {
         "containerId": 20,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -4614,7 +4614,7 @@
       },
       {
         "containerId": 21,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -4643,7 +4643,7 @@
       },
       {
         "containerId": 22,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -4661,7 +4661,7 @@
       },
       {
         "containerId": 23,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -4679,7 +4679,7 @@
       },
       {
         "containerId": 24,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -4697,7 +4697,7 @@
       },
       {
         "containerId": 25,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -4715,7 +4715,7 @@
       },
       {
         "containerId": 26,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -4733,7 +4733,7 @@
       },
       {
         "containerId": 27,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -4751,7 +4751,7 @@
       },
       {
         "containerId": 28,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -4769,7 +4769,7 @@
       },
       {
         "containerId": 29,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -4787,7 +4787,7 @@
       },
       {
         "containerId": 30,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -4805,7 +4805,7 @@
       },
       {
         "containerId": 31,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -4834,7 +4834,7 @@
       },
       {
         "containerId": 32,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -4852,7 +4852,7 @@
       },
       {
         "containerId": 33,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -4870,7 +4870,7 @@
       },
       {
         "containerId": 34,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -4888,7 +4888,7 @@
       },
       {
         "containerId": 35,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -4906,7 +4906,7 @@
       },
       {
         "containerId": 36,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -4924,7 +4924,7 @@
       },
       {
         "containerId": 37,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -4942,7 +4942,7 @@
       },
       {
         "containerId": 38,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -4960,7 +4960,7 @@
       },
       {
         "containerId": 39,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -4978,7 +4978,7 @@
       },
       {
         "containerId": 40,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -4996,7 +4996,7 @@
       },
       {
         "containerId": 41,
-        "numberOfKeys": 1,
+        "numberOfBlocks": 1,
         "pipelines": [
           {
             "id": {
@@ -5025,7 +5025,7 @@
       },
       {
         "containerId": 42,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -5043,7 +5043,7 @@
       },
       {
         "containerId": 43,
-        "numberOfKeys": 3,
+        "numberOfBlocks": 3,
         "pipelines": [
           {
             "id": {
@@ -5061,7 +5061,7 @@
       },
       {
         "containerId": 44,
-        "numberOfKeys": 4,
+        "numberOfBlocks": 4,
         "pipelines": [
           {
             "id": {
@@ -5079,7 +5079,7 @@
       },
       {
         "containerId": 45,
-        "numberOfKeys": 5,
+        "numberOfBlocks": 5,
         "pipelines": [
           {
             "id": {
@@ -5097,7 +5097,7 @@
       },
       {
         "containerId": 46,
-        "numberOfKeys": 6,
+        "numberOfBlocks": 6,
         "pipelines": [
           {
             "id": {
@@ -5115,7 +5115,7 @@
       },
       {
         "containerId": 47,
-        "numberOfKeys": 7,
+        "numberOfBlocks": 7,
         "pipelines": [
           {
             "id": {
@@ -5133,7 +5133,7 @@
       },
       {
         "containerId": 48,
-        "numberOfKeys": 8,
+        "numberOfBlocks": 8,
         "pipelines": [
           {
             "id": {
@@ -5151,7 +5151,7 @@
       },
       {
         "containerId": 49,
-        "numberOfKeys": 9,
+        "numberOfBlocks": 9,
         "pipelines": [
           {
             "id": {
@@ -5169,7 +5169,7 @@
       },
       {
         "containerId": 50,
-        "numberOfKeys": 10,
+        "numberOfBlocks": 10,
         "pipelines": [
           {
             "id": {
@@ -6035,7 +6035,7 @@
     "containers": [
       {
         "containerId": 1,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6052,7 +6052,7 @@
       },
       {
         "containerId": 2,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6069,7 +6069,7 @@
       },
       {
         "containerId": 3,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6086,7 +6086,7 @@
       },
       {
         "containerId": 4,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6103,7 +6103,7 @@
       },
       {
         "containerId": 5,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6120,7 +6120,7 @@
       },
       {
         "containerId": 6,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6137,7 +6137,7 @@
       },
       {
         "containerId": 7,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6154,7 +6154,7 @@
       },
       {
         "containerId": 8,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6171,7 +6171,7 @@
       },
       {
         "containerId": 9,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6188,7 +6188,7 @@
       },
       {
         "containerId": 10,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6205,7 +6205,7 @@
       },
       {
         "containerId": 11,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6222,7 +6222,7 @@
       },
       {
         "containerId": 12,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6239,7 +6239,7 @@
       },
       {
         "containerId": 13,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6256,7 +6256,7 @@
       },
       {
         "containerId": 14,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6273,7 +6273,7 @@
       },
       {
         "containerId": 15,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6290,7 +6290,7 @@
       },
       {
         "containerId": 16,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6307,7 +6307,7 @@
       },
       {
         "containerId": 17,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6324,7 +6324,7 @@
       },
       {
         "containerId": 18,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6341,7 +6341,7 @@
       },
       {
         "containerId": 19,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6358,7 +6358,7 @@
       },
       {
         "containerId": 20,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6375,7 +6375,7 @@
       },
       {
         "containerId": 21,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6392,7 +6392,7 @@
       },
       {
         "containerId": 22,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6409,7 +6409,7 @@
       },
       {
         "containerId": 23,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6426,7 +6426,7 @@
       },
       {
         "containerId": 24,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6443,7 +6443,7 @@
       },
       {
         "containerId": 25,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6460,7 +6460,7 @@
       },
       {
         "containerId": 26,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6477,7 +6477,7 @@
       },
       {
         "containerId": 27,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6494,7 +6494,7 @@
       },
       {
         "containerId": 28,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6511,7 +6511,7 @@
       },
       {
         "containerId": 29,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6528,7 +6528,7 @@
       },
       {
         "containerId": 30,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6545,7 +6545,7 @@
       },
       {
         "containerId": 31,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {
@@ -6562,7 +6562,7 @@
       },
       {
         "containerId": 32,
-        "numberOfKeys": 2,
+        "numberOfBlocks": 2,
         "pipelines": [
           {
             "id": {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/containerMismatchTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/containerMismatchTable.tsx
@@ -119,10 +119,10 @@ const ContainerMismatchTable: React.FC<ContainerMismatchTableProps> = ({
       width: '20%'
     },
     {
-      title: 'Count Of Keys',
-      dataIndex: 'numberOfKeys',
-      key: 'numberOfKeys',
-      sorter: (a: Container, b: Container) => a.numberOfKeys - b.numberOfKeys
+      title: 'Count Of Blocks',
+      dataIndex: 'numberOfBlocks',
+      key: 'numberOfBlocks',
+      sorter: (a: Container, b: Container) => a.numberOfBlocks - b.numberOfBlocks
     },
     {
       title: 'Pipelines',

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletedContainerKeysTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletedContainerKeysTable.tsx
@@ -58,10 +58,10 @@ const COLUMNS: ColumnsType<Container> = [
     width: '20%'
   },
   {
-    title: 'Count Of Keys',
-    dataIndex: 'numberOfKeys',
-    key: 'numberOfKeys',
-    sorter: (a: Container, b: Container) => a.numberOfKeys - b.numberOfKeys
+    title: 'Count Of Blocks',
+    dataIndex: 'numberOfBlocks',
+    key: 'numberOfBlocks',
+    sorter: (a: Container, b: Container) => a.numberOfBlocks - b.numberOfBlocks
   },
   {
     title: 'Pipelines',

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/insights.types.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/insights.types.ts
@@ -72,7 +72,7 @@ export type Pipelines = {
 // Container Mismatch Info
 export type Container = {
   containerId: number;
-  numberOfKeys: number;
+  numberOfBlocks: number;
   pipelines: Pipelines[];
   existsAt: 'OM' | 'SCM';
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
@@ -479,7 +479,7 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
   handlefsoNonfsoMenuChange: MenuProps["onClick"] = (e) => {
     if (e.key === 'fso') {
       this.fetchOpenKeys(true, false);
-    }1
+    }
     else {
       this.fetchOpenKeys(false, true);
     }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
@@ -45,7 +45,7 @@ interface IContainerResponse {
   SCMContainerState: string;
   existsAt: string;
   pipelines: string[];
-  numberOfKeys: number;
+  numberOfBlocks: number;
 }
 
 interface IKeyLevelResponse {
@@ -152,10 +152,10 @@ const MISMATCH_TAB_COLUMNS = [
 
   },
   {
-    title: 'Count Of Keys',
-    dataIndex: 'numberOfKeys',
-    key: 'numberOfKeys',
-    sorter: (a: IContainerResponse, b: IContainerResponse) => a.numberOfKeys - b.numberOfKeys
+    title: 'Count Of Blocks',
+    dataIndex: 'numberOfBlocks',
+    key: 'numberOfBlocks',
+    sorter: (a: IContainerResponse, b: IContainerResponse) => a.numberOfBlocks - b.numberOfBlocks
   },
   {
     title: 'Pipelines',
@@ -260,10 +260,10 @@ const DELETED_TAB_COLUMNS = [
     isSearchable: true
   },
   {
-    title: 'Count Of Keys',
-    dataIndex: 'numberOfKeys',
-    key: 'numberOfKeys',
-    sorter: (a: IContainerResponse, b: IContainerResponse) => a.numberOfKeys - b.numberOfKeys
+    title: 'Count Of Blocks',
+    dataIndex: 'numberOfBlocks',
+    key: 'numberOfBlocks',
+    sorter: (a: IContainerResponse, b: IContainerResponse) => a.numberOfBlocks - b.numberOfBlocks
   },
   {
     title: 'Pipelines',
@@ -479,7 +479,7 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
   handlefsoNonfsoMenuChange: MenuProps["onClick"] = (e) => {
     if (e.key === 'fso') {
       this.fetchOpenKeys(true, false);
-    }
+    }1
     else {
       this.fetchOpenKeys(false, true);
     }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -649,11 +649,11 @@ public class TestContainerEndpoint {
     ContainerMetadata containerMetadata = iterator.next();
     assertEquals(1L, containerMetadata.getContainerID());
     // Number of keys for CID:1
-    assertEquals(5L, containerMetadata.getNumberOfKeys());
+    assertEquals(5L, containerMetadata.getNumberOfBlocks());
 
     containerMetadata = iterator.next();
     assertEquals(2L, containerMetadata.getContainerID());
-    assertEquals(5L, containerMetadata.getNumberOfKeys());
+    assertEquals(5L, containerMetadata.getNumberOfBlocks());
 
     // test if limit works as expected
     response = containerEndpoint.getContainers(2, 0L);
@@ -1605,7 +1605,7 @@ public class TestContainerEndpoint {
     assertEquals(expectedPipelineId, pipelines.get(0).getId(),
         "Container " + containerId + " should have correct pipeline");
     assertEquals("SCM", info.getExistsAt());
-    assertEquals(0, info.getNumberOfKeys());
+    assertEquals(0, info.getNumberOfBlocks());
     // Verify list isolation
     for (List<Pipeline> other : otherPipelineLists) {
       if (other != null) {
@@ -1717,7 +1717,7 @@ public class TestContainerEndpoint {
         responsePrevKey);
 
     assertEquals(3, containerDiscrepancyInfoList.get(0)
-        .getNumberOfKeys());
+        .getNumberOfBlocks());
     assertEquals(1, containerDiscrepancyInfoList.size());
   }
 
@@ -1752,7 +1752,7 @@ public class TestContainerEndpoint {
         responsePrevKey);
     assertEquals(2, responsePrevKey);
 
-    assertEquals(omContainers.get(2L).getNumberOfKeys(), containerDiscrepancyInfoList.get(0).getNumberOfKeys());
+    assertEquals(omContainers.get(2L).getNumberOfBlocks(), containerDiscrepancyInfoList.get(0).getNumberOfBlocks());
     assertEquals(1, containerDiscrepancyInfoList.size());
   }
 
@@ -1792,7 +1792,7 @@ public class TestContainerEndpoint {
         responsePrevKey);
 
     assertEquals(3, containerDiscrepancyInfoList.get(0)
-        .getNumberOfKeys());
+        .getNumberOfBlocks());
     assertEquals(1, containerDiscrepancyInfoList.size());
   }
 
@@ -1834,7 +1834,7 @@ public class TestContainerEndpoint {
         responsePrevKey);
 
     assertEquals(2, containerDiscrepancyInfoList.get(0)
-        .getNumberOfKeys());
+        .getNumberOfBlocks());
     assertEquals(1, containerDiscrepancyInfoList.size());
     assertEquals(2, containerDiscrepancyInfoList.get(0).getContainerID());
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestReconReplicationManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestReconReplicationManager.java
@@ -407,7 +407,7 @@ public class TestReconReplicationManager extends AbstractReconSqlDBTest {
     // No assertion needed - just verify no exceptions thrown
   }
 
-  private ContainerInfo mockContainerInfo(long containerId, long numberOfKeys,
+  private ContainerInfo mockContainerInfo(long containerId, long numberOfBlocks,
       long usedBytes, int requiredNodes) {
     ContainerInfo containerInfo = mock(ContainerInfo.class);
     ReplicationConfig replicationConfig = mock(ReplicationConfig.class);
@@ -416,7 +416,7 @@ public class TestReconReplicationManager extends AbstractReconSqlDBTest {
 
     when(containerInfo.getContainerID()).thenReturn(containerId);
     when(containerInfo.containerID()).thenReturn(ContainerID.valueOf(containerId));
-    when(containerInfo.getNumberOfKeys()).thenReturn(numberOfKeys);
+    when(containerInfo.getNumberOfKeys()).thenReturn(numberOfBlocks);
     when(containerInfo.getUsedBytes()).thenReturn(usedBytes);
     when(containerInfo.getReplicationConfig()).thenReturn(replicationConfig);
     when(containerInfo.getState()).thenReturn(HddsProtos.LifeCycleState.CLOSED);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
@@ -364,8 +364,8 @@ public class TestReconContainerMetadataManagerImpl {
         reconContainerMetadataManager.getContainers(-1, 0L);
     assertEquals(2, containerMap.size());
 
-    assertEquals(2, containerMap.get(containerId).getNumberOfKeys());
-    assertEquals(1, containerMap.get(nextContainerId).getNumberOfKeys());
+    assertEquals(2, containerMap.get(containerId).getNumberOfBlocks());
+    assertEquals(1, containerMap.get(nextContainerId).getNumberOfBlocks());
 
     // test if limit works
     containerMap = reconContainerMetadataManager.getContainers(


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Recon Unhealthy Container API currently exposes the field NumberOfKeys in its response payload. This is misleading, as the value represents the number of blocks, not keys.

This task involves updating the API response schema, implementation, and documentation to replace NumberOfKeys with NumberOfBlocks for clarity and correctness.

https://ozone.apache.org/docs/2.0.0/interface/swaggerreconapi.html#/Containers/getContainerInfo

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15123

## How was this patch tested?

Tested out using docker compose - 

<img width="451" height="292" alt="image" src="https://github.com/user-attachments/assets/ad1ccfd3-6490-41be-a1c4-685d39356609" />
