### PR TITLE
HDDS-11207. Allow reconciliation and scanner to move replicas out of the UNHEALTHY state

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
@@ -102,6 +102,13 @@ public interface Container<CONTAINERDATA extends ContainerData> {
   void markContainerUnhealthy() throws StorageContainerException;
 
   /**
+   * Marks the container replica as healthy after successful scan.
+   * For RATIS containers, restores the container from UNHEALTHY to QUASI_CLOSED state.
+   * For EC containers, restores the container from UNHEALTHY to CLOSED state.
+   */
+  boolean markContainerHealthy() throws StorageContainerException;
+
+  /**
    * Marks the container replica as deleted.
    */
   void markContainerForDelete();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
@@ -199,6 +199,17 @@ public abstract class Handler {
       throws IOException;
 
   /**
+   * Marks the container Healthy after successful scan.
+   * For RATIS containers, moves the container from UNHEALTHY to QUASI_CLOSED state.
+   * For EC containers, moves the container from UNHEALTHY to CLOSED state.
+   *
+   * @param container container to update
+   * @throws IOException in case of exception
+   */
+  public abstract boolean markContainerHealthy(Container container)
+      throws IOException;
+
+  /**
    * Moves the Container to QUASI_CLOSED state.
    *
    * @param container container to be quasi closed

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -98,6 +98,17 @@ public final class ContainerLogger {
   }
 
   /**
+   * Logged when a container is recovered from unhealthy state after successful scan.
+   *
+   * @param containerData The container that was marked healthy.
+   * @param newState The new state (QUASI_CLOSED for RATIS, CLOSED for EC).
+   */
+  public static void logHealthy(ContainerData containerData, String newState) {
+    LOG.info(getMessage(containerData, 
+        "Container recovered from UNHEALTHY to " + newState + " after successful scan"));
+  }
+
+  /**
    * Logged when a container is lost from this datanode. Currently this would
    * only happen on volume failure. Container deletes do not count as lost
    * containers.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -400,6 +400,34 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   }
 
   @Override
+  public boolean markContainerHealthy() throws StorageContainerException {
+    writeLock();
+    final State prevState = containerData.getState();
+    try {
+      if (prevState != UNHEALTHY) {
+        LOG.debug("Container {} is not UNHEALTHY (state={}), cannot mark healthy", 
+            containerData.getContainerID(), prevState);
+        return false;
+      }
+      final int replicaIndex = containerData.getReplicaIndex();
+      if (replicaIndex < 0) {
+        throw new StorageContainerException(
+            "Invalid replicaIndex=" + replicaIndex + " for container "
+                + containerData.getContainerID(),
+            INVALID_CONTAINER_STATE);
+      }
+      // replicaIndex == 0 is RATIS, > 0 is EC.
+      final State newState = replicaIndex == 0 ? QUASI_CLOSED : CLOSED;
+      updateContainerState(newState);
+      LOG.info("Marked container {} from UNHEALTHY to {} (replicaIndex={}): {}",
+          containerData.getContainerID(), newState, replicaIndex, containerData);
+      return true;
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  @Override
   public void markContainerForDelete() {
     writeLock();
     final State prevState = containerData.getState();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -683,6 +683,7 @@ public class KeyValueHandler extends Handler {
 
       final long numBytes = blockDataProto.getSerializedSize();
       metrics.incContainerBytesStats(Type.PutBlock, numBytes);
+
     } catch (StorageContainerException ex) {
       return ContainerUtils.logAndReturnError(LOG, ex, request);
     } catch (IOException ex) {
@@ -1541,6 +1542,45 @@ public class KeyValueHandler extends Handler {
     // SCM. Write a corresponding entry to the container log as well.
     ContainerLogger.logUnhealthy(container.getContainerData(), reason);
     sendICR(container);
+  }
+
+  @Override
+  public boolean markContainerHealthy(Container container)
+      throws IOException {
+    boolean transitionedToHealthy = false;
+    container.writeLock();
+    long containerID = container.getContainerData().getContainerID();
+    try {
+      if (container.getContainerState() != State.UNHEALTHY) {
+        LOG.debug("Call to mark non-unhealthy container {} as healthy (state={})",
+            containerID, container.getContainerState());
+        return false;
+      }
+      // If the volume is unhealthy, no action is needed. Container cannot be restored.
+      HddsVolume containerVolume = container.getContainerData().getVolume();
+      if (containerVolume.isFailed()) {
+        LOG.debug("Ignoring healthy container {} detected on an " +
+            "already failed volume {}", containerID, containerVolume);
+        return false;
+      }
+      transitionedToHealthy = container.markContainerHealthy();
+    } catch (StorageContainerException ex) {
+      LOG.warn("Unexpected error while marking container {} healthy",
+          containerID, ex);
+      return false;
+    } finally {
+      container.writeUnlock();
+    }
+    if (!transitionedToHealthy) {
+      return false;
+    }
+    updateContainerChecksumFromMetadataIfNeeded(container);
+    // Determine the new state for logging
+    State newState = container.getContainerState();
+    String stateStr = (newState == QUASI_CLOSED) ? "QUASI_CLOSED" : "CLOSED";
+    ContainerLogger.logHealthy(container.getContainerData(), stateStr);
+    sendICR(container);
+    return true;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -128,6 +128,29 @@ public class ContainerController {
   }
 
   /**
+   * Marks the container as HEALTHY after successful scan.
+   * For RATIS containers, moves from UNHEALTHY to QUASI_CLOSED state.
+   * For EC containers, moves from UNHEALTHY to CLOSED state.
+   *
+   * @param containerId Id of the container to update
+   * @throws IOException in case of exception
+   */
+  public boolean markContainerHealthy(final long containerId)
+          throws IOException {
+    Container container = getContainer(containerId);
+    if (container == null) {
+      LOG.warn("Container {} not found, may be deleted, skip marking HEALTHY", containerId);
+      return false;
+    } else if (container.getContainerState() != State.UNHEALTHY) {
+      LOG.debug("Container {} is not UNHEALTHY (state={}), skip marking HEALTHY", 
+          containerId, container.getContainerState());
+      return false;
+    } else {
+      return getHandler(container).markContainerHealthy(container);
+    }
+  }
+
+  /**
    * Updates the container checksum information on disk and in memory.
    *
    * @param containerId The ID of the container to update

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScanHelper.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.container.ozoneimpl;
 
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -64,6 +66,7 @@ public final class ContainerScanHelper {
     }
     ContainerData containerData = container.getContainerData();
     long containerId = containerData.getContainerID();
+    boolean wasUnhealthy = containerData.isUnhealthy();
     logScanStart(containerData, "data");
     DataScanResult result = container.scanData(throttler, canceler);
 
@@ -77,6 +80,13 @@ public final class ContainerScanHelper {
       }
       if (result.hasErrors()) {
         handleUnhealthyScanResult(containerData, result);
+      } else if (wasUnhealthy) {
+        if (container.getContainerState() == UNHEALTHY) {
+          handleHealthyScanResult(containerData);
+        } else {
+          log.debug("Container [{}] no longer UNHEALTHY after scan (state={}), skipping recovery call.",
+              containerId, container.getContainerState());
+        }
       }
       metrics.incNumContainersScanned();
     }
@@ -133,6 +143,15 @@ public final class ContainerScanHelper {
       metrics.incNumUnHealthyContainers();
       // triggering a volume scan for the unhealthy container
       triggerVolumeScan(containerData);
+    }
+  }
+
+  public void handleHealthyScanResult(ContainerData containerData) throws IOException {
+    long containerID = containerData.getContainerID();
+    log.info("Container [{}] passed scan. Recovering from UNHEALTHY to healthy state.", containerID);
+    boolean containerMarkedHealthy = controller.markContainerHealthy(containerID);
+    if (containerMarkedHealthy) {
+      log.info("Container [{}] successfully recovered from UNHEALTHY to healthy state.", containerID);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -1185,4 +1185,96 @@ public class TestKeyValueContainer {
     verify(volumeChoosingPolicy).chooseVolume(anyList(), anyLong()); // this would reserve commit space
     assertTrue(keyValueContainerData.isCommittedSpace());
   }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testMarkContainerHealthyReturnsTrue(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+    createContainer();
+
+    // Mark container as UNHEALTHY first
+    keyValueContainer.markContainerUnhealthy();
+    assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+        keyValueContainer.getContainerState());
+
+    // markContainerHealthy should return true for RATIS containers
+    boolean result = keyValueContainer.markContainerHealthy();
+    assertTrue(result);
+    assertEquals(ContainerProtos.ContainerDataProto.State.QUASI_CLOSED,
+        keyValueContainer.getContainerState());
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testMarkContainerHealthyReturnsFalseWhenNotUnhealthy(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+    createContainer();
+
+    // Container is OPEN, not UNHEALTHY
+    assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
+        keyValueContainer.getContainerState());
+
+    // markContainerHealthy should return false
+    boolean result = keyValueContainer.markContainerHealthy();
+    assertFalse(result);
+    // State should remain unchanged
+    assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
+        keyValueContainer.getContainerState());
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testMarkContainerHealthyReturnsFalseWhenClosed(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+    createContainer();
+
+    // Mark container as CLOSED
+    keyValueContainerData.setState(
+        ContainerProtos.ContainerDataProto.State.CLOSED);
+    keyValueContainer.update(keyValueContainerData.getMetadata(), true);
+
+    // markContainerHealthy should return false for CLOSED containers
+    boolean result = keyValueContainer.markContainerHealthy();
+    assertFalse(result);
+    assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
+        keyValueContainer.getContainerState());
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testMarkContainerHealthyWithECContainer(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+    // Set replicaIndex > 0 to simulate EC container
+    keyValueContainerData.setReplicaIndex(1);
+    createContainer();
+
+    // Mark as UNHEALTHY
+    keyValueContainer.markContainerUnhealthy();
+    assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+        keyValueContainer.getContainerState());
+
+    // EC containers should transition to CLOSED
+    boolean result = keyValueContainer.markContainerHealthy();
+    assertTrue(result);
+    assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
+        keyValueContainer.getContainerState());
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testMarkContainerHealthyThrowsExceptionForNegativeReplicaIndex(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+    // Set invalid replicaIndex
+    keyValueContainerData.setReplicaIndex(-1);
+    createContainer();
+
+    // Mark as UNHEALTHY
+    keyValueContainer.markContainerUnhealthy();
+
+    // Should throw exception for negative replicaIndex
+    StorageContainerException exception = assertThrows(
+        StorageContainerException.class,
+        () -> keyValueContainer.markContainerHealthy());
+    assertTrue(exception.getMessage().contains("Invalid replicaIndex"));
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -1086,4 +1086,220 @@ public class TestKeyValueHandler {
       ContainerMetrics.remove();
     }
   }
+
+  @Test
+  public void testMarkContainerHealthyReturnsTrue() throws Exception {
+    final long containerID = 1L;
+    final String datanodeId = UUID.randomUUID().toString();
+    final String clusterId = UUID.randomUUID().toString();
+    final ContainerSet containerSet = newContainerSet();
+    final MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+
+    HddsVolume hddsVolume = new HddsVolume.Builder(tempDir.toString())
+        .conf(conf).clusterID(clusterId).datanodeUuid(datanodeId)
+        .volumeSet(volumeSet).build();
+    hddsVolume.format(clusterId);
+    hddsVolume.createWorkingDir(clusterId, null);
+    hddsVolume.createTmpDirs(clusterId);
+
+    when(volumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(hddsVolume));
+
+    final KeyValueHandler kvHandler = new KeyValueHandler(conf,
+        datanodeId, containerSet, volumeSet, mock(ContainerMetrics.class),
+        c -> { }, new ContainerChecksumTreeManager(conf));
+    kvHandler.setClusterID(clusterId);
+
+    KeyValueContainerData containerData = new KeyValueContainerData(containerID,
+        ContainerLayoutVersion.FILE_PER_BLOCK,
+        (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+        datanodeId);
+    KeyValueContainer container = new KeyValueContainer(containerData, conf);
+    container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
+        clusterId);
+    containerSet.addContainer(container);
+
+    // Mark container as UNHEALTHY
+    container.markContainerUnhealthy();
+    assertEquals(UNHEALTHY, container.getContainerState());
+
+    // Mark container healthy should return true
+    boolean result = kvHandler.markContainerHealthy(container);
+    assertTrue(result);
+    assertEquals(QUASI_CLOSED, container.getContainerState());
+  }
+
+  @Test
+  public void testMarkContainerHealthyReturnsFalseWhenNotUnhealthy()
+      throws Exception {
+    final long containerID = 1L;
+    final String datanodeId = UUID.randomUUID().toString();
+    final String clusterId = UUID.randomUUID().toString();
+    final ContainerSet containerSet = newContainerSet();
+    final MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+
+    HddsVolume hddsVolume = new HddsVolume.Builder(tempDir.toString())
+        .conf(conf).clusterID(clusterId).datanodeUuid(datanodeId)
+        .volumeSet(volumeSet).build();
+    hddsVolume.format(clusterId);
+    hddsVolume.createWorkingDir(clusterId, null);
+
+    when(volumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(hddsVolume));
+
+    final KeyValueHandler kvHandler = new KeyValueHandler(conf,
+        datanodeId, containerSet, volumeSet, mock(ContainerMetrics.class),
+        c -> { }, new ContainerChecksumTreeManager(conf));
+    kvHandler.setClusterID(clusterId);
+
+    KeyValueContainerData containerData = new KeyValueContainerData(containerID,
+        ContainerLayoutVersion.FILE_PER_BLOCK,
+        (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+        datanodeId);
+    KeyValueContainer container = new KeyValueContainer(containerData, conf);
+    container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
+        clusterId);
+    containerSet.addContainer(container);
+
+    // Container is in OPEN state
+    assertEquals(State.OPEN, container.getContainerState());
+
+    // Mark container healthy should return false
+    boolean result = kvHandler.markContainerHealthy(container);
+    assertFalse(result);
+    assertEquals(State.OPEN, container.getContainerState());
+  }
+
+  @Test
+  public void testMarkContainerHealthyReturnsFalseWhenVolumeFailed()
+      throws Exception {
+    final long containerID = 1L;
+    final String datanodeId = UUID.randomUUID().toString();
+    final String clusterId = UUID.randomUUID().toString();
+    final ContainerSet containerSet = newContainerSet();
+    final MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+
+    HddsVolume hddsVolume = new HddsVolume.Builder(tempDir.toString())
+        .conf(conf).clusterID(clusterId).datanodeUuid(datanodeId)
+        .volumeSet(volumeSet).build();
+    hddsVolume.format(clusterId);
+    hddsVolume.createWorkingDir(clusterId, null);
+
+    when(volumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(hddsVolume));
+
+    final KeyValueHandler kvHandler = new KeyValueHandler(conf,
+        datanodeId, containerSet, volumeSet, mock(ContainerMetrics.class),
+        c -> { }, new ContainerChecksumTreeManager(conf));
+    kvHandler.setClusterID(clusterId);
+
+    KeyValueContainerData containerData = new KeyValueContainerData(containerID,
+        ContainerLayoutVersion.FILE_PER_BLOCK,
+        (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+        datanodeId);
+    KeyValueContainer container = new KeyValueContainer(containerData, conf);
+    container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
+        clusterId);
+    containerSet.addContainer(container);
+
+    // Mark container as UNHEALTHY
+    container.markContainerUnhealthy();
+    assertEquals(UNHEALTHY, container.getContainerState());
+
+    // Fail the volume
+    hddsVolume.failVolume();
+
+    // Should return false due to failed volume
+    boolean result = kvHandler.markContainerHealthy(container);
+    assertFalse(result);
+    assertEquals(UNHEALTHY, container.getContainerState());
+  }
+
+  @Test
+  public void testMarkContainerHealthyWithECContainer() throws Exception {
+    final long containerID = 1L;
+    final String datanodeId = UUID.randomUUID().toString();
+    final String clusterId = UUID.randomUUID().toString();
+    final ContainerSet containerSet = newContainerSet();
+    final MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+
+    HddsVolume hddsVolume = new HddsVolume.Builder(tempDir.toString())
+        .conf(conf).clusterID(clusterId).datanodeUuid(datanodeId)
+        .volumeSet(volumeSet).build();
+    hddsVolume.format(clusterId);
+    hddsVolume.createWorkingDir(clusterId, null);
+
+    when(volumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(hddsVolume));
+
+    final KeyValueHandler kvHandler = new KeyValueHandler(conf,
+        datanodeId, containerSet, volumeSet, mock(ContainerMetrics.class),
+        c -> { }, new ContainerChecksumTreeManager(conf));
+    kvHandler.setClusterID(clusterId);
+
+    KeyValueContainerData containerData = new KeyValueContainerData(containerID,
+        ContainerLayoutVersion.FILE_PER_BLOCK,
+        (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+        datanodeId);
+    // Set replicaIndex > 0 for EC container
+    containerData.setReplicaIndex(2);
+
+    KeyValueContainer container = new KeyValueContainer(containerData, conf);
+    container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
+        clusterId);
+    containerSet.addContainer(container);
+
+    // Mark as UNHEALTHY
+    container.markContainerUnhealthy();
+    assertEquals(UNHEALTHY, container.getContainerState());
+
+    // EC container should transition to CLOSED
+    boolean result = kvHandler.markContainerHealthy(container);
+    assertTrue(result);
+    assertEquals(CLOSED, container.getContainerState());
+  }
+
+  @Test
+  public void testMarkContainerHealthyHandlesException() throws Exception {
+    final long containerID = 1L;
+    final String datanodeId = UUID.randomUUID().toString();
+    final String clusterId = UUID.randomUUID().toString();
+    final ContainerSet containerSet = newContainerSet();
+    final MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+
+    HddsVolume hddsVolume = new HddsVolume.Builder(tempDir.toString())
+        .conf(conf).clusterID(clusterId).datanodeUuid(datanodeId)
+        .volumeSet(volumeSet).build();
+    hddsVolume.format(clusterId);
+    hddsVolume.createWorkingDir(clusterId, null);
+
+    when(volumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(hddsVolume));
+
+    final KeyValueHandler kvHandler = new KeyValueHandler(conf,
+        datanodeId, containerSet, volumeSet, mock(ContainerMetrics.class),
+        c -> { }, new ContainerChecksumTreeManager(conf));
+    kvHandler.setClusterID(clusterId);
+
+    KeyValueContainerData containerData = new KeyValueContainerData(containerID,
+        ContainerLayoutVersion.FILE_PER_BLOCK,
+        (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+        datanodeId);
+    // Set invalid replicaIndex to trigger exception
+    containerData.setReplicaIndex(-1);
+
+    KeyValueContainer container = new KeyValueContainer(containerData, conf);
+    container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
+        clusterId);
+    containerSet.addContainer(container);
+
+    // Mark as UNHEALTHY
+    container.markContainerUnhealthy();
+    assertEquals(UNHEALTHY, container.getContainerState());
+
+    // Should return false when exception occurs
+    boolean result = kvHandler.markContainerHealthy(container);
+    assertFalse(result);
+    assertEquals(UNHEALTHY, container.getContainerState());
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerController.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerController.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.CLOSED;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.OPEN;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.interfaces.Handler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ContainerController}.
+ */
+public class TestContainerController {
+
+  private ContainerSet containerSet;
+  private Handler handler;
+  private ContainerController controller;
+
+  @BeforeEach
+  public void setup() {
+    containerSet = mock(ContainerSet.class);
+    handler = mock(Handler.class);
+
+    Map<ContainerProtos.ContainerType, Handler> handlers = new HashMap<>();
+    handlers.put(ContainerProtos.ContainerType.KeyValueContainer, handler);
+
+    controller = new ContainerController(containerSet, handlers);
+  }
+
+  @Test
+  public void testMarkContainerHealthyReturnsFalseWhenNotFound()
+      throws IOException {
+    final long containerID = 1L;
+    when(containerSet.getContainer(containerID)).thenReturn(null);
+
+    assertFalse(controller.markContainerHealthy(containerID));
+    verifyNoInteractions(handler);
+  }
+
+  @Test
+  public void testMarkContainerHealthyReturnsFalseWhenOpen()
+      throws Exception {
+    final long containerID = 1L;
+    Container<?> container = mockContainer(containerID, OPEN);
+
+    assertFalse(controller.markContainerHealthy(containerID));
+    verify(handler, never()).markContainerHealthy(container);
+  }
+
+  @Test
+  public void testMarkContainerHealthyReturnsFalseWhenClosed()
+      throws Exception {
+    final long containerID = 1L;
+    Container<?> container = mockContainer(containerID, CLOSED);
+
+    assertFalse(controller.markContainerHealthy(containerID));
+    verify(handler, never()).markContainerHealthy(container);
+  }
+
+  @Test
+  public void testMarkContainerHealthyPropagatesHandlerSuccess()
+      throws Exception {
+    final long containerID = 1L;
+    Container<?> container = mockContainer(containerID, UNHEALTHY);
+    when(handler.markContainerHealthy(container)).thenReturn(true);
+
+    assertTrue(controller.markContainerHealthy(containerID));
+    verify(handler).markContainerHealthy(container);
+  }
+
+  @Test
+  public void testMarkContainerHealthyPropagatesHandlerFailure()
+      throws Exception {
+    final long containerID = 1L;
+    Container<?> container = mockContainer(containerID, UNHEALTHY);
+    when(handler.markContainerHealthy(container)).thenReturn(false);
+
+    assertFalse(controller.markContainerHealthy(containerID));
+    verify(handler).markContainerHealthy(container);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private Container<?> mockContainer(long containerID,
+      ContainerProtos.ContainerDataProto.State state) {
+    Container container = mock(Container.class);
+    when(containerSet.getContainer(containerID)).thenReturn(container);
+    when(container.getContainerType())
+        .thenReturn(ContainerProtos.ContainerType.KeyValueContainer);
+    when(container.getContainerState()).thenReturn(state);
+    return container;
+  }
+}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/container-state-verifier.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/container-state-verifier.robot
@@ -37,6 +37,7 @@ Create Container State Rule
 
 Verify Container State with Rule
     [Arguments]          ${expected_state}
+    Remove All Byteman Rules    ${FAULT_INJ_DATANODE}
     ${rule_file} =       Create Container State Rule    ${expected_state}
     Add Byteman Rule     ${FAULT_INJ_DATANODE}    ${rule_file}
     List Byteman Rules   ${FAULT_INJ_DATANODE}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-keywords.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-keywords.robot
@@ -36,15 +36,15 @@ Execute replicas verify container state debug tool
 
 Parse replicas verify JSON output
     [Arguments]    ${output}
-    ${json_split} =  Evaluate  '''${output}'''.split('***')[0].strip()
-    ${json} =      Evaluate  json.loads('''${json_split}''')  json
+    # Split on the banner printed to stderr after JSON (stderr is merged with stdout in tests via 2>&1).
+    # Use $output in Evaluate so the value is not triple-embedded (avoids parse errors on quotes / ''' in text).
+    ${json} =    Evaluate    json.loads($output.partition('***************************************************')[0].strip())    json
     [Return]       ${json}
 
 Check to Verify Replicas
     [Arguments]    ${json}  ${check_type}  ${faulty_datanode}  ${expected_message}
     ${replicas} =    Get From Dictionary    ${json['keys'][0]['blocks'][0]}    replicas
-    Run Keyword If    '${check_type}' == 'containerState'    Check Container State Replicas    ${replicas}  ${faulty_datanode}  ${expected_message}
-    ...    ELSE    Check Standard Replicas    ${replicas}  ${check_type}  ${faulty_datanode}  ${expected_message}
+    Check Standard Replicas    ${replicas}  ${check_type}  ${faulty_datanode}  ${expected_message}
 
 Check Standard Replicas
     [Arguments]    ${replicas}  ${check_type}  ${faulty_datanode}  ${expected_message}
@@ -53,21 +53,6 @@ Check Standard Replicas
         ${hostname} =     Get From Dictionary    ${datanode}   hostname
         Run Keyword If    '${hostname}' == '${faulty_datanode}'    Check Replica Failed    ${replica}  ${check_type}  ${expected_message}
         Run Keyword If    '${hostname}' != '${faulty_datanode}'    Check Replica Passed    ${replica}  ${check_type}
-    END
-
-Check Container State Replicas
-    [Arguments]    ${replicas}  ${faulty_datanode}  ${expected_message}
-    FOR    ${replica}    IN    @{replicas}
-        ${datanode} =     Get From Dictionary    ${replica}    datanode
-        ${hostname} =     Get From Dictionary    ${datanode}   hostname
-        ${checks} =       Get From Dictionary    ${replica}    checks
-        ${check} =        Get From List          ${checks}     0
-        Should Be Equal    ${check['type']}    containerState
-        Should Be Equal    ${check['pass']}    ${False}
-        ${actual_message} =    Set Variable    ${check['failures'][0]['message']}
-
-        Run Keyword If    '${hostname}' == '${faulty_datanode}'    Should Contain    ${actual_message}    ${expected_message}
-        ...    ELSE    Should Match Regexp    ${actual_message}    Replica state is (OPEN|CLOSING|QUASI_CLOSED|CLOSED)
     END
 
 Check Replica Failed

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -107,6 +107,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECContainerOperationClient;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionMetrics;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.security.token.Token;
@@ -179,6 +180,10 @@ public class TestContainerCommandsEC {
         DatanodeConfiguration.class);
     dnConf.setBlockDeletionInterval(Duration.ofSeconds(1));
     config.setFromObject(dnConf);
+    ContainerScannerConfiguration scannerConf =
+        config.getObject(ContainerScannerConfiguration.class);
+    scannerConf.setEnabled(false);
+    config.setFromObject(scannerConf);
     startCluster(config);
     prepareData(KEY_SIZE_RANGES);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -2646,8 +2646,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     GenericTestUtils.waitFor(() -> {
       try {
         ContainerInfo containerInfo = scm.getContainerInfo(containerID);
-        System.out.println("state " + containerInfo.getState());
-        return containerInfo.getState() == HddsProtos.LifeCycleState.CLOSING;
+        HddsProtos.LifeCycleState state = containerInfo.getState();
+        System.out.println("state " + state);
+        return state == HddsProtos.LifeCycleState.CLOSING
+            || state == HddsProtos.LifeCycleState.QUASI_CLOSED;
       } catch (IOException e) {
         fail("Failed to get container info for " + e.getMessage());
         return false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.ReconstructECContainersCommandHandler;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,6 +102,10 @@ public class TestECContainerRecovery {
     datanodeConfiguration.setRecoveringContainerScrubInterval(
             Duration.of(10, ChronoUnit.SECONDS));
     conf.setFromObject(datanodeConfiguration);
+    ContainerScannerConfiguration scannerConf =
+            conf.getObject(ContainerScannerConfiguration.class);
+    scannerConf.setEnabled(false);
+    conf.setFromObject(scannerConf);
     ReplicationManager.ReplicationManagerConfiguration rmConfig = conf
             .getObject(
                     ReplicationManager.ReplicationManagerConfiguration.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a container replica is marked UNHEALTHY but its data is actually intact, the scanner now recovers it back to a healthy state (QUASI_CLOSED/CLOSED) automatically instead of leaving it stuck. This adds markContainerHealthy() to the container/handler interfaces, wires it through the scanner and reconciliation, and includes unit and integration tests.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11207

## How was this patch tested?
UT/CI/real cluster with fault injection. 