### PR TITLE
HDDS-15182. Avoid extra read for modification time on CopyObject/CopyPart

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
@@ -34,6 +35,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.StreamBuffer;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -255,7 +257,10 @@ public class BlockDataStreamOutputEntryPool implements KeyMetadataAware {
         commitUploadPartInfo =
             omClient.commitMultipartUploadPart(buildKeyArgs(), openID);
       } else {
-        omClient.commitKey(buildKeyArgs(), openID);
+        final OptionalLong modificationTime = omClient.commitKeyWithModificationTime(buildKeyArgs(), openID);
+        if (modificationTime.isPresent()) {
+          metadata.put(OzoneConsts.MODIFICATION_TIME, String.valueOf(modificationTime.getAsLong()));
+        }
       }
     } else {
       LOG.warn("Closing KeyDataStreamOutput, but key args is null");

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalLong;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
@@ -35,7 +34,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.StreamBuffer;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -62,6 +60,7 @@ public class BlockDataStreamOutputEntryPool implements KeyMetadataAware {
   private final Map<String, String> metadata = new HashMap<>();
   private final XceiverClientFactory xceiverClientFactory;
   private OmMultipartCommitUploadPartInfo commitUploadPartInfo;
+  private long modificationTime;
   private final long openID;
   private final ExcludeList excludeList;
   private List<StreamBuffer> bufferList;
@@ -256,11 +255,9 @@ public class BlockDataStreamOutputEntryPool implements KeyMetadataAware {
       if (keyArgs.getIsMultipartKey()) {
         commitUploadPartInfo =
             omClient.commitMultipartUploadPart(buildKeyArgs(), openID);
+        modificationTime = commitUploadPartInfo.getModificationTime();
       } else {
-        final OptionalLong modificationTime = omClient.commitKeyWithModificationTime(buildKeyArgs(), openID);
-        if (modificationTime.isPresent()) {
-          metadata.put(OzoneConsts.MODIFICATION_TIME, String.valueOf(modificationTime.getAsLong()));
-        }
+        modificationTime = omClient.commitKey(buildKeyArgs(), openID);
       }
     } else {
       LOG.warn("Closing KeyDataStreamOutput, but key args is null");
@@ -307,6 +304,10 @@ public class BlockDataStreamOutputEntryPool implements KeyMetadataAware {
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
     return commitUploadPartInfo;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
   }
 
   public ExcludeList getExcludeList() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -39,6 +40,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.BufferPool;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -330,7 +332,10 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
         commitUploadPartInfo =
             omClient.commitMultipartUploadPart(buildKeyArgs(), openID);
       } else {
-        omClient.commitKey(buildKeyArgs(), openID);
+        final OptionalLong modificationTime = omClient.commitKeyWithModificationTime(buildKeyArgs(), openID);
+        if (modificationTime.isPresent()) {
+          metadata.put(OzoneConsts.MODIFICATION_TIME, String.valueOf(modificationTime.getAsLong()));
+        }
       }
     } else {
       LOG.warn("Closing KeyOutputStream, but key args is null");

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -40,7 +39,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.BufferPool;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -85,6 +83,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
    */
   private final BufferPool bufferPool;
   private OmMultipartCommitUploadPartInfo commitUploadPartInfo;
+  private long modificationTime;
   private final long openID;
   private final ExcludeList excludeList;
   private final ContainerClientMetrics clientMetrics;
@@ -331,11 +330,9 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
       if (keyArgs.getIsMultipartKey()) {
         commitUploadPartInfo =
             omClient.commitMultipartUploadPart(buildKeyArgs(), openID);
+        modificationTime = commitUploadPartInfo.getModificationTime();
       } else {
-        final OptionalLong modificationTime = omClient.commitKeyWithModificationTime(buildKeyArgs(), openID);
-        if (modificationTime.isPresent()) {
-          metadata.put(OzoneConsts.MODIFICATION_TIME, String.valueOf(modificationTime.getAsLong()));
-        }
+        modificationTime = omClient.commitKey(buildKeyArgs(), openID);
       }
     } else {
       LOG.warn("Closing KeyOutputStream, but key args is null");
@@ -425,6 +422,10 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
     return commitUploadPartInfo;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
   }
 
   public ExcludeList getExcludeList() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -476,6 +476,10 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     return blockDataStreamOutputEntryPool.getCommitUploadPartInfo();
   }
 
+  public long getModificationTime() {
+    return blockDataStreamOutputEntryPool.getModificationTime();
+  }
+
   @VisibleForTesting
   public ExcludeList getExcludeList() {
     return blockDataStreamOutputEntryPool.getExcludeList();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -676,6 +676,10 @@ public class KeyOutputStream extends OutputStream
     return blockOutputStreamEntryPool.getCommitUploadPartInfo();
   }
 
+  public long getModificationTime() {
+    return blockOutputStreamEntryPool.getModificationTime();
+  }
+
   @VisibleForTesting
   public ExcludeList getExcludeList() {
     return blockOutputStreamEntryPool.getExcludeList();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
@@ -100,12 +100,20 @@ public class OzoneDataStreamOutput extends ByteBufferOutputStream
   }
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
+    final KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
     if (keyDataStreamOutput != null) {
       return keyDataStreamOutput.getCommitUploadPartInfo();
     }
     // Otherwise return null.
     return null;
+  }
+
+  public long getModificationTime() {
+    final KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
+    if (keyDataStreamOutput != null) {
+      return keyDataStreamOutput.getModificationTime();
+    }
+    throw new IllegalStateException("OutputStream is not a KeyDataStreamOutput: " + byteBufferStreamOutput.getClass());
   }
 
   public KeyDataStreamOutput getKeyDataStreamOutput() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -128,12 +128,20 @@ public class OzoneOutputStream extends ByteArrayStreamOutput
   }
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    KeyOutputStream keyOutputStream = getKeyOutputStream();
+    final KeyOutputStream keyOutputStream = getKeyOutputStream();
     if (keyOutputStream != null) {
       return keyOutputStream.getCommitUploadPartInfo();
     }
     // Otherwise return null.
     return null;
+  }
+
+  public long getModificationTime() {
+    final KeyOutputStream keyOutputStream = getKeyOutputStream();
+    if (keyOutputStream != null) {
+      return keyOutputStream.getModificationTime();
+    }
+    throw new IllegalStateException("OutputStream is not a KeyOutputStream: " + outputStream.getClass());
   }
 
   public OutputStream getOutputStream() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartCommitUploadPartInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartCommitUploadPartInfo.java
@@ -17,8 +17,6 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
-import java.util.OptionalLong;
-
 /**
  * This class holds information about the response from commit multipart
  * upload part request.
@@ -29,13 +27,9 @@ public class OmMultipartCommitUploadPartInfo {
 
   private final String eTag;
 
-  private final Long modificationTime;
+  private final long modificationTime;
 
-  public OmMultipartCommitUploadPartInfo(String partName, String eTag) {
-    this(partName, eTag, null);
-  }
-
-  public OmMultipartCommitUploadPartInfo(String partName, String eTag, Long modificationTime) {
+  public OmMultipartCommitUploadPartInfo(String partName, String eTag, long modificationTime) {
     this.partName = partName;
     this.eTag = eTag;
     this.modificationTime = modificationTime;
@@ -49,7 +43,7 @@ public class OmMultipartCommitUploadPartInfo {
     return partName;
   }
 
-  public OptionalLong getModificationTime() {
-    return modificationTime == null ? OptionalLong.empty() : OptionalLong.of(modificationTime);
+  public long getModificationTime() {
+    return modificationTime;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.UUID;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -250,6 +251,17 @@ public interface OzoneManagerProtocol
       throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented, as write requests use a new approach.");
+  }
+
+  /**
+   * Commit a key and optionally return the stored modification time (epoch millis).
+   * <p>
+   * This is backward compatible with older OM versions which do not return
+   * the value in {@code CommitKeyResponse}.
+   */
+  default OptionalLong commitKeyWithModificationTime(OmKeyArgs args, long clientID) throws IOException {
+    commitKey(args, clientID);
+    return OptionalLong.empty();
   }
 
   /**
@@ -1145,7 +1157,6 @@ public interface OzoneManagerProtocol
    */
   EchoRPCResponse echoRPCReq(byte[] payloadReq, int payloadSizeResp,
                              boolean writeToRatis) throws IOException;
-
 
   /**
    * Start the lease recovery of a file.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1147,6 +1147,7 @@ public interface OzoneManagerProtocol
   EchoRPCResponse echoRPCReq(byte[] payloadReq, int payloadSizeResp,
                              boolean writeToRatis) throws IOException;
 
+
   /**
    * Start the lease recovery of a file.
    *

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -22,7 +22,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 import java.util.UUID;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -245,23 +244,13 @@ public interface OzoneManagerProtocol
    *
    * @param args the key to commit
    * @param clientID the client identification
+   * @return the modification time of the committed key in epoch milliseconds
    * @throws IOException
    */
-  default void commitKey(OmKeyArgs args, long clientID)
+  default long commitKey(OmKeyArgs args, long clientID)
       throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented, as write requests use a new approach.");
-  }
-
-  /**
-   * Commit a key and optionally return the stored modification time (epoch millis).
-   * <p>
-   * This is backward compatible with older OM versions which do not return
-   * the value in {@code CommitKeyResponse}.
-   */
-  default OptionalLong commitKeyWithModificationTime(OmKeyArgs args, long clientID) throws IOException {
-    commitKey(args, clientID);
-    return OptionalLong.empty();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -829,6 +830,11 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
+  public OptionalLong commitKeyWithModificationTime(OmKeyArgs args, long clientId) throws IOException {
+    return updateKeyAndGetModificationTime(args, clientId, false, false);
+  }
+
+  @Override
   public void recoverKey(OmKeyArgs args, long clientId)
       throws IOException {
     updateKey(args, clientId, false, true);
@@ -848,6 +854,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   private void updateKey(OmKeyArgs args, long clientId, boolean hsync, boolean recovery)
+      throws IOException {
+    // Preserve legacy behavior (ignore response payload).
+    updateKeyAndGetModificationTime(args, clientId, hsync, recovery);
+  }
+
+  private OptionalLong updateKeyAndGetModificationTime(OmKeyArgs args, long clientId, boolean hsync, boolean recovery)
       throws IOException {
     CommitKeyRequest.Builder req = CommitKeyRequest.newBuilder();
     List<OmKeyLocationInfo> locationInfoList = args.getLocationInfoList();
@@ -874,7 +886,11 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setCommitKeyRequest(req)
         .build();
 
-    handleError(submitRequest(omRequest));
+    final OMResponse resp = handleError(submitRequest(omRequest));
+    if (resp.hasCommitKeyResponse() && resp.getCommitKeyResponse().hasModificationTime()) {
+      return OptionalLong.of(resp.getCommitKeyResponse().getModificationTime());
+    }
+    return OptionalLong.empty();
   }
 
   @Override
@@ -1791,7 +1807,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         handleError(submitRequest(omRequest))
         .getCommitMultiPartUploadResponse();
 
-    return new OmMultipartCommitUploadPartInfo(response.getPartName(), response.getETag());
+    final Long modificationTime = response.hasModificationTime() ? response.getModificationTime() : null;
+    return new OmMultipartCommitUploadPartInfo(response.getPartName(), response.getETag(), modificationTime);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -254,6 +253,7 @@ import org.apache.hadoop.ozone.upgrade.UpgradeFinalization;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.ozone.util.ProtobufUtils;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
 
 /**
  * The client side implementation of OzoneManagerProtocol.
@@ -824,13 +824,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public void commitKey(OmKeyArgs args, long clientId)
+  public long commitKey(OmKeyArgs args, long clientId)
           throws IOException {
-    updateKey(args, clientId, false, false);
-  }
-
-  @Override
-  public OptionalLong commitKeyWithModificationTime(OmKeyArgs args, long clientId) throws IOException {
     return updateKeyAndGetModificationTime(args, clientId, false, false);
   }
 
@@ -859,7 +854,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     updateKeyAndGetModificationTime(args, clientId, hsync, recovery);
   }
 
-  private OptionalLong updateKeyAndGetModificationTime(OmKeyArgs args, long clientId, boolean hsync, boolean recovery)
+  private long updateKeyAndGetModificationTime(OmKeyArgs args, long clientId, boolean hsync, boolean recovery)
       throws IOException {
     CommitKeyRequest.Builder req = CommitKeyRequest.newBuilder();
     List<OmKeyLocationInfo> locationInfoList = args.getLocationInfoList();
@@ -888,9 +883,9 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     final OMResponse resp = handleError(submitRequest(omRequest));
     if (resp.hasCommitKeyResponse() && resp.getCommitKeyResponse().hasModificationTime()) {
-      return OptionalLong.of(resp.getCommitKeyResponse().getModificationTime());
+      return resp.getCommitKeyResponse().getModificationTime();
     }
-    return OptionalLong.empty();
+    return Time.now();
   }
 
   @Override
@@ -1807,7 +1802,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         handleError(submitRequest(omRequest))
         .getCommitMultiPartUploadResponse();
 
-    final Long modificationTime = response.hasModificationTime() ? response.getModificationTime() : null;
+    final long modificationTime = response.hasModificationTime() ? response.getModificationTime() : Time.now();
     return new OmMultipartCommitUploadPartInfo(response.getPartName(), response.getETag(), modificationTime);
   }
 

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
@@ -31,6 +31,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.ozone.test.InputSubstream;
 
 /**
@@ -40,7 +44,36 @@ public final class S3SDKTestUtils {
 
   public static final Pattern UPLOAD_ID_PATTERN = Pattern.compile("<UploadId>(.+?)</UploadId>");
 
+  private static final int DEFAULT_LIST_PARTS_MAX = 100;
+
   private S3SDKTestUtils() {
+  }
+
+  /**
+   * Returns the modification time of a key stored in OM, in epoch milliseconds.
+   */
+  public static long getOmKeyModificationTime(MiniOzoneCluster cluster, String bucketName, String keyName)
+      throws IOException {
+    try (OzoneClient ozoneClient = cluster.newClient()) {
+      final OzoneBucket bucket = ozoneClient.getObjectStore().getS3Volume().getBucket(bucketName);
+      return bucket.getKey(keyName).getModificationTime().toEpochMilli();
+    }
+  }
+
+  /**
+   * Returns the modification time of a multipart upload part stored in OM, in epoch milliseconds.
+   */
+  public static long getOmPartModificationTime(MiniOzoneCluster cluster, String bucketName, String keyName,
+      String uploadId, int partNumber) throws IOException {
+    try (OzoneClient ozoneClient = cluster.newClient()) {
+      final OzoneBucket bucket = ozoneClient.getObjectStore().getS3Volume().getBucket(bucketName);
+      final OzoneMultipartUploadPartListParts parts = bucket.listParts(keyName, uploadId, 0, DEFAULT_LIST_PARTS_MAX);
+      return parts.getPartInfoList().stream()
+          .filter(part -> part.getPartNumber() == partNumber)
+          .findFirst()
+          .orElseThrow(() -> new IllegalStateException("Part " + partNumber + " not found for upload " + uploadId))
+          .getModificationTime();
+    }
   }
 
   /**

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/package-info.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared utilities and integration tests for the AWS S3 SDK.
+ */
+package org.apache.hadoop.ozone.s3.awssdk;

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.s3.awssdk.v1;
 import static org.apache.hadoop.ozone.OzoneConsts.MB;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.calculateDigest;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.createFile;
+import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.getOmKeyModificationTime;
+import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.getOmPartModificationTime;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.stripQuotes;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +45,8 @@ import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.CopyObjectResult;
+import com.amazonaws.services.s3.model.CopyPartRequest;
+import com.amazonaws.services.s3.model.CopyPartResult;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -512,6 +516,69 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
 
     CopyObjectResult copyResult = s3Client.copyObject(sourceBucketName, sourceKey, destBucketName, destKey);
     assertEquals("37b51d194a7513e45b56f6524f2d51f2", copyResult.getETag());
+  }
+
+  @Test
+  public void testCopyObjectLastModifiedMatchesOmDb() throws Exception {
+    final String sourceBucketName = getBucketName();
+    final String destBucketName = getBucketName();
+    final String sourceKey = getKeyName();
+    final String destKey = getKeyName();
+    final String content = "copy-last-modified-test-content";
+    s3Client.createBucket(sourceBucketName);
+    s3Client.createBucket(destBucketName);
+
+    final InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    s3Client.putObject(sourceBucketName, sourceKey, inputStream, new ObjectMetadata());
+
+    final long sourceModificationTime = getOmKeyModificationTime(cluster, sourceBucketName, sourceKey);
+
+    Thread.sleep(100);
+
+    final CopyObjectResult copyResult = s3Client.copyObject(sourceBucketName, sourceKey, destBucketName, destKey);
+
+    assertNotNull(copyResult.getLastModifiedDate());
+    final long responseModificationTime = copyResult.getLastModifiedDate().getTime();
+    final long destModificationTime = getOmKeyModificationTime(cluster, destBucketName, destKey);
+
+    assertEquals(destModificationTime, responseModificationTime);
+    assertNotEquals(sourceModificationTime, responseModificationTime);
+  }
+
+  @Test
+  public void testUploadPartCopyLastModifiedMatchesOmDb() throws Exception {
+    final String bucketName = getBucketName();
+    final String sourceKey = getKeyName();
+    final String destKey = getKeyName();
+    final String content = "copy-last-modified-test-content";
+    s3Client.createBucket(bucketName);
+
+    final InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    s3Client.putObject(bucketName, sourceKey, inputStream, new ObjectMetadata());
+
+    final long sourceModificationTime = getOmKeyModificationTime(cluster, bucketName, sourceKey);
+
+    Thread.sleep(100);
+
+    final InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(
+        new InitiateMultipartUploadRequest(bucketName, destKey));
+    final String uploadId = initResponse.getUploadId();
+
+    final CopyPartResult copyPartResult = s3Client.copyPart(
+        new CopyPartRequest()
+            .withSourceBucketName(bucketName)
+            .withSourceKey(sourceKey)
+            .withDestinationBucketName(bucketName)
+            .withDestinationKey(destKey)
+            .withUploadId(uploadId)
+            .withPartNumber(1));
+
+    assertNotNull(copyPartResult.getLastModifiedDate());
+    final long responseModificationTime = copyPartResult.getLastModifiedDate().getTime();
+    final long destPartModificationTime = getOmPartModificationTime(cluster, bucketName, destKey, uploadId, 1);
+
+    assertEquals(destPartModificationTime, responseModificationTime);
+    assertNotEquals(sourceModificationTime, responseModificationTime);
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.s3.awssdk.v2;
 import static org.apache.hadoop.ozone.OzoneConsts.MB;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.calculateDigest;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.createFile;
+import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.getOmKeyModificationTime;
+import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.getOmPartModificationTime;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.stripQuotes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -141,6 +143,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -990,6 +993,73 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
 
     CopyObjectResponse copyObjectResponse = s3Client.copyObject(copyReq);
     assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"", copyObjectResponse.copyObjectResult().eTag());
+  }
+
+  @Test
+  public void testCopyObjectLastModifiedMatchesOmDb() throws Exception {
+    final String sourceBucketName = getBucketName();
+    final String destBucketName = getBucketName();
+    final String sourceKey = getKeyName();
+    final String destKey = getKeyName();
+    final String content = "copy-last-modified-test-content";
+    s3Client.createBucket(b -> b.bucket(sourceBucketName));
+    s3Client.createBucket(b -> b.bucket(destBucketName));
+
+    s3Client.putObject(b -> b.bucket(sourceBucketName).key(sourceKey), RequestBody.fromString(content));
+
+    final long sourceModificationTime = getOmKeyModificationTime(cluster, sourceBucketName, sourceKey);
+
+    Thread.sleep(100);
+
+    final CopyObjectResponse copyObjectResponse = s3Client.copyObject(
+        CopyObjectRequest.builder()
+            .sourceBucket(sourceBucketName)
+            .sourceKey(sourceKey)
+            .destinationBucket(destBucketName)
+            .destinationKey(destKey)
+            .build());
+
+    assertNotNull(copyObjectResponse.copyObjectResult().lastModified());
+    final long responseModificationTime = copyObjectResponse.copyObjectResult().lastModified().toEpochMilli();
+    final long destModificationTime = getOmKeyModificationTime(cluster, destBucketName, destKey);
+
+    assertEquals(destModificationTime, responseModificationTime);
+    assertNotEquals(sourceModificationTime, responseModificationTime);
+  }
+
+  @Test
+  public void testUploadPartCopyLastModifiedMatchesOmDb() throws Exception {
+    final String bucketName = getBucketName();
+    final String sourceKey = getKeyName();
+    final String destKey = getKeyName();
+    final String content = "copy-last-modified-test-content";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    s3Client.putObject(b -> b.bucket(bucketName).key(sourceKey), RequestBody.fromString(content));
+
+    final long sourceModificationTime = getOmKeyModificationTime(cluster, bucketName, sourceKey);
+
+    Thread.sleep(100);
+
+    final CreateMultipartUploadResponse initResponse = s3Client.createMultipartUpload(
+        b -> b.bucket(bucketName).key(destKey));
+    final String uploadId = initResponse.uploadId();
+
+    final UploadPartCopyResponse copyPartResponse = s3Client.uploadPartCopy(
+        b -> b
+            .sourceBucket(bucketName)
+            .sourceKey(sourceKey)
+            .destinationBucket(bucketName)
+            .destinationKey(destKey)
+            .uploadId(uploadId)
+            .partNumber(1));
+
+    assertNotNull(copyPartResponse.copyPartResult().lastModified());
+    final long responseModificationTime = copyPartResponse.copyPartResult().lastModified().toEpochMilli();
+    final long destPartModificationTime = getOmPartModificationTime(cluster, bucketName, destKey, uploadId, 1);
+
+    assertEquals(destPartModificationTime, responseModificationTime);
+    assertNotEquals(sourceModificationTime, responseModificationTime);
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/package-info.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integration tests for the AWS Java SDK v2 S3 client.
+ */
+package org.apache.hadoop.ozone.s3.awssdk.v2;

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1586,6 +1586,8 @@ message CommitKeyRequest {
 
 message CommitKeyResponse {
 
+    // Modification time of the committed key, set by OM during preExecute.
+    optional uint64 modificationTime = 1;
 }
 
 message AllocateBlockRequest {
@@ -1790,6 +1792,8 @@ message MultipartCommitUploadPartResponse {
     optional string partName = 1;
     // This one is returned as Etag for S3.
     optional string eTag = 2;
+    // Modification time of the committed part key, set by OM during preExecute.
+    optional uint64 modificationTime = 3;
 }
 
 message MultipartUploadCompleteRequest {

--- a/hadoop-ozone/interface-client/src/main/resources/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/resources/proto.lock
@@ -5803,7 +5803,15 @@
             ]
           },
           {
-            "name": "CommitKeyResponse"
+            "name": "CommitKeyResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "modificationTime",
+                "type": "uint64",
+                "optional": true
+              }
+            ]
           },
           {
             "name": "AllocateBlockRequest",
@@ -6371,6 +6379,12 @@
                 "id": 2,
                 "name": "eTag",
                 "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "modificationTime",
+                "type": "uint64",
                 "optional": true
               }
             ]

--- a/hadoop-ozone/interface-client/src/main/resources/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/resources/proto.lock
@@ -5803,15 +5803,7 @@
             ]
           },
           {
-            "name": "CommitKeyResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "modificationTime",
-                "type": "uint64",
-                "optional": true
-              }
-            ]
+            "name": "CommitKeyResponse"
           },
           {
             "name": "AllocateBlockRequest",
@@ -6379,12 +6371,6 @@
                 "id": 2,
                 "name": "eTag",
                 "type": "string",
-                "optional": true
-              },
-              {
-                "id": 3,
-                "name": "modificationTime",
-                "type": "uint64",
                 "optional": true
               }
             ]

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -408,6 +409,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           dbOzoneKey, omKeyInfo, trxnLogIndex);
 
       omBucketInfo.incrUsedBytes(correctedSpace);
+
+      omResponse.setCommitKeyResponse(CommitKeyResponse.newBuilder()
+          .setModificationTime(commitKeyArgs.getModificationTime())
+          .build());
 
       omClientResponse = new OMKeyCommitResponse(omResponse.build(),
           omKeyInfo, dbOzoneKey, dbOpenKey, omBucketInfo.copyObject(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponseWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -346,6 +347,10 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
               omKeyInfo, fileName, trxnLogIndex);
 
       omBucketInfo.incrUsedBytes(correctedSpace);
+
+      omResponse.setCommitKeyResponse(CommitKeyResponse.newBuilder()
+          .setModificationTime(commitKeyArgs.getModificationTime())
+          .build());
 
       omClientResponse = new OMKeyCommitResponseWithFSO(omResponse.build(),
           omKeyInfo, dbFileKey, dbOpenFileKey, omBucketInfo.copyObject(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -268,6 +268,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       if (eTag != null) {
         commitResponseBuilder.setETag(eTag);
       }
+      commitResponseBuilder.setModificationTime(keyArgs.getModificationTime());
       omResponse.setCommitMultiPartUploadResponse(commitResponseBuilder);
       omClientResponse =
           getOmClientResponse(ozoneManager, keyVersionsToDeleteMap, openKey,

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
@@ -46,8 +46,12 @@ public class CopyPartResult {
   }
 
   public CopyPartResult(String eTag) {
+    this(eTag, Instant.now());
+  }
+
+  public CopyPartResult(String eTag, Instant lastModified) {
     this.eTag = eTag;
-    this.lastModified = Instant.now();
+    this.lastModified = lastModified;
   }
 
   public Instant getLastModified() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
@@ -42,13 +42,6 @@ public class CopyPartResult {
   @XmlElement(name = OzoneConsts.ETAG)
   private String eTag;
 
-  public CopyPartResult() {
-  }
-
-  public CopyPartResult(String eTag) {
-    this(eTag, Instant.now());
-  }
-
   public CopyPartResult(String eTag, Instant lastModified) {
     this.eTag = eTag;
     this.lastModified = lastModified;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyPartResult.java
@@ -42,6 +42,9 @@ public class CopyPartResult {
   @XmlElement(name = OzoneConsts.ETAG)
   private String eTag;
 
+  public CopyPartResult() {
+  }
+
   public CopyPartResult(String eTag, Instant lastModified) {
     this.eTag = eTag;
     this.lastModified = lastModified;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyResult.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyResult.java
@@ -15,29 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.om.helpers;
-
-import java.util.OptionalLong;
+package org.apache.hadoop.ozone.s3.endpoint;
 
 /**
- * This class holds information about the response from commit multipart
- * upload part request.
+ * Result of a copy operation.
  */
-public class OmMultipartCommitUploadPartInfo {
-
-  private final String partName;
-
+public class CopyResult {
   private final String eTag;
+  private final long size;
+  private final long modificationTime;
 
-  private final Long modificationTime;
-
-  public OmMultipartCommitUploadPartInfo(String partName, String eTag) {
-    this(partName, eTag, null);
-  }
-
-  public OmMultipartCommitUploadPartInfo(String partName, String eTag, Long modificationTime) {
-    this.partName = partName;
+  public CopyResult(String eTag, long size, long modificationTime) {
     this.eTag = eTag;
+    this.size = size;
     this.modificationTime = modificationTime;
   }
 
@@ -45,11 +35,11 @@ public class OmMultipartCommitUploadPartInfo {
     return eTag;
   }
 
-  public String getPartName() {
-    return partName;
+  public long getSize() {
+    return size;
   }
 
-  public OptionalLong getModificationTime() {
-    return modificationTime == null ? OptionalLong.empty() : OptionalLong.of(modificationTime);
+  public long getModificationTime() {
+    return modificationTime;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -80,6 +80,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger.PerformanceStringBuilder;
 import org.apache.hadoop.ozone.audit.S3GAction;
@@ -984,7 +985,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       } else {
         getMetrics().updateCreateMultipartKeyFailureStats(startNanos);
       }
-      final OMException omEx = findOMException(ex);
+      final OMException omEx = (OMException) HddsClientUtils.containsException(ex, OMException.class);
       if (omEx != null) {
         if (omEx.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
           throw newError(NO_SUCH_UPLOAD, uploadID, omEx);
@@ -1000,17 +1001,6 @@ public class ObjectEndpoint extends ObjectOperationHandler {
         multiDigestInputStream.resetDigests();
       }
     }
-  }
-
-  private static OMException findOMException(Throwable t) {
-    Throwable currentException = t;
-    while (currentException != null) {
-      if (currentException instanceof OMException) {
-        return (OMException) currentException;
-      }
-      currentException = currentException.getCause();
-    }
-    return null;
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
-import static org.apache.hadoop.ozone.audit.AuditLogger.PerformanceStringBuilder;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
@@ -82,6 +81,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.audit.AuditLogger.PerformanceStringBuilder;
 import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKey;
@@ -955,7 +955,10 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       if (copyHeader != null) {
         getMetrics().updateCopyObjectSuccessStats(startNanos);
-        return Response.ok(new CopyPartResult(eTag)).build();
+        final Instant lastModified = omMultipartCommitUploadPartInfo.getModificationTime().isPresent()
+            ? Instant.ofEpochMilli(omMultipartCommitUploadPartInfo.getModificationTime().getAsLong())
+            : Instant.now();
+        return Response.ok(new CopyPartResult(eTag, lastModified)).build();
       } else {
         getMetrics().updateCreateMultipartKeySuccessStats(startNanos);
         return Response.ok().header(HttpHeaders.ETAG, eTag).build();
@@ -976,6 +979,22 @@ public class ObjectEndpoint extends ObjectOperationHandler {
         throw os3Exception;
       }
       throw newError(bucketName, key, ex);
+    } catch (IOException ex) {
+      // Ensure we handle permission failures - these can surface as IOException wrapping OMException.
+      if (copyHeader != null) {
+        getMetrics().updateCopyObjectFailureStats(startNanos);
+      } else {
+        getMetrics().updateCreateMultipartKeyFailureStats(startNanos);
+      }
+      final OMException omEx = findOMException(ex);
+      if (omEx != null) {
+        if (omEx.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
+          throw newError(NO_SUCH_UPLOAD, uploadID, omEx);
+        } else {
+          throw newError(bucketName, key, omEx);
+        }
+      }
+      throw ex;
     } finally {
       // Reset the thread-local message digest instance in case of exception
       // and MessageDigest#digest is never called
@@ -985,8 +1004,19 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     }
   }
 
+  private static OMException findOMException(Throwable t) {
+    Throwable currentException = t;
+    while (currentException != null) {
+      if (currentException instanceof OMException) {
+        return (OMException) currentException;
+      }
+      currentException = currentException.getCause();
+    }
+    return null;
+  }
+
   @SuppressWarnings("checkstyle:ParameterNumber")
-  void copy(OzoneVolume volume, DigestInputStream src, long srcKeyLen,
+  CopyResult copy(OzoneVolume volume, DigestInputStream src, long srcKeyLen,
       String destKey, String destBucket,
       ReplicationConfig replication,
       Map<String, String> metadata,
@@ -995,16 +1025,21 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       S3ConditionalRequest.WriteConditions writeConditions)
       throws IOException {
     long copyLength;
-
+    final String eTag;
+    final long modificationTime;
     if (isDatastreamEnabled() && !(replication != null &&
         replication.getReplicationType() == EC) &&
         srcKeyLen > getDatastreamMinLength()) {
       perf.appendStreamMode();
-      copyLength = ObjectEndpointStreaming
+      final CopyResult copyResult = ObjectEndpointStreaming
           .copyKeyWithStream(volume.getBucket(destBucket), destKey, srcKeyLen,
               getChunkSize(), replication, metadata, src, perf, startNanos, tags,
               writeConditions);
+      eTag = copyResult.getETag();
+      copyLength = copyResult.getSize();
+      modificationTime = copyResult.getModificationTime();
     } else {
+      Map<String, String> destMetadata;
       try (OzoneOutputStream dest = openKeyForPut(
           volume.getName(), destBucket, destKey, srcKeyLen,
           replication, metadata, tags, writeConditions)) {
@@ -1012,12 +1047,16 @@ public class ObjectEndpoint extends ObjectOperationHandler {
             getMetrics().updateCopyKeyMetadataStats(startNanos);
         perf.appendMetaLatencyNanos(metadataLatencyNs);
         copyLength = IOUtils.copyLarge(src, dest, 0, srcKeyLen, new byte[getIOBufferSize(srcKeyLen)]);
-        final String md5Hash = DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
-        dest.getMetadata().put(OzoneConsts.ETAG, md5Hash);
+        eTag = DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
+        destMetadata = dest.getMetadata();
+        destMetadata.put(OzoneConsts.ETAG, eTag);
       }
+
+      modificationTime = S3Utils.getModificationTimeOrDefault(destMetadata, Time.now());
     }
     getMetrics().incCopyObjectSuccessLength(copyLength);
     perf.appendSizeBytes(copyLength);
+    return new CopyResult(eTag, copyLength, modificationTime);
   }
 
   private CopyObjectResponse copyObject(OzoneVolume volume,
@@ -1116,19 +1155,14 @@ public class ObjectEndpoint extends ObjectOperationHandler {
               "GetObject", () -> getClientProtocol().getKey(volume.getName(), sourceBucket, sourceKey));
            DigestInputStream sourceDigestInputStream = new DigestInputStream(src, md5Digest)) {
         getMetrics().updateCopyKeyMetadataStats(startNanos);
-        runWithS3ActionString("PutObject", () -> {
-          copy(volume, sourceDigestInputStream, sourceKeyLen, destkey, destBucket,
-              replicationConfig, customMetadata, perf, startNanos, tags, writeConditions);
-          return null;
-        });
-
-        final OzoneKeyDetails destKeyDetails = getClientProtocol().getKeyDetails(
-            volume.getName(), destBucket, destkey);
+        final CopyResult copyResult = runWithS3ActionString("PutObject", () ->
+            copy(volume, sourceDigestInputStream, sourceKeyLen, destkey, destBucket,
+              replicationConfig, customMetadata, perf, startNanos, tags, writeConditions));
 
         getMetrics().updateCopyObjectSuccessStats(startNanos);
         CopyObjectResponse copyObjectResponse = new CopyObjectResponse();
-        copyObjectResponse.setETag(wrapInQuotes(destKeyDetails.getMetadata().get(OzoneConsts.ETAG)));
-        copyObjectResponse.setLastModified(destKeyDetails.getModificationTime());
+        copyObjectResponse.setETag(wrapInQuotes(copyResult.getETag()));
+        copyObjectResponse.setLastModified(Instant.ofEpochMilli(copyResult.getModificationTime()));
         return copyObjectResponse;
       }
     } catch (OMException ex) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -955,9 +955,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       if (copyHeader != null) {
         getMetrics().updateCopyObjectSuccessStats(startNanos);
-        final Instant lastModified = omMultipartCommitUploadPartInfo.getModificationTime().isPresent()
-            ? Instant.ofEpochMilli(omMultipartCommitUploadPartInfo.getModificationTime().getAsLong())
-            : Instant.now();
+        final Instant lastModified = Instant.ofEpochMilli(omMultipartCommitUploadPartInfo.getModificationTime());
         return Response.ok(new CopyPartResult(eTag, lastModified)).build();
       } else {
         getMetrics().updateCreateMultipartKeySuccessStats(startNanos);
@@ -1039,20 +1037,18 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       copyLength = copyResult.getSize();
       modificationTime = copyResult.getModificationTime();
     } else {
-      Map<String, String> destMetadata;
-      try (OzoneOutputStream dest = openKeyForPut(
+      final OzoneOutputStream destStream = openKeyForPut(
           volume.getName(), destBucket, destKey, srcKeyLen,
-          replication, metadata, tags, writeConditions)) {
+          replication, metadata, tags, writeConditions);
+      try (OzoneOutputStream dest = destStream) {
         long metadataLatencyNs =
             getMetrics().updateCopyKeyMetadataStats(startNanos);
         perf.appendMetaLatencyNanos(metadataLatencyNs);
         copyLength = IOUtils.copyLarge(src, dest, 0, srcKeyLen, new byte[getIOBufferSize(srcKeyLen)]);
         eTag = DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
-        destMetadata = dest.getMetadata();
-        destMetadata.put(OzoneConsts.ETAG, eTag);
+        destStream.getMetadata().put(OzoneConsts.ETAG, eTag);
       }
-
-      modificationTime = S3Utils.getModificationTimeOrDefault(destMetadata, Time.now());
+      modificationTime = destStream.getModificationTime();
     }
     getMetrics().incCopyObjectSuccessLength(copyLength);
     perf.appendSizeBytes(copyLength);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -180,7 +180,7 @@ final class ObjectEndpointStreaming {
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
-  public static long copyKeyWithStream(
+  public static CopyResult copyKeyWithStream(
       OzoneBucket bucket,
       String keyPath,
       long length,
@@ -192,18 +192,23 @@ final class ObjectEndpointStreaming {
       S3ConditionalRequest.WriteConditions writeConditions)
       throws IOException {
     long writeLen;
+    String eTag;
+    Map<String, String> metadata;
     try (OzoneDataStreamOutput streamOutput = openStreamKeyForPut(bucket,
         keyPath, length, replicationConfig, keyMetadata, tags,
         writeConditions)) {
       long metadataLatencyNs =
           METRICS.updateCopyKeyMetadataStats(startNanos);
       writeLen = writeToStreamOutput(streamOutput, body, bufferSize, length);
-      String eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
+      eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
           .toLowerCase();
       perf.appendMetaLatencyNanos(metadataLatencyNs);
-      ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);
+      metadata = streamOutput.getMetadata();
+      metadata.put(OzoneConsts.ETAG, eTag);
     }
-    return writeLen;
+
+    final long modificationTime = S3Utils.getModificationTimeOrDefault(metadata, Time.now());
+    return new CopyResult(eTag, writeLen, modificationTime);
   }
 
   private static long writeToStreamOutput(OzoneDataStreamOutput streamOutput,

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -193,22 +193,20 @@ final class ObjectEndpointStreaming {
       throws IOException {
     long writeLen;
     String eTag;
-    Map<String, String> metadata;
-    try (OzoneDataStreamOutput streamOutput = openStreamKeyForPut(bucket,
+    final OzoneDataStreamOutput streamOutput = openStreamKeyForPut(bucket,
         keyPath, length, replicationConfig, keyMetadata, tags,
-        writeConditions)) {
+        writeConditions);
+    try (OzoneDataStreamOutput stream = streamOutput) {
       long metadataLatencyNs =
           METRICS.updateCopyKeyMetadataStats(startNanos);
       writeLen = writeToStreamOutput(streamOutput, body, bufferSize, length);
       eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
           .toLowerCase();
       perf.appendMetaLatencyNanos(metadataLatencyNs);
-      metadata = streamOutput.getMetadata();
-      metadata.put(OzoneConsts.ETAG, eTag);
+      streamOutput.getMetadata().put(OzoneConsts.ETAG, eTag);
     }
 
-    final long modificationTime = S3Utils.getModificationTimeOrDefault(metadata, Time.now());
-    return new CopyResult(eTag, writeLen, modificationTime);
+    return new CopyResult(eTag, writeLen, streamOutput.getModificationTime());
   }
 
   private static long writeToStreamOutput(OzoneDataStreamOutput streamOutput,

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
@@ -35,6 +35,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Map;
 import java.util.Objects;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
@@ -44,6 +45,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -272,6 +274,27 @@ public final class S3Utils {
     } catch (IllegalArgumentException ex) {
       throw newError(INVALID_DIGEST, resource);
     }
+  }
+
+  /**
+   * Extracts the modification time from the metadata map or returns the default time.
+   *
+   * @param metadata    the metadata map
+   * @param defaultTime the default time to return if not found or malformed
+   * @return the modification time
+   */
+  public static long getModificationTimeOrDefault(Map<String, String> metadata, long defaultTime) {
+    if (metadata != null) {
+      String modificationTimeStr = metadata.get(OzoneConsts.MODIFICATION_TIME);
+      if (modificationTimeStr != null) {
+        try {
+          return Long.parseLong(modificationTimeStr);
+        } catch (NumberFormatException ignore) {
+          // Fall back to defaultTime
+        }
+      }
+    }
+    return defaultTime;
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
@@ -35,7 +35,6 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Map;
 import java.util.Objects;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
@@ -45,7 +45,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -274,27 +273,6 @@ public final class S3Utils {
     } catch (IllegalArgumentException ex) {
       throw newError(INVALID_DIGEST, resource);
     }
-  }
-
-  /**
-   * Extracts the modification time from the metadata map or returns the default time.
-   *
-   * @param metadata    the metadata map
-   * @param defaultTime the default time to return if not found or malformed
-   * @return the modification time
-   */
-  public static long getModificationTimeOrDefault(Map<String, String> metadata, long defaultTime) {
-    if (metadata != null) {
-      String modificationTimeStr = metadata.get(OzoneConsts.MODIFICATION_TIME);
-      if (modificationTimeStr != null) {
-        try {
-          return Long.parseLong(modificationTimeStr);
-        } catch (NumberFormatException ignore) {
-          // Fall back to defaultTime
-        }
-      }
-    }
-    return defaultTime;
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -145,20 +145,21 @@ public final class OzoneBucketStub extends OzoneBucket {
         new KeyMetadataAwareOutputStream(metadata) {
           @Override
           public void close() throws IOException {
+            super.close();
             keyContents.put(key, toByteArray());
+            final long mtime = getModificationTime();
             keyDetails.put(key, new OzoneKeyDetails(
                 getVolumeName(),
                 getName(),
                 key,
                 size,
-                System.currentTimeMillis(),
-                System.currentTimeMillis(),
+                mtime,
+                mtime,
                 new ArrayList<>(), finalReplicationCon, getMetadata(), null,
                 () -> readKey(key), true,
                 UserGroupInformation.getCurrentUser().getShortUserName(),
                 tags
             ));
-            super.close();
           }
         };
 
@@ -179,18 +180,19 @@ public final class OzoneBucketStub extends OzoneBucket {
         new KeyMetadataAwareOutputStream(metadata) {
           @Override
           public void close() throws IOException {
+            super.close();
             keyContents.put(keyName, toByteArray());
+            final long mtime = getModificationTime();
             keyDetails.put(keyName, new OzoneKeyDetails(
                 getVolumeName(),
                 getName(),
                 keyName,
                 size,
-                System.currentTimeMillis(),
-                System.currentTimeMillis(),
+                mtime,
+                mtime,
                 new ArrayList<>(), finalReplicationCon, metadata, null,
                 () -> readKey(keyName), true, null, null
             ));
-            super.close();
           }
         };
 
@@ -254,13 +256,14 @@ public final class OzoneBucketStub extends OzoneBucket {
             Map<String, String> objectMetadata = keyMetadata == null ?
                 new HashMap<>() : keyMetadata;
 
+            final long mtime = getModificationTime();
             keyDetails.put(key, new OzoneKeyDetails(
                 getVolumeName(),
                 getName(),
                 key,
                 size,
-                System.currentTimeMillis(),
-                System.currentTimeMillis(),
+                mtime,
+                mtime,
                 new ArrayList<>(), rConfig, objectMetadata, null,
                 null, false,
                 UserGroupInformation.getCurrentUser().getShortUserName(),
@@ -340,7 +343,7 @@ public final class OzoneBucketStub extends OzoneBucket {
               buffer.get(bytes);
 
               Part part = new Part(key + size, bytes,
-                  getMetadata().get(ETAG));
+                  getMetadata().get(ETAG), getModificationTime());
               if (partList.get(key) == null) {
                 Map<Integer, Part> parts = new TreeMap<>();
                 parts.put(partNumber, part);
@@ -518,8 +521,9 @@ public final class OzoneBucketStub extends OzoneBucket {
           new KeyMetadataAwareOutputStream((int) size, new HashMap<>()) {
             @Override
             public void close() throws IOException {
+              super.close();
               Part part = new Part(key + size,
-                  toByteArray(), getMetadata().get(ETAG));
+                  toByteArray(), getMetadata().get(ETAG), getModificationTime());
               if (partList.get(key) == null) {
                 Map<Integer, Part> parts = new TreeMap<>();
                 parts.put(partNumber, part);
@@ -527,7 +531,6 @@ public final class OzoneBucketStub extends OzoneBucket {
               } else {
                 partList.get(key).put(partNumber, part);
               }
-              super.close();
             }
           };
       return new OzoneOutputStreamStub(keyOutputStream, key + size);
@@ -649,7 +652,7 @@ public final class OzoneBucketStub extends OzoneBucket {
         if (partEntry.getKey() > partNumberMarker) {
           PartInfo partInfo = new PartInfo(partEntry.getKey(),
               partEntry.getValue().getPartName(),
-              Time.now(), partEntry.getValue().getContent().length,
+              partEntry.getValue().getModificationTime(), partEntry.getValue().getContent().length,
               DatatypeConverter.printHexBinary(eTagProvider.digest(partEntry
                   .getValue().getContent())).toLowerCase());
           partInfoList.add(partInfo);
@@ -732,13 +735,18 @@ public final class OzoneBucketStub extends OzoneBucket {
   public static class Part {
     private String partName;
     private byte[] content;
-
     private String eTag;
+    private long modificationTime;
 
-    public Part(String name, byte[] data, String eTag) {
+    public Part(String name, byte[] data, String eTag, long modificationTime) {
       this.partName = name;
       this.content = data.clone();
       this.eTag = eTag;
+      this.modificationTime = modificationTime;
+    }
+
+    public long getModificationTime() {
+      return modificationTime;
     }
 
     public String getPartName() {
@@ -798,6 +806,7 @@ public final class OzoneBucketStub extends OzoneBucket {
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     private final Map<String, String> metadata;
     private List<CheckedRunnable<IOException>> preCommits = Collections.emptyList();
+    private long modificationTime;
 
     public KeyMetadataAwareOutputStream(Map<String, String> metadata) {
       super(null, null);
@@ -831,7 +840,13 @@ public final class OzoneBucketStub extends OzoneBucket {
       for (CheckedRunnable<IOException> preCommit : preCommits) {
         preCommit.run();
       }
+      modificationTime = Time.now();
       buffer.close();
+    }
+
+    @Override
+    public long getModificationTime() {
+      return modificationTime;
     }
 
     @Override
@@ -859,6 +874,7 @@ public final class OzoneBucketStub extends OzoneBucket {
 
     private final Map<String, String> metadata;
     private List<CheckedRunnable<IOException>> preCommits = Collections.emptyList();
+    private long modificationTime;
 
     public KeyMetadataAwareByteBufferStreamOutput(
         Map<String, String> metadata) {
@@ -878,10 +894,15 @@ public final class OzoneBucketStub extends OzoneBucket {
 
     @Override
     public void close() throws IOException {
-
       for (CheckedRunnable<IOException> preCommit : preCommits) {
         preCommit.run();
       }
+      modificationTime = Time.now();
+    }
+
+    @Override
+    public long getModificationTime() {
+      return modificationTime;
     }
 
     @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneDataStreamOutputStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneDataStreamOutputStub.java
@@ -63,8 +63,22 @@ public class OzoneDataStreamOutputStub extends OzoneDataStreamOutput {
 
   @Override
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    return closed ? new OmMultipartCommitUploadPartInfo(partName,
-        getMetadata().get(OzoneConsts.ETAG)) : null;
+    final KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
+    if (closed && keyDataStreamOutput != null) {
+      return new OmMultipartCommitUploadPartInfo(
+          partName, getMetadata().get(OzoneConsts.ETAG), keyDataStreamOutput.getModificationTime());
+    }
+    return null;
+  }
+
+  @Override
+  public long getModificationTime() {
+    final KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
+    if (keyDataStreamOutput != null) {
+      return keyDataStreamOutput.getModificationTime();
+    }
+    throw new IllegalStateException(
+        "OutputStream is not a KeyDataStreamOutput: " + getByteBufStreamOutput().getClass());
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.io.KeyMetadataAware;
+import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 
@@ -69,7 +70,22 @@ public class OzoneOutputStreamStub extends OzoneOutputStream {
 
   @Override
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    return closed ? new OmMultipartCommitUploadPartInfo(partName,
-        ((KeyMetadataAware)getOutputStream()).getMetadata().get(OzoneConsts.ETAG)) : null;
+    final KeyOutputStream keyOutputStream = getKeyOutputStream();
+    if (closed && keyOutputStream != null) {
+      return new OmMultipartCommitUploadPartInfo(
+          partName, ((KeyMetadataAware) getOutputStream()).getMetadata().get(OzoneConsts.ETAG),
+          keyOutputStream.getModificationTime());
+    }
+    return null;
+  }
+
+  @Override
+  public long getModificationTime() {
+    final KeyOutputStream keyOutputStream = getKeyOutputStream();
+    if (keyOutputStream != null) {
+      return keyOutputStream.getModificationTime();
+    }
+    throw new IllegalStateException(
+        "OutputStream is not a KeyOutputStream: " + getOutputStream().getClass());
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCopyObjectAndUploadPartCopyLastModified.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCopyObjectAndUploadPartCopyLastModified.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.initiateMultipartUpload;
+import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.X_AMZ_CONTENT_SHA256;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.urlEncode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import java.util.HashMap;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies CopyObject and UploadPartCopy return LastModified from the commit
+ * response rather than the source key time or a synthetic gateway timestamp.
+ */
+public class TestCopyObjectAndUploadPartCopyLastModified {
+
+  private static final String SOURCE_BUCKET = "source-bucket";
+  private static final String DEST_BUCKET = "dest-bucket";
+  private static final String SOURCE_KEY = "source-key";
+  private static final String DEST_KEY = "dest-key";
+  private static final String MPU_KEY = "mpu-key";
+  private static final String CONTENT = "copy-last-modified-test-content";
+  private static final long SOURCE_AGE_MS = 100L;
+
+  private ObjectEndpoint endpoint;
+  private HttpHeaders headers;
+  private OzoneBucket sourceBucket;
+  private OzoneBucket destBucket;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(X_AMZ_CONTENT_SHA256)).thenReturn("UNSIGNED-PAYLOAD");
+    when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("STANDARD");
+
+    final OzoneClient client = EndpointBuilder.newObjectEndpointBuilder()
+        .setHeaders(headers)
+        .build()
+        .getClient();
+    client.getObjectStore().createS3Bucket(SOURCE_BUCKET);
+    client.getObjectStore().createS3Bucket(DEST_BUCKET);
+    sourceBucket = client.getObjectStore().getS3Bucket(SOURCE_BUCKET);
+    destBucket = client.getObjectStore().getS3Bucket(DEST_BUCKET);
+
+    createSourceKey();
+
+    endpoint = EndpointBuilder.newObjectEndpointBuilder()
+        .setHeaders(headers)
+        .setClient(client)
+        .build();
+  }
+
+  @Test
+  void testCopyObjectLastModifiedReflectsDestCommitTime() throws Exception {
+    final long sourceModificationTime = sourceBucket.getKey(SOURCE_KEY)
+        .getModificationTime().toEpochMilli();
+    Thread.sleep(SOURCE_AGE_MS);
+
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        SOURCE_BUCKET + "/" + urlEncode(SOURCE_KEY));
+
+    try (Response response = put(endpoint, DEST_BUCKET, DEST_KEY, CONTENT)) {
+      assertEquals(200, response.getStatus());
+
+      final CopyObjectResponse copyObjectResponse = (CopyObjectResponse) response.getEntity();
+      assertNotNull(copyObjectResponse.getLastModified());
+      assertNotNull(copyObjectResponse.getETag());
+
+      final long responseModificationTime = copyObjectResponse.getLastModified().toEpochMilli();
+      final long destModificationTime = destBucket.getKey(DEST_KEY).getModificationTime().toEpochMilli();
+
+      assertEquals(destModificationTime, responseModificationTime);
+      assertNotEquals(sourceModificationTime, responseModificationTime);
+    }
+  }
+
+  @Test
+  void testUploadPartCopyLastModifiedReflectsPartCommitTime() throws Exception {
+    final long sourceModificationTime = sourceBucket.getKey(SOURCE_KEY)
+        .getModificationTime().toEpochMilli();
+    Thread.sleep(SOURCE_AGE_MS);
+
+    final String uploadId = initiateMultipartUpload(endpoint, DEST_BUCKET, MPU_KEY);
+
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(SOURCE_BUCKET + "/" + urlEncode(SOURCE_KEY));
+
+    try (Response response = put(endpoint, DEST_BUCKET, MPU_KEY, 1, uploadId, "")) {
+      assertEquals(200, response.getStatus());
+
+      final CopyPartResult copyPartResult = (CopyPartResult) response.getEntity();
+      assertNotNull(copyPartResult.getETag());
+      assertNotNull(copyPartResult.getLastModified());
+
+      final long responseModificationTime = copyPartResult.getLastModified().toEpochMilli();
+
+      // Retrieve the actual modification time of the newly uploaded part from the bucket
+      final OzoneMultipartUploadPartListParts parts = destBucket.listParts(
+          MPU_KEY, uploadId, 0, 100);
+      final long destPartModificationTime = parts.getPartInfoList().get(0).getModificationTime();
+
+      // Assert that the response precisely matches the part's actual commit time
+      assertEquals(destPartModificationTime, responseModificationTime);
+      assertNotEquals(sourceModificationTime, responseModificationTime);
+    }
+  }
+
+  private void createSourceKey() throws Exception {
+    try (OutputStream stream = sourceBucket.createKey(
+        SOURCE_KEY, CONTENT.length(), ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.RATIS, ReplicationFactor.THREE), new HashMap<>())) {
+      stream.write(CONTENT.getBytes(UTF_8));
+    }
+    Thread.sleep(SOURCE_AGE_MS);
+  }
+}


### PR DESCRIPTION
Please describe your PR in detail:
* In STS, CopyObject requires s3:GetObject action on source and s3:PutObject action on destination in order to successfully invoke the api. In the latent S3 implementation, the code was doing an additional read on the destination object to get the eTag and modificationTime when the file was created. This is problematic, because AWS doesn't require s3:GetObject action on the destination file, so this extra read was causing STS smoke tests to fail.

In order to address, don't do the extra read (which will help performance as well) and instead make the commit key call return the modification time in the response and use that. Furthermore, the code already knows what the md5Hash/eTag is, so there is no need to read the destination object.

For consistency, make uploadPartCopy similarly return the modification time as well.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15182

## How was this patch tested?
unit tests, smoke tests
