### PR TITLE
HDDS-15262. [Recon] Fix incorrect datanode insight values when a DN goes down

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/DataNodeMetricsService.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/DataNodeMetricsService.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -42,7 +41,7 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.ozone.recon.MetricsServiceProviderFactory;
@@ -123,7 +122,7 @@ public class DataNodeMetricsService {
       return;
     }
 
-    Set<DatanodeDetails> nodes = reconNodeManager.getNodeStats().keySet();
+    List<DatanodeInfo> nodes = reconNodeManager.getAllNodes();
     if (nodes.isEmpty()) {
       LOG.warn("No datanodes found to query");
       resetState();
@@ -151,7 +150,7 @@ public class DataNodeMetricsService {
   /**
    * Collects metrics from all datanodes. Processes completed tasks first, waits for all.
    */
-  private void collectMetrics(Set<DatanodeDetails> nodes) {
+  private void collectMetrics(List<DatanodeInfo> nodes) {
     try {
       CollectionContext context = submitMetricsCollectionTasks(nodes);
       processCollectionFutures(context);
@@ -167,14 +166,14 @@ public class DataNodeMetricsService {
    * Submits metrics collection tasks for all given datanodes.
    * @return A context object containing tracking structures for the submitted futures.
    */
-  private CollectionContext submitMetricsCollectionTasks(Set<DatanodeDetails> nodes) {
+  private CollectionContext submitMetricsCollectionTasks(List<DatanodeInfo> nodes) {
     // Initialize state
     List<DatanodePendingDeletionMetrics> results = new ArrayList<>(nodes.size());
     // Submit all collection tasks
     Map<DatanodePendingDeletionMetrics, Future<DatanodePendingDeletionMetrics>> futures = new HashMap<>();
 
     long submissionTime = System.currentTimeMillis();
-    for (DatanodeDetails node : nodes) {
+    for (DatanodeInfo node : nodes) {
       DataNodeMetricsCollectionTask task = new DataNodeMetricsCollectionTask(
           node, httpsEnabled, metricsServiceProviderFactory);
       DatanodePendingDeletionMetrics key = new DatanodePendingDeletionMetrics(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/DataNodeMetricsCollectionTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/DataNodeMetricsCollectionTask.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.recon.tasks;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.ozone.recon.MetricsServiceProviderFactory;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.DatanodePendingDeletionMetrics;
@@ -39,14 +39,14 @@ import org.slf4j.LoggerFactory;
 public class DataNodeMetricsCollectionTask implements Callable<DatanodePendingDeletionMetrics> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataNodeMetricsCollectionTask.class);
-  private final DatanodeDetails nodeDetails;
+  private final DatanodeInfo nodeDetails;
   private final boolean httpsEnabled;
   private final MetricsServiceProvider metricsServiceProvider;
   private static final String BEAN_NAME = "Hadoop:service=HddsDatanode,name=BlockDeletingService";
   private static final String METRICS_KEY = "TotalPendingBlockBytes";
 
   public DataNodeMetricsCollectionTask(
-      DatanodeDetails nodeDetails,
+      DatanodeInfo nodeDetails,
       boolean httpsEnabled,
       MetricsServiceProviderFactory factory) {
     this.nodeDetails = nodeDetails;
@@ -78,7 +78,7 @@ public class DataNodeMetricsCollectionTask implements Callable<DatanodePendingDe
 
   private String getJmxMetricsUrl() {
     String protocol = httpsEnabled ? "https" : "http";
-    Name portName = httpsEnabled ?  DatanodeDetails.Port.Name.HTTPS : DatanodeDetails.Port.Name.HTTP;
+    Name portName = httpsEnabled ?  Name.HTTPS : Name.HTTP;
     return String.format("%s://%s:%d/jmx",
         protocol,
         nodeDetails.getHostName(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request updates the metrics collection logic by migrating from DatanodeDetails to DatanodeInfo so that it can track dead nodes. So that the number of dn showing in storageDistribution and pendingDeletion will match and it will avoid confusions.

## What is the link to the Apache JIRA

HDDS-15262

## How was this patch tested?

Tested using existing unit testcases.
