### PR TITLE
HDDS-15279. populate-cache should use Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ on:
         required: false
 
 env:
+  # BUILD_ARGS and TEST_JAVA_VERSION are duplicated in populate-cache.yml, please keep in sync
   BUILD_ARGS: "-Pdist -Psrc -Dmaven.javadoc.skip=true -Drocks_tools_native"
   TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
-  # MAVEN_ARGS and MAVEN_OPTS are duplicated in check.yml, please keep in sync
+  # MAVEN_ARGS and MAVEN_OPTS are duplicated in check.yml and populate-cache.yml, please keep in sync
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -22,6 +22,8 @@ on:
     branches:
       - master
       - ozone-1.4
+      - ozone-2.0
+      - ozone-2.1
     paths:
       - 'pom.xml'
       - '**/pom.xml'

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -31,6 +31,13 @@ on:
 
 permissions: { }
 
+env:
+  # variables are duplicated from ci.yml, please keep in sync
+  BUILD_ARGS: "-Pdist -Psrc -Dmaven.javadoc.skip=true -Drocks_tools_native"
+  TEST_JAVA_VERSION: 21 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
+  MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -54,7 +61,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: ${{ env.TEST_JAVA_VERSION }}
 
       - name: Get NodeJS version
         id: nodejs-version
@@ -77,7 +84,7 @@ jobs:
 
       - name: Fetch dependencies
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: mvn --batch-mode --no-transfer-progress --show-version -Pgo-offline -Pdist -Drocks_tools_native clean verify
+        run: mvn $BUILD_ARGS $MAVEN_ARGS --no-transfer-progress --show-version -Pgo-offline clean verify
 
       - name: Delete Ozone jars from repo
         if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -44,6 +44,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.cli</artifactId>
+      <version>${jacoco.version}</version>
+      <classifier>nodeps</classifier>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-container-service</artifactId>
       <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2666,6 +2666,9 @@
     <profile>
       <id>go-offline</id>
       <properties>
+        <cyclonedx.skip>true</cyclonedx.skip>
+        <enforcer.skip>true</enforcer.skip>
+        <jacoco.skip>true</jacoco.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <mdep.analyze.skip>true</mdep.analyze.skip>
         <skip.installnodepnpm>true</skip.installnodepnpm>

--- a/pom.xml
+++ b/pom.xml
@@ -2201,13 +2201,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${pmd.version}</version>
-          <configuration>
-            <rulesets>
-              <ruleset>dev-support/pmd/pmd-ruleset.xml</ruleset>
-            </rulesets>
-            <printFailingErrors>true</printFailingErrors>
-            <includeTests>true</includeTests>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
@@ -2406,6 +2399,17 @@
             <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <rulesets>
+            <ruleset>dev-support/pmd/pmd-ruleset.xml</ruleset>
+          </rulesets>
+          <printFailingErrors>true</printFailingErrors>
+          <includeTests>true</includeTests>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some jars are missing from Maven cache, because the workflow uses Java 8, while regular CI uses 21.  Thus, due to build differences, these jars need to be downloaded during CI build, which may sometimes encounter network error, or request may be [rejected](https://github.com/apache/ozone/actions/runs/25898312506/job/76117160275#step:16:19) by Central.  This is fixed by changing Java version to 21 in `populate-cache`.

Also:
- Use the same Maven options for consistency.
- Skip execution of some plugins to reduce run time.
- Move PMD plugin config to `<plugins>` so that the plugin is downloaded during build, not only in PMD check
- Add `jacoco-cli` as `provided` dependency in `ozone-dist` for the same reason
- Enable `populate-cache` for newer release branches

https://issues.apache.org/jira/browse/HDDS-15279

## How was this patch tested?

Compared cache contents [before](https://github.com/apache/ozone/actions/runs/25791984305/job/75759605750#step:10:8)/[after](https://github.com/adoroszlai/ozone/actions/runs/25903087635/job/76130525715#step:10:12) the change.

- AspectJ is upgraded from 1.9.7 to 1.9.24
- Some notable additions: Iceberg artifacts, `maven-pmd-plugin`, `jacoco-cli`

```diff
--- 1-before.txt	2026-05-15 09:33:13.971009431 +0200
+++ 2-after.txt	2026-05-15 09:32:30.646002264 +0200
@@ -5,6 +5,14 @@
 aopalliance/aopalliance/1.0/aopalliance-1.0.jar.sha1
 aopalliance/aopalliance/1.0/aopalliance-1.0.pom
 aopalliance/aopalliance/1.0/aopalliance-1.0.pom.sha1
+args4j/args4j-site/2.0.28/_remote.repositories
+args4j/args4j-site/2.0.28/args4j-site-2.0.28.pom
+args4j/args4j-site/2.0.28/args4j-site-2.0.28.pom.sha1
+args4j/args4j/2.0.28/_remote.repositories
+args4j/args4j/2.0.28/args4j-2.0.28.jar
+args4j/args4j/2.0.28/args4j-2.0.28.jar.sha1
+args4j/args4j/2.0.28/args4j-2.0.28.pom
+args4j/args4j/2.0.28/args4j-2.0.28.pom.sha1
 ch/qos/reload4j/reload4j/1.2.26/_remote.repositories
 ch/qos/reload4j/reload4j/1.2.26/reload4j-1.2.26.jar
 ch/qos/reload4j/reload4j/1.2.26/reload4j-1.2.26.jar.sha1
@@ -209,6 +217,9 @@
 com/fasterxml/jackson/jackson-bom/2.19.1/_remote.repositories
 com/fasterxml/jackson/jackson-bom/2.19.1/jackson-bom-2.19.1.pom
 com/fasterxml/jackson/jackson-bom/2.19.1/jackson-bom-2.19.1.pom.sha1
+com/fasterxml/jackson/jackson-bom/2.19.2/_remote.repositories
+com/fasterxml/jackson/jackson-bom/2.19.2/jackson-bom-2.19.2.pom
+com/fasterxml/jackson/jackson-bom/2.19.2/jackson-bom-2.19.2.pom.sha1
 com/fasterxml/jackson/jackson-bom/2.21.3/_remote.repositories
 com/fasterxml/jackson/jackson-bom/2.21.3/jackson-bom-2.21.3.pom
 com/fasterxml/jackson/jackson-bom/2.21.3/jackson-bom-2.21.3.pom.sha1
@@ -227,6 +238,9 @@
 com/fasterxml/jackson/jackson-parent/2.19.2/_remote.repositories
 com/fasterxml/jackson/jackson-parent/2.19.2/jackson-parent-2.19.2.pom
 com/fasterxml/jackson/jackson-parent/2.19.2/jackson-parent-2.19.2.pom.sha1
+com/fasterxml/jackson/jackson-parent/2.19.3/_remote.repositories
+com/fasterxml/jackson/jackson-parent/2.19.3/jackson-parent-2.19.3.pom
+com/fasterxml/jackson/jackson-parent/2.19.3/jackson-parent-2.19.3.pom.sha1
 com/fasterxml/jackson/jackson-parent/2.21/_remote.repositories
 com/fasterxml/jackson/jackson-parent/2.21/jackson-parent-2.21.pom
 com/fasterxml/jackson/jackson-parent/2.21/jackson-parent-2.21.pom.sha1
@@ -281,6 +295,9 @@
 com/fasterxml/oss-parent/68/_remote.repositories
 com/fasterxml/oss-parent/68/oss-parent-68.pom
 com/fasterxml/oss-parent/68/oss-parent-68.pom.sha1
+com/fasterxml/oss-parent/69/_remote.repositories
+com/fasterxml/oss-parent/69/oss-parent-69.pom
+com/fasterxml/oss-parent/69/oss-parent-69.pom.sha1
 com/fasterxml/oss-parent/75/_remote.repositories
 com/fasterxml/oss-parent/75/oss-parent-75.pom
 com/fasterxml/oss-parent/75/oss-parent-75.pom.sha1
@@ -294,6 +311,11 @@
 com/fasterxml/woodstox/woodstox-core/6.7.0/woodstox-core-6.7.0.jar.sha1
 com/fasterxml/woodstox/woodstox-core/6.7.0/woodstox-core-6.7.0.pom
 com/fasterxml/woodstox/woodstox-core/6.7.0/woodstox-core-6.7.0.pom.sha1
+com/github/ben-manes/caffeine/caffeine/2.9.3/_remote.repositories
+com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3.jar
+com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3.jar.sha1
+com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3.pom
+com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3.pom.sha1
 com/github/cliftonlabs/json-simple/3.0.2/_remote.repositories
 com/github/cliftonlabs/json-simple/3.0.2/json-simple-3.0.2.jar
 com/github/cliftonlabs/json-simple/3.0.2/json-simple-3.0.2.jar.sha1
@@ -450,8 +472,6 @@
 com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.pom
 com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.pom.sha1
 com/google/auto/value/auto-value-annotations/1.8.1/_remote.repositories
-com/google/auto/value/auto-value-annotations/1.8.1/auto-value-annotations-1.8.1.jar
-com/google/auto/value/auto-value-annotations/1.8.1/auto-value-annotations-1.8.1.jar.sha1
 com/google/auto/value/auto-value-annotations/1.8.1/auto-value-annotations-1.8.1.pom
 com/google/auto/value/auto-value-annotations/1.8.1/auto-value-annotations-1.8.1.pom.sha1
 com/google/auto/value/auto-value-parent/1.11.0/_remote.repositories
@@ -755,14 +775,25 @@
 com/squareup/okio/okio/3.6.0/okio-3.6.0.jar.sha1
 com/squareup/okio/okio/3.6.0/okio-3.6.0.pom
 com/squareup/okio/okio/3.6.0/okio-3.6.0.pom.sha1
+com/sun/activation/all/1.2.0/_remote.repositories
+com/sun/activation/all/1.2.0/all-1.2.0.pom
+com/sun/activation/all/1.2.0/all-1.2.0.pom.sha1
 com/sun/activation/all/1.2.2/_remote.repositories
 com/sun/activation/all/1.2.2/all-1.2.2.pom
 com/sun/activation/all/1.2.2/all-1.2.2.pom.sha1
+com/sun/activation/all/2.0.0/_remote.repositories
+com/sun/activation/all/2.0.0/all-2.0.0.pom
+com/sun/activation/all/2.0.0/all-2.0.0.pom.sha1
 com/sun/activation/jakarta.activation/1.2.2/_remote.repositories
 com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar
 com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar.sha1
 com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.pom
 com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.pom.sha1
+com/sun/activation/jakarta.activation/2.0.0/_remote.repositories
+com/sun/activation/jakarta.activation/2.0.0/jakarta.activation-2.0.0.jar
+com/sun/activation/jakarta.activation/2.0.0/jakarta.activation-2.0.0.jar.sha1
+com/sun/activation/jakarta.activation/2.0.0/jakarta.activation-2.0.0.pom
+com/sun/activation/jakarta.activation/2.0.0/jakarta.activation-2.0.0.pom.sha1
 com/sun/istack/istack-commons-runtime/3.0.12/_remote.repositories
 com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar
 com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar.sha1
@@ -805,18 +836,36 @@
 com/sun/jersey/jersey-servlet/1.19.4/jersey-servlet-1.19.4.jar.sha1
 com/sun/jersey/jersey-servlet/1.19.4/jersey-servlet-1.19.4.pom
 com/sun/jersey/jersey-servlet/1.19.4/jersey-servlet-1.19.4.pom.sha1
-com/sun/tools/1.8.0_482/tools-1.8.0_482.pom.lastUpdated
 com/sun/xml/bind/jaxb-bom-ext/2.3.9/_remote.repositories
 com/sun/xml/bind/jaxb-bom-ext/2.3.9/jaxb-bom-ext-2.3.9.pom
 com/sun/xml/bind/jaxb-bom-ext/2.3.9/jaxb-bom-ext-2.3.9.pom.sha1
+com/sun/xml/bind/jaxb-bom-ext/3.0.0/_remote.repositories
+com/sun/xml/bind/jaxb-bom-ext/3.0.0/jaxb-bom-ext-3.0.0.pom
+com/sun/xml/bind/jaxb-bom-ext/3.0.0/jaxb-bom-ext-3.0.0.pom.sha1
+com/sun/xml/bind/jaxb-core/3.0.0/_remote.repositories
+com/sun/xml/bind/jaxb-core/3.0.0/jaxb-core-3.0.0.jar
+com/sun/xml/bind/jaxb-core/3.0.0/jaxb-core-3.0.0.jar.sha1
+com/sun/xml/bind/jaxb-core/3.0.0/jaxb-core-3.0.0.pom
+com/sun/xml/bind/jaxb-core/3.0.0/jaxb-core-3.0.0.pom.sha1
 com/sun/xml/bind/jaxb-impl/2.2.3-1/_remote.repositories
 com/sun/xml/bind/jaxb-impl/2.2.3-1/jaxb-impl-2.2.3-1.jar
 com/sun/xml/bind/jaxb-impl/2.2.3-1/jaxb-impl-2.2.3-1.jar.sha1
 com/sun/xml/bind/jaxb-impl/2.2.3-1/jaxb-impl-2.2.3-1.pom
 com/sun/xml/bind/jaxb-impl/2.2.3-1/jaxb-impl-2.2.3-1.pom.sha1
+com/sun/xml/bind/jaxb-impl/3.0.0/_remote.repositories
+com/sun/xml/bind/jaxb-impl/3.0.0/jaxb-impl-3.0.0.jar
+com/sun/xml/bind/jaxb-impl/3.0.0/jaxb-impl-3.0.0.jar.sha1
+com/sun/xml/bind/jaxb-impl/3.0.0/jaxb-impl-3.0.0.pom
+com/sun/xml/bind/jaxb-impl/3.0.0/jaxb-impl-3.0.0.pom.sha1
+com/sun/xml/bind/mvn/jaxb-bundles/3.0.0/_remote.repositories
+com/sun/xml/bind/mvn/jaxb-bundles/3.0.0/jaxb-bundles-3.0.0.pom
+com/sun/xml/bind/mvn/jaxb-bundles/3.0.0/jaxb-bundles-3.0.0.pom.sha1
 com/sun/xml/bind/mvn/jaxb-parent/2.3.9/_remote.repositories
 com/sun/xml/bind/mvn/jaxb-parent/2.3.9/jaxb-parent-2.3.9.pom
 com/sun/xml/bind/mvn/jaxb-parent/2.3.9/jaxb-parent-2.3.9.pom.sha1
+com/sun/xml/bind/mvn/jaxb-parent/3.0.0/_remote.repositories
+com/sun/xml/bind/mvn/jaxb-parent/3.0.0/jaxb-parent-3.0.0.pom
+com/sun/xml/bind/mvn/jaxb-parent/3.0.0/jaxb-parent-3.0.0.pom.sha1
 com/sun/xml/bind/mvn/jaxb-runtime-parent/2.3.9/_remote.repositories
 com/sun/xml/bind/mvn/jaxb-runtime-parent/2.3.9/jaxb-runtime-parent-2.3.9.pom
 com/sun/xml/bind/mvn/jaxb-runtime-parent/2.3.9/jaxb-runtime-parent-2.3.9.pom.sha1
@@ -865,8 +914,6 @@
 commons-cli/commons-cli/1.2/commons-cli-1.2.pom
 commons-cli/commons-cli/1.2/commons-cli-1.2.pom.sha1
 commons-cli/commons-cli/1.5.0/_remote.repositories
-commons-cli/commons-cli/1.5.0/commons-cli-1.5.0.jar
-commons-cli/commons-cli/1.5.0/commons-cli-1.5.0.jar.sha1
 commons-cli/commons-cli/1.5.0/commons-cli-1.5.0.pom
 commons-cli/commons-cli/1.5.0/commons-cli-1.5.0.pom.sha1
 commons-cli/commons-cli/1.9.0/_remote.repositories
@@ -903,8 +950,6 @@
 commons-codec/commons-codec/1.22.0/commons-codec-1.22.0.pom
 commons-codec/commons-codec/1.22.0/commons-codec-1.22.0.pom.sha1
 commons-collections/commons-collections/3.2.1/_remote.repositories
-commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar
-commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar.sha1
 commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.pom
 commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.pom.sha1
 commons-collections/commons-collections/3.2.2/_remote.repositories
@@ -985,8 +1030,6 @@
 commons-io/commons-io/2.5/commons-io-2.5.pom
 commons-io/commons-io/2.5/commons-io-2.5.pom.sha1
 commons-lang/commons-lang/2.4/_remote.repositories
-commons-lang/commons-lang/2.4/commons-lang-2.4.jar
-commons-lang/commons-lang/2.4/commons-lang-2.4.jar.sha1
 commons-lang/commons-lang/2.4/commons-lang-2.4.pom
 commons-lang/commons-lang/2.4/commons-lang-2.4.pom.sha1
 commons-lang/commons-lang/2.6/_remote.repositories
@@ -1406,6 +1449,9 @@
 javax/activation/activation/1.1/_remote.repositories
 javax/activation/activation/1.1/activation-1.1.pom
 javax/activation/activation/1.1/activation-1.1.pom.sha1
+javax/activation/javax.activation-api/1.2.0/_remote.repositories
+javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.pom
+javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.pom.sha1
 javax/annotation/javax.annotation-api/1.2/_remote.repositories
 javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar
 javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar.sha1
@@ -1471,6 +1517,9 @@
 javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.jar.sha1
 javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.pom
 javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.pom.sha1
+javax/xml/bind/jaxb-api-parent/2.3.1/_remote.repositories
+javax/xml/bind/jaxb-api-parent/2.3.1/jaxb-api-parent-2.3.1.pom
+javax/xml/bind/jaxb-api-parent/2.3.1/jaxb-api-parent-2.3.1.pom.sha1
 javax/xml/bind/jaxb-api/2.2.11/_remote.repositories
 javax/xml/bind/jaxb-api/2.2.11/jaxb-api-2.2.11.jar
 javax/xml/bind/jaxb-api/2.2.11/jaxb-api-2.2.11.jar.sha1
@@ -1480,14 +1529,14 @@
 javax/xml/bind/jaxb-api/2.2.12/jaxb-api-2.2.12.pom
 javax/xml/bind/jaxb-api/2.2.12/jaxb-api-2.2.12.pom.sha1
 javax/xml/bind/jaxb-api/2.2.2/_remote.repositories
-javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar
-javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar.sha1
 javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.pom
 javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.pom.sha1
+javax/xml/bind/jaxb-api/2.3.1/_remote.repositories
+javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.pom
+javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.pom.sha1
 javax/xml/stream/stax-api/1.0-2/_remote.repositories
 javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.pom
 javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.pom.sha1
-jdk/tools/jdk.tools/1.8/jdk.tools-1.8.pom.lastUpdated
 joda-time/joda-time/2.12.7/_remote.repositories
 joda-time/joda-time/2.12.7/joda-time-2.12.7.jar
 joda-time/joda-time/2.12.7/joda-time-2.12.7.jar.sha1
@@ -1538,8 +1587,6 @@
 net/bytebuddy/byte-buddy-parent/1.18.3/byte-buddy-parent-1.18.3.pom
 net/bytebuddy/byte-buddy-parent/1.18.3/byte-buddy-parent-1.18.3.pom.sha1
 net/bytebuddy/byte-buddy/1.12.19/_remote.repositories
-net/bytebuddy/byte-buddy/1.12.19/byte-buddy-1.12.19.jar
-net/bytebuddy/byte-buddy/1.12.19/byte-buddy-1.12.19.jar.sha1
 net/bytebuddy/byte-buddy/1.12.19/byte-buddy-1.12.19.pom
 net/bytebuddy/byte-buddy/1.12.19/byte-buddy-1.12.19.pom.sha1
 net/bytebuddy/byte-buddy/1.18.3/_remote.repositories
@@ -1562,12 +1609,18 @@
 net/java/dev/jna/jna/5.2.0/jna-5.2.0.jar.sha1
 net/java/dev/jna/jna/5.2.0/jna-5.2.0.pom
 net/java/dev/jna/jna/5.2.0/jna-5.2.0.pom.sha1
+net/java/jvnet-parent/1/_remote.repositories
+net/java/jvnet-parent/1/jvnet-parent-1.pom
+net/java/jvnet-parent/1/jvnet-parent-1.pom.sha1
 net/java/jvnet-parent/3/_remote.repositories
 net/java/jvnet-parent/3/jvnet-parent-3.pom
 net/java/jvnet-parent/3/jvnet-parent-3.pom.sha1
 net/java/jvnet-parent/4/_remote.repositories
 net/java/jvnet-parent/4/jvnet-parent-4.pom
 net/java/jvnet-parent/4/jvnet-parent-4.pom.sha1
+net/java/jvnet-parent/5/_remote.repositories
+net/java/jvnet-parent/5/jvnet-parent-5.pom
+net/java/jvnet-parent/5/jvnet-parent-5.pom.sha1
 net/minidev/accessors-smart/2.4.9/_remote.repositories
 net/minidev/accessors-smart/2.4.9/accessors-smart-2.4.9.pom
 net/minidev/accessors-smart/2.4.9/accessors-smart-2.4.9.pom.sha1
@@ -1689,14 +1742,25 @@
 org/apache/avro/avro-parent/1.11.4/_remote.repositories
 org/apache/avro/avro-parent/1.11.4/avro-parent-1.11.4.pom
 org/apache/avro/avro-parent/1.11.4/avro-parent-1.11.4.pom.sha1
+org/apache/avro/avro-parent/1.12.0/_remote.repositories
+org/apache/avro/avro-parent/1.12.0/avro-parent-1.12.0.pom
+org/apache/avro/avro-parent/1.12.0/avro-parent-1.12.0.pom.sha1
 org/apache/avro/avro-toplevel/1.11.4/_remote.repositories
 org/apache/avro/avro-toplevel/1.11.4/avro-toplevel-1.11.4.pom
 org/apache/avro/avro-toplevel/1.11.4/avro-toplevel-1.11.4.pom.sha1
+org/apache/avro/avro-toplevel/1.12.0/_remote.repositories
+org/apache/avro/avro-toplevel/1.12.0/avro-toplevel-1.12.0.pom
+org/apache/avro/avro-toplevel/1.12.0/avro-toplevel-1.12.0.pom.sha1
 org/apache/avro/avro/1.11.4/_remote.repositories
 org/apache/avro/avro/1.11.4/avro-1.11.4.jar
 org/apache/avro/avro/1.11.4/avro-1.11.4.jar.sha1
 org/apache/avro/avro/1.11.4/avro-1.11.4.pom
 org/apache/avro/avro/1.11.4/avro-1.11.4.pom.sha1
+org/apache/avro/avro/1.12.0/_remote.repositories
+org/apache/avro/avro/1.12.0/avro-1.12.0.jar
+org/apache/avro/avro/1.12.0/avro-1.12.0.jar.sha1
+org/apache/avro/avro/1.12.0/avro-1.12.0.pom
+org/apache/avro/avro/1.12.0/avro-1.12.0.pom.sha1
 org/apache/commons/commons-collections4/4.4/_remote.repositories
 org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar
 org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar.sha1
@@ -2173,9 +2237,29 @@
 org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar.sha1
 org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom
 org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom.sha1
+org/apache/iceberg/iceberg-api/1.10.1/_remote.repositories
+org/apache/iceberg/iceberg-api/1.10.1/iceberg-api-1.10.1.jar
+org/apache/iceberg/iceberg-api/1.10.1/iceberg-api-1.10.1.jar.sha1
+org/apache/iceberg/iceberg-api/1.10.1/iceberg-api-1.10.1.pom
+org/apache/iceberg/iceberg-api/1.10.1/iceberg-api-1.10.1.pom.sha1
 org/apache/iceberg/iceberg-bom/1.10.1/_remote.repositories
 org/apache/iceberg/iceberg-bom/1.10.1/iceberg-bom-1.10.1.pom
 org/apache/iceberg/iceberg-bom/1.10.1/iceberg-bom-1.10.1.pom.sha1
+org/apache/iceberg/iceberg-bundled-guava/1.10.1/_remote.repositories
+org/apache/iceberg/iceberg-bundled-guava/1.10.1/iceberg-bundled-guava-1.10.1.jar
+org/apache/iceberg/iceberg-bundled-guava/1.10.1/iceberg-bundled-guava-1.10.1.jar.sha1
+org/apache/iceberg/iceberg-bundled-guava/1.10.1/iceberg-bundled-guava-1.10.1.pom
+org/apache/iceberg/iceberg-bundled-guava/1.10.1/iceberg-bundled-guava-1.10.1.pom.sha1
+org/apache/iceberg/iceberg-common/1.10.1/_remote.repositories
+org/apache/iceberg/iceberg-common/1.10.1/iceberg-common-1.10.1.jar
+org/apache/iceberg/iceberg-common/1.10.1/iceberg-common-1.10.1.jar.sha1
+org/apache/iceberg/iceberg-common/1.10.1/iceberg-common-1.10.1.pom
+org/apache/iceberg/iceberg-common/1.10.1/iceberg-common-1.10.1.pom.sha1
+org/apache/iceberg/iceberg-core/1.10.1/_remote.repositories
+org/apache/iceberg/iceberg-core/1.10.1/iceberg-core-1.10.1.jar
+org/apache/iceberg/iceberg-core/1.10.1/iceberg-core-1.10.1.jar.sha1
+org/apache/iceberg/iceberg-core/1.10.1/iceberg-core-1.10.1.pom
+org/apache/iceberg/iceberg-core/1.10.1/iceberg-core-1.10.1.pom.sha1
 org/apache/kerby/kerb-admin/2.0.3/_remote.repositories
 org/apache/kerby/kerb-admin/2.0.3/kerb-admin-2.0.3.jar
 org/apache/kerby/kerb-admin/2.0.3/kerb-admin-2.0.3.jar.sha1
@@ -2202,8 +2286,6 @@
 org/apache/kerby/kerb-crypto/1.0.1/kerb-crypto-1.0.1.pom
 org/apache/kerby/kerb-crypto/1.0.1/kerb-crypto-1.0.1.pom.sha1
 org/apache/kerby/kerb-crypto/2.0.3/_remote.repositories
-org/apache/kerby/kerb-crypto/2.0.3/kerb-crypto-2.0.3.jar
-org/apache/kerby/kerb-crypto/2.0.3/kerb-crypto-2.0.3.jar.sha1
 org/apache/kerby/kerb-crypto/2.0.3/kerb-crypto-2.0.3.pom
 org/apache/kerby/kerb-crypto/2.0.3/kerb-crypto-2.0.3.pom.sha1
 org/apache/kerby/kerb-identity/2.0.3/_remote.repositories
@@ -2249,8 +2331,6 @@
 org/apache/kerby/kerby-config/1.0.1/kerby-config-1.0.1.pom
 org/apache/kerby/kerby-config/1.0.1/kerby-config-1.0.1.pom.sha1
 org/apache/kerby/kerby-config/2.0.3/_remote.repositories
-org/apache/kerby/kerby-config/2.0.3/kerby-config-2.0.3.jar
-org/apache/kerby/kerby-config/2.0.3/kerby-config-2.0.3.jar.sha1
 org/apache/kerby/kerby-config/2.0.3/kerby-config-2.0.3.pom
 org/apache/kerby/kerby-config/2.0.3/kerby-config-2.0.3.pom.sha1
 org/apache/kerby/kerby-kerb/1.0.1/_remote.repositories
@@ -3056,6 +3136,11 @@
 org/apache/maven/plugins/maven-plugins/47/_remote.repositories
 org/apache/maven/plugins/maven-plugins/47/maven-plugins-47.pom
 org/apache/maven/plugins/maven-plugins/47/maven-plugins-47.pom.sha1
+org/apache/maven/plugins/maven-pmd-plugin/3.28.0/_remote.repositories
+org/apache/maven/plugins/maven-pmd-plugin/3.28.0/maven-pmd-plugin-3.28.0.jar
+org/apache/maven/plugins/maven-pmd-plugin/3.28.0/maven-pmd-plugin-3.28.0.jar.sha1
+org/apache/maven/plugins/maven-pmd-plugin/3.28.0/maven-pmd-plugin-3.28.0.pom
+org/apache/maven/plugins/maven-pmd-plugin/3.28.0/maven-pmd-plugin-3.28.0.pom.sha1
 org/apache/maven/plugins/maven-remote-resources-plugin/3.3.0/_remote.repositories
 org/apache/maven/plugins/maven-remote-resources-plugin/3.3.0/maven-remote-resources-plugin-3.3.0.jar
 org/apache/maven/plugins/maven-remote-resources-plugin/3.3.0/maven-remote-resources-plugin-3.3.0.jar.sha1
@@ -3603,16 +3688,16 @@
 org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar.sha1
 org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.pom
 org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.pom.sha1
-org/aspectj/aspectjrt/1.9.7/_remote.repositories
-org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar
-org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar.sha1
-org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.pom
-org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.pom.sha1
-org/aspectj/aspectjtools/1.9.7/_remote.repositories
-org/aspectj/aspectjtools/1.9.7/aspectjtools-1.9.7.jar
-org/aspectj/aspectjtools/1.9.7/aspectjtools-1.9.7.jar.sha1
-org/aspectj/aspectjtools/1.9.7/aspectjtools-1.9.7.pom
-org/aspectj/aspectjtools/1.9.7/aspectjtools-1.9.7.pom.sha1
+org/aspectj/aspectjrt/1.9.24/_remote.repositories
+org/aspectj/aspectjrt/1.9.24/aspectjrt-1.9.24.jar
+org/aspectj/aspectjrt/1.9.24/aspectjrt-1.9.24.jar.sha1
+org/aspectj/aspectjrt/1.9.24/aspectjrt-1.9.24.pom
+org/aspectj/aspectjrt/1.9.24/aspectjrt-1.9.24.pom.sha1
+org/aspectj/aspectjtools/1.9.24/_remote.repositories
+org/aspectj/aspectjtools/1.9.24/aspectjtools-1.9.24.jar
+org/aspectj/aspectjtools/1.9.24/aspectjtools-1.9.24.jar.sha1
+org/aspectj/aspectjtools/1.9.24/aspectjtools-1.9.24.pom
+org/aspectj/aspectjtools/1.9.24/aspectjtools-1.9.24.pom.sha1
 org/assertj/assertj-bom/3.25.3/_remote.repositories
 org/assertj/assertj-bom/3.25.3/assertj-bom-3.25.3.pom
 org/assertj/assertj-bom/3.25.3/assertj-bom-3.25.3.pom.sha1
@@ -4213,8 +4298,6 @@
 org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.pom
 org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.pom.sha1
 org/codehaus/woodstox/stax2-api/4.2/_remote.repositories
-org/codehaus/woodstox/stax2-api/4.2/stax2-api-4.2.jar
-org/codehaus/woodstox/stax2-api/4.2/stax2-api-4.2.jar.sha1
 org/codehaus/woodstox/stax2-api/4.2/stax2-api-4.2.pom
 org/codehaus/woodstox/stax2-api/4.2/stax2-api-4.2.pom.sha1
 org/codehaus/woodstox/wstx-asl/3.2.6/_remote.repositories
@@ -4552,6 +4635,9 @@
 org/glassfish/jaxb/jaxb-bom/2.3.9/_remote.repositories
 org/glassfish/jaxb/jaxb-bom/2.3.9/jaxb-bom-2.3.9.pom
 org/glassfish/jaxb/jaxb-bom/2.3.9/jaxb-bom-2.3.9.pom.sha1
+org/glassfish/jaxb/jaxb-bom/3.0.0/_remote.repositories
+org/glassfish/jaxb/jaxb-bom/3.0.0/jaxb-bom-3.0.0.pom
+org/glassfish/jaxb/jaxb-bom/3.0.0/jaxb-bom-3.0.0.pom.sha1
 org/glassfish/jaxb/jaxb-runtime/2.3.9/_remote.repositories
 org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar
 org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar.sha1
@@ -4662,6 +4748,11 @@
 org/jacoco/org.jacoco.build/0.8.14/_remote.repositories
 org/jacoco/org.jacoco.build/0.8.14/org.jacoco.build-0.8.14.pom
 org/jacoco/org.jacoco.build/0.8.14/org.jacoco.build-0.8.14.pom.sha1
+org/jacoco/org.jacoco.cli/0.8.14/_remote.repositories
+org/jacoco/org.jacoco.cli/0.8.14/org.jacoco.cli-0.8.14-nodeps.jar
+org/jacoco/org.jacoco.cli/0.8.14/org.jacoco.cli-0.8.14-nodeps.jar.sha1
+org/jacoco/org.jacoco.cli/0.8.14/org.jacoco.cli-0.8.14.pom
+org/jacoco/org.jacoco.cli/0.8.14/org.jacoco.cli-0.8.14.pom.sha1
 org/jacoco/org.jacoco.core/0.8.14/_remote.repositories
 org/jacoco/org.jacoco.core/0.8.14/org.jacoco.core-0.8.14.jar
 org/jacoco/org.jacoco.core/0.8.14/org.jacoco.core-0.8.14.jar.sha1
@@ -4959,6 +5050,9 @@
 org/kohsuke/pom/21/_remote.repositories
 org/kohsuke/pom/21/pom-21.pom
 org/kohsuke/pom/21/pom-21.pom.sha1
+org/kohsuke/pom/8/_remote.repositories
+org/kohsuke/pom/8/pom-8.pom
+org/kohsuke/pom/8/pom-8.pom.sha1
 org/mockito/mockito-bom/4.11.0/_remote.repositories
 org/mockito/mockito-bom/4.11.0/mockito-bom-4.11.0.pom
 org/mockito/mockito-bom/4.11.0/mockito-bom-4.11.0.pom.sha1
```