### PR TITLE
HDDS-15038. Move container directory back to tmp when container import is failed

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -664,9 +664,13 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
         BlockUtils.removeContainerFromDB(containerData, config);
       }
-      deleteDirectory(new File(containerData.getChunksPath()));
-      deleteDirectory(new File(containerData.getMetadataPath()));
-      deleteDirectory(new File(getContainerData().getContainerPath()));
+      File containerDir = new File(getContainerData().getContainerPath());
+      if (containerDir.exists()) {
+        KeyValueContainerUtil.moveToDeletedContainerDir(containerData,
+            containerData.getVolume());
+        deleteDirectory(KeyValueContainerUtil.getTmpDirectoryPath(containerData,
+            containerData.getVolume()).toFile());
+      }
     } catch (Exception ex) {
       LOG.error("Failed to cleanup destination directories for container {}",
           containerData.getContainerID(), ex);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -664,13 +664,18 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
         BlockUtils.removeContainerFromDB(containerData, config);
       }
-      FileUtils.deleteDirectory(new File(containerData.getMetadataPath()));
-      FileUtils.deleteDirectory(new File(containerData.getChunksPath()));
-      FileUtils.deleteDirectory(new File(getContainerData().getContainerPath()));
+      deleteDirectory(new File(containerData.getChunksPath()));
+      deleteDirectory(new File(containerData.getMetadataPath()));
+      deleteDirectory(new File(getContainerData().getContainerPath()));
     } catch (Exception ex) {
       LOG.error("Failed to cleanup destination directories for container {}",
           containerData.getContainerID(), ex);
     }
+  }
+
+  @VisibleForTesting
+  void deleteDirectory(File directory) throws IOException {
+    FileUtils.deleteDirectory(directory);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -496,7 +496,7 @@ public class TestKeyValueContainer {
   }
 
   @ContainerTestVersionInfo.ContainerTest
-  public void testFailedImportCleanupDeletesChunksBeforeMetadata(
+  public void testFailedImportCleanupMovesContainerBeforeDelete(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
 
@@ -507,8 +507,10 @@ public class TestKeyValueContainer {
         keyValueContainerData, CONF) {
       @Override
       void deleteDirectory(File directory) throws IOException {
-        if (directory.equals(new File(getContainerData().getMetadataPath()))) {
-          throw new IOException("Injected metadata cleanup failure");
+        File deletedContainerDir = KeyValueContainerUtil.getTmpDirectoryPath(
+            getContainerData(), getContainerData().getVolume()).toFile();
+        if (directory.equals(deletedContainerDir)) {
+          throw new IOException("Injected tmp cleanup failure");
         }
         super.deleteDirectory(directory);
       }
@@ -543,8 +545,16 @@ public class TestKeyValueContainer {
     assertThrows(IOException.class, () -> container.importContainerData(
         new ByteArrayInputStream(new byte[0]), failingPacker));
 
-    assertFalse(new File(container.getContainerData().getChunksPath()).exists());
-    assertTrue(new File(container.getContainerData().getMetadataPath()).exists());
+    assertFalse(new File(container.getContainerData().getContainerPath())
+        .exists());
+    File deletedContainerDir = KeyValueContainerUtil.getTmpDirectoryPath(
+        container.getContainerData(), container.getContainerData().getVolume())
+        .toFile();
+    assertTrue(deletedContainerDir.exists());
+    assertTrue(new File(deletedContainerDir, OzoneConsts.STORAGE_DIR_CHUNKS)
+        .exists());
+    assertTrue(new File(deletedContainerDir, OzoneConsts.CONTAINER_META_PATH)
+        .exists());
   }
 
   private void checkContainerFilesPresent(KeyValueContainerData data,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,6 +80,8 @@ import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
@@ -490,6 +493,58 @@ public class TestKeyValueContainer {
         }
       });
     }
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testFailedImportCleanupDeletesChunksBeforeMetadata(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+
+    HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(
+        StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()), 1);
+
+    KeyValueContainer container = new KeyValueContainer(
+        keyValueContainerData, CONF) {
+      @Override
+      void deleteDirectory(File directory) throws IOException {
+        if (directory.equals(new File(getContainerData().getMetadataPath()))) {
+          throw new IOException("Injected metadata cleanup failure");
+        }
+        super.deleteDirectory(directory);
+      }
+    };
+    container.populatePathFields(scmId, containerVolume);
+
+    ContainerPacker<KeyValueContainerData> failingPacker =
+        new ContainerPacker<KeyValueContainerData>() {
+          @Override
+          public byte[] unpackContainerData(
+              Container<KeyValueContainerData> containerToUnpack,
+              InputStream inputStream, Path tmpDir, Path destContainerDir)
+              throws IOException {
+            Files.createDirectories(new File(containerToUnpack
+                .getContainerData().getChunksPath()).toPath());
+            Files.createDirectories(new File(containerToUnpack
+                .getContainerData().getMetadataPath()).toPath());
+            throw new IOException("Injected import failure");
+          }
+
+          @Override
+          public void pack(Container<KeyValueContainerData> containerToPack,
+              OutputStream destination) {
+          }
+
+          @Override
+          public byte[] unpackContainerDescriptor(InputStream inputStream) {
+            return null;
+          }
+        };
+
+    assertThrows(IOException.class, () -> container.importContainerData(
+        new ByteArrayInputStream(new byte[0]), failingPacker));
+
+    assertFalse(new File(container.getContainerData().getChunksPath()).exists());
+    assertTrue(new File(container.getContainerData().getMetadataPath()).exists());
   }
 
   private void checkContainerFilesPresent(KeyValueContainerData data,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -545,16 +545,16 @@ public class TestKeyValueContainer {
     assertThrows(IOException.class, () -> container.importContainerData(
         new ByteArrayInputStream(new byte[0]), failingPacker));
 
-    assertFalse(new File(container.getContainerData().getContainerPath())
-        .exists());
+    assertThat(new File(container.getContainerData().getContainerPath()))
+        .doesNotExist();
     File deletedContainerDir = KeyValueContainerUtil.getTmpDirectoryPath(
         container.getContainerData(), container.getContainerData().getVolume())
         .toFile();
-    assertTrue(deletedContainerDir.exists());
-    assertTrue(new File(deletedContainerDir, OzoneConsts.STORAGE_DIR_CHUNKS)
-        .exists());
-    assertTrue(new File(deletedContainerDir, OzoneConsts.CONTAINER_META_PATH)
-        .exists());
+    assertThat(deletedContainerDir).exists();
+    assertThat(new File(deletedContainerDir, OzoneConsts.STORAGE_DIR_CHUNKS))
+        .exists();
+    assertThat(new File(deletedContainerDir, OzoneConsts.CONTAINER_META_PATH))
+        .exists();
   }
 
   private void checkContainerFilesPresent(KeyValueContainerData data,


### PR DESCRIPTION
## What changes were proposed in this pull request?
 This PR handles failed container import cleanup on the DataNode. `KeyValueContainer.cleanupFailedImport()` now deletes the chunks/ directory before deleting the metadata/ directory. If cleanup is interrupted or partially fails between child-
directory deletions, the remaining on-disk state now preferentially preserves metadata instead of leaving a harder-to-diagnose chunks/-only residual directory.

A focused test was added to inject an import cleanup failure at metadata deletion and verify that chunks/ has already been removed while metadata/ remains.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15038

## How was this patch tested?
Added `TestKeyValueContainer#testFailedImportCleanupDeletesChunksBeforeMetadata`