### PR TITLE
HDDS-15005. Delete EC replica when container state is DELETING in SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -246,6 +246,7 @@ abstract class AbstractContainerReportHandler {
 
     final ContainerID containerId = container.containerID();
     boolean replicaIsEmpty = replica.hasIsEmpty() && replica.getIsEmpty();
+    HddsProtos.ReplicationType replicationType = container.getReplicationType();
 
     switch (container.getState()) {
     case OPEN:
@@ -274,8 +275,7 @@ abstract class AbstractContainerReportHandler {
         guaranteed to have block data. So, update the container's state in SCM
         only if replica index is one of these indexes.
          */
-        if (container.getReplicationType()
-            .equals(HddsProtos.ReplicationType.EC)) {
+        if (replicationType.equals(HddsProtos.ReplicationType.EC)) {
           int replicaIndex = replica.getReplicaIndex();
           int dataNum =
               ((ECReplicationConfig)container.getReplicationConfig()).getData();
@@ -314,19 +314,23 @@ abstract class AbstractContainerReportHandler {
         deleteReplica(containerId, datanode, publisher, "DELETED", false, detailsForLogging);
         return false;
       }
-      if (container.getReplicationType().equals(HddsProtos.ReplicationType.EC)) {
+      if (replicationType.equals(HddsProtos.ReplicationType.EC)) {
         // In case of EC container, delete its replica to avoid orphan replica
         deleteReplica(containerId, datanode, publisher, "DELETED", true, detailsForLogging);
         return false;
       }
       // HDDS-12421: fall-through to case DELETING
     case DELETING:
+      if (replicationType.equals(HddsProtos.ReplicationType.EC) && !replicaIsEmpty) {
+        deleteReplica(containerId, datanode, publisher, "DELETING", true, detailsForLogging);
+        return false;
+      }
       // HDDS-11136: If a DELETING container has a non-empty CLOSED replica, transition the container to CLOSED
       // HDDS-12421: If a DELETING or DELETED container has a non-empty replica, transition the container to CLOSED
       boolean isReplicaClosed = replica.getState() == State.CLOSED;
       boolean isReplicaQuasiClosed = replica.getState() == State.QUASI_CLOSED;
       if ((isReplicaClosed || isReplicaQuasiClosed) && replica.getBlockCommitSequenceId() <= container.getSequenceId()
-          && container.getReplicationType().equals(HddsProtos.ReplicationType.RATIS)) {
+          && replicationType.equals(HddsProtos.ReplicationType.RATIS)) {
         deleteReplica(containerId, datanode, publisher, "DELETED", true, detailsForLogging);
         // We should not move back CLOSED or QUASI_CLOSED if replica bcsId <= container bcsId
         return false;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -209,10 +210,6 @@ public class TestContainerReportHandler {
               replicaState.equals(ContainerReplicaProto.State.QUASI_CLOSED)) &&
               (containerState.equals(HddsProtos.LifeCycleState.DELETED) ||
               containerState.equals(HddsProtos.LifeCycleState.DELETING))) {
-            continue;
-          }
-          if (replicationType == HddsProtos.ReplicationType.EC &&
-              containerState.equals(HddsProtos.LifeCycleState.DELETED)) {
             continue;
           }
           for (ContainerReplicaProto.State invalidState : invalidReplicaStates) {
@@ -514,13 +511,13 @@ public class TestContainerReportHandler {
   }
 
   /**
-   * Tests that a DELETING or DELETED RATIS/EC container transitions to CLOSED if a non-empty replica in OPEN, CLOSING,
-   * CLOSED, QUASI_CLOSED or UNHEALTHY state is reported.
+   * Tests that a DELETING or DELETED RATIS container transitions to CLOSED or QUASI_CLOSED depending on
+   * non-empty replica state. EC does not resurrect and non-empty replica gets a force-delete command.
    * It should not transition if the replica is in INVALID or DELETED states.
    */
   @ParameterizedTest
   @MethodSource("containerAndReplicaStates")
-  public void containerShouldTransitionFromDeletingOrDeletedToClosedWhenNonEmptyReplica(
+  public void containerTransitionFromDeletingOrDeletedWhenNonEmptyReplica(
       HddsProtos.ReplicationType replicationType,
       LifeCycleState containerState,
       ContainerReplicaProto.State replicaState,
@@ -565,22 +562,23 @@ public class TestContainerReportHandler {
      * replicationType        EC
      */
 
-    // should transition on processing the valid replica's report
+    clearInvocations(publisher);
+
     ContainerReportsProto closedContainerReport = getContainerReports(validReplica);
     containerReportHandler
         .onMessage(new ContainerReportFromDatanode(dnWithValidReplica, closedContainerReport), publisher);
-    // Determine expected state based on replica state
-    LifeCycleState expectedState;
-    if (replicaState == ContainerReplicaProto.State.CLOSED) {
-      expectedState = LifeCycleState.CLOSED;
-    } else {
-      expectedState = LifeCycleState.QUASI_CLOSED;
-    }
-    assertEquals(expectedState, containerStateManager.getContainer(container.containerID()).getState());
 
-    // verify that no delete command is issued for non-empty replica, regardless of container state
-    verify(publisher, times(0))
-        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), any(CommandForDatanode.class));
+    if (replicationType == HddsProtos.ReplicationType.EC) {
+      assertEquals(containerState, containerStateManager.getContainer(container.containerID()).getState());
+      verify(publisher, times(1))
+          .fireEvent(eq(SCMEvents.DATANODE_COMMAND), any(CommandForDatanode.class));
+    } else {
+      LifeCycleState expectedState = replicaState == ContainerReplicaProto.State.CLOSED
+          ? LifeCycleState.CLOSED : LifeCycleState.QUASI_CLOSED;
+      assertEquals(expectedState, containerStateManager.getContainer(container.containerID()).getState());
+      verify(publisher, times(0))
+          .fireEvent(eq(SCMEvents.DATANODE_COMMAND), any(CommandForDatanode.class));
+    }
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -302,18 +302,20 @@ public class TestContainerStateManager {
   }
 
   /**
-   * DELETED EC container in SCM.
+   * DELETED/DELETING EC container in SCM.
    * Expected: Should send force delete to DN
    */
-  @Test
-  public void testDeletedECContainerWithStaleClosedReplicaShouldNotForceDelete()
+  @ParameterizedTest
+  @EnumSource(value = HddsProtos.LifeCycleState.class,
+      names = {"DELETING", "DELETED"})
+  public void testECContainerWithStaleClosedReplicaShouldForceDelete(HddsProtos.LifeCycleState state)
       throws IOException {
     final DatanodeDetails datanode = randomDatanodeDetails();
     nodeManager.register(datanode, null, null);
-    // Create a DELETED EC container
+    // Create an EC container
     ECReplicationConfig repConfig = new ECReplicationConfig(3, 2);
     final ContainerInfo ecContainer = getECContainer(
-        HddsProtos.LifeCycleState.DELETED,
+        state,
         PipelineID.randomId(),
         repConfig);
     containerStateManager.addContainer(ecContainer.getProtobuf());
@@ -322,8 +324,8 @@ public class TestContainerStateManager {
     // Verify delete command sent
     sendReportAndCaptureDeleteCommand(ecContainer, datanode,
         ecContainer.getSequenceId(), false, 1, true);
-    // Container should remain as DELETED
-    verifyContainerState(ecContainer.containerID(), HddsProtos.LifeCycleState.DELETED);
+    // Container should be deleted
+    verifyContainerState(ecContainer.containerID(), state);
   }
 
   private DeleteContainerCommand sendReportAndCaptureDeleteCommand(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -322,8 +322,10 @@ public class TestContainerStateManager {
     assertEquals(HddsProtos.ReplicationType.EC, ecContainer.getReplicationType());
 
     // Verify delete command sent
-    sendReportAndCaptureDeleteCommand(ecContainer, datanode,
+    DeleteContainerCommand deleteCmd = sendReportAndCaptureDeleteCommand(ecContainer, datanode,
         ecContainer.getSequenceId(), false, 1, true);
+    verifyForceDeleteCommand(deleteCmd, ecContainer.containerID(), true, 
+        "Delete command should have force=true for stale EC non-empty replica");
     // Container should be deleted
     verifyContainerState(ecContainer.containerID(), state);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -34,8 +34,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -54,7 +57,8 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for container report handling.
@@ -63,32 +67,63 @@ public class TestContainerReportHandling {
   private static final String VOLUME = "vol1";
   private static final String BUCKET = "bucket1";
   private static final String KEY = "key1";
+  
+  private enum ReplicationInput {
+    RATIS(3, RatisReplicationConfig.getInstance(THREE)),
+    EC(5, new ECReplicationConfig(3, 2));
+
+    private final int numDatanodes;
+    private final ReplicationConfig replicationConfig;
+
+    ReplicationInput(int numDatanodes, ReplicationConfig replicationConfig) {
+      this.numDatanodes = numDatanodes;
+      this.replicationConfig = replicationConfig;
+    }
+
+    int getNumDatanodes() {
+      return numDatanodes;
+    }
+
+    ReplicationConfig getReplicationConfig() {
+      return replicationConfig;
+    }
+  }
+
+  private static Stream<Arguments> delStatesAndReplication() {
+    return Stream.of(
+            HddsProtos.LifeCycleState.DELETING,
+            HddsProtos.LifeCycleState.DELETED)
+        .flatMap(state -> Stream.of(
+            Arguments.of(state, ReplicationInput.RATIS),
+            Arguments.of(state, ReplicationInput.EC)));
+  }
 
   /**
    * Tests that a DELETING (or DELETED) container replica gets deleted when replica bcsid <= container bcsid
+   * applicable to RATIS; EC ignores bcsid.
    * To do this, the test first creates a key and closes its corresponding container. Then it moves that container to
    * DELETING (or DELETED) state using ContainerManager. Then it restarts a Datanode hosting that container,
    * making it send a full container report.
-   * Tests wait for a DELETING (or DELETED) container replica gets deleted when replica bcsid <= container bcsid
+   * Tests wait for a DELETING (or DELETED) container replica gets deleted based on the bcsid comparison.
    */
   @ParameterizedTest
-  @EnumSource(value = HddsProtos.LifeCycleState.class,
-      names = {"DELETING", "DELETED"})
+  @MethodSource("delStatesAndReplication")
   void testDeletingOrDeletedContainerWhenNonEmptyReplicaIsReported(
-      HddsProtos.LifeCycleState desiredState)
+      HddsProtos.LifeCycleState desiredState,
+      ReplicationInput replicationInput)
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
 
     Path clusterPath = null;
-    try (MiniOzoneCluster cluster = newCluster(conf)) {
+    try (MiniOzoneCluster cluster = newCluster(conf, replicationInput.getNumDatanodes())) {
       cluster.waitForClusterToBeReady();
       clusterPath = Paths.get(cluster.getBaseDir());
 
       try (OzoneClient client = cluster.newClient()) {
         // create a container and close it
-        createTestData(client);
+        createTestData(client, replicationInput.getReplicationConfig());
         List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
         assertThat(keyLocations).isNotEmpty();
         OmKeyLocationInfo keyLocation = keyLocations.get(0);
@@ -136,10 +171,10 @@ public class TestContainerReportHandling {
     }
   }
 
-  private static MiniOzoneCluster newCluster(OzoneConfiguration conf)
+  private static MiniOzoneCluster newCluster(OzoneConfiguration conf, int numDatanodes)
       throws IOException {
     return MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(3)
+        .setNumDatanodes(numDatanodes)
         .build();
   }
 
@@ -156,7 +191,7 @@ public class TestContainerReportHandling {
     return locations.getLocationList();
   }
 
-  private void createTestData(OzoneClient client) throws IOException {
+  private void createTestData(OzoneClient client, ReplicationConfig replicationConfig) throws IOException {
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(VOLUME);
     OzoneVolume volume = objectStore.getVolume(VOLUME);
@@ -164,8 +199,7 @@ public class TestContainerReportHandling {
 
     OzoneBucket bucket = volume.getBucket(BUCKET);
 
-    TestDataUtil.createKey(bucket, KEY,
-        RatisReplicationConfig.getInstance(THREE), "Hello".getBytes(UTF_8));
+    TestDataUtil.createKey(bucket, KEY, replicationConfig, "Hello".getBytes(UTF_8));
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
@@ -36,8 +35,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -67,35 +64,14 @@ public class TestContainerReportHandling {
   private static final String VOLUME = "vol1";
   private static final String BUCKET = "bucket1";
   private static final String KEY = "key1";
-  
-  private enum ReplicationInput {
-    RATIS(3, RatisReplicationConfig.getInstance(THREE)),
-    EC(5, new ECReplicationConfig(3, 2));
-
-    private final int numDatanodes;
-    private final ReplicationConfig replicationConfig;
-
-    ReplicationInput(int numDatanodes, ReplicationConfig replicationConfig) {
-      this.numDatanodes = numDatanodes;
-      this.replicationConfig = replicationConfig;
-    }
-
-    int getNumDatanodes() {
-      return numDatanodes;
-    }
-
-    ReplicationConfig getReplicationConfig() {
-      return replicationConfig;
-    }
-  }
 
   private static Stream<Arguments> delStatesAndReplication() {
     return Stream.of(
             HddsProtos.LifeCycleState.DELETING,
             HddsProtos.LifeCycleState.DELETED)
         .flatMap(state -> Stream.of(
-            Arguments.of(state, ReplicationInput.RATIS),
-            Arguments.of(state, ReplicationInput.EC)));
+            Arguments.of(state, TestHelper.ReplicationInput.RATIS),
+            Arguments.of(state, TestHelper.ReplicationInput.EC)));
   }
 
   /**
@@ -110,7 +86,7 @@ public class TestContainerReportHandling {
   @MethodSource("delStatesAndReplication")
   void testDeletingOrDeletedContainerWhenNonEmptyReplicaIsReported(
       HddsProtos.LifeCycleState desiredState,
-      ReplicationInput replicationInput)
+      TestHelper.ReplicationInput replicationInput)
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
@@ -152,7 +128,7 @@ public class TestContainerReportHandling {
         }
 
         // Since replica state is CLOSED and container is DELETED/DELETING in SCM
-        // also bcsid of replica and container is same, SCM will trigger delete replica
+        // bcsid of replica and container is same, SCM will trigger delete replica for RATIS, while EC ignores bcsid
         // wait for all replica to be deleted
         GenericTestUtils.waitFor(() -> {
           try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -35,8 +35,11 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -57,7 +60,8 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for container report handling with SCM High Availability.
@@ -67,18 +71,49 @@ public class TestContainerReportHandlingWithHA {
   private static final String BUCKET = "bucket1";
   private static final String KEY = "key1";
 
+  private enum ReplicationInput {
+    RATIS(3, RatisReplicationConfig.getInstance(THREE)),
+    EC(5, new ECReplicationConfig(3, 2));
+
+    private final int numDatanodes;
+    private final ReplicationConfig replicationConfig;
+
+    ReplicationInput(int numDatanodes, ReplicationConfig replicationConfig) {
+      this.numDatanodes = numDatanodes;
+      this.replicationConfig = replicationConfig;
+    }
+
+    int getNumDatanodes() {
+      return numDatanodes;
+    }
+
+    ReplicationConfig getReplicationConfig() {
+      return replicationConfig;
+    }
+  }
+
+  private static Stream<Arguments> delStatesAndReplication() {
+    return Stream.of(
+            HddsProtos.LifeCycleState.DELETING,
+            HddsProtos.LifeCycleState.DELETED)
+        .flatMap(state -> Stream.of(
+            Arguments.of(state, ReplicationInput.RATIS),
+            Arguments.of(state, ReplicationInput.EC)));
+  }
+
   /**
    * Tests that a DELETING (or DELETED) container replica gets deleted when replica bcsid <= container bcsid
+   * applicable to RATIS; EC ignores bcsid.
    * To do this, the test first creates a key and closes its corresponding container. Then it moves that container to
    * DELETING (or DELETED) state using ContainerManager. Then it restarts Datanodes hosting that container,
    * making it send a full container report.
-   * Tests wait for a DELETING (or DELETED) container replica gets deleted when replica bcsid <= container bcsid
+   * Tests wait for a DELETING (or DELETED) container replica gets deleted based on the bcsid comparison.
    */
   @ParameterizedTest
-  @EnumSource(value = HddsProtos.LifeCycleState.class,
-      names = {"DELETING", "DELETED"})
+  @MethodSource("delStatesAndReplication")
   void testDeletingOrDeletedContainerWhenNonEmptyReplicaIsReportedWithScmHA(
-      HddsProtos.LifeCycleState desiredState)
+      HddsProtos.LifeCycleState desiredState,
+      ReplicationInput replicationInput)
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
@@ -86,13 +121,13 @@ public class TestContainerReportHandlingWithHA {
 
     int numSCM = 3;
     Path clusterPath = null;
-    try (MiniOzoneHAClusterImpl cluster = newHACluster(conf, numSCM)) {
+    try (MiniOzoneHAClusterImpl cluster = newHACluster(conf, numSCM, replicationInput.getNumDatanodes())) {
       cluster.waitForClusterToBeReady();
       clusterPath = Paths.get(cluster.getBaseDir());
 
       try (OzoneClient client = cluster.newClient()) {
         // create a container and close it
-        createTestData(client);
+        createTestData(client, replicationInput.getReplicationConfig());
         List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
         assertThat(keyLocations).isNotEmpty();
         OmKeyLocationInfo keyLocation = keyLocations.get(0);
@@ -138,13 +173,15 @@ public class TestContainerReportHandlingWithHA {
     }
   }
 
-  private static MiniOzoneHAClusterImpl newHACluster(OzoneConfiguration conf, int numSCM) throws IOException {
-    return MiniOzoneCluster.newHABuilder(conf)
+  private static MiniOzoneHAClusterImpl newHACluster(OzoneConfiguration conf, int numSCM, int numDatanodes)
+      throws IOException {
+    MiniOzoneHAClusterImpl.Builder haBuilder = MiniOzoneCluster.newHABuilder(conf)
         .setOMServiceId("om-service")
         .setSCMServiceId("scm-service")
         .setNumOfOzoneManagers(1)
-        .setNumOfStorageContainerManagers(numSCM)
-        .build();
+        .setNumOfStorageContainerManagers(numSCM);
+    haBuilder.setNumDatanodes(numDatanodes);
+    return haBuilder.build();
   }
 
   private static List<OmKeyLocationInfo> lookupKey(MiniOzoneCluster cluster)
@@ -160,7 +197,7 @@ public class TestContainerReportHandlingWithHA {
     return locations.getLocationList();
   }
 
-  private void createTestData(OzoneClient client) throws IOException {
+  private void createTestData(OzoneClient client, ReplicationConfig replicationConfig) throws IOException {
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(VOLUME);
     OzoneVolume volume = objectStore.getVolume(VOLUME);
@@ -168,8 +205,7 @@ public class TestContainerReportHandlingWithHA {
 
     OzoneBucket bucket = volume.getBucket(BUCKET);
 
-    TestDataUtil.createKey(bucket, KEY,
-        RatisReplicationConfig.getInstance(THREE), "Hello".getBytes(UTF_8));
+    TestDataUtil.createKey(bucket, KEY, replicationConfig, "Hello".getBytes(UTF_8));
   }
 
   private static void waitForContainerStateInAllSCMs(MiniOzoneHAClusterImpl cluster, ContainerID containerID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
@@ -37,8 +36,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -71,34 +68,13 @@ public class TestContainerReportHandlingWithHA {
   private static final String BUCKET = "bucket1";
   private static final String KEY = "key1";
 
-  private enum ReplicationInput {
-    RATIS(3, RatisReplicationConfig.getInstance(THREE)),
-    EC(5, new ECReplicationConfig(3, 2));
-
-    private final int numDatanodes;
-    private final ReplicationConfig replicationConfig;
-
-    ReplicationInput(int numDatanodes, ReplicationConfig replicationConfig) {
-      this.numDatanodes = numDatanodes;
-      this.replicationConfig = replicationConfig;
-    }
-
-    int getNumDatanodes() {
-      return numDatanodes;
-    }
-
-    ReplicationConfig getReplicationConfig() {
-      return replicationConfig;
-    }
-  }
-
   private static Stream<Arguments> delStatesAndReplication() {
     return Stream.of(
             HddsProtos.LifeCycleState.DELETING,
             HddsProtos.LifeCycleState.DELETED)
         .flatMap(state -> Stream.of(
-            Arguments.of(state, ReplicationInput.RATIS),
-            Arguments.of(state, ReplicationInput.EC)));
+            Arguments.of(state, TestHelper.ReplicationInput.RATIS),
+            Arguments.of(state, TestHelper.ReplicationInput.EC)));
   }
 
   /**
@@ -113,7 +89,7 @@ public class TestContainerReportHandlingWithHA {
   @MethodSource("delStatesAndReplication")
   void testDeletingOrDeletedContainerWhenNonEmptyReplicaIsReportedWithScmHA(
       HddsProtos.LifeCycleState desiredState,
-      ReplicationInput replicationInput)
+      TestHelper.ReplicationInput replicationInput)
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
@@ -155,7 +131,7 @@ public class TestContainerReportHandlingWithHA {
         }
 
         // Since replica state is CLOSED and container is DELETED/DELETING in SCM
-        // also bcsid of replica and container is same, SCM will trigger delete replica
+        // bcsid of replica and container is same, SCM will trigger delete replica for RATIS, while EC ignores bcsid
         // wait for all replica to be deleted
         GenericTestUtils.waitFor(() -> {
           try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,6 +37,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -485,5 +488,29 @@ public final class TestHelper {
         return false;
       }
     }, 2000, 20000);
+  }
+
+  /**
+   * Defines the replication configs and required DN counts for different replication types (such as RATIS and EC).
+   */
+  public enum ReplicationInput {
+    RATIS(3, RatisReplicationConfig.getInstance(THREE)),
+    EC(5, new ECReplicationConfig(3, 2));
+
+    private final int numDatanodes;
+    private final ReplicationConfig replicationConfig;
+
+    ReplicationInput(int numDatanodes, ReplicationConfig replicationConfig) {
+      this.numDatanodes = numDatanodes;
+      this.replicationConfig = replicationConfig;
+    }
+
+    int getNumDatanodes() {
+      return numDatanodes;
+    }
+
+    ReplicationConfig getReplicationConfig() {
+      return replicationConfig;
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When EC container state is `DELETING` in SCM, and any EC non-empty replica reports back to SCM, SCM should delete this replica as this replica will remain in orphan state. This can happen when some old DN is bought back which was containing some replica.

## What is the link to the Apache JIRA
[HDDS-15005](https://issues.apache.org/jira/browse/HDDS-15005)

## How was this patch tested?
Added unit and integration tests.
