### PR TITLE
HDDS-15258. Include x-amz-tagging-count header in HEAD object tagging responses

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -35,6 +35,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.Bucket;
@@ -70,6 +71,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.SetObjectAclRequest;
+import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
@@ -1099,6 +1101,28 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
       }
       assertEquals(content, bos.toString("UTF-8"));
     }
+  }
+
+  @Test
+  public void testHeadObjectReturnsTaggingCount() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    final String content = "head-object-tag-count";
+    s3Client.createBucket(bucketName);
+
+    s3Client.putObject(bucketName, keyName,
+        new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), new ObjectMetadata());
+
+    List<Tag> tags = Arrays.asList(new Tag("tag1", "v1"), new Tag("tag2", "v2"));
+    s3Client.setObjectTagging(
+        new SetObjectTaggingRequest(bucketName, keyName, new ObjectTagging(tags)));
+
+    ObjectMetadata head = s3Client.getObjectMetadata(bucketName, keyName);
+    // AWS SDK v1: getTaggingCount() exists on S3Object (GET), not on ObjectMetadata (HEAD).
+    // x-amz-tagging-count is exposed via raw metadata.
+    Object tagCountHeader = head.getRawMetadataValue(Headers.S3_TAGGING_COUNT);
+    assertNotNull(tagCountHeader);
+    assertEquals(tags.size(), Integer.parseInt(tagCountHeader.toString()));
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -1250,6 +1250,25 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
   }
 
   @Test
+  public void testHeadObjectReturnsTaggingCount() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.fromString("obj"));
+
+    List<Tag> tags = Arrays.asList(
+        Tag.builder().key("tag1").value("v1").build(),
+        Tag.builder().key("tag2").value("v2").build());
+
+    s3Client.putObjectTagging(b -> b.bucket(bucketName).key(keyName)
+        .tagging(Tagging.builder().tagSet(tags).build()));
+
+    HeadObjectResponse head = s3Client.headObject(b -> b.bucket(bucketName).key(keyName));
+    assertNotNull(head.tagCount());
+    assertEquals(tags.size(), head.tagCount().intValue());
+  }
+
+  @Test
   public void testResumableDownloadWithEtagMismatch() throws Exception {
     // Arrange
     final String bucketName = getBucketName("resumable");

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -580,6 +580,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     addEntityTagHeader(response, key);
 
     addLastModifiedDate(response, key);
+    addTagCountIfAny(response, key);
     addCustomMetadataHeaders(response, key);
     getMetrics().updateHeadKeySuccessStats(startNanos);
     auditReadSuccess(s3GAction);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -27,9 +27,12 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_NONE_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_UNMODIFIED_SINCE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_COUNT_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.X_AMZ_CONTENT_SHA256;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,6 +94,9 @@ public class TestObjectHead {
 
     DateTimeFormatter.RFC_1123_DATE_TIME
         .parse(response.getHeaderString("Last-Modified"));
+
+    assertNull(response.getHeaderString(TAG_COUNT_HEADER),
+        "HeadObject must omit x-amz-tagging-count (AWS TagCount) when object has no tags");
   }
 
   @Test
@@ -208,6 +214,21 @@ public class TestObjectHead {
     createKey(keyPath);
 
     assertStatus(HttpStatus.SC_NOT_FOUND, () -> keyEndpoint.head(bucketName, keyPath + "/"));
+  }
+
+  @Test
+  public void testHeadObjectIncludesTagCount()
+      throws Exception {
+    String keyName = "head-with-tags";
+    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
+    assertSucceeds(() -> put(keyEndpoint, bucketName, keyName, "c"));
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+    assertEquals(HttpStatus.SC_OK, response.getStatus());
+    // S3 HeadObject TagCount in the AWS API is driven by x-amz-tagging-count
+    assertNotNull(response.getHeaderString(TAG_COUNT_HEADER),
+        "HeadObject must include x-amz-tagging-count when object has tags (AWS TagCount)");
+    assertEquals("2", response.getHeaderString(TAG_COUNT_HEADER));
   }
 
   private byte[] createKey(String keyPath) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the Ozone S3 Gateway does not return the `x-amz-tagging-count` header when a **HEAD** request is made against an object.
Per the AWS S3 specification, this header should indicate the total number of tags associated with the object. This causes failures in compatibility suites `s3-tests (specifically test_get_obj_head_tagging)`.

**Proposed Fix:**
 > Modify the ObjectEndpoint.head() method to retrieve the tag set for the requested object. If tags exist, count them and append the x-amz-tagging-count header to the HTTP response.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15258

## How was this patch tested?
Added unit test in `TestObjectHead`.
Tested manually:

**Before Fix:**
```
bash-5.1$ aws s3api put-object-tagging --bucket buck1 --key k1   --tagging 'TagSet=[{Key=tag1,Value=v1},{Key=tag2,Value=v2}]'   --endpoint-url http://s3g:9878 

bash-5.1$ aws s3api get-object-tagging --bucket buck1 --key k1 --endpoint-url http://s3g:9878 
{
    "TagSet": [
        {
            "Key": "tag1",
            "Value": "v1"
        },
        {
            "Key": "tag2",
            "Value": "v2"
        }
    ]
}

bash-5.1$ aws s3api head-object --bucket buck1 --key k1 --endpoint-url http://s3g:9878/    --debug 2>&1 | grep -i 'tagging-count\|x-amz-tagging'
<---------- x-amz-tagging Not present --------------->
```
**After Fix:**
```
bash-5.1$ aws s3api put-object-tagging --bucket buck1 --key key1   --tagging 'TagSet=[{Key=tag1,Value=v1},{Key=tag2,Value=v2}]'   --endpoint-url http://s3g:9878
bash-5.1$ aws s3api get-object-tagging --bucket buck1 --key key1 --endpoint-url http://s3g:9878
{
    "TagSet": [
        {
            "Key": "tag1",
            "Value": "v1"
        },
        {
            "Key": "tag2",
            "Value": "v2"
        }
    ]
}
bash-5.1$ aws s3api head-object --bucket buck1 --key key1 --endpoint-url http://s3g:9878 \
  --debug 2>&1 | grep -i 'tagging-count\|x-amz-tagging'
2026-05-14 06:31:02,559 - MainThread - botocore.parsers - DEBUG - Response headers: 
{
'Date': 'Thu, 14 May 2026 06:31:02 GMT', 
'Cache-Control': 'no-cache',
'Expires': 'Thu, 14 May 2026 06:31:02 GMT',
'Pragma': 'no-cache',
'Content-Type': 'binary/octet-stream',
'X-Content-Type-Options': 'nosniff', 
'X-XSS-Protection': '1; mode=block', 
'X-FRAME-OPTIONS': 'SAMEORIGIN', 
'x-amz-storage-class': 'STANDARD',
'Last-Modified': 'Thu, 14 May 2026 06:25:17 GMT',
'x-amz-tagging-count': '2',                         <------------------------ present after fix
'Server': 'Ozone',
'x-amz-id-2': 'zak2tBOJ0hnDdLw',
'x-amz-request-id': 'b1b92416-e79a-4a5d-9a4a-486089dbcd67',
'Content-Length': '25'
}
```
