### PR TITLE
HDDS-15260. Escape more elements in xml_to_md.py

### DIFF
--- a/dev-support/ci/xml_to_md.py
+++ b/dev-support/ci/xml_to_md.py
@@ -27,6 +27,15 @@ import sys
 
 Property = namedtuple('Property', ['name', 'value', 'tag', 'description'])
 
+def escape_mdx_markup(text):
+  """Escapes special characters to prevent MDX/JSX parsing errors."""
+  if not text:
+    return text
+  text = text.replace('&', '&amp;')
+  text = text.replace('<', '&lt;')
+  text = text.replace('>', '&gt;')
+  return text
+
 def extract_xml_from_jar(jar_path, xml_filename):
   xml_files = []
   with zipfile.ZipFile(jar_path, 'r') as jar:
@@ -120,6 +129,7 @@ This page provides a comprehensive overview of the configuration keys available 
     # Escape pipe characters and wrap {placeholders} in backticks
     description = prop.description.replace('|', '\\|')
     description = placeholder_pattern.sub(r'`\1{\2}`', description)
+    description = escape_mdx_markup(description)
 
     value = prop.value
     if value:

--- a/dev-support/ci/xml_to_md.py
+++ b/dev-support/ci/xml_to_md.py
@@ -137,6 +137,7 @@ This page provides a comprehensive overview of the configuration keys available 
       value = placeholder_pattern.sub(r'`\1{\2}`', value)
       value = value.replace('\n', ' ')
       value = multi_space_pattern.sub(' ', value)
+      value = escape_mdx_markup(value)
     
     markdown += f"| `{prop.name}` | {value} | {prop.tag} | {description} |\n"
   


### PR DESCRIPTION
## What changes were proposed in this pull request?

> Docusaurus build [fails](https://github.com/apache/ozone-site/actions/runs/25787702552/job/75746588814?pr=426#step:5:34) for [update](https://github.com/apache/ozone-site/pull/426) with <= in config property's description:
> ```
> "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`"
> ```
> There may be other characters or patterns to escape. 

Escapes characters (`&`, `<`, `>`) in addition to the existing `{...}` placeholder sanitisation to prevent MDX/JSX parsing errors in config values and descriptions.

## What is the link to the Apache JIRA
[HDDS-15260](https://issues.apache.org/jira/browse/HDDS-15260)

## How was this patch tested?
`Configurations.md` generated from [CI](https://github.com/sarvekshayr/ozone/actions/runs/26092414836).

```
| Minimum fraction of volume capacity reserved for local enforcement: writes fail when available space would drop below max(this ratio * capacity, `hdds.datanode.volume.min.free.space`). Should be &lt;= min.free.space.percent so SCM can plan for a larger headroom than the DN enforces locally. |
```           
Rendered view                                                                       
<img width="644" height="83" alt="Screenshot 2026-05-19 at 4 30 25 PM" src="https://github.com/user-attachments/assets/23bd7f29-8ad2-45e0-b0b7-2650d8524693" />
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
