### PR TITLE
HDDS-15259. PutObject should treat null tag value for x-amz-tagging header as empty tag value

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -47,6 +47,8 @@ import com.amazonaws.services.s3.model.CopyObjectResult;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.Grantee;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
@@ -1101,6 +1103,42 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
       }
       assertEquals(content, bos.toString("UTF-8"));
     }
+  }
+
+  static Stream<Arguments> onlyTagKeyCasesV1() {
+    Map<String, String> fooBarEmptyBar = new HashMap<>();
+    fooBarEmptyBar.put("foo", "bar");
+    fooBarEmptyBar.put("bar", null);
+    return Stream.of(
+        Arguments.of(
+            new ObjectTagging(Collections.singletonList(new Tag("tag1", null))),
+            Collections.singletonMap("tag1", null)),
+        Arguments.of(
+            new ObjectTagging(Arrays.asList(new Tag("foo", "bar"), new Tag("bar", null))),
+            fooBarEmptyBar)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("onlyTagKeyCasesV1")
+  public void testPutObjectWithOnlyTagKey(ObjectTagging objectTagging,
+      Map<String, String> expectedTags) throws Exception {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    final String content = "0123456789";
+    s3Client.createBucket(bucketName);
+
+    try (InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+      PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, keyName, is, new ObjectMetadata())
+          .withTagging(objectTagging);
+      s3Client.putObject(putObjectRequest);
+    }
+
+    GetObjectTaggingResult taggingResult = s3Client.getObjectTagging(
+        new GetObjectTaggingRequest(bucketName, keyName));
+    Map<String, String> actualTags = taggingResult.getTagSet().stream()
+        .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+    assertEquals(expectedTags, actualTags);
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -1108,11 +1108,11 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
   static Stream<Arguments> onlyTagKeyCasesV1() {
     Map<String, String> fooBarEmptyBar = new HashMap<>();
     fooBarEmptyBar.put("foo", "bar");
-    fooBarEmptyBar.put("bar", null);
+    fooBarEmptyBar.put("bar", "");
     return Stream.of(
         Arguments.of(
             new ObjectTagging(Collections.singletonList(new Tag("tag1", null))),
-            Collections.singletonMap("tag1", null)),
+            Collections.singletonMap("tag1", "")),
         Arguments.of(
             new ObjectTagging(Arrays.asList(new Tag("foo", "bar"), new Tag("bar", null))),
             fooBarEmptyBar)

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -243,6 +243,40 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"", getObjectResponse.eTag());
   }
 
+  static Stream<Arguments> onlyTagKeyCasesV2() {
+    Map<String, String> fooBarEmptyBar = new HashMap<>();
+    fooBarEmptyBar.put("foo", "bar");
+    fooBarEmptyBar.put("bar", "");
+    return Stream.of(
+        Arguments.of("tag1", Collections.singletonMap("tag1", "")),
+        Arguments.of("foo=bar&bar", fooBarEmptyBar)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("onlyTagKeyCasesV2")
+  public void testPutObjectWithOnlyTagKey(String taggingHeader,
+      Map<String, String> expectedTags) {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    final String content = "0123456789";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    PutObjectRequest request = PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(keyName)
+        .tagging(taggingHeader)
+        .build();
+    s3Client.putObject(request, RequestBody.fromString(content));
+
+    Map<String, String> actualTags = s3Client.getObjectTagging(
+            b -> b.bucket(bucketName).key(keyName))
+        .tagSet()
+        .stream()
+        .collect(Collectors.toMap(Tag::key, Tag::value));
+    assertEquals(expectedTags, actualTags);
+  }
+
   @Test
   public void testPutObjectIfNoneMatch() {
     final String bucketName = getBucketName();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -363,7 +363,16 @@ public abstract class EndpointBase {
 
     List<NameValuePair> tagPairs = URLEncodedUtils.parse(tagString, UTF_8);
 
-    return validateAndGetTagging(tagPairs, NameValuePair::getName, NameValuePair::getValue);
+    // Put Object with x-amz-tagging header. A segment with no '=' (e.g."foo=bar&bar") is
+    // typically represented as (key=bar, value=null). AWS S3 treats that as an empty value for "bar".
+    // We map null → "" here only for this header path.
+    // PutObjectTagging is different: the XML/JSON API requires each Tag to
+    // include a Value element; so a missing Value stays null and fails validation.
+    return validateAndGetTagging(tagPairs, NameValuePair::getName,
+        pair -> {
+          String v = pair.getValue();
+          return v != null ? v : "";
+        });
   }
 
   protected static <KV> Map<String, String> validateAndGetTagging(
@@ -389,7 +398,8 @@ public abstract class EndpointBase {
       }
 
       if (tagValue == null) {
-        // For example for query parameter with only value (e.g. "tag1")
+        // Missing tag value is invalid for PutObjectTagging XML/JSON; x-amz-tagging must
+        // normalize null to "" in getTaggingFromHeaders before calling this method.
         OS3Exception ex = S3ErrorTable.newError(INVALID_TAG, tagKey);
         ex.setErrorMessage("Some tag values are not specified, please specify the tag values");
         throw ex;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -174,13 +174,27 @@ class TestObjectPut {
     assertEquals("value2", tags.get("tag2"));
   }
 
-  @Test
-  public void testPutObjectWithOnlyTagKey() {
-    // Try to send with only the key (no value)
-    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1");
+  static Stream<Arguments> onlyTagKeyCases() {
+    return Stream.of(
+        Arguments.of("tag1", ImmutableMap.of("tag1", "")),
+        Arguments.of("foo=bar&bar", ImmutableMap.of("foo", "bar", "bar", ""))
+    );
+  }
 
-    OS3Exception ex = assertErrorResponse(INVALID_TAG, () -> putObject(CONTENT));
-    assertThat(ex.getErrorMessage()).contains("Some tag values are not specified");
+  /**
+   * Put Object with {@code x-amz-tagging} header where key with a null value is treated as
+   * an empty string value (AWS), e.g. foo=bar&bar, here bar = " ".
+   */
+  @ParameterizedTest
+  @MethodSource("onlyTagKeyCases")
+  void testPutObjectWithOnlyTagKey(String tagHeader,
+      Map<String, String> expectedTags) throws Exception {
+    when(headers.getHeaderString(TAG_HEADER)).thenReturn(tagHeader);
+
+    assertSucceeds(() -> putObject(CONTENT));
+
+    assertThat(bucket.getKey(KEY_NAME).getTags())
+        .containsExactlyInAnyOrderEntriesOf(expectedTags);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
This JIRA addresses issues in the object tagging implementation:

Null Tag Value Support for `x-amz-tagging-header`: The S3 Gateway validator currently rejects x-amz-tagging on put object tags with a null value string (e.g., Key=TagA, Value) with an InvalidTag error. AWS S3 permits null tag value to be considered as empty string values. This causes **`test_put_obj_with_tags`** to fail.
While a normal put-object-tagging is correctly rejecting null tag value.
```
// wrong behaviour
// put object with x-amz-tagging header with null tag value should be treated as an empty value.

bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'tag1'   --endpoint-url  http://s3g:9878
An error occurred (InvalidTag) when calling the PutObject operation: Some tag values are not specified, please specify the tag values

// no tags applied which is wrong
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878
{
    "TagSet": []
}
```

**Proposed Fix:** 
Update **validateAndGetTagging()** in EndpointBase to allow values with zero length when x-amz-tagging header is present else on normal put object tagging this null tag value should fail, while maintaining the requirement that the Key must have at least one character.
**After fix:**

```
// put object with x-amz-tagging header succeded for null tag value
bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'tag1'   --endpoint-url  http://s3g:9878
{
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\""
}
// confirming with get object tagging
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878
{
    "TagSet": [
        {
            "Key": "tag1",
            "Value": ""
        }
    ]
} 
```


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15259

## How was this patch tested?
Added unit and Integration Tests.
Also tested manually.

**Before fix:** [**Test Suit Link**](https://ozone.s3.peterxcli.dev/?q=test_put_obj_with_tags&run=2026-05-17T05-56-28Z&caseSuite=s3_tests&test=test_put_obj_with_tags#search-section)
```
1.
// wrong behaviour
// put object with x-amz-tagging header with null tag value should be treated as an empty value.

bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'tag1'   --endpoint-url  http://s3g:9878/
An error occurred (InvalidTag) when calling the PutObject operation: Some tag values are not specified, please specify the tag values

// no tags applied which is wrong
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878/
{
    "TagSet": []
}
```
**After Fix:**
```
// put object with x-amz-tagging header succeded for null tag value
bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'tag1'   --endpoint-url  http://s3g:9878/
{
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\""
}
// confirming with get object tagging
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878/
{
    "TagSet": [
        {
            "Key": "tag1",
            "Value": ""
        }
    ]
}

// 2nd example which succeded. This also shows correctly replacing the old tags with new tags.
bash-5.1$ aws s3api put-object   --bucket buck1   --key key1  --tagging 'foo=bar&bar'   --endpoint-url  http://s3g:9878/
{
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\""
}
bash-5.1$ aws s3api get-object-tagging   --bucket buck1   --key key1 --endpoint-url  http://s3g:9878/
{
    "TagSet": [
       {
            "Key": "bar",
            "Value": ""
        },
        {
            "Key": "foo",
            "Value": "bar"
        }
    ]
}
```