### PR TITLE
HDDS-15184. Atomic Create-If-Absent Should Use 0 for Generation Match

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -319,7 +319,7 @@ public final class OzoneConsts {
   public static final String USER_PREFIX = "userPrefix";
   public static final String REWRITE_GENERATION = "rewriteGeneration";
   /** Sentinel generation used to request atomic create-if-not-exists(put if absent) semantics. */
-  public static final long EXPECTED_GEN_CREATE_IF_NOT_EXISTS = -1L;
+  public static final long EXPECTED_GEN_CREATE_IF_ABSENT = 0L;
   public static final String FROM_SNAPSHOT = "fromSnapshot";
   public static final String TO_SNAPSHOT = "toSnapshot";
   public static final String TOKEN = "token";

--- a/hadoop-hdds/docs/content/design/s3-conditional-requests.md
+++ b/hadoop-hdds/docs/content/design/s3-conditional-requests.md
@@ -253,7 +253,7 @@ sequenceDiagram
 
     User->>GW: PUT object with If-None-Match:* or If-Match:etag
     alt If-None-Match: *
-        GW->>OM: createKey(expectedDataGeneration = -1)
+        GW->>OM: createKey(expectedDataGeneration = 0)
         OM->>OM: Reject if key already exists
         OM-->>GW: Open key or KEY_ALREADY_EXISTS
         opt Open key created

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1439,7 +1439,7 @@ public class RpcClient implements ClientProtocol {
     OmKeyArgs.Builder builder = createWriteKeyArgsBuilder(volumeName,
         bucketName, keyName, size, replicationConfig, metadata, tags);
     builder.setExpectedDataGeneration(
-        OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS);
+        OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT);
     return openOutputStream(builder.build(), size);
   }
 
@@ -1550,7 +1550,7 @@ public class RpcClient implements ClientProtocol {
         volumeName, bucketName, keyName, size, replicationConfig, metadata,
         tags);
     builder.setExpectedDataGeneration(
-        OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS);
+        OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT);
     return openDataStreamOutput(builder.build());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -36,7 +36,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAU
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.DEFAULT_OM_UPDATE_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
-import static org.apache.hadoop.ozone.OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS;
+import static org.apache.hadoop.ozone.OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT;
 import static org.apache.hadoop.ozone.OzoneConsts.GB;
 import static org.apache.hadoop.ozone.OzoneConsts.MD5_HASH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -1450,7 +1450,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         () -> {
         bucket.rewriteKey("key2",
             1024,
-            EXPECTED_GEN_CREATE_IF_NOT_EXISTS,
+            EXPECTED_GEN_CREATE_IF_ABSENT,
             RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
             singletonMap("key", "value"));
         });
@@ -3957,7 +3957,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     // Complete with If-None-Match semantics (key doesn't exist, should succeed)
     OmMultipartUploadCompleteInfo result = bucket.completeMultipartUpload(
         keyName, uploadID, partsMap,
-        EXPECTED_GEN_CREATE_IF_NOT_EXISTS, null);
+        EXPECTED_GEN_CREATE_IF_ABSENT, null);
 
     assertNotNull(result);
     assertEquals(keyName, result.getKey());
@@ -3993,7 +3993,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     // Complete with If-None-Match semantics (key exists, should fail)
     OMException omEx = assertThrows(OMException.class,
         () -> bucket.completeMultipartUpload(keyName, uploadID, partsMap,
-            EXPECTED_GEN_CREATE_IF_NOT_EXISTS, null));
+            EXPECTED_GEN_CREATE_IF_ABSENT, null));
 
     assertEquals(KEY_ALREADY_EXISTS, omEx.getResult());
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -95,7 +95,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
     if (keyArgs.hasExpectedDataGeneration()) {
       if (keyArgs.getExpectedDataGeneration()
-          == OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+          == OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT) {
         ozoneManager.checkFeatureEnabled(
             OzoneManagerVersion.ATOMIC_CREATE_IF_NOT_EXISTS);
       } else {
@@ -625,7 +625,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       Long expectedGen = toCommit.getExpectedDataGeneration();
       auditMap.put(OzoneConsts.REWRITE_GENERATION, String.valueOf(expectedGen));
 
-      if (expectedGen == OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+      if (expectedGen == OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT) {
         if (existing != null) {
           throw new OMException("Atomic create-if-not-exists conflicted with an existing key",
               OMException.ResultCodes.ATOMIC_WRITE_CONFLICT);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -97,7 +97,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
     if (keyArgs.hasExpectedDataGeneration()) {
       if (keyArgs.getExpectedDataGeneration()
-          == OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+          == OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT) {
         ozoneManager.checkFeatureEnabled(
             OzoneManagerVersion.ATOMIC_CREATE_IF_NOT_EXISTS);
       } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1324,7 +1324,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (keyArgs.hasExpectedDataGeneration()) {
       long expectedGen = keyArgs.getExpectedDataGeneration();
       // If expectedGen is EXPECTED_GEN_CREATE_IF_NOT_EXISTS, it means the key MUST NOT exist (If-None-Match)
-      if (expectedGen == OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+      if (expectedGen == OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT) {
         if (dbKeyInfo != null) {
           throw new OMException("Key already exists",
               OMException.ResultCodes.KEY_ALREADY_EXISTS);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -300,7 +300,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OmKeyInfo.Builder omKeyInfoBuilder = OMRequestTestUtils.createOmKeyInfo(
         volumeName, bucketName, keyName, replicationConfig,
         new OmKeyLocationInfoGroup(version, new ArrayList<>()));
-    omKeyInfoBuilder.setExpectedDataGeneration(OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS);
+    omKeyInfoBuilder.setExpectedDataGeneration(OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT);
 
     String openKey = addKeyToOpenKeyTable(allocatedLocationList, omKeyInfoBuilder);
     assertNotNull(openKeyTable.get(openKey));
@@ -335,7 +335,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OmKeyInfo.Builder omKeyInfoBuilder = OMRequestTestUtils.createOmKeyInfo(
         volumeName, bucketName, keyName, replicationConfig,
         new OmKeyLocationInfoGroup(version, new ArrayList<>()));
-    omKeyInfoBuilder.setExpectedDataGeneration(OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS);
+    omKeyInfoBuilder.setExpectedDataGeneration(OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT);
 
     String openKey = addKeyToOpenKeyTable(allocatedLocationList, omKeyInfoBuilder);
     assertNotNull(openKeyTable.get(openKey));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -156,7 +156,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     OMRequest modifiedOmRequest = doPreExecute(createKeyRequest(
         false, 0, 100L, replicationConfig,
-        OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS));
+        OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT));
     OMKeyCreateRequest omKeyCreateRequest = getOMKeyCreateRequest(modifiedOmRequest);
 
     addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager, getBucketLayout());
@@ -170,7 +170,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo openKeyInfo = omMetadataManager.getOpenKeyTable(getBucketLayout())
         .get(getOpenKey(id));
     assertNotNull(openKeyInfo);
-    assertEquals(OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS,
+    assertEquals(OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT,
         openKeyInfo.getExpectedDataGeneration());
   }
 
@@ -183,7 +183,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     OMRequest modifiedOmRequest = doPreExecute(createKeyRequest(
         false, 0, 100L, replicationConfig,
-        OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS));
+        OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT));
     OMKeyCreateRequest omKeyCreateRequest = getOMKeyCreateRequest(modifiedOmRequest);
 
     addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager, getBucketLayout());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -744,7 +744,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       Long expectedDataGeneration = null;
       String expectedETag = null;
       if (writeConditions.hasIfNoneMatch()) {
-        expectedDataGeneration = OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS;
+        expectedDataGeneration = OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT;
       } else if (writeConditions.hasIfMatch()) {
         expectedETag = writeConditions.getExpectedETag();
       }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.client;
 
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
-import static org.apache.hadoop.ozone.OzoneConsts.EXPECTED_GEN_CREATE_IF_NOT_EXISTS;
+import static org.apache.hadoop.ozone.OzoneConsts.EXPECTED_GEN_CREATE_IF_ABSENT;
 import static org.apache.hadoop.ozone.OzoneConsts.MD5_HASH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
@@ -587,9 +587,9 @@ public final class OzoneBucketStub extends OzoneBucket {
   public OmMultipartUploadCompleteInfo completeMultipartUpload(String key,
       String uploadID, Map<Integer, String> partsMap,
       Long expectedDataGeneration, String expectedETag) throws IOException {
-    // Handle If-None-Match: * (expectedDataGeneration == -1 means create-if-absent)
+    // Handle If-None-Match: * (expectedDataGeneration == 0 means create-if-absent)
     if (expectedDataGeneration != null &&
-        expectedDataGeneration == EXPECTED_GEN_CREATE_IF_NOT_EXISTS) {
+        expectedDataGeneration == EXPECTED_GEN_CREATE_IF_ABSENT) {
       if (keyContents.containsKey(key)) {
         throw new OMException("Key already exists", ResultCodes.KEY_ALREADY_EXISTS);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We currently use an expected data generation of -1 to represent “create if absent”. In contrast, GCS uses `-if-generation-match=0` for its create-if-absent semantics.
> https://docs.cloud.google.com/storage/docs/xml-api/reference-headers#xgoogifgenerationmatch
> If you set the x-goog-if-generation-match header to 0, Cloud Storage only performs the specified request if the object does not currently exist. For example, you can perform a PUT request to create a new object with a x-goog-if-generation-match, and the object will only get created if it doesn't already exist as a live version. If the object exists, the request is aborted.


One potential concern is whether the first object we create in Ozone could have a generation/update ID of 0, which would conflict with this encoding. In practice, this does not happen: committed keys in Ozone derive their updateID from the Ratis transaction index at commit time. The very first Ratis index (0) is reserved for startup/configuration log state before any client writes, so actual OM write requests always receive positive indices. As a result, committed keys will never have `updateID == 0`, and using 0 to encode “absent” is safe.

relate to: https://github.com/apache/ozone/pull/9332

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15184

## How was this patch tested?

existing test