### PR TITLE
HDDS-15223. Stabilize TestReconAndAdminContainerCLI.testMissingContainer

### DIFF
--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -107,9 +107,9 @@ class TestReconAndAdminContainerCLI {
 
   /** Pause between SCM/Recon checks while waiting for matching reports. */
   private static final int RM_RECON_COMPARE_POLL_INTERVAL_MS = 1000;
-  /** Max wait (Recon can trail SCM briefly; CI load makes this worse). */
+  /** Max wait (Recon can trail SCM briefly). */
   private static final int RM_RECON_COMPARE_WAIT_MS = 90_000;
-  /** Matching reports must hold this many polls in a row so one lucky tick does not pass the test. */
+  /** Matching reports must hold this many polls in a row. */
   private static final int RM_RECON_COMPARE_STABLE_POLLS = 2;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -109,7 +109,10 @@ class TestReconAndAdminContainerCLI {
   private static final int RM_RECON_COMPARE_POLL_INTERVAL_MS = 1000;
   /** Max wait (Recon can trail SCM briefly). */
   private static final int RM_RECON_COMPARE_WAIT_MS = 90_000;
-  /** Matching reports must hold this many polls in a row. */
+  /**
+   * Two matches in a row on purpose. A single agreeing poll can be luck while RM and Recon counts
+   * are still drifting past each other (HDDS-15223).
+   */
   private static final int RM_RECON_COMPARE_STABLE_POLLS = 2;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -103,6 +104,13 @@ import org.slf4j.event.Level;
 class TestReconAndAdminContainerCLI {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestReconAndAdminContainerCLI.class);
+
+  /** Pause between SCM/Recon checks while waiting for matching reports. */
+  private static final int RM_RECON_COMPARE_POLL_INTERVAL_MS = 1000;
+  /** Max wait (Recon can trail SCM briefly; CI load makes this worse). */
+  private static final int RM_RECON_COMPARE_WAIT_MS = 90_000;
+  /** Matching reports must hold this many polls in a row so one lucky tick does not pass the test. */
+  private static final int RM_RECON_COMPARE_STABLE_POLLS = 2;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
   private static ScmClient scmClient;
@@ -186,7 +194,6 @@ class TestReconAndAdminContainerCLI {
    * but it's easier to test with Ratis ONE.
    */
   @Test
-  @Flaky("HDDS-15223")
   void testMissingContainer() throws Exception {
     String keyNameR1 = "key2";
     long containerID = setupRatisKey(recon, keyNameR1,
@@ -311,18 +318,22 @@ class TestReconAndAdminContainerCLI {
   }
 
   /**
-   * The purpose of this method, isn't to validate the numbers
-   * but to make sure that they are consistent between
-   * Recon and the ReplicationManager.
+   * Checks that SCM's replication manager and Recon show the same unhealthy stats
+   * (counts and RM sample IDs in Recon's list). Waits until that lines up for a short
+   * stretch of time so a one-off tick does not hide a real mismatch (HDDS-15223).
    */
   private static void compareRMReportToReconResponse(UnHealthyContainerStates containerState)
       throws Exception {
     assertNotNull(containerState);
 
-    // Both threads are running every 1 second.
-    // Wait until all values are equal.
-    GenericTestUtils.waitFor(() -> assertReportsMatch(containerState),
-        1000, 40000);
+    AtomicInteger stablePolls = new AtomicInteger(0);
+    GenericTestUtils.waitFor(() -> {
+      if (assertReportsMatch(containerState)) {
+        return stablePolls.incrementAndGet() >= RM_RECON_COMPARE_STABLE_POLLS;
+      }
+      stablePolls.set(0);
+      return false;
+    }, RM_RECON_COMPARE_POLL_INTERVAL_MS, RM_RECON_COMPARE_WAIT_MS);
   }
 
   private static boolean assertReportsMatch(UnHealthyContainerStates state) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The test now waits longer for Replication Manager and Recon to report the same unhealthy container numbers.
- It only passes when those numbers match on two polls in a row, not a single check.
- The `@Flaky("HDDS-15223")` tag was removed from testMissingContainer.

Please describe your PR in detail:
Replication Manager and Recon don’t always update at the exact same moment. Under CI load, the test could see them briefly disagree (or “cross” each other) while both sides are still catching up. The old wait was short (40 seconds) and treated one matching snapshot as success, which was easy to hit as a timeout or a misleading pass.

This change only hardens the test:

- 90 second cap on waiting (still polling every second).
- Two consecutive successful full comparisons before the test continues.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15223

## How was this patch tested?
1. Triggered flakky-test-check
https://github.com/arunsarin85/ozone/actions/runs/25793920652