### PR TITLE
HDDS-15127. Add a switch to toggle the RocksDb open test for volume health

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -384,7 +384,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   )
   private boolean isDiskCheckEnabled = true;
 
-  @Config(key = "hdds.datanode.rocksdb.disk.check.io.test.enabled",
+  @Config(key = "hdds.datanode.disk.check.rocksdb.check.io.test.enabled",
       defaultValue = "true",
       type = ConfigType.BOOLEAN,
       tags = {DATANODE},

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -384,6 +384,14 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   )
   private boolean isDiskCheckEnabled = true;
 
+  @Config(key = "hdds.datanode.rocksdb.disk.check.io.test.enabled",
+      defaultValue = "true",
+      type = ConfigType.BOOLEAN,
+      tags = {DATANODE},
+      description = "The configuration to enable or disable RocksDb disk IO checks."
+  )
+  private boolean isRocksDbDiskCheckEnabled = true;
+
   @Config(key = "hdds.datanode.disk.check.io.failures.tolerated",
       defaultValue = "1",
       type = ConfigType.INT,
@@ -1011,6 +1019,10 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   public boolean isDiskCheckEnabled() {
     return isDiskCheckEnabled;
+  }
+
+  public boolean isRocksDbDiskCheckEnabled() {
+    return isRocksDbDiskCheckEnabled;
   }
 
   public Duration getDiskCheckSlidingWindowTimeout() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -306,7 +306,7 @@ public class HddsVolume extends StorageVolume {
 
   @VisibleForTesting
   public VolumeCheckResult checkDbHealth(File dbFile) throws InterruptedException {
-    if (!getDiskCheckEnabled()) {
+    if (!(getDiskCheckEnabled() && getDatanodeConfig().isRocksDbDiskCheckEnabled())) {
       return VolumeCheckResult.HEALTHY;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
As part of the volume health check, we open RocksDb as one of the tests to determine the health of the volume.

This PR adds a switch which can be used to toggle this test as needed. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15127

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/25011396365