### PR TITLE
HDDS-10767. Reducing DatanodeDetails in the ContainerLocationCache

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -758,7 +758,7 @@ public class DatanodeDetails extends NodeImpl implements Comparable<DatanodeDeta
       this.id = details.id;
       this.ipAddress = details.getIpAddressAsByteString();
       this.hostName = details.getHostNameAsByteString();
-      this.networkName = details.getHostNameAsByteString();
+      this.networkName = details.getNetworkNameAsByteString();
       this.networkLocation = details.getNetworkLocationAsByteString();
       this.level = details.getLevel();
       this.ports = details.getPorts();

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4423,6 +4423,16 @@
   </property>
 
   <property>
+    <name>ozone.om.container.location.datanode.cache.size</name>
+    <value>10000</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      The size of the datanode details cache used to reduce duplicate datanode objects
+      retained by the container location cache in Ozone Manager.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.container.location.cache.ttl</name>
     <value>360m</value>
     <tag>OZONE, OM</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -547,6 +547,11 @@ public final class OMConfigKeys {
   public static final int OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE_DEFAULT
       = 100_000;
 
+  public static final String OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE
+      = "ozone.om.container.location.datanode.cache.size";
+  public static final int
+      OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE_DEFAULT = 10_000;
+
   public static final String OZONE_OM_CONTAINER_LOCATION_CACHE_TTL
       = "ozone.om.container.location.cache.ttl";
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -57,35 +57,34 @@ public class ScmClient {
   private final StorageContainerLocationProtocol containerClient;
   private final LoadingCache<Long, Pipeline> containerLocationCache;
   private final CacheMetrics containerCacheMetrics;
+  private final CacheMetrics datanodeDetailsCacheMetrics;
 
   ScmClient(ScmBlockLocationProtocol blockClient,
             StorageContainerLocationProtocol containerClient,
             OzoneConfiguration configuration) {
     this.containerClient = containerClient;
     this.blockClient = blockClient;
+    Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache =
+        createDatanodeDetailsCache(configuration);
     this.containerLocationCache =
-        createContainerLocationCache(configuration, containerClient);
+        createContainerLocationCache(configuration, containerClient,
+            datanodeDetailsCache);
     this.containerCacheMetrics = CacheMetrics.create(containerLocationCache,
         "ContainerInfo");
+    this.datanodeDetailsCacheMetrics = CacheMetrics.create(
+        datanodeDetailsCache, "DatanodeDetails");
   }
 
   static LoadingCache<Long, Pipeline> createContainerLocationCache(
       OzoneConfiguration configuration,
-      StorageContainerLocationProtocol containerClient) {
+      StorageContainerLocationProtocol containerClient,
+      Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache) {
     int maxSize = configuration.getInt(OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE,
         OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE_DEFAULT);
     TimeUnit unit =  OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getUnit();
     long ttl = configuration.getTimeDuration(
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL,
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getDuration(), unit);
-    int datanodeCacheMaxSize = configuration.getInt(
-        OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE,
-        OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE_DEFAULT);
-
-    final Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache =
-        CacheBuilder.newBuilder()
-            .maximumSize(datanodeCacheMaxSize)
-            .build();
     return CacheBuilder.newBuilder()
         .maximumSize(maxSize)
         .expireAfterWrite(ttl, unit)
@@ -112,6 +111,18 @@ public class ScmClient {
                 ));
           }
         });
+  }
+
+  static Cache<DatanodeID, DatanodeDetails> createDatanodeDetailsCache(
+      OzoneConfiguration configuration) {
+    int datanodeCacheMaxSize = configuration.getInt(
+        OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE,
+        OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE_DEFAULT);
+
+    return CacheBuilder.newBuilder()
+        .maximumSize(datanodeCacheMaxSize)
+        .recordStats()
+        .build();
   }
 
   static Pipeline newPipelineWithDNCache(Pipeline pipeline,
@@ -201,6 +212,7 @@ public class ScmClient {
 
   public void close() {
     containerCacheMetrics.unregister();
+    datanodeDetailsCacheMetrics.unregister();
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -21,7 +21,10 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATIO
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_TTL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE_DEFAULT;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.CacheLoader.InvalidCacheLoadException;
@@ -32,7 +35,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -76,9 +78,14 @@ public class ScmClient {
     long ttl = configuration.getTimeDuration(
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL,
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getDuration(), unit);
+    int datanodeCacheMaxSize = configuration.getInt(
+        OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE,
+        OZONE_OM_CONTAINER_LOCATION_DATANODE_CACHE_SIZE_DEFAULT);
 
-    final Map<DatanodeID, DatanodeDetails>
-        datanodeDetailsCache = new ConcurrentHashMap<>();
+    final Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(datanodeCacheMaxSize)
+            .build();
     return CacheBuilder.newBuilder()
         .maximumSize(maxSize)
         .expireAfterWrite(ttl, unit)
@@ -108,12 +115,12 @@ public class ScmClient {
   }
 
   static Pipeline newPipelineWithDNCache(Pipeline pipeline,
-      Map<DatanodeID, DatanodeDetails> datanodeDetailsCache) {
+      Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache) {
     Pipeline.Builder builder = pipeline.toBuilder();
     List<DatanodeDetails> nodes = new ArrayList<>();
     for (DatanodeDetails node : pipeline.getNodes()) {
       DatanodeDetails datanodeDetails =
-          datanodeDetailsCache.get(node.getID());
+          datanodeDetailsCache.getIfPresent(node.getID());
       // Call compareNodeValues to handle IP / hostname changes
       if (datanodeDetails != null && node.compareNodeValues(datanodeDetails)) {
         nodes.add(datanodeDetails);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +40,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
@@ -77,7 +77,7 @@ public class ScmClient {
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL,
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getDuration(), unit);
 
-    final Map<UUID, DatanodeDetails>
+    final Map<DatanodeID, DatanodeDetails>
         datanodeDetailsCache = new ConcurrentHashMap<>();
     return CacheBuilder.newBuilder()
         .maximumSize(maxSize)
@@ -108,16 +108,16 @@ public class ScmClient {
   }
 
   static Pipeline newPipelineWithDNCache(Pipeline pipeline,
-      Map<UUID, DatanodeDetails> datanodeDetailsCache) {
-    Pipeline.Builder builder = Pipeline.newBuilder(pipeline);
+      Map<DatanodeID, DatanodeDetails> datanodeDetailsCache) {
+    Pipeline.Builder builder = pipeline.toBuilder();
     List<DatanodeDetails> nodes = new ArrayList<>();
     for (DatanodeDetails node : pipeline.getNodes()) {
       DatanodeDetails datanodeDetails =
-          datanodeDetailsCache.get(node.getUuid());
-      if (node.equals(datanodeDetails)) {
+          datanodeDetailsCache.get(node.getID());
+      if (datanodeDetails != null && node.compareNodeValues(datanodeDetails)) {
         nodes.add(datanodeDetails);
       } else {
-        datanodeDetailsCache.put(node.getUuid(), node);
+        datanodeDetailsCache.put(node.getID(), node);
         nodes.add(node);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -114,6 +114,7 @@ public class ScmClient {
     for (DatanodeDetails node : pipeline.getNodes()) {
       DatanodeDetails datanodeDetails =
           datanodeDetailsCache.get(node.getID());
+      // Call compareNodeValues to handle IP / hostname changes
       if (datanodeDetails != null && node.compareNodeValues(datanodeDetails)) {
         nodes.add(datanodeDetails);
       } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -28,16 +28,19 @@ import com.google.common.cache.CacheLoader.InvalidCacheLoadException;
 import com.google.common.cache.LoadingCache;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
@@ -73,6 +76,9 @@ public class ScmClient {
     long ttl = configuration.getTimeDuration(
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL,
         OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getDuration(), unit);
+
+    final Map<UUID, DatanodeDetails>
+        datanodeDetailsCache = new ConcurrentHashMap<>();
     return CacheBuilder.newBuilder()
         .maximumSize(maxSize)
         .expireAfterWrite(ttl, unit)
@@ -81,7 +87,9 @@ public class ScmClient {
           @Nonnull
           @Override
           public Pipeline load(@Nonnull Long key) throws Exception {
-            return containerClient.getContainerWithPipeline(key).getPipeline();
+            Pipeline pipeline =
+                containerClient.getContainerWithPipeline(key).getPipeline();
+            return newPipelineWithDNCache(pipeline, datanodeDetailsCache);
           }
 
           @Nonnull
@@ -92,10 +100,29 @@ public class ScmClient {
                 .stream()
                 .collect(Collectors.toMap(
                     x -> x.getContainerInfo().getContainerID(),
-                    ContainerWithPipeline::getPipeline
+                    x -> newPipelineWithDNCache(x.getPipeline(),
+                        datanodeDetailsCache)
                 ));
           }
         });
+  }
+
+  static Pipeline newPipelineWithDNCache(Pipeline pipeline,
+      Map<UUID, DatanodeDetails> datanodeDetailsCache) {
+    Pipeline.Builder builder = Pipeline.newBuilder(pipeline);
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    for (DatanodeDetails node : pipeline.getNodes()) {
+      DatanodeDetails datanodeDetails =
+          datanodeDetailsCache.get(node.getUuid());
+      if (node.equals(datanodeDetails)) {
+        nodes.add(datanodeDetails);
+      } else {
+        datanodeDetailsCache.put(node.getUuid(), node);
+        nodes.add(node);
+      }
+    }
+    builder.setNodes(nodes);
+    return builder.build();
   }
 
   public ScmBlockLocationProtocol getBlockClient() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -174,22 +174,36 @@ public class TestScmClient {
   }
 
   @Test
+  public void testDatanodeDetailsCacheRecordsStats() {
+    Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache =
+        ScmClient.createDatanodeDetailsCache(new OzoneConfiguration());
+
+    datanodeDetailsCache.getIfPresent(DatanodeID.randomID());
+
+    assertEquals(1, datanodeDetailsCache.stats().missCount());
+  }
+
+  @Test
   public void testDatanodeDetailsCacheUpdatesIpAddressChange() {
     Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache =
         CacheBuilder.newBuilder().build();
     DatanodeDetails original = randomDatanode();
+    String originalIp = original.getIpAddress();
     DatanodeDetails updated = DatanodeDetails.newBuilder()
         .setDatanodeDetails(original)
         .setIpAddress("updated-ip")
         .build();
 
-    ScmClient.newPipelineWithDNCache(
+    Pipeline originalPipeline = ScmClient.newPipelineWithDNCache(
         createPipeline(1L, asList(original)).getPipeline(),
         datanodeDetailsCache);
     Pipeline refreshed = ScmClient.newPipelineWithDNCache(
         createPipeline(2L, asList(updated)).getPipeline(),
         datanodeDetailsCache);
 
+    assertSame(original, originalPipeline.getNodes().get(0));
+    assertEquals(originalIp, original.getIpAddress());
+    assertEquals(originalIp, originalPipeline.getNodes().get(0).getIpAddress());
     DatanodeDetails refreshedNode = refreshed.getNodes().get(0);
     assertSame(updated, refreshedNode);
     assertEquals("updated-ip", refreshedNode.getIpAddress());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.om;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static java.util.Arrays.asList;
 import static org.apache.hadoop.hdds.client.ReplicationConfig.fromTypeAndFactor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -106,9 +105,12 @@ public class TestScmClient {
       throws IOException {
 
     Map<Long, ContainerWithPipeline> actualLocations = new HashMap<>();
-
+    List<DatanodeDetails> dnList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      dnList.add(randomDatanode());
+    }
     for (long containerId : prepopulatedIds) {
-      ContainerWithPipeline pipeline = createPipeline(containerId);
+      ContainerWithPipeline pipeline = createPipeline(containerId, dnList);
       actualLocations.put(containerId, pipeline);
     }
 
@@ -128,7 +130,7 @@ public class TestScmClient {
     if (!expectedScmCallIds.isEmpty()) {
       List<ContainerWithPipeline> scmLocations = new ArrayList<>();
       for (long containerId : expectedScmCallIds) {
-        ContainerWithPipeline pipeline = createPipeline(containerId);
+        ContainerWithPipeline pipeline = createPipeline(containerId, dnList);
         scmLocations.add(pipeline);
         actualLocations.put(containerId, pipeline);
       }
@@ -166,13 +168,14 @@ public class TestScmClient {
     assertEquals(runtimeException, actualRt.getCause());
   }
 
-  ContainerWithPipeline createPipeline(long containerId) {
+  ContainerWithPipeline createPipeline(long containerId,
+                                       List<DatanodeDetails> dnList) {
     ContainerInfo containerInfo = new ContainerInfo.Builder()
         .setContainerID(containerId)
         .build();
     Pipeline pipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
-        .setNodes(asList(randomDatanode(), randomDatanode()))
+        .setNodes(dnList)
         .setReplicationConfig(fromTypeAndFactor(
             ReplicationType.RATIS, ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.OPEN)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -173,7 +175,8 @@ public class TestScmClient {
 
   @Test
   public void testDatanodeDetailsCacheUpdatesIpAddressChange() {
-    Map<DatanodeID, DatanodeDetails> datanodeDetailsCache = new HashMap<>();
+    Cache<DatanodeID, DatanodeDetails> datanodeDetailsCache =
+        CacheBuilder.newBuilder().build();
     DatanodeDetails original = randomDatanode();
     DatanodeDetails updated = DatanodeDetails.newBuilder()
         .setDatanodeDetails(original)
@@ -190,7 +193,7 @@ public class TestScmClient {
     DatanodeDetails refreshedNode = refreshed.getNodes().get(0);
     assertSame(updated, refreshedNode);
     assertEquals("updated-ip", refreshedNode.getIpAddress());
-    assertSame(updated, datanodeDetailsCache.get(original.getID()));
+    assertSame(updated, datanodeDetailsCache.getIfPresent(original.getID()));
   }
 
   ContainerWithPipeline createPipeline(long containerId,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -18,8 +18,10 @@
 package org.apache.hadoop.ozone.om;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Arrays.asList;
 import static org.apache.hadoop.hdds.client.ReplicationConfig.fromTypeAndFactor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -40,6 +42,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -166,6 +169,28 @@ public class TestScmClient {
     RuntimeException actualRt = assertThrows(RuntimeException.class,
         () -> scmClient.getContainerLocations(newHashSet(2L), false));
     assertEquals(runtimeException, actualRt.getCause());
+  }
+
+  @Test
+  public void testDatanodeDetailsCacheUpdatesIpAddressChange() {
+    Map<DatanodeID, DatanodeDetails> datanodeDetailsCache = new HashMap<>();
+    DatanodeDetails original = randomDatanode();
+    DatanodeDetails updated = DatanodeDetails.newBuilder()
+        .setDatanodeDetails(original)
+        .setIpAddress("updated-ip")
+        .build();
+
+    ScmClient.newPipelineWithDNCache(
+        createPipeline(1L, asList(original)).getPipeline(),
+        datanodeDetailsCache);
+    Pipeline refreshed = ScmClient.newPipelineWithDNCache(
+        createPipeline(2L, asList(updated)).getPipeline(),
+        datanodeDetailsCache);
+
+    DatanodeDetails refreshedNode = refreshed.getNodes().get(0);
+    assertSame(updated, refreshedNode);
+    assertEquals("updated-ip", refreshedNode.getIpAddress());
+    assertSame(updated, datanodeDetailsCache.get(original.getID()));
   }
 
   ContainerWithPipeline createPipeline(long containerId,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cache DatanodeDetails alongside ContainerLocationCache

Also fixed a regression on HDDS-10811 which seems to mistakenly set networkName to hostNameAsByteString.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10767

## How was this patch tested?

UT (Clean CI: https://github.com/ivandika3/ozone/actions/runs/25145879476)