### PR TITLE
HDDS-15238. ContainerSafeModeRule containers list refresh with only removing deleted containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRule.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -78,6 +79,27 @@ public abstract class AbstractContainerSafeModeRule extends SafeModeExitRule<Nod
         .filter(c -> c.getNumberOfKeys() > 0)
         .forEach(c -> containers.put(c.containerID(), c.getReplicationConfig().getMinimumNodes()));
     totalContainers.set(containers.size());
+    final long cutOff = (long) Math.ceil(getTotalNumberOfContainers() * getSafeModeCutoff());
+    getSafeModeMetrics().setNumContainerReportedThreshold(getContainerType(), cutOff);
+    SCMSafeModeManager.getLogger().info("Initialized {} Containers threshold count to {}.", getContainerType(), cutOff);
+  }
+
+  protected void reinitializeRule() {
+    // Remove closed containers that are moved to deleted state as DN will not report those containers during
+    // registration. Update totalContainers, cutoff and threshold based on reduced containers.
+    // Since ContainerSafeModeRule is updated with container list notified during DN registration only,
+    // So its not required to add newly created container after DN registration.
+    int oldContainerCount = containers.size();
+    Set<ContainerID> containerInfoSet = containerManager.getContainers(getContainerType()).stream()
+        .filter(this::isClosed)
+        .filter(c -> c.getNumberOfKeys() > 0)
+        .filter(c -> containers.containsKey(ContainerID.valueOf(c.getContainerID())))
+        .map(c -> ContainerID.valueOf(c.getContainerID()))
+        .collect(Collectors.toSet());
+    // remove deleted containers from containers list
+    containers.keySet().removeIf(c -> !containerInfoSet.contains(c));
+    // update new total with reducing removed containers
+    totalContainers.set(totalContainers.get() - (oldContainerCount - containers.size()));
     final long cutOff = (long) Math.ceil(getTotalNumberOfContainers() * getSafeModeCutoff());
     getSafeModeMetrics().setNumContainerReportedThreshold(getContainerType(), cutOff);
     SCMSafeModeManager.getLogger().info("Refreshed {} Containers threshold count to {}.", getContainerType(), cutOff);
@@ -136,7 +158,7 @@ public abstract class AbstractContainerSafeModeRule extends SafeModeExitRule<Nod
   @Override
   public synchronized void refresh(boolean forceRefresh) {
     if (forceRefresh || !validate()) {
-      initializeRule();
+      reinitializeRule();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
@@ -51,13 +51,17 @@ import org.junit.jupiter.params.provider.EnumSource;
 public abstract class AbstractContainerSafeModeRuleTest {
   private List<ContainerInfo> containers;
   private AbstractContainerSafeModeRule rule;
+  private SCMSafeModeManager safeModeManager;
+  private ConfigurationSource conf;
+  private ContainerManager containerManager;
+  private EventQueue eventQueue;
 
   @BeforeEach
   public void setup() throws ContainerNotFoundException {
-    final ContainerManager containerManager = mock(ContainerManager.class);
-    final ConfigurationSource conf = mock(ConfigurationSource.class);
-    final EventQueue eventQueue = mock(EventQueue.class);
-    final SCMSafeModeManager safeModeManager = mock(SCMSafeModeManager.class);
+    containerManager = mock(ContainerManager.class);
+    conf = mock(ConfigurationSource.class);
+    eventQueue = mock(EventQueue.class);
+    safeModeManager = mock(SCMSafeModeManager.class);
     final SafeModeMetrics metrics = mock(SafeModeMetrics.class);
 
     when(safeModeManager.getSafeModeMetrics()).thenReturn(metrics);
@@ -70,18 +74,25 @@ public abstract class AbstractContainerSafeModeRuleTest {
           .findFirst()
           .orElseThrow(ContainerNotFoundException::new);
     });
-
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
-    rule.setValidateBasedOnReportProcessing(false);
   }
 
   @Test
   public void testRefreshInitializeContainers() {
     containers.add(mockContainer(LifeCycleState.OPEN, 1L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 2L));
+    containers.add(mockContainer(LifeCycleState.CLOSED, 8L));
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(false);
+    assertEquals(2, rule.getTotalNumberOfContainers(), "Total number of containers should be 2");
+    containers.add(mockContainer(LifeCycleState.CLOSED, 2L));
+    containers.add(mockContainer(LifeCycleState.OPEN, 3L));
+    containers.add(mockContainer(LifeCycleState.CLOSED, 4L));
+    containers.removeIf(c -> c.containerID().equals(ContainerID.valueOf(8L)));
+    containers.add(mockContainer(LifeCycleState.DELETED, 8L));
     rule.refresh(true);
 
     assertEquals(0.0, rule.getCurrentContainerThreshold());
+    assertEquals(1, rule.getTotalNumberOfContainers(), "Total number of containers should be 1 after delete");
   }
 
   @ParameterizedTest
@@ -89,7 +100,8 @@ public abstract class AbstractContainerSafeModeRuleTest {
       names = {"OPEN", "CLOSING", "QUASI_CLOSED", "CLOSED", "DELETING", "DELETED", "RECOVERING"})
   public void testValidateReturnsTrueAndFalse(LifeCycleState state) {
     containers.add(mockContainer(state, 1L));
-    rule.refresh(true);
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(false);
 
     boolean expected = state != LifeCycleState.QUASI_CLOSED && state != LifeCycleState.CLOSED;
     assertEquals(expected, rule.validate());
@@ -99,7 +111,8 @@ public abstract class AbstractContainerSafeModeRuleTest {
   public void testProcessContainer() {
     long containerId = 123L;
     containers.add(mockContainer(LifeCycleState.CLOSED, containerId));
-    rule.refresh(true);
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(false);
 
     assertEquals(0.0, rule.getCurrentContainerThreshold());
 
@@ -129,21 +142,33 @@ public abstract class AbstractContainerSafeModeRuleTest {
 
   @Test
   public void testAllContainersClosed() {
+    containers.add(mockContainer(LifeCycleState.CLOSED, 1L));
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(false);
     containers.add(mockContainer(LifeCycleState.CLOSED, 11L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 32L));
     rule.refresh(true);
 
     assertEquals(0.0, rule.getCurrentContainerThreshold(), "Threshold should be 0.0 when all containers are closed");
     assertFalse(rule.validate(), "Validate should return false when all containers are closed");
+    assertEquals(1, rule.getTotalNumberOfContainers(), "Total number of containers should be 1 even after refresh");
   }
 
   @Test
   public void testAllContainersOpen() {
     containers.add(mockContainer(LifeCycleState.OPEN, 11L));
     containers.add(mockContainer(LifeCycleState.OPEN, 32L));
-    rule.refresh(true);
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(false);
 
     assertEquals(1.0, rule.getCurrentContainerThreshold(), "Threshold should be 1.0 when all containers are open");
+    assertTrue(rule.validate(), "Validate should return true when all containers are open");
+
+    containers.add(mockContainer(LifeCycleState.OPEN, 11L));
+    containers.add(mockContainer(LifeCycleState.OPEN, 32L));
+    rule.refresh(true);
+
+    assertEquals(1.0, rule.getCurrentContainerThreshold(), "Threshold should be 1.0 after refresh also");
     assertTrue(rule.validate(), "Validate should return true when all containers are open");
   }
 
@@ -151,7 +176,8 @@ public abstract class AbstractContainerSafeModeRuleTest {
   public void testDuplicateContainerIdsInReports() {
     long containerId = 42L;
     containers.add(mockContainer(LifeCycleState.OPEN, containerId));
-    rule.refresh(true);
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(false);
 
     ContainerReplicaProto replica = mock(ContainerReplicaProto.class);
     ContainerReportsProto containerReport = mock(ContainerReportsProto.class);
@@ -172,10 +198,10 @@ public abstract class AbstractContainerSafeModeRuleTest {
 
   @Test
   public void testValidateBasedOnReportProcessingTrue() {
-    rule.setValidateBasedOnReportProcessing(true);
     long containerId = 1L;
     containers.add(mockContainer(LifeCycleState.OPEN, containerId));
-    rule.refresh(true);
+    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    rule.setValidateBasedOnReportProcessing(true);
 
     ContainerReplicaProto replica = mock(ContainerReplicaProto.class);
     ContainerReportsProto reportsProto = mock(ContainerReportsProto.class);
@@ -196,10 +222,10 @@ public abstract class AbstractContainerSafeModeRuleTest {
   protected abstract ReplicationType getReplicationType();
 
   protected abstract AbstractContainerSafeModeRule createRule(
-      EventQueue eventQueue,
-      ConfigurationSource conf,
-      ContainerManager containerManager,
-      SCMSafeModeManager safeModeManager
+      EventQueue eventQueueParam,
+      ConfigurationSource confParam,
+      ContainerManager containerManagerParam,
+      SCMSafeModeManager safeModeManagerParam
   );
 
   protected abstract ContainerInfo mockContainer(LifeCycleState state, long containerID);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.params.provider.EnumSource;
  */
 public abstract class AbstractContainerSafeModeRuleTest {
   private List<ContainerInfo> containers;
-  private AbstractContainerSafeModeRule rule;
   private SCMSafeModeManager safeModeManager;
   private ConfigurationSource conf;
   private ContainerManager containerManager;
@@ -81,7 +80,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
     containers.add(mockContainer(LifeCycleState.OPEN, 1L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 2L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 8L));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
     assertEquals(2, rule.getTotalNumberOfContainers(), "Total number of containers should be 2");
     containers.add(mockContainer(LifeCycleState.CLOSED, 2L));
@@ -100,7 +99,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
       names = {"OPEN", "CLOSING", "QUASI_CLOSED", "CLOSED", "DELETING", "DELETED", "RECOVERING"})
   public void testValidateReturnsTrueAndFalse(LifeCycleState state) {
     containers.add(mockContainer(state, 1L));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
 
     boolean expected = state != LifeCycleState.QUASI_CLOSED && state != LifeCycleState.CLOSED;
@@ -111,7 +110,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
   public void testProcessContainer() {
     long containerId = 123L;
     containers.add(mockContainer(LifeCycleState.CLOSED, containerId));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
 
     assertEquals(0.0, rule.getCurrentContainerThreshold());
@@ -143,7 +142,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
   @Test
   public void testAllContainersClosed() {
     containers.add(mockContainer(LifeCycleState.CLOSED, 1L));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
     containers.add(mockContainer(LifeCycleState.CLOSED, 11L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 32L));
@@ -158,7 +157,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
   public void testAllContainersOpen() {
     containers.add(mockContainer(LifeCycleState.OPEN, 11L));
     containers.add(mockContainer(LifeCycleState.OPEN, 32L));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
 
     assertEquals(1.0, rule.getCurrentContainerThreshold(), "Threshold should be 1.0 when all containers are open");
@@ -176,7 +175,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
   public void testDuplicateContainerIdsInReports() {
     long containerId = 42L;
     containers.add(mockContainer(LifeCycleState.OPEN, containerId));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
 
     ContainerReplicaProto replica = mock(ContainerReplicaProto.class);
@@ -200,7 +199,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
   public void testValidateBasedOnReportProcessingTrue() {
     long containerId = 1L;
     containers.add(mockContainer(LifeCycleState.OPEN, containerId));
-    rule = createRule(eventQueue, conf, containerManager, safeModeManager);
+    AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(true);
 
     ContainerReplicaProto replica = mock(ContainerReplicaProto.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refresh for (RatisContainerSafeModeRule / ECContainerSafeModeRule) can result in adding newly created containers. But DN which has already registered, will not notify again newly created container to Safemode Rule.

So this can result in stuck of safemode rule if 99% of containers are not reported by DN.

As fix,
- keep same containers list in Safemode rule as initialized during startup
- remove deleted containers from the list and update reduced total containers, cutoff, threshold

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15238

## How was this patch tested?

- Test cases updated for the change of refresh
