### PR TITLE
HDDS-15191. Add ScmInvoker subclasses for the remaining SCMHandler(s)

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvokerCodeGenerator;
-import org.apache.hadoop.hdds.scm.ha.invoker.SequenceIdStateManagerInvoker;
+import org.apache.hadoop.hdds.scm.ha.invoker.SequenceIdGeneratorStateManagerInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
@@ -332,7 +332,7 @@ public class SequenceIdGenerator {
 
         final StateManager impl = new StateManagerImpl(table, buffer);
 
-        return ratisServer.getProxyHandler(new SequenceIdStateManagerInvoker(impl, ratisServer));
+        return ratisServer.getProxyHandler(new SequenceIdGeneratorStateManagerInvoker(impl, ratisServer));
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvokerCodeGenerator;
+import org.apache.hadoop.hdds.scm.ha.invoker.SequenceIdStateManagerInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
@@ -187,7 +189,7 @@ public class SequenceIdGenerator {
   /**
    * Maintain SequenceIdTable in RocksDB.
    */
-  interface StateManager extends SCMHandler {
+  public interface StateManager extends SCMHandler {
     /**
      * Compare And Swap lastId saved in db from expectedLastId to newLastId.
      * If based on Ratis, it will submit a raft client request.
@@ -217,6 +219,10 @@ public class SequenceIdGenerator {
     @Override
     default RequestType getType() {
       return RequestType.SEQUENCE_ID;
+    }
+
+    static void main(String[] args) {
+      ScmInvokerCodeGenerator.generate(StateManager.class, true);
     }
   }
 
@@ -326,7 +332,7 @@ public class SequenceIdGenerator {
 
         final StateManager impl = new StateManagerImpl(table, buffer);
 
-        return ratisServer.getProxyHandler(StateManager.class, impl);
+        return ratisServer.getProxyHandler(new SequenceIdStateManagerInvoker(impl, ratisServer));
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.ha;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvokerCodeGenerator;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.utils.db.Table;
 
@@ -70,5 +71,9 @@ public interface StatefulServiceStateManager extends SCMHandler {
   @Override
   default RequestType getType() {
     return RequestType.STATEFUL_SERVICE_CONFIG;
+  }
+
+  static void main(String[] args) {
+    ScmInvokerCodeGenerator.generate(StatefulServiceStateManager.class, true);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/StatefulServiceStateManagerImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.ha;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.hadoop.hdds.scm.ha.invoker.StatefulServiceStateManagerInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.slf4j.Logger;
@@ -129,11 +130,11 @@ public final class StatefulServiceStateManagerImpl
       Objects.requireNonNull(statefulServiceConfig, "statefulServiceConfig == null");
       Objects.requireNonNull(transactionBuffer, "transactionBuffer == null");
 
-      final StatefulServiceStateManager stateManager =
+      final StatefulServiceStateManager impl =
           new StatefulServiceStateManagerImpl(statefulServiceConfig,
               transactionBuffer);
 
-      return scmRatisServer.getProxyHandler(StatefulServiceStateManager.class, stateManager);
+      return scmRatisServer.getProxyHandler(new StatefulServiceStateManagerInvoker(impl, scmRatisServer));
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/FinalizationStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/FinalizationStateManagerInvoker.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha.invoker;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationCheckpoint;
+import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationStateManager;
+import org.apache.hadoop.hdds.scm.server.upgrade.SCMUpgradeFinalizationContext;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.ratis.protocol.Message;
+
+/** Code generated for {@link FinalizationStateManager}.  Do not modify. */
+public class FinalizationStateManagerInvoker extends ScmInvoker<FinalizationStateManager> {
+  enum ReplicateMethod implements NameAndParameterTypes {
+    addFinalizingMark(new Class<?>[][] {
+        new Class<?>[] {}
+    }),
+    finalizeLayoutFeature(new Class<?>[][] {
+        null,
+        new Class<?>[] {Integer.class}
+    }),
+    removeFinalizingMark(new Class<?>[][] {
+        new Class<?>[] {}
+    });
+
+    private final Class<?>[][] parameterTypes;
+
+    ReplicateMethod(Class<?>[][] parameterTypes) {
+      this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes(int numArgs) {
+      return parameterTypes[numArgs];
+    }
+  }
+
+  public FinalizationStateManagerInvoker(FinalizationStateManager impl, SCMRatisServer ratis) {
+    super(impl, FinalizationStateManagerInvoker::newProxy, ratis);
+  }
+
+  @Override
+  public Class<FinalizationStateManager> getApi() {
+    return FinalizationStateManager.class;
+  }
+
+  static FinalizationStateManager newProxy(ScmInvoker<FinalizationStateManager> invoker) {
+    return new FinalizationStateManager() {
+
+      @Override
+      public void addFinalizingMark() throws IOException {
+        final Object[] args = {};
+        invoker.invokeReplicateDirect(ReplicateMethod.addFinalizingMark, args);
+      }
+
+      @Override
+      public boolean crossedCheckpoint(FinalizationCheckpoint arg0) {
+        return invoker.getImpl().crossedCheckpoint(arg0);
+      }
+
+      @Override
+      public void finalizeLayoutFeature(Integer arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.finalizeLayoutFeature, args);
+      }
+
+      @Override
+      public FinalizationCheckpoint getFinalizationCheckpoint() {
+        return invoker.getImpl().getFinalizationCheckpoint();
+      }
+
+      @Override
+      public void reinitialize(Table<String, String> arg0) throws IOException {
+        invoker.getImpl().reinitialize(arg0);
+      }
+
+      @Override
+      public void removeFinalizingMark() throws IOException {
+        final Object[] args = {};
+        invoker.invokeReplicateDirect(ReplicateMethod.removeFinalizingMark, args);
+      }
+
+      @Override
+      public void setUpgradeContext(SCMUpgradeFinalizationContext arg0) {
+        invoker.getImpl().setUpgradeContext(arg0);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
+    switch (methodName) {
+    case "addFinalizingMark":
+      getImpl().addFinalizingMark();
+      return Message.EMPTY;
+
+    case "crossedCheckpoint":
+      final FinalizationCheckpoint arg0 = p.length > 0 ? (FinalizationCheckpoint) p[0] : null;
+      returnType = boolean.class;
+      returnValue = getImpl().crossedCheckpoint(arg0);
+      break;
+
+    case "finalizeLayoutFeature":
+      final Integer arg1 = p.length > 0 ? (Integer) p[0] : null;
+      getImpl().finalizeLayoutFeature(arg1);
+      return Message.EMPTY;
+
+    case "getFinalizationCheckpoint":
+      returnType = FinalizationCheckpoint.class;
+      returnValue = getImpl().getFinalizationCheckpoint();
+      break;
+
+    case "reinitialize":
+      final Table<String, String> arg2 = p.length > 0 ? (Table<String, String>) p[0] : null;
+      getImpl().reinitialize(arg2);
+      return Message.EMPTY;
+
+    case "removeFinalizingMark":
+      getImpl().removeFinalizingMark();
+      return Message.EMPTY;
+
+    case "setUpgradeContext":
+      final SCMUpgradeFinalizationContext arg3 = p.length > 0 ? (SCMUpgradeFinalizationContext) p[0] : null;
+      getImpl().setUpgradeContext(arg3);
+      return Message.EMPTY;
+
+    default:
+      throw new IllegalArgumentException("Method not found: " + methodName + " in FinalizationStateManager");
+    }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -88,8 +88,13 @@ public final class ScmInvokerCodeGenerator {
   private ScmInvokerCodeGenerator(Class<?> api) {
     this.api = api;
     this.apiName = api.getSimpleName();
-    this.invokerClassName = apiName + "Invoker";
+    this.invokerClassName = getInvokerClassName(api);
+  }
 
+  static String getInvokerClassName(Class<?> api) {
+    final String name = api.getSimpleName() + "Invoker";
+    final Class<?> enclosing = api.getEnclosingClass();
+    return enclosing == null ? name : enclosing.getSimpleName() + name;
   }
 
   void printf(String format, Object... args) {
@@ -562,12 +567,14 @@ public final class ScmInvokerCodeGenerator {
       final String args = IntStream.range(0, method.getParameterCount())
           .mapToObj(i -> "arg" + i)
           .reduce("", (a, b) -> a.isEmpty() ? b : a + ", " + b);
-      final String returnString = method.getReturnType() == void.class ? "" : "return ";
+      final Class<?> returnType = method.getReturnType();
       if (r != null) {
+        final String returnString = returnType == void.class ? "" : "return (" + returnType.getSimpleName() + ")";
         final String type = r.invocationType() == Replicate.InvocationType.DIRECT ? "Direct" : "Client";
         println("final Object[] args = {%s};", args);
         println("%sinvoker.invokeReplicate%s(ReplicateMethod.%s, args);", returnString, type, method.getName());
       } else {
+        final String returnString = returnType == void.class ? "" : "return ";
         println("%sinvoker.getImpl().%s(%s);", returnString, method.getName(), args);
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SecretKeyStateInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SecretKeyStateInvoker.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha.invoker;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
+import org.apache.hadoop.hdds.security.symmetric.SecretKeyState;
+import org.apache.ratis.protocol.Message;
+
+/** Code generated for {@link SecretKeyState}.  Do not modify. */
+public class SecretKeyStateInvoker extends ScmInvoker<SecretKeyState> {
+  enum ReplicateMethod implements NameAndParameterTypes {
+    updateKeys(new Class<?>[][] {
+        null,
+        new Class<?>[] {List.class}
+    });
+
+    private final Class<?>[][] parameterTypes;
+
+    ReplicateMethod(Class<?>[][] parameterTypes) {
+      this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes(int numArgs) {
+      return parameterTypes[numArgs];
+    }
+  }
+
+  public SecretKeyStateInvoker(SecretKeyState impl, SCMRatisServer ratis) {
+    super(impl, SecretKeyStateInvoker::newProxy, ratis);
+  }
+
+  @Override
+  public Class<SecretKeyState> getApi() {
+    return SecretKeyState.class;
+  }
+
+  static SecretKeyState newProxy(ScmInvoker<SecretKeyState> invoker) {
+    return new SecretKeyState() {
+
+      @Override
+      public ManagedSecretKey getCurrentKey() {
+        return invoker.getImpl().getCurrentKey();
+      }
+
+      @Override
+      public ManagedSecretKey getKey(UUID arg0) {
+        return invoker.getImpl().getKey(arg0);
+      }
+
+      @Override
+      public List<ManagedSecretKey> getSortedKeys() {
+        return invoker.getImpl().getSortedKeys();
+      }
+
+      @Override
+      public void reinitialize(List<ManagedSecretKey> arg0) {
+        invoker.getImpl().reinitialize(arg0);
+      }
+
+      @Override
+      public void updateKeys(List<ManagedSecretKey> arg0) throws SCMException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.updateKeys, args);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
+    switch (methodName) {
+    case "getCurrentKey":
+      returnType = ManagedSecretKey.class;
+      returnValue = getImpl().getCurrentKey();
+      break;
+
+    case "getKey":
+      final UUID arg0 = p.length > 0 ? (UUID) p[0] : null;
+      returnType = ManagedSecretKey.class;
+      returnValue = getImpl().getKey(arg0);
+      break;
+
+    case "getSortedKeys":
+      returnType = List.class;
+      returnValue = getImpl().getSortedKeys();
+      break;
+
+    case "reinitialize":
+      final List<ManagedSecretKey> arg1 = p.length > 0 ? (List<ManagedSecretKey>) p[0] : null;
+      getImpl().reinitialize(arg1);
+      return Message.EMPTY;
+
+    case "updateKeys":
+      final List<ManagedSecretKey> arg2 = p.length > 0 ? (List<ManagedSecretKey>) p[0] : null;
+      getImpl().updateKeys(arg2);
+      return Message.EMPTY;
+
+    default:
+      throw new IllegalArgumentException("Method not found: " + methodName + " in SecretKeyState");
+    }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SequenceIdGeneratorStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SequenceIdGeneratorStateManagerInvoker.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator.StateManager;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.ratis.protocol.Message;
 
-/** Code generated for {@link SequenceIdGenerator.StateManager}.  Do not modify. */
+/** Code generated for {@link StateManager}.  Do not modify. */
 public class SequenceIdGeneratorStateManagerInvoker extends ScmInvoker<StateManager> {
   enum ReplicateMethod implements NameAndParameterTypes {
     allocateBatch(new Class<?>[][] {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SequenceIdGeneratorStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SequenceIdGeneratorStateManagerInvoker.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator.StateManager;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.ratis.protocol.Message;
 
-/** Code generated for {@link StateManager}.  Do not modify. */
-public class SequenceIdStateManagerInvoker extends ScmInvoker<StateManager> {
+/** Code generated for {@link SequenceIdGenerator.StateManager}.  Do not modify. */
+public class SequenceIdGeneratorStateManagerInvoker extends ScmInvoker<StateManager> {
   enum ReplicateMethod implements NameAndParameterTypes {
     allocateBatch(new Class<?>[][] {
         null,
@@ -47,8 +47,8 @@ public class SequenceIdStateManagerInvoker extends ScmInvoker<StateManager> {
     }
   }
 
-  public SequenceIdStateManagerInvoker(StateManager impl, SCMRatisServer ratis) {
-    super(impl, SequenceIdStateManagerInvoker::newProxy, ratis);
+  public SequenceIdGeneratorStateManagerInvoker(StateManager impl, SCMRatisServer ratis) {
+    super(impl, SequenceIdGeneratorStateManagerInvoker::newProxy, ratis);
   }
 
   @Override
@@ -62,7 +62,7 @@ public class SequenceIdStateManagerInvoker extends ScmInvoker<StateManager> {
       @Override
       public Boolean allocateBatch(String arg0, Long arg1, Long arg2) throws SCMException {
         final Object[] args = {arg0, arg1, arg2};
-        return (Boolean) invoker.invokeReplicateDirect(ReplicateMethod.allocateBatch, args);
+        return (Boolean)invoker.invokeReplicateDirect(ReplicateMethod.allocateBatch, args);
       }
 
       @Override
@@ -71,7 +71,7 @@ public class SequenceIdStateManagerInvoker extends ScmInvoker<StateManager> {
       }
 
       @Override
-      public void reinitialize(Table<String, Long> arg0) throws IOException {
+      public void reinitialize(Table arg0) throws IOException {
         invoker.getImpl().reinitialize(arg0);
       }
     };
@@ -98,12 +98,13 @@ public class SequenceIdStateManagerInvoker extends ScmInvoker<StateManager> {
       break;
 
     case "reinitialize":
-      final Table<String, Long> arg4 = p.length > 0 ? (Table<String, Long>) p[0] : null;
+      final Table arg4 = p.length > 0 ? (Table) p[0] : null;
       getImpl().reinitialize(arg4);
       return Message.EMPTY;
 
     default:
-      throw new IllegalArgumentException("Method not found: " + methodName + " in StateManager");
+      throw new IllegalArgumentException("Method not found: " + methodName
+          + " in SequenceIdGenerator.StateManager");
     }
 
     return SCMRatisResponse.encode(returnValue, returnType);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SequenceIdStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/SequenceIdStateManagerInvoker.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha.invoker;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator.StateManager;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.ratis.protocol.Message;
+
+/** Code generated for {@link StateManager}.  Do not modify. */
+public class SequenceIdStateManagerInvoker extends ScmInvoker<StateManager> {
+  enum ReplicateMethod implements NameAndParameterTypes {
+    allocateBatch(new Class<?>[][] {
+        null,
+        null,
+        null,
+        new Class<?>[] {String.class, Long.class, Long.class}
+    });
+
+    private final Class<?>[][] parameterTypes;
+
+    ReplicateMethod(Class<?>[][] parameterTypes) {
+      this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes(int numArgs) {
+      return parameterTypes[numArgs];
+    }
+  }
+
+  public SequenceIdStateManagerInvoker(StateManager impl, SCMRatisServer ratis) {
+    super(impl, SequenceIdStateManagerInvoker::newProxy, ratis);
+  }
+
+  @Override
+  public Class<StateManager> getApi() {
+    return StateManager.class;
+  }
+
+  static StateManager newProxy(ScmInvoker<StateManager> invoker) {
+    return new StateManager() {
+
+      @Override
+      public Boolean allocateBatch(String arg0, Long arg1, Long arg2) throws SCMException {
+        final Object[] args = {arg0, arg1, arg2};
+        return (Boolean) invoker.invokeReplicateDirect(ReplicateMethod.allocateBatch, args);
+      }
+
+      @Override
+      public Long getLastId(String arg0) {
+        return invoker.getImpl().getLastId(arg0);
+      }
+
+      @Override
+      public void reinitialize(Table<String, Long> arg0) throws IOException {
+        invoker.getImpl().reinitialize(arg0);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
+    switch (methodName) {
+    case "allocateBatch":
+      final String arg0 = p.length > 0 ? (String) p[0] : null;
+      final Long arg1 = p.length > 1 ? (Long) p[1] : null;
+      final Long arg2 = p.length > 2 ? (Long) p[2] : null;
+      returnType = Boolean.class;
+      returnValue = getImpl().allocateBatch(arg0, arg1, arg2);
+      break;
+
+    case "getLastId":
+      final String arg3 = p.length > 0 ? (String) p[0] : null;
+      returnType = Long.class;
+      returnValue = getImpl().getLastId(arg3);
+      break;
+
+    case "reinitialize":
+      final Table<String, Long> arg4 = p.length > 0 ? (Table<String, Long>) p[0] : null;
+      getImpl().reinitialize(arg4);
+      return Message.EMPTY;
+
+    default:
+      throw new IllegalArgumentException("Method not found: " + methodName + " in StateManager");
+    }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/StatefulServiceStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/StatefulServiceStateManagerInvoker.java
@@ -74,7 +74,7 @@ public class StatefulServiceStateManagerInvoker extends ScmInvoker<StatefulServi
       }
 
       @Override
-      public void reinitialize(Table<String, ByteString> arg0) {
+      public void reinitialize(Table arg0) {
         invoker.getImpl().reinitialize(arg0);
       }
 
@@ -104,7 +104,7 @@ public class StatefulServiceStateManagerInvoker extends ScmInvoker<StatefulServi
       break;
 
     case "reinitialize":
-      final Table<String, ByteString> arg2 = p.length > 0 ? (Table<String, ByteString>) p[0] : null;
+      final Table arg2 = p.length > 0 ? (Table) p[0] : null;
       getImpl().reinitialize(arg2);
       return Message.EMPTY;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/StatefulServiceStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/StatefulServiceStateManagerInvoker.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha.invoker;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.ratis.protocol.Message;
+
+/** Code generated for {@link StatefulServiceStateManager}.  Do not modify. */
+public class StatefulServiceStateManagerInvoker extends ScmInvoker<StatefulServiceStateManager> {
+  enum ReplicateMethod implements NameAndParameterTypes {
+    deleteConfiguration(new Class<?>[][] {
+        null,
+        new Class<?>[] {String.class}
+    }),
+    saveConfiguration(new Class<?>[][] {
+        null,
+        null,
+        new Class<?>[] {String.class, ByteString.class}
+    });
+
+    private final Class<?>[][] parameterTypes;
+
+    ReplicateMethod(Class<?>[][] parameterTypes) {
+      this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes(int numArgs) {
+      return parameterTypes[numArgs];
+    }
+  }
+
+  public StatefulServiceStateManagerInvoker(StatefulServiceStateManager impl, SCMRatisServer ratis) {
+    super(impl, StatefulServiceStateManagerInvoker::newProxy, ratis);
+  }
+
+  @Override
+  public Class<StatefulServiceStateManager> getApi() {
+    return StatefulServiceStateManager.class;
+  }
+
+  static StatefulServiceStateManager newProxy(ScmInvoker<StatefulServiceStateManager> invoker) {
+    return new StatefulServiceStateManager() {
+
+      @Override
+      public void deleteConfiguration(String arg0) throws IOException {
+        final Object[] args = {arg0};
+        invoker.invokeReplicateDirect(ReplicateMethod.deleteConfiguration, args);
+      }
+
+      @Override
+      public ByteString readConfiguration(String arg0) throws IOException {
+        return invoker.getImpl().readConfiguration(arg0);
+      }
+
+      @Override
+      public void reinitialize(Table<String, ByteString> arg0) {
+        invoker.getImpl().reinitialize(arg0);
+      }
+
+      @Override
+      public void saveConfiguration(String arg0, ByteString arg1) throws IOException {
+        final Object[] args = {arg0, arg1};
+        invoker.invokeReplicateDirect(ReplicateMethod.saveConfiguration, args);
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Message invokeLocal(String methodName, Object[] p) throws Exception {
+    final Class<?> returnType;
+    final Object returnValue;
+    switch (methodName) {
+    case "deleteConfiguration":
+      final String arg0 = p.length > 0 ? (String) p[0] : null;
+      getImpl().deleteConfiguration(arg0);
+      return Message.EMPTY;
+
+    case "readConfiguration":
+      final String arg1 = p.length > 0 ? (String) p[0] : null;
+      returnType = ByteString.class;
+      returnValue = getImpl().readConfiguration(arg1);
+      break;
+
+    case "reinitialize":
+      final Table<String, ByteString> arg2 = p.length > 0 ? (Table<String, ByteString>) p[0] : null;
+      getImpl().reinitialize(arg2);
+      return Message.EMPTY;
+
+    case "saveConfiguration":
+      final String arg3 = p.length > 0 ? (String) p[0] : null;
+      final ByteString arg4 = p.length > 1 ? (ByteString) p[1] : null;
+      getImpl().saveConfiguration(arg3, arg4);
+      return Message.EMPTY;
+
+    default:
+      throw new IllegalArgumentException("Method not found: " + methodName + " in StatefulServiceStateManager");
+    }
+
+    return SCMRatisResponse.encode(returnValue, returnType);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/ScmSecretKeyStateBuilder.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/ScmSecretKeyStateBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.security;
 
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.ha.invoker.SecretKeyStateInvoker;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyState;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyStateImpl;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyStore;
@@ -44,6 +45,6 @@ public class ScmSecretKeyStateBuilder {
 
   public SecretKeyState build() {
     final SecretKeyState impl = new SecretKeyStateImpl(secretKeyStore);
-    return scmRatisServer.getProxyHandler(SecretKeyState.class, impl);
+    return scmRatisServer.getProxyHandler(new SecretKeyStateInvoker(impl, scmRatisServer));
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.server.upgrade;
 import java.io.IOException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.ha.SCMHandler;
+import org.apache.hadoop.hdds.scm.ha.invoker.ScmInvokerCodeGenerator;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.utils.db.Table;
 
@@ -58,5 +59,9 @@ public interface FinalizationStateManager extends SCMHandler {
   @Override
   default RequestType getType() {
     return RequestType.FINALIZE;
+  }
+
+  static void main(String[] args) {
+    ScmInvokerCodeGenerator.generate(FinalizationStateManager.class, true);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationStateManagerImpl.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.ha.invoker.FinalizationStateManagerInvoker;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
@@ -326,7 +327,8 @@ public class FinalizationStateManagerImpl implements FinalizationStateManager {
       Objects.requireNonNull(transactionBuffer, "transactionBuffer == null");
       Objects.requireNonNull(upgradeFinalizer, "upgradeFinalizer == null");
 
-      return scmRatisServer.getProxyHandler(FinalizationStateManager.class, new FinalizationStateManagerImpl(this));
+      final FinalizationStateManager impl = new FinalizationStateManagerImpl(this);
+      return scmRatisServer.getProxyHandler(new FinalizationStateManagerInvoker(impl, scmRatisServer));
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The remaining SCMHandler(s) are:
* FinalizationStateManager
* SecretKeyState
* SequenceIdGenerator$StateManager
* StatefulServiceStateManager

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15191

## How was this patch tested?
CI(https://github.com/YutaLin/ozone/actions/runs/25711803021)