### PR TITLE
HDDS-15302. Throw S3 InvalidArgument for RequestParameters getInt if parsing error

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/RequestParameters.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/RequestParameters.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.s3.commontypes;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -44,12 +43,8 @@ public interface RequestParameters {
     try {
       return Integer.parseInt(value);
     } catch (NumberFormatException e) {
-      throw translateException(e);
+      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, key, e);
     }
-  }
-
-  default WebApplicationException translateException(RuntimeException e) {
-    return new WebApplicationException(e.getMessage(), S3ErrorTable.INVALID_ARGUMENT.getHttpCode());
   }
 
   /** Additional methods for tests. */

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -461,6 +461,19 @@ public class TestBucketList {
   }
 
   @Test
+  public void testListObjectsWithNonIntegerMaxKeys() throws Exception {
+    OzoneClient client = new OzoneClientStub();
+    client.getObjectStore().createS3Bucket("bucket");
+    BucketEndpoint bucketEndpoint = newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    bucketEndpoint.queryParamsForTest().set(QueryParams.MAX_KEYS, "blah");
+    OS3Exception e = assertThrows(OS3Exception.class, () -> bucketEndpoint.get("bucket"));
+    assertEquals(S3ErrorTable.INVALID_ARGUMENT.getCode(), e.getCode());
+  }
+
+  @Test
   public void testListObjectsWithNegativeMaxKeys() throws Exception {
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket("bucket");


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Tests: [test_bucket_list_maxkeys_invalid](https://ozone.s3.peterxcli.dev/?q=test_bucket_list_maxkeys_invalid&run=2026-05-17T05-56-28Z&caseSuite=s3_tests&test=test_bucket_list_maxkeys_invalid#search-section)
 * Failure: s3-tests expects `InvalidArgument`; Ozone returns an empty or differently mapped error code.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15302

## How was this patch tested?

UT