### PR TITLE
HDDS-14578. Ozone admin command gives inconsistent error messages on expired keytab.

### DIFF
--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -25,6 +25,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.NoSuchFileException;
 import java.util.Map;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.util.ExitUtils;
@@ -88,18 +89,21 @@ public abstract class GenericCli implements GenericParentCommand {
 
   @Override
   public void printError(Throwable error) {
-    //message could be null in case of NPE. This is unexpected so we can
-    //print out the stack trace.
     final String rawMessage = error.getMessage();
     if (verbose || rawMessage == null || rawMessage.isEmpty()) {
       error.printStackTrace(cmd.getErr());
+      return;
+    }
+    String aclLine = HddsUtils.formatAccessControlExceptionLine(error);
+    if (aclLine != null) {
+      cmd.getErr().println(aclLine);
+      return;
+    }
+    if (error instanceof FileSystemException) {
+      String errorMessage = handleFileSystemException((FileSystemException) error);
+      cmd.getErr().println(errorMessage);
     } else {
-      if (error instanceof FileSystemException) {
-        String errorMessage = handleFileSystemException((FileSystemException) error);
-        cmd.getErr().println(errorMessage);
-      } else {
-        cmd.getErr().println(rawMessage.split("\n")[0]);
-      }
+      cmd.getErr().println(rawMessage.split("\n")[0]);
     }
   }
 

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -102,9 +102,9 @@ public abstract class GenericCli implements GenericParentCommand {
     if (error instanceof FileSystemException) {
       String errorMessage = handleFileSystemException((FileSystemException) error);
       cmd.getErr().println(errorMessage);
-    } else {
-      cmd.getErr().println(rawMessage.split("\n")[0]);
+      return;
     }
+    cmd.getErr().println(rawMessage.split("\n")[0]);
   }
 
   @Override

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -97,7 +97,7 @@ public abstract class GenericCli implements GenericParentCommand {
     String aclLine = HddsUtils.formatAccessControlExceptionLine(error);
     if (aclLine != null) {
       cmd.getErr().println(aclLine);
-      return;
+      ExitUtils.terminate(EXECUTION_ERROR_EXIT_CODE, aclLine, null);
     }
     if (error instanceof FileSystemException) {
       String errorMessage = handleFileSystemException((FileSystemException) error);

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -89,6 +89,8 @@ public abstract class GenericCli implements GenericParentCommand {
 
   @Override
   public void printError(Throwable error) {
+    //message could be null in case of NPE. This is unexpected so we can
+    //print out the stack trace.
     final String rawMessage = error.getMessage();
     if (verbose || rawMessage == null || rawMessage.isEmpty()) {
       error.printStackTrace(cmd.getErr());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -874,4 +874,26 @@ public final class HddsUtils {
     String scmServiceId = getScmServiceId(configuration);
     return getSCMNodeIds(configuration, scmServiceId);
   }
+
+  /**
+   * If {@code error} exposes an {@link AccessControlException} , returns one line error message.
+   */
+  public static String formatAccessControlExceptionLine(Throwable error) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      if (t instanceof AccessControlException) {
+        return t.toString();
+      }
+    }
+    String msg = error != null ? error.getMessage() : null;
+    if (msg != null) {
+      String marker = AccessControlException.class.getName() + ": ";
+      int i = msg.indexOf(marker);
+      if (i >= 0) {
+        int end = msg.indexOf('\n', i);
+        String line = end < 0 ? msg.substring(i) : msg.substring(i, end);
+        return line.trim();
+      }
+    }
+    return null;
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -413,26 +413,26 @@ public final class HAUtils {
     try {
       return retriableTask.call();
     } catch (Exception ex) {
-      if (containsAccessControlException(ex)) {
-        Throwable cause = ex;
-        while (cause != null && !(cause instanceof AccessControlException)) {
-          cause = cause.getCause();
-        }
-        throw new IOException(
-            cause != null ? cause.getMessage() : ex.getMessage(), ex);
+      AccessControlException ace = accessControlExceptionInCauseChain(ex);
+      if (ace != null) {
+        throw new IOException(ace.getMessage(), ex);
       }
       throw new SCMSecurityException("Unable to obtain complete CA list", ex);
     }
   }
 
-  private static boolean containsAccessControlException(Throwable e) {
+  private static AccessControlException accessControlExceptionInCauseChain(Throwable e) {
     while (e != null) {
       if (e instanceof AccessControlException) {
-        return true;
+        return (AccessControlException) e;
       }
       e = e.getCause();
     }
-    return false;
+    return null;
+  }
+
+  private static boolean containsAccessControlException(Throwable e) {
+    return accessControlExceptionInCauseChain(e) != null;
   }
 
   private static List<String> waitForCACerts(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -414,7 +414,12 @@ public final class HAUtils {
       return retriableTask.call();
     } catch (Exception ex) {
       if (containsAccessControlException(ex)) {
-        throw new AccessControlException();
+        Throwable cause = ex;
+        while (cause != null && !(cause instanceof AccessControlException)) {
+          cause = cause.getCause();
+        }
+        throw new IOException(
+            cause != null ? cause.getMessage() : ex.getMessage(), ex);
       }
       throw new SCMSecurityException("Unable to obtain complete CA list", ex);
     }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
@@ -122,7 +122,7 @@ public class SafeModeCheckSubcommand extends AbstractSubcommand implements Calla
 
       return null;
     } catch (IOException e) {
-      throw new IOException("Could not determine leader node", e);
+      throw new IOException("Could not determine leader node. " + e.getMessage(), e);
     }
   }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
@@ -171,8 +171,7 @@ public class SafeModeCheckSubcommand extends AbstractSubcommand implements Calla
         }
       }
     } catch (Exception e) {
-      System.out.printf("%s [%s]: ERROR: Failed to get safe mode status for SCM node: %s%n",
-          node.getScmClientAddress(), nodeId, e.getMessage());
+      rootCommand().printError(e);
     }
   }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -112,7 +112,7 @@ public class InfoSubcommand extends ScmSubcommand {
       container = scmClient.getContainerWithPipeline(containerID);
       Objects.requireNonNull(container, "Container cannot be null");
     } catch (IOException e) {
-      printError("Unable to retrieve the container details for " + containerID + ". " + e.getMessage());
+      rootCommand().printError(e);
       return;
     }
 
@@ -120,7 +120,7 @@ public class InfoSubcommand extends ScmSubcommand {
     try {
       replicas = scmClient.getContainerReplicas(containerID);
     } catch (IOException e) {
-      printError("Unable to retrieve the replica details: " + e.getMessage());
+      rootCommand().printError(e);
     }
 
     if (json) {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -64,10 +64,6 @@ public class InfoSubcommand extends ScmSubcommand {
 
   private boolean multiContainer = false;
 
-  private static boolean isAuthenticationFailure(Throwable t) {
-    return HddsUtils.formatAccessControlExceptionLine(t) != null;
-  }
-
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     // validate all container IDs and fail fast
@@ -81,9 +77,7 @@ public class InfoSubcommand extends ScmSubcommand {
       if (!first) {
         printBreak();
       }
-      if (printDetails(scmClient, containerID)) {
-        break;
-      }
+      printDetails(scmClient, containerID);
       first = false;
     }
     printFooter();
@@ -113,14 +107,14 @@ public class InfoSubcommand extends ScmSubcommand {
     }
   }
 
-  private boolean printDetails(ScmClient scmClient, long containerID) throws IOException {
+  private void printDetails(ScmClient scmClient, long containerID) throws IOException {
     final ContainerWithPipeline container;
     try {
       container = scmClient.getContainerWithPipeline(containerID);
       Objects.requireNonNull(container, "Container cannot be null");
     } catch (IOException e) {
       rootCommand().printError(e);
-      return isAuthenticationFailure(e);
+      return;
     }
 
     List<ContainerReplicaInfo> replicas = null;
@@ -128,9 +122,6 @@ public class InfoSubcommand extends ScmSubcommand {
       replicas = scmClient.getContainerReplicas(containerID);
     } catch (IOException e) {
       rootCommand().printError(e);
-      if (isAuthenticationFailure(e)) {
-        return true;
-      }
     }
 
     if (json) {
@@ -166,9 +157,9 @@ public class InfoSubcommand extends ScmSubcommand {
         if (SCMHAUtils.unwrapException(
             ioe) instanceof PipelineNotFoundException) {
           System.out.println("Write Pipeline State: CLOSED");
-        } else if (isAuthenticationFailure(ioe)) {
+        } else if (HddsUtils.formatAccessControlExceptionLine(ioe) != null) {
           rootCommand().printError(ioe);
-          return true;
+          return;
         } else {
           printError("Failed to retrieve pipeline info");
         }
@@ -191,7 +182,6 @@ public class InfoSubcommand extends ScmSubcommand {
         System.out.printf("Replicas: [%s]%n", replicaStr);
       }
     }
-    return false;
   }
 
   private static String buildDatanodeDetails(DatanodeDetails details) {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -63,6 +64,10 @@ public class InfoSubcommand extends ScmSubcommand {
 
   private boolean multiContainer = false;
 
+  private static boolean isAuthenticationFailure(Throwable t) {
+    return HddsUtils.formatAccessControlExceptionLine(t) != null;
+  }
+
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     // validate all container IDs and fail fast
@@ -76,7 +81,9 @@ public class InfoSubcommand extends ScmSubcommand {
       if (!first) {
         printBreak();
       }
-      printDetails(scmClient, containerID);
+      if (printDetails(scmClient, containerID)) {
+        break;
+      }
       first = false;
     }
     printFooter();
@@ -106,14 +113,14 @@ public class InfoSubcommand extends ScmSubcommand {
     }
   }
 
-  private void printDetails(ScmClient scmClient, long containerID) throws IOException {
+  private boolean printDetails(ScmClient scmClient, long containerID) throws IOException {
     final ContainerWithPipeline container;
     try {
       container = scmClient.getContainerWithPipeline(containerID);
       Objects.requireNonNull(container, "Container cannot be null");
     } catch (IOException e) {
       rootCommand().printError(e);
-      return;
+      return isAuthenticationFailure(e);
     }
 
     List<ContainerReplicaInfo> replicas = null;
@@ -121,6 +128,9 @@ public class InfoSubcommand extends ScmSubcommand {
       replicas = scmClient.getContainerReplicas(containerID);
     } catch (IOException e) {
       rootCommand().printError(e);
+      if (isAuthenticationFailure(e)) {
+        return true;
+      }
     }
 
     if (json) {
@@ -156,6 +166,9 @@ public class InfoSubcommand extends ScmSubcommand {
         if (SCMHAUtils.unwrapException(
             ioe) instanceof PipelineNotFoundException) {
           System.out.println("Write Pipeline State: CLOSED");
+        } else if (isAuthenticationFailure(ioe)) {
+          rootCommand().printError(ioe);
+          return true;
         } else {
           printError("Failed to retrieve pipeline info");
         }
@@ -178,6 +191,7 @@ public class InfoSubcommand extends ScmSubcommand {
         System.out.printf("Replicas: [%s]%n", replicaStr);
       }
     }
+    return false;
   }
 
   private static String buildDatanodeDetails(DatanodeDetails details) {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -112,7 +112,7 @@ public class InfoSubcommand extends ScmSubcommand {
       container = scmClient.getContainerWithPipeline(containerID);
       Objects.requireNonNull(container, "Container cannot be null");
     } catch (IOException e) {
-      printError("Unable to retrieve the container details for " + containerID + e.getMessage());
+      printError("Unable to retrieve the container details for " + containerID + ". " + e.getMessage());
       return;
     }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -112,7 +112,7 @@ public class InfoSubcommand extends ScmSubcommand {
       container = scmClient.getContainerWithPipeline(containerID);
       Objects.requireNonNull(container, "Container cannot be null");
     } catch (IOException e) {
-      printError("Unable to retrieve the container details for " + containerID);
+      printError("Unable to retrieve the container details for " + containerID + e.getMessage());
       return;
     }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
@@ -56,6 +56,16 @@ public class ReconcileSubcommand extends ScmSubcommand {
       description = "Display the reconciliation status of this container's replicas")
   private boolean status;
 
+  private enum StatusProcessing {
+    OK,
+    FAILED_CONTINUE,
+    FAILED_ABORT_AUTH
+  }
+
+  private static boolean isAuthenticationFailure(Throwable t) {
+    return HddsUtils.formatAccessControlExceptionLine(t) != null;
+  }
+
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     if (status) {
@@ -75,8 +85,13 @@ public class ReconcileSubcommand extends ScmSubcommand {
       // containers. If EC containers are given, print a  message to stderr and eventually exit non-zero, but continue
       // processing the remaining containers.
       for (Long containerID : containerIDs) {
-        if (!printReconciliationStatus(scmClient, containerID, arrayWriter, errorBuilder)) {
+        StatusProcessing outcome =
+            printReconciliationStatus(scmClient, containerID, arrayWriter, errorBuilder);
+        if (outcome != StatusProcessing.OK) {
           failureCount++;
+          if (outcome == StatusProcessing.FAILED_ABORT_AUTH) {
+            break;
+          }
         }
       }
       arrayWriter.flush();
@@ -94,20 +109,21 @@ public class ReconcileSubcommand extends ScmSubcommand {
     }
   }
 
-  private boolean printReconciliationStatus(ScmClient scmClient, long containerID, SequenceWriter arrayWriter,
-      StringBuilder errorBuilder) {
+  private StatusProcessing printReconciliationStatus(ScmClient scmClient, long containerID,
+                                                     SequenceWriter arrayWriter, StringBuilder errorBuilder) {
     try {
       ContainerInfo containerInfo = scmClient.getContainer(containerID);
       if (containerInfo.isOpen()) {
         errorBuilder.append("Cannot get status of container ").append(containerID)
             .append(". Reconciliation is not supported for open containers")
             .append(System.lineSeparator());
-        return false;
-      } else if (containerInfo.getReplicationType() != HddsProtos.ReplicationType.RATIS) {
+        return StatusProcessing.FAILED_CONTINUE;
+      }
+      if (containerInfo.getReplicationType() != HddsProtos.ReplicationType.RATIS) {
         errorBuilder.append("Cannot get status of container ").append(containerID)
             .append(". Reconciliation is only supported for Ratis replicated containers")
             .append(System.lineSeparator());
-        return false;
+        return StatusProcessing.FAILED_CONTINUE;
       }
       List<ContainerReplicaInfo> replicas = scmClient.getContainerReplicas(containerID);
       arrayWriter.write(new ContainerWrapper(containerInfo, replicas));
@@ -115,9 +131,11 @@ public class ReconcileSubcommand extends ScmSubcommand {
     } catch (Exception ex) {
       errorBuilder.append("Failed to get reconciliation status of container ")
           .append(containerID).append(": ").append(getExceptionMessage(ex)).append(System.lineSeparator());
-      return false;
+      return isAuthenticationFailure(ex)
+          ? StatusProcessing.FAILED_ABORT_AUTH
+          : StatusProcessing.FAILED_CONTINUE;
     }
-    return true;
+    return StatusProcessing.OK;
   }
 
   private void executeReconcile(ScmClient scmClient) {
@@ -131,6 +149,9 @@ public class ReconcileSubcommand extends ScmSubcommand {
       } catch (Exception ex) {
         System.err.println(getExceptionMessage(ex));
         failureCount++;
+        if (isAuthenticationFailure(ex)) {
+          break;
+        }
       }
     }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -128,8 +129,7 @@ public class ReconcileSubcommand extends ScmSubcommand {
         System.out.println("Reconciliation has been triggered for container " + containerID);
         successCount++;
       } catch (Exception ex) {
-        System.err.println("Failed to trigger reconciliation for container " + containerID + ": " +
-            getExceptionMessage(ex));
+        System.err.println(getExceptionMessage(ex));
         failureCount++;
       }
     }
@@ -150,7 +150,12 @@ public class ReconcileSubcommand extends ScmSubcommand {
    * display that to the user.
    */
   private String getExceptionMessage(Exception ex) {
+    String aclLine = HddsUtils.formatAccessControlExceptionLine(ex);
+    if (aclLine != null) {
+      return aclLine;
+    }
     return ex.getMessage().split("\n", 2)[0];
+
   }
 
   /**

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
@@ -58,8 +58,7 @@ public class ReconcileSubcommand extends ScmSubcommand {
 
   private enum StatusProcessing {
     OK,
-    FAILED_CONTINUE,
-    FAILED_ABORT_AUTH
+    FAILED_CONTINUE
   }
 
   private static boolean isAuthenticationFailure(Throwable t) {
@@ -89,9 +88,6 @@ public class ReconcileSubcommand extends ScmSubcommand {
             printReconciliationStatus(scmClient, containerID, arrayWriter, errorBuilder);
         if (outcome != StatusProcessing.OK) {
           failureCount++;
-          if (outcome == StatusProcessing.FAILED_ABORT_AUTH) {
-            break;
-          }
         }
       }
       arrayWriter.flush();
@@ -129,11 +125,13 @@ public class ReconcileSubcommand extends ScmSubcommand {
       arrayWriter.write(new ContainerWrapper(containerInfo, replicas));
       arrayWriter.flush();
     } catch (Exception ex) {
+      if (isAuthenticationFailure(ex)) {
+        rootCommand().printError(ex);
+      }
       errorBuilder.append("Failed to get reconciliation status of container ")
-          .append(containerID).append(": ").append(getExceptionMessage(ex)).append(System.lineSeparator());
-      return isAuthenticationFailure(ex)
-          ? StatusProcessing.FAILED_ABORT_AUTH
-          : StatusProcessing.FAILED_CONTINUE;
+          .append(containerID).append(": ").append(getExceptionMessage(ex))
+          .append(System.lineSeparator());
+      return StatusProcessing.FAILED_CONTINUE;
     }
     return StatusProcessing.OK;
   }
@@ -147,11 +145,8 @@ public class ReconcileSubcommand extends ScmSubcommand {
         System.out.println("Reconciliation has been triggered for container " + containerID);
         successCount++;
       } catch (Exception ex) {
-        System.err.println(getExceptionMessage(ex));
+        rootCommand().printError(ex);
         failureCount++;
-        if (isAuthenticationFailure(ex)) {
-          break;
-        }
       }
     }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
@@ -56,11 +56,6 @@ public class ReconcileSubcommand extends ScmSubcommand {
       description = "Display the reconciliation status of this container's replicas")
   private boolean status;
 
-  private enum StatusProcessing {
-    OK,
-    FAILED_CONTINUE
-  }
-
   private static boolean isAuthenticationFailure(Throwable t) {
     return HddsUtils.formatAccessControlExceptionLine(t) != null;
   }
@@ -84,9 +79,7 @@ public class ReconcileSubcommand extends ScmSubcommand {
       // containers. If EC containers are given, print a  message to stderr and eventually exit non-zero, but continue
       // processing the remaining containers.
       for (Long containerID : containerIDs) {
-        StatusProcessing outcome =
-            printReconciliationStatus(scmClient, containerID, arrayWriter, errorBuilder);
-        if (outcome != StatusProcessing.OK) {
+        if (!printReconciliationStatus(scmClient, containerID, arrayWriter, errorBuilder)) {
           failureCount++;
         }
       }
@@ -105,21 +98,21 @@ public class ReconcileSubcommand extends ScmSubcommand {
     }
   }
 
-  private StatusProcessing printReconciliationStatus(ScmClient scmClient, long containerID,
-                                                     SequenceWriter arrayWriter, StringBuilder errorBuilder) {
+  private boolean printReconciliationStatus(ScmClient scmClient, long containerID, SequenceWriter arrayWriter,
+                                             StringBuilder errorBuilder) {
     try {
       ContainerInfo containerInfo = scmClient.getContainer(containerID);
       if (containerInfo.isOpen()) {
         errorBuilder.append("Cannot get status of container ").append(containerID)
             .append(". Reconciliation is not supported for open containers")
             .append(System.lineSeparator());
-        return StatusProcessing.FAILED_CONTINUE;
+        return false;
       }
       if (containerInfo.getReplicationType() != HddsProtos.ReplicationType.RATIS) {
         errorBuilder.append("Cannot get status of container ").append(containerID)
             .append(". Reconciliation is only supported for Ratis replicated containers")
             .append(System.lineSeparator());
-        return StatusProcessing.FAILED_CONTINUE;
+        return false;
       }
       List<ContainerReplicaInfo> replicas = scmClient.getContainerReplicas(containerID);
       arrayWriter.write(new ContainerWrapper(containerInfo, replicas));
@@ -131,9 +124,9 @@ public class ReconcileSubcommand extends ScmSubcommand {
       errorBuilder.append("Failed to get reconciliation status of container ")
           .append(containerID).append(": ").append(getExceptionMessage(ex))
           .append(System.lineSeparator());
-      return StatusProcessing.FAILED_CONTINUE;
+      return false;
     }
-    return StatusProcessing.OK;
+    return true;
   }
 
   private void executeReconcile(ScmClient scmClient) {
@@ -166,12 +159,7 @@ public class ReconcileSubcommand extends ScmSubcommand {
    * display that to the user.
    */
   private String getExceptionMessage(Exception ex) {
-    String aclLine = HddsUtils.formatAccessControlExceptionLine(ex);
-    if (aclLine != null) {
-      return aclLine;
-    }
     return ex.getMessage().split("\n", 2)[0];
-
   }
 
   /**

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReconcileSubcommand.java
@@ -99,7 +99,7 @@ public class ReconcileSubcommand extends ScmSubcommand {
   }
 
   private boolean printReconciliationStatus(ScmClient scmClient, long containerID, SequenceWriter arrayWriter,
-                                             StringBuilder errorBuilder) {
+      StringBuilder errorBuilder) {
     try {
       ContainerInfo containerInfo = scmClient.getContainer(containerID);
       if (containerInfo.isOpen()) {

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/scm/RotateKeySubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/scm/RotateKeySubCommand.java
@@ -49,7 +49,7 @@ public class RotateKeySubCommand extends ScmSubcommand {
       try {
         status = client.rotateSecretKeys(force);
       } catch (IOException e) {
-        System.err.println("Secret key rotation failed: " + e.getMessage());
+        rootCommand().printError(e);
         return;
       }
       if (status) {

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -270,10 +270,7 @@ public class TestInfoSubCommand {
         .collect(Collectors.toList());
     assertEquals(0, replica.size());
 
-    Pattern p = Pattern.compile(
-        "^Unable to retrieve the replica details.*", Pattern.MULTILINE);
-    Matcher m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    assertThat(errContent.toString(DEFAULT_ENCODING)).contains("Error getting Replicas");
   }
 
   @Test

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReconcileSubcommand.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -61,6 +62,8 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaInfo;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.security.AccessControlException;
+import org.apache.ratis.util.ExitUtils;
+import org.apache.ratis.util.ExitUtils.ExitException;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +89,9 @@ public class TestReconcileSubcommand {
 
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
+  private static final class TestGenericCliRoot extends GenericCli {
+  }
+
   @BeforeEach
   public void setup() throws IOException {
     scmClient = mock(ScmClient.class);
@@ -94,6 +100,7 @@ public class TestReconcileSubcommand {
 
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+    ExitUtils.disableSystemExit();
   }
 
   @AfterEach
@@ -101,6 +108,7 @@ public class TestReconcileSubcommand {
     System.setOut(originalOut);
     System.setErr(originalErr);
     System.setIn(originalIn);
+    ExitUtils.clear();
   }
 
   @Test
@@ -331,10 +339,7 @@ public class TestReconcileSubcommand {
         new AccessControlException("Client cannot authenticate via:[KERBEROS]"));
     doThrow(authWrapped).when(scmClient).reconcileContainer(1L);
 
-    RuntimeException thrown =
-        assertThrows(RuntimeException.class, () -> executeReconcileFromArgs(1, 2));
-
-    assertThat(thrown.getMessage()).contains("Failed to trigger reconciliation for 1 container");
+    assertThrows(ExitException.class, () -> executeReconcileFromArgs(1, 2));
 
     verify(scmClient, times(1)).reconcileContainer(1L);
     verify(scmClient, never()).reconcileContainer(2L);
@@ -413,7 +418,13 @@ public class TestReconcileSubcommand {
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
 
     ReconcileSubcommand cmd = new ReconcileSubcommand();
-    new CommandLine(cmd).parseArgs(args);
+    TestGenericCliRoot root = new TestGenericCliRoot();
+    CommandLine commandLine = new CommandLine(root);
+    commandLine.addSubcommand("reconcile", cmd);
+    String[] fullArgs = new String[args.length + 1];
+    fullArgs[0] = "reconcile";
+    System.arraycopy(args, 0, fullArgs, 1, args.length);
+    commandLine.parseArgs(fullArgs);
     cmd.execute(scmClient);
   }
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReconcileSubcommand.java
@@ -232,7 +232,7 @@ public class TestReconcileSubcommand {
 
     RuntimeException exception = assertThrows(RuntimeException.class, () -> executeReconcileFromArgs(1));
 
-    assertThatOutput(errContent).contains("Failed to trigger reconciliation for container 1: " + mockMessage);
+    assertThatOutput(errContent).contains(mockMessage);
 
     assertThat(exception.getMessage()).contains("Failed to trigger reconciliation for 1 container");
 
@@ -302,8 +302,8 @@ public class TestReconcileSubcommand {
     });
 
     // Should have error messages for EC containers
-    assertThatOutput(errContent).contains("Failed to trigger reconciliation for container 1: " + EC_CONTAINER_MESSAGE);
-    assertThatOutput(errContent).contains("Failed to trigger reconciliation for container 3: " + EC_CONTAINER_MESSAGE);
+    assertThatOutput(errContent).contains(EC_CONTAINER_MESSAGE);
+    assertThatOutput(errContent).contains(EC_CONTAINER_MESSAGE);
     assertThatOutput(errContent).doesNotContain("Failed to trigger reconciliation for container 2");
 
     // Exception message should indicate 2 failed containers
@@ -367,7 +367,7 @@ public class TestReconcileSubcommand {
 
     assertThrows(RuntimeException.class, () -> parseArgsAndExecute("123", "456"));
     // Should have error message for unreachable container
-    assertThatOutput(errContent).contains("Failed to trigger reconciliation for container 456: " + exceptionMessage);
+    assertThatOutput(errContent).contains(exceptionMessage);
     assertThatOutput(errContent).doesNotContain("123");
     assertThatOutput(outContent).doesNotContain("Reconciliation has been triggered for container 456");
     validateReconcileOutput(123);

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReconcileSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReconcileSubcommand.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,6 +60,7 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaInfo;
 import org.apache.hadoop.hdds.server.JsonUtils;
+import org.apache.hadoop.security.AccessControlException;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -303,7 +306,6 @@ public class TestReconcileSubcommand {
 
     // Should have error messages for EC containers
     assertThatOutput(errContent).contains(EC_CONTAINER_MESSAGE);
-    assertThatOutput(errContent).contains(EC_CONTAINER_MESSAGE);
     assertThatOutput(errContent).doesNotContain("Failed to trigger reconciliation for container 2");
 
     // Exception message should indicate 2 failed containers
@@ -313,6 +315,33 @@ public class TestReconcileSubcommand {
     validateReconcileOutput(2);
     assertThatOutput(outContent).doesNotContain("container 1");
     assertThatOutput(outContent).doesNotContain("container 3");
+  }
+
+  /**
+   * Tests that the reconciliation loop terminates immediately upon an
+   * authentication failure.
+   */
+  @Test
+  public void testReconcileStopsAfterAuthenticationFailure() throws Exception {
+    mockContainer(1, 3, RatisReplicationConfig.getInstance(THREE), true);
+    mockContainer(2, 3, RatisReplicationConfig.getInstance(THREE), true);
+
+    IOException authWrapped = new IOException(
+        "RPC failed",
+        new AccessControlException("Client cannot authenticate via:[KERBEROS]"));
+    doThrow(authWrapped).when(scmClient).reconcileContainer(1L);
+
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> executeReconcileFromArgs(1, 2));
+
+    assertThat(thrown.getMessage()).contains("Failed to trigger reconciliation for 1 container");
+
+    verify(scmClient, times(1)).reconcileContainer(1L);
+    verify(scmClient, never()).reconcileContainer(2L);
+
+    assertThat(errContent.toString(DEFAULT_ENCODING))
+        .contains("AccessControlException")
+        .contains("Client cannot authenticate via:[KERBEROS]");
   }
 
   /**

--- a/hadoop-ozone/dist/src/main/smoketest/scmha/container-create.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/scmha/container-create.robot
@@ -21,4 +21,4 @@ Resource            ../lib/os.robot
 *** Test Cases ***
 Create container without kinit
     ${output} =         Execute And Ignore Error          ozone admin container create
-                        Should contain        ${output}   Permission denied
+                        Should contain        ${output}   Client cannot authenticate via:[KERBEROS]


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone admin command gives inconsistent error messages on expired keytab for the following commands.

1. ozone admin safemode status
2. ozone admin container create
3. ozone admin container info

```
bash-5.1$ ozone admin safemode status
Service ID: scmservice
Could not determine leader node
```
```
bash-5.1$ ozone admin container create
java.security.cert.CertificateException: org.apache.hadoop.security.AccessControlException: Permission denied.
```
```
~# ozone admin container info 69017
Unable to retrieve the container details for 69017
~# klist
Ticket cache: FILE:/tmp/krb5cc_0
Default principal: scm@example.COMValid starting       Expires              Service principal
01/30/2026 10:33:22  01/30/2026 20:33:22  krbtgt/example.COM@example.COM
        renew until 01/31/2026 10:33:10
~# date
Fri Feb  6 12:05:53 PM UTC 2026
root@ve1328:~# ozone admin scm roles
DestHost:destPort ve.example.com:9860 , LocalHost:localPort ve.example.com/10.xx:0. Failed on local exception: java.io.IOException: org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
root@ve1328:~# ozone admin container info 69017
Unable to retrieve the container details for 69017
~# kinit -kt scm.keytab scm
~# ozone admin container info 69017
Container id: 69017
Pipeline id: 3c8208ce-46ca-4435-8554-f07a58ec6bf7
Write PipelineId: 7a571825-4751-4876-a6ac-acc4c097f282
Write Pipeline State: CLOSED
Container State: CLOSED
```
Works again on renewing the Kerberos credentials

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14578
## How was this patch tested?
Manual test of ozone admin commands.

```
bash-5.1$ ozone admin container close 1
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin container report
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin om finalizeupgrade --service-id=omservice
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
bash-5.1$ ozone admin om lof
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
bash-5.1$ ozone admin om lok
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
bash-5.1$ ozone admin om roles
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
bash-5.1$ ozone admin datanode usageinfo --node-id=ba1d4f8a-1b59-4a12-80f8-d78e61a8f85
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin datanode status decommission
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin datanode decommission ba1d4f8a-1b59-4a12-80f8-d78e61a8f85
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin datanode maintenance ba1d4f8a-1b59-4a12-80f8-d78e61a8f85
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin datanode recommission ba1d4f8a-1b59-4a12-80f8-d78e61a8f85
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin containerbalancer start
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin containerbalancer status
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin safemode status
Service ID: scmservice
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin container create
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
```

### Reconcile command:
manula and unit test.
#### no keytab:
```
bash-5.1$ ozone admin container reconcile 1
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
bash-5.1$ ozone admin container reconcile 1 2 3
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
```
#### non ratis contianer: (failure not form authentication)
```
bash-5.1$ ozone admin container reconcile 1 2 3
Container #1 not found for reconciliation.
Container #2 not found for reconciliation.
Container #3 not found for reconciliation.
Failed to trigger reconciliation for 3 containers
bash-5.1$ ozone admin container create
Container 1 is created with replication config STANDALONE/ONE.
bash-5.1$ ozone admin container create
Container 2 is created with replication config STANDALONE/ONE.
bash-5.1$ ozone admin container create
Container 3 is created with replication config STANDALONE/ONE.
bash-5.1$ ozone admin container reconcile 1 2 3
Cannot reconcile container 1 in state OPEN.
Cannot reconcile container 2 in state OPEN.
Cannot reconcile container 3 in state OPEN.
Failed to trigger reconciliation for 3 containers
bash-5.1$ ozone admin container close 1
bash-5.1$ ozone admin container close 2
bash-5.1$ ozone admin container close 3
ozone admin container reconcile 1 2 3
Cannot reconcile container #1 with replication type STAND_ALONE. Reconciliation is currently only supported for Ratis containers.
Cannot reconcile container #2 with replication type STAND_ALONE. Reconciliation is currently only supported for Ratis containers.
Cannot reconcile container #3 with replication type STAND_ALONE. Reconciliation is currently only supported for Ratis containers.
Failed to trigger reconciliation for 3 containers
```
#### normal:
```
bash-5.1$ ozone admin container create -t RATIS -r THREE
ozone admin container create -t RATIS -r THREE
ozone admin container create -t RATIS -r THREE
Container 4 is created with replication config RATIS/THREE.
Container 5 is created with replication config RATIS/THREE.
Container 6 is created with replication config RATIS/THREE.
bash-5.1$ ozone admin container close 4 5 6
bash-5.1$ ozone admin container reconcile 4 5 6
Reconciliation has been triggered for container 4
Reconciliation has been triggered for container 5
Reconciliation has been triggered for container 6
```