### PR TITLE
HDDS-15229. Allow running acceptance test with local-only image

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -56,12 +56,14 @@ source "$COMPOSE_DIR/../testlib.sh"
 
 for HADOOP_TEST_IMAGE in $HADOOP_TEST_IMAGES; do
   export HADOOP_TEST_IMAGE
-  hadoop_version=$(docker run --rm "${HADOOP_TEST_IMAGE}" bash -c "hadoop version | grep -m1 '^Hadoop' | cut -f2 -d' '")
-  export HADOOP_MAJOR_VERSION=${hadoop_version%%.*}
 
   if [[ "${CI:-}" == "true" ]]; then
     retry docker-compose --ansi never --profile hadoop pull nm rm || true
   fi
+
+  hadoop_version=$(docker run --rm "${HADOOP_TEST_IMAGE}" bash -c "hadoop version | grep -m1 '^Hadoop' | cut -f2 -d' '")
+  export HADOOP_MAJOR_VERSION=${hadoop_version%%.*}
+
   docker-compose --ansi never --profile hadoop up -d nm rm
 
   execute_command_in_container rm hadoop version

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -59,7 +59,9 @@ for HADOOP_TEST_IMAGE in $HADOOP_TEST_IMAGES; do
   hadoop_version=$(docker run --rm "${HADOOP_TEST_IMAGE}" bash -c "hadoop version | grep -m1 '^Hadoop' | cut -f2 -d' '")
   export HADOOP_MAJOR_VERSION=${hadoop_version%%.*}
 
-  retry docker-compose --ansi never --profile hadoop pull nm rm || true
+  if [[ "${CI:-}" == "true" ]]; then
+    retry docker-compose --ansi never --profile hadoop pull nm rm || true
+  fi
   docker-compose --ansi never --profile hadoop up -d nm rm
 
   execute_command_in_container rm hadoop version

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -59,7 +59,7 @@ for HADOOP_TEST_IMAGE in $HADOOP_TEST_IMAGES; do
   hadoop_version=$(docker run --rm "${HADOOP_TEST_IMAGE}" bash -c "hadoop version | grep -m1 '^Hadoop' | cut -f2 -d' '")
   export HADOOP_MAJOR_VERSION=${hadoop_version%%.*}
 
-  retry docker-compose --ansi never --profile hadoop pull nm rm
+  retry docker-compose --ansi never --profile hadoop pull nm rm || true
   docker-compose --ansi never --profile hadoop up -d nm rm
 
   execute_command_in_container rm hadoop version

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -179,7 +179,9 @@ start_docker_env(){
 
   docker-compose --ansi never down --remove-orphans
 
-  retry docker-compose --ansi never pull || true
+  if [[ "${CI:-}" == "true" ]]; then
+    retry docker-compose --ansi never pull || true
+  fi
 
   opts=""
   if has_scalable_datanode; then

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -179,7 +179,7 @@ start_docker_env(){
 
   docker-compose --ansi never down --remove-orphans
 
-  retry docker-compose --ansi never pull
+  retry docker-compose --ansi never pull || true
 
   opts=""
   if has_scalable_datanode; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-14963 added explicit `docker compose pull`, which fails with local-only images (e.g. `ozone-runner:dev` created locally).  We should treat pull error as non-fatal, continue running tests.  If image is not available, `docker compose up` will fail anyway.

https://issues.apache.org/jira/browse/HDDS-15229

## How was this patch tested?

Verified that the test continues after failing to pull non-existent image:

```bash
$ cd hadoop-ozone/dist/target/ozone-2.2.0-SNAPSHOT/compose/ozone
$ OZONE_RUNNER_VERSION=dev ./test.sh
Error response from daemon: manifest for apache/ozone-runner:dev not found: manifest unknown: manifest unknown
Error response from daemon: manifest for apache/ozone-runner:dev not found: manifest unknown: manifest unknown
Error response from daemon: manifest for apache/ozone-runner:dev not found: manifest unknown: manifest unknown
ERROR: 3 attempts failed to: docker-compose --ansi never pull
Error response from daemon: manifest for apache/ozone-runner:dev not found: manifest unknown: manifest unknown
```

https://github.com/adoroszlai/ozone/actions/runs/25659953967