### PR TITLE
HDDS-15231. Wait for healthy KDC before starting Ozone

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -24,6 +24,9 @@ x-common-config:
     - ./krb5.conf:/etc/krb5.conf
   env_file:
     - docker-config
+  depends_on:
+    kdc:
+      condition: service_healthy
 
 services:
   kdc:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -25,6 +25,9 @@ x-common-config:
     - ./krb5.conf:/etc/krb5.conf
   env_file:
     - docker-config
+  depends_on:
+    kdc:
+      condition: service_healthy
 
 services:
   kdc:

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
@@ -22,6 +22,9 @@ x-common-config:
     - ../../../common/security.conf
   image: ${OZONE_TEST_IMAGE}
   dns_search: .
+  depends_on:
+    kdc:
+      condition: service_healthy
 
 x-environment:
   &environment
@@ -29,7 +32,6 @@ x-environment:
   OZONE_UPGRADE_TO: ${OZONE_UPGRADE_TO:-0}
   OZONE_UPGRADE_FROM: ${OZONE_UPGRADE_FROM:-0}
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-  WAITFOR: kdc:88
 
 x-datanode:
   &datanode


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up to HDDS-15177: wait for healthy KDC before starting Ozone services (in remaining secure acceptance tests), to prevent intermittent failure due to keytab/KDC not being ready yet:

```
failure to login: for principal: s3g/s3g@EXAMPLE.COM from keytab /etc/security/keytabs/s3g.keytab javax.security.auth.login.LoginException: Unable to obtain password from user
```

https://issues.apache.org/jira/browse/HDDS-15231

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/25785072552