### PR TITLE
HDDS-15290. DiskBalancer should write info file atomically

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -332,17 +332,55 @@ public class DiskBalancerService extends BackgroundService {
   private synchronized void writeDiskBalancerInfoTo(
       DiskBalancerInfo diskBalancerInfo, File path)
       throws IOException {
-    if (path.exists()) {
-      if (!path.delete() || !path.createNewFile()) {
-        throw new IOException("Unable to overwrite the DiskBalancerInfo file.");
-      }
-    } else {
-      if (!path.getParentFile().exists() &&
-          !path.getParentFile().mkdirs()) {
-        throw new IOException("Unable to create DiskBalancerInfo directories.");
+    writeDiskBalancerInfoAtomically(
+        diskBalancerInfo, path, DiskBalancerYaml::createDiskBalancerInfoFile);
+  }
+
+  @VisibleForTesting
+  static void writeDiskBalancerInfoAtomically(DiskBalancerInfo diskBalancerInfo,
+      File path, DiskBalancerInfoWriter writer) throws IOException {
+    Path target = path.toPath().toAbsolutePath();
+    Path parent = target.getParent();
+    if (parent != null) {
+      try {
+        Files.createDirectories(parent);
+      } catch (IOException e) {
+        throw new IOException(
+            "Unable to create DiskBalancerInfo directories: " + parent, e);
       }
     }
-    DiskBalancerYaml.createDiskBalancerInfoFile(diskBalancerInfo, path);
+
+    final Path tempFile;
+    try {
+      tempFile = Files.createTempFile(parent, path.getName(), ".tmp");
+    } catch (IOException e) {
+      throw new IOException(
+          "Unable to create temporary DiskBalancerInfo file under: "
+              + parent, e);
+    }
+    boolean moved = false;
+    try {
+      writer.write(diskBalancerInfo, tempFile.toFile());
+      try {
+        Files.move(tempFile, target, StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException e) {
+        throw new IOException(
+            "Unable to overwrite the DiskBalancerInfo file: " + target, e);
+      }
+      moved = true;
+    } finally {
+      if (!moved) {
+        Files.deleteIfExists(tempFile);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  @FunctionalInterface
+  interface DiskBalancerInfoWriter {
+    void write(DiskBalancerInfo diskBalancerInfo, File path)
+        throws IOException;
   }
 
   public void setThreshold(double threshold) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -335,7 +335,6 @@ public class DiskBalancerService extends BackgroundService {
     writeDiskBalancerInfoFile(diskBalancerInfo, path);
   }
 
-  @VisibleForTesting
   static void writeDiskBalancerInfoFile(DiskBalancerInfo diskBalancerInfo,
       File path) throws IOException {
     Path target = path.toPath().toAbsolutePath();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -341,13 +341,16 @@ public class DiskBalancerService extends BackgroundService {
       File path, DiskBalancerInfoWriter writer) throws IOException {
     Path target = path.toPath().toAbsolutePath();
     Path parent = target.getParent();
-    if (parent != null) {
-      try {
-        Files.createDirectories(parent);
-      } catch (IOException e) {
-        throw new IOException(
-            "Unable to create DiskBalancerInfo directories: " + parent, e);
-      }
+    if (parent == null) {
+      throw new IOException(
+          "Unable to determine parent directory for DiskBalancerInfo file: "
+              + target);
+    }
+    try {
+      Files.createDirectories(parent);
+    } catch (IOException e) {
+      throw new IOException(
+          "Unable to create DiskBalancerInfo directories: " + parent, e);
     }
 
     final Path tempFile;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -332,11 +332,6 @@ public class DiskBalancerService extends BackgroundService {
   private synchronized void writeDiskBalancerInfoTo(
       DiskBalancerInfo diskBalancerInfo, File path)
       throws IOException {
-    writeDiskBalancerInfoFile(diskBalancerInfo, path);
-  }
-
-  static void writeDiskBalancerInfoFile(DiskBalancerInfo diskBalancerInfo,
-      File path) throws IOException {
     Path target = path.toPath().toAbsolutePath();
     Path parent = target.getParent();
     if (parent == null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -332,13 +332,12 @@ public class DiskBalancerService extends BackgroundService {
   private synchronized void writeDiskBalancerInfoTo(
       DiskBalancerInfo diskBalancerInfo, File path)
       throws IOException {
-    writeDiskBalancerInfoAtomically(
-        diskBalancerInfo, path, DiskBalancerYaml::createDiskBalancerInfoFile);
+    writeDiskBalancerInfoFile(diskBalancerInfo, path);
   }
 
   @VisibleForTesting
-  static void writeDiskBalancerInfoAtomically(DiskBalancerInfo diskBalancerInfo,
-      File path, DiskBalancerInfoWriter writer) throws IOException {
+  static void writeDiskBalancerInfoFile(DiskBalancerInfo diskBalancerInfo,
+      File path) throws IOException {
     Path target = path.toPath().toAbsolutePath();
     Path parent = target.getParent();
     if (parent == null) {
@@ -353,37 +352,13 @@ public class DiskBalancerService extends BackgroundService {
           "Unable to create DiskBalancerInfo directories: " + parent, e);
     }
 
-    final Path tempFile;
     try {
-      tempFile = Files.createTempFile(parent, path.getName(), ".tmp");
+      DiskBalancerYaml.createDiskBalancerInfoFile(diskBalancerInfo,
+          target.toFile());
     } catch (IOException e) {
       throw new IOException(
-          "Unable to create temporary DiskBalancerInfo file under: "
-              + parent, e);
+          "Unable to write DiskBalancerInfo file: " + target, e);
     }
-    boolean moved = false;
-    try {
-      writer.write(diskBalancerInfo, tempFile.toFile());
-      try {
-        Files.move(tempFile, target, StandardCopyOption.ATOMIC_MOVE,
-            StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException e) {
-        throw new IOException(
-            "Unable to overwrite the DiskBalancerInfo file: " + target, e);
-      }
-      moved = true;
-    } finally {
-      if (!moved) {
-        Files.deleteIfExists(tempFile);
-      }
-    }
-  }
-
-  @VisibleForTesting
-  @FunctionalInterface
-  interface DiskBalancerInfoWriter {
-    void write(DiskBalancerInfo diskBalancerInfo, File path)
-        throws IOException;
   }
 
   public void setThreshold(double threshold) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.diskbalancer;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
 import static org.apache.hadoop.ozone.container.common.volume.StorageVolume.TMP_DIR_NAME;
 import static org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerVolumeCalculation.getVolumeUsages;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -380,27 +381,20 @@ public class TestDiskBalancerService {
   }
 
   @Test
-  public void testDiskBalancerInfoAtomicWritePreservesExistingFileOnFailure()
+  public void testDiskBalancerInfoWriteCreatesParentDirectory()
       throws Exception {
-    File infoFile = tmpDir.resolve("diskBalancer.info").toFile();
-    DiskBalancerInfo oldInfo = new DiskBalancerInfo(
-        DiskBalancerRunningStatus.STOPPED, 10.0d, 100L, 5, true);
-    DiskBalancerInfo newInfo = new DiskBalancerInfo(
-        DiskBalancerRunningStatus.RUNNING, 20.0d, 200L, 10, false);
-    DiskBalancerYaml.createDiskBalancerInfoFile(oldInfo, infoFile);
+    File infoFile = tmpDir.resolve("nested").resolve("diskBalancer.info")
+        .toFile();
+    DiskBalancerInfo info = new DiskBalancerInfo(
+        DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
 
-    IOException exception = assertThrows(IOException.class,
-        () -> DiskBalancerService.writeDiskBalancerInfoAtomically(
-            newInfo, infoFile, (info, path) -> {
-              throw new IOException("simulated write failure");
-            }));
+    DiskBalancerService.writeDiskBalancerInfoFile(info, infoFile);
 
-    assertEquals("simulated write failure", exception.getMessage());
-    assertEquals(oldInfo, DiskBalancerYaml.readDiskBalancerInfoFile(infoFile));
+    assertEquals(info, DiskBalancerYaml.readDiskBalancerInfoFile(infoFile));
   }
 
   @Test
-  public void testDiskBalancerInfoAtomicWriteReportsDirectoryCreationFailure()
+  public void testDiskBalancerInfoWriteReportsDirectoryCreationFailure()
       throws Exception {
     File parent = tmpDir.resolve("diskBalancer-parent").toFile();
     assertTrue(parent.createNewFile());
@@ -409,15 +403,14 @@ public class TestDiskBalancerService {
         DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
 
     IOException exception = assertThrows(IOException.class,
-        () -> DiskBalancerService.writeDiskBalancerInfoAtomically(
-            info, infoFile, DiskBalancerYaml::createDiskBalancerInfoFile));
+        () -> DiskBalancerService.writeDiskBalancerInfoFile(info, infoFile));
 
-    assertTrue(exception.getMessage()
-        .startsWith("Unable to create DiskBalancerInfo directories: "));
+    assertThat(exception)
+        .hasMessageStartingWith("Unable to create DiskBalancerInfo directories: ");
   }
 
   @Test
-  public void testDiskBalancerInfoAtomicWriteReportsOverwriteFailure()
+  public void testDiskBalancerInfoWriteReportsFileWriteFailure()
       throws Exception {
     File infoFile = tmpDir.resolve("diskBalancer.info").toFile();
     assertTrue(infoFile.mkdirs());
@@ -426,11 +419,10 @@ public class TestDiskBalancerService {
         DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
 
     IOException exception = assertThrows(IOException.class,
-        () -> DiskBalancerService.writeDiskBalancerInfoAtomically(
-            info, infoFile, DiskBalancerYaml::createDiskBalancerInfoFile));
+        () -> DiskBalancerService.writeDiskBalancerInfoFile(info, infoFile));
 
-    assertTrue(exception.getMessage()
-        .startsWith("Unable to overwrite the DiskBalancerInfo file: "));
+    assertThat(exception)
+        .hasMessageStartingWith("Unable to write DiskBalancerInfo file: ");
   }
 
   private OzoneContainer mockDependencies(ContainerSet containerSet,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -404,9 +404,10 @@ public class TestDiskBalancerService {
         100, 5000);
   }
 
-  @Test
-  public void testDiskBalancerInfoWriteCreatesParentDirectory()
-      throws Exception {
+  @ContainerTestVersionInfo.ContainerTest
+  public void testDiskBalancerInfoWriteCreatesParentDirectory(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
     File infoDir = tmpDir.resolve("nested").toFile();
     DiskBalancerServiceTestImpl svc =
         getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir));
@@ -421,9 +422,10 @@ public class TestDiskBalancerService {
     svc.shutdown();
   }
 
-  @Test
-  public void testDiskBalancerInfoWriteReportsDirectoryCreationFailure()
-      throws Exception {
+  @ContainerTestVersionInfo.ContainerTest
+  public void testDiskBalancerInfoWriteReportsDirectoryCreationFailure(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
     File infoDir = tmpDir.resolve("diskBalancer-parent").toFile();
     assertTrue(infoDir.createNewFile());
 
@@ -434,9 +436,10 @@ public class TestDiskBalancerService {
         .hasMessageStartingWith("Unable to create DiskBalancerInfo directories: ");
   }
 
-  @Test
-  public void testDiskBalancerInfoWriteReportsFileWriteFailure()
-      throws Exception {
+  @ContainerTestVersionInfo.ContainerTest
+  public void testDiskBalancerInfoWriteReportsFileWriteFailure(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
     File infoDir = tmpDir.resolve("diskBalancer-info-dir").toFile();
     DiskBalancerServiceTestImpl svc =
         getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.container.diskbalancer;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_SCM_DATANODE_DISK_BALANCER_INFO_FILE_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
 import static org.apache.hadoop.ozone.container.common.volume.StorageVolume.TMP_DIR_NAME;
 import static org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerVolumeCalculation.getVolumeUsages;
@@ -271,6 +272,29 @@ public class TestDiskBalancerService {
         threadCount);
   }
 
+  private DiskBalancerServiceTestImpl getDiskBalancerService(
+      OzoneConfiguration config) throws IOException {
+    ContainerSet containerSet = ContainerSet.newReadOnlyContainerSet(1000);
+    ContainerMetrics metrics = ContainerMetrics.create(config);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(config, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        }, new ContainerChecksumTreeManager(config));
+    return getDiskBalancerService(containerSet, config, keyValueHandler, null, 1);
+  }
+
+  private OzoneConfiguration confWithDiskBalancerInfoDir(File infoDir) {
+    OzoneConfiguration testConf = new OzoneConfiguration(conf);
+    testConf.set("hdds.datanode.disk.balancer.info.dir",
+        infoDir.getAbsolutePath());
+    return testConf;
+  }
+
+  private File getDiskBalancerInfoFile(File infoDir) {
+    return new File(infoDir,
+        OZONE_SCM_DATANODE_DISK_BALANCER_INFO_FILE_DEFAULT);
+  }
+
   public static Stream<Arguments> values() {
     return Stream.of(
         Arguments.arguments(0, 0, 0),
@@ -383,27 +407,28 @@ public class TestDiskBalancerService {
   @Test
   public void testDiskBalancerInfoWriteCreatesParentDirectory()
       throws Exception {
-    File infoFile = tmpDir.resolve("nested").resolve("diskBalancer.info")
-        .toFile();
+    File infoDir = tmpDir.resolve("nested").toFile();
+    DiskBalancerServiceTestImpl svc =
+        getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir));
     DiskBalancerInfo info = new DiskBalancerInfo(
         DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
 
-    DiskBalancerService.writeDiskBalancerInfoFile(info, infoFile);
+    svc.refresh(info);
 
-    assertEquals(info, DiskBalancerYaml.readDiskBalancerInfoFile(infoFile));
+    assertEquals(info,
+        DiskBalancerYaml.readDiskBalancerInfoFile(
+            getDiskBalancerInfoFile(infoDir)));
+    svc.shutdown();
   }
 
   @Test
   public void testDiskBalancerInfoWriteReportsDirectoryCreationFailure()
       throws Exception {
-    File parent = tmpDir.resolve("diskBalancer-parent").toFile();
-    assertTrue(parent.createNewFile());
-    File infoFile = new File(parent, "diskBalancer.info");
-    DiskBalancerInfo info = new DiskBalancerInfo(
-        DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
+    File infoDir = tmpDir.resolve("diskBalancer-parent").toFile();
+    assertTrue(infoDir.createNewFile());
 
     IOException exception = assertThrows(IOException.class,
-        () -> DiskBalancerService.writeDiskBalancerInfoFile(info, infoFile));
+        () -> getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir)));
 
     assertThat(exception)
         .hasMessageStartingWith("Unable to create DiskBalancerInfo directories: ");
@@ -412,17 +437,22 @@ public class TestDiskBalancerService {
   @Test
   public void testDiskBalancerInfoWriteReportsFileWriteFailure()
       throws Exception {
-    File infoFile = tmpDir.resolve("diskBalancer.info").toFile();
+    File infoDir = tmpDir.resolve("diskBalancer-info-dir").toFile();
+    DiskBalancerServiceTestImpl svc =
+        getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir));
+    File infoFile = getDiskBalancerInfoFile(infoDir);
+    assertTrue(infoFile.delete());
     assertTrue(infoFile.mkdirs());
     assertTrue(new File(infoFile, "existing").createNewFile());
     DiskBalancerInfo info = new DiskBalancerInfo(
         DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
 
     IOException exception = assertThrows(IOException.class,
-        () -> DiskBalancerService.writeDiskBalancerInfoFile(info, infoFile));
+        () -> svc.refresh(info));
 
     assertThat(exception)
         .hasMessageStartingWith("Unable to write DiskBalancerInfo file: ");
+    svc.shutdown();
   }
 
   private OzoneContainer mockDependencies(ContainerSet containerSet,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -379,6 +379,60 @@ public class TestDiskBalancerService {
         100, 5000);
   }
 
+  @Test
+  public void testDiskBalancerInfoAtomicWritePreservesExistingFileOnFailure()
+      throws Exception {
+    File infoFile = tmpDir.resolve("diskBalancer.info").toFile();
+    DiskBalancerInfo oldInfo = new DiskBalancerInfo(
+        DiskBalancerRunningStatus.STOPPED, 10.0d, 100L, 5, true);
+    DiskBalancerInfo newInfo = new DiskBalancerInfo(
+        DiskBalancerRunningStatus.RUNNING, 20.0d, 200L, 10, false);
+    DiskBalancerYaml.createDiskBalancerInfoFile(oldInfo, infoFile);
+
+    IOException exception = assertThrows(IOException.class,
+        () -> DiskBalancerService.writeDiskBalancerInfoAtomically(
+            newInfo, infoFile, (info, path) -> {
+              throw new IOException("simulated write failure");
+            }));
+
+    assertEquals("simulated write failure", exception.getMessage());
+    assertEquals(oldInfo, DiskBalancerYaml.readDiskBalancerInfoFile(infoFile));
+  }
+
+  @Test
+  public void testDiskBalancerInfoAtomicWriteReportsDirectoryCreationFailure()
+      throws Exception {
+    File parent = tmpDir.resolve("diskBalancer-parent").toFile();
+    assertTrue(parent.createNewFile());
+    File infoFile = new File(parent, "diskBalancer.info");
+    DiskBalancerInfo info = new DiskBalancerInfo(
+        DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
+
+    IOException exception = assertThrows(IOException.class,
+        () -> DiskBalancerService.writeDiskBalancerInfoAtomically(
+            info, infoFile, DiskBalancerYaml::createDiskBalancerInfoFile));
+
+    assertTrue(exception.getMessage()
+        .startsWith("Unable to create DiskBalancerInfo directories: "));
+  }
+
+  @Test
+  public void testDiskBalancerInfoAtomicWriteReportsOverwriteFailure()
+      throws Exception {
+    File infoFile = tmpDir.resolve("diskBalancer.info").toFile();
+    assertTrue(infoFile.mkdirs());
+    assertTrue(new File(infoFile, "existing").createNewFile());
+    DiskBalancerInfo info = new DiskBalancerInfo(
+        DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true);
+
+    IOException exception = assertThrows(IOException.class,
+        () -> DiskBalancerService.writeDiskBalancerInfoAtomically(
+            info, infoFile, DiskBalancerYaml::createDiskBalancerInfoFile));
+
+    assertTrue(exception.getMessage()
+        .startsWith("Unable to overwrite the DiskBalancerInfo file: "));
+  }
+
   private OzoneContainer mockDependencies(ContainerSet containerSet,
       KeyValueHandler keyValueHandler, ContainerController controller) {
     OzoneContainer ozoneContainer = mock(OzoneContainer.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR updates DiskBalancer to persist `diskBalancer.info` atomically.

Previously, DiskBalancer overwrote `diskBalancer.info` by deleting the existing file and creating a new one. If the write failed between these steps, the existing configuration could be lost or left incomplete.

This patch changes the persistence flow to:

- create the parent directory if needed;
- write the new `DiskBalancerInfo` to a temporary file in the same directory;
- atomically move the temporary file to `diskBalancer.info`;
- preserve the existing file if the temporary write fails;
- provide clear `IOException` messages for directory creation, temporary file creation, and overwrite failures.

This makes DiskBalancer info persistence more robust and avoids losing the previous valid configuration on write failure.

## What is the link to the Apache JIRA

JIRA: HDDS-15290. DiskBalancer should write info file atomically.

## How was this patch tested?

Added unit tests.