### PR TITLE
HDDS-3936. Use suggested OM leader information to guide the client failover

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.exceptions;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.ratis.protocol.RaftPeer;
@@ -51,16 +52,15 @@ public class OMNotLeaderException extends IOException {
   private static final String UNRESOLVED_IP = "unresolved";
 
   /**
-   *
-   * Patterns for parsing the suggested leader information from the exception message of the form
+   * Pattern for parsing the suggested-leader fields from the exception message of the form
+   * <pre>
    * OM:om2 is not the leader. Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=10.0.0.5).
    * OM:om2 is not the leader. Suggested leader is OM:om1 at [fe80::1]:9862 (ip=fe80::1).
    * OM:om2 is not the leader. Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=unresolved).
+   * </pre>
    */
-  private static final Pattern CURRENT_PEER_ID_PATTERN =
-      Pattern.compile("^OM:(\\S+) is not the leader\\..*", Pattern.DOTALL);
   private static final Pattern SUGGESTED_LEADER_PATTERN =
-      Pattern.compile(".*Suggested leader is OM:(\\S+) at (\\S+) \\(ip=(\\S+?)\\)\\.\\s*$", Pattern.DOTALL);
+      Pattern.compile(".*Suggested leader is OM:(\\S+) at (\\S+) \\(ip=(\\S+?)\\)\\..*", Pattern.DOTALL);
 
   public OMNotLeaderException(RaftPeerId currentPeerId) {
     super(String.format(NO_LEADER_FORMAT, currentPeerId));
@@ -69,13 +69,8 @@ public class OMNotLeaderException extends IOException {
     this.leaderIpAddress = null;
   }
 
-  public OMNotLeaderException(RaftPeerId currentPeerId,
-      RaftPeerId suggestedLeaderPeerId) {
-    this(currentPeerId, suggestedLeaderPeerId, null);
-  }
-
   /**
-   *
+   * Note that the port here is the RPC port of the suggested leader and not the Ratis port
    * @param suggestedLeaderHostPort host:rpcPort
    */
   public OMNotLeaderException(RaftPeerId currentPeerId,
@@ -92,9 +87,19 @@ public class OMNotLeaderException extends IOException {
 
   public OMNotLeaderException(String msg) {
     super(msg);
-    this.leaderPeerId = null;
-    this.leaderAddress = null;
-    this.leaderIpAddress = null;
+    Matcher matcher = SUGGESTED_LEADER_PATTERN.matcher(msg);
+    String parsedLeaderPeerId = null;
+    String parsedLeaderAddress = null;
+    String parsedLeaderIpAddress = null;
+    if (matcher.matches()) {
+      parsedLeaderPeerId = matcher.group(1);
+      parsedLeaderAddress = matcher.group(2);
+      parsedLeaderIpAddress = matcher.group(3);
+      parsedLeaderIpAddress = parsedLeaderIpAddress.equals(UNRESOLVED_IP) ? null : parsedLeaderIpAddress;
+    }
+    this.leaderPeerId = parsedLeaderPeerId;
+    this.leaderAddress = parsedLeaderAddress;
+    this.leaderIpAddress = parsedLeaderIpAddress;
   }
 
   public String getSuggestedLeaderNodeId() {
@@ -103,6 +108,10 @@ public class OMNotLeaderException extends IOException {
 
   public String getSuggestedLeaderAddress() {
     return leaderAddress;
+  }
+
+  public String getSuggestedLeaderIpAddress() {
+    return leaderIpAddress;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
@@ -70,7 +70,7 @@ public class OMNotLeaderException extends IOException {
   }
 
   /**
-   * Note that the port here is the RPC port of the suggested leader and not the Ratis port
+   * Note that the port here is the RPC port of the suggested leader and not the Ratis port.
    * @param suggestedLeaderHostPort host:rpcPort
    */
   public OMNotLeaderException(RaftPeerId currentPeerId,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
@@ -18,6 +18,11 @@
 package org.apache.hadoop.ozone.om.exceptions;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 
@@ -27,15 +32,41 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
  * a read request is received by a non leader OM node.
  */
 public class OMNotLeaderException extends IOException {
-
   private final String leaderPeerId;
   private final String leaderAddress;
+  private final String leaderIpAddress;
+
+  /**
+   * Do NOT change the format of the exception message without changing the parsing logic.
+   * <p>
+   * The exception message pattern with the suggested leader has been updated for efficient parsing.
+   * One of the considerations is IPv6 addresses. They may or may not be enclosed in square brackets "[fe80::1]:9862"
+   * when used in URIs/URLs. As such, square brackets should be avoided for other purposes in the
+   * same exception message to avoid parsing conflicts.
+   */
+  private static final String NO_LEADER_FORMAT =
+      "OM:%s is not the leader. Could not determine the leader node.";
+  private static final String SUGGESTED_LEADER_FORMAT =
+      "OM:%s is not the leader. Suggested leader is OM:%s at %s (ip=%s).";
+  private static final String UNRESOLVED_IP = "unresolved";
+
+  /**
+   *
+   * Patterns for parsing the suggested leader information from the exception message of the form
+   * OM:om2 is not the leader. Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=10.0.0.5).
+   * OM:om2 is not the leader. Suggested leader is OM:om1 at [fe80::1]:9862 (ip=fe80::1).
+   * OM:om2 is not the leader. Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=unresolved).
+   */
+  private static final Pattern CURRENT_PEER_ID_PATTERN =
+      Pattern.compile("^OM:(\\S+) is not the leader\\..*", Pattern.DOTALL);
+  private static final Pattern SUGGESTED_LEADER_PATTERN =
+      Pattern.compile(".*Suggested leader is OM:(\\S+) at (\\S+) \\(ip=(\\S+?)\\)\\.\\s*$", Pattern.DOTALL);
 
   public OMNotLeaderException(RaftPeerId currentPeerId) {
-    super("OM:" + currentPeerId + " is not the leader. Could not " +
-        "determine the leader node.");
+    super(String.format(NO_LEADER_FORMAT, currentPeerId));
     this.leaderPeerId = null;
     this.leaderAddress = null;
+    this.leaderIpAddress = null;
   }
 
   public OMNotLeaderException(RaftPeerId currentPeerId,
@@ -43,18 +74,27 @@ public class OMNotLeaderException extends IOException {
     this(currentPeerId, suggestedLeaderPeerId, null);
   }
 
+  /**
+   *
+   * @param suggestedLeaderHostPort host:rpcPort
+   */
   public OMNotLeaderException(RaftPeerId currentPeerId,
-      RaftPeerId suggestedLeaderPeerId, String suggestedLeaderAddress) {
-    super("OM:" + currentPeerId + " is not the leader. Suggested leader is" +
-        " OM:" + suggestedLeaderPeerId + "[" + suggestedLeaderAddress + "].");
+      RaftPeerId suggestedLeaderPeerId,
+      String suggestedLeaderHostPort,
+      String suggestedLeaderIp) {
+    super(String.format(SUGGESTED_LEADER_FORMAT,
+        currentPeerId, suggestedLeaderPeerId, suggestedLeaderHostPort,
+        suggestedLeaderIp != null ? suggestedLeaderIp : UNRESOLVED_IP));
     this.leaderPeerId = suggestedLeaderPeerId.toString();
-    this.leaderAddress = suggestedLeaderAddress;
+    this.leaderAddress = suggestedLeaderHostPort;
+    this.leaderIpAddress = suggestedLeaderIp;
   }
 
   public OMNotLeaderException(String msg) {
     super(msg);
     this.leaderPeerId = null;
     this.leaderAddress = null;
+    this.leaderIpAddress = null;
   }
 
   public String getSuggestedLeaderNodeId() {
@@ -72,21 +112,20 @@ public class OMNotLeaderException extends IOException {
    * @return OMNotLeaderException
    */
   public static OMNotLeaderException convertToOMNotLeaderException(
-      NotLeaderException notLeaderException, RaftPeerId currentPeer) {
-    RaftPeerId suggestedLeader =
-        notLeaderException.getSuggestedLeader() != null ?
-            notLeaderException.getSuggestedLeader().getId() : null;
-    String suggestedLeaderAddress =
-        notLeaderException.getSuggestedLeader() != null ?
-            notLeaderException.getSuggestedLeader().getAddress() : null;
-    OMNotLeaderException omNotLeaderException;
-    if (suggestedLeader != null) {
-      omNotLeaderException = new OMNotLeaderException(currentPeer,
-          suggestedLeader, suggestedLeaderAddress);
-    } else {
-      omNotLeaderException =
-          new OMNotLeaderException(currentPeer);
+      NotLeaderException notLeaderException,
+      RaftPeerId currentPeer,
+      Function<RaftPeerId, OMNodeDetails> peerResolver) {
+    RaftPeer suggestedLeader = notLeaderException.getSuggestedLeader();
+    if (suggestedLeader == null) {
+      return new OMNotLeaderException(currentPeer);
     }
-    return omNotLeaderException;
+    OMNodeDetails leaderDetails = peerResolver.apply(suggestedLeader.getId());
+    if (leaderDetails == null) {
+      return new OMNotLeaderException(currentPeer);
+    }
+    String rpcHostPort = leaderDetails.getRpcAddressString();
+    InetAddress inet = leaderDetails.getInetAddress();
+    String ip = inet == null ? null : inet.getHostAddress();
+    return new OMNotLeaderException(currentPeer, suggestedLeader.getId(), rpcHostPort, ip);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/exceptions/TestOMNotLeaderExceptionMessageParsing.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/exceptions/TestOMNotLeaderExceptionMessageParsing.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import org.apache.hadoop.ipc_.RemoteException;
+import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProviderBase;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trip tests for {@link OMNotLeaderException}'s message format and parser.
+ * <p>
+ * Hadoop RPC's exception protocol carries only (className, message); the
+ * client side reconstructs via reflection through the {@code (String)} ctor
+ * (see {@link RemoteException#unwrapRemoteException()}). Therefore the
+ * suggested-leader hint must be embedded in the message string and re-parsed
+ * in the {@code (String)} ctor. These tests cover the parser directly, the
+ * producer-to-parser round trip, and the production round-trip path used by
+ * the failover proxy provider.
+ */
+class TestOMNotLeaderExceptionMessageParsing {
+
+  private static final RaftPeerId LOCAL = RaftPeerId.valueOf("om2");
+  private static final RaftPeerId LEADER = RaftPeerId.valueOf("om1");
+
+  @Test
+  void testParsesIPv4HappyPath() {
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=10.0.0.5).";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862", parsed.getSuggestedLeaderAddress());
+    assertEquals("10.0.0.5", parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesIPv6HostPortWithBrackets() {
+    // IPv6 host:port is conventionally written as [fe80::1]:9862. The message
+    // wrapper for the IP uses parentheses so the bracket form here does not
+    // collide with the format delimiters.
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at [fe80::1]:9862 (ip=fe80::1).";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("[fe80::1]:9862", parsed.getSuggestedLeaderAddress());
+    assertEquals("fe80::1", parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesUnresolvedSentinelAsNullIp() {
+    // When the producer's startup-time DNS lookup failed, it ships the
+    // sentinel `unresolved`; the parser must normalize it back to null.
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=unresolved).";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862", parsed.getSuggestedLeaderAddress());
+    assertNull(parsed.getSuggestedLeaderIpAddress(),
+        "ip=unresolved sentinel must round-trip back to null");
+  }
+
+  @Test
+  void testNoLeaderFormLeavesAllSuggestedFieldsNull() {
+    String msg = "OM:om2 is not the leader. Could not determine the leader node.";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertNull(parsed.getSuggestedLeaderNodeId());
+    assertNull(parsed.getSuggestedLeaderAddress());
+    assertNull(parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testMalformedMessageLeavesAllFieldsNull() {
+    OMNotLeaderException parsed =
+        new OMNotLeaderException("entirely unrelated text");
+    assertNull(parsed.getSuggestedLeaderNodeId());
+    assertNull(parsed.getSuggestedLeaderAddress());
+    assertNull(parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testEmptyMessageLeavesAllFieldsNull() {
+    OMNotLeaderException parsed = new OMNotLeaderException("");
+    assertNull(parsed.getSuggestedLeaderNodeId());
+    assertNull(parsed.getSuggestedLeaderAddress());
+    assertNull(parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testTruncatedSuggestedLeaderLeavesAllFieldsNull() {
+    // Has the prefix but is missing the (ip=.*) wrapper. A partial parse
+    // would be worse than no parse — the consumer would set the next proxy
+    // based on a half-recovered hint. Require all-or-nothing.
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at om1.cluster.local:9862.";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertNull(parsed.getSuggestedLeaderNodeId());
+    assertNull(parsed.getSuggestedLeaderAddress());
+    assertNull(parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesEvenWithoutLeadingPrefix() {
+    // No `OM:<id> is not the leader.` gate: the suggested-leader fragment
+    // alone is distinctive enough to parse. This reflects the deliberate
+    // choice to be loose at both ends of the regex. A caller that
+    // wraps the message with any prefix should still surface the hint to
+    // the consumer rather than silently falling back to round-robin.
+    String msg = "Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=10.0.0.5).";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862", parsed.getSuggestedLeaderAddress());
+    assertEquals("10.0.0.5", parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesIPv4WithTrailingStackTrace() {
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=10.0.0.5).\n" +
+        "\tat org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException" +
+        ".convertToOMNotLeaderException(OMNotLeaderException.java:128)\n" +
+        "\tat org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer" +
+        ".createOmResponseImpl(OzoneManagerRatisServer.java:597)";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862", parsed.getSuggestedLeaderAddress());
+    assertEquals("10.0.0.5", parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesIPv6WithTrailingStackTrace() {
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at [fe80::1]:9862 (ip=fe80::1).\n" +
+        "\tat org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer" +
+        ".createOmResponseImpl(OzoneManagerRatisServer.java:597)";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("[fe80::1]:9862", parsed.getSuggestedLeaderAddress());
+    assertEquals("fe80::1", parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesUnresolvedSentinelWithTrailingStackTrace() {
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=unresolved).\n" +
+        "\tat org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.foo(...)";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862", parsed.getSuggestedLeaderAddress());
+    assertNull(parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testParsesIPv4WithTrailingWhitespaceOnly() {
+    // Whitespace-only tail also exercised, since the previous strict anchor
+    // explicitly tolerated `\\s*$` — keep that behavior under the loose form.
+    String msg = "OM:om2 is not the leader. " +
+        "Suggested leader is OM:om1 at om1.cluster.local:9862 (ip=10.0.0.5).   \n\t  ";
+    OMNotLeaderException parsed = new OMNotLeaderException(msg);
+    assertEquals("om1", parsed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862", parsed.getSuggestedLeaderAddress());
+    assertEquals("10.0.0.5", parsed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testProducerToParserRoundTripIPv4() {
+    OMNotLeaderException original = new OMNotLeaderException(
+        LOCAL, LEADER, "om1.cluster.local:9862", "10.0.0.5");
+    OMNotLeaderException reconstructed =
+        new OMNotLeaderException(original.getMessage());
+    assertEquals(original.getSuggestedLeaderNodeId(),
+        reconstructed.getSuggestedLeaderNodeId());
+    assertEquals(original.getSuggestedLeaderAddress(),
+        reconstructed.getSuggestedLeaderAddress());
+    assertEquals(original.getSuggestedLeaderIpAddress(),
+        reconstructed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testProducerToParserRoundTripIPv6() {
+    OMNotLeaderException original = new OMNotLeaderException(
+        LOCAL, LEADER, "[fe80::1]:9862", "fe80::1");
+    OMNotLeaderException reconstructed =
+        new OMNotLeaderException(original.getMessage());
+    assertEquals("om1", reconstructed.getSuggestedLeaderNodeId());
+    assertEquals("[fe80::1]:9862", reconstructed.getSuggestedLeaderAddress());
+    assertEquals("fe80::1", reconstructed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testProducerToParserRoundTripNullIpRendersAsUnresolvedSentinel() {
+    OMNotLeaderException original = new OMNotLeaderException(
+        LOCAL, LEADER, "om1.cluster.local:9862", null);
+
+    // Producer must serialize a null IP as the documented sentinel ...
+    assertTrue(original.getMessage().contains("(ip=unresolved)"),
+        "null IP should serialize as the `unresolved` sentinel; was: "
+            + original.getMessage());
+
+    // ... and the parser must turn the sentinel back into null.
+    OMNotLeaderException reconstructed =
+        new OMNotLeaderException(original.getMessage());
+    assertEquals("om1", reconstructed.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862",
+        reconstructed.getSuggestedLeaderAddress());
+    assertNull(reconstructed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testProducerToParserRoundTripNoLeaderForm() {
+    OMNotLeaderException original = new OMNotLeaderException(LOCAL);
+    OMNotLeaderException reconstructed =
+        new OMNotLeaderException(original.getMessage());
+    assertNull(reconstructed.getSuggestedLeaderNodeId());
+    assertNull(reconstructed.getSuggestedLeaderAddress());
+    assertNull(reconstructed.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testRoundTripThroughRemoteExceptionUnwrap() throws IOException {
+    OMNotLeaderException original = new OMNotLeaderException(
+        LOCAL, LEADER, "om1.cluster.local:9862", "10.0.0.5");
+
+    // Simulate the wire: Hadoop RPC reduces an exception to (className, message).
+    RemoteException remote = new RemoteException(
+        OMNotLeaderException.class.getName(), original.getMessage());
+
+    IOException unwrapped = remote.unwrapRemoteException();
+    assertInstanceOf(OMNotLeaderException.class, unwrapped,
+        "unwrapRemoteException must reflectively rebuild an OMNotLeaderException");
+    OMNotLeaderException recovered = (OMNotLeaderException) unwrapped;
+    assertEquals("om1", recovered.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862",
+        recovered.getSuggestedLeaderAddress());
+    assertEquals("10.0.0.5", recovered.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testRoundTripThroughGetNotLeaderExceptionIPv6() {
+    OMNotLeaderException original = new OMNotLeaderException(
+        LOCAL, LEADER, "[fe80::1]:9862", "fe80::1");
+
+    // Mimic the wire shape that OMFailoverProxyProviderBase consumes:
+    //   ServiceException(RemoteException(className, message))
+    ServiceException wireEx = new ServiceException(new RemoteException(
+        OMNotLeaderException.class.getName(), original.getMessage()));
+
+    OMNotLeaderException recovered =
+        OMFailoverProxyProviderBase.getNotLeaderException(wireEx);
+    assertNotNull(recovered,
+        "getNotLeaderException must recognize the wire shape");
+    assertEquals("om1", recovered.getSuggestedLeaderNodeId());
+    assertEquals("[fe80::1]:9862", recovered.getSuggestedLeaderAddress());
+    assertEquals("fe80::1", recovered.getSuggestedLeaderIpAddress());
+  }
+
+  @Test
+  void testRoundTripThroughGetNotLeaderExceptionUnresolved() {
+    // Stale-DNS scenario the user explicitly wanted catchable: the producer
+    // could not resolve its own peer and shipped the sentinel.
+    OMNotLeaderException original = new OMNotLeaderException(
+        LOCAL, LEADER, "om1.cluster.local:9862", null);
+
+    ServiceException wireEx = new ServiceException(new RemoteException(
+        OMNotLeaderException.class.getName(), original.getMessage()));
+
+    OMNotLeaderException recovered =
+        OMFailoverProxyProviderBase.getNotLeaderException(wireEx);
+    assertNotNull(recovered);
+    assertEquals("om1", recovered.getSuggestedLeaderNodeId());
+    assertEquals("om1.cluster.local:9862",
+        recovered.getSuggestedLeaderAddress());
+    assertNull(recovered.getSuggestedLeaderIpAddress(),
+        "unresolved sentinel must surface as null IP on the consumer side");
+  }
+
+  @Test
+  void testRoundTripThroughGetNotLeaderExceptionNoLeaderForm() {
+    OMNotLeaderException original = new OMNotLeaderException(LOCAL);
+
+    ServiceException wireEx = new ServiceException(new RemoteException(
+        OMNotLeaderException.class.getName(), original.getMessage()));
+
+    OMNotLeaderException recovered =
+        OMFailoverProxyProviderBase.getNotLeaderException(wireEx);
+    assertNotNull(recovered,
+        "no-leader form must still unwrap to OMNotLeaderException");
+    assertNull(recovered.getSuggestedLeaderNodeId());
+    assertNull(recovered.getSuggestedLeaderAddress());
+    assertNull(recovered.getSuggestedLeaderIpAddress());
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
@@ -23,10 +23,12 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.protobuf.ServiceException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,9 +39,14 @@ import java.util.List;
 import java.util.StringJoiner;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.io.retry.RetryPolicy.RetryAction.RetryDecision;
+import org.apache.hadoop.ipc_.RemoteException;
 import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -219,6 +226,90 @@ public class TestOMFailoverProxyProvider {
       assertEquals(attempt * waitBetweenRetries,
           provider.getWaitTime());
     }
+  }
+
+  /**
+   * The retry policy must use the suggested-leader hint to set the next
+   * proxy directly to that node, instead of advancing one step in the
+   * round-robin order. The test cluster has [omNode-1, omNode-2, omNode-3]
+   * and starts at omNode-1, so round-robin would land on omNode-2 — the
+   * hint must skip ahead to omNode-3 to make this distinguishable.
+   */
+  @Test
+  public void testHintDrivesFailoverToSuggestedLeader() throws Exception {
+    String currentNodeId = provider.getCurrentProxyOMNodeId();
+    String roundRobinDestination = pickAdjacentNodeId(currentNodeId);
+    String suggestedNodeId = pickNonAdjacentNodeId(currentNodeId);
+    assertNotEquals(roundRobinDestination, suggestedNodeId,
+        "test setup needs the hint destination to differ from round-robin");
+
+    OMNotLeaderException notLeader = new OMNotLeaderException(
+        RaftPeerId.valueOf(currentNodeId),
+        RaftPeerId.valueOf(suggestedNodeId),
+        DUMMY_NODE_ADDR,
+        null);
+    ServiceException wireEx = new ServiceException(new RemoteException(
+        OMNotLeaderException.class.getName(), notLeader.getMessage()));
+
+    RetryPolicy.RetryAction action =
+        provider.getRetryPolicy(10).shouldRetry(wireEx, 0, 0, true);
+
+    assertEquals(RetryDecision.FAILOVER_AND_RETRY, action.action);
+    assertEquals(suggestedNodeId, provider.getNextProxyOMNodeId(),
+        "suggested-leader hint must override round-robin");
+  }
+
+  /**
+   * Without a suggested-leader hint (the no-leader form), the retry policy
+   * falls back to round-robin: next proxy is the one immediately after the
+   * current proxy in the configured order, not an arbitrary other node.
+   */
+  @Test
+  public void testNoHintFallsBackToRoundRobin() throws Exception {
+    String currentNodeId = provider.getCurrentProxyOMNodeId();
+    String expectedRoundRobinDestination = pickAdjacentNodeId(currentNodeId);
+
+    OMNotLeaderException notLeader = new OMNotLeaderException(
+        RaftPeerId.valueOf(currentNodeId));
+    ServiceException wireEx = new ServiceException(new RemoteException(
+        OMNotLeaderException.class.getName(), notLeader.getMessage()));
+
+    RetryPolicy.RetryAction action =
+        provider.getRetryPolicy(10).shouldRetry(wireEx, 0, 0, true);
+
+    assertEquals(RetryDecision.FAILOVER_AND_RETRY, action.action);
+    assertEquals(expectedRoundRobinDestination,
+        provider.getNextProxyOMNodeId(),
+        "no-leader form must round-robin to the adjacent node");
+  }
+
+  /**
+   * Returns the node id at (currentIdx + 1) mod size — the destination
+   * round-robin would pick after a single failover.
+   */
+  private String pickAdjacentNodeId(String currentNodeId) {
+    List<String> ids = new ArrayList<>(provider.getOMProxyMap().getNodeIds());
+    int idx = ids.indexOf(currentNodeId);
+    assertTrue(idx >= 0, "currentNodeId must be in the proxy map");
+    return ids.get((idx + 1) % ids.size());
+  }
+
+  /**
+   * Returns a node id that is *not* adjacent to current in the configured
+   * order — guaranteed to differ from the round-robin destination so the
+   * hint vs round-robin paths are distinguishable.
+   */
+  private String pickNonAdjacentNodeId(String currentNodeId) {
+    List<String> ids = new ArrayList<>(provider.getOMProxyMap().getNodeIds());
+    int idx = ids.indexOf(currentNodeId);
+    int adjacent = (idx + 1) % ids.size();
+    for (int i = 0; i < ids.size(); i++) {
+      if (i != idx && i != adjacent) {
+        return ids.get(i);
+      }
+    }
+    throw new IllegalStateException(
+        "test fixture needs at least 3 OMs to expose round-robin vs hint");
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
@@ -136,26 +136,20 @@ public class TestOzoneManagerHAFollowerReadWithAllRunning extends TestOzoneManag
    */
   @Test
   public void testFailoverWithSuggestedLeader() throws Exception {
-    HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> omFailoverProxyProvider =
-        OmTestUtil.getFailoverProxyProvider(getObjectStore());
-
     // Make sure All OMs are ready.
     createVolumeTest(true);
 
-    String leaderOMNodeId = null;
+    OzoneManager leaderOM = null;
     OzoneManager followerOM = null;
     for (OzoneManager om: getCluster().getOzoneManagersList()) {
       if (om.isLeaderReady()) {
-        leaderOMNodeId = om.getOMNodeId();
+        leaderOM = om;
       } else if (followerOM == null) {
         followerOM = om;
       }
     }
     assertNotNull(followerOM);
-    assertNotNull(leaderOMNodeId);
-    String leaderOMAddress = ((OMProxyInfo)
-        omFailoverProxyProvider.getOMProxyMap().get(leaderOMNodeId))
-        .getAddress().getAddress().toString();
+    assertNotNull(leaderOM);
     assertSame(OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER,
         followerOM.getOmRatisServer().getLeaderStatus());
 
@@ -180,8 +174,16 @@ public class TestOzoneManagerHAFollowerReadWithAllRunning extends TestOzoneManag
         followerOM.getOmServerProtocol();
     ServiceException ex = assertThrows(ServiceException.class,
         () -> omServerProtocol.submitRequest(null, writeRequest));
-    assertThat(ex).hasCauseInstanceOf(OMNotLeaderException.class)
-        .hasMessageEndingWith("Suggested leader is OM:" + leaderOMNodeId + "[" + leaderOMAddress + "].");
+
+    // In-process path: cause is the actual OMNotLeaderException with all
+    // structured fields populated by the producer ctor (no RPC stripping).
+    assertThat(ex).hasCauseInstanceOf(OMNotLeaderException.class);
+    OMNotLeaderException notLeader = (OMNotLeaderException) ex.getCause();
+    assertEquals(leaderOM.getOMNodeId(), notLeader.getSuggestedLeaderNodeId());
+    assertEquals(leaderOM.getNodeDetails().getRpcAddressString(),
+        notLeader.getSuggestedLeaderAddress());
+    assertNotNull(notLeader.getSuggestedLeaderIpAddress(),
+        "leader IP must be populated when DNS resolution succeeded at startup");
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -387,6 +387,31 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
   }
 
   @Test
+  public void testWriteFailoverHitsLeaderHint() throws Exception {
+    ObjectStore store = getObjectStore();
+    HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> provider =
+        OmTestUtil.getFailoverProxyProvider(store);
+
+    // Pick a real follower from cluster state.
+    String followerId = getCluster().getOzoneManagersList().stream()
+        .filter(om -> !om.isLeaderReady())
+        .map(OzoneManager::getOMNodeId)
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No follower OM found"));
+
+    // setNextOmProxy only updates nextProxyIndex; performFailover commits it
+    // into currentProxyIndex so leaderProxy.getProxy() will return the follower.
+    provider.setNextOmProxy(followerId);
+    provider.performFailover(null);
+
+    // Write goes through FollowerReadInvocationHandler.invoke() ->
+    // leaderProxy.getProxy() (now the follower) -> server returns
+    // ServiceException(RemoteException(OMNotLeaderException)) -> RetryProxy ->
+    // OMFailoverProxyProviderBase retry policy -> line 221.
+    store.createVolume("vol-" + RandomStringUtils.secure().nextNumeric(5));
+  }
+
+  @Test
   public void testJMXMetrics() throws Exception {
     // Verify any one ratis metric is exposed by JMX MBeanServer
     OzoneManagerRatisServer ratisServer =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -324,8 +324,8 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
     // The OMFailoverProxyProvider will point to the current leader OM node.
     String leaderOMNodeId = omFailoverProxyProvider.getCurrentProxyOMNodeId();
-    String leaderOMAddress = omFailoverProxyProvider.getOMProxyMap().get(leaderOMNodeId)
-        .getAddress().getAddress().toString();
+    OzoneManager leaderOM = getCluster().getOMLeader();
+    assertEquals(leaderOMNodeId, leaderOM.getOMNodeId());
     OzoneManager followerOM = null;
     for (OzoneManager om: getCluster().getOzoneManagersList()) {
       if (!om.isLeaderReady()) {
@@ -348,8 +348,21 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
         followerOM.getOmServerProtocol();
     ServiceException ex = assertThrows(ServiceException.class,
         () -> omServerProtocol.submitRequest(null, readRequest));
-    assertThat(ex).hasCauseInstanceOf(OMNotLeaderException.class)
-        .hasMessageEndingWith("Suggested leader is OM:" + leaderOMNodeId + "[" + leaderOMAddress + "].");
+
+    // In-process path: cause is the actual OMNotLeaderException with all
+    // structured fields populated by the producer ctor (no RPC stripping).
+    // Assert the structured fields rather than the message string so the
+    // assertion is robust to format edits.
+    assertThat(ex).hasCauseInstanceOf(OMNotLeaderException.class);
+    OMNotLeaderException notLeader = (OMNotLeaderException) ex.getCause();
+    assertEquals(leaderOMNodeId, notLeader.getSuggestedLeaderNodeId());
+    assertEquals(leaderOM.getNodeDetails().getRpcAddressString(),
+        notLeader.getSuggestedLeaderAddress());
+    // IP comes from the producer's cached InetAddress; null only if the
+    // hostname was unresolved at OM startup, which shouldn't happen in
+    // MiniOzoneCluster.
+    assertNotNull(notLeader.getSuggestedLeaderIpAddress(),
+        "leader IP must be populated when DNS resolution succeeded at startup");
   }
 
   @Test
@@ -392,23 +405,40 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> provider =
         OmTestUtil.getFailoverProxyProvider(store);
 
-    // Pick a real follower from cluster state.
+    // Pick the real leader and one real follower from cluster state.
+    String leaderId = getCluster().getOMLeader().getOMNodeId();
     String followerId = getCluster().getOzoneManagersList().stream()
-        .filter(om -> !om.isLeaderReady())
         .map(OzoneManager::getOMNodeId)
+        .filter(id -> !id.equals(leaderId))
         .findFirst()
         .orElseThrow(() -> new IllegalStateException("No follower OM found"));
 
-    // setNextOmProxy only updates nextProxyIndex; performFailover commits it
-    // into currentProxyIndex so leaderProxy.getProxy() will return the follower.
+    // Aim the proxy at a follower. setNextOmProxy stages nextProxyIndex;
+    // performFailover commits it into currentProxyIndex so the next call
+    // through the proxy will hit the follower.
     provider.setNextOmProxy(followerId);
     provider.performFailover(null);
+    assertEquals(followerId, provider.getCurrentProxyOMNodeId(),
+        "test setup: proxy must start pointed at a follower");
 
-    // Write goes through FollowerReadInvocationHandler.invoke() ->
-    // leaderProxy.getProxy() (now the follower) -> server returns
-    // ServiceException(RemoteException(OMNotLeaderException)) -> RetryProxy ->
-    // OMFailoverProxyProviderBase retry policy -> line 221.
-    store.createVolume("vol-" + RandomStringUtils.secure().nextNumeric(5));
+    // Issue a write. Path: invocation handler → follower OM → server returns
+    // ServiceException(RemoteException(OMNotLeaderException)) → RetryProxy →
+    // OMFailoverProxyProviderBase retry policy reads the suggested leader
+    // hint and routes the retry to the leader.
+    String volumeName = "vol-" + RandomStringUtils.secure().nextNumeric(5);
+    store.createVolume(volumeName);
+
+    // The write succeeded — volume is visible.
+    assertEquals(volumeName, store.getVolume(volumeName).getName());
+
+    // The retry landed on the leader. (Necessary but not sufficient on its
+    // own — a round-robin failover would also eventually reach the leader.
+    // The unit-level RemoteException round-trip in
+    // TestOMNotLeaderExceptionMessageParsing is what proves the hint
+    // mechanism itself is wired up; this assertion is the integration-level
+    // smoke check that the path doesn't regress to the round-robin fallback
+    // for some other reason.)
+    assertEquals(leaderId, provider.getCurrentProxyOMNodeId());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -607,7 +607,7 @@ public final class OzoneManagerRatisServer {
 
       LeaderSteppingDownException leaderSteppingDownException = reply.getLeaderSteppingDownException();
       if (leaderSteppingDownException != null) {
-        throw new ServiceException(new OMNotLeaderException(leaderSteppingDownException.getMessage()));
+        throw new ServiceException(newOMNotLeaderException());
       }
 
       ReadIndexException readIndexException = reply.getReadIndexException();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -595,7 +595,7 @@ public final class OzoneManagerRatisServer {
       if (notLeaderException != null) {
         throw new ServiceException(
             OMNotLeaderException.convertToOMNotLeaderException(
-                  notLeaderException, getRaftPeerId()));
+                notLeaderException, getRaftPeerId(), this::resolvePeerDetails));
       }
 
       LeaderNotReadyException leaderNotReadyException =
@@ -913,8 +913,22 @@ public final class OzoneManagerRatisServer {
     if (leader == null) {
       return new OMNotLeaderException(raftPeerId);
     }
-    final String leaderAddress = getRaftLeaderAddress(leader);
-    return new OMNotLeaderException(raftPeerId, leader.getId(), leaderAddress);
+    OMNodeDetails leaderDetails = resolvePeerDetails(leader.getId());
+    if (leaderDetails == null) {
+      return new OMNotLeaderException(raftPeerId);
+    }
+    String rpcHostPort = leaderDetails.getRpcAddressString();
+    InetAddress inetAddress = leaderDetails.getInetAddress();
+    String ip = inetAddress == null ? null : inetAddress.getHostAddress();
+    return new OMNotLeaderException(raftPeerId, leader.getId(), rpcHostPort, ip);
+  }
+
+  private OMNodeDetails resolvePeerDetails(RaftPeerId peerId) {
+    String nodeId = peerId.toString();
+    if (nodeId.equals(ozoneManager.getOMNodeId())) {
+      return ozoneManager.getNodeDetails();
+    }
+    return ozoneManager.getPeerNode(nodeId);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
When OM client talks to a follower and receives the ServiceException, the OMNotLeaderException sets the suggested leader information to null. This results in no suggested leader information being propagated to the client and it has to fallback to round-robin discovery of the OM leader.
The exception string does preserve the leader information in the message but it needs to be parsed and extracted first. 

This PR
* Creates a new string format which contains the suggested leader information so that it can be parsed 
* Updates the suggested leader information when converting the exceptions to OMNotLeaderException
* Adds tests

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3936


## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/25620947837