### PR TITLE
HDDS-15310. [DiskBalancer] Fix Threshold range in negative

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -109,7 +109,7 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
         double idealUsage = p.getIdealUsage();
         double threshold = p.getDiskBalancerConf().getThreshold();
         double lt = Math.max(0.0, idealUsage - threshold / 100.0);
-        double ut = idealUsage + threshold / 100.0;
+        double ut = Math.min(1.0, idealUsage + threshold / 100.0);
         header.append("IdealUsage: ").append(String.format("%.8f", idealUsage))
             .append(" | Threshold: ").append(threshold).append('%')
             .append(" | ThresholdRange: (").append(String.format("%.8f", lt))
@@ -193,7 +193,7 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
       double idealUsage = report.getIdealUsage();
       double threshold = report.getDiskBalancerConf().getThreshold();
       double lt = Math.max(0.0, idealUsage - threshold / 100.0);
-      double ut = idealUsage + threshold / 100.0;
+      double ut = Math.min(1.0, idealUsage + threshold / 100.0);
       result.put("idealUsage", String.format("%.8f", idealUsage));
       result.put("threshold %", report.getDiskBalancerConf().getThreshold());
       result.put("thresholdRange", String.format("(%.08f, %.08f)", lt, ut));

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -108,7 +108,7 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
           && p.getDiskBalancerConf().hasThreshold()) {
         double idealUsage = p.getIdealUsage();
         double threshold = p.getDiskBalancerConf().getThreshold();
-        double lt = idealUsage - threshold / 100.0;
+        double lt = Math.max(0.0, idealUsage - threshold / 100.0);
         double ut = idealUsage + threshold / 100.0;
         header.append("IdealUsage: ").append(String.format("%.8f", idealUsage))
             .append(" | Threshold: ").append(threshold).append('%')
@@ -192,7 +192,7 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
         && report.getDiskBalancerConf().hasThreshold()) {
       double idealUsage = report.getIdealUsage();
       double threshold = report.getDiskBalancerConf().getThreshold();
-      double lt = idealUsage - threshold / 100.0;
+      double lt = Math.max(0.0, idealUsage - threshold / 100.0);
       double ut = idealUsage + threshold / 100.0;
       result.put("idealUsage", String.format("%.8f", idealUsage));
       result.put("threshold %", report.getDiskBalancerConf().getThreshold());

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -591,6 +591,26 @@ public class TestDiskBalancerSubCommands {
   // ========== DiskBalancerReportSubcommand Tests ==========
 
   @Test
+  public void testReportThresholdRangeLowerBoundNotNegative() throws Exception {
+    DiskBalancerReportSubcommand cmd = new DiskBalancerReportSubcommand();
+    double idealUsage = 0.08426521;
+    double thresholdPercent = 10.0;
+    DatanodeDiskBalancerInfoProto reportProto = createReportProto("host-1", idealUsage,
+        thresholdPercent);
+
+    when(mockProtocol.getDiskBalancerInfo()).thenReturn(reportProto);
+
+    try (DiskBalancerMocks mocks = setupAllMocks()) {
+      CommandLine c = new CommandLine(cmd);
+      c.parseArgs("host-1");
+      cmd.call();
+
+      String output = outContent.toString(DEFAULT_ENCODING);
+      assertTrue(output.contains("ThresholdRange: (0.00000000, 0.18426521)"));
+    }
+  }
+
+  @Test
   public void testReportDiskBalancerWithInServiceDatanodes() throws Exception {
     DiskBalancerReportSubcommand cmd = new DiskBalancerReportSubcommand();
     
@@ -821,6 +841,25 @@ public class TestDiskBalancerSubCommands {
         .setDiskBalancerConf(configProto)
         .addVolumeInfo(vol1)
         .addVolumeInfo(vol2)
+        .build();
+  }
+
+  private DatanodeDiskBalancerInfoProto createReportProto(String hostname, double idealUsage,
+      double thresholdPercent) {
+    DatanodeDetailsProto nodeProto = DatanodeDetailsProto.newBuilder()
+        .setHostName(hostname)
+        .setIpAddress("127.0.0.1")
+        .addPorts(HddsProtos.Port.newBuilder()
+            .setName("CLIENT_RPC")
+            .setValue(HDDS_DATANODE_CLIENT_PORT_DEFAULT)
+            .build())
+        .build();
+
+    return DatanodeDiskBalancerInfoProto.newBuilder()
+        .setNode(nodeProto)
+        .setCurrentVolumeDensitySum(0.1408700123786014)
+        .setIdealUsage(idealUsage)
+        .setDiskBalancerConf(createConfigProto(thresholdPercent, 100L, 5, true))
         .build();
   }
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_PORT_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,6 +43,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -56,6 +58,9 @@ import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import picocli.CommandLine;
@@ -590,23 +595,42 @@ public class TestDiskBalancerSubCommands {
 
   // ========== DiskBalancerReportSubcommand Tests ==========
 
-  @Test
-  public void testReportThresholdRangeLowerBoundNotNegative() throws Exception {
+  static Stream<Arguments> thresholdRangeReportCases() {
+    return Stream.of(
+        Arguments.of(0.08426521, 10.0, false,
+            "ThresholdRange: (0.00000000, 0.18426521)", "ThresholdRange: (-"),
+        Arguments.of(0.95, 10.0, false,
+            "ThresholdRange: (0.85000000, 1.00000000)", "1.05000000"),
+        Arguments.of(0.95, 10.0, true,
+            "\"thresholdRange\" : \"(0.85000000, 1.00000000)\"", "1.05000000"));
+  }
+
+  @ParameterizedTest(name = "idealUsage={0}, threshold={1}%, json={2}")
+  @MethodSource("thresholdRangeReportCases")
+  public void testReportThresholdRangeClamped(double idealUsage,
+      double thresholdPercent, boolean jsonOutput, String expectedRangeSubstring,
+      String mustNotContain) throws Exception {
+    outContent.reset();
+    errContent.reset();
+
     DiskBalancerReportSubcommand cmd = new DiskBalancerReportSubcommand();
-    double idealUsage = 0.08426521;
-    double thresholdPercent = 10.0;
-    DatanodeDiskBalancerInfoProto reportProto = createReportProto("host-1", idealUsage,
-        thresholdPercent);
+    DatanodeDiskBalancerInfoProto reportProto =
+        createReportProto("host-1", idealUsage, thresholdPercent);
 
     when(mockProtocol.getDiskBalancerInfo()).thenReturn(reportProto);
 
     try (DiskBalancerMocks mocks = setupAllMocks()) {
       CommandLine c = new CommandLine(cmd);
-      c.parseArgs("host-1");
+      if (jsonOutput) {
+        c.parseArgs("--json", "host-1");
+      } else {
+        c.parseArgs("host-1");
+      }
       cmd.call();
 
       String output = outContent.toString(DEFAULT_ENCODING);
-      assertTrue(output.contains("ThresholdRange: (0.00000000, 0.18426521)"));
+      assertThat(output).contains(expectedRangeSubstring);
+      assertThat(output).doesNotContain(mustNotContain);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
ThresholdRange lower side value is shown in negative.
ThresholdRange upper bound can also go beyond 100% when idealUsage of a DN is across 85% to 95%.
A trivial issue as it cannot be less than 0.

```
Datanode: datanode1.com (10.82.238.73:19864)
Aggregate VolumeDataDensity: 0.1408700123786014
IdealUsage: 0.08426521 | Threshold: 10.0% | ThresholdRange: (-0.01573479, 0.18426521)

Volume Details:

StorageID                                     StoragePath                                TotalCapacity       UsedSpace   Container Pre-AllocatedSpace   EffectiveUsedSpace     Utilization   VolumeDensity
DS-f543b851-ec6a-4229-a95d-68e60b5a12b9       /hadoop-ozone/datanode/data/hdds               349.27 GB         6.07 MB                            0 B             47.10 GB      0.13486543      0.05060022
DS-d3b3f53f-02c8-4982-80c9-7d1cce2a484d       /data0/nvme1n1/hadoop-ozone/datanode/data/hdds       195.78 GB         6.11 MB                            0 B             10.64 GB      0.05436899      0.02989622
DS-2ec41da1-a185-42e1-8b33-88de998c6fd1       /data0/nvme3n1/hadoop-ozone/datanode/data/hdds       195.78 GB         6.12 MB                            0 B             10.96 GB      0.05597013      0.02829508
DS-a4e9901e-e856-4660-bd3f-db695f3648c4       /data0/nvme2n1/hadoop-ozone/datanode/data/hdds       195.78 GB         6.11 MB                            0 B             10.22 GB      0.05218671      0.03207850
 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15310

## How was this patch tested?

Added unit test and tested manually.
**After Fix:**
```
bash-5.1$ ozone admin datanode diskbalancer report --in-service-datanodes
Report result:
Datanode: ozone-datanode-1.ozone_default (172.18.0.2:19864)
Aggregate VolumeDataDensity: 0.0024470187365063373
IdealUsage: 0.09599255 | Threshold: 10.0% | ThresholdRange: (0.00000000, 0.19599255)

Volume Details:

StorageID                                     StoragePath                                TotalCapacity       UsedSpace   Container Pre-AllocatedSpace   EffectiveUsedSpace     Utilization   VolumeDensity
DS-b7280aed-120a-40f7-b673-911fe5c7c061       /data/hdds1/hdds                              1006.75 GB         1.81 GB                            0 B             96.02 GB      0.09538079      0.00061175
DS-bc7b4a02-c4dd-4dd2-aa7c-e41612a9d92b       /data/hdds2/hdds                              1006.75 GB         1.16 GB                        1.85 GB             97.87 GB      0.09721606      0.00122351
DS-f26b66b9-a0b6-4661-a831-d65c3e1801fd       /data/hdds3/hdds                              1006.75 GB         3.61 GB                            0 B             96.02 GB      0.09538079      0.00061175

bash-5.1$ ozone admin datanode diskbalancer report --in-service-datanodes
Report result:
Datanode: ozone-datanode-1.ozone_default (172.18.0.2:19864)
Aggregate VolumeDataDensity: 5.4470187365063373
IdealUsage: 0.85992550 | Threshold: 20.0% | ThresholdRange: (0.65992550, 0.10000000)
```
