### PR TITLE
HDDS-15053. Update ScmInvokerCodeGenerator for generating the latest invokeLocal

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.ha.SCMHandler;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvokerCodeGenerator;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -236,4 +237,8 @@ public interface ContainerStateManager extends SCMHandler {
   @Replicate
   void updateContainerInfo(HddsProtos.ContainerInfoProto containerInfo)
       throws IOException;
+
+  static void main(String[] args) {
+    ScmInvokerCodeGenerator.generate(ContainerStateManager.class, true);
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdds.scm.container.states.ContainerState;
 import org.apache.hadoop.hdds.scm.container.states.ContainerStateMap;
 import org.apache.hadoop.hdds.scm.ha.ExecutionUtil;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.ha.invoker.ContainerStateManagerInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
@@ -653,7 +654,7 @@ public final class ContainerStateManagerImpl
           conf, pipelineMgr, table, transactionBuffer,
           containerReplicaPendingOps);
 
-      return scmRatisServer.getProxyHandler(ContainerStateManager.class, csm);
+      return scmRatisServer.getProxyHandler(new ContainerStateManagerInvoker(csm, scmRatisServer));
     }
 
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha.invoker;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.apache.ratis.protocol.Message;
+
+/** Code generated for {@link ContainerStateManager}.  Do not modify. */
+public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManager> {
+  enum ReplicateMethod implements NameAndParameterTypes {
+    addContainer(new Class<?>[][] {
+        null,
+        new Class<?>[] {ContainerInfoProto.class}
+    }),
+    removeContainer(new Class<?>[][] {
+        null,
+        new Class<?>[] {HddsProtos.ContainerID.class}
+    }),
+    transitionDeletingOrDeletedToTargetState(new Class<?>[][] {
+        null,
+        null,
+        new Class<?>[] {HddsProtos.ContainerID.class, LifeCycleState.class}
+    }),
+    updateContainerInfo(new Class<?>[][] {
+        null,
+        new Class<?>[] {ContainerInfoProto.class}
+    }),
+    updateContainerStateWithSequenceId(new Class<?>[][] {
+        null,
+        null,
+        null,
+        new Class<?>[] {HddsProtos.ContainerID.class, LifeCycleEvent.class, Long.class}
+    });
+
+    private final Class<?>[][] parameterTypes;
+
+    ReplicateMethod(Class<?>[][] parameterTypes) {
+      this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes(int numArgs) {
+      return parameterTypes[numArgs];
+    }
+  }
+
+  public ContainerStateManagerInvoker(ContainerStateManager impl, SCMRatisServer ratis) {
+    super(impl, ContainerStateManagerInvoker::newProxy, ratis);
+  }
+
+  @Override
+  public Class<ContainerStateManager> getApi() {
+    return ContainerStateManager.class;
+  }
+
+  static ContainerStateManager newProxy(ScmInvoker<ContainerStateManager> invoker) {
+    return new ContainerStateManager() {
+
+      @Override
+      public void addContainer(ContainerInfoProto arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.addContainer, args);
+      }
+
+      @Override
+      public boolean contains(ContainerID arg0) {
+        return invoker.getImpl().contains(arg0);
+      }
+
+      @Override
+      public ContainerInfo getContainer(ContainerID arg0) {
+        return invoker.getImpl().getContainer(arg0);
+      }
+
+      @Override
+      public int getContainerCount(LifeCycleState arg0) {
+        return invoker.getImpl().getContainerCount(arg0);
+      }
+
+      @Override
+      public List<ContainerID> getContainerIDs(LifeCycleState arg0, ContainerID arg1, int arg2) {
+        return invoker.getImpl().getContainerIDs(arg0, arg1, arg2);
+      }
+
+      @Override
+      public List<ContainerInfo> getContainerInfos(ReplicationType arg0) {
+        return invoker.getImpl().getContainerInfos(arg0);
+      }
+
+      @Override
+      public List<ContainerInfo> getContainerInfos(LifeCycleState arg0) {
+        return invoker.getImpl().getContainerInfos(arg0);
+      }
+
+      @Override
+      public List<ContainerInfo> getContainerInfos(ContainerID arg0, int arg1) {
+        return invoker.getImpl().getContainerInfos(arg0, arg1);
+      }
+
+      @Override
+      public List<ContainerInfo> getContainerInfos(LifeCycleState arg0, ContainerID arg1, int arg2) {
+        return invoker.getImpl().getContainerInfos(arg0, arg1, arg2);
+      }
+
+      @Override
+      public Set<ContainerReplica> getContainerReplicas(ContainerID arg0) {
+        return invoker.getImpl().getContainerReplicas(arg0);
+      }
+
+      @Override
+      public ContainerInfo getMatchingContainer(long arg0, String arg1, PipelineID arg2, NavigableSet arg3) {
+        return invoker.getImpl().getMatchingContainer(arg0, arg1, arg2, arg3);
+      }
+
+      @Override
+      public void reinitialize(Table arg0) throws IOException {
+        invoker.getImpl().reinitialize(arg0);
+      }
+
+      @Override
+      public void removeContainer(HddsProtos.ContainerID arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.removeContainer, args);
+      }
+
+      @Override
+      public void removeContainerReplica(ContainerReplica arg0) {
+        invoker.getImpl().removeContainerReplica(arg0);
+      }
+
+      @Override
+      public void transitionDeletingOrDeletedToTargetState(HddsProtos.ContainerID arg0, LifeCycleState arg1) throws
+          IOException {
+        final Object[] args = {arg0, arg1};
+        invoker.invokeReplicateDirect(ReplicateMethod.transitionDeletingOrDeletedToTargetState, args);
+      }
+
+      @Override
+      public void updateContainerInfo(ContainerInfoProto arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.updateContainerInfo, args);
+      }
+
+      @Override
+      public void updateContainerReplica(ContainerReplica arg0) {
+        invoker.getImpl().updateContainerReplica(arg0);
+      }
+
+      @Override
+      public void updateContainerStateWithSequenceId(HddsProtos.ContainerID arg0, LifeCycleEvent arg1, Long arg2) throws
+          IOException, InvalidStateTransitionException {
+        final Object[] args = {arg0, arg1, arg2};
+        invoker.invokeReplicateDirect(ReplicateMethod.updateContainerStateWithSequenceId, args);
+      }
+
+      @Override
+      public void updateDeleteTransactionId(Map arg0) throws IOException {
+        invoker.getImpl().updateDeleteTransactionId(arg0);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
+    switch (methodName) {
+    case "addContainer":
+      final ContainerInfoProto arg0 = p.length > 0 ? (ContainerInfoProto) p[0] : null;
+      getImpl().addContainer(arg0);
+      return Message.EMPTY;
+
+    case "contains":
+      final ContainerID arg1 = p.length > 0 ? (ContainerID) p[0] : null;
+      returnType = boolean.class;
+      returnValue = getImpl().contains(arg1);
+      break;
+
+    case "getContainer":
+      final ContainerID arg2 = p.length > 0 ? (ContainerID) p[0] : null;
+      returnType = ContainerInfo.class;
+      returnValue = getImpl().getContainer(arg2);
+      break;
+
+    case "getContainerCount":
+      final LifeCycleState arg3 = p.length > 0 ? (LifeCycleState) p[0] : null;
+      returnType = int.class;
+      returnValue = getImpl().getContainerCount(arg3);
+      break;
+
+    case "getContainerIDs":
+      final LifeCycleState arg4 = p.length > 0 ? (LifeCycleState) p[0] : null;
+      final ContainerID arg5 = p.length > 1 ? (ContainerID) p[1] : null;
+      final int arg6 = p.length > 2 ? (int) p[2] : 0;
+      returnType = List.class;
+      returnValue = getImpl().getContainerIDs(arg4, arg5, arg6);
+      break;
+
+    case "getContainerInfos":
+      if (p.length == 1 && (p[0] == null || ReplicationType.class.isInstance(p[0]))) {
+        final ReplicationType arg7 = (ReplicationType) p[0];
+        returnType = List.class;
+        returnValue = getImpl().getContainerInfos(arg7);
+        break;
+      }
+      if (p.length == 1 && (p[0] == null || LifeCycleState.class.isInstance(p[0]))) {
+        final LifeCycleState arg8 = (LifeCycleState) p[0];
+        returnType = List.class;
+        returnValue = getImpl().getContainerInfos(arg8);
+        break;
+      }
+      if (p.length == 2 && (p[0] == null || ContainerID.class.isInstance(p[0])) && p[1] instanceof Integer) {
+        final ContainerID arg9 = (ContainerID) p[0];
+        final int arg10 = (int) p[1];
+        returnType = List.class;
+        returnValue = getImpl().getContainerInfos(arg9, arg10);
+        break;
+      }
+      if (p.length == 3 && (p[0] == null || LifeCycleState.class.isInstance(p[0])) && (p[1] == null ||
+          ContainerID.class.isInstance(p[1])) && p[2] instanceof Integer) {
+        final LifeCycleState arg11 = (LifeCycleState) p[0];
+        final ContainerID arg12 = (ContainerID) p[1];
+        final int arg13 = (int) p[2];
+        returnType = List.class;
+        returnValue = getImpl().getContainerInfos(arg11, arg12, arg13);
+        break;
+      }
+      throw new IllegalArgumentException("Method not found: " + methodName + " in ContainerStateManager");
+
+    case "getContainerReplicas":
+      final ContainerID arg14 = p.length > 0 ? (ContainerID) p[0] : null;
+      returnType = Set.class;
+      returnValue = getImpl().getContainerReplicas(arg14);
+      break;
+
+    case "getMatchingContainer":
+      final long arg15 = p.length > 0 ? (long) p[0] : 0L;
+      final String arg16 = p.length > 1 ? (String) p[1] : null;
+      final PipelineID arg17 = p.length > 2 ? (PipelineID) p[2] : null;
+      final NavigableSet arg18 = p.length > 3 ? (NavigableSet) p[3] : null;
+      returnType = ContainerInfo.class;
+      returnValue = getImpl().getMatchingContainer(arg15, arg16, arg17, arg18);
+      break;
+
+    case "reinitialize":
+      final Table arg19 = p.length > 0 ? (Table) p[0] : null;
+      getImpl().reinitialize(arg19);
+      return Message.EMPTY;
+
+    case "removeContainer":
+      final HddsProtos.ContainerID arg20 = p.length > 0 ? (HddsProtos.ContainerID) p[0] : null;
+      getImpl().removeContainer(arg20);
+      return Message.EMPTY;
+
+    case "removeContainerReplica":
+      final ContainerReplica arg21 = p.length > 0 ? (ContainerReplica) p[0] : null;
+      getImpl().removeContainerReplica(arg21);
+      return Message.EMPTY;
+
+    case "transitionDeletingOrDeletedToTargetState":
+      final HddsProtos.ContainerID arg22 = p.length > 0 ? (HddsProtos.ContainerID) p[0] : null;
+      final LifeCycleState arg23 = p.length > 1 ? (LifeCycleState) p[1] : null;
+      getImpl().transitionDeletingOrDeletedToTargetState(arg22, arg23);
+      return Message.EMPTY;
+
+    case "updateContainerInfo":
+      final ContainerInfoProto arg24 = p.length > 0 ? (ContainerInfoProto) p[0] : null;
+      getImpl().updateContainerInfo(arg24);
+      return Message.EMPTY;
+
+    case "updateContainerReplica":
+      final ContainerReplica arg25 = p.length > 0 ? (ContainerReplica) p[0] : null;
+      getImpl().updateContainerReplica(arg25);
+      return Message.EMPTY;
+
+    case "updateContainerStateWithSequenceId":
+      final HddsProtos.ContainerID arg26 = p.length > 0 ? (HddsProtos.ContainerID) p[0] : null;
+      final LifeCycleEvent arg27 = p.length > 1 ? (LifeCycleEvent) p[1] : null;
+      final Long arg28 = p.length > 2 ? (Long) p[2] : null;
+      getImpl().updateContainerStateWithSequenceId(arg26, arg27, arg28);
+      return Message.EMPTY;
+
+    case "updateDeleteTransactionId":
+      final Map arg29 = p.length > 0 ? (Map) p[0] : null;
+      getImpl().updateDeleteTransactionId(arg29);
+      return Message.EMPTY;
+
+    default:
+      throw new IllegalArgumentException("Method not found: " + methodName + " in ContainerStateManager");
+    }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/PipelineStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/PipelineStateManagerInvoker.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha.invoker;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableSet;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.pipeline.DuplicatedPipelineIdException;
+import org.apache.hadoop.hdds.scm.pipeline.InvalidPipelineStateException;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
+import org.apache.hadoop.hdds.utils.db.CodecException;
+import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.ratis.protocol.Message;
+
+/** Code generated for {@link PipelineStateManager}.  Do not modify. */
+public class PipelineStateManagerInvoker extends ScmInvoker<PipelineStateManager> {
+  enum ReplicateMethod implements NameAndParameterTypes {
+    addPipeline(new Class<?>[][] {
+        null,
+        new Class<?>[] {HddsProtos.Pipeline.class}
+    }),
+    removePipeline(new Class<?>[][] {
+        null,
+        new Class<?>[] {HddsProtos.PipelineID.class}
+    }),
+    updatePipelineState(new Class<?>[][] {
+        null,
+        null,
+        new Class<?>[] {HddsProtos.PipelineID.class, HddsProtos.PipelineState.class}
+    });
+
+    private final Class<?>[][] parameterTypes;
+
+    ReplicateMethod(Class<?>[][] parameterTypes) {
+      this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes(int numArgs) {
+      return parameterTypes[numArgs];
+    }
+  }
+
+  public PipelineStateManagerInvoker(PipelineStateManager impl, SCMRatisServer ratis) {
+    super(impl, PipelineStateManagerInvoker::newProxy, ratis);
+  }
+
+  @Override
+  public Class<PipelineStateManager> getApi() {
+    return PipelineStateManager.class;
+  }
+
+  static PipelineStateManager newProxy(ScmInvoker<PipelineStateManager> invoker) {
+    return new PipelineStateManager() {
+
+      @Override
+      public void addContainerToPipeline(PipelineID arg0, ContainerID arg1) throws PipelineNotFoundException,
+          InvalidPipelineStateException {
+        invoker.getImpl().addContainerToPipeline(arg0, arg1);
+      }
+
+      @Override
+      public void addContainerToPipelineForce(PipelineID arg0, ContainerID arg1) throws PipelineNotFoundException {
+        invoker.getImpl().addContainerToPipelineForce(arg0, arg1);
+      }
+
+      @Override
+      public void addPipeline(HddsProtos.Pipeline arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.addPipeline, args);
+      }
+
+      @Override
+      public void close() {
+        invoker.getImpl().close();
+      }
+
+      @Override
+      public NavigableSet<ContainerID> getContainers(PipelineID arg0) throws PipelineNotFoundException {
+        return invoker.getImpl().getContainers(arg0);
+      }
+
+      @Override
+      public int getNumberOfContainers(PipelineID arg0) throws PipelineNotFoundException {
+        return invoker.getImpl().getNumberOfContainers(arg0);
+      }
+
+      @Override
+      public Pipeline getPipeline(PipelineID arg0) throws PipelineNotFoundException {
+        return invoker.getImpl().getPipeline(arg0);
+      }
+
+      @Override
+      public int getPipelineCount(ReplicationConfig arg0, Pipeline.PipelineState arg1) {
+        return invoker.getImpl().getPipelineCount(arg0, arg1);
+      }
+
+      @Override
+      public List<Pipeline> getPipelines() {
+        return invoker.getImpl().getPipelines();
+      }
+
+      @Override
+      public List<Pipeline> getPipelines(ReplicationConfig arg0) {
+        return invoker.getImpl().getPipelines(arg0);
+      }
+
+      @Override
+      public List<Pipeline> getPipelines(ReplicationConfig arg0, Pipeline.PipelineState arg1) {
+        return invoker.getImpl().getPipelines(arg0, arg1);
+      }
+
+      @Override
+      public List<Pipeline> getPipelines(ReplicationConfig arg0, Pipeline.PipelineState arg1, Collection arg2,
+          Collection arg3) {
+        return invoker.getImpl().getPipelines(arg0, arg1, arg2, arg3);
+      }
+
+      @Override
+      public void reinitialize(Table arg0) throws RocksDatabaseException, DuplicatedPipelineIdException,
+          CodecException {
+        invoker.getImpl().reinitialize(arg0);
+      }
+
+      @Override
+      public void removeContainerFromPipeline(PipelineID arg0, ContainerID arg1) {
+        invoker.getImpl().removeContainerFromPipeline(arg0, arg1);
+      }
+
+      @Override
+      public void removePipeline(HddsProtos.PipelineID arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.removePipeline, args);
+      }
+
+      @Override
+      public void updatePipelineState(HddsProtos.PipelineID arg0, HddsProtos.PipelineState arg1) throws IOException {
+        final Object[] args = {arg0, arg1};
+        invoker.invokeReplicateDirect(ReplicateMethod.updatePipelineState, args);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
+    switch (methodName) {
+    case "addContainerToPipeline":
+      final PipelineID arg0 = p.length > 0 ? (PipelineID) p[0] : null;
+      final ContainerID arg1 = p.length > 1 ? (ContainerID) p[1] : null;
+      getImpl().addContainerToPipeline(arg0, arg1);
+      return Message.EMPTY;
+
+    case "addContainerToPipelineForce":
+      final PipelineID arg2 = p.length > 0 ? (PipelineID) p[0] : null;
+      final ContainerID arg3 = p.length > 1 ? (ContainerID) p[1] : null;
+      getImpl().addContainerToPipelineForce(arg2, arg3);
+      return Message.EMPTY;
+
+    case "addPipeline":
+      final HddsProtos.Pipeline arg4 = p.length > 0 ? (HddsProtos.Pipeline) p[0] : null;
+      getImpl().addPipeline(arg4);
+      return Message.EMPTY;
+
+    case "close":
+      getImpl().close();
+      return Message.EMPTY;
+
+    case "getContainers":
+      final PipelineID arg5 = p.length > 0 ? (PipelineID) p[0] : null;
+      returnType = NavigableSet.class;
+      returnValue = getImpl().getContainers(arg5);
+      break;
+
+    case "getNumberOfContainers":
+      final PipelineID arg6 = p.length > 0 ? (PipelineID) p[0] : null;
+      returnType = int.class;
+      returnValue = getImpl().getNumberOfContainers(arg6);
+      break;
+
+    case "getPipeline":
+      final PipelineID arg7 = p.length > 0 ? (PipelineID) p[0] : null;
+      returnType = Pipeline.class;
+      returnValue = getImpl().getPipeline(arg7);
+      break;
+
+    case "getPipelineCount":
+      final ReplicationConfig arg8 = p.length > 0 ? (ReplicationConfig) p[0] : null;
+      final Pipeline.PipelineState arg9 = p.length > 1 ? (Pipeline.PipelineState) p[1] : null;
+      returnType = int.class;
+      returnValue = getImpl().getPipelineCount(arg8, arg9);
+      break;
+
+    case "getPipelines":
+      if (p.length == 0) {
+        returnType = List.class;
+        returnValue = getImpl().getPipelines();
+        break;
+      }
+      if (p.length == 1 && (p[0] == null || ReplicationConfig.class.isInstance(p[0]))) {
+        final ReplicationConfig arg10 = (ReplicationConfig) p[0];
+        returnType = List.class;
+        returnValue = getImpl().getPipelines(arg10);
+        break;
+      }
+      if (p.length == 2 && (p[0] == null || ReplicationConfig.class.isInstance(p[0])) && (p[1] == null ||
+          Pipeline.PipelineState.class.isInstance(p[1]))) {
+        final ReplicationConfig arg11 = (ReplicationConfig) p[0];
+        final Pipeline.PipelineState arg12 = (Pipeline.PipelineState) p[1];
+        returnType = List.class;
+        returnValue = getImpl().getPipelines(arg11, arg12);
+        break;
+      }
+      if (p.length == 4 && (p[0] == null || ReplicationConfig.class.isInstance(p[0])) && (p[1] == null ||
+          Pipeline.PipelineState.class.isInstance(p[1])) && (p[2] == null || Collection.class.isInstance(p[2])) && (p[3]
+          == null || Collection.class.isInstance(p[3]))) {
+        final ReplicationConfig arg13 = (ReplicationConfig) p[0];
+        final Pipeline.PipelineState arg14 = (Pipeline.PipelineState) p[1];
+        final Collection arg15 = (Collection) p[2];
+        final Collection arg16 = (Collection) p[3];
+        returnType = List.class;
+        returnValue = getImpl().getPipelines(arg13, arg14, arg15, arg16);
+        break;
+      }
+      throw new IllegalArgumentException("Method not found: " + methodName + " in PipelineStateManager");
+
+    case "reinitialize":
+      final Table arg17 = p.length > 0 ? (Table) p[0] : null;
+      getImpl().reinitialize(arg17);
+      return Message.EMPTY;
+
+    case "removeContainerFromPipeline":
+      final PipelineID arg18 = p.length > 0 ? (PipelineID) p[0] : null;
+      final ContainerID arg19 = p.length > 1 ? (ContainerID) p[1] : null;
+      getImpl().removeContainerFromPipeline(arg18, arg19);
+      return Message.EMPTY;
+
+    case "removePipeline":
+      final HddsProtos.PipelineID arg20 = p.length > 0 ? (HddsProtos.PipelineID) p[0] : null;
+      getImpl().removePipeline(arg20);
+      return Message.EMPTY;
+
+    case "updatePipelineState":
+      final HddsProtos.PipelineID arg21 = p.length > 0 ? (HddsProtos.PipelineID) p[0] : null;
+      final HddsProtos.PipelineState arg22 = p.length > 1 ? (HddsProtos.PipelineState) p[1] : null;
+      getImpl().updatePipelineState(arg21, arg22);
+      return Message.EMPTY;
+
+    default:
+      throw new IllegalArgumentException("Method not found: " + methodName + " in PipelineStateManager");
+    }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.util.Preconditions;
@@ -114,24 +115,38 @@ public final class ScmInvokerCodeGenerator {
     String s = lineBuffer.toString();
     lineBuffer.getBuffer().setLength(0);
 
-    if (s.length() <= LINE_LENGTH) {
-      out.append(s).append(System.lineSeparator());
-      return;
+    final int nonSpace = getLeadingSpaces(s);
+    String continuation = s.substring(0, nonSpace) + "    ";
+    while (s.length() > LINE_LENGTH) {
+      final int i = getLineBreakIndex(s);
+      out.append(stripTrailingSpaces(s.substring(0, i)))
+          .append(System.lineSeparator());
+      s = continuation + stripLeadingSpaces(s.substring(i));
     }
+    out.append(s).append(System.lineSeparator());
+  }
 
-    // break long lines
+  static int getLeadingSpaces(String s) {
     int nonSpace = 0;
-    while (s.charAt(nonSpace) == ' ') {
+    while (nonSpace < s.length() && s.charAt(nonSpace) == ' ') {
       nonSpace++;
     }
+    return nonSpace;
+  }
 
-    final int i = s.lastIndexOf(' ', LINE_LENGTH);
-    out.append(s.substring(0, i))
-        .append(System.lineSeparator());
-    out.append(s.substring(0, nonSpace)) // original indentation
-        .append("    ")
-        .append(s.substring(i + 1))
-        .append(System.lineSeparator());
+  static int getLineBreakIndex(String s) {
+    int i = s.lastIndexOf(' ', LINE_LENGTH);
+    if (i <= 0) {
+      return LINE_LENGTH;
+    }
+
+    if ("{".equals(s.substring(i).trim())) {
+      final int comma = s.lastIndexOf(',', i);
+      if (comma > 0) {
+        return comma + 1;
+      }
+    }
+    return i;
   }
 
   UncheckedAutoCloseable printScope() {
@@ -169,7 +184,9 @@ public final class ScmInvokerCodeGenerator {
   boolean hasSimpleNameConflict(Class<?> clazz) {
     final String simpleName = clazz.getSimpleName();
     return Arrays.stream(api.getMethods())
-        .flatMap(method -> Arrays.stream(method.getParameterTypes()))
+        .flatMap(method -> Stream.concat(
+            Arrays.stream(method.getParameterTypes()),
+            Stream.of(method.getReturnType())))
         .anyMatch(type -> type != clazz && type.getSimpleName().equals(simpleName));
   }
 
@@ -692,5 +709,21 @@ public final class ScmInvokerCodeGenerator {
       out.print(classString);
     }
     return java;
+  }
+
+  static String stripTrailingSpaces(String s) {
+    int end = s.length();
+    while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+      end--;
+    }
+    return s.substring(0, end);
+  }
+
+  static String stripLeadingSpaces(String s) {
+    int start = 0;
+    while (start < s.length() && Character.isWhitespace(s.charAt(start))) {
+      start++;
+    }
+    return s.substring(start);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -433,11 +433,11 @@ public final class ScmInvokerCodeGenerator {
       final Class<?> type = parameterTypes[i];
       final String checkType = getClassnameForApi(type.isPrimitive() ? getBoxedType(type) : type);
       if (type.isPrimitive()) {
-        b.append(" && ").append(actualParameter).append("[").append(i).append("] instanceof ")
+        b.append(" && ").append(actualParameter).append('[').append(i).append("] instanceof ")
             .append(checkType);
       } else {
-        b.append(" && (").append(actualParameter).append("[").append(i).append("] == null || ")
-            .append(checkType).append(".class.isInstance(").append(actualParameter).append("[")
+        b.append(" && (").append(actualParameter).append('[').append(i).append("] == null || ")
+            .append(checkType).append(".class.isInstance(").append(actualParameter).append('[')
             .append(i).append("]))");
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -38,7 +37,9 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -154,6 +155,39 @@ public final class ScmInvokerCodeGenerator {
 
   static String getClassname(Class<?> clazz) {
     return getClassnameBuilder(clazz).toString();
+  }
+
+  String getClassnameForApi(Class<?> clazz) {
+    if (clazz.getEnclosingClass() != null
+        && clazz.getEnclosingClass().getSimpleName().endsWith("Protos")
+        && hasSimpleNameConflict(clazz)) {
+      return clazz.getEnclosingClass().getSimpleName() + "." + clazz.getSimpleName();
+    }
+    return getClassname(clazz);
+  }
+
+  boolean hasSimpleNameConflict(Class<?> clazz) {
+    final String simpleName = clazz.getSimpleName();
+    return Arrays.stream(api.getMethods())
+        .flatMap(method -> Arrays.stream(method.getParameterTypes()))
+        .anyMatch(type -> type != clazz && type.getSimpleName().equals(simpleName));
+  }
+
+  String getParameterStringForApi(Class<?>[] types, String[] names) {
+    final StringBuilder b = new StringBuilder();
+    final int n = names != null ? names.length : types.length;
+    for (int i = 0; i < n; i++) {
+      b.append(getClassnameForApi(types[i])).append(' ')
+          .append(names != null ? names[i] : "arg" + i).append(", ");
+    }
+    if (b.length() > 0) {
+      b.setLength(b.length() - 2);
+    }
+    return b.toString();
+  }
+
+  String classesToStringForApi(Class<?>[] classes, String suffix) {
+    return arrayToString(classes, c -> getClassnameForApi(c) + suffix);
   }
 
   static StringBuilder getClassnameBuilder(Class<?> clazz) {
@@ -305,7 +339,7 @@ public final class ScmInvokerCodeGenerator {
         if (classes == null) {
           printf("null");
         } else {
-          printf("new Class<?>[] {%s}", classesToString(classes, ".class"));
+          printf("new Class<?>[] {%s}", classesToStringForApi(classes, ".class"));
         }
       }
     }
@@ -342,32 +376,123 @@ public final class ScmInvokerCodeGenerator {
     }
   }
 
-  void printCase(Method apiMethod, String actualParameter, AtomicInteger argCount) {
-    printf("case \"%s\":", apiMethod.getName());
+  void printCase(List<Method> apiMethods, String actualParameter, String switchName, AtomicInteger argCount) {
+    printf("case \"%s\":", apiMethods.get(0).getName());
     try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
-      final Parameter[] apiParameters = apiMethod.getParameters();
-      final StringBuilder b = new StringBuilder();
-      for (int i = 0; i < apiParameters.length; i++) {
-        final Parameter p = apiParameters[i];
-        final String classname = getClassname(p.getType());
-        final String arg = "arg" + argCount.getAndIncrement();
-        b.append(arg).append(", ");
-        println("final %s %s = %s.length > %d ? (%s) %s[%d] : null;", classname, arg,
-            actualParameter, i, classname, actualParameter, i);
-      }
-      if (b.length() > 0) {
-        b.setLength(b.length() - 2);
-      }
-      if (apiMethod.getReturnType() == void.class) {
-        println("getImpl().%s(%s);", apiMethod.getName(), b);
-        println("return Message.EMPTY;");
+      if (apiMethods.size() == 1) {
+        printMethodCall(apiMethods.get(0), actualParameter, argCount, false);
       } else {
-        println("returnType = %s.class;", getClassname(apiMethod.getReturnType()));
-        println("returnValue = getImpl().%s(%s);", apiMethod.getName(), b);
-        println("break;");
+        for (Method apiMethod : apiMethods) {
+          printf("if (%s)", getParameterMatchCondition(apiMethod, actualParameter));
+          try (UncheckedAutoCloseable ignored = printScope()) {
+            printMethodCall(apiMethod, actualParameter, argCount, true);
+          }
+        }
+        printMethodNotFound(null, switchName);
       }
     }
     println();
+  }
+
+  void printMethodCall(Method apiMethod, String actualParameter, AtomicInteger argCount, boolean exactArgs) {
+    final Parameter[] apiParameters = apiMethod.getParameters();
+    final StringBuilder b = new StringBuilder();
+    for (int i = 0; i < apiParameters.length; i++) {
+      final Parameter p = apiParameters[i];
+      final String classname = getClassnameForApi(p.getType());
+      final String arg = "arg" + argCount.getAndIncrement();
+      b.append(arg).append(", ");
+      if (exactArgs) {
+        println("final %s %s = (%s) %s[%d];", classname, arg, classname, actualParameter, i);
+      } else {
+        println("final %s %s = %s.length > %d ? (%s) %s[%d] : %s;", classname, arg,
+            actualParameter, i, classname, actualParameter, i, getDefaultValue(p.getType()));
+      }
+    }
+    if (b.length() > 0) {
+      b.setLength(b.length() - 2);
+    }
+    if (apiMethod.getReturnType() == void.class) {
+      println("getImpl().%s(%s);", apiMethod.getName(), b);
+      println("return Message.EMPTY;");
+    } else {
+      println("returnType = %s.class;", getClassname(apiMethod.getReturnType()));
+      println("returnValue = getImpl().%s(%s);", apiMethod.getName(), b);
+      println("break;");
+    }
+  }
+
+  String getParameterMatchCondition(Method method, String actualParameter) {
+    final StringBuilder b = new StringBuilder()
+        .append(actualParameter)
+        .append(".length == ")
+        .append(method.getParameterCount());
+
+    final Class<?>[] parameterTypes = method.getParameterTypes();
+    for (int i = 0; i < parameterTypes.length; i++) {
+      final Class<?> type = parameterTypes[i];
+      final String checkType = getClassnameForApi(type.isPrimitive() ? getBoxedType(type) : type);
+      if (type.isPrimitive()) {
+        b.append(" && ").append(actualParameter).append("[").append(i).append("] instanceof ")
+            .append(checkType);
+      } else {
+        b.append(" && (").append(actualParameter).append("[").append(i).append("] == null || ")
+            .append(checkType).append(".class.isInstance(").append(actualParameter).append("[")
+            .append(i).append("]))");
+      }
+    }
+    return b.toString();
+  }
+
+  static Class<?> getBoxedType(Class<?> type) {
+    if (type == boolean.class) {
+      return Boolean.class;
+    } else if (type == byte.class) {
+      return Byte.class;
+    } else if (type == char.class) {
+      return Character.class;
+    } else if (type == short.class) {
+      return Short.class;
+    } else if (type == int.class) {
+      return Integer.class;
+    } else if (type == long.class) {
+      return Long.class;
+    } else if (type == float.class) {
+      return Float.class;
+    } else if (type == double.class) {
+      return Double.class;
+    }
+    return type;
+  }
+
+  static String getDefaultValue(Class<?> type) {
+    if (!type.isPrimitive()) {
+      return "null";
+    } else if (type == boolean.class) {
+      return "false";
+    } else if (type == char.class) {
+      return "'\\0'";
+    } else if (type == long.class) {
+      return "0L";
+    } else if (type == float.class) {
+      return "0F";
+    } else if (type == double.class) {
+      return "0D";
+    }
+    return "0";
+  }
+
+  void printMethodNotFound(String label, String switchName) {
+    if (label != null) {
+      printf("%s:", label);
+      try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
+        println("throw new IllegalArgumentException(\"Method not found: \" + %s + \" in %s\");",
+            switchName, apiName);
+      }
+    } else {
+      println("throw new IllegalArgumentException(\"Method not found: \" + %s + \" in %s\");",
+          switchName, apiName);
+    }
   }
 
   void printSwitch(DeclaredMethod method) {
@@ -375,15 +500,15 @@ public final class ScmInvokerCodeGenerator {
     printf("switch (%s)", switchName);
     try (UncheckedAutoCloseable ignored = printScope(true, 0)) {
       final AtomicInteger argCount = new AtomicInteger(0);
-      for (Method apiMethod : getMethods(false, null)) {
-        printCase(apiMethod, method.getParameterName(1), argCount);
+      final Map<String, List<Method>> methodsByName = getMethods(false, null).stream()
+          .collect(Collectors.groupingBy(
+              Method::getName, LinkedHashMap::new, Collectors.toList()));
+
+      for (List<Method> apiMethods : methodsByName.values()) {
+        printCase(apiMethods, method.getParameterName(1), switchName, argCount);
       }
 
-      printf("default:");
-      try (UncheckedAutoCloseable ignore = printScope(false, 1)) {
-        println("throw new IllegalArgumentException(\"Method not found: \" + %s + \" in %s\");",
-            switchName, apiName);
-      }
+      printMethodNotFound("default", switchName);
     }
   }
 
@@ -413,7 +538,7 @@ public final class ScmInvokerCodeGenerator {
     printf("public %s %s(%s)%s",
         getReturnTypeString(method),
         method.getName(),
-        getParameterString(method.getParameterTypes(), null),
+        getParameterStringForApi(method.getParameterTypes(), null),
         getThrowsString(method.getExceptionTypes()));
 
     try (UncheckedAutoCloseable ignored = printScope()) {
@@ -464,7 +589,7 @@ public final class ScmInvokerCodeGenerator {
   File updateFile(String classString) throws IOException {
     final File java = new File(DIR, invokerClassName + ".java");
     if (!java.isFile()) {
-      throw new FileNotFoundException("Not found: " + java.getAbsolutePath());
+      return createFile(java, classString);
     }
     final File tmp = new File(DIR, invokerClassName + "_tmp.java");
     if (tmp.exists()) {
@@ -536,5 +661,36 @@ public final class ScmInvokerCodeGenerator {
           getParameterString(parameterTypes, parameterNames),
           getThrowsString(exceptionTypes));
     }
+  }
+
+  File createFile(File java, String classString) throws IOException {
+    try (OutputStream outStream = Files.newOutputStream(java.toPath(), StandardOpenOption.CREATE_NEW);
+        PrintWriter out = new PrintWriter(new OutputStreamWriter(outStream, UTF_8), true)) {
+      out.println("/*");
+      out.println(" * Licensed to the Apache Software Foundation (ASF) under one or more");
+      out.println(" * contributor license agreements. See the NOTICE file distributed with");
+      out.println(" * this work for additional information regarding copyright ownership.");
+      out.println(" * The ASF licenses this file to You under the Apache License, Version 2.0");
+      out.println(" * (the \"License\"); you may not use this file except in compliance with");
+      out.println(" * the License. You may obtain a copy of the License at");
+      out.println(" *");
+      out.println(" *      http://www.apache.org/licenses/LICENSE-2.0");
+      out.println(" *");
+      out.println(" * Unless required by applicable law or agreed to in writing, software");
+      out.println(" * distributed under the License is distributed on an \"AS IS\" BASIS,");
+      out.println(" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.");
+      out.println(" * See the License for the specific language governing permissions and");
+      out.println(" * limitations under the License.");
+      out.println(" */");
+      out.println();
+      out.println("package org.apache.hadoop.hdds.scm.ha.invoker;");
+      out.println();
+      out.println("import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;");
+      out.println("import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;");
+      out.println("import org.apache.ratis.protocol.Message;");
+      out.println();
+      out.print(classString);
+    }
+    return java;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -45,6 +45,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
+import org.apache.ratis.protocol.Message;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.UncheckedAutoCloseable;
 
@@ -69,7 +70,7 @@ public final class ScmInvokerCodeGenerator {
   static final DeclaredMethod INVOKE_LOCAL = new DeclaredMethod("invokeLocal",
       new Class[]{String.class, Object[].class},
       new String[]{"methodName", "p"},
-      Object.class,
+      Message.class,
       new Class<?>[]{Exception.class});
 
   private final Class<?> api;
@@ -359,9 +360,11 @@ public final class ScmInvokerCodeGenerator {
       }
       if (apiMethod.getReturnType() == void.class) {
         println("getImpl().%s(%s);", apiMethod.getName(), b);
-        println("return null;");
+        println("return Message.EMPTY;");
       } else {
-        println("return getImpl().%s(%s);", apiMethod.getName(), b);
+        println("returnType = %s.class;", getClassname(apiMethod.getReturnType()));
+        println("returnValue = getImpl().%s(%s);", apiMethod.getName(), b);
+        println("break;");
       }
     }
     println();
@@ -390,7 +393,11 @@ public final class ScmInvokerCodeGenerator {
     println("@Override");
     printf(method.getSignature());
     try (UncheckedAutoCloseable ignored = printScope()) {
+      println("final Class<?> returnType;");
+      println("final Object returnValue;");
       printSwitch(method);
+      println();
+      println("return SCMRatisResponse.encode(returnValue, returnType);");
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -433,7 +434,7 @@ public final class ScmInvokerCodeGenerator {
       println("getImpl().%s(%s);", apiMethod.getName(), b);
       println("return Message.EMPTY;");
     } else {
-      println("returnType = %s.class;", getClassname(apiMethod.getReturnType()));
+      println("returnType = %s.class;", getClassnameForApi(apiMethod.getReturnType()));
       println("returnValue = getImpl().%s(%s);", apiMethod.getName(), b);
       println("break;");
     }
@@ -606,7 +607,7 @@ public final class ScmInvokerCodeGenerator {
   File updateFile(String classString) throws IOException {
     final File java = new File(DIR, invokerClassName + ".java");
     if (!java.isFile()) {
-      return createFile(java, classString);
+      throw new FileNotFoundException("Not found: " + java.getAbsolutePath());
     }
     final File tmp = new File(DIR, invokerClassName + "_tmp.java");
     if (tmp.exists()) {
@@ -680,40 +681,9 @@ public final class ScmInvokerCodeGenerator {
     }
   }
 
-  File createFile(File java, String classString) throws IOException {
-    try (OutputStream outStream = Files.newOutputStream(java.toPath(), StandardOpenOption.CREATE_NEW);
-        PrintWriter out = new PrintWriter(new OutputStreamWriter(outStream, UTF_8), true)) {
-      out.println("/*");
-      out.println(" * Licensed to the Apache Software Foundation (ASF) under one or more");
-      out.println(" * contributor license agreements. See the NOTICE file distributed with");
-      out.println(" * this work for additional information regarding copyright ownership.");
-      out.println(" * The ASF licenses this file to You under the Apache License, Version 2.0");
-      out.println(" * (the \"License\"); you may not use this file except in compliance with");
-      out.println(" * the License. You may obtain a copy of the License at");
-      out.println(" *");
-      out.println(" *      http://www.apache.org/licenses/LICENSE-2.0");
-      out.println(" *");
-      out.println(" * Unless required by applicable law or agreed to in writing, software");
-      out.println(" * distributed under the License is distributed on an \"AS IS\" BASIS,");
-      out.println(" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.");
-      out.println(" * See the License for the specific language governing permissions and");
-      out.println(" * limitations under the License.");
-      out.println(" */");
-      out.println();
-      out.println("package org.apache.hadoop.hdds.scm.ha.invoker;");
-      out.println();
-      out.println("import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;");
-      out.println("import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;");
-      out.println("import org.apache.ratis.protocol.Message;");
-      out.println();
-      out.print(classString);
-    }
-    return java;
-  }
-
   static String stripTrailingSpaces(String s) {
     int end = s.length();
-    while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+    while (end > 0 && s.charAt(end - 1) == ' ') {
       end--;
     }
     return s.substring(0, end);
@@ -721,7 +691,7 @@ public final class ScmInvokerCodeGenerator {
 
   static String stripLeadingSpaces(String s) {
     int start = 0;
-    while (start < s.length() && Character.isWhitespace(s.charAt(start))) {
+    while (start < s.length() && s.charAt(start) == ' ') {
       start++;
     }
     return s.substring(start);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.ha.SCMHandler;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvokerCodeGenerator;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.utils.db.CodecException;
 import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
@@ -113,5 +114,9 @@ public interface PipelineStateManager extends SCMHandler {
   @Override
   default RequestType getType() {
     return RequestType.PIPELINE;
+  }
+
+  static void main(String[] args) {
+    ScmInvokerCodeGenerator.generate(PipelineStateManager.class, true);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.ha.invoker.PipelineStateManagerInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.utils.db.CodecException;
@@ -363,7 +364,7 @@ public final class PipelineStateManagerImpl implements PipelineStateManager {
           pipelineStore, nodeManager, transactionBuffer);
       pipelineStateManager.initialize();
 
-      return scmRatisServer.getProxyHandler(PipelineStateManager.class, pipelineStateManager);
+      return scmRatisServer.getProxyHandler(new PipelineStateManagerInvoker(pipelineStateManager, scmRatisServer));
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
* Updated `ScmInvokerCodeGenerator` to generate `Message`-returning `invokeLocal` methods for HDDS-14974.
* Changed generated local invocation handling so non-void methods store `returnType`/`returnValue` and encode the result with `SCMRatisResponse.encode(...)`.
* Changed generated void local invocations to return `Message.EMPTY`.
* Added generated `invokeLocal` support for overloaded API methods by grouping methods by name and dispatching by argument count/type.
* Added API-aware class name generation to avoid proto nested class name conflicts such as `HddsProtos.ContainerID` vs `ContainerID`.
* Added generated invokers for `ContainerStateManager` and `PipelineStateManager`.
* Switched `ContainerStateManagerImpl` and `PipelineStateManagerImpl` to use the generated invokers.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15053
## How was this patch tested?
- All CI checks passed
   -  https://github.com/Russole/ozone/actions/runs/25267404850
