### PR TITLE
HDDS-15179. Support Chunked Transfer without Content Length

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -74,14 +74,6 @@ public final class ECKeyOutputStream extends KeyOutputStream
   private final Future<Boolean> flushFuture;
   private final AtomicLong flushCheckpoint;
 
-  /**
-   * Indicates if an atomic write is required. When set to true,
-   * the amount of data written must match the declared size during the commit.
-   * A mismatch will prevent the commit from succeeding.
-   * This is essential for operations like S3 put to ensure atomicity.
-   */
-  private boolean atomicKeyCreation;
-
   private volatile boolean closed;
   private volatile boolean closing;
   // how much of data is actually written yet to underlying stream
@@ -130,7 +122,6 @@ public final class ECKeyOutputStream extends KeyOutputStream
       return flushStripeFromQueue();
     });
     this.flushCheckpoint = new AtomicLong(0);
-    this.atomicKeyCreation = builder.getAtomicKeyCreation();
   }
 
   @Override
@@ -489,12 +480,6 @@ public final class ECKeyOutputStream extends KeyOutputStream
         Preconditions.checkArgument(writeOffset == offset,
             "Expected writeOffset= " + writeOffset
                 + " Expected offset=" + offset);
-        if (atomicKeyCreation) {
-          long expectedSize = blockOutputStreamEntryPool.getDataSize();
-          Preconditions.checkState(expectedSize == offset, String.format(
-              "Expected: %d and actual %d write sizes do not match",
-                  expectedSize, offset));
-        }
         for (CheckedRunnable<IOException> preCommit : preCommits) {
           preCommit.run();
         }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -77,14 +77,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
 
   private long clientID;
 
-  /**
-   * Indicates if an atomic write is required. When set to true,
-   * the amount of data written must match the declared size during the commit.
-   * A mismatch will prevent the commit from succeeding.
-   * This is essential for operations like S3 put to ensure atomicity.
-   */
-  private boolean atomicKeyCreation;
-
   private List<CheckedRunnable<IOException>> preCommits = Collections.emptyList();
 
   public void setPreCommits(@Nonnull List<CheckedRunnable<IOException>> preCommits) {
@@ -129,7 +121,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
 
     this.writeOffset = 0;
     this.clientID = 0L;
-    this.atomicKeyCreation = false;
   }
 
   @SuppressWarnings({"parameternumber", "squid:S00107"})
@@ -140,9 +131,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       OzoneManagerProtocol omClient, int chunkSize,
       String requestId, ReplicationConfig replicationConfig,
       String uploadID, int partNumber, boolean isMultipart,
-      boolean unsafeByteBufferConversion,
-      boolean atomicKeyCreation
-  ) {
+      boolean unsafeByteBufferConversion) {
     super(HddsClientUtils.getRetryPolicyByException(
         config.getMaxRetryCount(), config.getRetryInterval()));
     this.config = config;
@@ -162,7 +151,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     // encrypted bucket.
     this.writeOffset = 0;
     this.clientID = handler.getId();
-    this.atomicKeyCreation = atomicKeyCreation;
   }
 
   /**
@@ -457,12 +445,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       if (!isException()) {
         Preconditions.checkArgument(writeOffset == offset);
       }
-      if (atomicKeyCreation) {
-        long expectedSize = blockDataStreamOutputEntryPool.getDataSize();
-        Preconditions.checkArgument(expectedSize == offset,
-            String.format("Expected: %d and actual %d write sizes do not match",
-                expectedSize, offset));
-      }
       for (CheckedRunnable<IOException> preCommit : preCommits) {
         preCommit.run();
       }
@@ -501,7 +483,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     private boolean unsafeByteBufferConversion;
     private OzoneClientConfig clientConfig;
     private ReplicationConfig replicationConfig;
-    private boolean atomicKeyCreation = false;
 
     public Builder setMultipartUploadID(String uploadID) {
       this.multipartUploadID = uploadID;
@@ -553,11 +534,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       return this;
     }
 
-    public Builder setAtomicKeyCreation(boolean atomicKey) {
-      this.atomicKeyCreation = atomicKey;
-      return this;
-    }
-
     public KeyDataStreamOutput build() {
       return new KeyDataStreamOutput(
           clientConfig,
@@ -570,8 +546,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
           multipartUploadID,
           multipartNumber,
           isMultipartKey,
-          unsafeByteBufferConversion,
-          atomicKeyCreation);
+          unsafeByteBufferConversion);
     }
 
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -98,13 +98,6 @@ public class KeyOutputStream extends OutputStream
   private long clientID;
   private StreamBufferArgs streamBufferArgs;
 
-  /**
-   * Indicates if an atomic write is required. When set to true,
-   * the amount of data written must match the declared size during the commit.
-   * A mismatch will prevent the commit from succeeding.
-   * This is essential for operations like S3 put to ensure atomicity.
-   */
-  private boolean atomicKeyCreation;
   private ContainerClientMetrics clientMetrics;
   private OzoneManagerVersion ozoneManagerVersion;
   private final Lock writeLock = new ReentrantLock();
@@ -186,7 +179,6 @@ public class KeyOutputStream extends OutputStream
     this.isException = false;
     this.writeOffset = 0;
     this.clientID = b.getOpenHandler().getId();
-    this.atomicKeyCreation = b.getAtomicKeyCreation();
     this.streamBufferArgs = b.getStreamBufferArgs();
     this.clientMetrics = b.getClientMetrics();
     this.ozoneManagerVersion = b.ozoneManagerVersion;
@@ -656,12 +648,6 @@ public class KeyOutputStream extends OutputStream
       if (!isException) {
         Preconditions.checkArgument(writeOffset == offset);
       }
-      if (atomicKeyCreation) {
-        long expectedSize = blockOutputStreamEntryPool.getDataSize();
-        Preconditions.checkState(expectedSize == offset,
-            String.format("Expected: %d and actual %d write sizes do not match",
-                expectedSize, offset));
-      }
       for (CheckedRunnable<IOException> preCommit : preCommits) {
         preCommit.run();
       }
@@ -701,7 +687,6 @@ public class KeyOutputStream extends OutputStream
     private OzoneClientConfig clientConfig;
     private ReplicationConfig replicationConfig;
     private ContainerClientMetrics clientMetrics;
-    private boolean atomicKeyCreation = false;
     private StreamBufferArgs streamBufferArgs;
     private Supplier<ExecutorService> executorServiceSupplier;
     private OzoneManagerVersion ozoneManagerVersion;
@@ -800,11 +785,6 @@ public class KeyOutputStream extends OutputStream
       return this;
     }
 
-    public Builder setAtomicKeyCreation(boolean atomicKey) {
-      this.atomicKeyCreation = atomicKey;
-      return this;
-    }
-
     public Builder setClientMetrics(ContainerClientMetrics clientMetrics) {
       this.clientMetrics = clientMetrics;
       return this;
@@ -812,10 +792,6 @@ public class KeyOutputStream extends OutputStream
 
     public ContainerClientMetrics getClientMetrics() {
       return clientMetrics;
-    }
-
-    public boolean getAtomicKeyCreation() {
-      return atomicKeyCreation;
     }
 
     public Builder setExecutorServiceSupplier(Supplier<ExecutorService> executorServiceSupplier) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1473,11 +1473,9 @@ public class RpcClient implements ClientProtocol {
   private OzoneOutputStream openOutputStream(OmKeyArgs keyArgs, long size)
       throws IOException {
     OpenKeySession openKey = ozoneManagerClient.openKey(keyArgs);
-    // For bucket with layout OBJECT_STORE, when create an empty file (size=0),
-    // OM will set DataSize to OzoneConfigKeys#OZONE_SCM_BLOCK_SIZE,
-    // which will cause S3G's atomic write length check to fail,
-    // so reset size to 0 here.
-    if (isS3GRequest.get() && size == 0) {
+    // Keep non-positive S3 writes from carrying OM's preallocated block size
+    // or an internal unknown-length marker into later allocate-block requests.
+    if (isS3GRequest.get() && size <= 0) {
       openKey.getKeyInfo().setDataSize(0);
     }
     return createOutputStream(openKey);
@@ -2117,7 +2115,8 @@ public class RpcClient implements ClientProtocol {
       keyOutputStream.addPreallocateBlocks(
           openKey.getKeyInfo().getLatestVersionLocations(),
           openKey.getOpenVersion());
-      final OzoneOutputStream secureOut = createSecureOutputStream(openKey, keyOutputStream, null);
+      final OzoneOutputStream secureOut = createSecureOutputStream(openKey,
+          keyOutputStream, null);
       out = secureOut != null ? secureOut : keyOutputStream;
     } else {
       out = createMultipartOutputStream(openKey, uploadID, partNumber);
@@ -2579,7 +2578,8 @@ public class RpcClient implements ClientProtocol {
       keyOutputStream.addPreallocateBlocks(
           openKey.getKeyInfo().getLatestVersionLocations(),
           openKey.getOpenVersion());
-      final OzoneOutputStream secureOut = createSecureOutputStream(openKey, keyOutputStream, null);
+      final OzoneOutputStream secureOut = createSecureOutputStream(openKey,
+          keyOutputStream, null);
       out = secureOut != null ? secureOut : keyOutputStream;
     } else {
       out = createOutputStream(openKey);
@@ -2588,21 +2588,17 @@ public class RpcClient implements ClientProtocol {
   }
 
   private KeyDataStreamOutput.Builder newKeyOutputStreamBuilder() {
-    // Amazon S3 never adds partial objects, So for S3 requests we need to
-    // set atomicKeyCreation to true
     // refer: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     return new KeyDataStreamOutput.Builder()
         .setXceiverClientManager(xceiverClientManager)
         .setOmClient(ozoneManagerClient)
         .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
-        .setConfig(clientConfig)
-        .setAtomicKeyCreation(isS3GRequest.get());
+        .setConfig(clientConfig);
   }
 
   private OzoneOutputStream createOutputStream(OpenKeySession openKey)
       throws IOException {
-    KeyOutputStream keyOutputStream = createKeyOutputStream(openKey)
-        .build();
+    KeyOutputStream keyOutputStream = createKeyOutputStream(openKey).build();
     return createOutputStream(openKey, keyOutputStream);
   }
 
@@ -2670,7 +2666,6 @@ public class RpcClient implements ClientProtocol {
         .setOmClient(ozoneManagerClient)
         .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
         .setConfig(clientConfig)
-        .setAtomicKeyCreation(isS3GRequest.get())
         .setClientMetrics(clientMetrics)
         .setExecutorServiceSupplier(writeExecutor)
         .setStreamBufferArgs(streamBufferArgs)

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -220,38 +220,70 @@ public class TestOzoneClient {
     }
   }
 
-  /**
-   * This test validates that for S3G,
-   * the key upload process needs to be atomic.
-   * It simulates two mismatch scenarios where the actual write data size does
-   * not match the expected size.
-   */
   @Test
-  public void testPutKeySizeMismatch() throws IOException {
+  public void testPutKeySizeMismatchCommitsActualSizeForS3Request()
+      throws IOException {
     String value = new String(new byte[1024], UTF_8);
     OzoneBucket bucket = getOzoneBucket();
-    String keyName = UUID.randomUUID().toString();
+    String shortKeyName = UUID.randomUUID().toString();
+    String shortValue = value.substring(0, value.length() - 1);
+    String longKeyName = UUID.randomUUID().toString();
+    String longValue = value + "1";
     try {
-      // Simulating first mismatch: Write less data than expected
       client.getProxy().setIsS3Request(true);
-      OzoneOutputStream out1 = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, ReplicationType.RATIS, ONE,
-          new HashMap<>());
-      out1.write(value.substring(0, value.length() - 1).getBytes(UTF_8));
-      assertThrows(IllegalStateException.class, out1::close,
-          "Expected IllegalArgumentException due to size mismatch.");
-
-      // Simulating second mismatch: Write more data than expected
-      OzoneOutputStream out2 = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, ReplicationType.RATIS, ONE,
-          new HashMap<>());
-      value += "1";
-      out2.write(value.getBytes(UTF_8));
-      assertThrows(IllegalStateException.class, out2::close,
-          "Expected IllegalArgumentException due to size mismatch.");
+      writeKey(bucket, shortKeyName, value.getBytes(UTF_8).length,
+          shortValue);
+      writeKey(bucket, longKeyName, value.getBytes(UTF_8).length,
+          longValue);
     } finally {
       client.getProxy().setIsS3Request(false);
     }
+    assertKeyContent(bucket, shortKeyName, shortValue);
+    assertKeyContent(bucket, longKeyName, longValue);
+  }
+
+  @Test
+  public void testPutKeyWithUnknownSizeForS3Request() throws IOException {
+    String value = "sample value";
+    OzoneBucket bucket = getOzoneBucket();
+    String keyName = UUID.randomUUID().toString();
+    try {
+      client.getProxy().setIsS3Request(true);
+      writeKey(bucket, keyName, -1, value);
+    } finally {
+      client.getProxy().setIsS3Request(false);
+    }
+    assertKeyContent(bucket, keyName, value);
+  }
+
+  private void writeKey(OzoneBucket bucket, String keyName, long size,
+      String value) throws IOException {
+    try (OzoneOutputStream out = bucket.createKey(keyName, size,
+        ReplicationType.RATIS, ONE, new HashMap<>())) {
+      out.write(value.getBytes(UTF_8));
+    }
+  }
+
+  private void assertKeyContent(OzoneBucket bucket, String keyName,
+      String value) throws IOException {
+    byte[] bytes = value.getBytes(UTF_8);
+    OzoneKey key = bucket.getKey(keyName);
+    assertEquals(bytes.length, key.getDataSize());
+
+    byte[] fileContent = new byte[bytes.length];
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      int offset = 0;
+      while (offset < fileContent.length) {
+        int read = is.read(fileContent, offset, fileContent.length - offset);
+        if (read == -1) {
+          break;
+        }
+        offset += read;
+      }
+      assertEquals(fileContent.length, offset);
+      assertEquals(-1, is.read());
+    }
+    assertEquals(value, new String(fileContent, UTF_8));
   }
 
   private OzoneBucket getOzoneBucket() throws IOException {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -695,8 +695,8 @@ public abstract class EndpointBase {
       LOG.warn("buffer size is set to {}", IOUtils.DEFAULT_BUFFER_SIZE);
       bufferSize = IOUtils.DEFAULT_BUFFER_SIZE;
     }
-    if (fileLength == 0) {
-      // for empty file
+    if (fileLength <= 0) {
+      // for empty file or unknown length
       return bufferSize;
     } else {
       return fileLength < bufferSize ? (int) fileLength : bufferSize;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -207,8 +207,8 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       final String lengthHeader = getHeaders().getHeaderString(HttpHeaders.CONTENT_LENGTH);
       long length = lengthHeader != null ? Long.parseLong(lengthHeader) : 0;
       if (lengthHeader == null && body != null) {
-        spooledBody = new FileBackedOutputStream(getIOBufferSize(1));
-        length = IOUtils.copyLarge(body, spooledBody);
+        spooledBody = new FileBackedOutputStream(32);
+        length = IOUtils.copyLarge(body, spooledBody, new byte[getIOBufferSize(0)]);
         body = spooledBody.asByteSource().openStream();
       }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -41,6 +41,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_HEADER_SUPPORTED_UN
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_COUNT_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_DIRECTIVE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.hasMultiChunksPayload;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.stripQuotes;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.validateSignatureHeader;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
@@ -205,11 +206,16 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       OzoneVolume volume = context.getVolume();
       OzoneBucket bucket = context.getBucket();
       final String lengthHeader = getHeaders().getHeaderString(HttpHeaders.CONTENT_LENGTH);
+      final String rawAmzContentSha256Header = getHeaders().getHeaderString(S3Consts.X_AMZ_CONTENT_SHA256);
+      final boolean hasMultiChunksUpload =
+          rawAmzContentSha256Header != null && hasMultiChunksPayload(rawAmzContentSha256Header);
+      boolean hasCalculatedLength = false;
       long length = lengthHeader != null ? Long.parseLong(lengthHeader) : 0;
-      if (lengthHeader == null && body != null) {
+      if (lengthHeader == null && body != null && !hasMultiChunksUpload) {
         spooledBody = new FileBackedOutputStream(32);
         length = IOUtils.copyLarge(body, spooledBody, new byte[getIOBufferSize(0)]);
         body = spooledBody.asByteSource().openStream();
+        hasCalculatedLength = true;
       }
 
       if (uploadID != null && !uploadID.equals("")) {
@@ -252,8 +258,10 @@ public class ObjectEndpoint extends ObjectOperationHandler {
           getHeaders().getHeaderString(S3Consts.DECODED_CONTENT_LENGTH_HEADER);
       boolean hasAmzDecodedLengthZero = amzDecodedLength != null &&
           Long.parseLong(amzDecodedLength) == 0;
+      boolean hasKnownZeroLength = hasAmzDecodedLengthZero ||
+          (length == 0 && (lengthHeader != null || hasCalculatedLength || body == null));
       if (canCreateDirectory &&
-          (length == 0 || hasAmzDecodedLengthZero) &&
+          hasKnownZeroLength &&
           StringUtils.endsWith(keyPath, "/")
       ) {
         context.setAction(S3GAction.CREATE_DIRECTORY);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -47,10 +47,10 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.validateSignatureHeader;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.FileBackedOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.time.Instant;
@@ -123,6 +123,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
   private static final String BUCKET = "bucket";
   private static final String PATH = "path";
+  private static final long UNKNOWN_KEY_SIZE = -1L;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ObjectEndpoint.class);
@@ -200,23 +201,13 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     final long startNanos = context.getStartNanos();
 
     String copyHeader = null;
-    FileBackedOutputStream spooledBody = null;
     MultiDigestInputStream multiDigestInputStream = null;
     try {
       OzoneVolume volume = context.getVolume();
       OzoneBucket bucket = context.getBucket();
       final String lengthHeader = getHeaders().getHeaderString(HttpHeaders.CONTENT_LENGTH);
-      final String rawAmzContentSha256Header = getHeaders().getHeaderString(S3Consts.X_AMZ_CONTENT_SHA256);
-      final boolean hasMultiChunksUpload =
-          rawAmzContentSha256Header != null && hasMultiChunksPayload(rawAmzContentSha256Header);
-      boolean hasCalculatedLength = false;
+      final boolean hasContentLength = lengthHeader != null;
       long length = lengthHeader != null ? Long.parseLong(lengthHeader) : 0;
-      if (lengthHeader == null && body != null && !hasMultiChunksUpload) {
-        spooledBody = new FileBackedOutputStream(32);
-        length = IOUtils.copyLarge(body, spooledBody, new byte[getIOBufferSize(0)]);
-        body = spooledBody.asByteSource().openStream();
-        hasCalculatedLength = true;
-      }
 
       if (uploadID != null && !uploadID.equals("")) {
         if (getHeaders().getHeaderString(COPY_SOURCE_HEADER) == null) {
@@ -258,19 +249,30 @@ public class ObjectEndpoint extends ObjectOperationHandler {
           getHeaders().getHeaderString(S3Consts.DECODED_CONTENT_LENGTH_HEADER);
       boolean hasAmzDecodedLengthZero = amzDecodedLength != null &&
           Long.parseLong(amzDecodedLength) == 0;
-      boolean hasKnownZeroLength = hasAmzDecodedLengthZero ||
-          (length == 0 && (lengthHeader != null || hasCalculatedLength || body == null));
+      String rawAmzContentSha256Header =
+          getHeaders().getHeaderString(S3Consts.X_AMZ_CONTENT_SHA256);
+      boolean hasMultiChunksUpload =
+          rawAmzContentSha256Header != null &&
+              hasMultiChunksPayload(rawAmzContentSha256Header);
+      boolean hasUnknownLength =
+          !hasContentLength && body != null && !hasMultiChunksUpload;
+
+      DirectoryProbe directoryProbe = probeUnknownLengthDirectory(
+          canCreateDirectory, hasUnknownLength, keyPath, body);
+      if (directoryProbe.isEmptyDirectory()) {
+        return createDirectory(context, volume.getName(), bucketName, keyPath);
+      }
+      body = directoryProbe.getBody();
+
       if (canCreateDirectory &&
-          hasKnownZeroLength &&
+          (hasAmzDecodedLengthZero ||
+              (length == 0 && (hasContentLength || body == null))) &&
           StringUtils.endsWith(keyPath, "/")
       ) {
-        context.setAction(S3GAction.CREATE_DIRECTORY);
-        getClientProtocol()
-            .createDirectory(volume.getName(), bucketName, keyPath);
-        long metadataLatencyNs =
-            getMetrics().updatePutKeyMetadataStats(startNanos);
-        perf.appendMetaLatencyNanos(metadataLatencyNs);
-        return Response.ok().status(HttpStatus.SC_OK).build();
+        return createDirectory(context, volume.getName(), bucketName, keyPath);
+      }
+      if (hasUnknownLength) {
+        length = UNKNOWN_KEY_SIZE;
       }
 
       S3ConditionalRequest.WriteConditions writeConditions =
@@ -288,7 +290,8 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       long putLength;
       final String md5Hash;
-      if (isDatastreamEnabled() && !enableEC && length > getDatastreamMinLength()) {
+      if (isDatastreamEnabled() && !enableEC &&
+          (length == UNKNOWN_KEY_SIZE || length > getDatastreamMinLength())) {
         perf.appendStreamMode();
         Pair<String, Long> keyWriteResult = ObjectEndpointStreaming
             .put(bucket, keyPath, length, replicationConfig, getChunkSize(),
@@ -358,9 +361,59 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       if (multiDigestInputStream != null) {
         multiDigestInputStream.resetDigests();
       }
-      if (spooledBody != null) {
-        spooledBody.reset();
-      }
+    }
+  }
+
+  private DirectoryProbe probeUnknownLengthDirectory(
+      boolean canCreateDirectory, boolean hasUnknownLength, String keyPath,
+      InputStream body) throws IOException {
+    if (!hasUnknownLength || !canCreateDirectory ||
+        !StringUtils.endsWith(keyPath, "/")) {
+      return DirectoryProbe.object(body);
+    }
+
+    PushbackInputStream pushbackInputStream = new PushbackInputStream(body, 1);
+    int firstByte = pushbackInputStream.read();
+    if (firstByte == -1) {
+      return DirectoryProbe.emptyDirectory();
+    }
+    pushbackInputStream.unread(firstByte);
+    return DirectoryProbe.object(pushbackInputStream);
+  }
+
+  private Response createDirectory(ObjectRequestContext context,
+      String volumeName, String bucketName, String keyPath) throws IOException {
+    context.setAction(S3GAction.CREATE_DIRECTORY);
+    getClientProtocol().createDirectory(volumeName, bucketName, keyPath);
+    long metadataLatencyNs =
+        getMetrics().updatePutKeyMetadataStats(context.getStartNanos());
+    context.getPerf().appendMetaLatencyNanos(metadataLatencyNs);
+    return Response.ok().status(HttpStatus.SC_OK).build();
+  }
+
+  private static final class DirectoryProbe {
+    private final InputStream body;
+    private final boolean emptyDirectory;
+
+    private DirectoryProbe(InputStream body, boolean emptyDirectory) {
+      this.body = body;
+      this.emptyDirectory = emptyDirectory;
+    }
+
+    private static DirectoryProbe object(InputStream body) {
+      return new DirectoryProbe(body, false);
+    }
+
+    private static DirectoryProbe emptyDirectory() {
+      return new DirectoryProbe(null, true);
+    }
+
+    private InputStream getBody() {
+      return body;
+    }
+
+    private boolean isEmptyDirectory() {
+      return emptyDirectory;
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -46,6 +46,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.validateSignatureHeader;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.FileBackedOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -198,12 +199,18 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     final long startNanos = context.getStartNanos();
 
     String copyHeader = null;
+    FileBackedOutputStream spooledBody = null;
     MultiDigestInputStream multiDigestInputStream = null;
     try {
       OzoneVolume volume = context.getVolume();
       OzoneBucket bucket = context.getBucket();
       final String lengthHeader = getHeaders().getHeaderString(HttpHeaders.CONTENT_LENGTH);
       long length = lengthHeader != null ? Long.parseLong(lengthHeader) : 0;
+      if (lengthHeader == null && body != null) {
+        spooledBody = new FileBackedOutputStream(getIOBufferSize(1));
+        length = IOUtils.copyLarge(body, spooledBody);
+        body = spooledBody.asByteSource().openStream();
+      }
 
       if (uploadID != null && !uploadID.equals("")) {
         if (getHeaders().getHeaderString(COPY_SOURCE_HEADER) == null) {
@@ -342,6 +349,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       // and MessageDigest#digest is never called
       if (multiDigestInputStream != null) {
         multiDigestInputStream.resetDigests();
+      }
+      if (spooledBody != null) {
+        spooledBody.reset();
       }
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -208,8 +208,9 @@ final class ObjectEndpointStreaming {
       throws IOException {
     final byte[] buffer = new byte[bufferSize];
     long n = 0;
-    while (n < length) {
-      final int toRead = Math.toIntExact(Math.min(bufferSize, length - n));
+    while (length < 0 || n < length) {
+      final int toRead = length < 0 ? bufferSize :
+          Math.toIntExact(Math.min(bufferSize, length - n));
       final int readLength = body.read(buffer, 0, toRead);
       if (readLength == -1) {
         break;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -145,12 +145,13 @@ public final class OzoneBucketStub extends OzoneBucket {
         new KeyMetadataAwareOutputStream(metadata) {
           @Override
           public void close() throws IOException {
-            keyContents.put(key, toByteArray());
+            byte[] content = toByteArray();
+            keyContents.put(key, content);
             keyDetails.put(key, new OzoneKeyDetails(
                 getVolumeName(),
                 getName(),
                 key,
-                size,
+                size >= 0 ? size : content.length,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 new ArrayList<>(), finalReplicationCon, getMetadata(), null,
@@ -240,15 +241,15 @@ public final class OzoneBucketStub extends OzoneBucket {
     ByteBufferStreamOutput byteBufferStreamOutput =
         new KeyMetadataAwareByteBufferStreamOutput(keyMetadata) {
 
-          private final ByteBuffer buffer = ByteBuffer.allocate((int) size);
+          private final ByteArrayOutputStream buffer =
+              new ByteArrayOutputStream(
+                  size > 0 && size <= Integer.MAX_VALUE ? (int) size : 32);
 
           @Override
           public void close() throws IOException {
             super.close();
 
-            buffer.flip();
-            byte[] bytes1 = new byte[buffer.remaining()];
-            buffer.get(bytes1);
+            byte[] bytes1 = buffer.toByteArray();
             keyContents.put(key, bytes1);
 
             Map<String, String> objectMetadata = keyMetadata == null ?
@@ -258,7 +259,7 @@ public final class OzoneBucketStub extends OzoneBucket {
                 getVolumeName(),
                 getName(),
                 key,
-                size,
+                size >= 0 ? size : bytes1.length,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 new ArrayList<>(), rConfig, objectMetadata, null,
@@ -272,8 +273,11 @@ public final class OzoneBucketStub extends OzoneBucket {
           public void write(ByteBuffer b, int off, int len)
               throws IOException {
             byte[] bytes = new byte[len];
-            b.get(bytes, off, len);
-            buffer.put(bytes);
+            ByteBuffer duplicate = b.duplicate();
+            duplicate.position(off);
+            duplicate.limit(off + len);
+            duplicate.get(bytes);
+            buffer.write(bytes);
           }
 
           @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -555,6 +555,23 @@ class TestObjectPut {
   }
 
   @Test
+  void testChunkedTransferEncodingCreatesObjectForNonEmptySlashKey() throws Exception {
+    final String path = "dir/";
+    when(objectEndpoint.getContext().getMethod()).thenReturn(HttpMethod.PUT);
+    when(headers.getHeaderString(HttpHeaders.CONTENT_LENGTH)).thenReturn(null);
+    when(headers.getHeaderString("Transfer-Encoding")).thenReturn("chunked");
+    when(headers.getHeaderString(X_AMZ_CONTENT_SHA256)).thenReturn(sha256Hex(CONTENT));
+
+    try (InputStream body = new ByteArrayInputStream(CONTENT.getBytes(StandardCharsets.UTF_8))) {
+      assertSucceeds(() -> objectEndpoint.put(FSO_BUCKET_NAME, path, body));
+    }
+
+    OzoneKeyDetails key = assertKeyContent(fsoBucket, path, CONTENT);
+    assertThat(key.isFile()).as("object").isTrue();
+    assertEquals(CONTENT.length(), key.getDataSize());
+  }
+
+  @Test
   void testDirectoryCreationOverFile() throws Exception {
     // GIVEN
     final String path = "key";

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
@@ -246,6 +247,33 @@ class TestObjectPut {
     OzoneKeyDetails keyDetails = assertKeyContent(bucket, KEY_NAME, "1234567890abcde");
     assertNotNull(keyDetails.getMetadata());
     assertThat(keyDetails.getMetadata().get(OzoneConsts.ETAG)).isNotEmpty();
+    assertEquals(15, keyDetails.getDataSize());
+  }
+
+  @Test
+  void testPutObjectWithSignedChunksWithoutContentLengthDoesNotCalculateTransferLength() throws Exception {
+    String chunkedContent = "0a;chunk-signature=signature\r\n"
+        + "1234567890\r\n"
+        + "05;chunk-signature=signature\r\n"
+        + "abcde\r\n";
+    String keyName = "streaming-object/";
+    when(objectEndpoint.getContext().getMethod()).thenReturn(HttpMethod.PUT);
+    when(headers.getHeaderString(HttpHeaders.CONTENT_LENGTH)).thenReturn(null);
+    when(headers.getHeaderString(X_AMZ_CONTENT_SHA256))
+        .thenReturn(STREAMING_AWS4_HMAC_SHA256_PAYLOAD);
+    when(headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER))
+        .thenReturn("15");
+
+    try (MockedStatic<IOUtils> mocked = mockStatic(IOUtils.class, CALLS_REAL_METHODS);
+         InputStream body = new ByteArrayInputStream(chunkedContent.getBytes(StandardCharsets.UTF_8))) {
+      mocked.when(() -> IOUtils.copyLarge(any(InputStream.class), any(OutputStream.class), any(byte[].class)))
+          .thenThrow(new AssertionError("streaming payload should not be buffered for length calculation"));
+
+      assertSucceeds(() -> objectEndpoint.put(FSO_BUCKET_NAME, keyName, body));
+    }
+
+    OzoneKeyDetails keyDetails = assertKeyContent(fsoBucket, keyName, "1234567890abcde");
+    assertThat(keyDetails.isFile()).as("object").isTrue();
     assertEquals(15, keyDetails.getDataSize());
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -512,6 +512,21 @@ class TestObjectPut {
   }
 
   @Test
+  void testDirectoryCreationWithChunkedTransferEncoding() throws Exception {
+    final String path = "dir/";
+    when(objectEndpoint.getContext().getMethod()).thenReturn(HttpMethod.PUT);
+    when(headers.getHeaderString(HttpHeaders.CONTENT_LENGTH)).thenReturn(null);
+    when(headers.getHeaderString("Transfer-Encoding")).thenReturn("chunked");
+
+    try (InputStream body = new ByteArrayInputStream(new byte[0])) {
+      assertSucceeds(() -> objectEndpoint.put(FSO_BUCKET_NAME, path, body));
+    }
+
+    OzoneKeyDetails key = fsoBucket.getKey(path);
+    assertThat(key.isFile()).as("directory").isFalse();
+  }
+
+  @Test
   void testDirectoryCreationOverFile() throws Exception {
     // GIVEN
     final String path = "key";

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -63,10 +64,12 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Map;
 import java.util.stream.Stream;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -244,6 +247,21 @@ class TestObjectPut {
     assertNotNull(keyDetails.getMetadata());
     assertThat(keyDetails.getMetadata().get(OzoneConsts.ETAG)).isNotEmpty();
     assertEquals(15, keyDetails.getDataSize());
+  }
+
+  @Test
+  void testPutObjectWithChunkedTransferEncoding() throws Exception {
+    when(objectEndpoint.getContext().getMethod()).thenReturn(HttpMethod.PUT);
+    when(headers.getHeaderString(HttpHeaders.CONTENT_LENGTH)).thenReturn(null);
+    when(headers.getHeaderString("Transfer-Encoding")).thenReturn("chunked");
+    when(headers.getHeaderString(X_AMZ_CONTENT_SHA256)).thenReturn(sha256Hex(CONTENT));
+
+    try (InputStream body = new ByteArrayInputStream(CONTENT.getBytes(StandardCharsets.UTF_8))) {
+      assertSucceeds(() -> objectEndpoint.put(BUCKET_NAME, KEY_NAME, body));
+    }
+
+    OzoneKeyDetails keyDetails = assertKeyContent(bucket, KEY_NAME, CONTENT);
+    assertEquals(CONTENT.length(), keyDetails.getDataSize());
   }
 
   @Test
@@ -671,5 +689,11 @@ class TestObjectPut {
   /** Put object at {@link #BUCKET_NAME}/{@link #KEY_NAME} with the specified content. */
   private Response putObject(String content) throws IOException, OS3Exception {
     return put(objectEndpoint, BUCKET_NAME, KEY_NAME, content);
+  }
+
+  private static String sha256Hex(String content) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance(OzoneConsts.FILE_HASH);
+    byte[] contentDigest = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+    return DatatypeConverter.printHexBinary(contentDigest).toLowerCase();
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
@@ -29,9 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
@@ -90,6 +93,22 @@ public class TestUploadWithStream {
   @Test
   public void testUpload() throws Exception {
     assertSucceeds(() -> put(rest, S3BUCKET, S3KEY, S3_COPY_EXISTING_KEY_CONTENT));
+  }
+
+  @Test
+  public void testUploadWithoutContentLength() throws Exception {
+    when(rest.getContext().getMethod()).thenReturn(HttpMethod.PUT);
+    when(rest.getHeaders().getHeaderString(HttpHeaders.CONTENT_LENGTH))
+        .thenReturn(null);
+
+    try (InputStream body = new ByteArrayInputStream(
+        S3_COPY_EXISTING_KEY_CONTENT.getBytes(UTF_8))) {
+      assertSucceeds(() -> rest.put(S3BUCKET, S3KEY, body));
+    }
+
+    OzoneBucket bucket = client.getObjectStore().getS3Bucket(S3BUCKET);
+    assertEquals(S3_COPY_EXISTING_KEY_CONTENT.length(),
+        bucket.getKey(S3KEY).getDataSize());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently chunked transfer would fail if we don't specify content length
```python
def _ev_add_te_header(request, **kwargs):
    request.headers.add_header('Transfer-Encoding', 'chunked')

def test_object_write_with_chunked_transfer_encoding():
    bucket_name = get_new_bucket()
    client = get_client()

    client.meta.events.register_first('before-sign.*.*', _ev_add_te_header)
    response = client.put_object(Bucket=bucket_name, Key='foo', Body='bar')

    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
```

with the following error:

```python
botocore.exceptions.ClientError: An error occurred (XAmzContentSHA256Mismatch) when calling the PutObject operation: The provided 'x-amz-content-sha256' header does not match the computed hash.
```

https://github.com/ceph/s3-tests/blob/fb8b73092bb1dd8db829f1205a9e52e73bf9a232/s3tests/functional/test_s3.py#L1589-L1599

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15179

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
