### PR TITLE
HDDS-14830. Handle interrupt gracefully in XceiverClientGrpc.sendCommandWithRetry

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -542,6 +542,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       } catch (InterruptedException e) {
         LOG.error("Command execution was interrupted ", e);
         Thread.currentThread().interrupt();
+        throw (IOException) new InterruptedIOException(
+            "Command " + processForDebug(request) + " was interrupted.")
+            .initCause(e);
       }
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -20,8 +20,10 @@ package org.apache.hadoop.hdds.scm;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -146,6 +148,31 @@ public class TestXceiverClientGrpc {
       e.printStackTrace();
     }
     assertEquals(0, allDNs.size());
+  }
+
+  @Test
+  public void testInterruptedCommandThrowsInterruptedIOException()
+      throws IOException {
+    final CompletableFuture<ContainerProtos.ContainerCommandResponseProto> response =
+        new CompletableFuture<>();
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      @Override
+      public XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request,
+          DatanodeDetails dn) {
+        return new XceiverClientReply(response);
+      }
+    }) {
+      Thread.currentThread().interrupt();
+      try {
+        InterruptedIOException ex = assertThrows(InterruptedIOException.class,
+            () -> invokeXceiverClientGetBlock(client));
+        assertThat(ex).hasCauseInstanceOf(InterruptedException.class);
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      } finally {
+        Thread.interrupted();
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`XceiverClientGrpc.sendCommandWithRetry` retries a request across the pipeline's datanodes and rethrows the last captured `ioException` after the loop. The `catch (InterruptedException)` branch logged the error and restored the interrupt flag, but did not assign `ioException` or exit the loop. With the flag restored, each subsequent `Future.get()` throws `InterruptedException` immediately, so the loop falls through every datanode and exits with `ioException == null`. The post-loop `Objects.requireNonNull(ioException, ...)` then throws `NullPointerException`, masking the real interrupt — which is what the EC reconstruction worker pool sees during datanode shutdown.

The fix throws `InterruptedIOException` (with the original `InterruptedException` as cause) directly from the catch block. This matches the existing convention already used in `XceiverClientGrpc.sendCommand` (lines 396-411) and `XceiverClientSpi`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14830

## How was this patch tested?

**New unit test** `TestXceiverClientGrpc#testInterruptedCommandThrowsInterruptedIOException` reproduces the original NPE deterministically (pre-sets the test thread's interrupt flag and stubs `sendCommandAsync` to return a never-completing future) and asserts:

- `InterruptedIOException` is thrown — the regression that this PR fixes (was `NullPointerException`).
- The cause is the original `InterruptedException` — debugging info preserved.
- `Thread.currentThread().isInterrupted()` is still true — callers can still detect the interrupt.

The flag is cleared in `finally` before `client.close()` runs, so channel shutdown is not affected by the test setup.

The test fails on master without the production-code change in this PR, confirming it exercises the actual bug path:

<img width="2554" height="1154" alt="Screenshot 2026-05-02 at 7 47 28 PM" src="https://github.com/user-attachments/assets/c0b9a158-9460-4fe4-a3ba-c3512b1aa615" />

**Local checks**: `mvn checkstyle:check -pl hadoop-hdds/client,hadoop-ozone/integration-test` → 0 violations. 
**Full CI**: Runs via the `build-branch` workflow on the fork. https://github.com/chihsuan/ozone/actions/runs/25251708235