### PR TITLE
HDDS-15300. Handle zero-capacity volumes in DiskBalancer policy.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java
@@ -118,17 +118,21 @@ public final class DiskBalancerVolumeCalculation {
     }
     
     try {
-      // If there is only one volume, return 0.0 as there's no imbalance to measure
-      if (volumeSet.size() <= 1) {
+      final List<VolumeFixedUsage> usableVolumes = volumeSet.stream()
+          .filter(v -> v.getUsage().getCapacity() > 0)
+          .collect(Collectors.toList());
+
+      // If there is only one usable volume, return 0.0 as there's no imbalance to measure
+      if (usableVolumes.size() <= 1) {
         return 0.0;
       }
 
       // Calculate ideal usage using the same immutable volume snapshot
-      final double idealUsage = getIdealUsage(volumeSet);
+      final double idealUsage = getIdealUsage(usableVolumes);
       double volumeDensitySum = 0.0;
 
       // Calculate density for each volume using the same snapshot
-      for (VolumeFixedUsage volumeUsage : volumeSet) {
+      for (VolumeFixedUsage volumeUsage : usableVolumes) {
         final double currentUsage = volumeUsage.getUtilization();
 
         // Calculate density as absolute difference from ideal usage

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultContainerChoosingPolicy.java
@@ -83,9 +83,13 @@ public class DefaultContainerChoosingPolicy implements ContainerChoosingPolicy {
       // Use storage ID as secondary sort for deterministic ordering when utilizations are equal
       final List<VolumeFixedUsage> volumeUsages = allVolumes.stream()
           .map(v -> newVolumeFixedUsage(v, deltaMap))
+          .filter(DefaultContainerChoosingPolicy::hasPositiveCapacity)
           .sorted(Comparator.comparingDouble(VolumeFixedUsage::getUtilization)
               .thenComparing(v -> v.getVolume().getStorageID()))
           .collect(Collectors.toList());
+      if (volumeUsages.size() < 2) {
+        return null;
+      }
 
       // Calculate ideal usage and threshold range (once)
       final double idealUsage = getIdealUsage(volumeUsages);
@@ -143,6 +147,16 @@ public class DefaultContainerChoosingPolicy implements ContainerChoosingPolicy {
     } finally {
       lock.unlock();
     }
+  }
+
+  private static boolean hasPositiveCapacity(VolumeFixedUsage volumeUsage) {
+    long capacity = volumeUsage.getUsage().getCapacity();
+    if (capacity > 0) {
+      return true;
+    }
+    LOG.debug("Skipping volume {} for disk balancing because capacity is {}",
+        volumeUsage.getVolume(), capacity);
+    return false;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDefaultContainerChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDefaultContainerChoosingPolicy.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -434,6 +435,21 @@ public class TestDefaultContainerChoosingPolicy {
         Arguments.arguments(DiskBalancerConfiguration.DEFAULT_CONTAINER_STATES, 2L),
         Arguments.arguments("CLOSED", 3L)
     );
+  }
+
+  @Test
+  public void testChooseVolumesSkipsZeroCapacityVolume() throws IOException {
+    HddsVolume zeroCapacityVolume = createVolume("zero-capacity", 0, 0);
+    HddsVolume normalVolume = createVolume("normal", 0.80, VOLUME_CAPACITY);
+    volumeSet = createVolumeSetForUsages(Arrays.asList(
+        zeroCapacityVolume, normalVolume));
+    mockContainerSet(newContainerSet());
+
+    ContainerCandidate result = policy.chooseVolumesAndContainer(ozoneContainer,
+        volumeSet, deltaMap, inProgressContainerIDs, THRESHOLD,
+        DEFAULT_MOVABLE_STATES);
+
+    assertNull(result);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
@@ -56,6 +57,30 @@ class TestDiskBalancerVolumeCalculation {
         Collections.singletonList(
             DiskBalancerVolumeCalculation.newVolumeFixedUsage(
                 zeroCapacityVolume, null))));
+  }
+
+  @Test
+  void calculateVolumeDataDensityIgnoresZeroCapacityVolumes()
+      throws IOException {
+    HddsVolume zeroCapacityVolume = createVolume("zero-capacity", 0, 0);
+    HddsVolume lowUsageVolume = createVolume("low-usage", 100, 90);
+    HddsVolume highUsageVolume = createVolume("high-usage", 100, 50);
+
+    DiskBalancerVolumeCalculation.VolumeFixedUsage lowUsage =
+        DiskBalancerVolumeCalculation.newVolumeFixedUsage(lowUsageVolume, null);
+    DiskBalancerVolumeCalculation.VolumeFixedUsage highUsage =
+        DiskBalancerVolumeCalculation.newVolumeFixedUsage(highUsageVolume, null);
+    DiskBalancerVolumeCalculation.VolumeFixedUsage zeroCapacity =
+        DiskBalancerVolumeCalculation.newVolumeFixedUsage(
+            zeroCapacityVolume, null);
+
+    double densityWithoutZeroCapacityVolume =
+        DiskBalancerVolumeCalculation.calculateVolumeDataDensity(
+            Arrays.asList(lowUsage, highUsage));
+
+    assertEquals(densityWithoutZeroCapacityVolume,
+        DiskBalancerVolumeCalculation.calculateVolumeDataDensity(
+            Arrays.asList(zeroCapacity, lowUsage, highUsage)), 0.0);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes DiskBalancer skip zero-capacity volumes during volume candidate selection.

`DefaultContainerChoosingPolicy` sorts volumes by `VolumeFixedUsage#getUtilization`. However, `VolumeFixedUsage` stores utilization as `null` when the volume capacity is 0. If such a volume is included in the volume set, sorting can trigger a `NullPointerException` before DiskBalancer chooses source/destination volumes.

This change filters out volumes whose capacity is less than or equal to 0 before sorting by utilization. If fewer than two usable volumes remain after filtering, the policy returns no candidate instead of failing.

> Detailed analysis of the execution process

1. When the volume capacity is 0, `VolumeFixedUsage` sets utilization to null.

https://github.com/apache/ozone/blob/7b829183a0eddde0d0de542b19fef757eff5d7d4/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java#L168-L172

This means:
- if `capacity > 0`, utilization is calculated;
- if `capacity == 0`, utilization is not calculated and remains null.

2. However, getUtilization() does not allow null.

https://github.com/apache/ozone/blob/7b829183a0eddde0d0de542b19fef757eff5d7d4/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java#L187-L189

So if utilization is null, calling this method throws:

```
NullPointerException: utilization == null
```

3. DefaultContainerChoosingPolicy calls getUtilization() while sorting volumes.

https://github.com/apache/ozone/blob/7b829183a0eddde0d0de542b19fef757eff5d7d4/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/policy/DefaultContainerChoosingPolicy.java#L84-L88

During sorting, Java calls `getUtilization()` for each `VolumeFixedUsage`. If any volume has `capacity == 0`, its `utilization` is null, and sorting fails with an NPE before DiskBalancer can choose source/destination volumes.

## What is the link to the Apache JIRA

JIRA: HDDS-15300. Handle zero-capacity volumes in DiskBalancer policy.

## How was this patch tested?

Add Junit Test

CI: https://github.com/slfan1989/ozone/actions/runs/25983890878