### PR TITLE
HDDS-15305. ozone admin container list --all returns duplicate containers due to sort/pagination key mismatch

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -40,6 +40,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -512,7 +513,7 @@ public class SCMClientProtocolServer implements
       
       List<ContainerInfo> containerInfos =
           containerStream.filter(info -> info.containerID().getId() >= startContainerID)
-              .sorted().collect(Collectors.toList());
+              .sorted(Comparator.comparing(ContainerInfo::containerID)).collect(Collectors.toList());
       List<ContainerInfo> limitedContainers =
           containerInfos.stream().limit(count).collect(Collectors.toList());
       long totalCount = (long) containerInfos.size();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -29,7 +29,11 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -155,12 +159,49 @@ public class TestSCMClientProtocolServer {
       scmServer.stop();
     }
   }
+  
+  @Test
+  public void testListContainerPaginationHasNoDuplicates() throws Exception {
+    Instant base = Instant.parse("2026-01-01T00:00:00Z");
+    List<ContainerInfo> infos = new ArrayList<>();
+    infos.add(newContainerWithLastUsedTime(100, base));
+    infos.add(newContainerWithLastUsedTime(5, base.plusMillis(1)));
+    infos.add(newContainerWithLastUsedTime(10, base.plusMillis(2)));
+
+    SCMClientProtocolServer scmServer =
+        new SCMClientProtocolServer(new OzoneConfiguration(),
+            mockStorageContainerManager(infos),
+            mock(ReconfigurationHandler.class));
+    try {
+      List<Long> ids = new ArrayList<>();
+      long start = 0;
+      int batchSize = 2;
+      while (true) {
+        List<ContainerInfo> page =
+            scmServer.listContainer(start, batchSize, null, null, null).getContainerInfoList();
+        if (page.isEmpty()) {
+          break;
+        }
+        for (ContainerInfo c : page) {
+          ids.add(c.getContainerID());
+        }
+        start = page.get(page.size() - 1).getContainerID() + 1;
+      }
+      assertEquals(ids.size(), new HashSet<>(ids).size());
+    } finally {
+      scmServer.stop();
+    }
+  }
 
   private StorageContainerManager mockStorageContainerManager() {
     List<ContainerInfo> infos = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       infos.add(newContainerInfoForTest());
     }
+    return mockStorageContainerManager(infos);
+  }
+
+  private StorageContainerManager mockStorageContainerManager(List<ContainerInfo> infos) {
     ContainerManagerImpl containerManager = mock(ContainerManagerImpl.class);
     when(containerManager.getContainers()).thenReturn(infos);
     when(containerManager.getContainerStateCount(any(LifeCycleState.class))).thenReturn(infos.size());
@@ -172,6 +213,18 @@ public class TestSCMClientProtocolServer {
     when(scmNodeDetails.getClientProtocolServerAddressKey()).thenReturn("test");
     when(storageContainerManager.getScmNodeDetails()).thenReturn(scmNodeDetails);
     return storageContainerManager;
+  }
+
+  private ContainerInfo newContainerWithLastUsedTime(long containerId,
+      Instant fixedLastUsedInstant) {
+    return new ContainerInfo.Builder()
+        .setContainerID(containerId)
+        .setClock(Clock.fixed(fixedLastUsedInstant, ZoneOffset.UTC))
+        .setPipelineID(PipelineID.randomId())
+        .setReplicationConfig(
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
+        .build();
   }
 
   private ContainerInfo newContainerInfoForTest() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -33,6 +33,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -168,10 +169,8 @@ public class TestSCMClientProtocolServer {
     infos.add(newContainerWithLastUsedTime(5, base.plusMillis(1)));
     infos.add(newContainerWithLastUsedTime(10, base.plusMillis(2)));
 
-    SCMClientProtocolServer scmServer =
-        new SCMClientProtocolServer(new OzoneConfiguration(),
-            mockStorageContainerManager(infos),
-            mock(ReconfigurationHandler.class));
+    SCMClientProtocolServer scmServer = new SCMClientProtocolServer(new OzoneConfiguration(),
+        mockStorageContainerManager(infos), mock(ReconfigurationHandler.class));
     try {
       List<Long> ids = new ArrayList<>();
       long start = 0;
@@ -187,7 +186,9 @@ public class TestSCMClientProtocolServer {
         }
         start = page.get(page.size() - 1).getContainerID() + 1;
       }
+      List<Long> expectedIds = Arrays.asList(5L, 10L, 100L);
       assertEquals(ids.size(), new HashSet<>(ids).size());
+      assertEquals(expectedIds, ids);
     } finally {
       scmServer.stop();
     }
@@ -221,9 +222,7 @@ public class TestSCMClientProtocolServer {
         .setContainerID(containerId)
         .setClock(Clock.fixed(fixedLastUsedInstant, ZoneOffset.UTC))
         .setPipelineID(PipelineID.randomId())
-        .setReplicationConfig(
-            RatisReplicationConfig
-                .getInstance(HddsProtos.ReplicationFactor.THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE))
         .build();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The ozone admin container list --all command produces duplicate container entries in its output. The duplicates are non-deterministic across runs, which containers are duplicated depends on the order in which the SCM returns them, which can vary.

Root Cause:
The bug is a mismatch between the server-side sort key and the client-side pagination key.
Server side (SCMClientProtocolServer.listContainerInternal):The method filters containers by `containerID >= startContainerID`, then calls `.sorted()` which invokes `ContainerInfo.compareTo()`. 
That comparator is defined as:

> private static final Comparator<ContainerInfo> COMPARATOR = Comparator.comparingLong(info -> info.getLastUsed().toEpochMilli());  

So the batch is returned sorted by lastUsed timestamp, not by containerID.

Client side (ListSubcommand.listAllContainers): The pagination loop advances the cursor using the last returned element's container ID.
This assumes the last element of the batch has the highest container ID. That is only true if the batch is sorted by container ID. Since it is actually sorted by lastUsed, the last element can have a lower container ID than other elements already in the same batch.
 
Example: With batch size 40, a batch may return containers with IDs [..., 41, 42, 44, 40] (sorted by lastUsed). The cursor is set to 40 + 1 = 41. The next batch fetches containers with containerID >= 41, returning [41, 42, 43, 44, 45, ...] — re-fetching 41, 42, and 44.
 
Fix : 
In SCMClientProtocolServer.listContainerInternal, replace the lastUsed-based sort with a containerID-based sort, aligning the sort key with the pagination key:

> .sorted(Comparator.comparing(ContainerInfo::containerID))

## What is the link to the Apache JIRA
[HDDS-15305](https://issues.apache.org/jira/browse/HDDS-15305)

## How was this patch tested?
Manually tested in docket cluster.
Green CI : https://github.com/sreejasahithi/ozone/actions/runs/26017534135