### PR TITLE
HDDS-14942. Implement manifest selection logic for rewrite based on snapshot delta

### DIFF
--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -224,8 +224,10 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
     Set<Snapshot> deltaSnapshots = deltaSnapshots(startMetadata, rewriteVersionResult.toRewrite());
+    Set<Snapshot> validSnapshots = new HashSet<>(RewriteTablePathOzoneUtils.snapshotSet(endMetadata));
+    validSnapshots.removeAll(RewriteTablePathOzoneUtils.snapshotSet(startMetadata));
     //TODO: manifestsToRewrite will be used while re-write of manifest-list files.
-    Set<String> manifestsToRewrite = manifestsToRewrite(deltaSnapshots, startMetadata, endMetadata);
+    Set<String> manifestsToRewrite = manifestsToRewrite(deltaSnapshots, validSnapshots, startMetadata);
 
     Set<Pair<String, String>> copyPlan = new HashSet<>();
     copyPlan.addAll(rewriteVersionResult.copyPlan());
@@ -273,8 +275,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     return result;
   }
 
-  private Set<String> manifestsToRewrite(Set<Snapshot> deltaSnapshots, TableMetadata startMetadata, 
-      TableMetadata endMetadata) {
+  private Set<String> manifestsToRewrite(Set<Snapshot> deltaSnapshots, Set<Snapshot> validSnapshots,
+      TableMetadata startMetadata) {
 
     final Set<Long> deltaSnapshotIds;
     if (startMetadata != null) {
@@ -293,7 +295,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     int completedTasks = 0;
 
     try {
-      for (Snapshot snapshot : endMetadata.snapshots()) {
+      for (Snapshot snapshot : validSnapshots) {
         semaphore.acquire(); // blocks when maxInFlight tasks are already in-flight
 
         final long snapshotId = snapshot.snapshotId();

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -224,7 +224,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
     Set<Snapshot> deltaSnapshots = deltaSnapshots(startMetadata, rewriteVersionResult.toRewrite());
-    Set<String> manifestsToRewrite = manifestsToRewrite(deltaSnapshots, startMetadata);
+    //TODO: manifestsToRewrite will be used while re-write of manifest-list files.
+    Set<String> manifestsToRewrite = manifestsToRewrite(deltaSnapshots, startMetadata, endMetadata);
 
     Set<Pair<String, String>> copyPlan = new HashSet<>();
     copyPlan.addAll(rewriteVersionResult.copyPlan());
@@ -272,8 +273,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     return result;
   }
 
-  private Set<String> manifestsToRewrite(Set<Snapshot> deltaSnapshots, TableMetadata startMetadata) {
-    Table endStaticTable = RewriteTablePathOzoneUtils.newStaticTable(endVersionName, table.io());
+  private Set<String> manifestsToRewrite(Set<Snapshot> deltaSnapshots, TableMetadata startMetadata, 
+      TableMetadata endMetadata) {
 
     final Set<Long> deltaSnapshotIds;
     if (startMetadata != null) {
@@ -292,7 +293,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     int completedTasks = 0;
 
     try {
-      for (Snapshot snapshot : endStaticTable.snapshots()) {
+      for (Snapshot snapshot : endMetadata.snapshots()) {
         semaphore.acquire(); // blocks when maxInFlight tasks are already in-flight
 
         final long snapshotId = snapshot.snapshotId();

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -224,10 +224,12 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
     Set<Snapshot> deltaSnapshots = deltaSnapshots(startMetadata, rewriteVersionResult.toRewrite());
+    Set<Long> deltaSnapshotIds =  deltaSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
     Set<Snapshot> validSnapshots = new HashSet<>(RewriteTablePathOzoneUtils.snapshotSet(endMetadata));
     validSnapshots.removeAll(RewriteTablePathOzoneUtils.snapshotSet(startMetadata));
     //TODO: manifestsToRewrite will be used while re-write of manifest-list files.
-    Set<String> manifestsToRewrite = manifestsToRewrite(deltaSnapshots, validSnapshots, startMetadata);
+    Set<String> manifestsToRewrite = manifestsToRewrite(validSnapshots, 
+        startMetadata != null ? deltaSnapshotIds : null);
 
     Set<Pair<String, String>> copyPlan = new HashSet<>();
     copyPlan.addAll(rewriteVersionResult.copyPlan());
@@ -275,15 +277,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     return result;
   }
 
-  private Set<String> manifestsToRewrite(Set<Snapshot> deltaSnapshots, Set<Snapshot> validSnapshots,
-      TableMetadata startMetadata) {
-
-    final Set<Long> deltaSnapshotIds;
-    if (startMetadata != null) {
-      deltaSnapshotIds = deltaSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
-    } else {
-      deltaSnapshotIds = null;
-    }
+  private Set<String> manifestsToRewrite(Set<Snapshot> validSnapshots, Set<Long> deltaSnapshotIds) {
 
     Set<String> manifestPaths = ConcurrentHashMap.newKeySet();
     int maxInFlight = parallelism * MAX_INFLIGHT_MULTIPLIER;

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneAction.java
@@ -22,10 +22,21 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.GenericManifestFile;
+import org.apache.iceberg.GenericPartitionFieldSummary;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.InternalData;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
@@ -37,6 +48,7 @@ import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.actions.ImmutableRewriteTablePath;
 import org.apache.iceberg.actions.RewriteTablePath;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.Pair;
 
 /**
@@ -57,11 +69,15 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   private String stagingDir;
   private int parallelism;
 
+  private ExecutorService executorService;
+  private static final int MAX_INFLIGHT_MULTIPLIER = 4;
+  private static final int DEFAULT_THREAD_COUNT = 10;
+
   private final Table table;
 
   public RewriteTablePathOzoneAction(Table table) {
     this.table = table;
-    this.parallelism = Runtime.getRuntime().availableProcessors();
+    this.parallelism = DEFAULT_THREAD_COUNT;
   }
 
   public RewriteTablePathOzoneAction(Table table, int parallelism) {
@@ -102,8 +118,7 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
   @Override
   public Result execute() {
     validateInputs();
-    // TODO: should use for parallel manifest and position delete file rewriting.
-    ExecutorService executorService = Executors.newFixedThreadPool(parallelism);
+    executorService = Executors.newFixedThreadPool(parallelism);
     try {
       return doExecute();
     } finally {
@@ -197,6 +212,9 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
 
   private String rebuildMetadata() {
     //TODO need to implement rewrite of manifest list , manifest files and position delete files.
+    TableMetadata startMetadata = startVersionName != null
+        ? new StaticTableOperations(startVersionName, table.io()).current()
+        : null;
     TableMetadata endMetadata = new StaticTableOperations(endVersionName, table.io()).current();
 
     List<PartitionStatisticsFile> partitionStats = endMetadata.partitionStatisticsFiles();
@@ -205,6 +223,8 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
     }
 
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
+    Set<Snapshot> deltaSnapshots = deltaSnapshots(startMetadata, rewriteVersionResult.toRewrite());
+    Set<String> manifestsToRewrite = manifestsToRewrite(deltaSnapshots, startMetadata);
 
     Set<Pair<String, String>> copyPlan = new HashSet<>();
     copyPlan.addAll(rewriteVersionResult.copyPlan());
@@ -250,5 +270,110 @@ public class RewriteTablePathOzoneAction implements RewriteTablePath {
             metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
 
     return result;
+  }
+
+  private Set<String> manifestsToRewrite(Set<Snapshot> deltaSnapshots, TableMetadata startMetadata) {
+    Table endStaticTable = RewriteTablePathOzoneUtils.newStaticTable(endVersionName, table.io());
+
+    final Set<Long> deltaSnapshotIds;
+    if (startMetadata != null) {
+      deltaSnapshotIds = deltaSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+    } else {
+      deltaSnapshotIds = null;
+    }
+
+    Set<String> manifestPaths = ConcurrentHashMap.newKeySet();
+    int maxInFlight = parallelism * MAX_INFLIGHT_MULTIPLIER;
+    Semaphore semaphore = new Semaphore(maxInFlight);
+
+    ExecutorCompletionService<Void> completionService = new ExecutorCompletionService<>(executorService);
+
+    int submittedTasks = 0;
+    int completedTasks = 0;
+
+    try {
+      for (Snapshot snapshot : endStaticTable.snapshots()) {
+        semaphore.acquire(); // blocks when maxInFlight tasks are already in-flight
+
+        final long snapshotId = snapshot.snapshotId();
+        final String manifestListLocation = snapshot.manifestListLocation();
+
+        boolean taskSubmitted = false;
+        try {
+          completionService.submit(() -> {
+            try (CloseableIterable<ManifestFile> manifests =
+                     InternalData.read(
+                             FileFormat.AVRO,
+                             table.io().newInputFile(manifestListLocation))
+                         .setRootType(GenericManifestFile.class)
+                         .setCustomType(
+                             ManifestFile.PARTITION_SUMMARIES_ELEMENT_ID,
+                             GenericPartitionFieldSummary.class)
+                         .project(ManifestFile.schema())
+                         .build()) {
+
+              for (ManifestFile manifest : manifests) {
+                if (deltaSnapshotIds == null) {
+                  manifestPaths.add(manifest.path());
+                } else if (manifest.snapshotId() != null
+                    && deltaSnapshotIds.contains(manifest.snapshotId())) {
+                  manifestPaths.add(manifest.path());
+                }
+              }
+
+            } catch (Exception e) {
+              throw new RuntimeException(
+                  "Failed to read manifests for snapshot " + snapshotId, e);
+            } finally {
+              semaphore.release();
+            }
+            return null;
+          });
+          taskSubmitted = true;
+          submittedTasks++;
+        } finally {
+          if (!taskSubmitted) {
+            semaphore.release();
+          }
+        }
+        Future<Void> done;
+        while ((done = completionService.poll()) != null) {
+          done.get();
+          completedTasks++;
+        }
+      }
+      
+      while (completedTasks < submittedTasks) {
+        completionService.take().get();
+        completedTasks++;
+      }
+
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      executorService.shutdownNow();
+      throw new RuntimeException("Interrupted while processing manifests", e);
+
+    } catch (ExecutionException e) {
+      executorService.shutdownNow();
+      throw new RuntimeException(
+          "Failed to collect manifests to rewrite. "
+              + "The end version may contain invalid snapshots. "
+              + "Please choose an earlier version.",
+          e.getCause());
+    }
+
+    return manifestPaths;
+  }
+
+  private Set<Snapshot> deltaSnapshots(TableMetadata startMetadata, Set<Snapshot> allSnapshots) {
+    if (startMetadata == null) {
+      return allSnapshots;
+    } else {
+      Set<Long> startSnapshotIds =
+          startMetadata.snapshots().stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      return allSnapshots.stream()
+          .filter(s -> !startSnapshotIds.contains(s.snapshotId()))
+          .collect(Collectors.toSet());
+    }
   }
 }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
@@ -25,12 +25,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.RewriteTablePathUtil;
-import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
@@ -116,8 +116,11 @@ final class RewriteTablePathOzoneUtils {
     }
   }
 
-  static Table newStaticTable(String metadataFileLocation, FileIO io) {
-    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
-    return new BaseTable(ops, metadataFileLocation);
+  static Set<Snapshot> snapshotSet(TableMetadata metadata) {
+    if (metadata == null) {
+      return new HashSet<>();
+    } else {
+      return new HashSet<>(metadata.snapshots());
+    }
   }
 }

--- a/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
+++ b/hadoop-ozone/iceberg/src/main/java/org/apache/hadoop/ozone/iceberg/RewriteTablePathOzoneUtils.java
@@ -25,8 +25,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.RewriteTablePathUtil;
+import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -112,5 +114,10 @@ final class RewriteTablePathOzoneUtils {
       LOG.error("Failed to write CSV to {}", outputFile.location(), e);
       throw new RuntimeIOException(e);
     }
+  }
+
+  static Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR provides logic to determine the specific subset of Iceberg manifest files that require path rewriting, avoiding redundant processing of manifests.

  - Compute delta snapshots as the difference between the start and end table metadata versions. If no start version is provided, all snapshots are treated as delta.
  - Iterate over all snapshots in the end-version table and read each snapshot's manifest list in parallel.
  - If no start metadata is provided, include all manifests unconditionally.
  - If start metadata is provided, filter at the manifest level — only include manifests whose added snapshotId belongs to the delta snapshot ID set.
  - Deduplicate manifest paths so that manifests shared across multiple snapshots are only collected once.

## What is the link to the Apache JIRA

[HDDS-14942](https://issues.apache.org/jira/browse/HDDS-14942)

## How was this patch tested?

https://github.com/sreejasahithi/ozone/actions/runs/24986534925
