### PR TITLE
HDDS-15280. Fix EC pipeline factor calculation.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -187,7 +187,8 @@ public class WritableECContainerProvider
     int volumeBasedCount = 0;
     if (factor > 0) {
       int volumes = nodeManager.totalHealthyVolumeCount();
-      volumeBasedCount = (int) factor * volumes / repConfig.getRequiredNodes();
+      volumeBasedCount =
+          (int) (factor * volumes / repConfig.getRequiredNodes());
     }
     return Math.max(volumeBasedCount, providerConfig.getMinimumPipelines());
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -187,8 +187,7 @@ public class WritableECContainerProvider
     int volumeBasedCount = 0;
     if (factor > 0) {
       int volumes = nodeManager.totalHealthyVolumeCount();
-      volumeBasedCount =
-          (int) (factor * volumes / repConfig.getRequiredNodes());
+      volumeBasedCount = (int) (factor * volumes / repConfig.getRequiredNodes());
     }
     return Math.max(volumeBasedCount, providerConfig.getMinimumPipelines());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -183,30 +183,13 @@ public class TestWritableECContainerProvider {
   void testPipelinesCreatedBasedOnTotalDiskCountWithFactor(
       PipelineChoosePolicy policy) throws IOException {
     provider = createSubject(policy);
-    int factor = 10;
-    providerConf.setMinimumPipelines(1);
-    providerConf.setPipelinePerVolumeFactor(factor);
-    nodeManager.setNumHealthyVolumes(5);
-
-    int volumeCount = nodeManager.totalHealthyVolumeCount();
-    int pipelineLimit = factor * volumeCount / repConfig.getRequiredNodes();
-    Set<ContainerInfo> allocated = assertDistinctContainers(pipelineLimit);
-    assertReusesExisting(allocated, pipelineLimit);
-  }
-
-  @ParameterizedTest
-  @MethodSource("policies")
-  void testPipelinesCreatedBasedOnTotalDiskCountWithFractionalFactor(
-      PipelineChoosePolicy policy) throws IOException {
-    provider = createSubject(policy);
     double factor = 0.5;
     providerConf.setMinimumPipelines(1);
     providerConf.setPipelinePerVolumeFactor(factor);
     nodeManager.setNumHealthyVolumes(20);
 
     int volumeCount = nodeManager.totalHealthyVolumeCount();
-    int pipelineLimit =
-        (int) (factor * volumeCount / repConfig.getRequiredNodes());
+    int pipelineLimit = (int) (factor * volumeCount / repConfig.getRequiredNodes());
     Set<ContainerInfo> allocated = assertDistinctContainers(pipelineLimit);
     assertReusesExisting(allocated, pipelineLimit);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -196,6 +196,23 @@ public class TestWritableECContainerProvider {
 
   @ParameterizedTest
   @MethodSource("policies")
+  void testPipelinesCreatedBasedOnTotalDiskCountWithFractionalFactor(
+      PipelineChoosePolicy policy) throws IOException {
+    provider = createSubject(policy);
+    double factor = 0.5;
+    providerConf.setMinimumPipelines(1);
+    providerConf.setPipelinePerVolumeFactor(factor);
+    nodeManager.setNumHealthyVolumes(20);
+
+    int volumeCount = nodeManager.totalHealthyVolumeCount();
+    int pipelineLimit =
+        (int) (factor * volumeCount / repConfig.getRequiredNodes());
+    Set<ContainerInfo> allocated = assertDistinctContainers(pipelineLimit);
+    assertReusesExisting(allocated, pipelineLimit);
+  }
+
+  @ParameterizedTest
+  @MethodSource("policies")
   void testPipelinesCreatedUpToMinLimitAndRandomPipelineReturned(
       PipelineChoosePolicy policy) throws IOException {
     provider = createSubject(policy);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the EC pipeline limit calculation in WritableECContainerProvider.

`ozone.scm.ec.pipeline.per.volume.factor` is a double configuration, but the previous calculation cast the factor to int before multiplying it by the healthy volume count. 

As a result, fractional values such as `0.5` were truncated to `0`, causing the volume-based EC pipeline limit to be calculated incorrectly.

This PR updates the calculation to apply the factor first and cast only the final result to int.

It also adds unit test coverage for fractional factor values.

## What is the link to the Apache JIRA

JIRA: HDDS-15280. Fix EC pipeline factor calculation.

## How was this patch tested?

Add Junit Test.