### PR TITLE
HDDS-15124. [Docs] Fix broken /docs/current/ links in CONTRIBUTING.md and dist/README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ cd hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone
 OZONE_REPLICATION_FACTOR=3 ./run.sh -d
 ```
 
-See more details in the [README](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/ozone/README.md) and in the [docs](https://ozone.apache.org/docs/current/start.html).
+See more details in the [README](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/ozone/README.md) and in the [docs](https://ozone.apache.org/docs/developer-guide/run/docker-compose/).
 
 ## Jira guideline
 

--- a/hadoop-ozone/dist/README.md
+++ b/hadoop-ozone/dist/README.md
@@ -30,7 +30,7 @@ docker-compose up -d
 ```
 
 More information can be found in the Getting Started Guide:
-* [Getting Started: Run Ozone with Docker Compose](https://ozone.apache.org/docs/current/start/runningviadocker.html)
+* [Getting Started: Run Ozone with Docker Compose](https://ozone.apache.org/docs/quick-start/installation/docker/)
 
 ## Testing on Kubernetes
 
@@ -38,8 +38,8 @@ More information can be found in the Getting Started Guide:
 ### Installation
 
 Please refer to the Getting Started guide for a couple of options for testing Ozone on Kubernetes:
-* [Getting Started: Minikube and Ozone](https://ozone.apache.org/docs/current/start/minikube.html)
-* [Getting Started: Ozone on Kubernetes](https://ozone.apache.org/docs/current/start/kubernetes.html)
+* [Getting Started: Minikube and Ozone](https://ozone.apache.org/docs/quick-start/installation/kubernetes/#minikube)
+* [Getting Started: Ozone on Kubernetes](https://ozone.apache.org/docs/quick-start/installation/kubernetes/)
 
 ### Monitoring
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updates four broken `https://ozone.apache.org/docs/current/...html` links that
404 after the docs site moved from Hugo to Docusaurus (the `current/` namespace
and `.html` suffix were dropped).

### URL mapping

| File:Line | Old URL | New URL |
|---|---|---|
| `CONTRIBUTING.md:78` | `…/docs/current/start.html` | `…/docs/developer-guide/run/docker-compose/` |
| `dist/README.md:33` | `…/docs/current/start/runningviadocker.html` | `…/docs/quick-start/installation/docker/` |
| `dist/README.md:41` | `…/docs/current/start/minikube.html` | `…/docs/quick-start/installation/kubernetes/#minikube` |
| `dist/README.md:42` | `…/docs/current/start/kubernetes.html` | `…/docs/quick-start/installation/kubernetes/` |

### Why these targets

The two files target different audiences, so the same "Docker Compose" topic
maps to different pages:

- **`CONTRIBUTING.md:78`** — Surrounding text walks contributors through
  building from source and running the in-tree compose. The dev-guide page
  documents that exact flow, opening with the same
  `cd ./hadoop-ozone/dist/target/ozone-<VERSION>/compose/ozone` command.

- **`dist/README.md:33,41,42`** — Both the link text (`"Getting Started: ..."`)
  and the surrounding intro (`"More information can be found in the Getting
  Started Guide:"`) explicitly invoke the Quick Start framing, so the URLs
  match those labels.

### Out of scope

- Other broken `…/docs/edge/...html` links and the OEP link on
  `CONTRIBUTING.md:98` — covered by **HDDS-14663 / apache/ozone-site#351**,
  which restores `/docs/edge/` as a frozen archive.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15124

## How was this patch tested?

- Verified each new URL exists in the apache/ozone-site Docusaurus source:
  - `docs/02-quick-start/01-installation/02-kubernetes.md` (with a `## Minikube`
    heading for the anchor)
  - `docs/08-developer-guide/02-run/02-docker-compose.md`
  - `docs/02-quick-start/01-installation/README.mdx`
- Markdown-only change; no code, config, or test files modified.
- `build-branch` CI on the fork: docs / RAT / checkstyle / PMD / findbugs /
  acceptance jobs all green. Two integration jobs hit known flakes:
  - `integration (recon)` cleared on rerun (transient).
  - `integration (hdds)` → `TestDeadNodeHandler.testOnMessage` is the failure
    tracked by **HDDS-14977** (Open).