### PR TITLE
HDDS-15283. GetObjectTagging should return TagSet in sorted order of key

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -46,6 +46,8 @@ import com.amazonaws.services.s3.model.CopyObjectResult;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.Grantee;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
@@ -70,6 +72,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.SetObjectAclRequest;
+import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
@@ -1099,6 +1102,27 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
       }
       assertEquals(content, bos.toString("UTF-8"));
     }
+  }
+
+  @Test
+  public void testGetObjectTaggingReturnsTagsSortedByKey() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(bucketName);
+    s3Client.putObject(bucketName, keyName, "");
+
+    List<Tag> tagsPutOrder = Arrays.asList(new Tag("key2", "val2"), new Tag("key", "val"));
+    s3Client.setObjectTagging(
+        new SetObjectTaggingRequest(bucketName, keyName, new ObjectTagging(tagsPutOrder)));
+
+    GetObjectTaggingResult taggingResult =
+        s3Client.getObjectTagging(new GetObjectTaggingRequest(bucketName, keyName));
+    List<Tag> tagSet = taggingResult.getTagSet();
+    assertEquals(2, tagSet.size());
+    assertEquals("key", tagSet.get(0).getKey());
+    assertEquals("val", tagSet.get(0).getValue());
+    assertEquals("key2", tagSet.get(1).getKey());
+    assertEquals("val2", tagSet.get(1).getValue());
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -120,6 +120,7 @@ import software.amazon.awssdk.services.s3.model.GetBucketAclRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -241,6 +242,28 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
 
     assertEquals(content, objectBytes.asUtf8String());
     assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"", getObjectResponse.eTag());
+  }
+
+  @Test
+  public void testGetObjectTaggingReturnsTagsSortedByKey() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.empty());
+
+    List<Tag> tagsPutOrder = Arrays.asList(
+        Tag.builder().key("key2").value("val2").build(),
+        Tag.builder().key("key").value("val").build());
+    s3Client.putObjectTagging(b -> b.bucket(bucketName).key(keyName)
+        .tagging(Tagging.builder().tagSet(tagsPutOrder).build()));
+
+    GetObjectTaggingResponse taggingResult = s3Client.getObjectTagging(b -> b.bucket(bucketName).key(keyName));
+    List<Tag> tagSet = taggingResult.tagSet();
+    assertEquals(2, tagSet.size());
+    assertEquals("key", tagSet.get(0).key());
+    assertEquals("val", tagSet.get(0).value());
+    assertEquals("key2", tagSet.get(1).key());
+    assertEquals("val2", tagSet.get(1).value());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3Tagging.java
@@ -118,16 +118,16 @@ public class S3Tagging {
 
   /**
    * Creates a S3 tagging instance (xml representation) from a Map retrieved
-   * from OM.
+   * from OM. Tags are ordered by key for stable responses,
+   * consistent with AWS S3 {@code GetObjectTagging}.
    * @param tagMap Map representing the tags.
    * @return {@link S3Tagging}
    */
   public static S3Tagging fromMap(Map<String, String> tagMap) {
     List<Tag> tags = tagMap.entrySet()
         .stream()
-        .map(
-            tagEntry -> new Tag(tagEntry.getKey(), tagEntry.getValue())
-        )
+        .sorted(Map.Entry.comparingByKey())
+        .map(tagEntry -> new Tag(tagEntry.getKey(), tagEntry.getValue()))
         .collect(Collectors.toList());
     return new S3Tagging(new TagSet(tags));
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectTaggingGet.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.util.List;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -50,6 +51,7 @@ public class TestObjectTaggingGet {
   private static final String BUCKET_NAME = "b1";
   private static final String KEY_WITH_TAG = "keyWithTag";
   private ObjectEndpoint rest;
+  private HttpHeaders headers;
 
   @BeforeEach
   public void init() throws Exception {
@@ -57,7 +59,7 @@ public class TestObjectTaggingGet {
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(BUCKET_NAME);
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    headers = Mockito.mock(HttpHeaders.class);
     Mockito.when(headers.getHeaderString(X_AMZ_CONTENT_SHA256))
         .thenReturn("UNSIGNED-PAYLOAD");
 
@@ -65,14 +67,13 @@ public class TestObjectTaggingGet {
         .setClient(client)
         .setHeaders(headers)
         .build();
-
-    // Create a key with object tags
-    Mockito.when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
-    assertSucceeds(() -> put(rest, BUCKET_NAME, KEY_WITH_TAG, CONTENT));
   }
 
   @Test
   public void testGetTagging() throws IOException, OS3Exception {
+    Mockito.when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
+    assertSucceeds(() -> put(rest, BUCKET_NAME, KEY_WITH_TAG, CONTENT));
+
     //WHEN
     Response response = getTagging(rest, BUCKET_NAME, KEY_WITH_TAG);
 
@@ -90,6 +91,22 @@ public class TestObjectTaggingGet {
         fail("Unknown tag found");
       }
     }
+  }
+
+  @Test
+  public void testGetTaggingReturnsTagsSortedByKey() throws IOException, OS3Exception {
+    final String reverseOrderKey = "keyReverseTagOrder";
+    Mockito.when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag2=value2&tag=value");
+    assertSucceeds(() -> put(rest, BUCKET_NAME, reverseOrderKey, CONTENT));
+
+    Response response = getTagging(rest, BUCKET_NAME, reverseOrderKey);
+    assertEquals(HTTP_OK, response.getStatus());
+    List<Tag> tags = ((S3Tagging) response.getEntity()).getTagSet().getTags();
+    assertEquals(2, tags.size());
+    assertEquals("tag", tags.get(0).getKey());
+    assertEquals("value", tags.get(0).getValue());
+    assertEquals("tag2", tags.get(1).getKey());
+    assertEquals("value2", tags.get(1).getValue());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Object tags are handled internally as a Map. When TagSet is built from map iteration (e.g. HashMap), the order of <Tag> elements in the XML response is undefined. That order can differ from the order the client sent on PutObjectTagging, even though keys and values are correct.

Some S3 compatibility suites `test_put_modify_tags` (e.g. boto/s3tests)` assert response["TagSet"] == expected_tag_set `as Python lists, which requires same keys, values, and order.

**Expected behavior**
GetObjectTagging should return tags in a stable order. Aligning with common S3 behavior, tags should be ordered lexicographically by tag key (Unicode/string natural order).

**Example**
```
PutObjectTagging Input
TagSet: [
 { Key: key, Value: val },
 { Key: key2, Value: val2 }
 ] 
 
```
**Wrong  Output(fails strict tests):**
```
GetObjectTagging----->

 "TagSet": [
   {"Key":"key2","Value":"val2"},
   {"Key":"key","Value":"val"} 
  ] 
```
**Correct (stable, passes strict equality when expectation is key-first):**
```
 "TagSet": [
{"Key":"key","Value":"val"},
{"Key":"key2","Value":"val2"} 
] 
```
Emit TagSet sorted by tag key when building the GetObjectTagging response (e.g. sort map entries before XML).


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15283

## How was this patch tested?

Added UT and IT tests.
Tested manually.
Before fix: **test_put_modify_tags** s3 test was failing from ozone compatibility.
```
bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'foo=bar&bar=val'   --endpoint-url  http://s3g:9878/
{
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\""
}
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878/
{
    "TagSet": [
        {
            "Key": "foo",
            "Value": "bar"
        },                                 -------------------------------------> wrong order that's why it fails on s3 compatibilty test
        {
            "Key": "bar",
            "Value": "val"
        }
    ]
}
```

After fix:
```
bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'foo=bar&bar=bar1'   --endpoint-url  http://s3g:9878/
{
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\""
}
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878/
{
    "TagSet": [
        {
            "Key": "bar",
            "Value": "bar1"
        },
        {
            "Key": "foo",
            "Value": "bar"
        }
    ]
}
bash-5.1$ aws s3api put-object-tagging  --bucket buck1  --key key1 --tagging 'TagSet=[{Key=test2,Value=replace},{Key=test1,Value=replace1}]' --endpoint-url http://s3g:9878/

bash-5.1$ aws s3api get-object-tagging  --bucket buck1  --key key1 --endpoint-url http://s3g:9878/
{
  "TagSet": [
    {
      "Key": "test1",
      "Value": "replace1"
    },
    {
      "Key": "test2",
      "Value": "replace"
    }
  ]
}
```
