### PR TITLE
HDDS-15203. Clarify ozone.om.namespace.s3.strict in ozone-default.xml

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4411,8 +4411,9 @@
     <value>true</value>
     <tag>OZONE, OM</tag>
     <description>
-      Ozone namespace should follow S3 naming rule by default.
-      However this parameter allows the namespace to support non-S3 compatible characters.
+      When `true` (the default), volume and bucket names follow strict S3 naming rules.
+      When `false`, S3 rules still apply except that underscore (`_`) is additionally
+      allowed in volume and bucket names; no other non-S3 characters are permitted.
     </description>
   </property>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://github.com/apache/ozone/blob/0f811d443ce260cb7c2dd4adb0977dada1ac0456/hadoop-hdds/common/src/main/resources/ozone-default.xml#L4373

Suggest to update the description to "When `true` (the default), volume and bucket names follow strict S3 naming rules. When `false`, S3 rules still apply except that underscore (`_`) is additionally allowed in volume and bucket names; no other non-S3 characters are permitted."

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15203

## How was this patch tested?
CI (https://github.com/YutaLin/ozone/actions/runs/25615921794)
