### PR TITLE
HDDS-15303. Enable prefix filter for OBS

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -180,11 +180,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     if (maxKeys > 0) {
       while (ozoneKeyIterator != null && ozoneKeyIterator.hasNext()) {
         OzoneKey next = ozoneKeyIterator.next();
-        if (bucket != null && bucket.getBucketLayout().isFileSystemOptimized() &&
-            StringUtils.isNotEmpty(prefix) &&
-            !next.getName().startsWith(prefix)) {
-          // prefix has delimiter but key don't have
-          // example prefix: dir1/ key: dir123
+        if (StringUtils.isNotEmpty(prefix) && !next.getName().startsWith(prefix)) {
           continue;
         }
         if (startAfter != null && count == 0 && Objects.equals(startAfter, next.getName())) {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -137,6 +137,20 @@ public class TestBucketList {
   }
 
   @Test
+  public void listWithDelimiterAndPrefixMatchingNoKeys() throws OS3Exception, IOException {
+    OzoneClient ozoneClient =
+        createClientWithKeys("b/a/r", "b/a/c", "b/a/g", "g");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(ozoneClient).build();
+
+    endpoint.queryParamsForTest().set(QueryParams.DELIMITER, "d");
+    endpoint.queryParamsForTest().set(QueryParams.PREFIX, "/");
+    ListObjectResponse response = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertEquals(0, response.getContents().size());
+    assertEquals(0, response.getCommonPrefixes().size());
+  }
+
+  @Test
   public void listWithPrefixAndDelimiter() throws OS3Exception, IOException {
     OzoneClient ozoneClient =
         createClientWithKeys("dir1/file2", "dir1/dir2/file2", "dir1bh/file",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tests: 
- [test_bucket_list_prefix_delimiter_prefix_not_exist](https://ozone.s3.peterxcli.dev/?q=test_bucket_list_prefix_delimiter_prefix_not_exist&run=2026-05-17T05-56-28Z&caseSuite=s3_tests&test=test_bucket_list_prefix_delimiter_prefix_not_exist#search-section)
- [test_bucket_listv2_prefix_delimiter_prefix_not_exist](https://ozone.s3.peterxcli.dev/?q=test_bucket_list_prefix_delimiter_prefix_not_exist&run=2026-05-17T05-56-28Z&caseSuite=s3_tests&test=test_bucket_listv2_prefix_delimiter_prefix_not_exist#search-section)

Failure: Expected no keys for a missing prefix; Ozone returns keys such as b/a/c, b/a/g, b/a/r, and g.

Fix: also apply prefix filtering for `OBS`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15303

## How was this patch tested?

UT and clean fork ci