### PR TITLE
HDDS-15337. Catch all exception during container move in DiskBalancerTask

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -530,7 +530,6 @@ public class DiskBalancerService extends BackgroundService {
         State containerState = container.getContainerData().getState();
         if (!movableContainerStates.contains(containerState)) {
           LOG.warn("Container {} is in {} state, skipping move process.", containerId, containerState);
-          moveSucceeded = false;
           return BackgroundTaskResult.EmptyTaskResult.newResult();
         }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -508,7 +508,7 @@ public class DiskBalancerService extends BackgroundService {
     @Override
     public BackgroundTaskResult call() {
       long startTime = Time.monotonicNow();
-      boolean moveSucceeded = true;
+      boolean moveSucceeded = false;
       Container newContainer = null;
       long containerId = containerData.getContainerID();
       Container container = ozoneContainer.getContainerSet().getContainer(containerId);
@@ -595,6 +595,7 @@ public class DiskBalancerService extends BackgroundService {
         pauseInjector();
         // Mark old container as DELETED and persist state.
         // markContainerForDelete require writeLock, so release readLock first
+        moveSucceeded = true;
         container.readUnlock();
         readLockReleased = true;
         try {
@@ -609,9 +610,8 @@ public class DiskBalancerService extends BackgroundService {
         balancedBytesInLastWindow.addAndGet(containerSize);
         metrics.incrSuccessBytes(containerSize);
         totalBalancedBytes.addAndGet(containerSize);
-      } catch (IOException e) {
+      } catch (Throwable e) {
         pauseInjector();
-        moveSucceeded = false;
         LOG.warn("Failed to move container {}", containerId, e);
         if (diskBalancerTmpDir != null) {
           try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently only IOException is catched to cleanup the left data. We should catch all exceptions. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15337

## How was this patch tested?

existing unit tests 