### PR TITLE
HDDS-15254. Pass OZONE_OPTS to more containers to ensure coverage collection

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -23,8 +23,9 @@ x-common-config:
   env_file:
     - docker-config
 
-x-replication:
-  &replication
+x-environment:
+  &environment
+  OZONE_OPTS:
   OZONE-SITE.XML_ozone.server.default.replication: ${OZONE_REPLICATION_FACTOR:-1}
 
 services:
@@ -34,14 +35,14 @@ services:
       - 19864
       - 9882
     environment:
-      <<: *replication
+      <<: *environment
     command: ["ozone","datanode"]
   om1:
     <<: *common-config
     environment:
       WAITFOR: scm3:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
+      <<: *environment
     ports:
       - 9874:9874
       - 9862
@@ -52,7 +53,7 @@ services:
     environment:
       WAITFOR: scm3:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
+      <<: *environment
     ports:
       - 9874
       - 9862
@@ -63,7 +64,7 @@ services:
     environment:
       WAITFOR: scm3:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
+      <<: *environment
     ports:
       - 9874
       - 9862
@@ -76,7 +77,7 @@ services:
     environment:
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-      <<: *replication
+      <<: *environment
     command: ["ozone","scm"]
   scm2:
     <<: *common-config
@@ -86,7 +87,7 @@ services:
       WAITFOR: scm1:9894
       ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-      <<: *replication
+      <<: *environment
     command: ["ozone","scm"]
   scm3:
     <<: *common-config
@@ -96,20 +97,20 @@ services:
       WAITFOR: scm2:9894
       ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-      <<: *replication
+      <<: *environment
     command: ["ozone","scm"]
   httpfs:
     <<: *common-config
     environment:
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-      <<: *replication
+      <<: *environment
     ports:
       - 14000:14000
     command: [ "ozone","httpfs" ]
   s3g:
     <<: *common-config
     environment:
-      <<: *replication
+      <<: *environment
     ports:
       - 9878:9878
     command: ["ozone","s3g"]
@@ -118,5 +119,5 @@ services:
     ports:
       - 9888:9888
     environment:
-      <<: *replication
+      <<: *environment
     command: ["ozone","recon"]

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -14,42 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+x-common-config:
+  &common-config
+  build:
+    context: .
+    args:
+      - OZONE_RUNNER_IMAGE
+      - OZONE_RUNNER_VERSION
+  env_file:
+    - ./docker-config
+  environment:
+    OZONE_OPTS:
+  volumes:
+    - ../..:/opt/hadoop
+
 services:
-   datanode:
-      build:
-         context: .
-         args:
-            - OZONE_RUNNER_IMAGE
-            - OZONE_RUNNER_VERSION
-      volumes:
-        - ../..:/opt/hadoop
-      ports:
-        - 19864
-      env_file:
-        - ./docker-config
-   om:
-      build:
-         context: .
-         args:
-            - OZONE_RUNNER_IMAGE
-            - OZONE_RUNNER_VERSION
-      volumes:
-         - ../..:/opt/hadoop
-      ports:
-         - 9874:9874
-         - 9862:9862
-      env_file:
-          - ./docker-config
-   scm:
-      build:
-         context: .
-         args:
-            - OZONE_RUNNER_IMAGE
-            - OZONE_RUNNER_VERSION
-      volumes:
-         - ../..:/opt/hadoop
-      ports:
-         - 9876:9876
-         - 9860:9860
-      env_file:
-          - ./docker-config
+  datanode:
+    <<: *common-config
+    ports:
+      - 19864
+  om:
+    <<: *common-config
+    ports:
+      - 9874:9874
+      - 9862:9862
+  scm:
+    <<: *common-config
+    ports:
+      - 9876:9876
+      - 9860:9860

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -64,7 +64,8 @@ services:
       - 9862:9862
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      OZONE_OPTS: -Dcom.sun.net.ssl.checkRevocation=false
+      OZONE_OM_OPTS: -Dcom.sun.net.ssl.checkRevocation=false
+      OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","om"]
   httpfs:
     <<: *common-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
@@ -19,7 +19,6 @@ services:
     env_file:
       - vault.conf
     environment:
-      - OZONE_OPTS=-Dcom.sun.net.ssl.checkRevocation=false
       - OZONE_MANAGER_CLASSPATH=/opt/hadoop/share/ozone/lib/ozone-s3-secret-store-@project.version@.jar:/opt/hadoop/share/ozone/lib/vault-java-driver-@vault.driver.version@.jar
   vault:
     image: hashicorp/vault:1.13.2

--- a/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
@@ -21,8 +21,9 @@ x-common-config:
     - docker-config
   image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
-x-replication:
-  &replication
+x-environment:
+  &environment
+  OZONE_OPTS:
   OZONE-SITE.XML_ozone.server.default.replication: ${OZONE_REPLICATION_FACTOR:-1}
 
 x-datanode:
@@ -30,7 +31,7 @@ x-datanode:
   command: ["ozone","datanode"]
   <<: *common-config
   environment:
-    <<: *replication
+    <<: *environment
   ports:
     - 19864
     - 9882
@@ -68,7 +69,7 @@ services:
     <<: *common-config
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
+      <<: *environment
     networks:
       net:
         ipv4_address: 10.9.0.14
@@ -83,7 +84,7 @@ services:
     command: ["ozone","recon"]
     <<: *common-config
     environment:
-      <<: *replication
+      <<: *environment
     networks:
       net:
         ipv4_address: 10.9.0.15
@@ -97,7 +98,7 @@ services:
     command: ["ozone","s3g"]
     <<: *common-config
     environment:
-      <<: *replication
+      <<: *environment
     networks:
       net:
         ipv4_address: 10.9.0.16
@@ -113,7 +114,7 @@ services:
     environment:
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
-      <<: *replication
+      <<: *environment
     networks:
       net:
         ipv4_address: 10.9.0.17

--- a/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
@@ -66,7 +66,8 @@ services:
     hostname: om
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      OZONE_OPTS: -Dcom.sun.net.ssl.checkRevocation=false
+      OZONE_OM_OPTS: -Dcom.sun.net.ssl.checkRevocation=false
+      OZONE_OPTS:
     ports:
       - 9874:9874
       - 9862:9862


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance tests send coverage data via `jacoco-agent`, defined in `OZONE_OPTS`:

https://github.com/apache/ozone/blob/8c89c58b254d16b6a950084e75d5ea423207c6d0/hadoop-ozone/dist/src/main/compose/test-all.sh#L37

For this we pass `OZONE_OPTS` from local environment to containers (using the syntax `OZONE_OPTS:` without value).  This was missing in some compose definitions, and overwritten with different value in few specific cases, before this PR.  

Adding it increases coverage for code paths that are only tested in acceptance check, e.g. Vault integration.

<img width="711" height="56" alt="1-before" src="https://github.com/user-attachments/assets/47a769ef-45a2-4c51-99f4-5154230ea442" />

https://issues.apache.org/jira/browse/HDDS-15254

## How was this patch tested?

<img width="711" height="56" alt="2-after" src="https://github.com/user-attachments/assets/46e7fd11-92e3-4789-acd9-3325931ebc44" />

CI:
https://github.com/adoroszlai/ozone/actions/runs/25795532236