### PR TITLE
HDDS-15178. Allow creating EncodingTypeObject for empty String

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/EncodingTypeObject.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/EncodingTypeObject.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.s3.commontypes;
 
 import jakarta.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A converter to encode string if needed.
@@ -41,12 +40,12 @@ public final class EncodingTypeObject {
   }
 
   /**
-   * Create a EncodingTypeObject Object, if the parameter name is null.
+   * Create a EncodingTypeObject Object, if the parameter name is not null.
    * @return If name is null return null else return a EncodingTypeObject object
    */
   @Nullable public static EncodingTypeObject createNullable(
       @Nullable String name, @Nullable String encodingType) {
-    if (StringUtils.isEmpty(name)) {
+    if (name == null) {
       return null;
     }
     return new EncodingTypeObject(name, encodingType);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/commontypes/TestObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/commontypes/TestObjectKeyNameAdapter.java
@@ -42,6 +42,11 @@ public class TestObjectKeyNameAdapter {
         .marshal(EncodingTypeObject.createNullable("a b c/", null)));
     assertEquals("a+b+c/", getAdapter()
         .marshal(EncodingTypeObject.createNullable("a+b+c/", null)));
+
+    assertEquals("", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("", null)));
+    assertEquals("", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("", ENCODING_TYPE)));
   }
 
   private XmlAdapter<String, EncodingTypeObject> getAdapter() {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -58,6 +58,9 @@ public class TestBucketList {
     endpoint.queryParamsForTest().set(QueryParams.PREFIX, "");
     ListObjectResponse getBucketResponse = (ListObjectResponse) endpoint.get("b1").getEntity();
 
+    assertNotNull(getBucketResponse.getPrefix());
+    assertEquals("", getBucketResponse.getPrefix().getName());
+
     assertEquals(1, getBucketResponse.getCommonPrefixes().size());
     assertEquals("dir1/",
         getBucketResponse.getCommonPrefixes().get(0).getPrefix().getName());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updates the handling of empty string values for the `name` parameter in the `EncodingTypeObject` class, ensuring that empty strings are treated as valid (rather than null) and are properly marshaled and tested. It also improves test coverage and correctness for these cases.

this fixes two s3-test test cases:
- https://github.com/ceph/s3-tests/blob/fb8b73092bb1dd8db829f1205a9e52e73bf9a232/s3tests/functional/test_s3.py#L747-L758
  - <img width="1130" height="172" alt="image" src="https://github.com/user-attachments/assets/bc822598-bfbe-40e5-961d-5c7e43d17087" />
- https://github.com/ceph/s3-tests/blob/fb8b73092bb1dd8db829f1205a9e52e73bf9a232/s3tests/functional/test_s3.py#L774-L785
  - <img width="1128" height="179" alt="image" src="https://github.com/user-attachments/assets/0d383d72-1efb-492b-b681-290bca82ebf1" />

relate to: https://github.com/apache/ozone/pull/4127

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15178

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
