### PR TITLE
HDDS-15213. Use common commit output for stream outputs

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyCommitOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyCommitOutput.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.client.io;
+
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
+import org.apache.ratis.util.function.CheckedRunnable;
+
+/**
+ * Common commit-time behavior for key output implementations.
+ */
+interface KeyCommitOutput extends KeyMetadataAware {
+
+  void setPreCommits(
+      @Nonnull List<CheckedRunnable<IOException>> preCommits);
+
+  OmMultipartCommitUploadPartInfo getCommitUploadPartInfo();
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * TODO : currently not support multi-thread access.
  */
 public class KeyDataStreamOutput extends AbstractDataStreamOutput
-    implements KeyMetadataAware {
+    implements KeyCommitOutput {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(KeyDataStreamOutput.class);
@@ -87,6 +87,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
 
   private List<CheckedRunnable<IOException>> preCommits = Collections.emptyList();
 
+  @Override
   public void setPreCommits(@Nonnull List<CheckedRunnable<IOException>> preCommits) {
     this.preCommits = preCommits;
   }
@@ -472,6 +473,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     }
   }
 
+  @Override
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
     return blockDataStreamOutputEntryPool.getCommitUploadPartInfo();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
  * TODO : currently not support multi-thread access.
  */
 public class KeyOutputStream extends OutputStream
-    implements Syncable, KeyMetadataAware {
+    implements Syncable, KeyCommitOutput {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(KeyOutputStream.class);
@@ -114,6 +114,7 @@ public class KeyOutputStream extends OutputStream
   private final KeyOutputStreamSemaphore keyOutputStreamSemaphore;
   private List<CheckedRunnable<IOException>> preCommits = Collections.emptyList();
 
+  @Override
   public void setPreCommits(@Nonnull List<CheckedRunnable<IOException>> preCommits) {
     this.preCommits = preCommits;
   }
@@ -671,7 +672,8 @@ public class KeyOutputStream extends OutputStream
     }
   }
 
-  synchronized OmMultipartCommitUploadPartInfo
+  @Override
+  public synchronized OmMultipartCommitUploadPartInfo
       getCommitUploadPartInfo() {
     return blockOutputStreamEntryPool.getCommitUploadPartInfo();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.client.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import org.apache.hadoop.crypto.CryptoOutputStream;
 import org.apache.hadoop.fs.Syncable;
 import org.apache.hadoop.hdds.scm.storage.ByteBufferStreamOutput;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
+import org.apache.ratis.util.function.CheckedRunnable;
 
 /**
  * OzoneDataStreamOutput is used to write data into Ozone.
@@ -100,38 +102,65 @@ public class OzoneDataStreamOutput extends ByteBufferOutputStream
   }
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
-    if (keyDataStreamOutput != null) {
-      return keyDataStreamOutput.getCommitUploadPartInfo();
+    KeyCommitOutput keyCommitOutput = getKeyCommitOutput();
+    if (keyCommitOutput != null) {
+      return keyCommitOutput.getCommitUploadPartInfo();
     }
     // Otherwise return null.
     return null;
   }
 
   public KeyDataStreamOutput getKeyDataStreamOutput() {
+    if (byteBufferStreamOutput instanceof KeyDataStreamOutput) {
+      return ((KeyDataStreamOutput) byteBufferStreamOutput);
+    }
     if (byteBufferStreamOutput instanceof OzoneOutputStream) {
       OutputStream outputStream =
           ((OzoneOutputStream) byteBufferStreamOutput).getOutputStream();
-      if (outputStream instanceof KeyDataStreamOutput) {
-        return ((KeyDataStreamOutput) outputStream);
-      } else if (outputStream instanceof CryptoOutputStream) {
-        OutputStream wrappedStream =
-            ((CryptoOutputStream) outputStream).getWrappedStream();
-        if (wrappedStream instanceof KeyDataStreamOutput) {
-          return ((KeyDataStreamOutput) wrappedStream);
-        }
-      } else if (outputStream instanceof CipherOutputStreamOzone) {
-        OutputStream wrappedStream =
-            ((CipherOutputStreamOzone) outputStream).getWrappedStream();
-        if (wrappedStream instanceof KeyDataStreamOutput) {
-          return ((KeyDataStreamOutput) wrappedStream);
-        }
+      OutputStream unwrappedStream = unwrap(outputStream);
+      if (unwrappedStream instanceof KeyDataStreamOutput) {
+        return ((KeyDataStreamOutput) unwrappedStream);
       }
-    } else if (byteBufferStreamOutput instanceof KeyDataStreamOutput) {
-      return ((KeyDataStreamOutput) byteBufferStreamOutput);
     }
     // Otherwise return null.
     return null;
+  }
+
+  private KeyCommitOutput getKeyCommitOutput() {
+    if (byteBufferStreamOutput instanceof KeyCommitOutput) {
+      return (KeyCommitOutput) byteBufferStreamOutput;
+    }
+    if (byteBufferStreamOutput instanceof OzoneOutputStream) {
+      OutputStream outputStream =
+          ((OzoneOutputStream) byteBufferStreamOutput).getOutputStream();
+      OutputStream unwrappedStream = unwrap(outputStream);
+      if (unwrappedStream instanceof KeyCommitOutput) {
+        return (KeyCommitOutput) unwrappedStream;
+      }
+    }
+    // Otherwise return null.
+    return null;
+  }
+
+  public void setPreCommits(
+      List<CheckedRunnable<IOException>> preCommits) {
+    KeyCommitOutput keyCommitOutput = getKeyCommitOutput();
+    if (keyCommitOutput != null) {
+      keyCommitOutput.setPreCommits(preCommits);
+      return;
+    }
+    throw new IllegalStateException(
+        "Output stream is not backed by KeyCommitOutput: " +
+            byteBufferStreamOutput.getClass());
+  }
+
+  private static OutputStream unwrap(OutputStream outputStream) {
+    if (outputStream instanceof CryptoOutputStream) {
+      return ((CryptoOutputStream) outputStream).getWrappedStream();
+    } else if (outputStream instanceof CipherOutputStreamOzone) {
+      return ((CipherOutputStreamOzone) outputStream).getWrappedStream();
+    }
+    return outputStream;
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -29,7 +29,6 @@ import java.nio.ByteBuffer;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.HttpHeaders;
@@ -154,7 +153,7 @@ final class ObjectEndpointStreaming {
         preCommits.add(checkSha256Hook);
       }
 
-      streamOutput.getKeyDataStreamOutput().setPreCommits(preCommits);
+      streamOutput.setPreCommits(preCommits);
     }
     return Pair.of(md5Hash, writeLen);
   }
@@ -235,13 +234,15 @@ final class ObjectEndpointStreaming {
             writeToStreamOutput(streamOutput, body, chunkSize, length);
         eTag = DatatypeConverter.printHexBinary(
             body.getMessageDigest(OzoneConsts.MD5_HASH).digest()).toLowerCase();
+        List<CheckedRunnable<IOException>> preCommits = new ArrayList<>();
         String clientContentMD5 = headers.getHeaderString(S3Consts.CHECKSUM_HEADER);
         if (clientContentMD5 != null) {
           CheckedRunnable<IOException> checkContentMD5Hook = () -> {
             S3Utils.validateContentMD5(clientContentMD5, eTag, key);
           };
-          streamOutput.getKeyDataStreamOutput().setPreCommits(Collections.singletonList(checkContentMD5Hook));
+          preCommits.add(checkContentMD5Hook);
         }
+        streamOutput.setPreCommits(preCommits);
         ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);
         METRICS.incPutKeySuccessLength(putLength);
         perf.appendMetaLatencyNanos(metadataLatencyNs);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -326,6 +326,12 @@ public final class OzoneBucketStub extends OzoneBucket {
     if (multipartInfo == null || !multipartInfo.getUploadId().equals(uploadID)) {
       throw new OMException(ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
     } else {
+      if (isECMultipartUpload(multipartInfo)) {
+        OzoneOutputStream outputStream =
+            createMultipartKey(key, size, partNumber, uploadID);
+        return new OzoneDataStreamOutputStub(outputStream, key + size);
+      }
+
       ByteBufferStreamOutput byteBufferStreamOutput =
           new KeyMetadataAwareByteBufferStreamOutput(new HashMap<>()) {
             private final ByteBuffer buffer = ByteBuffer.allocate(1024 * 1024);
@@ -362,6 +368,12 @@ public final class OzoneBucketStub extends OzoneBucket {
 
       return new OzoneDataStreamOutputStub(byteBufferStreamOutput, key + size);
     }
+  }
+
+  private boolean isECMultipartUpload(MultipartInfoStub multipartInfo) {
+    ReplicationConfig config = multipartInfo.getReplicationConfig();
+    return config != null &&
+        config.getReplicationType() == HddsProtos.ReplicationType.EC;
   }
 
   @Override
@@ -502,7 +514,8 @@ public final class OzoneBucketStub extends OzoneBucket {
        ReplicationConfig config, Map<String, String> metadata, Map<String, String> tags)
       throws IOException {
     String uploadID = UUID.randomUUID().toString();
-    keyToMultipartUpload.put(keyName, new MultipartInfoStub(uploadID, metadata, tags));
+    keyToMultipartUpload.put(keyName,
+        new MultipartInfoStub(uploadID, config, metadata, tags));
     return new OmMultipartInfo(getVolumeName(), getName(), keyName, uploadID);
   }
 
@@ -911,18 +924,24 @@ public final class OzoneBucketStub extends OzoneBucket {
   private static class MultipartInfoStub {
 
     private final String uploadId;
+    private final ReplicationConfig replicationConfig;
     private final Map<String, String> metadata;
     private final Map<String, String> tags;
 
-    MultipartInfoStub(String uploadId, Map<String, String> metadata,
-                      Map<String, String> tags) {
+    MultipartInfoStub(String uploadId, ReplicationConfig replicationConfig,
+                      Map<String, String> metadata, Map<String, String> tags) {
       this.uploadId = uploadId;
+      this.replicationConfig = replicationConfig;
       this.metadata = metadata;
       this.tags = tags;
     }
 
     public String getUploadId() {
       return uploadId;
+    }
+
+    public ReplicationConfig getReplicationConfig() {
+      return replicationConfig;
     }
 
     public Map<String, String> getMetadata() {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.hadoop.ozone.s3.util.S3StorageType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.Parameter;
@@ -124,6 +125,42 @@ public class TestPartUpload {
       assertNotNull(newETag);
       assertNotEquals(eTag, newETag);
     }
+  }
+
+  @Test
+  public void testPartUploadWithStandardIA() throws Exception {
+    when(headers.getHeaderString(STORAGE_CLASS_HEADER))
+        .thenReturn(S3StorageType.STANDARD_IA.name(), (String)null);
+    String keyName = UUID.randomUUID().toString();
+    String uploadID = initiateMultipartUpload(rest, OzoneConsts.S3_BUCKET, keyName);
+
+    String content = "Multipart Upload";
+    try (Response response = put(rest, OzoneConsts.S3_BUCKET, keyName, 1, uploadID, content)) {
+      assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
+      assertEquals(200, response.getStatus());
+    }
+    assertContentLength(uploadID, keyName, content.length());
+  }
+
+  @Test
+  public void testPartUploadWithStandardIAAndContentMD5() throws Exception {
+    when(headers.getHeaderString(STORAGE_CLASS_HEADER))
+        .thenReturn(S3StorageType.STANDARD_IA.name(), (String)null);
+    String content = "Multipart Upload Part";
+    byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+    byte[] md5Bytes = MessageDigest.getInstance("MD5").digest(contentBytes);
+    String md5Base64 = Base64.getEncoder().encodeToString(md5Bytes);
+    when(headers.getHeaderString("Content-MD5")).thenReturn(md5Base64);
+
+    String keyName = UUID.randomUUID().toString();
+    String uploadID = initiateMultipartUpload(rest, OzoneConsts.S3_BUCKET, keyName);
+
+    try (Response response = put(rest, OzoneConsts.S3_BUCKET, keyName, 1,
+        uploadID, content)) {
+      assertNotNull(response.getHeaderString(OzoneConsts.ETAG));
+      assertEquals(200, response.getStatus());
+    }
+    assertContentLength(uploadID, keyName, content.length());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce a new `KeyCommitOutput` interface to unify commit-time behaviors for key output implementations in the Ozone client, and refactors related classes to use this interface. It also simplifies the handling of pre-commit hooks and improves multipart upload handling, especially for EC mpu.


Testing:

- Added new tests for multipart uploads with the STANDARD_IA storage class, including verification of content MD5 handling. which **originally would fail on master**

the `InstanceOf` check refactor is similar to https://github.com/apache/ozone/pull/9370

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15213

## How was this patch tested?

IT/UT