### PR TITLE
HDDS-15289. Add persistentVolumeClaimRetentionPolicy to pod templates

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone/definitions/persistence.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone/definitions/persistence.yaml
@@ -22,6 +22,9 @@ description: Add real PVC based persistence
   trigger:
     kind: StatefulSet
   value:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Delete
+        whenScaled: Retain
       volumeClaimTemplates:
       - metadata:
           name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/datanode-statefulset.yaml
@@ -61,6 +61,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/httpfs-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/httpfs-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/om-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/om-statefulset.yaml
@@ -61,6 +61,9 @@ spec:
         - name: data
           mountPath: /data
       volumes: []
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/recon-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/recon-statefulset.yaml
@@ -59,6 +59,9 @@ spec:
         - name: data
           mountPath: /data
       volumes: []
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/s3g-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/s3g-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/scm-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/scm-statefulset.yaml
@@ -80,6 +80,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/datanode-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/datanode-statefulset.yaml
@@ -61,6 +61,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/httpfs-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/httpfs-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/om-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/om-statefulset.yaml
@@ -61,6 +61,9 @@ spec:
         - name: data
           mountPath: /data
       volumes: []
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/recon-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/recon-statefulset.yaml
@@ -59,6 +59,9 @@ spec:
         - name: data
           mountPath: /data
       volumes: []
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/s3g-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/s3g-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/scm-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/scm-statefulset.yaml
@@ -68,6 +68,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -90,17 +90,32 @@ pre_run_setup() {
   wait_for_startup
 }
 
+dump_pv_pvc_state() {
+   local -r label="${1:-state}"
+   echo "===== PV/PVC ${label} ====="
+   kubectl get pv,pvc -o wide --all-namespaces 2>&1 || true
+   echo "----- PV finalizers / status -----"
+   kubectl get pv -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,CLAIM:.spec.claimRef.name,FINALIZERS:.metadata.finalizers,DELETION:.metadata.deletionTimestamp 2>&1 || true
+   echo "----- Recent events (last 30) -----"
+   kubectl get events --sort-by=.lastTimestamp --all-namespaces 2>&1 | tail -30 || true
+   echo "===== end ${label} ====="
+}
+
 reset_k8s_env() {
    print_phase "Deleting existing k8s resources"
    #reset environment
-   kubectl delete statefulset --all
-   kubectl delete daemonset --all
-   kubectl delete deployment --all
-   kubectl delete service --all
-   kubectl delete configmap --all
-   kubectl delete pod --all
-   kubectl delete pvc --all
-   kubectl delete pv --all
+   local -r DEL_TIMEOUT="${RESET_TIMEOUT:-120s}"
+   dump_pv_pvc_state "before delete"
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found statefulset --all
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found daemonset --all
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found deployment --all
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found service --all
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found configmap --all
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found pod --all
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found pvc --all
+   dump_pv_pvc_state "after pvc delete"
+   kubectl delete --timeout="$DEL_TIMEOUT" --ignore-not-found pv --all
+   dump_pv_pvc_state "after pv delete"
 }
 
 start_k8s_env() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The CI upon running K8s tests gets blocked and timesout after 1 hour. 
It is observed that this happens after PVC cleanup but before PV cleanup. 

This PR 
1. Adds a timeout so that the CI is not stuck when cleaning up k8s resources
2. Updates the PV retain policy to delete so that no k8s finalizers block the cleanup of PVs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15289

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/25935306665