### PR TITLE
HDDS-15318. Download libhadoop library during maven build

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -149,14 +149,14 @@ done
 NATIVE_LIBS_DIR="${ROOT}/target/native-lib"
 
 # Check if the libhadoop files actually exist before attempting to copy
-if ls "${NATIVE_LIBS_DIR}"/libhadoop.* 1> /dev/null 2>&1; then
+if ls "${NATIVE_LIBS_DIR}"/libhadoop* 1> /dev/null 2>&1; then
   echo "Found Hadoop native libraries. Copying to distribution..."
 
   # Create the native directory in the final staging area
   run mkdir -p ./lib/native
 
   # Copy the files and symlinks safely
-  run cp -rP "${NATIVE_LIBS_DIR}/"libhadoop.* ./lib/native
+  run cp -rP "${NATIVE_LIBS_DIR}/"libhadoop* ./lib/native
 else
   echo "Hadoop native libraries not found. Skipping native copy."
 fi

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -148,7 +148,7 @@ done
 # ---------------------------------------------------------
 NATIVE_LIBS_DIR="${ROOT}/target/native-lib"
 
-# Check if the .so files actually exist before attempting to copy
+# Check if the libhadoop files actually exist before attempting to copy
 if ls "${NATIVE_LIBS_DIR}"/libhadoop.* 1> /dev/null 2>&1; then
   echo "Found Hadoop native libraries. Copying to distribution..."
 

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -143,6 +143,24 @@ for file in $(find "${ROOT}" -path '*/share/ozone/lib/*jar' | sort); do
   cp -p "$file" share/ozone/lib/
 done
 
+# ---------------------------------------------------------
+# Copy Hadoop Native Libraries (libhadoop.so) - Conditionally
+# ---------------------------------------------------------
+NATIVE_LIBS_DIR="${ROOT}/target/native-lib"
+
+# Check if the .so files actually exist before attempting to copy
+if ls "${NATIVE_LIBS_DIR}"/libhadoop.* 1> /dev/null 2>&1; then
+  echo "Found Hadoop native libraries. Copying to distribution..."
+
+  # Create the native directory in the final staging area
+  run mkdir -p ./lib/native
+
+  # Copy the files and symlinks safely
+  run cp -rP "${NATIVE_LIBS_DIR}/"libhadoop.* ./lib/native
+else
+  echo "Hadoop native libraries not found. Skipping native copy."
+fi
+
 #workaround for https://issues.apache.org/jira/browse/MRESOURCES-236
 find ./compose -name "*.sh" -exec chmod 755 {} \;
 find ./kubernetes -name "*.sh" -exec chmod 755 {} \;

--- a/pom.xml
+++ b/pom.xml
@@ -2649,7 +2649,7 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>${download-maven-plugin.version}</version>
             <inherited>false</inherited>
             <executions>
               <execution>
@@ -2671,7 +2671,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>${maven-antrun-plugin.version}</version>
             <inherited>false</inherited>
             <executions>
               <execution>
@@ -2710,7 +2710,7 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>${download-maven-plugin.version}</version>
             <inherited>false</inherited>
             <executions>
               <execution>
@@ -2732,7 +2732,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>${maven-antrun-plugin.version}</version>
             <inherited>false</inherited>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2633,5 +2633,126 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>native</id>
+      <activation>
+        <os>
+          <family>linux</family>
+          <arch>x86_64</arch>
+        </os>
+        <property>
+          <name>fetch-native-hadoop</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>fetch-hadoop-native-tar</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <url>https://archive.apache.org/dist/hadoop/common/hadoop-${hadoop.version}/hadoop-${hadoop.version}.tar.gz</url>
+                  <unpack>true</unpack>
+                  <outputDirectory>${project.build.directory}/hadoop-bin</outputDirectory>
+                  <skipCache>false</skipCache>
+                  <overwrite>false</overwrite>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/native-lib" />
+                    <exec executable="bash" failonerror="true">
+                      <arg value="-c" />
+                      <arg value="cp -P ${project.build.directory}/hadoop-bin/hadoop-*/lib/native/libhadoop.so* ${project.build.directory}/native-lib/" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>native-mac</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+        <property>
+          <name>fetch-native-hadoop</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>fetch-mac-binary</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <!-- TODO: change ChenSammi to apache after https://github.com/apache/ozone-docker-runner/pull/66 is merged-->
+                  <url>https://raw.githubusercontent.com/ChenSammi/ozone-docker-runner/master/hadoop-native-lib/Mac_OS_X-aarch64/${hadoop.version}/libhadoop.1.0.0.dylib</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
+                  <skipCache>false</skipCache>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target>
+                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
+                      <arg value="-c" />
+                      <arg value="ln -sf libhadoop.1.0.0.dylib libhadoop.dylib" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2653,17 +2653,16 @@
             <inherited>false</inherited>
             <executions>
               <execution>
-                <id>fetch-hadoop-native-tar</id>
+                <id>fetch-linux-library</id>
                 <goals>
                   <goal>wget</goal>
                 </goals>
                 <phase>generate-resources</phase>
                 <configuration>
-                  <url>https://archive.apache.org/dist/hadoop/common/hadoop-${hadoop.version}/hadoop-${hadoop.version}.tar.gz</url>
-                  <unpack>true</unpack>
-                  <outputDirectory>${project.build.directory}/hadoop-bin</outputDirectory>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_x86_64.so</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
                   <skipCache>false</skipCache>
-                  <overwrite>false</overwrite>
                 </configuration>
               </execution>
             </executions>
@@ -2675,16 +2674,16 @@
             <inherited>false</inherited>
             <executions>
               <execution>
+                <id>extract-linux-library</id>
                 <goals>
                   <goal>run</goal>
                 </goals>
                 <phase>prepare-package</phase>
                 <configuration>
                   <target>
-                    <mkdir dir="${project.build.directory}/native-lib" />
-                    <exec executable="bash" failonerror="true">
+                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
                       <arg value="-c" />
-                      <arg value="cp -P ${project.build.directory}/hadoop-bin/hadoop-*/lib/native/libhadoop.so* ${project.build.directory}/native-lib/" />
+                      <arg value="ln -sf libhadoop_linux_x86_64.so libhadoop.so" />
                     </exec>
                   </target>
                 </configuration>
@@ -2714,14 +2713,13 @@
             <inherited>false</inherited>
             <executions>
               <execution>
-                <id>fetch-mac-binary</id>
+                <id>fetch-mac-library</id>
                 <goals>
                   <goal>wget</goal>
                 </goals>
                 <phase>generate-resources</phase>
                 <configuration>
-                  <!-- TODO: change ChenSammi to apache after https://github.com/apache/ozone-docker-runner/pull/66 is merged-->
-                  <url>https://raw.githubusercontent.com/ChenSammi/ozone-docker-runner/master/hadoop-native-lib/Mac_OS_X-aarch64/${hadoop.version}/libhadoop.1.0.0.dylib</url>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_osx_aarch_64.dylib</url>
                   <unpack>false</unpack>
                   <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
                   <skipCache>false</skipCache>
@@ -2736,6 +2734,7 @@
             <inherited>false</inherited>
             <executions>
               <execution>
+                <id>extract-mac-library</id>
                 <goals>
                   <goal>run</goal>
                 </goals>
@@ -2744,7 +2743,7 @@
                   <target>
                     <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
                       <arg value="-c" />
-                      <arg value="ln -sf libhadoop.1.0.0.dylib libhadoop.dylib" />
+                      <arg value="ln -sf libhadoop_osx_aarch_64.dylib libhadoop.dylib" />
                     </exec>
                   </target>
                 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

download libhadoop library during maven build, for local unit test, and dist package.  

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15318

## How was this patch tested?
Test locally. 

```
mvn clean package -DskipTests -Dmaven.javadoc.skip=true -s ~/workspace/tools/apache-maven-3.6.0/conf/settings-apache.xml -T 6 -Pnative-mac -Pdist

sammi@X3HF9K66K7 target % find . -name libhadoop* 
./ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.dylib
./ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.1.0.0.dylib

sammi@X3HF9K66K7 target % tar -tvf ozone-2.2.0-SNAPSHOT.tar.gz| grep libhadoop
lrwxr-xr-x  0 sammi  staff        0 May 18 20:30 ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.dylib -> libhadoop.1.0.0.dylib
-rw-r--r--  0 sammi  staff   157368 May 18 20:30 ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.1.0.0.dylib
```

```
mvn clean package -DskipTests -Dmaven.javadoc.skip=true -s ~/workspace/tools/apache-maven-3.6.0/conf/settings-apache.xml -T 6 -Pnative -Pdist

sammi@X3HF9K66K7 target % find . -name libhadoop*
./ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.so
./ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.so.1.0.0
sammi@X3HF9K66K7 target % tar -tvf ozone-2.2.0-SNAPSHOT.tar.gz| grep libhadoop
lrwxr-xr-x  0 sammi  staff        0 May 19 12:02 ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.so -> libhadoop.so.1.0.0
-rwxr-xr-x  0 sammi  staff   890256 May 19 12:02 ozone-2.2.0-SNAPSHOT/lib/native/libhadoop.so.1.0.0

```
```

mvn clean package -DskipTests -Dmaven.javadoc.skip=true -s ~/workspace/tools/apache-maven-3.6.0/conf/settings-apache.xml -T 6 -Pdist

sammi@X3HF9K66K7 target % find . -name libhadoop*                             
sammi@X3HF9K66K7 target % tar -tvf ozone-2.2.0-SNAPSHOT.tar.gz| grep libhadoop

```

The downloaded file in cached in maven local repo, so only download once if it's not changed. 
```
sammi@X3HF9K66K7 target % ls -al ~/.m2/repository/.cache/download-maven-plugin
total 1006024
drwxr-xr-x  5 sammi  staff        160 May 18 19:47 .
drwxr-xr-x  3 sammi  staff         96 May 18 10:56 ..
-rw-r--r--  1 sammi  staff  514917037 May 18 11:50 hadoop-3.4.3.tar.gz_0deb1bfef085d775400e262f41867f8e
-rw-r--r--  1 sammi  staff        478 May 18 19:47 index.ser
-rw-r--r--  1 sammi  staff     157368 May 18 19:47 libhadoop.1.0.0.dylib_1aa24cad2f558d1e1012dfd83037efc1
```

