### PR TITLE
HDDS-15211. Automatically create a github discussion for junit failures on `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,3 +401,37 @@ jobs:
           name: coverage
           path: target/coverage
         continue-on-error: true
+
+  junit-failure-discussion:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs:
+      - build-info
+      - integration
+    if: always() && github.repository == 'apache/ozone' && github.event_name == 'push' && github.ref_name == 'master' && needs.integration.result == 'failure'
+    permissions:
+      contents: read
+      discussions: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.build-info.outputs.sha }}
+          fetch-depth: 1
+
+      - name: Download integration job artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          pattern: integration-*
+          path: artifact-download
+          merge-multiple: false
+
+      - name: Assemble summary and open discussion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_NODE_ID: ${{ github.event.repository.node_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ needs.build-info.outputs.sha }}
+        run: bash dev-support/ci/create_junit_failure_discussion.sh

--- a/dev-support/ci/create_junit_failure_discussion.sh
+++ b/dev-support/ci/create_junit_failure_discussion.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assembles integration test failure summaries (matching check.yml "Summary of failures")
+# and opens a GitHub Discussion via GraphQL. Intended for GitHub Actions only.
+#
+# Required env: GH_TOKEN, REPOSITORY_NODE_ID, RUN_URL, COMMIT_SHA
+#   (REPOSITORY_NODE_ID is github.event.repository.node_id)
+# Optional env: ARTIFACT_DOWNLOAD_DIR (default artifact-download),
+#               DISCUSSION_BODY_FILE (default discussion_body.md)
+
+set -euo pipefail
+
+# GraphQL ID for the "General" category on github.com/apache/ozone (from
+# repository.discussionCategories; change only if GitHub recreates categories).
+readonly GENERAL_DISCUSSION_CATEGORY_ID='DIC_kwDODKiyxs4CWMZB'
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${REPOSITORY_NODE_ID:?REPOSITORY_NODE_ID must be set}"
+: "${RUN_URL:?RUN_URL must be set}"
+: "${COMMIT_SHA:?COMMIT_SHA must be set}"
+
+ARTIFACT_DOWNLOAD_DIR="${ARTIFACT_DOWNLOAD_DIR:-artifact-download}"
+DISCUSSION_BODY_FILE="${DISCUSSION_BODY_FILE:-discussion_body.md}"
+SUMMARY_HELPER="${SUMMARY_HELPER:-hadoop-ozone/dev-support/checks/_summary.sh}"
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+cd "${ROOT}"
+
+{
+  echo "**Workflow run:** ${RUN_URL}"
+  echo "**Commit:** ${COMMIT_SHA}"
+  echo
+  echo 'Flaky test Jiras should be filed as **subtasks of [HDDS-5626](https://issues.apache.org/jira/browse/HDDS-5626)**.'
+  echo
+  echo ---
+  echo
+} > "${DISCUSSION_BODY_FILE}"
+
+integration_dirs=()
+if [[ -d "${ARTIFACT_DOWNLOAD_DIR}" ]]; then
+  mapfile -t integration_dirs < <(find "${ARTIFACT_DOWNLOAD_DIR}" -mindepth 1 -maxdepth 1 -type d -name 'integration-*' | sort)
+fi
+if [[ ${#integration_dirs[@]} -eq 0 ]]; then
+  echo '_No `integration-*` artifacts were downloaded; see the workflow run logs._' >> "${DISCUSSION_BODY_FILE}"
+else
+  for dir in "${integration_dirs[@]}"; do
+    split=$(basename "${dir}")
+    {
+      echo "## ${split}"
+      echo
+      if [[ -s "${dir}/summary.md" ]]; then
+        cat "${dir}/summary.md"
+        echo
+      fi
+      set +e
+      bash "${SUMMARY_HELPER}" "${dir}/summary.txt"
+      set -e
+      echo
+    } >> "${DISCUSSION_BODY_FILE}"
+  done
+fi
+
+short_sha=$(echo -n "${COMMIT_SHA}" | cut -c1-7)
+title="[CI] JUnit failure on master (${short_sha})"
+
+# Construct GraphQL to create the discussion.
+create_json=$(jq -n \
+  --arg q 'mutation($input: CreateDiscussionInput!) { createDiscussion(input: $input) { discussion { url } } }' \
+  --arg rid "${REPOSITORY_NODE_ID}" \
+  --arg cid "${GENERAL_DISCUSSION_CATEGORY_ID}" \
+  --arg ttl "${title}" \
+  --rawfile body "${DISCUSSION_BODY_FILE}" \
+  '{query: $q, variables: {input: {repositoryId: $rid, categoryId: $cid, title: $ttl, body: $body}}}')
+
+# Create the discussion and parse the response.
+create_resp=$(echo "${create_json}" | gh api graphql --input -)
+if echo "${create_resp}" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+  echo "${create_resp}" | jq .
+  exit 1
+fi
+
+# Extract the URL of the discussion for logging.
+disc_url=$(echo "${create_resp}" | jq -r '.data.createDiscussion.discussion.url // empty')
+if [[ -z "${disc_url}" ]]; then
+  echo "${create_resp}" | jq .
+  exit 1
+fi
+echo "Created discussion: ${disc_url}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Draft generated with AI as an example to see if this is helpful.

We often do not check the master branch for flaky tests to proactively track them under HDDS-5626 and tag them with `@Flaky`. Usually they don't get tagged until they disrupt PRs, but even then tests are frequently just rerun without bothering to tag them going forward. This can cause the reliability of master to slowly degrade over time, until it gets bad enough that we inspect a lot of past runs and add lots of `@Flaky` tags all at once.

To help proactively tag these flaky tests, this PR contains a github actions job that will create a new github discussion for each test run on master that has junit failures. The current draft is sending this to the `General` category, but we could create a different category for these.

Format of the discussion would look like this:

```
[CI] JUnit failure on master (072f758)

**Workflow run:** https://github.com/errose28/ozone/actions/runs/25561938156
**Commit:** 072f758268491dd2b8945089f916f4421755741e
Flaky test Jiras should be filed as **subtasks of [HDDS-5626](https://issues.apache.org/jira/browse/HDDS-5626)**.
---
## integration-hdds
org.apache.hadoop.hdds.upgrade.TestDNDataDistributionFinalization
org.apache.hadoop.hdds.upgrade.TestScmDataDistributionFinalization
org.apache.hadoop.hdds.upgrade.TestScmHAFinalization
Error: Process completed with exit code 1.
```

Other alternatives were considered but dropped due to complexity:
- Automatically filing Jira issues:
  - Requires a new Jira token to be added by ASF Infra. I recall from past testing that our existing github token is enough to create discussions.
  - Requires deduplication of test failures. Each run needs to somehow figure out if a Jira was already filed for this test which has not been tagged yet.
  - Jira's notification system is not as good as github's. It would be hard to subscribe to notifications that there is a new flaky test without also pushing to a different channel.
- Automatically create a PR that adds the `@Flaky` annotation to the test. The corresponding Jira would then be filed by whoever reviews and merged the change.
  - This was my initial approach, but there is a lot of nuance in mapping the output of a maven surefire xml report to the line number to put the annotation on.
  - This also has similar deduplication trouble as automatically creating Jiras.
- Using failed run archives from https://github.com/adoroszlai/ozone-build-results
  - This creates a dependency pointing from Apache to a personal repo which is not ideal.

## What is the link to the Apache JIRA

HDDS-15211

## How was this patch tested?

I haven't done a dry run of this on my fork yet, this PR is mostly to see if the community is interested in this. If so I can proceed with testing.
