### PR TITLE
HDDS-15252. Consider forked Hadoop RPC for code coverage

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -34,7 +34,7 @@ source "$SCRIPT_DIR"/testlib.sh
 if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
    java -cp "$PROJECT_DIR"/share/coverage/$(ls "$PROJECT_DIR"/share/coverage | grep test-util):"$PROJECT_DIR"/share/coverage/jacoco-core.jar org.apache.ozone.test.JacocoServer &
    DOCKER_BRIDGE_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
-   export OZONE_OPTS="-javaagent:share/coverage/jacoco-agent.jar=output=tcpclient,address=$DOCKER_BRIDGE_IP,includes=org.apache.hadoop.ozone.*:org.apache.hadoop.hdds.*:org.apache.hadoop.fs.ozone.*:org.apache.ozone.*:org.hadoop.ozone.*"
+   export OZONE_OPTS="-javaagent:share/coverage/jacoco-agent.jar=output=tcpclient,address=$DOCKER_BRIDGE_IP,includes=org.apache.hadoop.ozone.*:org.apache.hadoop.hdds.*:org.apache.hadoop.fs.ozone.*:org.apache.ozone.*:org.apache.hadoop.ipc_.*:org.apache.hadoop.security_.*"
 fi
 
 cd "$SCRIPT_DIR"

--- a/pom.xml
+++ b/pom.xml
@@ -2340,7 +2340,7 @@
               <goal>prepare-agent</goal>
             </goals>
             <configuration>
-              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*,org.apache.hadoop.fs.ozone.*,org.apache.ozone.*</includes>
+              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*,org.apache.hadoop.fs.ozone.*,org.apache.ozone.*,org.apache.hadoop.ipc_.*,org.apache.hadoop.security_.*</includes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Coverage for RPC code forked from Hadoop is reported as 0%, because package names are missing from the include lists.

https://issues.apache.org/jira/browse/HDDS-15252

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/25753820223

1. [Download](https://github.com/adoroszlai/ozone/actions/runs/25753820223/artifacts/6954163947) and unzip coverage.zip. 
2. Verify that coverage increased from 0% for the packages affected:
    - `org.apache.hadoop.ipc_`
    - `org.apache.hadoop.ipc_.metrics`
    - `org.apache.hadoop.ipc_.protobuf`
    - `org.apache.hadoop.security_`

<img width="1356" height="60" alt="1-before" src="https://github.com/user-attachments/assets/eb2deb37-71f6-464a-a69d-223b28c5b889" />
<img width="1356" height="60" alt="2-after" src="https://github.com/user-attachments/assets/401e3baf-5096-448e-953d-d55979fe11fb" />
