### PR TITLE
HDDS-15146. Remove getDatanodeInfo(DatanodeDetails) from NodeManager.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -370,7 +370,7 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   List<SCMCommand<?>> getCommandQueue(DatanodeID dnID);
 
   /** @return the datanode of the given id if it exists; otherwise, return null. */
-  @Nullable DatanodeInfo getNode(@Nullable DatanodeID id);
+  @Nullable DatanodeDetails getNode(@Nullable DatanodeID id);
 
   /**
    * Given datanode address(Ipaddress or hostname), returns a list of

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -370,7 +370,7 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   List<SCMCommand<?>> getCommandQueue(DatanodeID dnID);
 
   /** @return the datanode of the given id if it exists; otherwise, return null. */
-  @Nullable DatanodeDetails getNode(@Nullable DatanodeID id);
+  @Nullable DatanodeInfo getNode(@Nullable DatanodeID id);
 
   /**
    * Given datanode address(Ipaddress or hostname), returns a list of

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -113,7 +113,7 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    * @param health - The health of the node
    * @return List of Datanodes that are Heartbeating SCM.
    */
-  List<DatanodeDetails> getNodes(
+  List<DatanodeInfo> getNodes(
       NodeOperationalState opState, NodeState health);
 
   /**
@@ -134,10 +134,8 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   int getNodeCount(
       NodeOperationalState opState, NodeState health);
 
-  /**
-   * @return all datanodes known to SCM.
-   */
-  List<? extends DatanodeDetails> getAllNodes();
+  /** @return a shadow copied list of all datanodes, sorted by {@link DatanodeID}. */
+  List<DatanodeInfo> getAllNodes();
 
   /** @return the number of datanodes. */
   default int getAllNodeCount() {
@@ -174,15 +172,6 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    * @return DatanodeUsageInfo of the specified datanode
    */
   DatanodeUsageInfo getUsageInfo(DatanodeDetails dn);
-
-  /**
-   * Get the datanode info of a specified datanode.
-   *
-   * @param dn the usage of which we want to get
-   * @return DatanodeInfo of the specified datanode
-   */
-  @Nullable
-  DatanodeInfo getDatanodeInfo(DatanodeDetails dn);
 
   /**
    * True if the node can accept another container of the given size.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -531,12 +531,8 @@ public class NodeStateManager implements Runnable, Closeable {
     return getVolumeFailuresNodes().size();
   }
 
-  /**
-   * Returns all the nodes which have registered to NodeStateManager.
-   *
-   * @return all the managed nodes
-   */
-  public List<DatanodeInfo> getAllNodes() {
+  /** @return a shadow copied list of all datanodes, sorted by {@link DatanodeID}. */
+  List<DatanodeInfo> getAllNodes() {
     return nodeStateMap.getAllDatanodeInfos();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -27,7 +27,6 @@ import static org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy.hasEnoughSpace
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.math.RoundingMode;
 import java.net.InetAddress;
@@ -260,11 +259,9 @@ public class SCMNodeManager implements NodeManager {
    * @return List of Datanodes that are known to SCM in the requested states.
    */
   @Override
-  public List<DatanodeDetails> getNodes(
+  public List<DatanodeInfo> getNodes(
       NodeOperationalState opState, NodeState health) {
-    return nodeStateManager.getNodes(opState, health)
-        .stream()
-        .map(node -> (DatanodeDetails)node).collect(Collectors.toList());
+    return nodeStateManager.getNodes(opState, health);
   }
 
   @Override
@@ -1005,8 +1002,7 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(
       boolean mostUsed) {
-    List<DatanodeDetails> healthyNodes =
-        getNodes(IN_SERVICE, NodeState.HEALTHY);
+    final List<DatanodeInfo> healthyNodes = getNodes(IN_SERVICE, NodeState.HEALTHY);
 
     List<DatanodeUsageInfo> datanodeUsageInfoList =
         new ArrayList<>(healthyNodes.size());
@@ -1051,24 +1047,6 @@ public class SCMNodeManager implements NodeManager {
       LOG.error("Unknown datanode {}.", dn, ex);
     }
     return usageInfo;
-  }
-
-  /**
-   * Get the usage info of a specified datanode.
-   *
-   * @param dn the usage of which we want to get
-   * @return DatanodeUsageInfo of the specified datanode
-   */
-  @Override
-  @Nullable
-  public DatanodeInfo getDatanodeInfo(DatanodeDetails dn) {
-    try {
-      return nodeStateManager.getNode(dn);
-    } catch (NodeNotFoundException e) {
-      LOG.warn("Cannot retrieve DatanodeInfo, datanode {} not found.",
-          dn.getUuid());
-      return null;
-    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -17,10 +17,10 @@
 
 package org.apache.hadoop.hdds.scm.node.states;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -41,7 +41,7 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
  */
 public class NodeStateMap {
   /** Map: {@link DatanodeID} -> ({@link DatanodeInfo}, {@link ContainerID}s). */
-  private final Map<DatanodeID, DatanodeEntry> nodeMap = new HashMap<>();
+  private final Map<DatanodeID, DatanodeEntry> nodeMap = new TreeMap<>();
 
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -166,11 +166,7 @@ public class NodeStateMap {
     }
   }
 
-  /**
-   * Returns the list of all the nodes as DatanodeInfo objects.
-   *
-   * @return list of all the node ids
-   */
+  /** @return a shadow copied list of all datanodes, sorted by {@link DatanodeID}. */
   public List<DatanodeInfo> getAllDatanodeInfos() {
     lock.readLock().lock();
     try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -703,34 +703,22 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public HddsProtos.Node queryNode(UUID uuid)
-      throws IOException {
+  public HddsProtos.Node queryNode(UUID uuid) {
     final Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("uuid", String.valueOf(uuid));
     HddsProtos.Node result = null;
-    try {
-      DatanodeDetails node = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
-      if (node != null) {
-        NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
-        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
-        HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
-            .setNodeID(node.getProtoBufMessage())
-            .addNodeStates(ns.getHealth())
-            .addNodeOperationalStates(ns.getOperationalState());
+    DatanodeInfo datanodeInfo = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
+    if (datanodeInfo != null) {
+      NodeStatus ns = datanodeInfo.getNodeStatus();
+      HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
+          .setNodeID(datanodeInfo.getProtoBufMessage())
+          .addNodeStates(ns.getHealth())
+          .addNodeOperationalStates(ns.getOperationalState());
 
-        if (datanodeInfo != null) {
-          nodeBuilder.setTotalVolumeCount(datanodeInfo.getStorageReports().size());
-          nodeBuilder.setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount());
-          addFailedVolumes(nodeBuilder, datanodeInfo);
-        }
-        result = nodeBuilder.build();
-      }
-    } catch (NodeNotFoundException e) {
-      IOException ex = new IOException(
-          "An unexpected error occurred querying the NodeStatus", e);
-      AUDIT.logReadFailure(buildAuditMessageForFailure(
-          SCMAction.QUERY_NODE, auditMap, ex));
-      throw ex;
+      nodeBuilder.setTotalVolumeCount(datanodeInfo.getStorageReports().size());
+      nodeBuilder.setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount());
+      addFailedVolumes(nodeBuilder, datanodeInfo);
+      result = nodeBuilder.build();
     }
     AUDIT.logReadSuccess(buildAuditMessageForSuccess(
         SCMAction.QUERY_NODE, auditMap));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -680,7 +679,7 @@ public class SCMClientProtocolServer implements
       List<HddsProtos.Node> result = new ArrayList<>();
       for (DatanodeDetails node : queryNode(opState, state)) {
         NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
-        DatanodeInfo datanodeInfo = scm.getScmNodeManager().getDatanodeInfo(node);
+        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
         HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
             .setNodeID(node.toProto(clientVersion))
             .addNodeStates(ns.getHealth())
@@ -713,7 +712,7 @@ public class SCMClientProtocolServer implements
       DatanodeDetails node = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
       if (node != null) {
         NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
-        DatanodeInfo datanodeInfo = scm.getScmNodeManager().getDatanodeInfo(node);
+        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
         HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
             .setNodeID(node.getProtoBufMessage())
             .addNodeStates(ns.getHealth())
@@ -1595,9 +1594,9 @@ public class SCMClientProtocolServer implements
    * @param state - NodeState.
    * @return List of Datanodes.
    */
-  public List<DatanodeDetails> queryNode(
+  public List<? extends DatanodeDetails> queryNode(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState state) {
-    return new ArrayList<>(queryNodeState(opState, state));
+    return queryNodeState(opState, state);
   }
 
   @VisibleForTesting
@@ -1619,15 +1618,9 @@ public class SCMClientProtocolServer implements
    * @param nodeState - NodeState that we are interested in matching.
    * @return Set of Datanodes that match the NodeState.
    */
-  private Set<DatanodeDetails> queryNodeState(
+  private List<? extends DatanodeDetails> queryNodeState(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodeState) {
-    Set<DatanodeDetails> returnSet = new TreeSet<>();
-    List<DatanodeDetails> tmp = scm.getScmNodeManager()
-        .getNodes(opState, nodeState);
-    if ((tmp != null) && (!tmp.isEmpty())) {
-      returnSet.addAll(tmp);
-    }
-    return returnSet;
+    return scm.getScmNodeManager().getNodes(opState, nodeState);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -108,6 +108,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.ipc_.Server;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
@@ -675,75 +676,43 @@ public class SCMClientProtocolServer implements
           SCMAction.QUERY_NODE, auditMap, ex));
       throw ex;
     }
-    try {
-      List<HddsProtos.Node> result = new ArrayList<>();
-      for (DatanodeDetails node : scm.getScmNodeManager().getNodes(opState, state)) {
-        NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
-        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
-        HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
-            .setNodeID(node.toProto(clientVersion))
-            .addNodeStates(ns.getHealth())
-            .addNodeOperationalStates(ns.getOperationalState());
-        
-        if (datanodeInfo != null) {
-          nodeBuilder.setTotalVolumeCount(datanodeInfo.getStorageReports().size());
-          nodeBuilder.setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount());
-          addFailedVolumes(nodeBuilder, datanodeInfo);
-        }
-        result.add(nodeBuilder.build());
-      }
-      AUDIT.logReadSuccess(buildAuditMessageForSuccess(
-          SCMAction.QUERY_NODE, auditMap));
-      return result;
-    } catch (NodeNotFoundException e) {
-      AUDIT.logReadFailure(buildAuditMessageForFailure(
-          SCMAction.QUERY_NODE, auditMap, e));
-      throw new IOException("An unexpected error occurred querying the NodeStatus", e);
+    final List<HddsProtos.Node> result = new ArrayList<>();
+    for (DatanodeInfo datanodeInfo : scm.getScmNodeManager().getNodes(opState, state)) {
+      result.add(buildNodeProto(datanodeInfo, clientVersion));
     }
+    AUDIT.logReadSuccess(buildAuditMessageForSuccess(SCMAction.QUERY_NODE, auditMap));
+    return result;
   }
 
   @Override
-  public HddsProtos.Node queryNode(UUID uuid)
-      throws IOException {
-    final Map<String, String> auditMap = Maps.newHashMap();
-    auditMap.put("uuid", String.valueOf(uuid));
+  public HddsProtos.Node queryNode(UUID uuid) {
+    final Map<String, String> auditMap = Collections.singletonMap("uuid", String.valueOf(uuid));
     HddsProtos.Node result = null;
-    try {
-      DatanodeDetails node = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
-      if (node != null) {
-        NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
-        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
-        HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
-            .setNodeID(node.getProtoBufMessage())
-            .addNodeStates(ns.getHealth())
-            .addNodeOperationalStates(ns.getOperationalState());
-
-        if (datanodeInfo != null) {
-          nodeBuilder.setTotalVolumeCount(datanodeInfo.getStorageReports().size());
-          nodeBuilder.setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount());
-          addFailedVolumes(nodeBuilder, datanodeInfo);
-        }
-        result = nodeBuilder.build();
-      }
-    } catch (NodeNotFoundException e) {
-      IOException ex = new IOException(
-          "An unexpected error occurred querying the NodeStatus", e);
-      AUDIT.logReadFailure(buildAuditMessageForFailure(
-          SCMAction.QUERY_NODE, auditMap, ex));
-      throw ex;
+    final DatanodeInfo datanodeInfo = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
+    if (datanodeInfo != null) {
+      result = buildNodeProto(datanodeInfo, ClientVersion.CURRENT_VERSION);
     }
     AUDIT.logReadSuccess(buildAuditMessageForSuccess(
         SCMAction.QUERY_NODE, auditMap));
     return result;
   }
 
-  private static void addFailedVolumes(HddsProtos.Node.Builder nodeBuilder,
-      DatanodeInfo datanodeInfo) {
-    for (StorageReportProto report : datanodeInfo.getStorageReports()) {
+  private static HddsProtos.Node buildNodeProto(DatanodeInfo datanodeInfo, int clientVersion) {
+    final List<StorageReportProto> reports = datanodeInfo.getStorageReports();
+    final HddsProtos.Node.Builder b = HddsProtos.Node.newBuilder()
+        .setTotalVolumeCount(reports.size());
+    for (StorageReportProto report : reports) {
       if (report.hasFailed() && report.getFailed()) {
-        nodeBuilder.addFailedVolumes(report.getStorageLocation());
+        b.addFailedVolumes(report.getStorageLocation());
       }
     }
+
+    final NodeStatus ns = datanodeInfo.getNodeStatus();
+    return b.setNodeID(datanodeInfo.toProto(clientVersion))
+        .setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount())
+        .addNodeStates(ns.getHealth())
+        .addNodeOperationalStates(ns.getOperationalState())
+        .build();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -108,7 +108,6 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.ipc_.Server;
-import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
@@ -676,43 +675,75 @@ public class SCMClientProtocolServer implements
           SCMAction.QUERY_NODE, auditMap, ex));
       throw ex;
     }
-    final List<HddsProtos.Node> result = new ArrayList<>();
-    for (DatanodeInfo datanodeInfo : scm.getScmNodeManager().getNodes(opState, state)) {
-      result.add(buildNodeProto(datanodeInfo, clientVersion));
+    try {
+      List<HddsProtos.Node> result = new ArrayList<>();
+      for (DatanodeDetails node : scm.getScmNodeManager().getNodes(opState, state)) {
+        NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
+        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
+        HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
+            .setNodeID(node.toProto(clientVersion))
+            .addNodeStates(ns.getHealth())
+            .addNodeOperationalStates(ns.getOperationalState());
+        
+        if (datanodeInfo != null) {
+          nodeBuilder.setTotalVolumeCount(datanodeInfo.getStorageReports().size());
+          nodeBuilder.setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount());
+          addFailedVolumes(nodeBuilder, datanodeInfo);
+        }
+        result.add(nodeBuilder.build());
+      }
+      AUDIT.logReadSuccess(buildAuditMessageForSuccess(
+          SCMAction.QUERY_NODE, auditMap));
+      return result;
+    } catch (NodeNotFoundException e) {
+      AUDIT.logReadFailure(buildAuditMessageForFailure(
+          SCMAction.QUERY_NODE, auditMap, e));
+      throw new IOException("An unexpected error occurred querying the NodeStatus", e);
     }
-    AUDIT.logReadSuccess(buildAuditMessageForSuccess(SCMAction.QUERY_NODE, auditMap));
-    return result;
   }
 
   @Override
-  public HddsProtos.Node queryNode(UUID uuid) {
-    final Map<String, String> auditMap = Collections.singletonMap("uuid", String.valueOf(uuid));
+  public HddsProtos.Node queryNode(UUID uuid)
+      throws IOException {
+    final Map<String, String> auditMap = Maps.newHashMap();
+    auditMap.put("uuid", String.valueOf(uuid));
     HddsProtos.Node result = null;
-    final DatanodeInfo datanodeInfo = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
-    if (datanodeInfo != null) {
-      result = buildNodeProto(datanodeInfo, ClientVersion.CURRENT_VERSION);
+    try {
+      DatanodeDetails node = scm.getScmNodeManager().getNode(DatanodeID.of(uuid));
+      if (node != null) {
+        NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
+        DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
+        HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
+            .setNodeID(node.getProtoBufMessage())
+            .addNodeStates(ns.getHealth())
+            .addNodeOperationalStates(ns.getOperationalState());
+
+        if (datanodeInfo != null) {
+          nodeBuilder.setTotalVolumeCount(datanodeInfo.getStorageReports().size());
+          nodeBuilder.setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount());
+          addFailedVolumes(nodeBuilder, datanodeInfo);
+        }
+        result = nodeBuilder.build();
+      }
+    } catch (NodeNotFoundException e) {
+      IOException ex = new IOException(
+          "An unexpected error occurred querying the NodeStatus", e);
+      AUDIT.logReadFailure(buildAuditMessageForFailure(
+          SCMAction.QUERY_NODE, auditMap, ex));
+      throw ex;
     }
     AUDIT.logReadSuccess(buildAuditMessageForSuccess(
         SCMAction.QUERY_NODE, auditMap));
     return result;
   }
 
-  private static HddsProtos.Node buildNodeProto(DatanodeInfo datanodeInfo, int clientVersion) {
-    final List<StorageReportProto> reports = datanodeInfo.getStorageReports();
-    final HddsProtos.Node.Builder b = HddsProtos.Node.newBuilder()
-        .setTotalVolumeCount(reports.size());
-    for (StorageReportProto report : reports) {
+  private static void addFailedVolumes(HddsProtos.Node.Builder nodeBuilder,
+      DatanodeInfo datanodeInfo) {
+    for (StorageReportProto report : datanodeInfo.getStorageReports()) {
       if (report.hasFailed() && report.getFailed()) {
-        b.addFailedVolumes(report.getStorageLocation());
+        nodeBuilder.addFailedVolumes(report.getStorageLocation());
       }
     }
-
-    final NodeStatus ns = datanodeInfo.getNodeStatus();
-    return b.setNodeID(datanodeInfo.toProto(clientVersion))
-        .setHealthyVolumeCount(datanodeInfo.getHealthyVolumeCount())
-        .addNodeStates(ns.getHealth())
-        .addNodeOperationalStates(ns.getOperationalState())
-        .build();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -677,7 +677,7 @@ public class SCMClientProtocolServer implements
     }
     try {
       List<HddsProtos.Node> result = new ArrayList<>();
-      for (DatanodeDetails node : queryNode(opState, state)) {
+      for (DatanodeDetails node : scm.getScmNodeManager().getNodes(opState, state)) {
         NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
         DatanodeInfo datanodeInfo = node instanceof DatanodeInfo ? (DatanodeInfo) node : null;
         HddsProtos.Node.Builder nodeBuilder = HddsProtos.Node.newBuilder()
@@ -1579,26 +1579,6 @@ public class SCMClientProtocolServer implements
     }
   }
 
-  /**
-   * Queries a list of Node that match a set of statuses.
-   *
-   * <p>For example, if the nodeStatuses is HEALTHY and RAFT_MEMBER, then
-   * this call will return all
-   * healthy nodes which members in Raft pipeline.
-   *
-   * <p>Right now we don't support operations, so we assume it is an AND
-   * operation between the
-   * operators.
-   *
-   * @param opState - NodeOperational State
-   * @param state - NodeState.
-   * @return List of Datanodes.
-   */
-  public List<? extends DatanodeDetails> queryNode(
-      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState state) {
-    return queryNodeState(opState, state);
-  }
-
   @VisibleForTesting
   public StorageContainerManager getScm() {
     return scm;
@@ -1609,18 +1589,6 @@ public class SCMClientProtocolServer implements
    */
   public boolean getSafeModeStatus() {
     return scm.getScmContext().isInSafeMode();
-  }
-
-  /**
-   * Query the System for Nodes.
-   *
-   * @params opState - The node operational state
-   * @param nodeState - NodeState that we are interested in matching.
-   * @return Set of Datanodes that match the NodeState.
-   */
-  private List<? extends DatanodeDetails> queryNodeState(
-      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodeState) {
-    return scm.getScmNodeManager().getNodes(opState, nodeState);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,11 +86,15 @@ public class TestSCMCommonPlacementPolicy {
     conf = SCMTestUtils.getConf(testDir);
   }
 
+  static List<DatanodeDetails> getAllNodes(NodeManager nm) {
+    return new ArrayList<>(nm.getAllNodes());
+  }
+
   @Test
   public void testGetResultSet() throws SCMException {
     DummyPlacementPolicy dummyPlacementPolicy =
         new DummyPlacementPolicy(nodeManager, conf, 5);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> result = dummyPlacementPolicy.getResultSet(3, list);
     Set<DatanodeDetails> resultSet = new HashSet<>(result);
     assertNotEquals(1, resultSet.size());
@@ -137,7 +142,7 @@ public class TestSCMCommonPlacementPolicy {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 5);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 2, 3, 5)
                     .map(list::get).collect(Collectors.toList());
     List<ContainerReplica> replicas =
@@ -158,7 +163,7 @@ public class TestSCMCommonPlacementPolicy {
                             3, ImmutableList.of(3, 8),
                             4, ImmutableList.of(4, 9))), 5);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 2, 3, 5)
                     .map(list::get).collect(Collectors.toList());
     List<ContainerReplica> replicas =
@@ -179,7 +184,7 @@ public class TestSCMCommonPlacementPolicy {
                             3, ImmutableList.of(3, 8),
                             4, ImmutableList.of(4, 9))), 5);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 2, 3, 5)
                     .map(list::get).collect(Collectors.toList());
     List<ContainerReplica> replicas =
@@ -201,7 +206,7 @@ public class TestSCMCommonPlacementPolicy {
                             3, ImmutableList.of(3, 4, 8),
                             4, ImmutableList.of(9))), 5);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 2, 3, 4)
                     .map(list::get).collect(Collectors.toList());
     //Creating Replicas without replica Index
@@ -224,7 +229,7 @@ public class TestSCMCommonPlacementPolicy {
                             3, ImmutableList.of(3, 4, 8),
                             4, ImmutableList.of(9))), 5);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 3, 4)
                     .map(list::get).collect(Collectors.toList());
     //Creating Replicas without replica Index for replicas < number of racks
@@ -247,7 +252,7 @@ public class TestSCMCommonPlacementPolicy {
                             3, ImmutableList.of(3, 4, 8),
                             4, ImmutableList.of(9))), 5);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 2, 3, 4, 6)
                     .map(list::get).collect(Collectors.toList());
     //Creating Replicas without replica Index for replicas >number of racks
@@ -262,7 +267,7 @@ public class TestSCMCommonPlacementPolicy {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 2);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 2, 4, 6, 8)
                     .map(list::get).collect(Collectors.toList());
     List<ContainerReplica> replicas =
@@ -278,7 +283,7 @@ public class TestSCMCommonPlacementPolicy {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 2);
     List<Node> racks = dummyPlacementPolicy.racks;
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 2, 4, 6, 8)
             .map(list::get).collect(Collectors.toList());
     List<ContainerReplica> replicas =
@@ -297,7 +302,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasWithoutMisreplication() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 5);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     List<DatanodeDetails> replicaDns = Stream.of(0, 1, 2, 3, 4)
                     .map(list::get).collect(Collectors.toList());
     Map<ContainerReplica, Boolean> replicas =
@@ -314,7 +319,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasToRemoveWithOneOverreplication() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 5);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     Set<ContainerReplica> replicas = Sets.newHashSet(
             HddsTestUtils.getReplicasWithReplicaIndex(
                     ContainerID.valueOf(1), CLOSED, 0, 0, 0, list.subList(1, 6)));
@@ -335,7 +340,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasToRemoveWithTwoOverreplication() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 5);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
 
     Set<ContainerReplica> replicas = Sets.newHashSet(
             HddsTestUtils.getReplicasWithReplicaIndex(
@@ -356,7 +361,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasToRemoveWith2CountPerUniqueReplica() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 3);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
 
     Set<ContainerReplica> replicas = Sets.newHashSet(
             HddsTestUtils.getReplicasWithReplicaIndex(
@@ -382,7 +387,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasToRemoveWithoutReplicaIndex() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 3);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
 
     Set<ContainerReplica> replicas = Sets.newHashSet(HddsTestUtils.getReplicas(
                     ContainerID.valueOf(1), CLOSED, 0, list.subList(0, 5)));
@@ -402,7 +407,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasToRemoveWithOverreplicationWithinSameRack() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 3);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
 
     Set<ContainerReplica> replicas = Sets.newHashSet(
             HddsTestUtils.getReplicasWithReplicaIndex(
@@ -441,7 +446,7 @@ public class TestSCMCommonPlacementPolicy {
   public void testReplicasToRemoveWithNoOverreplication() {
     DummyPlacementPolicy dummyPlacementPolicy =
             new DummyPlacementPolicy(nodeManager, conf, 5);
-    List<DatanodeDetails> list = nodeManager.getAllNodes();
+    List<DatanodeDetails> list = getAllNodes(nodeManager);
     Set<ContainerReplica> replicas = Sets.newHashSet(
             HddsTestUtils.getReplicasWithReplicaIndex(
                     ContainerID.valueOf(1), CLOSED, 0, 0, 0, list.subList(1, 6)));
@@ -602,8 +607,9 @@ public class TestSCMCommonPlacementPolicy {
         when(node.getNetworkFullPath()).thenReturn(String.valueOf(i));
         return node;
       }).collect(Collectors.toList());
-      final List<? extends DatanodeDetails> datanodeDetails = nodeManager.getAllNodes();
-      rackMap = datanodeRackMap.entrySet().stream()
+      final List<DatanodeDetails> datanodeDetails = getAllNodes(nodeManager);
+      rackMap = datanodeRackMap
+          .entrySet().stream()
               .collect(Collectors.toMap(
                       entry -> datanodeDetails.get(entry.getKey()),
                       entry -> racks.get(entry.getValue())));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -902,9 +902,9 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
-  public DatanodeDetails getNode(DatanodeID id) {
+  public DatanodeInfo getNode(DatanodeID id) {
     Node node = clusterMap.getNode(NetConstants.DEFAULT_RACK + "/" + id);
-    return node == null ? null : (DatanodeDetails)node;
+    return node == null ? null : getDatanodeInfo((DatanodeDetails)node);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -902,9 +902,9 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
-  public DatanodeInfo getNode(DatanodeID id) {
+  public DatanodeDetails getNode(DatanodeID id) {
     Node node = clusterMap.getNode(NetConstants.DEFAULT_RACK + "/" + id);
-    return node == null ? null : getDatanodeInfo((DatanodeDetails)node);
+    return node == null ? null : (DatanodeDetails)node;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -105,7 +106,7 @@ public class MockNodeManager implements NodeManager {
   private final List<DatanodeDetails> healthyNodes;
   private final List<DatanodeDetails> staleNodes;
   private final List<DatanodeDetails> deadNodes;
-  private final Map<DatanodeDetails, SCMNodeStat> nodeMetricMap;
+  private final Map<DatanodeDetails, SCMNodeStat> nodeMetricMap = new TreeMap<>();
   private final SCMNodeStat aggregateStat;
   private final Map<DatanodeID, List<SCMCommand<?>>> commandMap;
   private Node2PipelineMap node2PipelineMap;
@@ -121,7 +122,6 @@ public class MockNodeManager implements NodeManager {
     this.healthyNodes = new LinkedList<>();
     this.staleNodes = new LinkedList<>();
     this.deadNodes = new LinkedList<>();
-    this.nodeMetricMap = new HashMap<>();
     this.node2PipelineMap = new Node2PipelineMap();
     this.node2ContainerMap = new NodeStateMap();
     this.dnsToUuidMap = new ConcurrentHashMap<>();
@@ -250,7 +250,7 @@ public class MockNodeManager implements NodeManager {
    */
   @Override
   public List<DatanodeDetails> getNodes(NodeStatus status) {
-    return getNodes(status.getOperationalState(), status.getHealth());
+    return getDatanodeDetails(status.getOperationalState(), status.getHealth());
   }
 
   /**
@@ -261,7 +261,15 @@ public class MockNodeManager implements NodeManager {
    * @return List of Datanodes that are Heartbeating SCM.
    */
   @Override
-  public List<DatanodeDetails> getNodes(
+  public List<DatanodeInfo> getNodes(HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodestate) {
+    final List<DatanodeDetails> details = getDatanodeDetails(opState, nodestate);
+    if (details == null) {
+      return null;
+    }
+    return details.stream().map(this::getDatanodeInfo).collect(Collectors.toList());
+  }
+
+  private List<DatanodeDetails> getDatanodeDetails(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodestate) {
     if (nodestate == HEALTHY) {
       // mock storage reports for SCMCommonPlacementPolicy.hasEnoughSpace()
@@ -322,22 +330,17 @@ public class MockNodeManager implements NodeManager {
   @Override
   public int getNodeCount(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodestate) {
-    List<DatanodeDetails> nodes = getNodes(opState, nodestate);
+    List<DatanodeDetails> nodes = getDatanodeDetails(opState, nodestate);
     if (nodes != null) {
       return nodes.size();
     }
     return 0;
   }
 
-  /**
-   * Get all datanodes known to SCM.
-   *
-   * @return List of DatanodeDetails known to SCM.
-   */
   @Override
-  public List<DatanodeDetails> getAllNodes() {
+  public List<DatanodeInfo> getAllNodes() {
     // mock storage reports for TestDiskBalancer
-    List<DatanodeDetails> healthyNodesWithInfo = new ArrayList<>();
+    List<DatanodeInfo> healthyNodesWithInfo = new ArrayList<>();
     for (Map.Entry<DatanodeDetails, SCMNodeStat> entry:
         nodeMetricMap.entrySet()) {
       NodeStatus nodeStatus = NodeStatus.inServiceHealthy();
@@ -399,7 +402,7 @@ public class MockNodeManager implements NodeManager {
   public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(
       boolean mostUsed) {
     List<DatanodeDetails> datanodeDetailsList =
-        getNodes(NodeOperationalState.IN_SERVICE, HEALTHY);
+        getDatanodeDetails(NodeOperationalState.IN_SERVICE, HEALTHY);
     if (datanodeDetailsList == null) {
       return new ArrayList<>();
     }
@@ -428,9 +431,11 @@ public class MockNodeManager implements NodeManager {
     return new DatanodeUsageInfo(datanodeDetails, stat);
   }
 
-  @Override
   @Nullable
   public DatanodeInfo getDatanodeInfo(DatanodeDetails dd) {
+    if (dd instanceof DatanodeInfo) {
+      return (DatanodeInfo) dd;
+    }
     if (nodeMetricMap.get(dd) == null) {
       return null;
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -353,7 +353,7 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public DatanodeInfo getNode(DatanodeID id) {
+  public DatanodeDetails getNode(DatanodeID id) {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.container;
 
-import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -193,7 +192,7 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public List<DatanodeDetails> getNodes(
+  public List<DatanodeInfo> getNodes(
       NodeOperationalState opState, HddsProtos.NodeState health) {
     return null;
   }
@@ -210,8 +209,8 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public List<DatanodeDetails> getAllNodes() {
-    return null;
+  public List<DatanodeInfo> getAllNodes() {
+    return Collections.emptyList();
   }
 
   @Override
@@ -240,12 +239,6 @@ public class SimpleMockNodeManager implements NodeManager {
 
   @Override
   public DatanodeUsageInfo getUsageInfo(DatanodeDetails datanodeDetails) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public DatanodeInfo getDatanodeInfo(DatanodeDetails dn) {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -353,7 +353,7 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public DatanodeDetails getNode(DatanodeID id) {
+  public DatanodeInfo getNode(DatanodeID id) {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/reconciliation/TestReconcileContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/reconciliation/TestReconcileContainerEventHandler.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
@@ -54,6 +53,7 @@ import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.container.reconciliation.ReconciliationEligibilityHandler.EligibilityResult;
 import org.apache.hadoop.hdds.scm.container.reconciliation.ReconciliationEligibilityHandler.Result;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -300,7 +300,7 @@ public class TestReconcileContainerEventHandler {
     // If no states are specified, replica list will be empty.
     Set<ContainerReplica> replicas = new HashSet<>();
     try (MockNodeManager nodeManager = new MockNodeManager(true, replicaStates.length)) {
-      List<DatanodeDetails> nodes = nodeManager.getAllNodes();
+      List<DatanodeInfo> nodes = nodeManager.getAllNodes();
       for (int i = 0; i < replicaStates.length; i++) {
         replicas.addAll(HddsTestUtils.getReplicas(CONTAINER_ID, replicaStates[i], nodes.get(i)));
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
@@ -213,7 +213,7 @@ public class TestDecommissionAndMaintenance {
 
     waitForDnToReachOpState(nm, toDecommission, DECOMMISSIONED);
     // Ensure one node transitioned to DECOMMISSIONING
-    List<DatanodeDetails> decomNodes = nm.getNodes(
+    List<DatanodeInfo> decomNodes = nm.getNodes(
         DECOMMISSIONED,
         HEALTHY);
     assertEquals(1, decomNodes.size());
@@ -325,7 +325,7 @@ public class TestDecommissionAndMaintenance {
         toDecommission.get(3).getIpAddress(), toDecommission.get(4).getIpAddress()), false);
 
     // Ensure no nodes transitioned to DECOMMISSIONING or DECOMMISSIONED
-    List<DatanodeDetails> decomNodes = nm.getNodes(
+    List<DatanodeInfo> decomNodes = nm.getNodes(
         DECOMMISSIONING,
         HEALTHY);
     assertEquals(0, decomNodes.size());
@@ -717,7 +717,7 @@ public class TestDecommissionAndMaintenance {
         getDNHostAndPort(toMaintenance.get(5))), 0, false);
 
     // Ensure no nodes transitioned to MAINTENANCE
-    List<DatanodeDetails> maintenanceNodes = nm.getNodes(
+    List<DatanodeInfo> maintenanceNodes = nm.getNodes(
         ENTERING_MAINTENANCE,
         HEALTHY);
     assertEquals(0, maintenanceNodes.size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancer.java
@@ -221,7 +221,7 @@ public class TestDiskBalancer {
     }
 
     // Query status from remaining IN_SERVICE DNs and verify they still show RUNNING
-    List<DatanodeDetails> inServiceDatanodes = nm.getNodes(IN_SERVICE, HddsProtos.NodeState.HEALTHY);
+    final List<DatanodeInfo> inServiceDatanodes = nm.getNodes(IN_SERVICE, HddsProtos.NodeState.HEALTHY);
     statusProtoList.clear();
     for (DatanodeDetails dn : inServiceDatanodes) {
       try (DiskBalancerProtocol proxy = getDiskBalancerProxy(dn)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancerDuringDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDiskBalancerDuringDecommissionAndMaintenance.java
@@ -139,20 +139,13 @@ public class TestDiskBalancerDuringDecommissionAndMaintenance {
   }
 
   /**
-   * Helper method to get all IN_SERVICE datanodes.
-   */
-  private List<DatanodeDetails> getInServiceDatanodes(NodeManager nm) {
-    return nm.getNodes(IN_SERVICE, HddsProtos.NodeState.HEALTHY);
-  }
-
-  /**
    * Helper method to query DiskBalancer info from all IN_SERVICE datanodes.
    * Similar to --in-service-datanodes option in CLI.
    */
   private <T> List<T> queryAllInServiceDatanodes(
       DiskBalancerQuery<T> query) throws IOException {
     NodeManager nm = cluster.getStorageContainerManager().getScmNodeManager();
-    List<DatanodeDetails> inServiceDatanodes = getInServiceDatanodes(nm);
+    final List<DatanodeInfo> inServiceDatanodes = nm.getNodes(IN_SERVICE, HddsProtos.NodeState.HEALTHY);
     List<T> results = new ArrayList<>();
     
     for (DatanodeDetails dn : inServiceDatanodes) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.DEAD;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -109,13 +110,14 @@ public class PipelineSyncTask extends ReconScmTask {
    */
   private void syncOperationalStateOnDeadNodes()
       throws IOException, NodeNotFoundException {
-    List<DatanodeDetails> deadNodesOnRecon = nodeManager.getNodes(null, DEAD);
+    final Set<String> deadNodesOnRecon = nodeManager.getNodes(null, DEAD).stream()
+        .map(info -> info.getID().getID())
+        .collect(Collectors.toSet());
 
     if (!deadNodesOnRecon.isEmpty()) {
       List<Node> scmNodes = scmClient.getNodes();
       List<Node> filteredScmNodes = scmNodes.stream()
-              .filter(n -> deadNodesOnRecon.contains(
-                  DatanodeDetails.getFromProtoBuf(n.getNodeID())))
+              .filter(n -> deadNodesOnRecon.contains(n.getNodeID().getUuid()))
               .collect(Collectors.toList());
 
       for (Node deadNode : filteredScmNodes) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -46,7 +46,9 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.IncrementalContainerReportFromDatanode;
@@ -133,11 +135,12 @@ public class TestReconIncrementalContainerReportHandler
       ReconContainerManager containerManager = getContainerManager();
       containerManager.addNewContainer(containerWithPipeline);
 
-      DatanodeDetails datanodeDetails =
-          containerWithPipeline.getPipeline().getFirstNode();
+      DatanodeInfo datanodeInfo = new DatanodeInfo(
+          containerWithPipeline.getPipeline().getFirstNode(),
+          NodeStatus.inServiceHealthy(), null, 1000);
       NodeManager nodeManagerMock = mock(NodeManager.class);
       when(nodeManagerMock.getNode(any(DatanodeID.class)))
-          .thenReturn(datanodeDetails);
+          .thenReturn(datanodeInfo);
       IncrementalContainerReportFromDatanode reportMock =
           mock(IncrementalContainerReportFromDatanode.class);
       when(reportMock.getDatanodeDetails())
@@ -145,7 +148,7 @@ public class TestReconIncrementalContainerReportHandler
 
       IncrementalContainerReportProto containerReport =
           getIncrementalContainerReportProto(containerID, state,
-              datanodeDetails.getUuidString());
+              datanodeInfo.getUuidString());
       when(reportMock.getReport()).thenReturn(containerReport);
       ReconIncrementalContainerReportHandler reconIcr =
           new ReconIncrementalContainerReportHandler(nodeManagerMock,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -46,7 +46,9 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.IncrementalContainerReportFromDatanode;
@@ -133,11 +135,11 @@ public class TestReconIncrementalContainerReportHandler
       ReconContainerManager containerManager = getContainerManager();
       containerManager.addNewContainer(containerWithPipeline);
 
-      DatanodeDetails datanodeDetails =
-          containerWithPipeline.getPipeline().getFirstNode();
+      final DatanodeInfo datanode = new DatanodeInfo(containerWithPipeline.getPipeline().getFirstNode(),
+          NodeStatus.inServiceHealthy(), null, 1000);
       NodeManager nodeManagerMock = mock(NodeManager.class);
       when(nodeManagerMock.getNode(any(DatanodeID.class)))
-          .thenReturn(datanodeDetails);
+          .thenReturn(datanode);
       IncrementalContainerReportFromDatanode reportMock =
           mock(IncrementalContainerReportFromDatanode.class);
       when(reportMock.getDatanodeDetails())
@@ -145,7 +147,7 @@ public class TestReconIncrementalContainerReportHandler
 
       IncrementalContainerReportProto containerReport =
           getIncrementalContainerReportProto(containerID, state,
-              datanodeDetails.getUuidString());
+              datanode.getUuidString());
       when(reportMock.getReport()).thenReturn(containerReport);
       ReconIncrementalContainerReportHandler reconIcr =
           new ReconIncrementalContainerReportHandler(nodeManagerMock,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -46,9 +46,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
-import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.IncrementalContainerReportFromDatanode;
@@ -135,11 +133,11 @@ public class TestReconIncrementalContainerReportHandler
       ReconContainerManager containerManager = getContainerManager();
       containerManager.addNewContainer(containerWithPipeline);
 
-      final DatanodeInfo datanode = new DatanodeInfo(containerWithPipeline.getPipeline().getFirstNode(),
-          NodeStatus.inServiceHealthy(), null, 1000);
+      DatanodeDetails datanodeDetails =
+          containerWithPipeline.getPipeline().getFirstNode();
       NodeManager nodeManagerMock = mock(NodeManager.class);
       when(nodeManagerMock.getNode(any(DatanodeID.class)))
-          .thenReturn(datanode);
+          .thenReturn(datanodeDetails);
       IncrementalContainerReportFromDatanode reportMock =
           mock(IncrementalContainerReportFromDatanode.class);
       when(reportMock.getDatanodeDetails())
@@ -147,7 +145,7 @@ public class TestReconIncrementalContainerReportHandler
 
       IncrementalContainerReportProto containerReport =
           getIncrementalContainerReportProto(containerID, state,
-              datanode.getUuidString());
+              datanodeDetails.getUuidString());
       when(reportMock.getReport()).thenReturn(containerReport);
       ReconIncrementalContainerReportHandler reconIcr =
           new ReconIncrementalContainerReportHandler(nodeManagerMock,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
@@ -229,7 +230,7 @@ public class TestReconNodeManager {
     reconNodeManager.updateNodeOperationalStateFromScm(node, datanodeDetails);
     assertEquals(DECOMMISSIONING, reconNodeManager
         .getNode(datanodeDetails.getID()).getPersistedOpState());
-    List<DatanodeDetails> nodes =
+    List<DatanodeInfo> nodes =
         reconNodeManager.getNodes(DECOMMISSIONING, null);
     assertEquals(1, nodes.size());
     assertEquals(datanodeDetails.getUuid(), nodes.get(0).getUuid());


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SCMNodeManager, the underlying DatanodeDetails object actually is already a DatanodeInfo.

## What is the link to the Apache JIRA

HDDS-15146

## How was this patch tested?

Updating existing tests.