### PR TITLE
HDDS-15276. Prevent root path NU API call, improve warnings

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/plots/nuPieChart.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/plots/nuPieChart.tsx
@@ -17,6 +17,7 @@
  */
 
 import React from 'react';
+import type { EChartsOption } from 'echarts';
 
 import EChart from '@/v2/components/eChart/eChart';
 import { byteToSize } from '@/utils/common';
@@ -36,6 +37,11 @@ type PieChartProps = {
 //-------Constants---------//
 const OTHER_PATH_NAME = 'Other Objects';
 const MIN_BLOCK_SIZE = 0.05;
+const getValidSizeValue = (sizeValue: unknown) => (
+  (typeof sizeValue === 'number' && Number.isFinite(sizeValue))
+    ? sizeValue
+    : 0
+);
 
 
 //----------Component---------//
@@ -48,14 +54,35 @@ const NUPieChart: React.FC<PieChartProps> = ({
   sizeWithReplica,
   loading
 }) => {
+  const safePath = (typeof path === 'string' && path.trim().length > 0)
+    ? path
+    : '/';
+  const safeSize = (typeof size === 'number' && Number.isFinite(size))
+    ? size
+    : 0;
+  const safeSizeWithReplica = (typeof sizeWithReplica === 'number' && Number.isFinite(sizeWithReplica))
+    ? sizeWithReplica
+    : -1;
+  const safeSubPaths = React.useMemo(() => {
+    if (!Array.isArray(subPaths)) {
+      return [] as NUSubpath[];
+    }
+    return subPaths.filter((subpath): subpath is NUSubpath => (
+      Boolean(subpath && typeof subpath.path === 'string')
+    ));
+  }, [subPaths]);
+  const safeSubPathCount = (typeof subPathCount === 'number' && Number.isFinite(subPathCount))
+    ? subPathCount
+    : safeSubPaths.length;
   const [subpathSize, setSubpathSize]  = React.useState<number>(0);
 
   function getSubpathSize(subpaths: NUSubpath[]): number {
-    const subpathSize = subpaths
-      .map((subpath) => subpath.size)
-      .reduce((acc, curr) => acc + curr, 0);
+    const subpathSize = subpaths.reduce((acc, curr) => {
+      const currentSize = getValidSizeValue(curr.size);
+      return acc + currentSize;
+    }, 0);
     // If there is no subpaths, then the size will be total size of path
-    return (subPaths.length === 0) ? size : subpathSize;
+    return (subpaths.length === 0) ? safeSize : subpathSize;
   }
 
   function updatePieData() {
@@ -69,36 +96,36 @@ const NUPieChart: React.FC<PieChartProps> = ({
      *     but we can't check on that, as the response will always have
      *     30 subpaths, but from the total size and the subpaths size we can calculate it).
      */
-    let subpaths: NUSubpath[] = subPaths;
+    let subpaths: NUSubpath[] = safeSubPaths.slice();
 
     let pathLabels: string[] = [];
     let percentage: string[] = [];
     let sizeStr: string[];
     let valuesWithMinBlockSize: number[] = [];
 
-    if (subPathCount > limit) {
+    if (safeSubPathCount > limit) {
       // If the subpath count is greater than the provided limit
       // Slice the subpath to the limit
       subpaths = subpaths.slice(0, limit);
       // Add the size of the subpath
       const limitedSize = getSubpathSize(subpaths);
-      const remainingSize = size - limitedSize;
+      const remainingSize = Math.max(0, safeSize - limitedSize);
       subpaths.push({
         path: OTHER_PATH_NAME,
         size: remainingSize,
-        sizeWithReplica: (sizeWithReplica === -1)
+        sizeWithReplica: (safeSizeWithReplica === -1)
           ? -1
-          : sizeWithReplica - remainingSize,
+          : safeSizeWithReplica - remainingSize,
         isKey: false
       })
     }
 
-    if (subPathCount === 0 || subpaths.length === 0) {
+    if (safeSubPathCount === 0 || subpaths.length === 0) {
       // No more subpaths available
-      pathLabels = [(path ?? '/').split('/').pop() ?? ''];
+      pathLabels = [safePath.split('/').pop() ?? ''];
       valuesWithMinBlockSize = [0.1];
       percentage = ['100.00'];
-      sizeStr = [byteToSize(size, 1)];
+      sizeStr = [byteToSize(safeSize, 1)];
     } else {
       pathLabels = subpaths.map(subpath => {
         const subpathName = subpath.path.split('/').pop() ?? '';
@@ -109,19 +136,18 @@ const NUPieChart: React.FC<PieChartProps> = ({
       });
 
       let values: number[] = [0];
-      if (size > 0) {
+      if (safeSize > 0) {
         values = subpaths.map(
-          subpath => (subpath.size / size)
+          subpath => (getValidSizeValue(subpath.size) / safeSize)
         );
       }
-      const valueClone = structuredClone(values);
-      valuesWithMinBlockSize = valueClone?.map(
+      valuesWithMinBlockSize = values.map(
         (val: number) => (val > 0)
           ? val + MIN_BLOCK_SIZE
           : val
       );
       percentage = values.map(value => (value * 100).toFixed(2));
-      sizeStr = subpaths.map((subpath) => byteToSize(subpath.size, 1));
+      sizeStr = subpaths.map((subpath) => byteToSize(getValidSizeValue(subpath.size), 1));
     }
 
     return valuesWithMinBlockSize.map((key, idx) => {
@@ -135,20 +161,24 @@ const NUPieChart: React.FC<PieChartProps> = ({
   }
 
   React.useEffect(() => {
-    setSubpathSize(getSubpathSize(subPaths));
-  }, [subPaths, limit]);
+    setSubpathSize(getSubpathSize(safeSubPaths));
+  }, [safeSubPaths, safeSize]);
 
-  const pieData = React.useMemo(() => updatePieData(), [path, subPaths, limit]);
+  const pieData = React.useMemo(
+    () => updatePieData(),
+    [safePath, safeSubPaths, safeSubPathCount, safeSize, safeSizeWithReplica, limit]
+  );
 
-  const eChartsOptions = {
+  const eChartsOptions: EChartsOption = {
     title: {
-      text: `${byteToSize(subpathSize, 1)} /  ${byteToSize(size, 1)}`,
+      text: `${byteToSize(subpathSize, 1)} /  ${byteToSize(safeSize, 1)}`,
       left: 'center',
       top: '95%'
     },
     tooltip: {
-      trigger: 'item',
-      formatter: ({ dataIndex, name, color }) => {
+      trigger: 'item' as const,
+      formatter: (params: any) => {
+        const { dataIndex, name, color } = params;
         const nameEl = `<strong style='color: ${color}'>${name}</strong><br>`;
         const dataEl = `Total Data Size: ${pieData[dataIndex]['size']}<br>`
         const percentageEl = `Percentage: ${pieData[dataIndex]['percentage']} %`
@@ -180,11 +210,16 @@ const NUPieChart: React.FC<PieChartProps> = ({
   };
 
   const handleLegendChange = ({selected}: {selected: Record<string, boolean>}) => {
-    const filteredPath = subPaths.filter((value) => {
+    if (!selected) {
+      return;
+    }
+
+    const filteredPath = safeSubPaths.filter((value) => {
       // In case of any leading '/' remove them and add a / at end
       // to make it similar to legend
       const splitPath = value.path?.split('/');
-      const pathName = splitPath[splitPath.length - 1] ?? '' + ((value.isKey) ? '' : '/');
+      const finalPathName = splitPath[splitPath.length - 1] ?? '';
+      const pathName = `${finalPathName}${(value.isKey) ? '' : '/'}`;
       return selected[pathName];
     })
     const newSize = getSubpathSize(filteredPath);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/namespaceUsage/namespaceUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/namespaceUsage/namespaceUsage.less
@@ -22,7 +22,7 @@
   box-shadow: -1px -2px 28px -14px rgba(0,0,0,0.68);
   -webkit-box-shadow: -1px -2px 28px -14px rgba(0,0,0,0.68);
   -moz-box-shadow: -1px -2px 28px -14px rgba(0,0,0,0.68);
-  margin-bottom: 20px;
+  margin-bottom: 8px;
 }
 
 .content-div {
@@ -59,6 +59,21 @@
   .du-content {
     width: 100%;
     display: flex;
+
+    .du-root-path-load-container {
+      width: 100%;
+      min-height: 50vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      gap: 8px;
+      p {
+        color: #767676;
+        font-size: 16px;
+      }
+    }
   }
 
   .tag-block {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/namespaceUsage/namespaceUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/namespaceUsage/namespaceUsage.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState } from 'react';
-import { Alert, Button, Tooltip } from 'antd';
+import { Alert, Button, Modal, Tooltip } from 'antd';
 import { InfoCircleFilled, ReloadOutlined, } from '@ant-design/icons';
 import { ValueType } from 'react-select';
 
@@ -50,54 +50,157 @@ const DEFAULT_NU_RESPONSE: NUResponse = {
   sizeDirectKey: 0
 };
 
+const getSafeNumber = (value: unknown, defaultValue = 0): number => (
+  typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : defaultValue
+);
+
+const normalizeNamespacePath = (path: string): string => {
+  const trimmedPath = path.trim();
+  if (!trimmedPath) {
+    return '';
+  }
+  return trimmedPath.startsWith('/')
+    ? trimmedPath
+    : `/${trimmedPath}`;
+};
+
+const getSafeNamespaceUsageResponse = (
+  data: NUResponse | null | undefined,
+  fallbackPath: string
+): NUResponse => {
+  const safeSubPaths = Array.isArray(data?.subPaths)
+    ? data.subPaths.filter((subPath): subPath is NUResponse['subPaths'][number] => (
+      Boolean(subPath && typeof subPath.path === 'string')
+    ))
+    : [];
+
+  return {
+    status: data?.status ?? '',
+    path: normalizeNamespacePath(data?.path ?? fallbackPath) || '/',
+    subPathCount: getSafeNumber(data?.subPathCount, safeSubPaths.length),
+    size: getSafeNumber(data?.size),
+    sizeWithReplica: getSafeNumber(data?.sizeWithReplica),
+    subPaths: safeSubPaths,
+    sizeDirectKey: getSafeNumber(data?.sizeDirectKey)
+  };
+};
+
 const NamespaceUsage: React.FC<{}> = () => {
   const [limit, setLimit] = useState<Option>(LIMIT_OPTIONS[1]);
   const [currentPath, setCurrentPath] = useState<string>('/');
+  const [showRootPathModal, setShowRootPathModal] = useState<boolean>(false);
+  const [isRootPathUsageEnabled, setIsRootPathUsageEnabled] = useState<boolean>(false);
+  const normalizedCurrentPath = normalizeNamespacePath(currentPath) || '/';
+  const shouldFetchNamespaceUsage = normalizedCurrentPath !== '/' || isRootPathUsageEnabled;
+  const showRootPathLoadPrompt = normalizedCurrentPath === '/' && !isRootPathUsageEnabled;
 
   // Use the modern hooks pattern
   const namespaceUsageData = useApiData<NUResponse>(
-    `/api/v1/namespace/usage?path=${currentPath}&files=true&sortSubPaths=true`,
+    shouldFetchNamespaceUsage
+      ? `/api/v1/namespace/usage?path=${normalizedCurrentPath}&files=true&sortSubPaths=true`
+      : '',
     DEFAULT_NU_RESPONSE,
     {
+      initialFetch: shouldFetchNamespaceUsage,
       retryAttempts: 2,
       onError: (error) => showDataFetchError(error)
     }
   );
 
+  const duResponse = React.useMemo(() => {
+    if (!shouldFetchNamespaceUsage) {
+      return {
+        ...DEFAULT_NU_RESPONSE,
+        path: normalizedCurrentPath,
+        subPaths: []
+      };
+    }
+    return getSafeNamespaceUsageResponse(namespaceUsageData.data, normalizedCurrentPath);
+  }, [namespaceUsageData.data, normalizedCurrentPath, shouldFetchNamespaceUsage]);
+
   // Process data when it changes
   React.useEffect(() => {
-    if (namespaceUsageData.data) {
-      const duResponse = namespaceUsageData.data;
-      const status = duResponse.status;
-      
-      if (status === 'PATH_NOT_FOUND') {
-        showDataFetchError(`Invalid Path: ${currentPath}`);
-        return;
-      }
-
-      if (status === 'INITIALIZING') {
-        showInfoNotification("Information being initialized", "Namespace Summary is being initialized, please wait.")
-        return;
-      }
+    if (!shouldFetchNamespaceUsage || namespaceUsageData.loading) {
+      return;
     }
-  }, [namespaceUsageData.data, currentPath]);
+
+    if (duResponse.status === 'PATH_NOT_FOUND') {
+      showDataFetchError(`Invalid Path: ${normalizedCurrentPath}`);
+      return;
+    }
+
+    if (duResponse.status === 'INITIALIZING') {
+      showInfoNotification("Information being initialized", "Namespace Summary is being initialized, please wait.");
+    }
+  }, [duResponse.status, normalizedCurrentPath, namespaceUsageData.loading, shouldFetchNamespaceUsage]);
+
+  const handleApiRequestFailure = (error: unknown) => {
+    showDataFetchError(error);
+  };
+
+  const requestRootPathLoad = () => {
+    if (normalizedCurrentPath !== '/') {
+      setIsRootPathUsageEnabled(false);
+    }
+    setCurrentPath('/');
+    setShowRootPathModal(true);
+  };
+
+  const handleReload = () => {
+    if (normalizedCurrentPath === '/') {
+      requestRootPathLoad();
+      return;
+    }
+    void namespaceUsageData.refetch().catch(handleApiRequestFailure);
+  };
+
+  const handleRootPathLoadConfirm = () => {
+    setShowRootPathModal(false);
+    if (!isRootPathUsageEnabled) {
+      setIsRootPathUsageEnabled(true);
+      return;
+    }
+    void namespaceUsageData.refetch().catch(handleApiRequestFailure);
+  };
 
   const loadData = (path: string) => {
-    setCurrentPath(path);
+    const normalizedPath = normalizeNamespacePath(path);
+    if (!normalizedPath) {
+      showDataFetchError('Invalid Path: Path cannot be empty');
+      return;
+    }
+
+    if (normalizedPath === '/') {
+      requestRootPathLoad();
+      return;
+    }
+    setShowRootPathModal(false);
+    setIsRootPathUsageEnabled(false);
+    setCurrentPath(normalizedPath);
   };
 
   function handleLimitChange(selected: ValueType<Option, false>) {
     setLimit(selected as Option);
   }
 
-  const duResponse = namespaceUsageData.data || DEFAULT_NU_RESPONSE;
-  const loading = namespaceUsageData.loading;
+  const loading = shouldFetchNamespaceUsage && namespaceUsageData.loading;
 
   return (
     <>
       <div className='page-header-v2'>
         Namespace Usage
       </div>
+      <Modal
+        centered={true}
+        title='Confirm Root Path Usage Load'
+        visible={showRootPathModal}
+        onOk={handleRootPathLoadConfirm}
+        onCancel={() => setShowRootPathModal(false)}>
+        <p>Root path usage calculation is an expensive operation in large deployments.</p>
+        <p><strong>Are you sure you want to continue?</strong></p>
+      </Modal>
       <div className='data-container'>
         <Alert
           className='du-alert-message'
@@ -107,6 +210,16 @@ const NamespaceUsage: React.FC<{}> = () => {
           icon={<InfoCircleFilled />}
           showIcon={true}
           closable={false} />
+        {
+          currentPath == '/' && (
+            <Alert
+              className='du-alert-message'
+              message='Root path usage can be expensive in large deployments. Enter an exact path to load usage directly.'
+              type='warning'
+              showIcon={true}
+              closable={false} />
+          )
+        }
         <div className='content-div'>
           <div
             style={{
@@ -122,7 +235,7 @@ const NamespaceUsage: React.FC<{}> = () => {
               <Button
                 type='primary'
                 icon={<ReloadOutlined />}
-                onClick={() => loadData(duResponse.path)} />
+                onClick={handleReload} />
             </Tooltip>
           </div>
           <div className='du-table-header-section'>
@@ -133,15 +246,28 @@ const NamespaceUsage: React.FC<{}> = () => {
               onChange={handleLimitChange} />
           </div>
           <div className='du-content'>
-            <NUPieChart
-              loading={loading}
-              limit={Number.parseInt(limit.value)}
-              path={duResponse.path}
-              subPathCount={duResponse.subPathCount}
-              subPaths={duResponse.subPaths}
-              sizeWithReplica={duResponse.sizeWithReplica}
-              size={duResponse.size} />
-            <NUMetadata path={currentPath} />
+            {showRootPathLoadPrompt ? (
+              <div className='du-root-path-load-container'>
+                <p>Root path usage is not loaded by default.</p>
+                <Button
+                  type='primary'
+                  onClick={requestRootPathLoad}>
+                  Load usage
+                </Button>
+              </div>
+            ) : (
+              <>
+                <NUPieChart
+                  loading={loading}
+                  limit={Number.parseInt(limit.value)}
+                  path={duResponse.path}
+                  subPathCount={duResponse.subPathCount}
+                  subPaths={duResponse.subPaths}
+                  sizeWithReplica={duResponse.sizeWithReplica}
+                  size={duResponse.size} />
+                <NUMetadata path={normalizedCurrentPath} />
+              </>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15276. Prevent root path NU API call, improve warnings

Please describe your PR in detail:
Currently the Namespace Usage page by default fetches the root path information on page load.
However on a large cluster deployment this can cause the page to crash or for the response to timeout and put pressure on the system while calculating the usage.

This PR makes the following changes:
- It does not load the root path when the namespace usage page is accessed, instead a button is shown to inform users that the data needs to be explicitly loaded
- Upon clicking the button the user is provided further warning that this could be an expensive operation.
- We also add additional warning notifications, and improve error handling for null data or API response failures

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15276

## How was this patch tested?
Patch was tested manually.

https://github.com/user-attachments/assets/0c850ff5-2562-4495-9de9-5d90015e69a2