### PR TITLE
HDDS-15261. Increment UNHEALTHY count when a container reaches sufficient unhealthy replicas

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -105,6 +105,12 @@ public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
       return true;
     }
 
+    if (health.getHealthState() == ContainerHealthResult.HealthState.UNHEALTHY) {
+      // Container is UNHEALTHY + SUFFICIENTLY REPLICATED
+      report.incrementAndSample(ContainerHealthState.UNHEALTHY, container);
+      LOG.debug("Container {} is sufficiently replicated with all unhealthy replicas", container);
+    }
+    
     return false;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
@@ -264,6 +264,24 @@ public class TestRatisUnhealthyReplicationCheckHandler {
   }
 
   @Test
+  public void testSufficientlyReplicatedWithAllUnhealthyReplicas() {
+    ContainerInfo container = createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(), 
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0);
+    requestBuilder.setContainerInfo(container).setContainerReplicas(replicas);
+
+    ContainerHealthResult health = handler.checkReplication(requestBuilder.build());
+    assertEquals(ContainerHealthResult.HealthState.UNHEALTHY, health.getHealthState());
+
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(ContainerHealthState.UNHEALTHY));
+    assertEquals(0, report.getStat(ContainerHealthState.UNHEALTHY_UNDER_REPLICATED));
+    assertEquals(0, report.getStat(ContainerHealthState.UNHEALTHY_OVER_REPLICATED));
+  }
+
+  @Test
   public void testOverReplicationWithAllUnhealthyReplicas() {
     ContainerInfo container =
         createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed a regression from [HDDS-14119](https://issues.apache.org/jira/browse/HDDS-14119) in `RatisUnhealthyReplicationCheckHandler`, where the `UNHEALTHY` container count was not being incremented in reports. While the handler correctly identified under- and over-replicated containers, it missed the count for containers that were sufficiently replicated but unhealthy. Added an explicit check to ensure these containers are accurately tracked after the replication health checks are performed.

## What is the link to the Apache JIRA
[HDDS-15261](https://issues.apache.org/jira/browse/HDDS-15261)

## How was this patch tested?
Before fix:
```
bash-5.1$ ozone admin container info 1
Container id: 1
Pipeline id: 60de5f05-1ac3-4ca7-9250-49a24d89fee0
Write PipelineId: 9c523134-f14d-466f-9a62-46faa585bcb7
Write Pipeline State: CLOSED
Container State: QUASI_CLOSED
SequenceId: 4
Datanodes: [f31498ed-62e5-4ecb-8758-dd65dab6a8cb/ozone-balancer-datanode2-1.ozone-balancer_default,
d2d8fd98-f8fb-46c0-80ec-116e8438f05f/ozone-balancer-datanode3-1.ozone-balancer_default,
c7174500-a46a-4038-82ee-ab0b780f4e1f/ozone-balancer-datanode1-1.ozone-balancer_default]
Replicas: [State: UNHEALTHY; ReplicaIndex: 0; SequenceId: 4; Origin: f31498ed-62e5-4ecb-8758-dd65dab6a8cb; Location: f31498ed-62e5-4ecb-8758-dd65dab6a8cb/ozone-balancer-datanode2-1.ozone-balancer_default,
State: UNHEALTHY; ReplicaIndex: 0; SequenceId: 4; Origin: c7174500-a46a-4038-82ee-ab0b780f4e1f; Location: d2d8fd98-f8fb-46c0-80ec-116e8438f05f/ozone-balancer-datanode3-1.ozone-balancer_default,
State: UNHEALTHY; ReplicaIndex: 0; SequenceId: 4; Origin: c7174500-a46a-4038-82ee-ab0b780f4e1f; Location: c7174500-a46a-4038-82ee-ab0b780f4e1f/ozone-balancer-datanode1-1.ozone-balancer_default]

bash-5.1$ ozone admin container report
Container Summary Report generated at 2026-05-13T10:00:57Z
==========================================================

Container State Summary
=======================
OPEN: 0
CLOSING: 0
QUASI_CLOSED: 1
CLOSED: 0
DELETING: 0
DELETED: 0
RECOVERING: 0

Container Health Summary
========================
HEALTHY: 0
UNDER_REPLICATED: 0
MIS_REPLICATED: 0
OVER_REPLICATED: 0
MISSING: 0
UNHEALTHY: 0
EMPTY: 0
OPEN_UNHEALTHY: 0
QUASI_CLOSED_STUCK: 1
OPEN_WITHOUT_PIPELINE: 0
UNHEALTHY_UNDER_REPLICATED: 0
UNHEALTHY_OVER_REPLICATED: 0
MISSING_UNDER_REPLICATED: 0
QUASI_CLOSED_STUCK_UNDER_REPLICATED: 0
QUASI_CLOSED_STUCK_OVER_REPLICATED: 0
QUASI_CLOSED_STUCK_MISSING: 0

First 100 QUASI_CLOSED_STUCK containers:
#1
```

After fix:
```
bash-5.1$ ozone admin container info 1
Container id: 1
Pipeline id: 22af1552-8a15-4beb-88cd-1a01a18539df
Write PipelineId: 67d407a5-07f9-4a53-a7e7-fc1bec2c1fd1
Write Pipeline State: OPEN
Container State: QUASI_CLOSED
SequenceId: 47
Datanodes: [1992c0bf-4e05-482b-a97f-7421d46a550d/ozone-balancer-datanode6-1.ozone-balancer_default,
2b8b19bb-832a-4a2b-9af1-577ea0eaee28/ozone-balancer-datanode2-1.ozone-balancer_default,
5a15ba14-ea5e-4db5-9ff2-25073f14bbda/ozone-balancer-datanode4-1.ozone-balancer_default]
Replicas: [State: UNHEALTHY; ReplicaIndex: 0; SequenceId: 47; Origin: 1992c0bf-4e05-482b-a97f-7421d46a550d; Location: 1992c0bf-4e05-482b-a97f-7421d46a550d/ozone-balancer-datanode6-1.ozone-balancer_default,
State: UNHEALTHY; ReplicaIndex: 0; SequenceId: 47; Origin: 2b8b19bb-832a-4a2b-9af1-577ea0eaee28; Location: 2b8b19bb-832a-4a2b-9af1-577ea0eaee28/ozone-balancer-datanode2-1.ozone-balancer_default,
State: UNHEALTHY; ReplicaIndex: 0; SequenceId: 47; Origin: 5a15ba14-ea5e-4db5-9ff2-25073f14bbda; Location: 5a15ba14-ea5e-4db5-9ff2-25073f14bbda/ozone-balancer-datanode4-1.ozone-balancer_default]

bash-5.1$ ozone admin container report

Container Summary Report generated at 2026-05-13T10:45:00Z
==========================================================

Container State Summary
=======================
OPEN: 0
CLOSING: 0
QUASI_CLOSED: 1
CLOSED: 0
DELETING: 0
DELETED: 0
RECOVERING: 0

Container Health Summary
========================
HEALTHY: 0
UNDER_REPLICATED: 0
MIS_REPLICATED: 0
OVER_REPLICATED: 0
MISSING: 0
UNHEALTHY: 1
EMPTY: 0
OPEN_UNHEALTHY: 0
QUASI_CLOSED_STUCK: 1
OPEN_WITHOUT_PIPELINE: 0
UNHEALTHY_UNDER_REPLICATED: 0
UNHEALTHY_OVER_REPLICATED: 0
MISSING_UNDER_REPLICATED: 0
QUASI_CLOSED_STUCK_UNDER_REPLICATED: 0
QUASI_CLOSED_STUCK_OVER_REPLICATED: 0
QUASI_CLOSED_STUCK_MISSING: 0

First 100 UNHEALTHY containers:
#1

First 100 QUASI_CLOSED_STUCK containers:
#1
```