### PR TITLE
HDDS-15067. Conditional CompleteMultipartUpload

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -951,6 +951,27 @@ public class OzoneBucket extends WithMetadata {
   }
 
   /**
+   * Complete Multipart upload with conditional write support.
+   * This will combine all the parts and make the key visible in ozone,
+   * but only if the specified preconditions are met.
+   *
+   * @param key key name
+   * @param uploadID multipart upload ID
+   * @param partsMap map of part numbers to ETags
+   * @param expectedDataGeneration expected data generation for conditional write
+   *        (use OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS for If-None-Match: *)
+   * @param expectedETag expected ETag for conditional write (for If-Match)
+   * @return OmMultipartUploadCompleteInfo
+   * @throws IOException if precondition fails or other I/O error occurs
+   */
+  public OmMultipartUploadCompleteInfo completeMultipartUpload(String key,
+      String uploadID, Map<Integer, String> partsMap,
+      Long expectedDataGeneration, String expectedETag) throws IOException {
+    return proxy.completeMultipartUpload(volumeName, name, key, uploadID,
+        partsMap, expectedDataGeneration, expectedETag);
+  }
+
+  /**
    * Abort multipart upload request.
    * @param keyName
    * @param uploadID

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -728,6 +728,27 @@ public interface ClientProtocol {
       Map<Integer, String> partsMap) throws IOException;
 
   /**
+   * Complete Multipart upload with conditional write support.
+   * This will combine all the parts and make the key visible in ozone,
+   * but only if the specified preconditions are met.
+   *
+   * @param volumeName volume name
+   * @param bucketName bucket name
+   * @param keyName key name
+   * @param uploadID multipart upload ID
+   * @param partsMap map of part numbers to ETags
+   * @param expectedDataGeneration expected data generation for conditional write
+   *        (use OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS for If-None-Match: *)
+   * @param expectedETag expected ETag for conditional write (for If-Match)
+   * @return OmMultipartUploadCompleteInfo
+   * @throws IOException if precondition fails or other I/O error occurs
+   */
+  OmMultipartUploadCompleteInfo completeMultipartUpload(String volumeName,
+      String bucketName, String keyName, String uploadID,
+      Map<Integer, String> partsMap,
+      Long expectedDataGeneration, String expectedETag) throws IOException;
+
+  /**
    * Abort Multipart upload request for the given key with given uploadID.
    * @param volumeName
    * @param bucketName

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2155,6 +2155,39 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public OmMultipartUploadCompleteInfo completeMultipartUpload(
+      String volumeName, String bucketName, String keyName, String uploadID,
+      Map<Integer, String> partsMap,
+      Long expectedDataGeneration, String expectedETag) throws IOException {
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
+    HddsClientUtils.checkNotNull(keyName, uploadID);
+    String ownerName = getRealUserInfo().getShortUserName();
+
+    OmKeyArgs.Builder builder = new OmKeyArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setMultipartUploadID(uploadID)
+        .setOwnerName(ownerName);
+
+    if (expectedDataGeneration != null) {
+      builder.setExpectedDataGeneration(expectedDataGeneration);
+    }
+    if (expectedETag != null) {
+      builder.setExpectedETag(expectedETag);
+    }
+
+    OmKeyArgs keyArgs = builder.build();
+
+    OmMultipartUploadCompleteList omMultipartUploadCompleteList =
+        new OmMultipartUploadCompleteList(partsMap);
+
+    return ozoneManagerClient.completeMultipartUpload(keyArgs,
+        omMultipartUploadCompleteList);
+  }
+
+  @Override
   public void abortMultipartUpload(String volumeName,
        String bucketName, String keyName, String uploadID) throws IOException {
     verifyVolumeName(volumeName);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1805,6 +1805,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
           OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
     }
 
+    if (omKeyArgs.getExpectedDataGeneration() != null) {
+      keyArgs.setExpectedDataGeneration(omKeyArgs.getExpectedDataGeneration());
+    }
+    if (omKeyArgs.getExpectedETag() != null) {
+      keyArgs.setExpectedETag(omKeyArgs.getExpectedETag());
+    }
+
     multipartUploadCompleteRequest.setKeyArgs(keyArgs.build());
     multipartUploadCompleteRequest.addAllPartsList(multipartUploadList
         .getPartsList());

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -656,6 +656,208 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
   }
 
   @Test
+  public void testCompleteMultipartUploadIfNoneMatch() throws Exception {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(bucketName);
+
+    // Initiate and complete multipart upload with If-None-Match: *
+    InitiateMultipartUploadRequest initRequest =
+        new InitiateMultipartUploadRequest(bucketName, keyName);
+    InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
+    String uploadId = initResponse.getUploadId();
+
+    // Upload a part
+    String partContent = "part1data";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartRequest uploadRequest = new UploadPartRequest()
+        .withBucketName(bucketName)
+        .withKey(keyName)
+        .withUploadId(uploadId)
+        .withPartNumber(1)
+        .withInputStream(new ByteArrayInputStream(partBytes))
+        .withPartSize(partBytes.length);
+    UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
+
+    // Complete with If-None-Match: * (key doesn't exist, should succeed)
+    List<PartETag> partETags = Collections.singletonList(uploadResult.getPartETag());
+    CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+        bucketName, keyName, uploadId, partETags);
+    completeRequest.putCustomRequestHeader("If-None-Match", "*");
+
+    CompleteMultipartUploadResult result = s3Client.completeMultipartUpload(completeRequest);
+    assertNotNull(result.getETag());
+
+    // Verify object was created
+    assertTrue(s3Client.doesObjectExist(bucketName, keyName));
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfNoneMatchFail() throws Exception {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(bucketName);
+
+    // First, create an existing key
+    s3Client.putObject(bucketName, keyName,
+        new ByteArrayInputStream("existing".getBytes(StandardCharsets.UTF_8)),
+        new ObjectMetadata());
+
+    // Initiate multipart upload for same key
+    InitiateMultipartUploadRequest initRequest =
+        new InitiateMultipartUploadRequest(bucketName, keyName);
+    InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
+    String uploadId = initResponse.getUploadId();
+
+    // Upload a part
+    String partContent = "part1data";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartRequest uploadRequest = new UploadPartRequest()
+        .withBucketName(bucketName)
+        .withKey(keyName)
+        .withUploadId(uploadId)
+        .withPartNumber(1)
+        .withInputStream(new ByteArrayInputStream(partBytes))
+        .withPartSize(partBytes.length);
+    UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
+
+    // Complete with If-None-Match: * (key exists, should fail)
+    List<PartETag> partETags = Collections.singletonList(uploadResult.getPartETag());
+    CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+        bucketName, keyName, uploadId, partETags);
+    completeRequest.putCustomRequestHeader("If-None-Match", "*");
+
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.completeMultipartUpload(completeRequest));
+
+    assertEquals(ErrorType.Client, ase.getErrorType());
+    assertEquals(412, ase.getStatusCode());
+    assertEquals("PreconditionFailed", ase.getErrorCode());
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfMatch() throws Exception {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(bucketName);
+
+    // First, create an existing key and get its ETag
+    PutObjectResult existingResult = s3Client.putObject(bucketName, keyName,
+        new ByteArrayInputStream("existing".getBytes(StandardCharsets.UTF_8)),
+        new ObjectMetadata());
+    String existingETag = existingResult.getETag();
+
+    // Initiate multipart upload for same key
+    InitiateMultipartUploadRequest initRequest =
+        new InitiateMultipartUploadRequest(bucketName, keyName);
+    InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
+    String uploadId = initResponse.getUploadId();
+
+    // Upload a part
+    String partContent = "newcontent";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartRequest uploadRequest = new UploadPartRequest()
+        .withBucketName(bucketName)
+        .withKey(keyName)
+        .withUploadId(uploadId)
+        .withPartNumber(1)
+        .withInputStream(new ByteArrayInputStream(partBytes))
+        .withPartSize(partBytes.length);
+    UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
+
+    // Complete with If-Match: <existingETag> (should succeed)
+    List<PartETag> partETags = Collections.singletonList(uploadResult.getPartETag());
+    CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+        bucketName, keyName, uploadId, partETags);
+    completeRequest.putCustomRequestHeader("If-Match", "\"" + existingETag + "\"");
+
+    CompleteMultipartUploadResult result = s3Client.completeMultipartUpload(completeRequest);
+    assertNotNull(result.getETag());
+    assertNotEquals(existingETag, stripQuotes(result.getETag()));
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfMatchFail() throws Exception {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(bucketName);
+
+    // First, create an existing key
+    s3Client.putObject(bucketName, keyName,
+        new ByteArrayInputStream("existing".getBytes(StandardCharsets.UTF_8)),
+        new ObjectMetadata());
+
+    // Initiate multipart upload for same key
+    InitiateMultipartUploadRequest initRequest =
+        new InitiateMultipartUploadRequest(bucketName, keyName);
+    InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
+    String uploadId = initResponse.getUploadId();
+
+    // Upload a part
+    String partContent = "newcontent";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartRequest uploadRequest = new UploadPartRequest()
+        .withBucketName(bucketName)
+        .withKey(keyName)
+        .withUploadId(uploadId)
+        .withPartNumber(1)
+        .withInputStream(new ByteArrayInputStream(partBytes))
+        .withPartSize(partBytes.length);
+    UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
+
+    // Complete with If-Match: wrong-etag (should fail)
+    List<PartETag> partETags = Collections.singletonList(uploadResult.getPartETag());
+    CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+        bucketName, keyName, uploadId, partETags);
+    completeRequest.putCustomRequestHeader("If-Match", "\"wrong-etag\"");
+
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.completeMultipartUpload(completeRequest));
+
+    assertEquals(ErrorType.Client, ase.getErrorType());
+    assertEquals(412, ase.getStatusCode());
+    assertEquals("PreconditionFailed", ase.getErrorCode());
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfMatchMissingKeyFail() throws Exception {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(bucketName);
+
+    // Initiate multipart upload (key doesn't exist)
+    InitiateMultipartUploadRequest initRequest =
+        new InitiateMultipartUploadRequest(bucketName, keyName);
+    InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(initRequest);
+    String uploadId = initResponse.getUploadId();
+
+    // Upload a part
+    String partContent = "newcontent";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartRequest uploadRequest = new UploadPartRequest()
+        .withBucketName(bucketName)
+        .withKey(keyName)
+        .withUploadId(uploadId)
+        .withPartNumber(1)
+        .withInputStream(new ByteArrayInputStream(partBytes))
+        .withPartSize(partBytes.length);
+    UploadPartResult uploadResult = s3Client.uploadPart(uploadRequest);
+
+    // Complete with If-Match on non-existent key (should fail)
+    List<PartETag> partETags = Collections.singletonList(uploadResult.getPartETag());
+    CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+        bucketName, keyName, uploadId, partETags);
+    completeRequest.putCustomRequestHeader("If-Match", "\"some-etag\"");
+
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.completeMultipartUpload(completeRequest));
+
+    assertEquals(ErrorType.Client, ase.getErrorType());
+    assertEquals(412, ase.getStatusCode());
+    assertEquals("PreconditionFailed", ase.getErrorCode());
+  }
+
+  @Test
   public void testPutDoubleSlashPrefixObject() throws IOException {
     final String bucketName = getBucketName();
     final String keyName = "//dir1";

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -644,6 +644,217 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
   }
 
   @Test
+  public void testCompleteMultipartUploadIfNoneMatch() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    // Initiate multipart upload
+    CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName));
+    String uploadId = createResponse.uploadId();
+
+    // Upload a part
+    String partContent = "part1data";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartResponse partResponse = s3Client.uploadPart(b -> b
+            .bucket(bucketName)
+            .key(keyName)
+            .uploadId(uploadId)
+            .partNumber(1),
+        RequestBody.fromBytes(partBytes));
+
+    // Complete with If-None-Match: * (key doesn't exist, should succeed)
+    CompletedPart completedPart = CompletedPart.builder()
+        .partNumber(1)
+        .eTag(partResponse.eTag())
+        .build();
+
+    CompleteMultipartUploadResponse result = s3Client.completeMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName)
+        .uploadId(uploadId)
+        .ifNoneMatch("*")
+        .multipartUpload(CompletedMultipartUpload.builder().parts(completedPart).build()));
+
+    assertNotNull(result.eTag());
+
+    // Verify object was created
+    assertDoesNotThrow(() -> s3Client.headObject(b -> b.bucket(bucketName).key(keyName)));
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfNoneMatchFail() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    // First, create an existing key
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName),
+        RequestBody.fromString("existing"));
+
+    // Initiate multipart upload for same key
+    CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName));
+    String uploadId = createResponse.uploadId();
+
+    // Upload a part
+    String partContent = "part1data";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartResponse partResponse = s3Client.uploadPart(b -> b
+            .bucket(bucketName)
+            .key(keyName)
+            .uploadId(uploadId)
+            .partNumber(1),
+        RequestBody.fromBytes(partBytes));
+
+    // Complete with If-None-Match: * (key exists, should fail)
+    CompletedPart completedPart = CompletedPart.builder()
+        .partNumber(1)
+        .eTag(partResponse.eTag())
+        .build();
+
+    S3Exception exception = assertThrows(S3Exception.class, () -> s3Client.completeMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName)
+        .uploadId(uploadId)
+        .ifNoneMatch("*")
+        .multipartUpload(CompletedMultipartUpload.builder().parts(completedPart).build())));
+
+    assertEquals(412, exception.statusCode());
+    assertEquals("PreconditionFailed", exception.awsErrorDetails().errorCode());
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfMatch() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    // First, create an existing key and get its ETag
+    PutObjectResponse existingResult = s3Client.putObject(
+        b -> b.bucket(bucketName).key(keyName),
+        RequestBody.fromString("existing"));
+    String existingETag = existingResult.eTag();
+
+    // Initiate multipart upload for same key
+    CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName));
+    String uploadId = createResponse.uploadId();
+
+    // Upload a part
+    String partContent = "newcontent";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartResponse partResponse = s3Client.uploadPart(b -> b
+            .bucket(bucketName)
+            .key(keyName)
+            .uploadId(uploadId)
+            .partNumber(1),
+        RequestBody.fromBytes(partBytes));
+
+    // Complete with If-Match: <existingETag> (should succeed)
+    CompletedPart completedPart = CompletedPart.builder()
+        .partNumber(1)
+        .eTag(partResponse.eTag())
+        .build();
+
+    CompleteMultipartUploadResponse result = s3Client.completeMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName)
+        .uploadId(uploadId)
+        .ifMatch(existingETag)
+        .multipartUpload(CompletedMultipartUpload.builder().parts(completedPart).build()));
+
+    assertNotNull(result.eTag());
+    assertNotEquals(existingETag, result.eTag());
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfMatchFail() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    // First, create an existing key
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName),
+        RequestBody.fromString("existing"));
+
+    // Initiate multipart upload for same key
+    CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName));
+    String uploadId = createResponse.uploadId();
+
+    // Upload a part
+    String partContent = "newcontent";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartResponse partResponse = s3Client.uploadPart(b -> b
+            .bucket(bucketName)
+            .key(keyName)
+            .uploadId(uploadId)
+            .partNumber(1),
+        RequestBody.fromBytes(partBytes));
+
+    // Complete with If-Match: wrong-etag (should fail)
+    CompletedPart completedPart = CompletedPart.builder()
+        .partNumber(1)
+        .eTag(partResponse.eTag())
+        .build();
+
+    S3Exception exception = assertThrows(S3Exception.class, () -> s3Client.completeMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName)
+        .uploadId(uploadId)
+        .ifMatch("\"wrong-etag\"")
+        .multipartUpload(CompletedMultipartUpload.builder().parts(completedPart).build())));
+
+    assertEquals(412, exception.statusCode());
+    assertEquals("PreconditionFailed", exception.awsErrorDetails().errorCode());
+  }
+
+  @Test
+  public void testCompleteMultipartUploadIfMatchMissingKeyFail() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    // Initiate multipart upload (key doesn't exist)
+    CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName));
+    String uploadId = createResponse.uploadId();
+
+    // Upload a part
+    String partContent = "newcontent";
+    byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
+    UploadPartResponse partResponse = s3Client.uploadPart(b -> b
+            .bucket(bucketName)
+            .key(keyName)
+            .uploadId(uploadId)
+            .partNumber(1),
+        RequestBody.fromBytes(partBytes));
+
+    // Complete with If-Match on non-existent key (should fail)
+    CompletedPart completedPart = CompletedPart.builder()
+        .partNumber(1)
+        .eTag(partResponse.eTag())
+        .build();
+
+    S3Exception exception = assertThrows(S3Exception.class, () -> s3Client.completeMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName)
+        .uploadId(uploadId)
+        .ifMatch("\"some-etag\"")
+        .multipartUpload(CompletedMultipartUpload.builder().parts(completedPart).build())));
+
+    assertEquals(412, exception.statusCode());
+    assertEquals("PreconditionFailed", exception.awsErrorDetails().errorCode());
+  }
+
+  @Test
   public void testListObjectsMany() throws Exception {
     testListObjectsMany(false);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -3936,6 +3936,159 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
   }
 
   @Test
+  public void testConditionalCompleteMultipartUploadIfNoneMatch() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    // Initiate and upload part
+    String uploadID = initiateMultipartUpload(bucket, keyName, anyReplication());
+    byte[] data = generateData(5 * 1024 * 1024, (byte) 97);
+    Pair<String, String> partInfo = uploadPart(bucket, keyName, uploadID, 1, data);
+
+    Map<Integer, String> partsMap = new LinkedHashMap<>();
+    partsMap.put(1, partInfo.getValue());
+
+    // Complete with If-None-Match semantics (key doesn't exist, should succeed)
+    OmMultipartUploadCompleteInfo result = bucket.completeMultipartUpload(
+        keyName, uploadID, partsMap,
+        EXPECTED_GEN_CREATE_IF_NOT_EXISTS, null);
+
+    assertNotNull(result);
+    assertEquals(keyName, result.getKey());
+    assertNotNull(result.getHash());
+
+    // Verify object exists
+    OzoneKeyDetails keyDetails = bucket.getKey(keyName);
+    assertNotNull(keyDetails);
+  }
+
+  @Test
+  public void testConditionalCompleteMultipartUploadIfNoneMatchFail() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    // First, create an existing key
+    createTestKey(bucket, keyName, "existing content");
+
+    // Initiate and upload part for same key
+    String uploadID = initiateMultipartUpload(bucket, keyName, anyReplication());
+    byte[] data = generateData(5 * 1024 * 1024, (byte) 97);
+    Pair<String, String> partInfo = uploadPart(bucket, keyName, uploadID, 1, data);
+
+    Map<Integer, String> partsMap = new LinkedHashMap<>();
+    partsMap.put(1, partInfo.getValue());
+
+    // Complete with If-None-Match semantics (key exists, should fail)
+    OMException omEx = assertThrows(OMException.class,
+        () -> bucket.completeMultipartUpload(keyName, uploadID, partsMap,
+            EXPECTED_GEN_CREATE_IF_NOT_EXISTS, null));
+
+    assertEquals(KEY_ALREADY_EXISTS, omEx.getResult());
+  }
+
+  @Test
+  public void testConditionalCompleteMultipartUploadIfMatch() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    // First, create an existing key with ETag
+    OzoneKeyDetails existingKey = createTestKeyWithETag(bucket, keyName, "existing content");
+    String existingETag = existingKey.getMetadata().get(ETAG);
+    assertNotNull(existingETag);
+
+    // Initiate and upload part for same key
+    String uploadID = initiateMultipartUpload(bucket, keyName, anyReplication());
+    byte[] data = generateData(5 * 1024 * 1024, (byte) 97);
+    Pair<String, String> partInfo = uploadPart(bucket, keyName, uploadID, 1, data);
+
+    Map<Integer, String> partsMap = new LinkedHashMap<>();
+    partsMap.put(1, partInfo.getValue());
+
+    // Complete with If-Match semantics (ETag matches, should succeed)
+    OmMultipartUploadCompleteInfo result = bucket.completeMultipartUpload(
+        keyName, uploadID, partsMap, null, existingETag);
+
+    assertNotNull(result);
+    assertEquals(keyName, result.getKey());
+    assertNotNull(result.getHash());
+  }
+
+  @Test
+  public void testConditionalCompleteMultipartUploadIfMatchFail() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    // First, create an existing key with ETag
+    createTestKeyWithETag(bucket, keyName, "existing content");
+
+    // Initiate and upload part for same key
+    String uploadID = initiateMultipartUpload(bucket, keyName, anyReplication());
+    byte[] data = generateData(5 * 1024 * 1024, (byte) 97);
+    Pair<String, String> partInfo = uploadPart(bucket, keyName, uploadID, 1, data);
+
+    Map<Integer, String> partsMap = new LinkedHashMap<>();
+    partsMap.put(1, partInfo.getValue());
+
+    // Complete with If-Match semantics (wrong ETag, should fail)
+    OMException omEx = assertThrows(OMException.class,
+        () -> bucket.completeMultipartUpload(keyName, uploadID, partsMap,
+            null, "wrong-etag"));
+
+    assertEquals(ETAG_MISMATCH, omEx.getResult());
+  }
+
+  @Test
+  public void testConditionalCompleteMultipartUploadIfMatchMissingKeyFail() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    // Initiate and upload part (key doesn't exist)
+    String uploadID = initiateMultipartUpload(bucket, keyName, anyReplication());
+    byte[] data = generateData(5 * 1024 * 1024, (byte) 97);
+    Pair<String, String> partInfo = uploadPart(bucket, keyName, uploadID, 1, data);
+
+    Map<Integer, String> partsMap = new LinkedHashMap<>();
+    partsMap.put(1, partInfo.getValue());
+
+    // Complete with If-Match on non-existent key (should fail)
+    OMException omEx = assertThrows(OMException.class,
+        () -> bucket.completeMultipartUpload(keyName, uploadID, partsMap,
+            null, "some-etag"));
+
+    assertEquals(KEY_NOT_FOUND, omEx.getResult());
+  }
+
+  @Test
   public void testAbortUploadSuccessWithOutAnyParts() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
@@ -4615,6 +4768,13 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     metadata.put(ETAG, UUID.randomUUID().toString());
     return createTestKey(bucket, getTestName(),
         UUID.randomUUID().toString().getBytes(UTF_8), metadata);
+  }
+
+  private OzoneKeyDetails createTestKeyWithETag(OzoneBucket bucket,
+      String keyName, String content) throws IOException {
+    Map<String, String> metadata = createTestKeyMetadata();
+    metadata.put(ETAG, UUID.randomUUID().toString());
+    return createTestKey(bucket, keyName, content.getBytes(UTF_8), metadata);
   }
 
   private static Map<String, String> createTestKeyMetadata() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -476,56 +476,6 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     return req;
   }
 
-  protected void validateAtomicRewrite(OmKeyInfo dbKeyInfo, KeyArgs keyArgs)
-      throws OMException {
-    if (keyArgs.hasExpectedDataGeneration()) {
-      long expectedGen = keyArgs.getExpectedDataGeneration();
-      // If expectedGen is EXPECTED_GEN_CREATE_IF_NOT_EXISTS, it means the key MUST NOT exist (If-None-Match)
-      if (expectedGen == OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
-        if (dbKeyInfo != null) {
-          throw new OMException("Key already exists",
-              OMException.ResultCodes.KEY_ALREADY_EXISTS);
-        }
-      } else {
-        // If a key does not exist, or if it exists but the updateID do not match, then fail this request.
-        if (dbKeyInfo == null) {
-          throw new OMException("Key not found during expected rewrite", OMException.ResultCodes.KEY_NOT_FOUND);
-        }
-        if (dbKeyInfo.getUpdateID() != expectedGen) {
-          throw new OMException("Generation mismatch during expected rewrite",
-              OMException.ResultCodes.KEY_NOT_FOUND);
-        }
-      }
-    }
-
-  }
-
-  protected KeyArgs validateAndRewriteIfMatchAsExpectedGeneration(
-      KeyArgs keyArgs, OmKeyInfo dbKeyInfo) throws OMException {
-    if (!keyArgs.hasExpectedETag()) {
-      return keyArgs;
-    }
-
-    String expectedETag = keyArgs.getExpectedETag();
-    if (dbKeyInfo == null) {
-      throw new OMException("Key not found for If-Match",
-          OMException.ResultCodes.KEY_NOT_FOUND);
-    }
-    if (!dbKeyInfo.hasEtag()) {
-      throw new OMException("Key does not have an ETag",
-          OMException.ResultCodes.ETAG_NOT_AVAILABLE);
-    }
-    if (!dbKeyInfo.isEtagEquals(expectedETag)) {
-      throw new OMException("ETag mismatch",
-          OMException.ResultCodes.ETAG_MISMATCH);
-    }
-    if (keyArgs.hasExpectedDataGeneration()) {
-      return keyArgs;
-    }
-
-    return keyArgs.toBuilder()
-        .setExpectedDataGeneration(dbKeyInfo.getUpdateID())
-        .clearExpectedETag()
-        .build();
-  }
+  // validateAtomicRewrite() and validateAndRewriteIfMatchAsExpectedGeneration()
+  // are inherited from OMKeyRequest base class
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -475,7 +475,4 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     }
     return req;
   }
-
-  // validateAtomicRewrite() and validateAndRewriteIfMatchAsExpectedGeneration()
-  // are inherited from OMKeyRequest base class
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1347,21 +1347,19 @@ public abstract class OMKeyRequest extends OMClientRequest {
   }
 
   /**
-   * Validates If-Match ETag condition and converts it to expectedDataGeneration.
+   * Validates If-Match ETag condition.
    * <p>
    * This method checks if the existing key's ETag matches the expected ETag.
-   * If it matches, the ETag condition is converted to a generation-based condition
-   * for atomic commit validation.
+   * Use this for single-phase operations (like MPU complete) where no rewrite is needed.
    *
    * @param keyArgs the key arguments containing expected ETag
    * @param dbKeyInfo the existing key info from the database
-   * @return updated KeyArgs with expectedDataGeneration set (if ETag matched)
    * @throws OMException if validation fails
    */
-  protected KeyArgs validateAndRewriteIfMatchAsExpectedGeneration(
-      KeyArgs keyArgs, OmKeyInfo dbKeyInfo) throws OMException {
+  protected void validateIfMatchETag(KeyArgs keyArgs, OmKeyInfo dbKeyInfo)
+      throws OMException {
     if (!keyArgs.hasExpectedETag()) {
-      return keyArgs;
+      return;
     }
 
     String expectedETag = keyArgs.getExpectedETag();
@@ -1377,7 +1375,25 @@ public abstract class OMKeyRequest extends OMClientRequest {
       throw new OMException("ETag mismatch",
           OMException.ResultCodes.ETAG_MISMATCH);
     }
-    if (keyArgs.hasExpectedDataGeneration()) {
+  }
+
+  /**
+   * Validates If-Match ETag condition and converts it to expectedDataGeneration.
+   * <p>
+   * This method checks if the existing key's ETag matches the expected ETag.
+   * If it matches, the ETag condition is converted to a generation-based condition
+   * for atomic commit validation in two-phase operations (CreateKey → CommitKey).
+   *
+   * @param keyArgs the key arguments containing expected ETag
+   * @param dbKeyInfo the existing key info from the database
+   * @return updated KeyArgs with expectedDataGeneration set (if ETag matched)
+   * @throws OMException if validation fails
+   */
+  protected KeyArgs validateAndRewriteIfMatchAsExpectedGeneration(
+      KeyArgs keyArgs, OmKeyInfo dbKeyInfo) throws OMException {
+    validateIfMatchETag(keyArgs, dbKeyInfo);
+
+    if (!keyArgs.hasExpectedETag() || keyArgs.hasExpectedDataGeneration()) {
       return keyArgs;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1309,4 +1309,81 @@ public abstract class OMKeyRequest extends OMClientRequest {
           keyArgs.getKeyName() + " in encrypted bucket " + keyArgs.getBucketName(), INVALID_REQUEST);
     }
   }
+
+  /**
+   * Validates atomic rewrite conditions for conditional writes.
+   * <p>
+   * For If-None-Match: * (expectedDataGeneration = EXPECTED_GEN_CREATE_IF_NOT_EXISTS),
+   * the key must NOT exist.
+   * <p>
+   * For If-Match with a specific generation, the key must exist with matching updateID.
+   *
+   * @param dbKeyInfo the existing key info from the database (null if key doesn't exist)
+   * @param keyArgs the key arguments containing expected generation
+   * @throws OMException if validation fails
+   */
+  protected void validateAtomicRewrite(OmKeyInfo dbKeyInfo, KeyArgs keyArgs)
+      throws OMException {
+    if (keyArgs.hasExpectedDataGeneration()) {
+      long expectedGen = keyArgs.getExpectedDataGeneration();
+      // If expectedGen is EXPECTED_GEN_CREATE_IF_NOT_EXISTS, it means the key MUST NOT exist (If-None-Match)
+      if (expectedGen == OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+        if (dbKeyInfo != null) {
+          throw new OMException("Key already exists",
+              OMException.ResultCodes.KEY_ALREADY_EXISTS);
+        }
+      } else {
+        // If a key does not exist, or if it exists but the updateID do not match, then fail this request.
+        if (dbKeyInfo == null) {
+          throw new OMException("Key not found during expected rewrite",
+              OMException.ResultCodes.KEY_NOT_FOUND);
+        }
+        if (dbKeyInfo.getUpdateID() != expectedGen) {
+          throw new OMException("Generation mismatch during expected rewrite",
+              OMException.ResultCodes.KEY_NOT_FOUND);
+        }
+      }
+    }
+  }
+
+  /**
+   * Validates If-Match ETag condition and converts it to expectedDataGeneration.
+   * <p>
+   * This method checks if the existing key's ETag matches the expected ETag.
+   * If it matches, the ETag condition is converted to a generation-based condition
+   * for atomic commit validation.
+   *
+   * @param keyArgs the key arguments containing expected ETag
+   * @param dbKeyInfo the existing key info from the database
+   * @return updated KeyArgs with expectedDataGeneration set (if ETag matched)
+   * @throws OMException if validation fails
+   */
+  protected KeyArgs validateAndRewriteIfMatchAsExpectedGeneration(
+      KeyArgs keyArgs, OmKeyInfo dbKeyInfo) throws OMException {
+    if (!keyArgs.hasExpectedETag()) {
+      return keyArgs;
+    }
+
+    String expectedETag = keyArgs.getExpectedETag();
+    if (dbKeyInfo == null) {
+      throw new OMException("Key not found for If-Match",
+          OMException.ResultCodes.KEY_NOT_FOUND);
+    }
+    if (!dbKeyInfo.hasEtag()) {
+      throw new OMException("Key does not have an ETag",
+          OMException.ResultCodes.ETAG_NOT_AVAILABLE);
+    }
+    if (!dbKeyInfo.isEtagEquals(expectedETag)) {
+      throw new OMException("ETag mismatch",
+          OMException.ResultCodes.ETAG_MISMATCH);
+    }
+    if (keyArgs.hasExpectedDataGeneration()) {
+      return keyArgs;
+    }
+
+    return keyArgs.toBuilder()
+        .setExpectedDataGeneration(dbKeyInfo.getUpdateID())
+        .clearExpectedETag()
+        .build();
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -272,12 +272,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       // Conditional write validation for If-None-Match / If-Match headers
       // Load existing committed key to check preconditions
       OmKeyInfo existingKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
-
-      // Validate If-None-Match: * (create-if-absent) or generation match
       validateAtomicRewrite(existingKeyInfo, keyArgs);
-
-      // Convert If-Match ETag to expectedDataGeneration for atomic validation
-      keyArgs = validateAndRewriteIfMatchAsExpectedGeneration(keyArgs, existingKeyInfo);
+      validateIfMatchETag(keyArgs, existingKeyInfo);
 
       if (!partsList.isEmpty()) {
         final OmMultipartKeyInfo.PartKeyInfoMap partKeyInfoMap

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -269,6 +269,16 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
 
+      // Conditional write validation for If-None-Match / If-Match headers
+      // Load existing committed key to check preconditions
+      OmKeyInfo existingKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
+
+      // Validate If-None-Match: * (create-if-absent) or generation match
+      validateAtomicRewrite(existingKeyInfo, keyArgs);
+
+      // Convert If-Match ETag to expectedDataGeneration for atomic validation
+      keyArgs = validateAndRewriteIfMatchAsExpectedGeneration(keyArgs, existingKeyInfo);
+
       if (!partsList.isEmpty()) {
         final OmMultipartKeyInfo.PartKeyInfoMap partKeyInfoMap
             = multipartKeyInfo.getPartKeyInfoMap();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -269,8 +269,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
 
-      // Conditional write validation for If-None-Match / If-Match headers
-      // Load existing committed key to check preconditions
+      // Conditional write validation (If-None-Match / If-Match).
+      // BUCKET_LOCK is held, so validation and commit are atomic.
+      // Only 412 PreconditionFailed is possible; 409 Conflict cannot occur.
       OmKeyInfo existingKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
       validateAtomicRewrite(existingKeyInfo, keyArgs);
       validateIfMatchETag(keyArgs, existingKeyInfo);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -726,6 +726,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     List<CompleteMultipartUploadRequest.Part> partList =
         multipartUploadRequest.getPartList();
 
+    S3ConditionalRequest.WriteConditions writeConditions =
+        S3ConditionalRequest.parseWriteConditions(getHeaders(), key);
+
     OmMultipartUploadCompleteInfo omMultipartUploadCompleteInfo;
     try {
       OzoneBucket ozoneBucket = volume.getBucket(bucket);
@@ -738,7 +741,16 @@ public class ObjectEndpoint extends ObjectOperationHandler {
         LOG.debug("Parts map {}", partsMap);
       }
 
-      omMultipartUploadCompleteInfo = ozoneBucket.completeMultipartUpload(key, uploadID, partsMap);
+      Long expectedDataGeneration = null;
+      String expectedETag = null;
+      if (writeConditions.hasIfNoneMatch()) {
+        expectedDataGeneration = OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS;
+      } else if (writeConditions.hasIfMatch()) {
+        expectedETag = writeConditions.getExpectedETag();
+      }
+
+      omMultipartUploadCompleteInfo = ozoneBucket.completeMultipartUpload(
+          key, uploadID, partsMap, expectedDataGeneration, expectedETag);
       CompleteMultipartUploadResponse completeMultipartUploadResponse =
           new CompleteMultipartUploadResponse();
       completeMultipartUploadResponse.setBucket(bucket);
@@ -770,6 +782,15 @@ public class ObjectEndpoint extends ObjectOperationHandler {
             "considered as Unix Paths. A directory already exists with a " +
             "given KeyName caused failure for MPU");
         throw os3Exception;
+      } else if (ex.getResult() == ResultCodes.KEY_ALREADY_EXISTS
+          || ex.getResult() == ResultCodes.ETAG_MISMATCH
+          || ex.getResult() == ResultCodes.ETAG_NOT_AVAILABLE) {
+        // Conditional write precondition failed
+        throw newError(PRECOND_FAILED, key, ex);
+      } else if (ex.getResult() == ResultCodes.KEY_NOT_FOUND
+          && writeConditions.hasIfMatch()) {
+        // If-Match failed because the key doesn't exist
+        throw newError(PRECOND_FAILED, key, ex);
       }
       throw newError(bucket, key, ex);
     } catch (Exception ex) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -785,11 +785,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       } else if (ex.getResult() == ResultCodes.KEY_ALREADY_EXISTS
           || ex.getResult() == ResultCodes.ETAG_MISMATCH
           || ex.getResult() == ResultCodes.ETAG_NOT_AVAILABLE) {
-        // Conditional write precondition failed
         throw newError(PRECOND_FAILED, key, ex);
       } else if (ex.getResult() == ResultCodes.KEY_NOT_FOUND
           && writeConditions.hasIfMatch()) {
-        // If-Match failed because the key doesn't exist
         throw newError(PRECOND_FAILED, key, ex);
       }
       throw newError(bucket, key, ex);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -410,6 +410,16 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public OmMultipartUploadCompleteInfo completeMultipartUpload(
+      String volumeName, String bucketName, String keyName, String uploadID,
+      Map<Integer, String> partsMap,
+      Long expectedDataGeneration, String expectedETag) throws IOException {
+    return getBucket(volumeName, bucketName)
+        .completeMultipartUpload(keyName, uploadID, partsMap,
+            expectedDataGeneration, expectedETag);
+  }
+
+  @Override
   public void abortMultipartUpload(String volumeName, String bucketName,
                                    String keyName, String uploadID)
       throws IOException {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.client;
 
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
+import static org.apache.hadoop.ozone.OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS;
 import static org.apache.hadoop.ozone.OzoneConsts.MD5_HASH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
@@ -580,6 +581,30 @@ public final class OzoneBucketStub extends OzoneBucket {
 
     return new OmMultipartUploadCompleteInfo(getVolumeName(), getName(), key,
         DigestUtils.sha256Hex(key));
+  }
+
+  @Override
+  public OmMultipartUploadCompleteInfo completeMultipartUpload(String key,
+      String uploadID, Map<Integer, String> partsMap,
+      Long expectedDataGeneration, String expectedETag) throws IOException {
+    // Handle If-None-Match: * (expectedDataGeneration == -1 means create-if-absent)
+    if (expectedDataGeneration != null &&
+        expectedDataGeneration == EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+      if (keyContents.containsKey(key)) {
+        throw new OMException("Key already exists", ResultCodes.KEY_ALREADY_EXISTS);
+      }
+    }
+
+    // Handle If-Match: <etag>
+    if (expectedETag != null) {
+      OzoneKeyDetails existingKey = keyDetails.get(key);
+      if (existingKey == null) {
+        throw new OMException("Key not found", ResultCodes.KEY_NOT_FOUND);
+      }
+      // Stub doesn't track ETag, so we just delegate
+    }
+
+    return completeMultipartUpload(key, uploadID, partsMap);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Conditional CompleteMultipartUpload

Please describe your PR in detail:

Conditional MPU completion should reuse the same conditional write fields already present in KeyArgs, but unlike normal conditional PUT, it does not need an open-key plus later commit bridge. The final key is assembled and committed inside one OM transaction in S3MultipartUploadCompleteRequest.validateAndUpdateCache(...) while holding the normal bucket write lock

https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15067

## How was this patch tested?
Add E2E tests, CI Action(https://github.com/YutaLin/ozone/actions/runs/25147780358)
