### PR TITLE
HDDS-13357. Fix OmSnapshotManager#inFlightSnapshotCount reset logic

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -962,42 +962,45 @@ public final class OmSnapshotManager implements AutoCloseable {
     checkSnapshotActive(toSnapInfo, false);
   }
 
+  /**
+   * Checks snapshot limit considering in-flight count and increments the counter if allowed.
+   * Called in preExecute() to track and limit concurrent snapshot creations.
+   *
+   * @throws IOException if failed to get snapshot count
+   * @throws OMException if the snapshot limit would be exceeded
+   */
   public void snapshotLimitCheck() throws IOException, OMException {
     OmMetadataManagerImpl omMetadataManager = (OmMetadataManagerImpl) ozoneManager.getMetadataManager();
     SnapshotChainManager snapshotChainManager = omMetadataManager.getSnapshotChainManager();
 
-    AtomicReference<IOException> exceptionRef = new AtomicReference<>(null);
+    AtomicReference<Exception> exceptionRef = new AtomicReference<>(null);
     inFlightSnapshotCount.updateAndGet(count -> {
-      int currentSnapshotNum = 0;
+      int currentSnapshotCount;
       try {
-        currentSnapshotNum = snapshotChainManager.getGlobalSnapshotChain().size();
+        currentSnapshotCount = snapshotChainManager.getGlobalSnapshotChain().size();
+        throwIfSnapshotLimitExceeded(currentSnapshotCount, count);
       } catch (IOException e) {
         exceptionRef.set(e);
-        return count;
-      }
-      if (currentSnapshotNum + count >= fsSnapshotMaxLimit) {
-        exceptionRef.set(new OMException(
-            String.format("Snapshot limit of %d reached. Cannot create more snapshots. " +
-                "Current snapshots: %d, In-flight creations: %d",
-                fsSnapshotMaxLimit, currentSnapshotNum, count) +
-                " If you already deleted some snapshots, " +
-                "please wait for the background service to complete the cleanup.",
-            OMException.ResultCodes.TOO_MANY_SNAPSHOTS));
         return count;
       }
       return count + 1;
     });
     if (exceptionRef.get() != null) {
-      throw exceptionRef.get();
+      Exception e = exceptionRef.get();
+      if (e instanceof OMException) {
+        throw (OMException) e;
+      }
+      throw (IOException) e;
     }
   }
 
   public void decrementInFlightSnapshotCount() {
-    // TODO this is a work around for the accounting logic of `inFlightSnapshotCount`.
-    //    - It incorrectly assumes that LeaderReady means that there are no inflight snapshot requests.
-    //    We may consider fixing it by waiting all the pending requests in notifyLeaderReady().
-    //    - Also, it seems to have another bug that the PrepareState could disallow snapshot requests.
-    //    In such case, `inFlightSnapshotCount` won't be decremented.
+    // The counter can go negative in the following scenario:
+    // 1. Old leader increments counter in preExecute()
+    // 2. Leader election happens, old leader calls resetInFlightSnapshotCount() in notifyNotLeader()
+    // 3. New leader applies the pending request via validateAndUpdateCache()
+    // 4. validateAndUpdateCache() decrements counter on new leader (which was 0)
+    // This is expected and handled by resetting to 0 when negative.
     int result = inFlightSnapshotCount.decrementAndGet();
     if (result < 0) {
       resetInFlightSnapshotCount();
@@ -1010,6 +1013,43 @@ public final class OmSnapshotManager implements AutoCloseable {
 
   public int getInFlightSnapshotCount() {
     return inFlightSnapshotCount.get();
+  }
+
+  /**
+   * Throws OMException if creating a new snapshot would exceed the limit.
+   * This is a pure check with no side effects.
+   *
+   * @param currentSnapshotCount current number of snapshots
+   * @param inFlightCount number of in-flight snapshot requests
+   * @throws OMException if the snapshot limit would be exceeded
+   */
+  private void throwIfSnapshotLimitExceeded(int currentSnapshotCount, int inFlightCount) throws OMException {
+    if (currentSnapshotCount + inFlightCount >= fsSnapshotMaxLimit) {
+      throw new OMException(
+          String.format("Snapshot limit of %d reached. Cannot create more snapshots. " +
+              "Current snapshots: %d, In-flight creations: %d. " +
+              "Please delete some snapshots before creating new ones.",
+              fsSnapshotMaxLimit, currentSnapshotCount, inFlightCount),
+          OMException.ResultCodes.TOO_MANY_SNAPSHOTS);
+    }
+  }
+
+  /**
+   * Hard check on snapshot limit without considering in-flight count.
+   * Used as a safety net in validateAndUpdateCache to ensure the limit
+   * is never exceeded, even if in-flight tracking has bugs.
+   *
+   * @throws OMException if the snapshot limit has been reached
+   * @throws IOException if failed to get snapshot count
+   */
+  public void assertSnapshotLimitNotExceeded() throws OMException, IOException {
+    OmMetadataManagerImpl omMetadataManager =
+        (OmMetadataManagerImpl) ozoneManager.getMetadataManager();
+    SnapshotChainManager snapshotChainManager =
+        omMetadataManager.getSnapshotChainManager();
+
+    int currentSnapshotCount = snapshotChainManager.getGlobalSnapshotChain().size();
+    throwIfSnapshotLimitExceeded(currentSnapshotCount, 0);
   }
 
   private String validateToken(final String token) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -188,7 +188,6 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
   @Override
   public void notifyLeaderReady() {
-    ozoneManager.getOmSnapshotManager().resetInFlightSnapshotCount();
     OMMetrics metrics = ozoneManager.getMetrics();
     if (metrics != null) {
       metrics.addRatisEvent("Ready to serve requests as the leader");
@@ -198,6 +197,10 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   @Override
   public void notifyNotLeader(Collection<TransactionContext> pendingEntries) {
     LOG.info("current leader OM steps down.");
+    // Reset in-flight snapshot count when stepping down as leader.
+    // Any in-flight snapshot requests tracked by this OM are no longer valid
+    // since this OM is no longer the leader processing client requests.
+    ozoneManager.getOmSnapshotManager().resetInFlightSnapshotCount();
     OMMetrics metrics = ozoneManager.getMetrics();
     if (metrics != null) {
       metrics.addRatisEvent("current leader OM steps down.");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -130,7 +130,12 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
         .setCreationTime(Time.now());
     return omRequest.toBuilder().setCreateSnapshotRequest(createSnapshotRequest.build()).build();
   }
-  
+
+  @Override
+  public void handleRequestFailure(OzoneManager ozoneManager) {
+    ozoneManager.getOmSnapshotManager().decrementInFlightSnapshotCount();
+  }
+
   @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, ExecutionContext context) {
 
@@ -167,6 +172,8 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
         LOG.debug("Snapshot '{}' already exists under '{}'", key, snapshotPath);
         throw new OMException("Snapshot already exists", FILE_ALREADY_EXISTS);
       }
+
+      ozoneManager.getOmSnapshotManager().assertSnapshotLimitNotExceeded();
 
       ByteString txnBytes = TransactionInfo.valueOf(context.getTermIndex()).toByteString();
       snapshotInfo.setCreateTransactionInfo(txnBytes);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -868,14 +869,21 @@ public class TestOzoneManagerStateMachine {
     verify(snapshotProvider, never()).init();
   }
 
-  // --- notifyLeaderReady tests ---
-
   @Test
   public void testNotifyLeaderReady() {
     OmSnapshotManager snapshotManager = mock(OmSnapshotManager.class);
     when(om.getOmSnapshotManager()).thenReturn(snapshotManager);
 
     sm.notifyLeaderReady();
+    verify(snapshotManager, never()).resetInFlightSnapshotCount();
+  }
+
+  @Test
+  public void testNotifyNotLeader() {
+    OmSnapshotManager snapshotManager = mock(OmSnapshotManager.class);
+    when(om.getOmSnapshotManager()).thenReturn(snapshotManager);
+
+    sm.notifyNotLeader(Collections.emptyList());
 
     verify(snapshotManager).resetInFlightSnapshotCount();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Move resetInFlightSnapshotCount() from notifyLeaderReady() to notifyNotLeader()
    The counter tracks requests where preExecute() ran but validateAndUpdateCache()
     hasn't completed. When an OM steps down as leader, it should reset its counter
     because those tracked requests are no longer its responsibility. Previously,
     resetting in notifyLeaderReady() was incorrect - the new leader never ran
     preExecute() for pending requests, so its counter should start at 0.
2. Override handleRequestFailure() in OMSnapshotCreateRequest
     When a request fails after preExecute() (e.g., PrepareState rejection),
     the counter was never decremented. This could cause the counter to grow
     unbounded during OM prepare mode for upgrades.

 3. Add safety net check in validateAndUpdateCache()
     Call assertSnapshotLimitNotExceeded() as a hard guarantee that the snapshot
     limit is never exceeded, even if in-flight tracking has bugs during leader
     transitions or other edge cases

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13357

## How was this patch tested?
Add tests and ci(https://github.com/YutaLin/ozone/actions/runs/25562315743)
