### PR TITLE
HDDS-15136. Missing OZONE_WEBSITE_BUILD in update-ozone-site-config-doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ on:
       DEVELOCITY_ACCESS_KEY:
         description: 'Token for submitting build scan to Develocity'
         required: false
+      OZONE_WEBSITE_BUILD:
+        description: 'Token for publishing to apache/ozone-site'
+        required: false
       SONARCLOUD_TOKEN:
         description: 'Token for submitting coverage data to SonarCloud'
         required: false
@@ -156,6 +159,8 @@ jobs:
     uses: ./.github/workflows/update-ozone-site-config-doc.yml
     permissions:
       contents: read
+    secrets:
+      OZONE_WEBSITE_BUILD: ${{ secrets.OZONE_WEBSITE_BUILD }}
 
   compile:
     needs:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -30,4 +30,5 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      OZONE_WEBSITE_BUILD: ${{ secrets.OZONE_WEBSITE_BUILD }}
       SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -16,6 +16,10 @@
 name: update-ozone-site-config-doc
 on:
   workflow_call:
+    secrets:
+      OZONE_WEBSITE_BUILD:
+        description: 'Token for publishing to apache/ozone-site'
+        required: false
 
 env:
   BRANCH_NAME: automated-config-doc-update


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up for HDDS-14920: need to pass secret `OZONE_WEBSITE_BUILD` to `update-ozone-site-config-doc`:

```
fatal: Authentication failed for 'https://github.com/apache/ozone-site.git/'
```

https://github.com/apache/ozone/actions/runs/25061119884/job/73419058785#step:8:40

https://issues.apache.org/jira/browse/HDDS-15136