### PR TITLE
HDDS-15335. Recon: parallelize NSSummaryTask sub-tasks and cache OmBucketInfo lookups

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -169,45 +169,66 @@ public class NSSummaryTask implements ReconOmTask {
     }
   }
 
+  // Shared executor for the three FSO/Legacy/OBS sub-tasks during process().
+  // The sub-tasks operate on disjoint slices of the event stream (filtered by
+  // table and bucket layout) and write to disjoint NSSummary entries, so they
+  // are safe to run in parallel.
+  private final ExecutorService subTaskExecutor = Executors.newFixedThreadPool(
+      3, new ThreadFactoryBuilder().setNameFormat("NSSummarySubTask-%d").setDaemon(true).build());
+
   @Override
   public TaskResult process(
       OMUpdateEventBatch events, Map<String, Integer> subTaskSeekPosMap) {
-    boolean anyFailure = false; // Track if any bucket fails
     Map<String, Integer> updatedSeekPositions = new HashMap<>();
 
-    // Process FSO bucket
-    Integer bucketSeek = subTaskSeekPosMap.getOrDefault(BucketType.FSO.name(), 0);
-    Pair<Integer, Boolean> bucketResult = nsSummaryTaskWithFSO.processWithFSO(events, bucketSeek);
-    updatedSeekPositions.put(BucketType.FSO.name(), bucketResult.getLeft());
-    if (!bucketResult.getRight()) {
-      LOG.error("processWithFSO failed.");
-      anyFailure = true;
-    }
+    int fsoSeek = subTaskSeekPosMap.getOrDefault(BucketType.FSO.name(), 0);
+    int legacySeek = subTaskSeekPosMap.getOrDefault(BucketType.LEGACY.name(), 0);
+    int obsSeek = subTaskSeekPosMap.getOrDefault(BucketType.OBS.name(), 0);
 
-    // Process Legacy bucket
-    bucketSeek = subTaskSeekPosMap.getOrDefault(BucketType.LEGACY.name(), 0);
-    bucketResult = nsSummaryTaskWithLegacy.processWithLegacy(events, bucketSeek);
-    updatedSeekPositions.put(BucketType.LEGACY.name(), bucketResult.getLeft());
-    if (!bucketResult.getRight()) {
-      LOG.error("processWithLegacy failed.");
-      anyFailure = true;
-    }
+    Future<Pair<Integer, Boolean>> fsoFuture = subTaskExecutor.submit(
+        () -> nsSummaryTaskWithFSO.processWithFSO(events, fsoSeek));
+    Future<Pair<Integer, Boolean>> legacyFuture = subTaskExecutor.submit(
+        () -> nsSummaryTaskWithLegacy.processWithLegacy(events, legacySeek));
+    Future<Pair<Integer, Boolean>> obsFuture = subTaskExecutor.submit(
+        () -> nsSummaryTaskWithOBS.processWithOBS(events, obsSeek));
 
-    // Process OBS bucket
-    bucketSeek = subTaskSeekPosMap.getOrDefault(BucketType.OBS.name(), 0);
-    bucketResult = nsSummaryTaskWithOBS.processWithOBS(events, bucketSeek);
-    updatedSeekPositions.put(BucketType.OBS.name(), bucketResult.getLeft());
-    if (!bucketResult.getRight()) {
-      LOG.error("processWithOBS failed.");
-      anyFailure = true;
-    }
+    boolean anyFailure = false;
+    anyFailure |= !awaitSubTask("processWithFSO", BucketType.FSO,
+        fsoFuture, fsoSeek, updatedSeekPositions);
+    anyFailure |= !awaitSubTask("processWithLegacy", BucketType.LEGACY,
+        legacyFuture, legacySeek, updatedSeekPositions);
+    anyFailure |= !awaitSubTask("processWithOBS", BucketType.OBS,
+        obsFuture, obsSeek, updatedSeekPositions);
 
-    // Return task failure if any bucket failed, while keeping each bucket's latest seek position
     return new TaskResult.Builder()
         .setTaskName(getTaskName())
         .setSubTaskSeekPositions(updatedSeekPositions)
         .setTaskSuccess(!anyFailure)
         .build();
+  }
+
+  private boolean awaitSubTask(String name, BucketType type,
+                               Future<Pair<Integer, Boolean>> future,
+                               int fallbackSeek,
+                               Map<String, Integer> updatedSeekPositions) {
+    try {
+      Pair<Integer, Boolean> result = future.get();
+      updatedSeekPositions.put(type.name(), result.getLeft());
+      if (!result.getRight()) {
+        LOG.error("{} failed.", name);
+        return false;
+      }
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.error("{} interrupted.", name, e);
+      updatedSeekPositions.put(type.name(), fallbackSeek);
+      return false;
+    } catch (ExecutionException e) {
+      LOG.error("{} threw an exception.", name, e.getCause());
+      updatedSeekPositions.put(type.name(), fallbackSeek);
+      return false;
+    }
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -83,6 +83,13 @@ public class NSSummaryTask implements ReconOmTask {
   private final NSSummaryTaskWithLegacy nsSummaryTaskWithLegacy;
   private final NSSummaryTaskWithOBS nsSummaryTaskWithOBS;
 
+  // Shared executor for the three FSO/Legacy/OBS sub-tasks during process().
+  // The sub-tasks operate on disjoint slices of the event stream (filtered by
+  // table and bucket layout) and write to disjoint NSSummary entries, so they
+  // are safe to run in parallel.
+  private final ExecutorService subTaskExecutor = Executors.newFixedThreadPool(
+      3, new ThreadFactoryBuilder().setNameFormat("NSSummarySubTask-%d").setDaemon(true).build());
+
   /**
    * Rebuild state enum to track NSSummary tree rebuild status.
    */
@@ -168,13 +175,6 @@ public class NSSummaryTask implements ReconOmTask {
       return description;
     }
   }
-
-  // Shared executor for the three FSO/Legacy/OBS sub-tasks during process().
-  // The sub-tasks operate on disjoint slices of the event stream (filtered by
-  // table and bucket layout) and write to disjoint NSSummary entries, so they
-  // are safe to run in parallel.
-  private final ExecutorService subTaskExecutor = Executors.newFixedThreadPool(
-      3, new ThreadFactoryBuilder().setNameFormat("NSSummarySubTask-%d").setDaemon(true).build());
 
   @Override
   public TaskResult process(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -87,8 +87,11 @@ public class NSSummaryTask implements ReconOmTask {
   // The sub-tasks operate on disjoint slices of the event stream (filtered by
   // table and bucket layout) and write to disjoint NSSummary entries, so they
   // are safe to run in parallel.
-  private final ExecutorService subTaskExecutor = Executors.newFixedThreadPool(
-      3, new ThreadFactoryBuilder().setNameFormat("NSSummarySubTask-%d").setDaemon(true).build());
+  private static final ExecutorService SUB_TASK_EXECUTOR =
+      Executors.newFixedThreadPool(3, new ThreadFactoryBuilder()
+          .setNameFormat("NSSummarySubTask-%d")
+          .setDaemon(true)
+          .build());
 
   /**
    * Rebuild state enum to track NSSummary tree rebuild status.
@@ -185,11 +188,11 @@ public class NSSummaryTask implements ReconOmTask {
     int legacySeek = subTaskSeekPosMap.getOrDefault(BucketType.LEGACY.name(), 0);
     int obsSeek = subTaskSeekPosMap.getOrDefault(BucketType.OBS.name(), 0);
 
-    Future<Pair<Integer, Boolean>> fsoFuture = subTaskExecutor.submit(
+    Future<Pair<Integer, Boolean>> fsoFuture = SUB_TASK_EXECUTOR.submit(
         () -> nsSummaryTaskWithFSO.processWithFSO(events, fsoSeek));
-    Future<Pair<Integer, Boolean>> legacyFuture = subTaskExecutor.submit(
+    Future<Pair<Integer, Boolean>> legacyFuture = SUB_TASK_EXECUTOR.submit(
         () -> nsSummaryTaskWithLegacy.processWithLegacy(events, legacySeek));
-    Future<Pair<Integer, Boolean>> obsFuture = subTaskExecutor.submit(
+    Future<Pair<Integer, Boolean>> obsFuture = SUB_TASK_EXECUTOR.submit(
         () -> nsSummaryTaskWithOBS.processWithOBS(events, obsSeek));
 
     boolean anyFailure = false;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -45,12 +45,16 @@ public class NSSummaryTaskDbEventHandler {
   private ReconNamespaceSummaryManager reconNamespaceSummaryManager;
   private ReconOMMetadataManager reconOMMetadataManager;
 
-  // Bucket layout never changes for an existing bucket, so cache OmBucketInfo
-  // lookups across process() calls. Each delta loop hits at most a few buckets;
-  // without this cache, every event pays a RocksDB point read in the Legacy and
-  // OBS sub-tasks.
+  // Cache OmBucketInfo lookups across process() calls so the Legacy and OBS
+  // sub-tasks don't pay a RocksDB point read per event. A bucket's objectID and
+  // layout are stable while the bucket exists, but a bucket can be deleted and
+  // recreated under the same volume/bucket name with a new objectID (same DB
+  // key, different identity). A recreate is always preceded by a delete, so the
+  // sub-tasks call invalidateBucketCache() when they observe a bucketTable
+  // delete event; a recreated bucket is then re-read instead of served stale.
   //
-  // Single-thread access only (one dispatcher thread per task). HashMap is fine.
+  // Single-thread access only (each sub-task runs on its own thread and owns
+  // its own cache instance). HashMap is fine.
   private final Map<String, OmBucketInfo> bucketInfoCache = new HashMap<>();
 
   public NSSummaryTaskDbEventHandler(ReconNamespaceSummaryManager
@@ -62,9 +66,12 @@ public class NSSummaryTaskDbEventHandler {
   }
 
   /** Look up an {@link OmBucketInfo} via {@code getBucketTable().getSkipCache}
-   *  and cache the result. Bucket layout/object-id are immutable for an existing
-   *  bucket, so an unbounded field-level cache is safe and avoids one RocksDB
-   *  point read per event in the per-event sub-task loops. */
+   *  and cache the result. Bucket layout/object-id are stable while a bucket
+   *  exists, so a field-level cache avoids one RocksDB point read per event in
+   *  the per-event sub-task loops. Entries are dropped via
+   *  {@link #invalidateBucketCache(String)} when a bucketTable delete event is
+   *  seen, so a bucket deleted and recreated under the same name is not served
+   *  stale. */
   protected OmBucketInfo lookupBucketCached(String bucketDBKey) throws IOException {
     OmBucketInfo cached = bucketInfoCache.get(bucketDBKey);
     if (cached != null) {
@@ -75,6 +82,15 @@ public class NSSummaryTaskDbEventHandler {
       bucketInfoCache.put(bucketDBKey, info);
     }
     return info;
+  }
+
+  /** Drop the cached {@link OmBucketInfo} for the given bucket DB key. Invoked
+   *  when a bucketTable delete event is observed so the next key event re-reads
+   *  the current bucket info. This matters when a bucket is deleted and
+   *  recreated under the same volume/bucket name, which assigns a new objectID;
+   *  the recreate always follows the delete, so invalidating on delete suffices. */
+  protected void invalidateBucketCache(String bucketDBKey) {
+    bucketInfoCache.remove(bucketDBKey);
   }
 
   public ReconNamespaceSummaryManager getReconNamespaceSummaryManager() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -61,10 +61,10 @@ public class NSSummaryTaskDbEventHandler {
     this.reconOMMetadataManager = reconOMMetadataManager;
   }
 
-  /** Look up an {@link OmBucketInfo} via {@link Table#getSkipCache} and cache
-   *  the result. Bucket layout/object-id are immutable for an existing bucket,
-   *  so an unbounded field-level cache is safe and avoids one RocksDB point
-   *  read per event in the per-event sub-task loops. */
+  /** Look up an {@link OmBucketInfo} via {@code getBucketTable().getSkipCache}
+   *  and cache the result. Bucket layout/object-id are immutable for an existing
+   *  bucket, so an unbounded field-level cache is safe and avoids one RocksDB
+   *  point read per event in the per-event sub-task loops. */
   protected OmBucketInfo lookupBucketCached(String bucketDBKey) throws IOException {
     OmBucketInfo cached = bucketInfoCache.get(bucketDBKey);
     if (cached != null) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -20,8 +20,10 @@ package org.apache.hadoop.ozone.recon.tasks;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.recon.ReconUtils;
@@ -43,12 +45,36 @@ public class NSSummaryTaskDbEventHandler {
   private ReconNamespaceSummaryManager reconNamespaceSummaryManager;
   private ReconOMMetadataManager reconOMMetadataManager;
 
+  // Bucket layout never changes for an existing bucket, so cache OmBucketInfo
+  // lookups across process() calls. Each delta loop hits at most a few buckets;
+  // without this cache, every event pays a RocksDB point read in the Legacy and
+  // OBS sub-tasks.
+  //
+  // Single-thread access only (one dispatcher thread per task). HashMap is fine.
+  private final Map<String, OmBucketInfo> bucketInfoCache = new HashMap<>();
+
   public NSSummaryTaskDbEventHandler(ReconNamespaceSummaryManager
                                      reconNamespaceSummaryManager,
                                      ReconOMMetadataManager
                                      reconOMMetadataManager) {
     this.reconNamespaceSummaryManager = reconNamespaceSummaryManager;
     this.reconOMMetadataManager = reconOMMetadataManager;
+  }
+
+  /** Look up an {@link OmBucketInfo} via {@link Table#getSkipCache} and cache
+   *  the result. Bucket layout/object-id are immutable for an existing bucket,
+   *  so an unbounded field-level cache is safe and avoids one RocksDB point
+   *  read per event in the per-event sub-task loops. */
+  protected OmBucketInfo lookupBucketCached(String bucketDBKey) throws IOException {
+    OmBucketInfo cached = bucketInfoCache.get(bucketDBKey);
+    if (cached != null) {
+      return cached;
+    }
+    OmBucketInfo info = reconOMMetadataManager.getBucketTable().getSkipCache(bucketDBKey);
+    if (info != null) {
+      bucketInfoCache.put(bucketDBKey, info);
+    }
+    return info;
   }
 
   public ReconNamespaceSummaryManager getReconNamespaceSummaryManager() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 
 import java.io.IOException;
@@ -91,9 +92,20 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       OMDBUpdateEvent.OMDBUpdateAction action = omdbUpdateEvent.getAction();
       eventCounter++;
 
-      // we only process updates on OM's KeyTable
       String table = omdbUpdateEvent.getTable();
+      // A bucket can be deleted and recreated under the same name with a new
+      // objectID. A recreate is always preceded by a delete, so dropping the
+      // cached OmBucketInfo on the delete event is enough for a later key event
+      // to re-read the recreated bucket. Bucket property updates don't change
+      // objectID or layout, so they need not invalidate the cache.
+      if (table.equals(BUCKET_TABLE)) {
+        if (action == OMDBUpdateEvent.OMDBUpdateAction.DELETE) {
+          invalidateBucketCache(omdbUpdateEvent.getKey());
+        }
+        continue;
+      }
 
+      // we only process updates on OM's KeyTable
       if (!table.equals(KEY_TABLE)) {
         continue;
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -363,8 +363,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       throws IOException {
     String bucketKey = getReconOMMetadataManager()
         .getBucketKey(keyInfo.getVolumeName(), keyInfo.getBucketName());
-    OmBucketInfo parentBucketInfo =
-        getReconOMMetadataManager().getBucketTable().getSkipCache(bucketKey);
+    OmBucketInfo parentBucketInfo = lookupBucketCached(bucketKey);
 
     if (parentBucketInfo != null) {
       return parentBucketInfo.getObjectID();
@@ -388,8 +387,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
     String volumeName = keyInfo.getVolumeName();
     String bucketName = keyInfo.getBucketName();
     String bucketDBKey = metadataManager.getBucketKey(volumeName, bucketName);
-    OmBucketInfo omBucketInfo =
-        metadataManager.getBucketTable().getSkipCache(bucketDBKey);
+    OmBucketInfo omBucketInfo = lookupBucketCached(bucketDBKey);
 
     if (omBucketInfo.getBucketLayout() != LEGACY_BUCKET_LAYOUT) {
       LOG.debug(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
@@ -234,15 +234,13 @@ public class NSSummaryTaskWithOBS extends NSSummaryTaskDbEventHandler {
         String bucketName = updatedKeyInfo.getBucketName();
         String bucketDBKey =
             getReconOMMetadataManager().getBucketKey(volumeName, bucketName);
-        // Get bucket info from bucket table
-        OmBucketInfo omBucketInfo = getReconOMMetadataManager().getBucketTable()
-            .getSkipCache(bucketDBKey);
+        OmBucketInfo omBucketInfo = lookupBucketCached(bucketDBKey);
 
         if (omBucketInfo.getBucketLayout() != BUCKET_LAYOUT) {
           continue;
         }
 
-        long parentObjectID = getKeyParentID(updatedKeyInfo);
+        long parentObjectID = omBucketInfo.getObjectID();
 
         switch (action) {
         case PUT:
@@ -253,9 +251,10 @@ public class NSSummaryTaskWithOBS extends NSSummaryTaskDbEventHandler {
           break;
         case UPDATE:
           if (oldKeyInfo != null) {
-            // delete first, then put
-            long oldKeyParentObjectID = getKeyParentID(oldKeyInfo);
-            handleDeleteKeyEvent(oldKeyInfo, nsSummaryMap, oldKeyParentObjectID);
+            // For OBS, parent is always the bucket, so same parentObjectID
+            // applies to old and new (a key cannot move between buckets via
+            // an UPDATE event — that would be a delete+put).
+            handleDeleteKeyEvent(oldKeyInfo, nsSummaryMap, parentObjectID);
           } else {
             LOG.warn("Update event does not have the old keyInfo for {}.",
                 updatedKey);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 
 import java.io.IOException;
@@ -201,10 +202,21 @@ public class NSSummaryTaskWithOBS extends NSSummaryTaskDbEventHandler {
       OMDBUpdateEvent.OMDBUpdateAction action = omdbUpdateEvent.getAction();
       eventCounter++;
 
-      // We only process updates on OM's KeyTable
       String table = omdbUpdateEvent.getTable();
-      boolean updateOnKeyTable = table.equals(KEY_TABLE);
-      if (!updateOnKeyTable) {
+      // A bucket can be deleted and recreated under the same name with a new
+      // objectID. A recreate is always preceded by a delete, so dropping the
+      // cached OmBucketInfo on the delete event is enough for a later key event
+      // to re-read the recreated bucket. Bucket property updates don't change
+      // objectID or layout, so they need not invalidate the cache.
+      if (table.equals(BUCKET_TABLE)) {
+        if (action == OMDBUpdateEvent.OMDBUpdateAction.DELETE) {
+          invalidateBucketCache(omdbUpdateEvent.getKey());
+        }
+        continue;
+      }
+
+      // We only process updates on OM's KeyTable
+      if (!table.equals(KEY_TABLE)) {
         continue;
       }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -27,7 +27,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -42,10 +44,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test for NSSummaryTask. Create one bucket of each layout
- * and test process and reprocess. Currently, there is no
- * support for OBS buckets. Check that the NSSummary
- * for the OBS bucket is null.
+ * Test for NSSummaryTask. Creates one bucket of each layout (FSO, Legacy, OBS)
+ * and exercises reprocess, parallel process(), and bucket-cache invalidation.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
@@ -263,6 +263,253 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
   }
 
   /**
+   * Exercises parallel FSO / Legacy / OBS sub-task dispatch beyond the happy
+   * path: interleaved multi-mutation batches, per-layout filtering in a shared
+   * event stream, and independent seek positions per sub-task on retry.
+   */
+  @Nested
+  public class TestProcessParallelMixedBatch {
+
+    @BeforeEach
+    public void reprocessBaseline() throws IOException {
+      nSSummaryTask.reprocess(getReconOMMetadataManager());
+    }
+
+    @Test
+    public void testInterleavedBatchAppliesAllLayoutMutations() throws IOException {
+      // Deliberately scramble layout order: OBS, Legacy, FSO, OBS, Legacy.
+      ReconOmTask.TaskResult result = nSSummaryTask.process(
+          new OMUpdateEventBatch(Arrays.asList(
+              obsDeleteEvent(KEY_THREE, KEY_THREE_OBJECT_ID, KEY_THREE_SIZE),
+              legacyPutEvent(KEY_FIVE, KEY_FIVE_OBJECT_ID, KEY_FIVE_SIZE),
+              fsoDeleteEvent(KEY_ONE, KEY_ONE_OBJECT_ID, KEY_ONE_SIZE),
+              obsPutEvent(KEY_FOUR, KEY_FOUR_OBJECT_ID, KEY_FOUR_SIZE),
+              legacyUpdateEvent(KEY_TWO, KEY_TWO_OBJECT_ID, KEY_TWO_SIZE,
+                  KEY_TWO_UPDATE_SIZE)),
+              0L),
+          Collections.emptyMap());
+
+      assertTrue(result.isTaskSuccess());
+
+      NSSummary fsoBucket =
+          getReconNamespaceSummaryManager().getNSSummary(BUCKET_ONE_OBJECT_ID);
+      assertNotNull(fsoBucket);
+      assertEquals(0, fsoBucket.getNumOfFiles());
+      assertEquals(0, fsoBucket.getSizeOfFiles());
+
+      NSSummary legacyBucket =
+          getReconNamespaceSummaryManager().getNSSummary(BUCKET_TWO_OBJECT_ID);
+      assertNotNull(legacyBucket);
+      assertEquals(2, legacyBucket.getNumOfFiles());
+      assertEquals(KEY_TWO_UPDATE_SIZE + KEY_FIVE_SIZE,
+          legacyBucket.getSizeOfFiles());
+
+      NSSummary obsBucket =
+          getReconNamespaceSummaryManager().getNSSummary(BUCKET_THREE_OBJECT_ID);
+      assertNotNull(obsBucket);
+      assertEquals(1, obsBucket.getNumOfFiles());
+      assertEquals(KEY_FOUR_SIZE, obsBucket.getSizeOfFiles());
+    }
+
+    @Test
+    public void testLayoutFilteringInMixedBatch() throws IOException {
+      // OBS-only keyTable events in a batch that still runs all three sub-tasks
+      // in parallel. Legacy and FSO must leave their buckets at the reprocess
+      // baseline while OBS applies delete+put.
+      ReconOmTask.TaskResult result = nSSummaryTask.process(
+          new OMUpdateEventBatch(Arrays.asList(
+              obsDeleteEvent(KEY_THREE, KEY_THREE_OBJECT_ID, KEY_THREE_SIZE),
+              obsPutEvent(KEY_FOUR, KEY_FOUR_OBJECT_ID, KEY_FOUR_SIZE)),
+              0L),
+          Collections.emptyMap());
+
+      assertTrue(result.isTaskSuccess());
+
+      assertEquals(1, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_ONE_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_ONE_SIZE, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_ONE_OBJECT_ID).getSizeOfFiles());
+      assertEquals(1, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_TWO_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_TWO_SIZE, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_TWO_OBJECT_ID).getSizeOfFiles());
+      assertEquals(1, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_THREE_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_FOUR_SIZE, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_THREE_OBJECT_ID).getSizeOfFiles());
+    }
+
+    @Test
+    public void testIndependentSubTaskSeekPositions() throws IOException {
+      // Shared stream (5 events): OBS delete, Legacy put, FSO delete, OBS put,
+      // Legacy update. Legacy seek=3 skips the first three stream positions
+      // (including its own put at position 2) while FSO/OBS start at 0.
+      OMUpdateEventBatch batch = new OMUpdateEventBatch(Arrays.asList(
+          obsDeleteEvent(KEY_THREE, KEY_THREE_OBJECT_ID, KEY_THREE_SIZE),
+          legacyPutEvent(KEY_FIVE, KEY_FIVE_OBJECT_ID, KEY_FIVE_SIZE),
+          fsoDeleteEvent(KEY_ONE, KEY_ONE_OBJECT_ID, KEY_ONE_SIZE),
+          obsPutEvent(KEY_FOUR, KEY_FOUR_OBJECT_ID, KEY_FOUR_SIZE),
+          legacyUpdateEvent(KEY_TWO, KEY_TWO_OBJECT_ID, KEY_TWO_SIZE,
+              KEY_TWO_UPDATE_SIZE)),
+          0L);
+
+      Map<String, Integer> legacySeekOnly = new HashMap<>();
+      legacySeekOnly.put(NSSummaryTask.BucketType.LEGACY.name(), 3);
+
+      ReconOmTask.TaskResult result =
+          nSSummaryTask.process(batch, legacySeekOnly);
+
+      assertTrue(result.isTaskSuccess());
+      // Each sub-task reports its resume position independently. Legacy was
+      // told to skip the first three stream indices; FSO/OBS consumed from 0.
+      assertNotNull(result.getSubTaskSeekPositions());
+      assertEquals(0, result.getSubTaskSeekPositions()
+          .get(NSSummaryTask.BucketType.FSO.name()).intValue());
+      assertEquals(3, result.getSubTaskSeekPositions()
+          .get(NSSummaryTask.BucketType.LEGACY.name()).intValue());
+      assertEquals(0, result.getSubTaskSeekPositions()
+          .get(NSSummaryTask.BucketType.OBS.name()).intValue());
+
+      // FSO/OBS processed from the start; Legacy only picked up the update.
+      assertEquals(0, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_ONE_OBJECT_ID).getNumOfFiles());
+      assertEquals(1, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_TWO_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_TWO_UPDATE_SIZE, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_TWO_OBJECT_ID).getSizeOfFiles());
+      assertEquals(1, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_THREE_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_FOUR_SIZE, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_THREE_OBJECT_ID).getSizeOfFiles());
+    }
+
+    @Test
+    public void testLegacySeekZeroAppliesAllLegacyEvents() throws IOException {
+      // Contrast with testIndependentSubTaskSeekPositions: without a Legacy
+      // seek offset, the interleaved batch applies both Legacy mutations.
+      OMUpdateEventBatch batch = new OMUpdateEventBatch(Arrays.asList(
+          obsDeleteEvent(KEY_THREE, KEY_THREE_OBJECT_ID, KEY_THREE_SIZE),
+          legacyPutEvent(KEY_FIVE, KEY_FIVE_OBJECT_ID, KEY_FIVE_SIZE),
+          fsoDeleteEvent(KEY_ONE, KEY_ONE_OBJECT_ID, KEY_ONE_SIZE),
+          obsPutEvent(KEY_FOUR, KEY_FOUR_OBJECT_ID, KEY_FOUR_SIZE),
+          legacyUpdateEvent(KEY_TWO, KEY_TWO_OBJECT_ID, KEY_TWO_SIZE,
+              KEY_TWO_UPDATE_SIZE)),
+          0L);
+
+      assertTrue(nSSummaryTask.process(batch, Collections.emptyMap()).isTaskSuccess());
+      assertEquals(2, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_TWO_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_TWO_UPDATE_SIZE + KEY_FIVE_SIZE,
+          getReconNamespaceSummaryManager()
+              .getNSSummary(BUCKET_TWO_OBJECT_ID).getSizeOfFiles());
+    }
+
+    @Test
+    public void testSequentialMixedBatches() throws IOException {
+      ReconOmTask.TaskResult batch1 = nSSummaryTask.process(
+          new OMUpdateEventBatch(Collections.singletonList(
+              fsoDeleteEvent(KEY_ONE, KEY_ONE_OBJECT_ID, KEY_ONE_SIZE)), 0L),
+          Collections.emptyMap());
+      assertTrue(batch1.isTaskSuccess());
+
+      ReconOmTask.TaskResult batch2 = nSSummaryTask.process(
+          new OMUpdateEventBatch(Arrays.asList(
+              legacyPutEvent(KEY_FIVE, KEY_FIVE_OBJECT_ID, KEY_FIVE_SIZE),
+              obsPutEvent(KEY_FOUR, KEY_FOUR_OBJECT_ID, KEY_FOUR_SIZE)),
+              0L),
+          Collections.emptyMap());
+      assertTrue(batch2.isTaskSuccess());
+
+      assertEquals(0, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_ONE_OBJECT_ID).getNumOfFiles());
+      assertEquals(2, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_TWO_OBJECT_ID).getNumOfFiles());
+      assertEquals(2, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_THREE_OBJECT_ID).getNumOfFiles());
+      assertEquals(KEY_THREE_SIZE + KEY_FOUR_SIZE, getReconNamespaceSummaryManager()
+          .getNSSummary(BUCKET_THREE_OBJECT_ID).getSizeOfFiles());
+    }
+
+    private OMDBUpdateEvent fsoDeleteEvent(String fileName, long objectId,
+                                           long dataSize) {
+      String key = BUCKET_ONE_OBJECT_ID + OM_KEY_PREFIX + fileName;
+      OmKeyInfo keyInfo = buildOmKeyInfo(
+          VOL, BUCKET_ONE, fileName, fileName, objectId, BUCKET_ONE_OBJECT_ID,
+          dataSize);
+      return new OMDBUpdateEvent.OMUpdateEventBuilder<String, OmKeyInfo>()
+          .setKey(key)
+          .setValue(keyInfo)
+          .setTable(getOmMetadataManager().getKeyTable(getFSOBucketLayout()).getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.DELETE)
+          .build();
+    }
+
+    private OMDBUpdateEvent legacyPutEvent(String keyName, long objectId,
+                                           long dataSize) {
+      String key = OM_KEY_PREFIX + VOL + OM_KEY_PREFIX + BUCKET_TWO
+          + OM_KEY_PREFIX + keyName;
+      OmKeyInfo keyInfo = buildOmKeyInfo(
+          VOL, BUCKET_TWO, keyName, keyName, objectId, BUCKET_TWO_OBJECT_ID,
+          dataSize);
+      return new OMDBUpdateEvent.OMUpdateEventBuilder<String, OmKeyInfo>()
+          .setKey(key)
+          .setValue(keyInfo)
+          .setTable(getOmMetadataManager().getKeyTable(getLegacyBucketLayout()).getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
+          .build();
+    }
+
+    private OMDBUpdateEvent legacyUpdateEvent(String keyName, long objectId,
+                                              long oldSize, long newSize) {
+      String key = OM_KEY_PREFIX + VOL + OM_KEY_PREFIX + BUCKET_TWO
+          + OM_KEY_PREFIX + keyName;
+      OmKeyInfo oldInfo = buildOmKeyInfo(
+          VOL, BUCKET_TWO, keyName, keyName, objectId, BUCKET_TWO_OBJECT_ID,
+          oldSize);
+      OmKeyInfo newInfo = buildOmKeyInfo(
+          VOL, BUCKET_TWO, keyName, keyName, objectId, BUCKET_TWO_OBJECT_ID,
+          newSize);
+      return new OMDBUpdateEvent.OMUpdateEventBuilder<String, OmKeyInfo>()
+          .setKey(key)
+          .setValue(newInfo)
+          .setOldValue(oldInfo)
+          .setTable(getOmMetadataManager().getKeyTable(getLegacyBucketLayout()).getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.UPDATE)
+          .build();
+    }
+
+    private OMDBUpdateEvent obsPutEvent(String keyName, long objectId,
+                                        long dataSize) {
+      String key = OM_KEY_PREFIX + VOL + OM_KEY_PREFIX + BUCKET_THREE
+          + OM_KEY_PREFIX + keyName;
+      OmKeyInfo keyInfo = buildOmKeyInfo(
+          VOL, BUCKET_THREE, keyName, keyName, objectId, BUCKET_THREE_OBJECT_ID,
+          dataSize);
+      return new OMDBUpdateEvent.OMUpdateEventBuilder<String, OmKeyInfo>()
+          .setKey(key)
+          .setValue(keyInfo)
+          .setTable(getOmMetadataManager().getKeyTable(getOBSBucketLayout()).getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
+          .build();
+    }
+
+    private OMDBUpdateEvent obsDeleteEvent(String keyName, long objectId,
+                                           long dataSize) {
+      String key = OM_KEY_PREFIX + VOL + OM_KEY_PREFIX + BUCKET_THREE
+          + OM_KEY_PREFIX + keyName;
+      OmKeyInfo keyInfo = buildOmKeyInfo(
+          VOL, BUCKET_THREE, keyName, keyName, objectId, BUCKET_THREE_OBJECT_ID,
+          dataSize);
+      return new OMDBUpdateEvent.OMUpdateEventBuilder<String, OmKeyInfo>()
+          .setKey(key)
+          .setValue(keyInfo)
+          .setTable(getOmMetadataManager().getKeyTable(getOBSBucketLayout()).getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.DELETE)
+          .build();
+    }
+  }
+
+  /**
    * Regression test for the field-level OmBucketInfo cache in
    * {@link NSSummaryTaskDbEventHandler}. A bucket deleted and recreated under
    * the same volume/bucket name gets a new objectID but reuses the same DB key.
@@ -305,9 +552,13 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
           getReconNamespaceSummaryManager().getNSSummary(OLD_BUCKET_OBJECT_ID);
       assertNotNull(oldBucketSummary);
       assertEquals(1, oldBucketSummary.getNumOfFiles());
+      assertEquals(RECREATE_KEY_SIZE, oldBucketSummary.getSizeOfFiles());
 
       // The bucket is deleted and recreated under the same name with a new
-      // objectID (same DB key, different identity).
+      // objectID (same DB key, different identity). The manual bucketTable put
+      // below simulates OM DB state after the recreate: synthetic events in this
+      // harness do not apply bucketTable writes to RocksDB (unlike production,
+      // where Recon commits the OM batch before tasks run).
       reconMetadataMgr.getBucketTable()
           .put(bucketKey, buildObsBucketInfo(NEW_BUCKET_OBJECT_ID));
 
@@ -339,10 +590,13 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
           getReconNamespaceSummaryManager().getNSSummary(NEW_BUCKET_OBJECT_ID);
       assertNotNull(newBucketSummary);
       assertEquals(1, newBucketSummary.getNumOfFiles());
+      assertEquals(RECREATE_KEY_SIZE, newBucketSummary.getSizeOfFiles());
 
       // ...and the stale (old) bucket must not have absorbed it.
-      assertEquals(1, getReconNamespaceSummaryManager()
-          .getNSSummary(OLD_BUCKET_OBJECT_ID).getNumOfFiles());
+      NSSummary staleBucketSummary =
+          getReconNamespaceSummaryManager().getNSSummary(OLD_BUCKET_OBJECT_ID);
+      assertEquals(1, staleBucketSummary.getNumOfFiles());
+      assertEquals(RECREATE_KEY_SIZE, staleBucketSummary.getSizeOfFiles());
     }
 
     private OmBucketInfo buildObsBucketInfo(long objectId) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -21,10 +21,12 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -67,6 +69,24 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
         getReconOMMetadataManager(),
         getOmConfiguration()
     );
+  }
+
+  @Test
+  public void testTaskInstancesReuseSharedProcessExecutor() throws Exception {
+    NSSummaryTask anotherTask = new NSSummaryTask(
+        getReconNamespaceSummaryManager(),
+        getReconOMMetadataManager(),
+        getOmConfiguration());
+
+    assertSame(getSubTaskExecutor(nSSummaryTask),
+        getSubTaskExecutor(anotherTask));
+  }
+
+  private Object getSubTaskExecutor(NSSummaryTask task) throws Exception {
+    Field executorField = NSSummaryTask.class.getDeclaredField(
+        "SUB_TASK_EXECUTOR");
+    executorField.setAccessible(true);
+    return executorField.get(task);
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -29,9 +29,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.recon.ReconConstants;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
+import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -257,6 +259,112 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
       assertNotNull(processResult.getSubTaskSeekPositions().get(NSSummaryTask.BucketType.FSO.name()));
       assertNotNull(processResult.getSubTaskSeekPositions().get(NSSummaryTask.BucketType.LEGACY.name()));
       assertNotNull(processResult.getSubTaskSeekPositions().get(NSSummaryTask.BucketType.OBS.name()));
+    }
+  }
+
+  /**
+   * Regression test for the field-level OmBucketInfo cache in
+   * {@link NSSummaryTaskDbEventHandler}. A bucket deleted and recreated under
+   * the same volume/bucket name gets a new objectID but reuses the same DB key.
+   * The cached entry must be invalidated when the bucketTable event is observed,
+   * otherwise key events for the recreated bucket would be attributed to the
+   * stale (old) bucket objectID.
+   */
+  @Nested
+  public class TestProcessBucketRecreate {
+
+    private static final String RECREATE_BUCKET = "bucketrecreate";
+    private static final long OLD_BUCKET_OBJECT_ID = 100L;
+    private static final long NEW_BUCKET_OBJECT_ID = 200L;
+    private static final long FIRST_KEY_OBJECT_ID = 101L;
+    private static final long SECOND_KEY_OBJECT_ID = 201L;
+    private static final long RECREATE_KEY_SIZE = 1024L;
+
+    @Test
+    public void testBucketCacheInvalidatedOnRecreate() throws IOException {
+      ReconOMMetadataManager reconMetadataMgr = getReconOMMetadataManager();
+      String bucketKey = reconMetadataMgr.getBucketKey(VOL, RECREATE_BUCKET);
+
+      // The bucket initially exists as an OBS bucket with the old objectID.
+      reconMetadataMgr.getBucketTable()
+          .put(bucketKey, buildObsBucketInfo(OLD_BUCKET_OBJECT_ID));
+
+      // A fresh task starts with an empty bucket cache and exercises the full
+      // parallel sub-task dispatch.
+      NSSummaryTask task = new NSSummaryTask(getReconNamespaceSummaryManager(),
+          reconMetadataMgr, getOmConfiguration());
+
+      // Batch 1: a key lands in the original bucket. This warms the OBS
+      // sub-task's bucket cache with the old objectID.
+      OMDBUpdateEvent firstKeyPut =
+          obsKeyPutEvent(bucketKey, KEY_ONE, FIRST_KEY_OBJECT_ID, OLD_BUCKET_OBJECT_ID);
+      task.process(new OMUpdateEventBatch(
+          Collections.singletonList(firstKeyPut), 0L), Collections.emptyMap());
+
+      NSSummary oldBucketSummary =
+          getReconNamespaceSummaryManager().getNSSummary(OLD_BUCKET_OBJECT_ID);
+      assertNotNull(oldBucketSummary);
+      assertEquals(1, oldBucketSummary.getNumOfFiles());
+
+      // The bucket is deleted and recreated under the same name with a new
+      // objectID (same DB key, different identity).
+      reconMetadataMgr.getBucketTable()
+          .put(bucketKey, buildObsBucketInfo(NEW_BUCKET_OBJECT_ID));
+
+      // Batch 2 mirrors the real recreate sequence: the old bucket is deleted,
+      // a new bucket is created under the same name, then a key lands in it.
+      // The bucketTable delete event must invalidate the stale cache entry so
+      // the key event re-reads the recreated bucket's objectID.
+      OMDBUpdateEvent bucketDelete = new OMDBUpdateEvent
+          .OMUpdateEventBuilder<String, OmBucketInfo>()
+          .setKey(bucketKey)
+          .setValue(buildObsBucketInfo(OLD_BUCKET_OBJECT_ID))
+          .setTable(reconMetadataMgr.getBucketTable().getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.DELETE)
+          .build();
+      OMDBUpdateEvent bucketPut = new OMDBUpdateEvent
+          .OMUpdateEventBuilder<String, OmBucketInfo>()
+          .setKey(bucketKey)
+          .setValue(buildObsBucketInfo(NEW_BUCKET_OBJECT_ID))
+          .setTable(reconMetadataMgr.getBucketTable().getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
+          .build();
+      OMDBUpdateEvent secondKeyPut =
+          obsKeyPutEvent(bucketKey, KEY_TWO, SECOND_KEY_OBJECT_ID, NEW_BUCKET_OBJECT_ID);
+      task.process(new OMUpdateEventBatch(
+          Arrays.asList(bucketDelete, bucketPut, secondKeyPut), 0L), Collections.emptyMap());
+
+      // The new key must be attributed to the recreated bucket's objectID...
+      NSSummary newBucketSummary =
+          getReconNamespaceSummaryManager().getNSSummary(NEW_BUCKET_OBJECT_ID);
+      assertNotNull(newBucketSummary);
+      assertEquals(1, newBucketSummary.getNumOfFiles());
+
+      // ...and the stale (old) bucket must not have absorbed it.
+      assertEquals(1, getReconNamespaceSummaryManager()
+          .getNSSummary(OLD_BUCKET_OBJECT_ID).getNumOfFiles());
+    }
+
+    private OmBucketInfo buildObsBucketInfo(long objectId) {
+      return OmBucketInfo.newBuilder()
+          .setVolumeName(VOL)
+          .setBucketName(RECREATE_BUCKET)
+          .setObjectID(objectId)
+          .setBucketLayout(getOBSBucketLayout())
+          .build();
+    }
+
+    private OMDBUpdateEvent obsKeyPutEvent(String bucketKey, String keyName,
+                                           long keyObjectId, long parentObjectId) {
+      String omKey = bucketKey + OM_KEY_PREFIX + keyName;
+      OmKeyInfo keyInfo = buildOmKeyInfo(VOL, RECREATE_BUCKET, keyName, keyName,
+          keyObjectId, parentObjectId, RECREATE_KEY_SIZE);
+      return new OMDBUpdateEvent.OMUpdateEventBuilder<String, OmKeyInfo>()
+          .setKey(omKey)
+          .setValue(keyInfo)
+          .setTable(getReconOMMetadataManager().getKeyTable(getOBSBucketLayout()).getName())
+          .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
+          .build();
     }
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -136,11 +137,15 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
 
     private NSSummary nsSummaryForBucket1;
     private NSSummary nsSummaryForBucket2;
+    private NSSummary nsSummaryForBucket3;
+    private ReconOmTask.TaskResult processResult;
 
     @BeforeEach
     public void setUp() throws IOException {
       nSSummaryTask.reprocess(getReconOMMetadataManager());
-      nSSummaryTask.process(processEventBatch(), Collections.emptyMap());
+      // Exercise process() across all three bucket layouts in a single batch
+      // so the parallel sub-task dispatch is covered end-to-end.
+      processResult = nSSummaryTask.process(processEventBatch(), Collections.emptyMap());
 
       nsSummaryForBucket1 =
           getReconNamespaceSummaryManager().getNSSummary(BUCKET_ONE_OBJECT_ID);
@@ -148,12 +153,13 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
       nsSummaryForBucket2 =
           getReconNamespaceSummaryManager().getNSSummary(BUCKET_TWO_OBJECT_ID);
       assertNotNull(nsSummaryForBucket2);
-      NSSummary nsSummaryForBucket3 = getReconNamespaceSummaryManager().getNSSummary(BUCKET_THREE_OBJECT_ID);
+      nsSummaryForBucket3 =
+          getReconNamespaceSummaryManager().getNSSummary(BUCKET_THREE_OBJECT_ID);
       assertNotNull(nsSummaryForBucket3);
     }
 
     private OMUpdateEventBatch processEventBatch() throws IOException {
-      // put file5 under bucket 2
+      // PUT file5 under bucket 2 (Legacy)
       String omPutKey =
           OM_KEY_PREFIX + VOL +
               OM_KEY_PREFIX + BUCKET_TWO +
@@ -169,7 +175,7 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
                                       .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
                                       .build();
 
-      // delete file 1 under bucket 1
+      // DELETE file1 under bucket 1 (FSO)
       String omDeleteKey = BUCKET_ONE_OBJECT_ID + OM_KEY_PREFIX + FILE_ONE;
       OmKeyInfo omDeleteInfo = buildOmKeyInfo(
           VOL, BUCKET_ONE, KEY_ONE, FILE_ONE,
@@ -183,7 +189,24 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
                                       .setAction(OMDBUpdateEvent.OMDBUpdateAction.DELETE)
                                       .build();
 
-      return new OMUpdateEventBatch(Arrays.asList(keyEvent1, keyEvent2), 0L);
+      // PUT file4 under bucket 3 (OBS) — exercises the OBS sub-task path so a
+      // regression in the OBS branch (e.g. missed events) is caught.
+      String omObsPutKey =
+          OM_KEY_PREFIX + VOL +
+              OM_KEY_PREFIX + BUCKET_THREE +
+              OM_KEY_PREFIX + KEY_FOUR;
+      OmKeyInfo omObsPutKeyInfo = buildOmKeyInfo(VOL, BUCKET_THREE, KEY_FOUR,
+          KEY_FOUR, KEY_FOUR_OBJECT_ID, BUCKET_THREE_OBJECT_ID, KEY_FOUR_SIZE);
+      OMDBUpdateEvent keyEvent3 = new OMDBUpdateEvent.
+                                          OMUpdateEventBuilder<String, OmKeyInfo>()
+                                      .setKey(omObsPutKey)
+                                      .setValue(omObsPutKeyInfo)
+                                      .setTable(getOmMetadataManager().getKeyTable(getOBSBucketLayout())
+                                                    .getName())
+                                      .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
+                                      .build();
+
+      return new OMUpdateEventBatch(Arrays.asList(keyEvent1, keyEvent2, keyEvent3), 0L);
     }
 
     @Test
@@ -215,6 +238,25 @@ public class TestNSSummaryTask extends AbstractNSSummaryTaskTest {
       for (int i = 2; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
         assertEquals(0, fileSizeDist[i]);
       }
+    }
+
+    @Test
+    public void testProcessObsBucket() {
+      // bucket 3 (OBS) had file3 from reprocess; the batch added file4.
+      assertEquals(2, nsSummaryForBucket3.getNumOfFiles());
+      assertEquals(KEY_THREE_SIZE + KEY_FOUR_SIZE,
+          nsSummaryForBucket3.getSizeOfFiles());
+    }
+
+    @Test
+    public void testProcessTaskResult() {
+      // Sub-task seek positions must be reported for all three layouts so the
+      // dispatcher can resume each sub-task independently on retry.
+      assertNotNull(processResult);
+      assertTrue(processResult.isTaskSuccess());
+      assertNotNull(processResult.getSubTaskSeekPositions().get(NSSummaryTask.BucketType.FSO.name()));
+      assertNotNull(processResult.getSubTaskSeekPositions().get(NSSummaryTask.BucketType.LEGACY.name()));
+      assertNotNull(processResult.getSubTaskSeekPositions().get(NSSummaryTask.BucketType.OBS.name()));
     }
   }
 }


### PR DESCRIPTION
This started out as digging what bottlenecks Recon currently has, then turned into focusing on NSSummaryTask and its benchmark. It has been a journey.

Generated-by: Claude Code (Opus 4.7 xhigh)

## What changes were proposed in this pull request?

## Background

`NSSummaryTask.process()` processes every batch of OM update events Recon ingests. On keyTable workloads (LEGACY or OBJECT_STORE bucket layout) it has two avoidable costs: every event triggers a fresh `getBucketTable().getSkipCache(...)` RocksDB point read even though bucket layout and objectID never change; and the three sub-tasks (FSO / Legacy / OBS) iterate the event list sequentially even though they operate on disjoint slices and write to disjoint NSSummary entries.

## Changes

1. **`NSSummaryTaskDbEventHandler` caches `OmBucketInfo` lookups in a field-level Map.** After the first lookup for a bucket, subsequent lookups become `HashMap.get()` calls.
2. **`NSSummaryTask.process()` submits the three sub-tasks to a 3-thread pool and joins on all three.** The threads see the same event list; each only processes events whose `(table, bucket layout)` matches its target. Target NSSummary entries are disjoint across sub-tasks so no cross-thread synchronization is needed, and the `TaskResult` contract is unchanged.
3. **The OBS UPDATE path drops a redundant `getKeyParentID(oldKeyInfo)` call.** The parent of an OBS key is its bucket, and an UPDATE event cannot move a key between buckets.

## Throughput

Intel Xeon Silver 4416+ (40 cores / 80 threads), OpenJDK 17, 500k events plus 500k preloaded keys, RATIS replication, mixed 60/30/10 create/update/delete:

| Code                | events/sec | vs vanilla |
| ------------------- | ---------: | ---------: |
| Vanilla             |     78,098 |      1.00x |
| + change 1 (cache)  |    672,172 |      8.61x |
| + changes 1 and 2   |    918,550 |     11.76x |

Change 1 is the dominant lever: it removes about 1.5M `getSkipCache(bucketDBKey)` RocksDB Gets per `process()` call (3 sub-task scans of 500k events, each scan doing one or more bucket lookups before bailing or processing). Change 2 gives a further ~1.37x. Change 3 is below measurement noise.

### Flame graphs for Change 1 (cache)

Before: Three RocksDB get tower under `NSSummaryTask.process`:

<img width="1377" height="726" alt="1 BEFORE" src="https://github.com/user-attachments/assets/69d75e1f-f068-4e7f-8049-a32a808ddf5f" />

After: Last three RocksDB get towers gone. `NSSummaryTask.process` is not even visible at this zoom level:

<img width="1378" height="731" alt="2 AFTER" src="https://github.com/user-attachments/assets/c9b4d548-d20c-46a8-8177-ed09e99be219" />

## Heap pressure

Reduced because change 1 stops allocating a transient `OmBucketInfo` per RocksDB Get. At 1M events / 1M preloaded keys with an 8 GB heap, total stop-the-world pause dropped 25% (1137 ms to 850 ms) and cumulative bytes reclaimed dropped 52% (522 GB to 249 GB) across the bench lifetime.

## FSO-heavy workloads

On a 100% FSO workload (`fileTable` / `dirTable` / `deletedDirTable`), change 1 is a no-op because the FSO sub-task reads `keyInfo.getParentObjectID()` directly without a bucket lookup. Change 2 still saves the bail-loop cost of Legacy and OBS scanning the event list to skip at the table-name check, but that cost is small relative to FSO's own processing, so the wall-clock speedup on FSO-heavy workloads is correspondingly smaller. The patch is non-regressive in any case.

## Reproduction

The reproduction harness (`NSSummaryProcessTimingTest` under `-Pbench`) is provided as a patch on the [JIRA](https://issues.apache.org/jira/browse/HDDS-15335).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15335

## How was this patch tested?

- All existing `TestNSSummaryTask*` unit tests pass
- Two regression tests are added to `TestNSSummaryTask`: one exercises the OBS sub-task path end-to-end (previously only FSO + Legacy events were sent through `process()`), and one asserts the returned `TaskResult` reports success and contains a seek position for each of `FSO`, `LEGACY`, and `OBS`.