### PR TITLE
HDDS-15278. DiskBalancer should validate persisted config before applying.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -243,18 +243,16 @@ public class DiskBalancerService extends BackgroundService {
 
   private void applyDiskBalancerInfo(DiskBalancerInfo diskBalancerInfo)
       throws IOException {
-    // verify ContainerStates first
-    DiskBalancerConfiguration validated = new DiskBalancerConfiguration();
-    validated.setContainerStates(diskBalancerInfo.getContainerStates());
+    DiskBalancerConfiguration validated = diskBalancerInfo.toConfiguration();
     // First store in local file, then update in memory variables
     writeDiskBalancerInfoTo(diskBalancerInfo, diskBalancerInfoFile);
 
     updateOperationalStateFromInfo(diskBalancerInfo);
 
-    setThreshold(diskBalancerInfo.getThreshold());
-    setBandwidthInMB(diskBalancerInfo.getBandwidthInMB());
-    setParallelThread(diskBalancerInfo.getParallelThread());
-    setStopAfterDiskEven(diskBalancerInfo.isStopAfterDiskEven());
+    setThreshold(validated.getThreshold());
+    setBandwidthInMB(validated.getDiskBandwidthInMB());
+    setParallelThread(validated.getParallelThread());
+    setStopAfterDiskEven(validated.isStopAfterDiskEven());
     setVersion(diskBalancerInfo.getVersion());
     setContainerStates(validated.getMovableContainerStates());
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -199,9 +199,11 @@ public class TestDiskBalancerService {
     svc.shutdown();
   }
 
-  @ContainerTestVersionInfo.ContainerTest
+  @ParameterizedTest
+  @MethodSource("invalidDiskBalancerInfo")
   public void testRefreshRejectsInvalidDiskBalancerInfo(
-      ContainerTestVersionInfo versionInfo) throws Exception {
+      ContainerTestVersionInfo versionInfo, DiskBalancerInfo diskBalancerInfo)
+      throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
     ContainerSet containerSet = ContainerSet.newReadOnlyContainerSet(1000);
     ContainerMetrics metrics = ContainerMetrics.create(conf);
@@ -213,16 +215,20 @@ public class TestDiskBalancerService {
         getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1);
 
     assertThrows(IllegalArgumentException.class,
-        () -> svc.refresh(new DiskBalancerInfo(
-            DiskBalancerRunningStatus.RUNNING, 0.0d, 100L, 5, true)));
-    assertThrows(IllegalArgumentException.class,
-        () -> svc.refresh(new DiskBalancerInfo(
-            DiskBalancerRunningStatus.RUNNING, 10.0d, 0L, 5, true)));
-    assertThrows(IllegalArgumentException.class,
-        () -> svc.refresh(new DiskBalancerInfo(
-            DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 0, true)));
+        () -> svc.refresh(diskBalancerInfo));
 
     svc.shutdown();
+  }
+
+  public static Stream<Arguments> invalidDiskBalancerInfo() {
+    return ContainerTestVersionInfo.getLayoutList().stream()
+        .flatMap(versionInfo -> Stream.of(
+            Arguments.arguments(versionInfo, new DiskBalancerInfo(
+                DiskBalancerRunningStatus.RUNNING, 0.0d, 100L, 5, true)),
+            Arguments.arguments(versionInfo, new DiskBalancerInfo(
+                DiskBalancerRunningStatus.RUNNING, 10.0d, 0L, 5, true)),
+            Arguments.arguments(versionInfo, new DiskBalancerInfo(
+                DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 0, true))));
   }
 
   @ContainerTestVersionInfo.ContainerTest

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -200,6 +200,32 @@ public class TestDiskBalancerService {
   }
 
   @ContainerTestVersionInfo.ContainerTest
+  public void testRefreshRejectsInvalidDiskBalancerInfo(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
+    ContainerSet containerSet = ContainerSet.newReadOnlyContainerSet(1000);
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        }, new ContainerChecksumTreeManager(conf));
+    DiskBalancerServiceTestImpl svc =
+        getDiskBalancerService(containerSet, conf, keyValueHandler, null, 1);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> svc.refresh(new DiskBalancerInfo(
+            DiskBalancerRunningStatus.RUNNING, 0.0d, 100L, 5, true)));
+    assertThrows(IllegalArgumentException.class,
+        () -> svc.refresh(new DiskBalancerInfo(
+            DiskBalancerRunningStatus.RUNNING, 10.0d, 0L, 5, true)));
+    assertThrows(IllegalArgumentException.class,
+        () -> svc.refresh(new DiskBalancerInfo(
+            DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 0, true)));
+
+    svc.shutdown();
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
   public void testPolicyClassInitialization(ContainerTestVersionInfo versionInfo) throws IOException {
     setLayoutAndSchemaForTest(versionInfo);
     ContainerSet containerSet = ContainerSet.newReadOnlyContainerSet(1000);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR validates persisted DiskBalancer configuration before applying it to the running service.

DiskBalancerService loads persisted configuration from diskbalancer.info and applies it through applyDiskBalancerInfo. Previously, only containerStates was explicitly validated in this path, while other fields such as threshold, bandwidthInMB, and parallelThread were applied directly from DiskBalancerInfo.

This PR updates applyDiskBalancerInfo to convert DiskBalancerInfo through DiskBalancerConfiguration, so the existing validation logic is reused consistently before updating the service state.

It also adds unit test coverage to verify that invalid persisted DiskBalancer configuration is rejected, including:

- invalid threshold
- invalid bandwidth
- invalid parallel thread count

## What is the link to the Apache JIRA

JIRA: HDDS-15278. DiskBalancer should validate persisted config before applying.

## How was this patch tested?

Add Some Junit Test.