### PR TITLE
HDDS-15177. acceptance test race condition in generating keytab and service start.

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -30,7 +30,7 @@
     <docker.hadoop.image.flavor />
     <docker.ozone-runner.client.version>20260207-1-jdk8</docker.ozone-runner.client.version>
     <docker.ozone-runner.version>20260206-2-jdk21</docker.ozone-runner.version>
-    <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20241129-1</docker.ozone-testkr5b.image>
+    <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20260507-1</docker.ozone-testkr5b.image>
     <docker.ozone.image>apache/ozone</docker.ozone.image>
     <!-- suffix appended to Ozone version to get Docker image version; only used in xcompat test, to avoid old centos-based images -->
     <docker.ozone.image.flavor>-rocky</docker.ozone.image.flavor>

--- a/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
@@ -25,6 +25,9 @@ x-new-config:
     - ../..:/opt/hadoop
     - ../_keytabs:/etc/security/keytabs
     - ./krb5.conf:/etc/krb5.conf
+  depends_on:
+    kdc:
+      condition: service_healthy
 
 services:
   kdc:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
@@ -25,6 +25,9 @@ x-old-config:
     - ../..:/opt/ozone
     - ../_keytabs:/etc/security/keytabs
     - ./krb5.conf:/etc/krb5.conf
+  depends_on:
+    kdc:
+      condition: service_healthy
 
 services:
   kdc:


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15177. acceptance test race condition in generating keytab and service start.

Fix intermittent xcompat failures where the new-cluster Compose stack could start SCM and other Kerberos-backed services before init-kdc finished exporting keytabs and starting the KDC. Add the same KDC healthcheck used on the old cluster (verify scm.keytab exists and port 88 accepts connections) and depend on the KDC being healthy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15177

## How was this patch tested?

CI + local tests.