### PR TITLE
HDDS-14920. (addendum) Check actions with zizmor

### DIFF
--- a/.github/workflows/schedule-label-pr.yml
+++ b/.github/workflows/schedule-label-pr.yml
@@ -22,7 +22,9 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
-permissions: { }
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add permissions in `scheduled-label-pull-requests` to match the called workflow to fix:

```
The nested job 'labeler' is requesting 'contents: read, pull-requests: write', but is only allowed 'contents: none, pull-requests: none'.
```

https://github.com/apache/ozone/actions/runs/25033478081

https://issues.apache.org/jira/browse/HDDS-14920