### PR TITLE
HDDS-15240. Support selecting volumes by StorageType when creating containers

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
@@ -46,6 +47,16 @@ public interface Container<CONTAINERDATA extends ContainerData> {
    */
   void create(VolumeSet volumeSet, VolumeChoosingPolicy volumeChoosingPolicy,
               String scmId) throws StorageContainerException;
+
+  /**
+   * Creates a container and optionally constrains the destination volume to a
+   * specific storage type.
+   */
+  default void create(VolumeSet volumeSet,
+      VolumeChoosingPolicy volumeChoosingPolicy, String scmId,
+      StorageType storageType) throws StorageContainerException {
+    create(volumeSet, volumeChoosingPolicy, scmId);
+  }
 
   /**
    * Deletes the container.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/VolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/VolumeChoosingPolicy.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.interfaces;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 
@@ -42,4 +43,19 @@ public interface VolumeChoosingPolicy {
    */
   HddsVolume chooseVolume(List<HddsVolume> volumes, long maxContainerSize)
       throws IOException;
+
+  /**
+   * Choose a volume to place a container, optionally constraining the choice
+   * to a specific storage type.
+   *
+   * @param volumes a list of available volumes.
+   * @param maxContainerSize the maximum size of the container for which a
+   *                         volume is sought.
+   * @param storageType the requested storage type, or {@code null} to allow
+   *                    the policy to choose from any volume.
+   * @return the chosen volume.
+   * @throws IOException when disks are unavailable or are full.
+   */
+  HddsVolume chooseVolume(List<HddsVolume> volumes,
+      long maxContainerSize, StorageType storageType) throws IOException;
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/VolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/VolumeChoosingPolicy.java
@@ -41,6 +41,7 @@ public interface VolumeChoosingPolicy {
    * @return the chosen volume.
    * @throws IOException when disks are unavailable or are full.
    */
+  @Deprecated
   HddsVolume chooseVolume(List<HddsVolume> volumes, long maxContainerSize)
       throws IOException;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AbstractStorageTypeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AbstractStorageTypeChoosingPolicy.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+
+/**
+ * Base volume choosing policy with optional storage-type filtering.
+ */
+public abstract class AbstractStorageTypeChoosingPolicy
+    implements VolumeChoosingPolicy {
+
+  @Override
+  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+      long maxContainerSize) throws IOException {
+    return chooseVolume(volumes, maxContainerSize, null);
+  }
+
+  @Override
+  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+      long maxContainerSize, StorageType storageType) throws IOException {
+    List<HddsVolume> candidates = volumes;
+    if (storageType != null) {
+      candidates = volumes.stream()
+          .filter(volume -> volume.getStorageType() == storageType)
+          .collect(Collectors.toList());
+    }
+    return chooseVolumeInternal(candidates, maxContainerSize);
+  }
+
+  protected abstract HddsVolume chooseVolumeInternal(List<HddsVolume> volumes,
+      long maxContainerSize) throws IOException;
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AbstractStorageTypeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AbstractStorageTypeChoosingPolicy.java
@@ -30,6 +30,7 @@ public abstract class AbstractStorageTypeChoosingPolicy
     implements VolumeChoosingPolicy {
 
   @Override
+  @Deprecated
   public HddsVolume chooseVolume(List<HddsVolume> volumes,
       long maxContainerSize) throws IOException {
     return chooseVolume(volumes, maxContainerSize, null);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
-import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +40,8 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Same algorithm as the SCMContainerPlacementCapacity.
  */
-public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
+public class CapacityVolumeChoosingPolicy
+    extends AbstractStorageTypeChoosingPolicy {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       CapacityVolumeChoosingPolicy.class);
@@ -58,7 +58,7 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
   }
 
   @Override
-  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+  protected HddsVolume chooseVolumeInternal(List<HddsVolume> volumes,
       long maxContainerSize) throws IOException {
 
     // No volumes available to choose from

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/RoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/RoundRobinVolumeChoosingPolicy.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
-import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,8 @@ import org.slf4j.LoggerFactory;
  * Choose volumes in round-robin order.
  * The caller should synchronize access to the list of volumes.
  */
-public class RoundRobinVolumeChoosingPolicy implements VolumeChoosingPolicy {
+public class RoundRobinVolumeChoosingPolicy
+    extends AbstractStorageTypeChoosingPolicy {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       RoundRobinVolumeChoosingPolicy.class);
@@ -53,7 +53,7 @@ public class RoundRobinVolumeChoosingPolicy implements VolumeChoosingPolicy {
   }
 
   @Override
-  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+  protected HddsVolume chooseVolumeInternal(List<HddsVolume> volumes,
       long maxContainerSize) throws IOException {
 
     // No volumes available to choose from

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -56,6 +56,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -148,6 +149,13 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   @Override
   public void create(VolumeSet volumeSet, VolumeChoosingPolicy
       volumeChoosingPolicy, String clusterId) throws StorageContainerException {
+    create(volumeSet, volumeChoosingPolicy, clusterId, null);
+  }
+
+  @Override
+  public void create(VolumeSet volumeSet, VolumeChoosingPolicy
+      volumeChoosingPolicy, String clusterId, StorageType storageType)
+      throws StorageContainerException {
     Objects.requireNonNull(volumeChoosingPolicy, "VolumeChoosingPolicy == null");
     Objects.requireNonNull(volumeSet, "volumeSet == null");
     Objects.requireNonNull(clusterId, "clusterId == null");
@@ -163,11 +171,15 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
         HddsVolume containerVolume;
         String hddsVolumeDir;
         try {
-          containerVolume = volumeChoosingPolicy.chooseVolume(volumes, maxSize);
+          containerVolume = storageType == null
+              ? volumeChoosingPolicy.chooseVolume(volumes, maxSize)
+              : volumeChoosingPolicy.chooseVolume(
+                  volumes, maxSize, storageType);
           hddsVolumeDir = containerVolume.getHddsRootDir().toString();
           // Set volume before getContainerDBFile(), because we may need the
           // volume to deduce the db file.
           containerData.setVolume(containerVolume);
+          containerData.setStorageType(containerVolume.getStorageType());
           // commit bytes have been reserved in volumeChoosingPolicy#chooseVolume
           containerData.setCommittedSpace(true);
         } catch (DiskOutOfSpaceException ex) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -147,6 +147,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   }
 
   @Override
+  @Deprecated
   public void create(VolumeSet volumeSet, VolumeChoosingPolicy
       volumeChoosingPolicy, String clusterId) throws StorageContainerException {
     create(volumeSet, volumeChoosingPolicy, clusterId, null);
@@ -171,6 +172,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
         HddsVolume containerVolume;
         String hddsVolumeDir;
         try {
+          // TODO Use the interface that supports `storageType` and `chooseVolume`
           containerVolume = storageType == null
               ? volumeChoosingPolicy.chooseVolume(volumes, maxSize)
               : volumeChoosingPolicy.chooseVolume(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -172,7 +172,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
         HddsVolume containerVolume;
         String hddsVolumeDir;
         try {
-          // TODO Use the interface that supports `storageType` and `chooseVolume`
+          // TODO Use the `chooseVolume` that supports `storageType`
           containerVolume = storageType == null
               ? volumeChoosingPolicy.chooseVolume(volumes, maxSize)
               : volumeChoosingPolicy.chooseVolume(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageTypeVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageTypeVolumeChoosingPolicy.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for storage-type-aware volume selection policies.
+ */
+public class TestStorageTypeVolumeChoosingPolicy {
+
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
+
+  @TempDir
+  private File folder;
+
+  private final String scmId = UUID.randomUUID().toString();
+  private final String datanodeId = UUID.randomUUID().toString();
+  private final List<HddsVolume> createdVolumes = new ArrayList<>();
+
+  @AfterEach
+  public void tearDown() {
+    createdVolumes.forEach(HddsVolume::shutdown);
+  }
+
+  @Test
+  public void testRoundRobinChoosesRequestedStorageType() throws Exception {
+    HddsVolume diskVolume = createVolume("disk", StorageType.DISK);
+    HddsVolume ssdVolume = createVolume("ssd", StorageType.SSD);
+
+    RoundRobinVolumeChoosingPolicy policy = new RoundRobinVolumeChoosingPolicy();
+    HddsVolume chosen = policy.chooseVolume(
+        Arrays.asList(diskVolume, ssdVolume), 1L, StorageType.SSD);
+
+    assertSame(ssdVolume, chosen);
+    assertEquals(1L, ssdVolume.getCommittedBytes());
+    assertEquals(0L, diskVolume.getCommittedBytes());
+  }
+
+  @Test
+  public void testCapacityPolicyRejectsMissingStorageType() throws Exception {
+    HddsVolume diskVolume = createVolume("disk", StorageType.DISK);
+
+    CapacityVolumeChoosingPolicy policy = new CapacityVolumeChoosingPolicy();
+
+    assertThrows(DiskOutOfSpaceException.class,
+        () -> policy.chooseVolume(
+            Collections.singletonList(diskVolume), 1L, StorageType.SSD));
+  }
+
+  private HddsVolume createVolume(String name, StorageType storageType)
+      throws Exception {
+    HddsVolume volume = new HddsVolume.Builder(
+        new File(folder, name).getAbsolutePath())
+        .conf(CONF)
+        .datanodeUuid(datanodeId)
+        .storageType(storageType)
+        .build();
+    StorageVolumeUtil.checkVolume(volume, scmId, scmId, CONF, null, null);
+    createdVolumes.add(volume);
+    return volume;
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -32,12 +32,14 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -63,6 +65,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -198,6 +201,32 @@ public class TestKeyValueContainer {
         ".Container File does not exist");
     assertTrue(keyValueContainer.getContainerDBFile().exists(), "Container " +
         "DB does not exist");
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testCreateContainerWithStorageType(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+
+    HddsVolume ssdVolume = new HddsVolume.Builder(
+        new File(folder, "ssd-volume").getAbsolutePath())
+        .conf(CONF)
+        .datanodeUuid(datanodeId.toString())
+        .storageType(StorageType.SSD)
+        .build();
+    StorageVolumeUtil.checkVolume(ssdVolume, scmId, scmId, CONF, null, null);
+    hddsVolumes.add(ssdVolume);
+
+    when(volumeChoosingPolicy.chooseVolume(anyList(), anyLong(),
+        eq(StorageType.SSD))).thenReturn(ssdVolume);
+
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId,
+        StorageType.SSD);
+
+    assertSame(ssdVolume, keyValueContainerData.getVolume());
+    assertEquals(StorageType.SSD, keyValueContainerData.getStorageType());
+    verify(volumeChoosingPolicy).chooseVolume(anyList(), anyLong(),
+        eq(StorageType.SSD));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support selecting volumes by StorageType when creating containers

* `VolumeChoosingPolicy#chooseVolume` add a `StorageType` parameter to support choose specific `StorageType` when Datanode create Container

---
FYI:
- Releated doc and discuss: https://github.com/apache/ozone/pull/6989
- A preview version for the full "Ozone Storage Policy"  feature: https://github.com/ivandika3/ozone/tree/refs/heads/backport-storage-policy-storage-class

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15240

## How was this patch tested?
Unit test