### PR TITLE
HDDS-15292. Reduce Thread.sleep usage in DiskBalancer tests

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -579,7 +580,7 @@ public class TestDiskBalancerTask {
 
   @ContainerTestVersionInfo.ContainerTest
   public void testOldReplicaDelayedDeletion(ContainerTestVersionInfo versionInfo)
-      throws IOException, InterruptedException {
+      throws IOException, InterruptedException, TimeoutException {
     setLayoutAndSchemaForTest(versionInfo);
     long delay = 2000L; // 2 second delay
     diskBalancerService.setReplicaDeletionDelay(delay);
@@ -598,8 +599,10 @@ public class TestDiskBalancerTask {
     // create another container to trigger the deletion of old replicas
     createContainer(CONTAINER_ID + 1, sourceVolume, State.CLOSED);
     task = getTask();
-    // Wait for the delay to pass
-    Thread.sleep(delay);
+    // Wait until the delayed deletion is eligible, then trigger cleanup.
+    long deletionEligibleAt = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delay);
+    GenericTestUtils.waitFor(
+        () -> System.nanoTime() >= deletionEligibleAt, 50, 12_000);
     task.call();
     // Verify that the old container is deleted
     assertFalse(oldContainerDir.exists());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerWithConcurrentBackgroundTasks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerWithConcurrentBackgroundTasks.java
@@ -285,7 +285,8 @@ class TestDiskBalancerWithConcurrentBackgroundTasks {
       }
     });
     assertThat(deleteThreadPastSchedule.await(10, TimeUnit.SECONDS)).isTrue();
-    Thread.sleep(200);
+    GenericTestUtils.waitFor(
+        () -> containerSet.getContainer(CONTAINER_ID) == null, 100, 10_000);
 
     raceInjector.continueBalancer();
 
@@ -367,7 +368,9 @@ class TestDiskBalancerWithConcurrentBackgroundTasks {
       }
     });
     assertThat(blockThreadStarted.await(10, TimeUnit.SECONDS)).isTrue();
-    Thread.sleep(200);
+    GenericTestUtils.waitFor(
+        () -> readPendingDeleteBlockCountUnchecked(newData) < pendingBefore,
+        100, 10_000);
 
     raceInjector.continueBalancer();
     CompletableFuture.allOf(balancerDone, blockDone).get(60, TimeUnit.SECONDS);
@@ -433,7 +436,8 @@ class TestDiskBalancerWithConcurrentBackgroundTasks {
       }
     });
     assertThat(unhealthyThreadStarted.await(10, TimeUnit.SECONDS)).isTrue();
-    Thread.sleep(200);
+    GenericTestUtils.waitFor(
+        () -> liveReplica.getContainerState() == State.UNHEALTHY, 100, 10_000);
 
     raceInjector.continueBalancer();
     CompletableFuture.allOf(balancerDone, unhealthyDone).get(60, TimeUnit.SECONDS);
@@ -497,7 +501,8 @@ class TestDiskBalancerWithConcurrentBackgroundTasks {
       }
     });
     assertThat(closeThreadStarted.await(10, TimeUnit.SECONDS)).isTrue();
-    Thread.sleep(200);
+    GenericTestUtils.waitFor(
+        () -> liveReplica.getContainerState() == State.CLOSED, 100, 10_000);
 
     raceInjector.continueBalancer();
     CompletableFuture.allOf(balancerDone, closeDone).get(60, TimeUnit.SECONDS);
@@ -532,6 +537,14 @@ class TestDiskBalancerWithConcurrentBackgroundTasks {
       Table<String, Long> meta = db.getStore().getMetadataTable();
       Long v = meta.get(data.getPendingDeleteBlockCountKey());
       return v == null ? 0L : v;
+    }
+  }
+
+  private long readPendingDeleteBlockCountUnchecked(KeyValueContainerData data) {
+    try {
+      return readPendingDeleteBlockCount(data);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR reduces fixed `Thread.sleep` usage in DiskBalancer tests.

Some DiskBalancer tests used fixed sleeps to wait for asynchronous state changes or delayed cleanup. Fixed waits can make tests slower than necessary and may also introduce flakiness on slow or busy CI machines.

This change replaces those sleeps with condition-based waits using `GenericTestUtils.waitFor`, so the tests continue as soon as the expected condition is met and fail with a timeout if it is not reached.

Specifically, the tests now wait for explicit conditions such as:
* delayed replica deletion becoming eligible;
* container deletion completion;
* pending deletion block count changes;
* container state transitions to `UNHEALTHY` or `CLOSED`.

## What is the link to the Apache JIRA

JIRA: HDDS-15292. Reduce Thread.sleep usage in DiskBalancer tests.

## How was this patch tested?

Add Junit Test.