### PR TITLE
HDDS-15150. Container scanner should not mark container as UNHEALTHY when FD exhausted

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
@@ -115,7 +115,14 @@ public final class ContainerScanHelper {
     logScanCompleted(containerData, now);
   }
 
+  /**
+   * Marks container UNHEALTHY when the scan reports real errors.
+   * If every scan error is related to file-descriptor exhaustion, return without marking container unhealthy.
+   */
   public void handleUnhealthyScanResult(ContainerData containerData, ScanResult result) throws IOException {
+    if (ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(result)) {
+      return;
+    }
     long containerID = containerData.getContainerID();
     log.error("Corruption detected in container [{}]. Marking it UNHEALTHY. {}", containerID, result);
     if (log.isDebugEnabled()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
@@ -66,27 +66,35 @@ public final class ContainerScanHelper {
     long containerId = containerData.getContainerID();
     logScanStart(containerData, "data");
     DataScanResult result = container.scanData(throttler, canceler);
-
+    Instant now = Instant.now();
+    
     if (result.isDeleted()) {
       log.debug("Container [{}] has been deleted during the data scan.", containerId);
-    } else {
+      logScanCompleted(containerData, now);
+      return;
+    }
+
+    boolean isTransientFailure = ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(result);
+
+    if (!isTransientFailure) {
       try {
         controller.updateContainerChecksum(containerId, result.getDataTree());
       } catch (IOException ex) {
         log.warn("Failed to update container checksum after scan of container {}", containerId, ex);
       }
-      if (result.hasErrors()) {
-        handleUnhealthyScanResult(containerData, result);
-      }
-      metrics.incNumContainersScanned();
     }
 
-    Instant now = Instant.now();
-    if (!result.isDeleted()) {
-      controller.updateDataScanTimestamp(containerId, now);
+    if (result.hasErrors()) {
+      handleUnhealthyScanResult(containerData, result, isTransientFailure);
     }
-    // Even if the container was deleted, mark the scan as completed since we already logged it as starting.
-    logScanCompleted(containerData, now);
+
+    if (!isTransientFailure) {
+      metrics.incNumContainersScanned();
+      controller.updateDataScanTimestamp(containerId, now);
+      logScanCompleted(containerData, now);
+    } else {
+      logScanIncomplete(containerData, now, "data");
+    }
   }
 
   public void scanMetadata(Container<?> container)
@@ -103,25 +111,33 @@ public final class ContainerScanHelper {
       log.debug("Container [{}] has been deleted during metadata scan.", containerId);
       return;
     }
+
+    boolean isTransientFailure = ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(result);
+
     if (result.hasErrors()) {
-      handleUnhealthyScanResult(containerData, result);
+      handleUnhealthyScanResult(containerData, result, isTransientFailure);
     }
 
     Instant now = Instant.now();
     // Do not update the scan timestamp after the scan since this was just a
     // metadata scan, not a full data scan.
-    metrics.incNumContainersScanned();
-    // Even if the container was deleted, mark the scan as completed since we already logged it as starting.
-    logScanCompleted(containerData, now);
+    if (!isTransientFailure) {
+      metrics.incNumContainersScanned();
+      // Even if the container was deleted, mark the scan as completed since we already logged it as starting.
+      logScanCompleted(containerData, now);
+    } else {
+      logScanIncomplete(containerData, now, "metadata");
+    }
   }
 
   /**
    * Marks container UNHEALTHY when the scan reports real errors.
    * If every scan error is related to file-descriptor exhaustion, return without marking container unhealthy.
    */
-  public void handleUnhealthyScanResult(ContainerData containerData, ScanResult result) throws IOException {
+  public void handleUnhealthyScanResult(ContainerData containerData, ScanResult result,
+      boolean isTransientFailure) throws IOException {
     long containerID = containerData.getContainerID();
-    if (ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(result)) {
+    if (isTransientFailure) {
       log.warn("Skipped marking container UNHEALTHY [{}]: scan failed due to transient " +
           "file descriptor exhaustion ('Too many open files'). {}", containerID, result);
       return;
@@ -213,5 +229,12 @@ public final class ContainerScanHelper {
       ContainerData containerData, Instant timestamp) {
     log.debug("Completed scan of container {} at {}",
         containerData.getContainerID(), timestamp);
+  }
+
+  private void logScanIncomplete(ContainerData containerData, Instant timestamp, String scanType) {
+    if (log.isDebugEnabled()) {
+      log.debug("Incomplete {} scan of container {} at {} due to transient file descriptor exhaustion",
+          scanType, containerData.getContainerID(), timestamp);
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
@@ -120,10 +120,12 @@ public final class ContainerScanHelper {
    * If every scan error is related to file-descriptor exhaustion, return without marking container unhealthy.
    */
   public void handleUnhealthyScanResult(ContainerData containerData, ScanResult result) throws IOException {
+    long containerID = containerData.getContainerID();
     if (ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(result)) {
+      log.warn("Skipped marking container UNHEALTHY [{}]: scan failed due to transient " +
+          "file descriptor exhaustion ('Too many open files'). {}", containerID, result);
       return;
     }
-    long containerID = containerData.getContainerID();
     log.error("Corruption detected in container [{}]. Marking it UNHEALTHY. {}", containerID, result);
     if (log.isDebugEnabled()) {
       StringBuilder allErrorString = new StringBuilder();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ScanTransientIOUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ScanTransientIOUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import java.util.Locale;
+import org.apache.hadoop.ozone.container.common.interfaces.ScanResult;
+
+/**
+ * Utility to catch transient scan failures (typically related to file-descriptor exhaustion)
+ * that should not be treated as container data corruption.
+ */
+public final class ScanTransientIOUtil {
+
+  private static final String TOO_MANY_OPEN_FILES = "too many open files";
+
+  private ScanTransientIOUtil() {
+  }
+
+  /**
+   * Returns true when every scan error is related to file-descriptor exhaustion.
+   * Each error's exception chain is checked via {@link #isTooManyOpenFiles(Throwable)}.
+   */
+  public static boolean scanErrorsAreOnlyTooManyOpenFiles(ScanResult scanResult) {
+    if (!scanResult.hasErrors()) {
+      return false;
+    }
+    return scanResult.getErrors().stream()
+        .allMatch(scanError -> isTooManyOpenFiles(scanError.getException()));
+  }
+
+  public static boolean isTooManyOpenFiles(Throwable throwable) {
+    for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+      String message = cause.getMessage();
+      if (message != null && containsTooManyOpenFiles(message)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsTooManyOpenFiles(String text) {
+    return text.toLowerCase(Locale.ROOT).contains(TOO_MANY_OPEN_FILES);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ScanTransientIOUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ScanTransientIOUtil.java
@@ -17,7 +17,11 @@
 
 package org.apache.hadoop.ozone.container.ozoneimpl;
 
+import java.nio.file.FileSystemException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Locale;
+import java.util.Set;
 import org.apache.hadoop.ozone.container.common.interfaces.ScanResult;
 
 /**
@@ -25,6 +29,8 @@ import org.apache.hadoop.ozone.container.common.interfaces.ScanResult;
  * that should not be treated as container data corruption.
  */
 public final class ScanTransientIOUtil {
+
+  private static final int MAX_CAUSE_CHAIN_DEPTH = 64;
 
   private static final String TOO_MANY_OPEN_FILES = "too many open files";
 
@@ -44,13 +50,33 @@ public final class ScanTransientIOUtil {
   }
 
   public static boolean isTooManyOpenFiles(Throwable throwable) {
-    for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
-      String message = cause.getMessage();
-      if (message != null && containsTooManyOpenFiles(message)) {
+    if (throwable == null) {
+      return false;
+    }
+    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    int depth = 0;
+    for (Throwable cause = throwable;
+        cause != null && depth < MAX_CAUSE_CHAIN_DEPTH;
+        cause = cause.getCause(), depth++) {
+      if (!visited.add(cause)) {
+        break;
+      }
+      if (matchesTooManyOpenFiles(cause)) {
         return true;
       }
     }
     return false;
+  }
+
+  private static boolean matchesTooManyOpenFiles(Throwable throwable) {
+    if (throwable instanceof FileSystemException) {
+      String reason = ((FileSystemException) throwable).getReason();
+      if (reason != null && containsTooManyOpenFiles(reason)) {
+        return true;
+      }
+    }
+    String message = throwable.getMessage();
+    return message != null && containsTooManyOpenFiles(message);
   }
 
   private static boolean containsTooManyOpenFiles(String text) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -56,12 +57,14 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdfs.util.Canceler;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.ozone.container.checksum.ContainerMerkleTreeWriter;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ScanResult;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaThreeDBDefinition;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScanError.FailureType;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -401,5 +404,25 @@ public class TestBackgroundContainerDataScanner extends
       verify(controller, times(1))
           .updateContainerChecksum(eq(container.getContainerData().getContainerID()), any());
     }
+  }
+
+  /**
+   * When data scan reports only "too many open files" errors due to file-descriptor exhaustion,
+   * the container must not be marked UNHEALTHY.
+   */
+  @Test
+  public void testDataScanOnlyTooManyOpenFilesDoesNotMarkUnhealthy() throws Exception {
+    Container<?> container = mockKeyValueContainer();
+    IOException ex = new IOException("Too many open files");
+    DataScanResult scanResult = DataScanResult.fromErrors(Collections.singletonList(
+                    new ContainerScanError(FailureType.CORRUPT_CHUNK, new File("."), ex)),
+            new ContainerMerkleTreeWriter());
+    when(container.scanData(any(DataTransferThrottler.class), any(Canceler.class))).thenReturn(scanResult);
+
+    setContainers(container, healthy);
+    scanner.runIteration();
+
+    verify(controller, never()).markContainerUnhealthy(anyLong(), any(ScanResult.class));
+    assertEquals(0, scanner.getMetrics().getNumUnHealthyContainers());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
@@ -419,10 +419,14 @@ public class TestBackgroundContainerDataScanner extends
             new ContainerMerkleTreeWriter());
     when(container.scanData(any(DataTransferThrottler.class), any(Canceler.class))).thenReturn(scanResult);
 
-    setContainers(container, healthy);
+    setContainers(container);
     scanner.runIteration();
 
     verify(controller, never()).markContainerUnhealthy(anyLong(), any(ScanResult.class));
+    verify(controller, never()).updateContainerChecksum(eq(container.getContainerData().getContainerID()), any());
+    verify(controller, never()).updateDataScanTimestamp(eq(container.getContainerData().getContainerID()), any());
+    assertEquals(1, scanner.getMetrics().getNumScanIterations());
+    assertEquals(0, scanner.getMetrics().getNumContainersScanned());
     assertEquals(0, scanner.getMetrics().getNumUnHealthyContainers());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -38,8 +38,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -49,6 +51,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ScanResult;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScanError.FailureType;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -255,5 +258,24 @@ public class TestBackgroundContainerMetadataScanner extends
     scanner.shutdown();
     // The container should remain healthy.
     verifyContainerMarkedUnhealthy(healthy, never());
+  }
+
+  /**
+   * When metadata scan reports only "too many open files" errors due to file-descriptor exhaustion, 
+   * the container must not be marked UNHEALTHY.
+   */
+  @Test
+  public void testMetadataScanOnlyTooManyOpenFilesDoesNotMarkUnhealthy() throws Exception {
+    Container<?> container = mockKeyValueContainer();
+    IOException emf = new IOException("Too many open files");
+    MetadataScanResult scanResult = MetadataScanResult.fromErrors(Collections.singletonList(
+            new ContainerScanError(FailureType.CORRUPT_CONTAINER_FILE, new File("."), emf)));
+    when(container.scanMetaData()).thenReturn(scanResult);
+
+    setContainers(container, healthy);
+    scanner.runIteration();
+
+    verify(controller, never()).markContainerUnhealthy(anyLong(), any(ScanResult.class));
+    assertEquals(0, scanner.getMetrics().getNumUnHealthyContainers());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -272,10 +272,12 @@ public class TestBackgroundContainerMetadataScanner extends
             new ContainerScanError(FailureType.CORRUPT_CONTAINER_FILE, new File("."), emf)));
     when(container.scanMetaData()).thenReturn(scanResult);
 
-    setContainers(container, healthy);
+    setContainers(container);
     scanner.runIteration();
 
     verify(controller, never()).markContainerUnhealthy(anyLong(), any(ScanResult.class));
+    assertEquals(1, scanner.getMetrics().getNumScanIterations());
+    assertEquals(0, scanner.getMetrics().getNumContainersScanned());
     assertEquals(0, scanner.getMetrics().getNumUnHealthyContainers());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestScanTransientIOUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestScanTransientIOUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileSystemException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScanError.FailureType;
+import org.junit.jupiter.api.Test;
+
+/** 
+ * Unit tests for {@link ScanTransientIOUtil}.
+ */
+public class TestScanTransientIOUtil {
+
+  @Test
+  public void detectsTooManyOpenFilesInFileSystemException() {
+    assertTrue(ScanTransientIOUtil.isTooManyOpenFiles(new FileSystemException(null, null, "Too many open files")));
+  }
+
+  @Test
+  public void detectsTooManyOpenFilesInFileNotFoundExceptionMessage() {
+    String msg = "/data/container/metadata/16341719.container (Too many open files)";
+    assertTrue(ScanTransientIOUtil.isTooManyOpenFiles(new FileNotFoundException(msg)));
+  }
+
+  @Test
+  public void detectsTooManyOpenFilesInMessageCauseChain() {
+    IOException throwable = new IOException("Too many open files");
+    assertTrue(ScanTransientIOUtil.isTooManyOpenFiles(new IOException(throwable)));
+  }
+
+  @Test
+  public void rejectsUnrelatedIOException() {
+    assertFalse(ScanTransientIOUtil.isTooManyOpenFiles(new IOException("disk full")));
+  }
+
+  @Test
+  public void scanErrorsOnlyTooManyOpenFilesReturnsTrue() {
+    IOException ex = new IOException("Too many open files");
+    MetadataScanResult scanResult = MetadataScanResult.fromErrors(Collections.singletonList(
+        new ContainerScanError(FailureType.CORRUPT_CONTAINER_FILE, new File("."), ex)));
+    assertTrue(ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(scanResult));
+  }
+
+  @Test
+  public void scanErrorsMixedReturnsFalse() {
+    IOException ioException = new IOException("Too many open files");
+    FileNotFoundException fileNotFoundException = new FileNotFoundException("missing");
+    MetadataScanResult scanResult = MetadataScanResult.fromErrors(Arrays.asList(
+        new ContainerScanError(FailureType.CORRUPT_CHUNK, new File("."), ioException),
+        new ContainerScanError(FailureType.MISSING_CONTAINER_FILE, new File("."), fileNotFoundException)));
+    assertFalse(ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(scanResult));
+  }
+
+  @Test
+  public void emptyScanResult() {
+    assertFalse(ScanTransientIOUtil.scanErrorsAreOnlyTooManyOpenFiles(
+        MetadataScanResult.fromErrors(Collections.emptyList())));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed a bug where background container scanners marked containers as `UNHEALTHY` due to resource issues rather than actual data corruption. Specifically, when the system encountered a `FileNotFoundException` or `FileSystemException` caused by file-descriptor exhaustion ("Too many open files"), the scanners incorrectly flagged these as corruption events. 

The logic has been updated to explicitly catch these resource-related exceptions, ensuring that containers remain in their current state when the scanner cannot perform its check due to system limits.

ContainerMetadataScanner
```
2026-04-20 22:01:43,978 ERROR [ContainerMetadataScanner]-org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerMetadataScanner: Corruption detected in container [3980819]. Marking it UNHEALTHY.
java.io.FileNotFoundException: /data6/hadoop-ozone/datanode/data/hdds/CID-637fe7c5-f40b-4e49-98b3-52154bd669e2/current/containerDir95/3980819/metadata/3980819.container (Too many open files)
```
ContainerDataScanner
```
2026-04-20 22:01:43,982 ERROR [ContainerDataScanner(/data12/hadoop-ozone/datanode/data/hdds)]-org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerDataScanner: Corruption detected in container [16326340]. Marking it UNHEALTHY.
java.nio.file.FileSystemException: /data12/hadoop-ozone/datanode/data/hdds/CID-637fe7c5-f40b-4e49-98b3-52154bd669e2/current/containerDir143/16326340/chunks/115816904944438982.block: Too many open files
```

## What is the link to the Apache JIRA
[HDDS-15150](https://issues.apache.org/jira/browse/HDDS-15150)

## How was this patch tested?
Added unit tests in `TestBackgroundContainerDataScanner` and `TestBackgroundContainerMetadataScanner`.
Verified that with fix, containers are not incorrectly marked as UNHEALTHY. 

2026-05-19 07:29:15,712 [ContainerMetadataScanner] WARN ozoneimpl.BackgroundContainerMetadataScanner: Skipped marking container UNHEALTHY [1]: scan failed due to transient file descriptor exhaustion ('Too many open files'). Container has 1 error: CORRUPT_CONTAINER_FILE for file /data/hdds/hdds/CID-123137c1-6a7e-4e0a-b412-b2279be5f2bb/current/containerDir0/1/metadata/1.container with exception: java.nio.file.FileSystemException: /data/hdds/hdds/CID-123137c1-6a7e-4e0a-b412-b2279be5f2bb/current/containerDir0/1/metadata/1.container: Too many open files

