### PR TITLE
HDDS-15173. FSORepairTool throws ClassNotFoundException: org.apache.ozone.compaction.log.CompactionLogEntry

### DIFF
--- a/hadoop-ozone/cli-repair/pom.xml
+++ b/hadoop-ozone/cli-repair/pom.xml
@@ -150,6 +150,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>rocksdb-checkpoint-differ</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
@@ -177,11 +182,6 @@
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-test-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>rocksdb-checkpoint-differ</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
FSO repair tool is throwing java.lang.ClassNotFoundException: org.apache.ozone.compaction.log.CompactionLogEntry error. This is caused by the changes done in [HDDS-14595](https://issues.apache.org/jira/browse/HDDS-14595).

```
GMGFH9VX2V:ozone-2.2.0-SNAPSHOT sarvekshayr$ bin/ozone repair om fso-tree --db /Users/sarvekshayr/MINDB/om.db --dry-run
[dry run] Skipping OM service check in dry run mode.
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/ozone/compaction/log/CompactionLogEntry
        at org.apache.hadoop.ozone.om.codec.OMDBDefinition.<clinit>(OMDBDefinition.java:316)
        at org.apache.hadoop.ozone.repair.om.FSORepairTool.getStoreFromPath(FSORepairTool.java:625)
        at org.apache.hadoop.ozone.repair.om.FSORepairTool$Impl.<init>(FSORepairTool.java:147)
        at org.apache.hadoop.ozone.repair.om.FSORepairTool.execute(FSORepairTool.java:113)
        at org.apache.hadoop.ozone.repair.RepairTool.call(RepairTool.java:71)
        at org.apache.hadoop.ozone.repair.RepairTool.call(RepairTool.java:28)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
        at picocli.CommandLine.execute(CommandLine.java:2170)
        at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:89)
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:80)
        at org.apache.hadoop.ozone.repair.OzoneRepair.main(OzoneRepair.java:37)
Caused by: java.lang.ClassNotFoundException: org.apache.ozone.compaction.log.CompactionLogEntry
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
```
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15173

## How was this patch tested?
Manual Testing.

```
bin/ozone repair om fso-tree --db /Users/vrevuri/outside-omdb/om.db --volume=/volfs --bucket=buckfs 
ATTENTION: Running as user vrevuri. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: vrevuri
No running OM service detected. Proceeding with repair.
Creating database with reachable and pendingToDelete tables at /Users/vrevuri/outside-omdb/temp.db
Processing volume: /volfs
Processing bucket: volfs/buckfs

Reachable:
        Directories: 2
        Files: 3
        Bytes: 18
Unreachable (Pending to delete):
        Directories: 0
        Files: 0
        Bytes: 0
Unreferenced (Orphaned):
        Directories: 0
        Files: 0
        Bytes: 0
```
```
bin/ozone repair om fso-tree --db /Users/vrevuri/outside-omdb/om.db                                                                                                                 
ATTENTION: Running as user vrevuri. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: vrevuri
No running OM service detected. Proceeding with repair.
Creating database with reachable and pendingToDelete tables at /Users/vrevuri/outside-omdb/temp.db
Processing volume: /s3v
Processing volume: /volfs
Processing bucket: volfs/buckfs

Reachable:
        Directories: 2
        Files: 3
        Bytes: 18
Unreachable (Pending to delete):
        Directories: 0
        Files: 0
        Bytes: 0
Unreferenced (Orphaned):
        Directories: 0
        Files: 0
        Bytes: 0
```