### PR TITLE
HDDS-15257. [DiskBalancer] Add CLOSING state to the "not movable" check

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerConfiguration.java
@@ -347,7 +347,7 @@ public final class DiskBalancerConfiguration {
                 + "Valid names are: " + Arrays.toString(State.values()),
             ex);
       }
-      if (HddsUtils.isOpenToWriteState(state) || state == State.DELETED) {
+      if (HddsUtils.isOpenToWriteState(state) || state == State.CLOSING || state == State.DELETED) {
         throw new IllegalArgumentException("State " + name + " is not movable.");
       }
       states.add(State.valueOf(name));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -520,8 +520,8 @@ public class TestDiskBalancerService {
             new HashSet<>(Arrays.asList(State.CLOSED, State.QUASI_CLOSED)), null),
         Arguments.of("  QUASI_CLOSED  ", true,
             new HashSet<>(Arrays.asList(State.QUASI_CLOSED)), null),
-        Arguments.of("CLOSING,CLOSED", true,
-            new HashSet<>(Arrays.asList(State.CLOSING, State.CLOSED)), null),
+        Arguments.of("CLOSING,CLOSED", false, new HashSet<>(Arrays.
+                asList(State.CLOSING, State.CLOSED)), "State CLOSING is not movable"),
         Arguments.of("  QUASI_CLOSED,CLOSED ", true,
             new HashSet<>(Arrays.asList(State.CLOSED, State.QUASI_CLOSED)), null),
         Arguments.of("  QUASI_CLOSED , CLOSED ", true,


### PR DESCRIPTION
## What changes were proposed in this pull request?
**isOpenToWriteState(state)** only returns true for `OPEN` and `RECOVERING`:

```
  public static boolean isOpenToWriteState(State state) {
    return state == State.OPEN || state == State.RECOVERING;
  } 
```
**CLOSING** is not covered. So when this validation in DiskBalancerConfiguration runs, it only blocks **OPEN, RECOVERING, and DELETED**. A user who configures `movableContainerStates = CLOSING` would not get an error — the config would silently allow DiskBalancer to try to move containers in CLOSING state.

**Fix:** 

```
if (HddsUtils.isOpenToWriteState(state) || state == State.CLOSING || state == State.DELETED) {
    throw new IllegalArgumentException("State " + name + " is not movable.");
} 
 
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15257

## How was this patch tested?

Updated unit test and tested manually.
