### PR TITLE
HDDS-15311. [DiskBalancer] Fix DiskBalancer DN container Log Format

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerLogger.java
@@ -181,40 +181,38 @@ public final class ContainerLogger {
   /**
    * Logged when a container is successfully moved from one data volume to another.
    *
-   * @param containerId The ID of the moved container.
+   * @param containerData The container after it has been moved to the destination volume.
    * @param sourceVolume The source volume path.
    * @param destinationVolume The destination volume path.
    * @param containerSize The size of data moved from container in bytes.
    * @param timeTaken The time taken for the move in milliseconds.
    */
-  public static void logMoveSuccess(long containerId, StorageVolume sourceVolume,
+  public static void logMoveSuccess(ContainerData containerData, StorageVolume sourceVolume,
       StorageVolume destinationVolume, long containerSize, long timeTaken) {
-    LOG.info(getMessage(containerId, sourceVolume, destinationVolume, containerSize, timeTaken));
+    LOG.info(getMessage(containerData,
+        "SrcVolume=" + sourceVolume,
+        "DestVolume=" + destinationVolume,
+        "Size=" + containerSize + " bytes",
+        "TimeTaken=" + timeTaken + " ms",
+        "Container is moved from SrcVolume to DestVolume"));
   }
 
-  private static String getMessage(ContainerData containerData,
-                                   String message) {
+  private static String getMessage(ContainerData containerData, String message) {
     return String.join(FIELD_SEPARATOR, getMessage(containerData), message);
   }
 
-  private static String getMessage(ContainerData containerData) {
+  private static String getMessage(ContainerData containerData, String... fields) {
     return String.join(FIELD_SEPARATOR,
         "ID=" + containerData.getContainerID(),
         "Index=" + containerData.getReplicaIndex(),
         "BCSID=" + containerData.getBlockCommitSequenceId(),
         "State=" + containerData.getState(),
-        "Volume=" + containerData.getVolume(),
-        "DataChecksum=" + checksumToString(containerData.getDataChecksum()));
+        String.join(FIELD_SEPARATOR, fields));
   }
 
-  private static String getMessage(long containerId, StorageVolume sourceVolume,
-      StorageVolume destinationVolume, long containerSize, long timeTaken) {
-    return String.join(FIELD_SEPARATOR,
-        "ID=" + containerId,
-        "SrcVolume=" + sourceVolume,
-        "DestVolume=" + destinationVolume,
-        "Size=" + containerSize + " bytes",
-        "TimeTaken=" + timeTaken + " ms",
-        "Container is moved from SrcVolume to DestVolume");
+  private static String getMessage(ContainerData containerData) {
+    return getMessage(containerData,
+        "Volume=" + containerData.getVolume(),
+        "DataChecksum=" + checksumToString(containerData.getDataChecksum()));
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -634,15 +634,14 @@ public class DiskBalancerService extends BackgroundService {
         if (!readLockReleased) {
           container.readUnlock();
         }
-        if (moveSucceeded) {
+        boolean moveCompleted = moveSucceeded && newContainer != null;
+        if (moveCompleted) {
           // Add current old container to pendingDeletionContainers.
           pendingDeletionContainers.put(System.currentTimeMillis() + replicaDeletionDelay, container);
-          if (newContainer != null) {
-            ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
-                destVolume, containerSize, Time.monotonicNow() - startTime);
-          }
+          ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
+              destVolume, containerSize, Time.monotonicNow() - startTime);
         }
-        postCall(moveSucceeded, startTime);
+        postCall(moveCompleted, startTime);
 
         // pick one expired container from pendingDeletionContainers to delete
         tryCleanupOnePendingDeletionContainer();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -509,6 +509,7 @@ public class DiskBalancerService extends BackgroundService {
     public BackgroundTaskResult call() {
       long startTime = Time.monotonicNow();
       boolean moveSucceeded = true;
+      Container newContainer = null;
       long containerId = containerData.getContainerID();
       Container container = ozoneContainer.getContainerSet().getContainer(containerId);
       boolean readLockReleased = false;
@@ -580,7 +581,7 @@ public class DiskBalancerService extends BackgroundService {
         }
 
         // Import the container. importContainer will reset container back to original state
-        Container newContainer = ozoneContainer.getController().importContainer(tempContainerData);
+        newContainer = ozoneContainer.getController().importContainer(tempContainerData);
 
         // Step 4: Update container for containerID and mark old container for deletion
         // first, update the in-memory set to point to the new replica.
@@ -636,8 +637,10 @@ public class DiskBalancerService extends BackgroundService {
         if (moveSucceeded) {
           // Add current old container to pendingDeletionContainers.
           pendingDeletionContainers.put(System.currentTimeMillis() + replicaDeletionDelay, container);
-          ContainerLogger.logMoveSuccess(containerId, sourceVolume,
-              destVolume, containerSize, Time.monotonicNow() - startTime);
+          if (newContainer != null) {
+            ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
+                destVolume, containerSize, Time.monotonicNow() - startTime);
+          }
         }
         postCall(moveSucceeded, startTime);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -634,14 +634,13 @@ public class DiskBalancerService extends BackgroundService {
         if (!readLockReleased) {
           container.readUnlock();
         }
-        boolean moveCompleted = moveSucceeded && newContainer != null;
-        if (moveCompleted) {
+        if (moveSucceeded && newContainer != null) {
           // Add current old container to pendingDeletionContainers.
           pendingDeletionContainers.put(System.currentTimeMillis() + replicaDeletionDelay, container);
           ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
               destVolume, containerSize, Time.monotonicNow() - startTime);
         }
-        postCall(moveCompleted, startTime);
+        postCall(moveSucceeded && newContainer != null, startTime);
 
         // pick one expired container from pendingDeletionContainers to delete
         tryCleanupOnePendingDeletionContainer();


### PR DESCRIPTION
## What changes were proposed in this pull request?
DN container log file format as key worded columns is different in case of DiskBalancer compared to existing log lines. This may cause issue in any dn container formatter or parser in future.

```
2026-05-15 04:24:11,501 | INFO  | ID=11 | Index=0 | BCSID=1374 | State=CLOSED | Volume=/hadoop-ozone/datanode/data/hdds | DataChecksum=47c5ddd3 |
2026-05-15 05:02:20,188 | INFO  | ID=11 | SrcVolume=/hadoop-ozone/datanode/data/hdds | DestVolume=/data0/nvme1n1/hadoop-ozone/datanode/data/hdds | Size=268435456 bytes | TimeTaken=490 ms | Container is moved from SrcVolume to DestVolume |
2026-05-15 07:12:08,285 | INFO  | ID=11 | Index=0 | BCSID=1374 | State=CLOSED | Volume=/data0/nvme1n1/hadoop-ozone/datanode/data/hdds | DataChecksum=47c5ddd3 | Container reconciled with peer a49d6e1b-ee75-46c5-84eb-3ebde58b686f(datanode1.com/xx.xx.xx.xx). No change in checksum. | 
```
DiskBalancer should maintain the same structure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15311

## How was this patch tested?

Tested manually.
**Before:**
```
2026-05-15 05:02:20,188 | INFO  | ID=11 | SrcVolume=/hadoop-ozone/datanode/data/hdds | DestVolume=/data0/nvme1n1/hadoop-ozone/datanode/data/hdds | Size=268435456 bytes | TimeTaken=490 ms | Container is moved from SrcVolume to DestVolume |
```

**After:**
```
2026-05-19 04:51:12,068 | INFO  | ID=13 | Index=0 | BCSID=16965 | State=CLOSED | Volume=/data/hdds1/hdds | DataChecksum=2cc81c5e |
2026-05-19 04:51:12,069 | INFO  | ID=14 | Index=0 | BCSID=16973 | State=CLOSED | Volume=/data/hdds1/hdds | DataChecksum=595237d2 |
2026-05-19 04:54:17,660 | INFO  | ID=13 | Index=0 | BCSID=16965 | State=CLOSED | SrcVolume=/data/hdds1/hdds | DestVolume=/data/hdds2/hdds | Size=967835648 bytes | TimeTaken=1777 ms | Container is moved from SrcVolume to DestVolume |
2026-05-19 04:55:17,405 | INFO  | ID=14 | Index=0 | BCSID=16973 | State=CLOSED | SrcVolume=/data/hdds1/hdds | DestVolume=/data/hdds2/hdds | Size=967835648 bytes | TimeTaken=1520 ms | Container is moved from SrcVolume to DestVolume |
```