### PR TITLE
HDDS-14242. Use native RocksDB bounds for prefix table iterators

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -107,6 +107,28 @@ public final class IOUtils {
     close(null, closeables);
   }
 
+  /**
+   * Close each argument and add any thrown {@link Throwable} to the original
+   * failure as suppressed.
+   */
+  public static void closeAndSuppress(Throwable failure,
+      AutoCloseable... closeables) {
+    if (closeables == null) {
+      return;
+    }
+    for (AutoCloseable c : closeables) {
+      if (c != null) {
+        try {
+          c.close();
+        } catch (Throwable t) {
+          if (failure != t) {
+            failure.addSuppressed(t);
+          }
+        }
+      }
+    }
+  }
+
   /** Write {@code properties} to the file at {@code path}, truncating any existing content. */
   public static void writePropertiesToFile(File file, Properties properties) throws IOException {
     try (OutputStream out = new AtomicFileOutputStream(file)) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestIOUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestIOUtils.java
@@ -17,7 +17,10 @@
 
 package org.apache.hadoop.hdds.utils;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,6 +32,20 @@ class TestIOUtils {
   void closeQuietlyNull() {
     ByteArrayOutputStream out = null;
     IOUtils.closeQuietly(out);
+  }
+
+  @Test
+  void closeAndSuppress() {
+    IOException failure = new IOException("original");
+    RuntimeException closeFailure = new RuntimeException("close");
+
+    IOUtils.closeAndSuppress(failure,
+        () -> {
+          throw closeFailure;
+        },
+        null);
+
+    assertSame(closeFailure, failure.getSuppressed()[0]);
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreAbstractIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreAbstractIterator.java
@@ -17,9 +17,11 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
+import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +44,7 @@ abstract class RDBStoreAbstractIterator<RAW>
   // prefix for each key.
   private final RAW prefix;
   private final IteratorType type;
+  private final ManagedReadOptions readOptions;
   private final AtomicBoolean isIteratorClosed = new AtomicBoolean(false);
 
   /**
@@ -50,10 +53,53 @@ abstract class RDBStoreAbstractIterator<RAW>
    * or always closed in a finally block to ensure accurate refcounting.
    */
   RDBStoreAbstractIterator(ManagedRocksIterator iterator, RDBTable table, RAW prefix, IteratorType type) {
+    this(iterator, table, prefix, type, null);
+  }
+
+  RDBStoreAbstractIterator(ManagedRocksIterator iterator, RDBTable table,
+      RAW prefix, IteratorType type, ManagedReadOptions readOptions) {
     this.rocksDBIterator = iterator;
     this.rocksDBTable = table;
     this.prefix = prefix;
     this.type = type;
+    this.readOptions = readOptions;
+  }
+
+  static byte[] copyNonEmpty(byte[] prefix) {
+    return prefix == null || prefix.length == 0 ? null
+        : Arrays.copyOf(prefix, prefix.length);
+  }
+
+  static byte[] getNextHigherPrefix(byte[] prefix) {
+    if (prefix == null || prefix.length == 0) {
+      return null;
+    }
+    for (int i = prefix.length - 1; i >= 0; i--) {
+      if ((prefix[i] & 0xFF) != 0xFF) {
+        byte[] upperBound = Arrays.copyOf(prefix, i + 1);
+        upperBound[i]++;
+        return upperBound;
+      }
+    }
+    return null;
+  }
+
+  static ManagedReadOptions newReadOptions(byte[] prefix, boolean fillCache) {
+    final byte[] lowerBound =
+        prefix == null || prefix.length == 0 ? null : prefix;
+    final ManagedReadOptions readOptions = new ManagedReadOptions(
+        lowerBound, getNextHigherPrefix(lowerBound));
+    try {
+      readOptions.setFillCache(fillCache);
+      return readOptions;
+    } catch (RuntimeException | Error e) {
+      try {
+        readOptions.close();
+      } catch (RuntimeException | Error closeException) {
+        e.addSuppressed(closeException);
+      }
+      throw e;
+    }
   }
 
   IteratorType getType() {
@@ -148,6 +194,8 @@ abstract class RDBStoreAbstractIterator<RAW>
 
   @Override
   public final Table.KeyValue<RAW, RAW> seek(RAW key) {
+    // Prefix-bounded RocksDB iterators must not seek below their native
+    // lower bound. RocksDB documents that case as undefined.
     seek0(key);
     setCurrentEntry();
     return currentEntry;
@@ -168,7 +216,13 @@ abstract class RDBStoreAbstractIterator<RAW>
   @Override
   public void close() {
     if (isIteratorClosed.compareAndSet(false, true)) {
-      rocksDBIterator.close();
+      try {
+        rocksDBIterator.close();
+      } finally {
+        if (readOptions != null) {
+          readOptions.close();
+        }
+      }
     }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreByteArrayIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreByteArrayIterator.java
@@ -17,20 +17,22 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
-import java.util.Arrays;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 
 /**
  * RocksDB store iterator using the byte[] API.
  */
 class RDBStoreByteArrayIterator extends RDBStoreAbstractIterator<byte[]> {
-  private static byte[] copyPrefix(byte[] prefix) {
-    return prefix == null || prefix.length == 0 ? null : Arrays.copyOf(prefix, prefix.length);
+  RDBStoreByteArrayIterator(ManagedRocksIterator iterator,
+      RDBTable table, byte[] prefix, IteratorType type) {
+    this(iterator, table, prefix, type, null);
   }
 
   RDBStoreByteArrayIterator(ManagedRocksIterator iterator,
-      RDBTable table, byte[] prefix, IteratorType type) {
-    super(iterator, table, copyPrefix(prefix), type);
+      RDBTable table, byte[] prefix, IteratorType type,
+      ManagedReadOptions readOptions) {
+    super(iterator, table, copyNonEmpty(prefix), type, readOptions);
     seekToFirst();
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.apache.ratis.util.Preconditions;
 
@@ -33,7 +34,12 @@ class RDBStoreCodecBufferIterator extends RDBStoreAbstractIterator<CodecBuffer> 
 
   RDBStoreCodecBufferIterator(ManagedRocksIterator iterator, RDBTable table,
       CodecBuffer prefix, IteratorType type) {
-    super(iterator, table, prefix, type);
+    this(iterator, table, prefix, type, null);
+  }
+
+  RDBStoreCodecBufferIterator(ManagedRocksIterator iterator, RDBTable table,
+      CodecBuffer prefix, IteratorType type, ManagedReadOptions readOptions) {
+    super(iterator, table, prefix, type, readOptions);
 
     final String name = table != null ? table.getName() : null;
     this.keyBuffer = new Buffer(
@@ -91,10 +97,13 @@ class RDBStoreCodecBufferIterator extends RDBStoreAbstractIterator<CodecBuffer> 
   @Override
   public void close() {
     if (closed.compareAndSet(false, true)) {
-      super.close();
-      Optional.ofNullable(getPrefix()).ifPresent(CodecBuffer::release);
-      keyBuffer.release();
-      valueBuffer.release();
+      try {
+        super.close();
+      } finally {
+        Optional.ofNullable(getPrefix()).ifPresent(CodecBuffer::release);
+        keyBuffer.release();
+        valueBuffer.release();
+      }
     }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -25,6 +25,8 @@ import java.util.function.Supplier;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -214,14 +216,48 @@ class RDBTable implements Table<byte[], byte[]> {
   @Override
   public KeyValueIterator<byte[], byte[]> iterator(byte[] prefix, IteratorType type)
       throws RocksDatabaseException {
-    return new RDBStoreByteArrayIterator(db.newIterator(family, false), this,
-        prefix, type);
+    final ManagedReadOptions readOptions =
+        RDBStoreAbstractIterator.newReadOptions(prefix, false);
+    ManagedRocksIterator rocksIterator = null;
+    try {
+      rocksIterator = db.newIterator(family, readOptions);
+      return new RDBStoreByteArrayIterator(rocksIterator, this, prefix, type,
+          readOptions);
+    } catch (RocksDatabaseException | RuntimeException e) {
+      if (rocksIterator != null) {
+        rocksIterator.close();
+      }
+      readOptions.close();
+      throw e;
+    }
   }
 
   KeyValueIterator<CodecBuffer, CodecBuffer> iterator(
       CodecBuffer prefix, IteratorType type) throws RocksDatabaseException {
-    return new RDBStoreCodecBufferIterator(db.newIterator(family, false),
-        this, prefix, type);
+    final ManagedReadOptions readOptions =
+        RDBStoreAbstractIterator.newReadOptions(toByteArray(prefix), false);
+    ManagedRocksIterator rocksIterator = null;
+    try {
+      rocksIterator = db.newIterator(family, readOptions);
+      return new RDBStoreCodecBufferIterator(rocksIterator, this, prefix, type,
+          readOptions);
+    } catch (RocksDatabaseException | RuntimeException e) {
+      if (rocksIterator != null) {
+        rocksIterator.close();
+      }
+      readOptions.close();
+      throw e;
+    }
+  }
+
+  private static byte[] toByteArray(CodecBuffer buffer) {
+    if (buffer == null || buffer.readableBytes() == 0) {
+      return null;
+    }
+    final ByteBuffer byteBuffer = buffer.asReadOnlyByteBuffer();
+    final byte[] bytes = new byte[byteBuffer.remaining()];
+    byteBuffer.get(bytes);
+    return bytes;
   }
 
   boolean isClosed() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -793,6 +793,17 @@ public final class RocksDatabase implements Closeable {
     }
   }
 
+  public ManagedRocksIterator newIterator(ColumnFamily family,
+      ManagedReadOptions readOptions) throws RocksDatabaseException {
+    final UncheckedAutoCloseable ref = acquire();
+    try {
+      return managed(db.get().newIterator(family.getHandle(), readOptions), ref);
+    } catch (RuntimeException e) {
+      ref.close();
+      throw e;
+    }
+  }
+
   public void batchWrite(ManagedWriteBatch writeBatch,
                          ManagedWriteOptions options)
       throws RocksDatabaseException {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreAbstractIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreAbstractIterator.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import static org.apache.hadoop.hdds.utils.db.IteratorType.KEY_AND_VALUE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rocksdb.RocksIterator;
+
+/**
+ * Tests prefix bounds used by RocksDB table iterators.
+ */
+public class TestRDBStoreAbstractIterator {
+
+  @BeforeEach
+  public void setup() {
+    ManagedRocksObjectUtils.loadRocksDBLibrary();
+  }
+
+  @Test
+  public void testNextHigherPrefixForNullAndEmptyPrefix() {
+    assertNull(RDBStoreAbstractIterator.getNextHigherPrefix(null));
+    assertNull(RDBStoreAbstractIterator.getNextHigherPrefix(new byte[0]));
+  }
+
+  @Test
+  public void testNextHigherPrefixForNormalPrefix() {
+    assertArrayEquals(new byte[] {'a', 'b', 'd'},
+        RDBStoreAbstractIterator.getNextHigherPrefix(
+            new byte[] {'a', 'b', 'c'}));
+  }
+
+  @Test
+  public void testNextHigherPrefixForTrailingFF() {
+    assertArrayEquals(new byte[] {0x02},
+        RDBStoreAbstractIterator.getNextHigherPrefix(
+            new byte[] {0x01, (byte) 0xFF}));
+  }
+
+  @Test
+  public void testNextHigherPrefixForAllFF() {
+    assertNull(RDBStoreAbstractIterator.getNextHigherPrefix(
+        new byte[] {(byte) 0xFF, (byte) 0xFF}));
+  }
+
+  @Test
+  public void testReadOptionsForNullAndEmptyPrefix() {
+    try (ManagedReadOptions nullPrefix =
+             RDBStoreAbstractIterator.newReadOptions(null, false);
+         ManagedReadOptions emptyPrefix =
+             RDBStoreAbstractIterator.newReadOptions(new byte[0], false)) {
+      assertNull(nullPrefix.getLowerBound());
+      assertNull(nullPrefix.getUpperBound());
+      assertNull(emptyPrefix.getLowerBound());
+      assertNull(emptyPrefix.getUpperBound());
+    }
+  }
+
+  @Test
+  public void testReadOptionsForNormalPrefix() {
+    final byte[] prefix = new byte[] {'a', 'b', 'c'};
+    try (ManagedReadOptions readOptions =
+             RDBStoreAbstractIterator.newReadOptions(prefix, false)) {
+      assertArrayEquals(prefix, readOptions.getLowerBound());
+      assertArrayEquals(new byte[] {'a', 'b', 'd'},
+          readOptions.getUpperBound());
+    }
+  }
+
+  @Test
+  public void testReadOptionsForAllFFPrefix() {
+    final byte[] prefix = new byte[] {(byte) 0xFF, (byte) 0xFF};
+    try (ManagedReadOptions readOptions =
+             RDBStoreAbstractIterator.newReadOptions(prefix, false)) {
+      assertArrayEquals(prefix, readOptions.getLowerBound());
+      assertNull(readOptions.getUpperBound());
+    }
+  }
+
+  @Test
+  public void testIteratorClosesOwnedReadOptions() {
+    final RocksIterator rocksIterator = mock(RocksIterator.class);
+    final CountingReadOptions readOptions = new CountingReadOptions();
+    final RDBStoreByteArrayIterator iterator = new RDBStoreByteArrayIterator(
+        new ManagedRocksIterator(rocksIterator), null, null, KEY_AND_VALUE,
+        readOptions);
+
+    iterator.close();
+
+    verify(rocksIterator, times(1)).close();
+    assertEquals(1, readOptions.getCloseCount());
+
+    iterator.close();
+    assertEquals(1, readOptions.getCloseCount());
+  }
+
+  private static final class CountingReadOptions extends ManagedReadOptions {
+    private int closeCount;
+
+    @Override
+    public void close() {
+      closeCount++;
+      super.close();
+    }
+
+    int getCloseCount() {
+      return closeCount;
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -563,6 +563,31 @@ public class TestRDBTableStore {
   }
 
   @Test
+  public void testPrefixedIteratorUsesNativeBounds() throws Exception {
+    Table<byte[], byte[]> testTable = rdbStore.getTable("PrefixFirst");
+    testTable.put(bytes("prefix-aa-key-01"), bytes("value-01"));
+    testTable.put(bytes("prefix-aa-key-02"), bytes("value-02"));
+    testTable.put(bytes("prefix-ab-key-01"), bytes("value-03"));
+    testTable.put(bytes("prefix-b-key-01"), bytes("value-04"));
+
+    try (Table.KeyValueIterator<byte[], byte[]> iter =
+             testTable.iterator(bytes("prefix-aa"))) {
+      List<String> keys = new ArrayList<>();
+      while (iter.hasNext()) {
+        keys.add(StringUtils.bytes2String(iter.next().getKey()));
+      }
+
+      assertEquals(Arrays.asList("prefix-aa-key-01", "prefix-aa-key-02"),
+          keys);
+
+      assertArrayEquals(bytes("prefix-aa-key-01"),
+          iter.seek(bytes("prefix-aa-key-01")).getKey());
+      assertNull(iter.seek(bytes("prefix-ab")));
+      assertFalse(iter.hasNext());
+    }
+  }
+
+  @Test
   public void testStringPrefixedIterator() throws Exception {
     final int prefixCount = 3;
     final int keyCount = 5;
@@ -764,6 +789,10 @@ public class TestRDBTableStore {
             entry.getValue().getBytes(StandardCharsets.UTF_8));
       }
     }
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
   }
 
   private void populateTable(Table<String, String> table,

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedReadOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedReadOptions.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.utils.db.managed;
 
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.track;
 
+import java.util.Arrays;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.ratis.util.UncheckedAutoCloseable;
 import org.rocksdb.ReadOptions;
 
@@ -27,13 +29,70 @@ import org.rocksdb.ReadOptions;
  */
 public class ManagedReadOptions extends ReadOptions {
   private final UncheckedAutoCloseable leakTracker = track(this);
+  private final byte[] lowerBound;
+  private final byte[] upperBound;
+  private final ManagedSlice lowerBoundSlice;
+  private final ManagedSlice upperBoundSlice;
+
+  public ManagedReadOptions() {
+    this(null, null);
+  }
+
+  public ManagedReadOptions(byte[] lowerBound, byte[] upperBound) {
+    this.lowerBound = copy(lowerBound);
+    this.upperBound = copy(upperBound);
+
+    ManagedSlice lowerSlice = null;
+    ManagedSlice upperSlice = null;
+    try {
+      lowerSlice = this.lowerBound != null
+          ? new ManagedSlice(this.lowerBound) : null;
+      upperSlice = this.upperBound != null
+          ? new ManagedSlice(this.upperBound) : null;
+
+      if (lowerSlice != null) {
+        setIterateLowerBound(lowerSlice);
+      }
+      if (upperSlice != null) {
+        setIterateUpperBound(upperSlice);
+      }
+    } catch (RuntimeException | Error e) {
+      closeOnConstructorFailure(lowerSlice, upperSlice, e);
+      throw e;
+    }
+
+    this.lowerBoundSlice = lowerSlice;
+    this.upperBoundSlice = upperSlice;
+  }
+
+  private static byte[] copy(byte[] bytes) {
+    return bytes != null ? Arrays.copyOf(bytes, bytes.length) : null;
+  }
+
+  public byte[] getLowerBound() {
+    return copy(lowerBound);
+  }
+
+  public byte[] getUpperBound() {
+    return copy(upperBound);
+  }
+
+  private void closeOnConstructorFailure(ManagedSlice lowerSlice,
+      ManagedSlice upperSlice, Throwable failure) {
+    IOUtils.closeAndSuppress(failure, this::closeReadOptions, lowerSlice,
+        upperSlice, leakTracker);
+  }
+
+  private void closeReadOptions() {
+    super.close();
+  }
 
   @Override
   public void close() {
     try {
       super.close();
     } finally {
-      leakTracker.close();
+      IOUtils.closeQuietly(lowerBoundSlice, upperBoundSlice, leakTracker);
     }
   }
 }


### PR DESCRIPTION
## What changed

Push prefix iterator bounds into RocksDB `ReadOptions` for `RDBTable` prefix iteration.

For a prefix scan, we now set:

- `iterate_lower_bound` = the requested prefix
- `iterate_upper_bound` = the next lexicographic prefix

The existing Java-side `startsWithPrefix` check stays in `hasNext()` as a defensive layer. It can be removed in a follow-up after this has baked in `master`, but this PR avoids bundling that behavioral cleanup with the native-bounds change.

## Why

Today, prefix scans seek to the prefix and rely on a Java-side check to stop once keys stop matching. That works, but RocksDB still has to read past the prefix range to give us those keys. Native bounds let RocksDB cut iteration off at the C++ layer instead, which avoids cross-JNI work and unnecessary block reads beyond the prefix.

Smoke run on a local cluster with OBS buckets returned exactly the expected matches with no leakage across prefixes.

## Implementation notes

- `ManagedReadOptions` gained an overload that owns optional lower/upper `ManagedSlice` bounds. The slices' lifetime is tied to the read options. Close order is `ReadOptions` -> slices -> leak tracker, with constructor failures unwinding everything they allocated.
- `RDBTable.iterator(prefix, ...)` builds the bounded read options and hands ownership to the returned iterator. On construction failure, the RocksDB iterator and read options are both closed in the catch block.
- Iterator `close()` closes the RocksDB iterator first, then the read options and bound slices. This matters because the C++ iterator holds raw pointers into the slice memory.
- Upper bound is computed by incrementing the last non-`0xFF` byte and truncating. The all-`0xFF` case has no valid upper bound, so it falls back to lower-bound-only iteration.

## Prior art

This is foundation work for the larger split-iterator effort explored in #8517. This PR lands the prefix-bounds piece as a smaller standalone change first; the split-iterator follow-up PR is a work in progress and we can review it once this is merged. 

## Testing

- `mvn -pl hadoop-hdds/managed-rocksdb -DskipTests clean install`
- `mvn -pl hadoop-hdds/managed-rocksdb test`
- `mvn -pl hadoop-hdds/framework -Dtest=TestRDBStoreAbstractIterator,TestRDBStoreByteArrayIterator,TestRDBStoreCodecBufferIterator,TestRDBTableStore,TestTypedTable test`
- `git diff --check`

New tests in `TestRDBStoreAbstractIterator` cover:

- `getNextHigherPrefix` for null, empty, normal, trailing-`0xFF`, and all-`0xFF` prefixes
- `newReadOptions` for null/empty/normal/all-`0xFF` cases
- iterator close ownership: read options are closed exactly once and repeated close is idempotent

`TestRDBTableStore` includes a RocksDB-backed regression test that writes keys inside and outside `[prefix, prefix++)` and verifies the prefix iterator returns only the in-range keys.

Smoke: local one-node Ozone cluster, OBS bucket prefix listings via `ozone sh key list --prefix=...` returned only matching keys across three buckets.
