### PR TITLE
HDDS-15285. Pin Grafana to 13.0.1+security-01, fix outdated config

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/grafana/provisioning/dashboards/dashboards.yml
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/provisioning/dashboards/dashboards.yml
@@ -14,9 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: 'default'
-  org_id: 1
-  folder: ''
-  type: 'file'
-  options:
-    folder: '/var/lib/grafana/dashboards'
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/hadoop-ozone/dist/src/main/compose/common/grafana/provisioning/datasources/datasources.yml
+++ b/hadoop-ozone/dist/src/main/compose/common/grafana/provisioning/datasources/datasources.yml
@@ -14,12 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: 1
+
 datasources:
-- name: 'Prometheus'
-  type: 'prometheus'
-  access: 'proxy'
-  org_id: 1
-  url: 'http://prometheus:9090'
-  is_default: true
-  version: 1
-  editable: true
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
@@ -34,7 +34,7 @@ services:
     ports:
       - 9090:9090
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:11.4.0
     volumes:
       - "../common/grafana/dashboards:/var/lib/grafana/dashboards"
       - "../common/grafana/provisioning:/etc/grafana/provisioning"

--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
@@ -34,7 +34,7 @@ services:
     ports:
       - 9090:9090
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:13.0.1-security-01
     volumes:
       - "../common/grafana/dashboards:/var/lib/grafana/dashboards"
       - "../common/grafana/provisioning:/etc/grafana/provisioning"


### PR DESCRIPTION
## What changes were proposed in this pull request?
While trying to start up a docker compose cluster with monitoring, I see that grafana process terminates instantly

```
export COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
docker compose up -d --scale datanode=3 
```
Grafana logs:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x6150894]

goroutine 1 [running]:
github.com/grafana/grafana/pkg/cmd/grafana-server/commands.RunServer.func2()
	github.com/grafana/grafana/pkg/cmd/grafana-server/commands/cli.go:89 +0x110
panic({0x88673c0?, 0x12b14680?})
	runtime/panic.go:783 +0x120
github.com/grafana/grafana/pkg/services/provisioning/dashboards.(*configReader).parseConfigs(0x4003106490, {0xb52c2c0?, 0x40019b0040?})
```

Grafana crashed because the bundled provisioning YAML used an old schema that current Grafana could not parse, so dashboard provisioning hit a null pointer during startup.
 https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards
The PR changes:
1. Dashboard provisioning: Rewrote dashboards.yml to apiVersion: 1 with a providers block and options.path, replacing the legacy root-level list so current Grafana can parse it without panicking at startup.
2. Datasource provisioning: Added apiVersion: 1 and camelCase fields (orgId, isDefault, etc.) in datasources.yml so Prometheus is provisioned in the format Grafana expects.
3. Image pin: Set grafana/grafana:13.0.1+security-01 in monitoring.yaml instead of floating latest, so local/CI runs stay reproducible and don’t break when Grafana releases change.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15285

## How was this patch tested?
Manually spinning up docker compose and loading up grafana

<img width="1695" height="864" alt="Screenshot 2026-05-15 at 2 30 48 PM" src="https://github.com/user-attachments/assets/1b4c7129-89cb-498e-a845-d3cbb80aca24" />

