### PR TITLE
HDDS-15312. Improve VolumeInfoMetrics to include MinFreeSpace and Non-Ozone used space

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -252,7 +252,7 @@ public class VolumeInfoMetrics implements MetricsSource {
           .addGauge(RESERVED, reserved)
           .addGauge(FS_CAPACITY, fsUsage.getCapacity())
           .addGauge(FS_AVAILABLE, fsUsage.getAvailable())
-          .addGauge(FS_USED, fsUsage.getUsedSpace())
+          .addGauge(FS_USED, fsUsage.getCapacity() - fsUsage.getAvailable())
           .addGauge(MIN_FREE_SPACE, volume.getReportedFreeSpaceToSpare(ozoneCapacity))
           .addGauge(NON_OZONE_USED, VolumeUsage.getOtherUsed(fsUsage));
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -51,14 +51,20 @@ public class VolumeInfoMetrics implements MetricsSource {
       Interns.info("OzoneUsed", "Ozone used space");
   private static final MetricsInfo RESERVED =
       Interns.info("Reserved", "Reserved Space");
-  private static final MetricsInfo TOTAL_CAPACITY =
-      Interns.info("TotalCapacity", "Ozone capacity + reserved space");
   private static final MetricsInfo FS_CAPACITY =
       Interns.info("FilesystemCapacity", "Filesystem capacity as reported by the local filesystem");
   private static final MetricsInfo FS_AVAILABLE =
       Interns.info("FilesystemAvailable", "Filesystem available space as reported by the local filesystem");
   private static final MetricsInfo FS_USED =
       Interns.info("FilesystemUsed", "Filesystem used space (FilesystemCapacity - FilesystemAvailable)");
+  private static final MetricsInfo MIN_FREE_SPACE =
+      Interns.info("MinFreeSpace",
+          "Minimum free space threshold (soft limit) reported to SCM, " +
+          "derived from hdds.datanode.volume.min.free.space.percent / hdds.datanode.volume.min.free.space");
+  private static final MetricsInfo NON_OZONE_USED =
+      Interns.info("NonOzoneUsed",
+          "Space on the filesystem consumed by non-Ozone workloads " +
+          "(FilesystemUsed - OzoneUsed)");
 
   private final MetricsRegistry registry;
   private final String metricsSourceName;
@@ -238,15 +244,17 @@ public class VolumeInfoMetrics implements MetricsSource {
       SpaceUsageSource.Fixed fsUsage = volumeUsage.realUsage();
       SpaceUsageSource usage = volumeUsage.getCurrentUsage(fsUsage);
       long reserved = volumeUsage.getReservedInBytes();
+      long ozoneCapacity = usage.getCapacity();
       builder
-          .addGauge(CAPACITY, usage.getCapacity())
+          .addGauge(CAPACITY, ozoneCapacity)
           .addGauge(AVAILABLE, usage.getAvailable())
           .addGauge(USED, usage.getUsedSpace())
           .addGauge(RESERVED, reserved)
-          .addGauge(TOTAL_CAPACITY, usage.getCapacity() + reserved)
           .addGauge(FS_CAPACITY, fsUsage.getCapacity())
           .addGauge(FS_AVAILABLE, fsUsage.getAvailable())
-          .addGauge(FS_USED, fsUsage.getUsedSpace());
+          .addGauge(FS_USED, fsUsage.getUsedSpace())
+          .addGauge(MIN_FREE_SPACE, volume.getReportedFreeSpaceToSpare(ozoneCapacity))
+          .addGauge(NON_OZONE_USED, VolumeUsage.getOtherUsed(fsUsage));
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -57,10 +57,11 @@
         <th>Ozone Used</th>
         <th>Ozone Available</th>
         <th>Reserved</th>
-        <th>Total Capacity (Ozone Capacity + Reserved)</th>
         <th>Filesystem Capacity</th>
         <th>Filesystem Available</th>
         <th>Filesystem Used</th>
+        <th>Min Free Space</th>
+        <th>Non-Ozone Used</th>
         <th>Containers</th>
         <th>State</th>
     </tr>
@@ -74,10 +75,11 @@
         <td>{{volumeInfo.OzoneUsed}}</td>
         <td>{{volumeInfo.OzoneAvailable}}</td>
         <td>{{volumeInfo.Reserved}}</td>
-        <td>{{volumeInfo.TotalCapacity}}</td>
         <td>{{volumeInfo.FilesystemCapacity}}</td>
         <td>{{volumeInfo.FilesystemAvailable}}</td>
         <td>{{volumeInfo.FilesystemUsed}}</td>
+        <td>{{volumeInfo.MinFreeSpace}}</td>
+        <td>{{volumeInfo.NonOzoneUsed}}</td>
         <td>{{volumeInfo.Containers}}</td>
         <td>{{volumeInfo["tag.VolumeState"]}}</td>
     </tr>

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
@@ -34,10 +34,11 @@
                  volume.OzoneUsed = transform(volume.OzoneUsed);
                  volume.OzoneAvailable = transform(volume.OzoneAvailable);
                  volume.Reserved = transform(volume.Reserved);
-                 volume.TotalCapacity = transform(volume.TotalCapacity);
                  volume.FilesystemCapacity = transform(volume.FilesystemCapacity);
                  volume.FilesystemAvailable = transform(volume.FilesystemAvailable);
                  volume.FilesystemUsed = transform(volume.FilesystemUsed);
+                 volume.MinFreeSpace = transform(volume.MinFreeSpace);
+                 volume.NonOzoneUsed = transform(volume.NonOzoneUsed);
                 })
                 });
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
@@ -75,7 +75,7 @@ class TestVolumeInfoMetrics {
 
       assertThat(findMetric(all, "FilesystemCapacity")).isEqualTo(2000L);
       assertThat(findMetric(all, "FilesystemAvailable")).isEqualTo(1100L);
-      assertThat(findMetric(all, "FilesystemUsed")).isEqualTo(500L);
+      assertThat(findMetric(all, "FilesystemUsed")).isEqualTo(900L); // FilesystemCapacity - FilesystemAvailable
 
       assertThat(findMetric(all, "MinFreeSpace")).isEqualTo(20L);
       assertThat(findMetric(all, "NonOzoneUsed")).isEqualTo(400L);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
@@ -45,7 +45,6 @@ class TestVolumeInfoMetrics {
     when(volume.getCommittedBytes()).thenReturn(10L);
     when(volume.getContainers()).thenReturn(3L);
     when(volume.getReportedFreeSpaceToSpare(anyLong())).thenReturn(20L);
-    when(volume.getFreeSpaceToSpare(anyLong())).thenReturn(10L);
 
     VolumeUsage volumeUsage = mock(VolumeUsage.class);
     when(volume.getVolumeUsage()).thenReturn(volumeUsage);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
@@ -45,20 +45,23 @@ class TestVolumeInfoMetrics {
     when(volume.getCommittedBytes()).thenReturn(10L);
     when(volume.getContainers()).thenReturn(3L);
     when(volume.getReportedFreeSpaceToSpare(anyLong())).thenReturn(20L);
+    when(volume.getFreeSpaceToSpare(anyLong())).thenReturn(10L);
 
     VolumeUsage volumeUsage = mock(VolumeUsage.class);
     when(volume.getVolumeUsage()).thenReturn(volumeUsage);
 
-    // Ozone-usable usage and reserved
-    when(volumeUsage.getCurrentUsage(any())).thenReturn(new SpaceUsageSource.Fixed(
-        1000L,
-        900L,
-        100L
-    ));
     when(volumeUsage.getReservedInBytes()).thenReturn(50L);
 
-    // Raw filesystem stats
-    when(volumeUsage.realUsage()).thenReturn(new SpaceUsageSource.Fixed(2000L, 1100L, 500L));
+    // Raw filesystem stats (used = Ozone DU usage on disk)
+    SpaceUsageSource.Fixed fsUsage = new SpaceUsageSource.Fixed(2000L, 1100L, 500L);
+    when(volumeUsage.realUsage()).thenReturn(fsUsage);
+
+    // getCurrentUsage(real) preserves real.getUsedSpace(); capacity/available are adjusted for reserved
+    when(volumeUsage.getCurrentUsage(any())).thenReturn(new SpaceUsageSource.Fixed(
+        1950L,  // fsCapacity - reserved
+        1100L,
+        500L    // same as fsUsage.getUsedSpace()
+    ));
 
     VolumeInfoMetrics metrics = new VolumeInfoMetrics("test-vol-1", volume);
     try {
@@ -69,15 +72,16 @@ class TestVolumeInfoMetrics {
       MetricsRecordImpl rec = collector.getRecords().get(0);
       Iterable<AbstractMetric> all = rec.metrics();
 
-      assertThat(findMetric(all, "OzoneCapacity")).isEqualTo(1000L);
-      assertThat(findMetric(all, "OzoneAvailable")).isEqualTo(900L);
-      assertThat(findMetric(all, "OzoneUsed")).isEqualTo(100L);
+      assertThat(findMetric(all, "OzoneCapacity")).isEqualTo(1950L);
+      assertThat(findMetric(all, "OzoneAvailable")).isEqualTo(1100L);
+      assertThat(findMetric(all, "OzoneUsed")).isEqualTo(500L);
 
       assertThat(findMetric(all, "FilesystemCapacity")).isEqualTo(2000L);
       assertThat(findMetric(all, "FilesystemAvailable")).isEqualTo(1100L);
       assertThat(findMetric(all, "FilesystemUsed")).isEqualTo(900L); // FilesystemCapacity - FilesystemAvailable
 
       assertThat(findMetric(all, "MinFreeSpace")).isEqualTo(20L);
+      // NonOzoneUsed = FilesystemUsed - OzoneUsed = 900 - 500
       assertThat(findMetric(all, "NonOzoneUsed")).isEqualTo(400L);
     } finally {
       metrics.unregister();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.volume;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +44,7 @@ class TestVolumeInfoMetrics {
     when(volume.getType()).thenReturn(HddsVolume.VolumeType.DATA_VOLUME);
     when(volume.getCommittedBytes()).thenReturn(10L);
     when(volume.getContainers()).thenReturn(3L);
+    when(volume.getReportedFreeSpaceToSpare(anyLong())).thenReturn(20L);
 
     VolumeUsage volumeUsage = mock(VolumeUsage.class);
     when(volume.getVolumeUsage()).thenReturn(volumeUsage);
@@ -56,7 +58,7 @@ class TestVolumeInfoMetrics {
     when(volumeUsage.getReservedInBytes()).thenReturn(50L);
 
     // Raw filesystem stats
-    when(volumeUsage.realUsage()).thenReturn(new SpaceUsageSource.Fixed(2000L, 1500L, 500L));
+    when(volumeUsage.realUsage()).thenReturn(new SpaceUsageSource.Fixed(2000L, 1100L, 500L));
 
     VolumeInfoMetrics metrics = new VolumeInfoMetrics("test-vol-1", volume);
     try {
@@ -72,8 +74,11 @@ class TestVolumeInfoMetrics {
       assertThat(findMetric(all, "OzoneUsed")).isEqualTo(100L);
 
       assertThat(findMetric(all, "FilesystemCapacity")).isEqualTo(2000L);
-      assertThat(findMetric(all, "FilesystemAvailable")).isEqualTo(1500L);
+      assertThat(findMetric(all, "FilesystemAvailable")).isEqualTo(1100L);
       assertThat(findMetric(all, "FilesystemUsed")).isEqualTo(500L);
+
+      assertThat(findMetric(all, "MinFreeSpace")).isEqualTo(20L);
+      assertThat(findMetric(all, "NonOzoneUsed")).isEqualTo(400L);
     } finally {
       metrics.unregister();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Min Free Space and Non-Ozone Used Space metrics are not available in JMX. Also, Total Capacity and Filesystem Capacity calculated value is same, so there is no need to expose both fields separately since it always shares same value. Therefore, we are removing the Total Capacity field and added Min Free Space and Non-Ozone Used Space metrics.
## What is the link to the Apache JIRA

HDDS-15312

## How was this patch tested?

Updated unit testcase.
Also tested manually
```
bash-5.1$ curl -XGET http://ozone-datanode-1:9882/jmx?qry=Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds
{
  "beans" : [ {
    "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds",
    "modelerType" : "VolumeInfoMetrics-/data/hdds",
    "tag.Context" : "ozone",
    "tag.StorageType" : "DISK",
    "tag.DatanodeUuid" : "96b844d8-283e-449b-a6dc-26dd1daf2569",
    "tag.VolumeType" : "DATA_VOLUME",
    "tag.StorageDirectory" : "/data/hdds/hdds",
    "tag.VolumeState" : "NORMAL",
    "tag.Hostname" : "3552d2e7b2dd",
    "AvailableSpaceInsufficient" : 0,
    "DbCompactLatencyNumOps" : 0,
    "DbCompactLatencyAvgTime" : 0.0,
    "NumContainerCreateRequestsInSoftBandMinFreeSpace" : 0,
    "NumContainerCreateRequestsRejectedHardMinFreeSpace" : 0,
    "NumScans" : 1,
    "NumScansSkipped" : 0,
    "NumWriteRequestsInSoftBandMinFreeSpace" : 0,
    "NumWriteRequestsRejectedHardMinFreeSpace" : 0,
    "ReservedCrossesLimit" : 1,
    "LayoutVersion" : 1,
    "Containers" : 0,
    "Committed" : 0,
    "OzoneCapacity" : 105076655700,
    "OzoneAvailable" : 88517070848,
    "OzoneUsed" : 4382720,
    "Reserved" : 10508716,
    "FilesystemCapacity" : 105087164416,
    "FilesystemAvailable" : 88517070848,
    "FilesystemUsed" : 16570093568,
    "MinFreeSpace" : 104857600,
    "NonOzoneUsed" : 16565710848
  } ]
}bash-5.1$ 
```