### PR TITLE
HDDS-15176. Ozone SCM fails to start when gRPC cipher policy list includes unsupported cipher

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -58,6 +58,7 @@ import org.apache.ratis.thirdparty.io.netty.channel.epoll.EpollServerSocketChann
 import org.apache.ratis.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +147,9 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
         SslContextBuilder sslContextBuilder = GrpcSslContexts.configure(
             sslClientContextBuilder, secConf.getGrpcSslProvider());
         sslContextBuilder.protocols(secConf.getGrpcTlsProtocols());
-        sslContextBuilder.ciphers(secConf.getGrpcTlsCiphers());
+        sslContextBuilder.ciphers(
+            secConf.getGrpcTlsCiphers(),
+            SupportedCipherSuiteFilter.INSTANCE);
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure datanode GRPC endpoint.", ex);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -44,6 +44,7 @@ import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +122,9 @@ public class ReplicationServer {
         sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
         sslContextBuilder.trustManager(caClient.getTrustManager());
         sslContextBuilder.protocols(secConf.getGrpcTlsProtocols());
-        sslContextBuilder.ciphers(secConf.getGrpcTlsCiphers());
+        sslContextBuilder.ciphers(
+            secConf.getGrpcTlsCiphers(),
+            SupportedCipherSuiteFilter.INSTANCE);
 
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (IOException ex) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestGrpcTlsConfig.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestGrpcTlsConfig.java
@@ -51,6 +51,7 @@ import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -146,6 +147,26 @@ public class TestGrpcTlsConfig {
     }
   }
 
+  @Test
+  public void testServerIgnoresUnsupportedConfiguredCiphers() throws Exception {
+    Server server = null;
+    ManagedChannel channel = null;
+    try {
+      String[] configuredCiphers = {
+          "TLS_FAKE_CIPHER_SUITE",
+          "TLS_AES_256_GCM_SHA384"
+      };
+      server = setupServer(new String[]{"TLSv1.3"}, configuredCiphers);
+      server.start();
+      channel = setupClient(server.getPort(), new String[]{"TLSv1.3"}, new String[]{"TLS_AES_256_GCM_SHA384"});
+      XceiverClientProtocolServiceStub asyncStub = XceiverClientProtocolServiceGrpc.newStub(channel);
+      ContainerCommandResponseProto response = sendRequest(asyncStub);
+      assertEquals(SUCCESS, response.getResult());
+    } finally {
+      shutdown(channel, server);
+    }
+  }
+
   private Server setupServer(String[] protocols, String[] ciphers)
       throws Exception {
     NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(0).addService(new GrpcService());
@@ -157,7 +178,9 @@ public class TestGrpcTlsConfig {
       sslContextBuilder.protocols(protocols);
     }
     if (ciphers != null) {
-      sslContextBuilder.ciphers(Arrays.asList(ciphers));
+      sslContextBuilder.ciphers(
+          Arrays.asList(ciphers),
+          SupportedCipherSuiteFilter.INSTANCE);
     }
     nettyServerBuilder.sslContext(sslContextBuilder.build());
     return nettyServerBuilder.build();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcProtocolService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcProtocolService.java
@@ -35,6 +35,7 @@ import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +76,9 @@ public class InterSCMGrpcProtocolService {
             sslServerContextBuilder, securityConfig.getGrpcSslProvider());
         sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
         sslContextBuilder.protocols(securityConfig.getGrpcTlsProtocols());
-        sslContextBuilder.ciphers(securityConfig.getGrpcTlsCiphers());
+        sslContextBuilder.ciphers(
+            securityConfig.getGrpcTlsCiphers(),
+            SupportedCipherSuiteFilter.INSTANCE);
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
@@ -38,6 +38,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import java.io.IOException;
 import java.util.OptionalInt;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -165,7 +166,9 @@ public class GrpcOzoneManagerServer {
             SslProvider.valueOf(omServerConfig.get(HDDS_GRPC_TLS_PROVIDER,
                 HDDS_GRPC_TLS_PROVIDER_DEFAULT)));
         sslContextBuilder.protocols(secConf.getGrpcTlsProtocols());
-        sslContextBuilder.ciphers(secConf.getGrpcTlsCiphers());
+        sslContextBuilder.ciphers(
+            secConf.getGrpcTlsCiphers(),
+            SupportedCipherSuiteFilter.INSTANCE);
         nettyServerBuilder.sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure Om S3g GRPC channel.", ex);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The gRPC server TLS setup applies the configured cipher list directly when building the Netty OpenSSL context. If any configured cipher is unsupported (and there is no supported cipher in the list before that), TLS context creation throws an error and SCM startup fails. Unsupported ciphers in the configured list should be filtered out and service startup should continue if at least one valid cipher remains.

Instead of this:
```
sslContextBuilder.ciphers(securityConfig.getGrpcTlsCiphers()); 
```
It should use Netty `SupportedCipherSuiteFilter.INSTANCE` when applying configured cipher lists in gRPC server TLS context builders: 

```
sslContextBuilder.ciphers(
    securityConfig.getGrpcTlsCiphers(),
    SupportedCipherSuiteFilter.INSTANCE); 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15176

## How was this patch tested?

Added a unit test for this scenario, which was failing before applying the fix. Green CI on my fork: https://github.com/dombizita/ozone/actions/runs/25378217331
