### PR TITLE
HDDS-14669. Implement a new async finalize command which does not block on the server

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -443,9 +443,11 @@ public interface ScmClient extends Closeable {
   List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count) throws IOException;
 
+  @Deprecated
   StatusAndMessages finalizeScmUpgrade(String upgradeClientID)
       throws IOException;
 
+  @Deprecated
   StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean force, boolean readonly)
       throws IOException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -450,6 +450,8 @@ public interface ScmClient extends Closeable {
       String upgradeClientID, boolean force, boolean readonly)
       throws IOException;
 
+  void finalizeUpgrade() throws IOException;
+
   HddsProtos.UpgradeStatus queryUpgradeStatus() throws IOException;
 
   DecommissionScmResponseProto decommissionScm(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -477,11 +477,13 @@ public interface StorageContainerLocationProtocol extends Closeable {
   List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count, int clientVersion) throws IOException;
 
+  @Deprecated
   StatusAndMessages finalizeScmUpgrade(String upgradeClientID)
       throws IOException;
 
   void finalizeUpgrade() throws IOException;
 
+  @Deprecated
   StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean force, boolean readonly)
       throws IOException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -480,6 +480,8 @@ public interface StorageContainerLocationProtocol extends Closeable {
   StatusAndMessages finalizeScmUpgrade(String upgradeClientID)
       throws IOException;
 
+  void finalizeUpgrade() throws IOException;
+
   StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean force, boolean readonly)
       throws IOException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeUpgradeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerCountRequestProto;
@@ -1126,6 +1127,14 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
     return new StatusAndMessages(
         UpgradeFinalization.Status.valueOf(status.getStatus().name()),
         status.getMessagesList());
+  }
+
+  @Override
+  public void finalizeUpgrade() throws IOException {
+    FinalizeUpgradeRequestProto req = FinalizeUpgradeRequestProto.newBuilder()
+        .build();
+    submitRequest(Type.FinalizeUpgrade, builder -> builder.setFinalizeUpgradeRequest(req))
+        .getFinalizeUpgradeResponse();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -1111,6 +1111,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   }
 
   @Override
+  @Deprecated
   public StatusAndMessages finalizeScmUpgrade(String upgradeClientID)
       throws IOException {
     FinalizeScmUpgradeRequestProto req = FinalizeScmUpgradeRequestProto.
@@ -1137,6 +1138,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   }
 
   @Override
+  @Deprecated
   public StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean force, boolean readonly)
       throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -1133,8 +1133,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   public void finalizeUpgrade() throws IOException {
     FinalizeUpgradeRequestProto req = FinalizeUpgradeRequestProto.newBuilder()
         .build();
-    submitRequest(Type.FinalizeUpgrade, builder -> builder.setFinalizeUpgradeRequest(req))
-        .getFinalizeUpgradeResponse();
+    submitRequest(Type.FinalizeUpgrade, builder -> builder.setFinalizeUpgradeRequest(req));
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
@@ -128,7 +128,7 @@ public abstract class BasicUpgradeFinalizer
     } catch (NotLeaderException e) {
       LOG.info("Leader change encountered during finalization. This component will continue finalization as " +
           "directed by the new leader.", e);
-      // TODO - should we throw here?
+      throw e;
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
@@ -116,6 +116,23 @@ public abstract class BasicUpgradeFinalizer
   }
 
   @Override
+  public void finalize(T service) throws IOException {
+    UpgradeFinalization.Status status = versionManager.getUpgradeState();
+    if (isFinalized(status)) {
+      return;
+    }
+    try {
+      if (status == FINALIZATION_REQUIRED) {
+        finalizationExecutor.execute(service, this);
+      }
+    } catch (NotLeaderException e) {
+      LOG.info("Leader change encountered during finalization. This component will continue finalization as " +
+          "directed by the new leader.", e);
+      // TODO - should we throw here?
+    }
+  }
+
+  @Override
   public synchronized StatusAndMessages reportStatus(
       String upgradeClientID, boolean takeover) throws UpgradeException {
     if (takeover) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
@@ -121,14 +121,8 @@ public abstract class BasicUpgradeFinalizer
     if (isFinalized(status)) {
       return;
     }
-    try {
-      if (status == FINALIZATION_REQUIRED) {
-        finalizationExecutor.execute(service, this);
-      }
-    } catch (NotLeaderException e) {
-      LOG.info("Leader change encountered during finalization. This component will continue finalization as " +
-          "directed by the new leader.", e);
-      throw e;
+    if (status == FINALIZATION_REQUIRED) {
+      finalizationExecutor.execute(service, this);
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/UpgradeFinalizer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/upgrade/UpgradeFinalizer.java
@@ -58,6 +58,13 @@ public interface UpgradeFinalizer<T> {
       throws IOException;
 
   /**
+   * Finalize the metadata upgrade. If finalization is not needed or is already underway, this call is a noop.
+   * @param service the service on which we run finalization.
+   * @throws IOException if the finalization fails at any stage.
+   */
+  void finalize(T service) throws IOException;
+
+  /**
    * Finalize the component if needed, and wait until completion.
    * @param upgradeClientID the initiating client's identifier.
    * @param service the service on which we run finalization.

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -88,6 +88,7 @@ message ScmContainerLocationRequest {
   optional ReconcileContainerRequestProto reconcileContainerRequest = 49;
   optional GetDeletedBlocksTxnSummaryRequestProto getDeletedBlocksTxnSummaryRequest = 50;
   optional QueryUpgradeStatusRequestProto queryUpgradeStatusRequest = 51;
+  optional FinalizeUpgradeRequestProto finalizeUpgradeRequest = 52;
 }
 
 message ScmContainerLocationResponse {
@@ -147,6 +148,7 @@ message ScmContainerLocationResponse {
   optional ReconcileContainerResponseProto reconcileContainerResponse = 49;
   optional GetDeletedBlocksTxnSummaryResponseProto getDeletedBlocksTxnSummaryResponse = 50;
   optional QueryUpgradeStatusResponseProto queryUpgradeStatusResponse = 51;
+  optional FinalizeUpgradeResponseProto finalizeUpgradeResponse = 52;
 
   enum Status {
     OK = 1;
@@ -205,6 +207,7 @@ enum Type {
   ReconcileContainer = 45;
   GetDeletedBlocksTransactionSummary = 46;
   QueryUpgradeStatus = 47;
+  FinalizeUpgrade = 48;
 }
 
 /**
@@ -578,6 +581,12 @@ message QueryUpgradeStatusRequestProto {
 
 message QueryUpgradeStatusResponseProto {
   required hadoop.hdds.UpgradeStatus status = 1;
+}
+
+message FinalizeUpgradeRequestProto {
+}
+
+message FinalizeUpgradeResponseProto {
 }
 
 message ContainerTokenSecretProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -754,6 +754,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setQueryUpgradeStatusResponse(getQueryUpgradeStatus(request.getQueryUpgradeStatusRequest()))
             .build();
+      case FinalizeUpgrade:
+        impl.finalizeUpgrade();
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .build();
       default:
         throw new IllegalArgumentException(
             "Unknown command type: " + request.getCmdType());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -29,6 +29,7 @@ import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpc
 import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.FINALIZATION_IN_PROGRESS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -1102,31 +1103,35 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
+  @Deprecated
   public StatusAndMessages finalizeScmUpgrade(String upgradeClientID) throws
       IOException {
-    final Map<String, String> auditMap = Maps.newHashMap();
-    auditMap.put("upgradeClientID", upgradeClientID);
-    try {
-      // check admin authorization
-      getScm().checkAdminAccess(getRemoteUser(), false);
-      // TODO HDDS-6762: Return to the client once the FINALIZATION_STARTED
-      //  checkpoint has been crossed and continue finalizing asynchronously.
-      StatusAndMessages result = scm.getFinalizationManager().finalizeUpgrade(upgradeClientID);
-      AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
-          SCMAction.FINALIZE_SCM_UPGRADE, auditMap));
-      return result;
-    } catch (Exception ex) {
-      AUDIT.logWriteFailure(buildAuditMessageForFailure(
-          SCMAction.FINALIZE_SCM_UPGRADE, auditMap, ex));
-      throw ex;
-    }
-
+    finalizeUpgrade();
+    return new StatusAndMessages(FINALIZATION_IN_PROGRESS, Collections.emptyList());
   }
 
   @Override
+  public void finalizeUpgrade() throws IOException {
+    final Map<String, String> auditMap = Collections.emptyMap();
+    try {
+      getScm().checkAdminAccess(getRemoteUser(), false);
+      scm.getFinalizationManager().finalizeUpgrade();
+      AUDIT.logWriteSuccess(buildAuditMessageForSuccess(SCMAction.FINALIZE_SCM_UPGRADE, auditMap));
+    } catch (Exception ex) {
+      AUDIT.logWriteFailure(buildAuditMessageForFailure(SCMAction.FINALIZE_SCM_UPGRADE, auditMap, ex));
+      throw ex;
+    }
+  }
+
+  @Override
+  @Deprecated
   public StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean force, boolean readonly)
       throws IOException {
+
+    // This method, we change to call the queryUpgradeStatus and create a StatusAndMessages object that reflects
+    // the state.
+
     Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("upgradeClientID", upgradeClientID);
     auditMap.put("force", String.valueOf(force));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -29,7 +29,8 @@ import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpc
 import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
-import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.FINALIZATION_IN_PROGRESS;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.ALREADY_FINALIZED;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.STARTING_FINALIZATION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -1106,8 +1107,11 @@ public class SCMClientProtocolServer implements
   @Deprecated
   public StatusAndMessages finalizeScmUpgrade(String upgradeClientID) throws
       IOException {
+    if (scm.getLayoutVersionManager().getUpgradeState() == ALREADY_FINALIZED) {
+      return new StatusAndMessages(ALREADY_FINALIZED, Collections.emptyList());
+    }
     finalizeUpgrade();
-    return new StatusAndMessages(FINALIZATION_IN_PROGRESS, Collections.emptyList());
+    return new StatusAndMessages(STARTING_FINALIZATION, Collections.emptyList());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManager.java
@@ -34,6 +34,8 @@ public interface FinalizationManager {
   UpgradeFinalization.StatusAndMessages finalizeUpgrade(String upgradeClientID)
       throws IOException;
 
+  void finalizeUpgrade() throws IOException;
+
   UpgradeFinalization.StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean takeover, boolean readonly
   ) throws IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManagerImpl.java
@@ -91,6 +91,12 @@ public class FinalizationManagerImpl implements FinalizationManager {
   }
 
   @Override
+  public void finalizeUpgrade() throws IOException {
+    Objects.requireNonNull(context, "Cannot finalize upgrade without first building the upgrade context.");
+    upgradeFinalizer.finalize(context);
+  }
+
+  @Override
   public UpgradeFinalization.StatusAndMessages queryUpgradeFinalizationProgress(
       String upgradeClientID, boolean takeover, boolean readonly
   ) throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -18,15 +18,12 @@
 package org.apache.hadoop.hdds.scm.server.upgrade;
 
 import java.io.IOException;
-import org.apache.hadoop.hdds.scm.exceptions.SCMException;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.ozone.upgrade.BasicUpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.LayoutFeature;
 import org.apache.hadoop.ozone.upgrade.UpgradeException;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizationExecutor;
-import org.apache.ratis.protocol.exceptions.NotLeaderException;
 
 /**
  * UpgradeFinalizer for the Storage Container Manager service.
@@ -84,54 +81,5 @@ public class SCMUpgradeFinalizer extends
     super.finalizeLayoutFeature(lf,
         lf.scmAction(),
         context.getStorage());
-  }
-
-  /**
-   * Wait for all HEALTHY datanodes to complete finalization before finishing
-   * SCM finalization. This ensures that when the client receives a
-   * FINALIZATION_DONE status, all healthy datanodes have also finalized.
-   *
-   * A datanode is considered finalized when its metadata layout version (MLV)
-   * equals its software layout version (SLV), indicating it has completed
-   * processing all layout features.
-   *
-   * @param context The finalization context containing node manager reference
-   * @throws SCMException if waiting is interrupted or SCM loses leadership
-   * @throws NotLeaderException if SCM is no longer the leader
-   */
-  private void waitForDatanodesToFinalize(SCMUpgradeFinalizationContext context)
-      throws SCMException, NotLeaderException {
-    NodeManager nodeManager = context.getNodeManager();
-
-    LOG.info("Waiting for all HEALTHY datanodes to complete finalization before finishing SCM finalization.");
-
-    boolean allDatanodesFinalized = false;
-    while (!allDatanodesFinalized) {
-      // Break out of the wait and step down from driving finalization if this
-      // SCM is no longer the leader by throwing NotLeaderException.
-      context.getSCMContext().getTermOfLeader();
-
-      NodeManager.DatanodeFinalizationCounts datanodeFinalizationCounts = nodeManager.getDatanodeFinalizationCounts();
-      int finalizedNodes = datanodeFinalizationCounts.getNumFinalizedDatanodes();
-      int totalHealthyNodes = datanodeFinalizationCounts.getTotalHealthyDatanodes();
-      allDatanodesFinalized = datanodeFinalizationCounts.allNodesFinalized();
-
-      if (!allDatanodesFinalized) {
-        int unfinalizedNodes = totalHealthyNodes - finalizedNodes;
-        LOG.info("Waiting for datanodes to finalize. Status: {}/{} healthy " +
-                "datanodes have finalized ({} remaining).",
-            finalizedNodes, totalHealthyNodes, unfinalizedNodes);
-        try {
-          Thread.sleep(5000);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new SCMException("Interrupted while waiting for datanodes to " +
-              "finalize.", SCMException.ResultCodes.INTERNAL_ERROR);
-        }
-      } else {
-        LOG.info("All {} HEALTHY datanodes have completed finalization.",
-            totalHealthyNodes);
-      }
-    }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -86,12 +86,6 @@ public class SCMUpgradeFinalizer extends
         context.getStorage());
   }
 
-  @Override
-  public void postFinalizeUpgrade(SCMUpgradeFinalizationContext context) throws IOException {
-    waitForDatanodesToFinalize(context);
-    super.postFinalizeUpgrade(context);
-  }
-
   /**
    * Wait for all HEALTHY datanodes to complete finalization before finishing
    * SCM finalization. This ensures that when the client receives a

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -583,6 +583,11 @@ public class ContainerOperationClient implements ScmClient {
   }
 
   @Override
+  public void finalizeUpgrade() throws IOException {
+    storageContainerLocationClient.finalizeUpgrade();
+  }
+
+  @Override
   public HddsProtos.UpgradeStatus queryUpgradeStatus() throws IOException {
     return storageContainerLocationClient.queryUpgradeStatus();
   }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -17,23 +17,27 @@
 
 package org.apache.hadoop.ozone.admin.upgrade;
 
-import org.apache.hadoop.hdds.cli.AdminSubcommand;
+import java.io.IOException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.kohsuke.MetaInfServices;
+import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
 
 /**
- * Subcommand to group upgrade related operations.
+ * Sub command to finalize a cluster upgrade.
  */
 @CommandLine.Command(
-    name = "upgrade",
-    description = "Operations related to Ozone cluster upgrade",
+    name = "finalize",
+    description = "Finalize a cluster upgrade",
     mixinStandardHelpOptions = true,
-    versionProvider = HddsVersionProvider.class,
-    subcommands = {
-        FinalizeSubCommand.class,
-        StatusSubCommand.class
-    })
-@MetaInfServices(AdminSubcommand.class)
-public class UpgradeCommands implements AdminSubcommand {
+    versionProvider = HddsVersionProvider.class)
+public class FinalizeSubCommand extends ScmSubcommand {
+
+  @Override
+  public void execute(ScmClient client) throws IOException {
+    client.finalizeUpgrade();
+
+    out().println("Cluster finalize has been started. Monitor progress with the ozone admin upgrade status command");
+  }
 }
+

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -37,7 +37,7 @@ public class FinalizeSubCommand extends ScmSubcommand {
   public void execute(ScmClient client) throws IOException {
     client.finalizeUpgrade();
 
-    out().println("Cluster finalize has been started. Monitor progress with the ozone admin upgrade status command");
+    out().println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status`");
   }
 }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/UpgradeUtil.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/UpgradeUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.upgrade;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+
+/**
+ * Static utility methods for upgrade commands.
+ */
+public final class UpgradeUtil {
+
+  private UpgradeUtil() { }
+
+  /** Utility method to test if the upgrade has completed (finalized) or not.
+   *
+   * @param scmClient
+   * @return True if the cluster has completed the upgrade and is finalized.
+   * @throws IOException
+   */
+  public static boolean isFinalizationComplete(
+      StorageContainerLocationProtocol scmClient) throws IOException {
+    return scmClient.queryUpgradeStatus().getShouldFinalize();
+  }
+
+}

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -62,7 +62,7 @@ public class TestFinalizeSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertTrue(output.contains("Cluster finalize has been started"));
+    assertTrue(output.contains("Cluster finalization has been started"));
     verify(scmClient).finalizeUpgrade();
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * Unit tests for {@link FinalizeSubCommand}.
+ */
+public class TestFinalizeSubCommand {
+
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private FinalizeSubCommand cmd;
+
+  @BeforeEach
+  public void setup() throws UnsupportedEncodingException {
+    cmd = new FinalizeSubCommand();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    System.setOut(originalOut);
+  }
+
+  @Test
+  public void testCommandRunsAndPrintsOutput() throws IOException {
+    ScmClient scmClient = mock(ScmClient.class);
+
+    new CommandLine(cmd).parseArgs();
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertTrue(output.contains("Cluster finalize has been started"));
+    verify(scmClient).finalizeUpgrade();
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestDNDataDistributionFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestDNDataDistributionFinalization.java
@@ -24,12 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfig;
@@ -55,17 +52,11 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests upgrade finalization failure scenarios and corner cases specific to DN data distribution feature.
  */
 public class TestDNDataDistributionFinalization {
-  private static final String CLIENT_ID = UUID.randomUUID().toString();
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestDNDataDistributionFinalization.class);
-
   private StorageContainerLocationProtocol scmClient;
   private MiniOzoneHAClusterImpl cluster;
 
@@ -167,20 +158,9 @@ public class TestDNDataDistributionFinalization {
     // Validate pre-finalization state
     validatePreDataDistributionFeatureState();
 
-    // Now trigger finalization
-    Future<?> finalizationFuture = Executors.newSingleThreadExecutor().submit(
-        () -> {
-          try {
-            scmClient.finalizeScmUpgrade(CLIENT_ID);
-          } catch (IOException ex) {
-            LOG.info("finalization client failed. This may be expected if the" +
-                " test injected failures.", ex);
-          }
-        });
-
     // Wait for finalization to complete
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
 
     // Verify finalization completed
     assertEquals(HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION.layoutVersion(),
@@ -215,18 +195,8 @@ public class TestDNDataDistributionFinalization {
       out.write(data);
     }
     bucket.deleteKey(keyName);
-    Future<?> finalizationFuture = Executors.newSingleThreadExecutor().submit(
-        () -> {
-          try {
-            scmClient.finalizeScmUpgrade(CLIENT_ID);
-          } catch (IOException ex) {
-            LOG.info("finalization client failed. This may be expected if the" +
-                " test injected failures.", ex);
-          }
-        });
-    // Wait for finalization
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
 
     assertEquals(HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION.layoutVersion(),
         cluster.getStorageContainerManager().getLayoutVersionManager().getMetadataLayoutVersion());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.admin.upgrade.UpgradeUtil;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
@@ -49,16 +50,11 @@ public final class TestHddsUpgradeUtils {
 
   private TestHddsUpgradeUtils() { }
 
-  // This is currently testing that the SCM and datanode side finalization is complete.
-  // TODO - should this test for SCM and DNs and OM?
-  public static void waitForFinalizationFromClient(
-      StorageContainerLocationProtocol scmClient)
-      throws Exception {
+  public static void waitForFinalizationFromClient(StorageContainerLocationProtocol scmClient) throws Exception {
     LambdaTestUtils.await(60_000, 1_000, () -> {
-      HddsProtos.UpgradeStatus status =  scmClient.queryUpgradeStatus();
-      LOG.info("Waiting for upgrade finalization to complete from client.Current status is {}.",
-          status.getShouldFinalize());
-      return status.getShouldFinalize();
+      boolean isComplete = UpgradeUtil.isFinalizationComplete(scmClient);
+      LOG.info("Waiting for upgrade finalization to complete from client.Current status is {}.", isComplete);
+      return isComplete;
     });
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
-import org.apache.hadoop.ozone.upgrade.UpgradeFinalization;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.slf4j.Logger;
@@ -50,16 +49,16 @@ public final class TestHddsUpgradeUtils {
 
   private TestHddsUpgradeUtils() { }
 
+  // This is currently testing that the SCM and datanode side finalization is complete.
+  // TODO - should this test for SCM and DNs and OM?
   public static void waitForFinalizationFromClient(
-      StorageContainerLocationProtocol scmClient, String clientID)
+      StorageContainerLocationProtocol scmClient)
       throws Exception {
     LambdaTestUtils.await(60_000, 1_000, () -> {
-      UpgradeFinalization.Status status = scmClient
-          .queryUpgradeFinalizationProgress(clientID, true, true)
-          .status();
-      LOG.info("Waiting for upgrade finalization to complete from client." +
-          " Current status is {}.", status);
-      return status == FINALIZATION_DONE || status == ALREADY_FINALIZED;
+      HddsProtos.UpgradeStatus status =  scmClient.queryUpgradeStatus();
+      LOG.info("Waiting for upgrade finalization to complete from client.Current status is {}.",
+          status.getShouldFinalize());
+      return status.getShouldFinalize();
     });
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmDataDistributionFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmDataDistributionFinalization.java
@@ -43,8 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -90,7 +88,6 @@ import org.slf4j.LoggerFactory;
  * Tests upgrade finalization failure scenarios and corner cases specific to SCM data distribution feature.
  */
 public class TestScmDataDistributionFinalization {
-  private static final String CLIENT_ID = UUID.randomUUID().toString();
   private static final Logger LOG =
       LoggerFactory.getLogger(TestScmDataDistributionFinalization.class);
 
@@ -98,7 +95,6 @@ public class TestScmDataDistributionFinalization {
   private MiniOzoneHAClusterImpl cluster;
   private static final int NUM_DATANODES = 3;
   private static final int NUM_SCMS = 3;
-  private Future<?> finalizationFuture;
   private final String volumeName = UUID.randomUUID().toString();
   private final String bucketName = UUID.randomUUID().toString();
   private OzoneBucket bucket;
@@ -158,22 +154,6 @@ public class TestScmDataDistributionFinalization {
       volume.createBucket(bucketName, builder.build());
       bucket = volume.getBucket(bucketName);
     }
-
-    // Launch finalization from the client. In the current implementation,
-    // this call will block until finalization completes. If the test
-    // involves restarts or leader changes the client may be disconnected,
-    // but finalization should still proceed.
-    if (doFinalize) {
-      finalizationFuture = Executors.newSingleThreadExecutor().submit(
-          () -> {
-            try {
-              scmClient.finalizeScmUpgrade(CLIENT_ID);
-            } catch (IOException ex) {
-              LOG.info("finalization client failed. This may be expected if the" +
-                  " test injected failures.", ex);
-            }
-          });
-    }
   }
 
   @AfterEach
@@ -192,8 +172,8 @@ public class TestScmDataDistributionFinalization {
     init(new OzoneConfiguration(), null, true);
     assertEquals(EMPTY_SUMMARY, cluster.getStorageContainerLocationClient().getDeletedBlockSummary());
 
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
     // Make sure old leader has caught up and all SCMs have finalized.
     waitForScmsToFinalize(cluster.getStorageContainerManagersList());
     assertEquals(HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION.layoutVersion(),
@@ -297,17 +277,8 @@ public class TestScmDataDistributionFinalization {
     flushDBTransactionBuffer(activeSCM);
     assertEquals(EMPTY_SUMMARY, cluster.getStorageContainerLocationClient().getDeletedBlockSummary());
 
-    finalizationFuture = Executors.newSingleThreadExecutor().submit(
-        () -> {
-          try {
-            scmClient.finalizeScmUpgrade(CLIENT_ID);
-          } catch (IOException ex) {
-            LOG.info("finalization client failed. This may be expected if the" +
-                " test injected failures.", ex);
-          }
-        });
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
     // Make sure old leader has caught up and all SCMs have finalized.
     waitForScmsToFinalize(cluster.getStorageContainerManagersList());
     assertEquals(HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION.layoutVersion(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
@@ -19,13 +19,9 @@ package org.apache.hadoop.hdds.upgrade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -53,7 +49,6 @@ import org.slf4j.LoggerFactory;
  * HA.
  */
 public class TestScmHAFinalization {
-  private static final String CLIENT_ID = UUID.randomUUID().toString();
   private static final Logger LOG =
       LoggerFactory.getLogger(TestScmHAFinalization.class);
 
@@ -61,7 +56,6 @@ public class TestScmHAFinalization {
   private MiniOzoneHAClusterImpl cluster;
   private static final int NUM_DATANODES = 3;
   private static final int NUM_SCMS = 3;
-  private Future<?> finalizationFuture;
 
   public void init(OzoneConfiguration conf,
       UpgradeFinalizationExecutor<SCMUpgradeFinalizationContext> executor,
@@ -88,20 +82,6 @@ public class TestScmHAFinalization {
 
     scmClient = cluster.getStorageContainerLocationClient();
     cluster.waitForClusterToBeReady();
-
-    // Launch finalization from the client. In the current implementation,
-    // this call will block until finalization completes. If the test
-    // involves restarts or leader changes the client may be disconnected,
-    // but finalization should still proceed.
-    finalizationFuture = Executors.newSingleThreadExecutor().submit(
-        () -> {
-          try {
-            scmClient.finalizeUpgrade();
-          } catch (IOException ex) {
-            LOG.info("finalization client failed. This may be expected if the" +
-                " test injected failures.", ex);
-          }
-        });
   }
 
   @AfterEach
@@ -115,8 +95,8 @@ public class TestScmHAFinalization {
   public void testFinalization() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     init(conf, new DefaultUpgradeFinalizationExecutor<>(), 0);
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
     // Ensure all SCMs finalize, indicating the message has been propagated across them all
     waitForScmsToFinalize(cluster.getStorageContainerManagersList());
 
@@ -153,8 +133,8 @@ public class TestScmHAFinalization {
     }
 
     // Wait for finalization from the client perspective.
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
     // Wait for two running SCMs to finish finalization.
     waitForScmsToFinalize(activeScms);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
@@ -96,7 +96,7 @@ public class TestScmHAFinalization {
     finalizationFuture = Executors.newSingleThreadExecutor().submit(
         () -> {
           try {
-            scmClient.finalizeScmUpgrade(CLIENT_ID);
+            scmClient.finalizeUpgrade();
           } catch (IOException ex) {
             LOG.info("finalization client failed. This may be expected if the" +
                 " test injected failures.", ex);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestBlockDeletionService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestBlockDeletionService.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature.HBASE_SUPPORT;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -32,8 +31,6 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -69,7 +66,6 @@ import org.mockito.ArgumentCaptor;
  * DeletionService test to Pass Usage from OM to SCM.
  */
 public class TestBlockDeletionService {
-  private static final String CLIENT_ID = UUID.randomUUID().toString();
   private static final String VOLUME_NAME = "vol1";
   private static final String BUCKET_NAME = "bucket1";
   private static final int KEY_SIZE = 5 * 1024; // 5 KB
@@ -142,16 +138,8 @@ public class TestBlockDeletionService {
     GenericTestUtils.waitFor(() -> metrics.getDeleteKeyFailedBlocks() - initialFailedBlocks == 0, 50, 1000);
 
     // UPGRADE SCM (if specified)
-    // Step 5: wait for finalizing upgrade
-    Future<?> finalizationFuture = Executors.newSingleThreadExecutor().submit(() -> {
-      try {
-        scmClient.finalizeScmUpgrade(CLIENT_ID);
-      } catch (IOException ex) {
-        fail("finalization client failed", ex);
-      }
-    });
-    finalizationFuture.get();
-    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient, CLIENT_ID);
+    scmClient.finalizeUpgrade();
+    TestHddsUpgradeUtils.waitForFinalizationFromClient(scmClient);
     assertEquals(STORAGE_SPACE_DISTRIBUTION.ordinal(),
         cluster.getStorageContainerManager().getLayoutVersionManager().getMetadataLayoutVersion());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The original scm finalize command blocked until SCM and enough datanodes had finalized. The new design is that the finalize command should kick off the finalize process and then return immediately. Any other process which needs to see the progress must call the finalize status command to see if it has completed or not.

This change adds a new protobuf message which triggers finalize and returns. There is a new "ozone admin upgrade finalize" command which triggers finalize.

The existing tests are adjusted so they call the new command and then poll the status command to see if finalize has completed or not.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14669

## How was this patch tested?

Existing integration tests modified to call the new flow.

Added a simple test to validate the new CLI command.