### PR TITLE
HDDS-15152. SSL protocol config is not applied to Jetty when set to default value

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -596,18 +596,16 @@ public final class HttpServer2 implements FilterContainer {
     private void setEnabledProtocols(SslContextFactory sslContextFactory) {
       String enabledProtocols = conf.get(OzoneConfigKeys.OZONE_SSL_ENABLED_PROTOCOLS,
           conf.get(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT));
-      if (!enabledProtocols.equals(SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT)) {
-        List<String> originalExcludedProtocols = Arrays.asList(sslContextFactory.getExcludeProtocols());
-        String[] enabledProtocolsArray = StringUtils.getTrimmedStrings(enabledProtocols);
+      List<String> originalExcludedProtocols = Arrays.asList(sslContextFactory.getExcludeProtocols());
+      String[] enabledProtocolsArray = StringUtils.getTrimmedStrings(enabledProtocols);
 
-        List<String> finalExcludedProtocols = new ArrayList<>(originalExcludedProtocols);
-        finalExcludedProtocols.removeAll(Arrays.asList(enabledProtocolsArray));
+      List<String> finalExcludedProtocols = new ArrayList<>(originalExcludedProtocols);
+      finalExcludedProtocols.removeAll(Arrays.asList(enabledProtocolsArray));
 
-        sslContextFactory.setExcludeProtocols(finalExcludedProtocols.toArray(new String[0]));
-        LOG.info("Disabled protocols: {}", finalExcludedProtocols);
-        sslContextFactory.setIncludeProtocols(enabledProtocolsArray);
-        LOG.info("Enabled protocols: {}", enabledProtocols);
-      }
+      sslContextFactory.setExcludeProtocols(finalExcludedProtocols.toArray(new String[0]));
+      LOG.info("Disabled protocols: {}", finalExcludedProtocols);
+      sslContextFactory.setIncludeProtocols(enabledProtocolsArray);
+      LOG.info("Enabled protocols: {}", enabledProtocols);
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2SSL.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2SSL.java
@@ -17,7 +17,10 @@
 
 package org.apache.hadoop.hdds.server.http;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -29,6 +32,7 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 import java.security.KeyStore;
+import java.util.Arrays;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
@@ -41,6 +45,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -169,9 +176,58 @@ public class TestHttpServer2SSL {
     }
   }
 
+  @Test
+  public void testEnabledProtocolAppliedWhenConfigUnset() throws Exception {
+    OzoneConfiguration serverConf = new OzoneConfiguration(conf);
+    serverConf.unset(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY);
+    assertServerAppliesEnabledProtocol(serverConf, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+  }
+
+  @Test
+  public void testEnabledProtocolAppliedWhenConfigSetToDefault() throws Exception {
+    OzoneConfiguration serverConf = new OzoneConfiguration(conf);
+    serverConf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+    assertServerAppliesEnabledProtocol(serverConf, SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT);
+  }
+
+  @Test
+  public void testEnabledProtocolAppliedWhenConfigSetToNonDefault() throws Exception {
+    OzoneConfiguration serverConf = new OzoneConfiguration(conf);
+    serverConf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, "TLSv1.3");
+    assertServerAppliesEnabledProtocol(serverConf, "TLSv1.3");
+  }
+
+  private void assertServerAppliesEnabledProtocol(
+      OzoneConfiguration serverConf, String protocol) throws Exception {
+    HttpServer2 server = buildServer(serverConf, null, null, null);
+    server.start();
+    try {
+      ServerConnector listener = server.getListeners().get(0);
+      SslConnectionFactory connectionFactory =
+          listener.getConnectionFactory(SslConnectionFactory.class);
+      assertNotNull(connectionFactory,
+          "Expected HTTPS listener with an SSL connection factory");
+
+      SslContextFactory.Server sslContextFactory =
+          (SslContextFactory.Server) connectionFactory.getSslContextFactory();
+      assertArrayEquals(new String[] {protocol},
+          sslContextFactory.getIncludeProtocols());
+      assertFalse(Arrays.asList(sslContextFactory.getExcludeProtocols())
+          .contains(protocol),
+          "Configured enabled protocol should be removed from excluded protocols");
+    } finally {
+      server.stop();
+    }
+  }
+
   private HttpServer2 buildServer(String excludeCiphers, String includeCiphers, String enabledProtocols)
       throws Exception {
     OzoneConfiguration serverConf = new OzoneConfiguration(conf);
+    return buildServer(serverConf, excludeCiphers, includeCiphers, enabledProtocols);
+  }
+
+  private HttpServer2 buildServer(OzoneConfiguration serverConf, String excludeCiphers,
+      String includeCiphers, String enabledProtocols) throws Exception {
     if (enabledProtocols != null) {
       serverConf.set(SSLFactory.SSL_ENABLED_PROTOCOLS_KEY, enabledProtocols);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In `HttpServer2.setEnabledProtocols()`, the logic that applies SSL protocol restrictions to the Jetty SslContextFactory is gated behind a check that compares the resolved configuration value against `SSLFactory.SSL_ENABLED_PROTOCOLS_DEFAULT` ("TLSv1.2"). 

This means that Jetty is not respecting the configuration, the condition check should be removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15152

## How was this patch tested?

Tested the changes manually with `openssl s_client -connect` commands.