### PR TITLE
HDDS-15248. Change KeyOutputStreamSemaphore log from debug to trace

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
@@ -49,9 +49,9 @@ public class KeyOutputStreamSemaphore {
   public void acquire() throws IOException {
     if (requestSemaphore != null) {
       try {
-        LOG.debug("Acquiring semaphore");
+        LOG.trace("Acquiring semaphore");
         requestSemaphore.acquire();
-        LOG.debug("Acquired semaphore");
+        LOG.trace("Acquired semaphore");
       } catch (InterruptedException e) {
         final String errMsg = "Write aborted. Interrupted waiting for KeyOutputStream semaphore: " + e.getMessage();
         LOG.error(errMsg);
@@ -63,9 +63,9 @@ public class KeyOutputStreamSemaphore {
 
   public void release() {
     if (requestSemaphore != null) {
-      LOG.debug("Releasing semaphore");
+      LOG.trace("Releasing semaphore");
       requestSemaphore.release();
-      LOG.debug("Released semaphore");
+      LOG.trace("Released semaphore");
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Downgraded the four semaphore log statements (Acquiring, Acquired, Releasing, Released) in KeyOutputStreamSemaphore.java from DEBUG to TRACE level. This makes them available for deep diagnostics without polluting normal debug logs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15248

## How was this patch tested?
Manual test with DEBUG logging.