### PR TITLE
HDDS-15314. Disable defrag DB metrics due to crash during snapshot defrag

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -242,6 +242,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   public static OmMetadataManagerImpl createCheckpointMetadataManager(
       OzoneConfiguration conf, DBCheckpoint checkpoint, boolean readOnly) throws IOException {
+    return createCheckpointMetadataManager(conf, checkpoint, readOnly, true);
+  }
+
+  public static OmMetadataManagerImpl createCheckpointMetadataManager(
+      OzoneConfiguration conf, DBCheckpoint checkpoint, boolean readOnly,
+      boolean enableRocksDBMetrics) throws IOException {
     Path path = checkpoint.getCheckpointLocation();
     Path parent = path.getParent();
     if (parent == null) {
@@ -254,7 +260,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       throw new IllegalStateException("DB checkpoint dir name should not "
           + "have been null. Checkpoint path is " + path);
     }
-    return new OmMetadataManagerImpl(conf, dir, name.toString(), readOnly);
+    return new OmMetadataManagerImpl(conf, dir, name.toString(), readOnly, enableRocksDBMetrics);
   }
 
   protected OmMetadataManagerImpl(OzoneConfiguration conf, File dir, String name) throws IOException {
@@ -271,6 +277,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    */
   public OmMetadataManagerImpl(OzoneConfiguration conf, File dir, String name, boolean readOnly)
       throws IOException {
+    this(conf, dir, name, readOnly, true);
+  }
+
+  public OmMetadataManagerImpl(OzoneConfiguration conf, File dir, String name, boolean readOnly,
+      boolean enableRocksDBMetrics) throws IOException {
     lock = new OmReadOnlyLock();
     hierarchicalLockManager = new ReadOnlyHierarchicalResourceLockManager();
     omEpoch = 0;
@@ -282,7 +293,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .setMaxNumberOfOpenFiles(maxOpenFiles)
         .setEnableCompactionDag(false, null)
         .setCreateCheckpointDirs(false)
-        .setEnableRocksDbMetrics(true)
+        .setEnableRocksDbMetrics(enableRocksDBMetrics)
         .build();
     initializeOmTables(CacheType.PARTIAL_CACHE, false);
     perfMetrics = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -247,7 +247,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   public static OmMetadataManagerImpl createCheckpointMetadataManager(
       OzoneConfiguration conf, DBCheckpoint checkpoint, boolean readOnly,
-      boolean enableRocksDBMetrics) throws IOException {
+      boolean enableRocksDbMetrics) throws IOException {
     Path path = checkpoint.getCheckpointLocation();
     Path parent = path.getParent();
     if (parent == null) {
@@ -260,7 +260,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       throw new IllegalStateException("DB checkpoint dir name should not "
           + "have been null. Checkpoint path is " + path);
     }
-    return new OmMetadataManagerImpl(conf, dir, name.toString(), readOnly, enableRocksDBMetrics);
+    return new OmMetadataManagerImpl(
+        conf, dir, name.toString(), readOnly, enableRocksDbMetrics);
   }
 
   protected OmMetadataManagerImpl(OzoneConfiguration conf, File dir, String name) throws IOException {
@@ -280,8 +281,21 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     this(conf, dir, name, readOnly, true);
   }
 
-  public OmMetadataManagerImpl(OzoneConfiguration conf, File dir, String name, boolean readOnly,
-      boolean enableRocksDBMetrics) throws IOException {
+  /**
+   * Metadata constructor for checkpoints.
+   *
+   * @param conf - Ozone conf.
+   * @param dir - Checkpoint parent directory.
+   * @param name - Checkpoint directory name.
+   * @param readOnly - Whether to open the checkpoint DB read-only.
+   * @param enableRocksDbMetrics - Whether to register generic RocksDB metrics.
+   *     Pass false for transient checkpoint DBs whose column families may be
+   *     dropped or recreated while the DB is open.
+   * @throws IOException
+   */
+  protected OmMetadataManagerImpl(OzoneConfiguration conf, File dir,
+      String name, boolean readOnly, boolean enableRocksDbMetrics)
+      throws IOException {
     lock = new OmReadOnlyLock();
     hierarchicalLockManager = new ReadOnlyHierarchicalResourceLockManager();
     omEpoch = 0;
@@ -293,7 +307,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .setMaxNumberOfOpenFiles(maxOpenFiles)
         .setEnableCompactionDag(false, null)
         .setCreateCheckpointDirs(false)
-        .setEnableRocksDbMetrics(enableRocksDBMetrics)
+        .setEnableRocksDbMetrics(enableRocksDbMetrics)
         .build();
     initializeOmTables(CacheType.PARTIAL_CACHE, false);
     perfMetrics = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -527,7 +527,7 @@ public class SnapshotDefragService extends BackgroundService
       RocksDBCheckpoint dbCheckpoint = new RocksDBCheckpoint(nextVersionPath);
       // Add a new version to the local data file.
       try (OmMetadataManagerImpl newVersionCheckpointMetadataManager =
-               OmMetadataManagerImpl.createCheckpointMetadataManager(conf, dbCheckpoint, true)) {
+               createDefragCheckpointMetadataManager(dbCheckpoint, true)) {
         RDBStore newVersionCheckpointStore = (RDBStore) newVersionCheckpointMetadataManager.getStore();
         snapshotLocalDataProvider.addSnapshotVersion(newVersionCheckpointStore);
         snapshotLocalDataProvider.commit();
@@ -547,6 +547,16 @@ public class SnapshotDefragService extends BackgroundService
 
       return EmptyTaskResult.newResult();
     }
+  }
+
+  @VisibleForTesting
+  OmMetadataManagerImpl createDefragCheckpointMetadataManager(
+      DBCheckpoint checkpoint, boolean readOnly) throws IOException {
+    // Defrag checkpoint DBs are transient and drop/recreate column families.
+    // Generic RocksDB metrics are not useful for them and can race with CF handle
+    // lifetime changes while the checkpoint is being rewritten.
+    return OmMetadataManagerImpl.createCheckpointMetadataManager(
+        conf, checkpoint, readOnly, false);
   }
 
   /**
@@ -570,7 +580,7 @@ public class SnapshotDefragService extends BackgroundService
         snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(), snapshotInfo.getName())) {
       DBCheckpoint checkpoint = snapshot.get().getMetadataManager().getStore().getCheckpoint(tmpDefragDir, true);
       try (OmMetadataManagerImpl metadataManagerBeforeTruncate =
-               OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint, false)) {
+               createDefragCheckpointMetadataManager(checkpoint, false)) {
         DBStore dbStore = metadataManagerBeforeTruncate.getStore();
         for (String table : metadataManagerBeforeTruncate.listTableNames()) {
           if (!incrementalColumnFamilies.contains(table)) {
@@ -581,7 +591,7 @@ public class SnapshotDefragService extends BackgroundService
         throw new IOException("Failed to close checkpoint of snapshot: " + snapshotInfo.getSnapshotId(), e);
       }
       // This will recreate the column families in the checkpoint.
-      return OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint, false);
+      return createDefragCheckpointMetadataManager(checkpoint, false);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
@@ -76,6 +76,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.RocksDBStoreMetrics;
 import org.apache.hadoop.hdds.utils.db.CodecBuffer;
 import org.apache.hadoop.hdds.utils.db.CodecBufferCodec;
 import org.apache.hadoop.hdds.utils.db.CodecException;
@@ -91,6 +92,7 @@ import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.hdds.utils.db.StringInMemoryTestTable;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TablePrefixInfo;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -458,6 +460,20 @@ public class TestSnapshotDefragService {
     );
   }
 
+  private static String rocksDBMetricsSourceName(Path dbLocation) {
+    return RocksDBStoreMetrics.ROCKSDB_CONTEXT_PREFIX + dbLocation.getFileName();
+  }
+
+  private static void assertNoRocksDBMetrics(Path dbLocation) {
+    assertNull(DefaultMetricsSystem.instance().getSource(
+        rocksDBMetricsSourceName(dbLocation)));
+  }
+
+  private static void assertRocksDBMetricsRegistered(Path dbLocation) {
+    assertNotNull(DefaultMetricsSystem.instance().getSource(
+        rocksDBMetricsSourceName(dbLocation)));
+  }
+
   private Map<String, Map<String, String>> createTableContents(Path path, String keyPrefix) throws IOException {
     DBCheckpoint snapshotCheckpointLocation = new RocksDBCheckpoint(path);
     Map<String, Map<String, String>> tableContents = new HashMap<>();
@@ -525,7 +541,31 @@ public class TestSnapshotDefragService {
           .filter(e -> !incrementalTables.contains(e.getKey()))
           .forEach(e -> e.getValue().clear());
       assertContents(tableContents, result.getStore());
+      assertNoRocksDBMetrics(result.getStore().getDbLocation().toPath());
     }
+  }
+
+  @Test
+  public void testDefragCheckpointMetadataManagerSkipsRocksDBMetrics() throws Exception {
+    Path checkpointPath = tempDir.resolve("defrag-metrics-" + UUID.randomUUID());
+    createTableContents(checkpointPath, "_metrics_");
+
+    assertNoRocksDBMetrics(checkpointPath);
+    try (OmMetadataManagerImpl defaultCheckpointMetadataManager =
+             OmMetadataManagerImpl.createCheckpointMetadataManager(
+                 configuration, new RocksDBCheckpoint(checkpointPath), false)) {
+      assertRocksDBMetricsRegistered(
+          defaultCheckpointMetadataManager.getStore().getDbLocation().toPath());
+    }
+    assertNoRocksDBMetrics(checkpointPath);
+
+    try (OmMetadataManagerImpl defragCheckpointMetadataManager =
+             defragService.createDefragCheckpointMetadataManager(
+                 new RocksDBCheckpoint(checkpointPath), false)) {
+      assertNoRocksDBMetrics(
+          defragCheckpointMetadataManager.getStore().getDbLocation().toPath());
+    }
+    assertNoRocksDBMetrics(checkpointPath);
   }
 
   private void assertContents(Map<String, Map<String, String>> contents, Path path) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
@@ -551,6 +551,8 @@ public class TestSnapshotDefragService {
     createTableContents(checkpointPath, "_metrics_");
 
     assertNoRocksDBMetrics(checkpointPath);
+    // The generic checkpoint path should keep the existing behavior and
+    // register RocksDB metrics.
     try (OmMetadataManagerImpl defaultCheckpointMetadataManager =
              OmMetadataManagerImpl.createCheckpointMetadataManager(
                  configuration, new RocksDBCheckpoint(checkpointPath), false)) {
@@ -559,6 +561,8 @@ public class TestSnapshotDefragService {
     }
     assertNoRocksDBMetrics(checkpointPath);
 
+    // Defrag checkpoint DBs are transient and must not register generic
+    // RocksDB metrics.
     try (OmMetadataManagerImpl defragCheckpointMetadataManager =
              defragService.createDefragCheckpointMetadataManager(
                  new RocksDBCheckpoint(checkpointPath), false)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable RocksDB metrics registration for defrag-created checkpoint DBs.

For stack trace, see JIRA description.

DB metrics should not have been enabled for defrag DBs in the first place. And previously it had been disabled for snapshot DBs in [HDDS-12193](https://issues.apache.org/jira/browse/HDDS-12193) (https://github.com/apache/ozone/commit/ad0debf5e1b) by default. Similar measure needs to be taken for defrag DBs as well.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15314

## How was this patch tested?

- Added unit test to verify metrics are disabled on defrag DB, without affecting regular checkpoint DB code path.