### PR TITLE
HDDS-15341. EC write can fail with ArrayIndexOutOfBoundsException due to CoderUtil emptyChunk resize race

### DIFF
--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/CoderUtil.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/CoderUtil.java
@@ -38,15 +38,23 @@ public final class CoderUtil {
    * @return empty chunk of zero bytes
    */
   static byte[] getEmptyChunk(int leastLength) {
-    if (emptyChunk.length >= leastLength) {
-      return emptyChunk; // In most time
+    byte[] chunk = emptyChunk;
+    if (chunk.length >= leastLength) {
+      return chunk; // In most time
     }
 
     synchronized (CoderUtil.class) {
-      emptyChunk = new byte[leastLength];
+      // Recheck under the lock: another caller may already have grown the
+      // cache while this caller waited. A larger cached chunk is valid for a
+      // smaller request, so only allocate when the cache is still too small.
+      chunk = emptyChunk;
+      if (chunk.length < leastLength) {
+        chunk = new byte[leastLength];
+        emptyChunk = chunk;
+      }
     }
 
-    return emptyChunk;
+    return chunk;
   }
 
   /**

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCoderUtil.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCoderUtil.java
@@ -17,7 +17,7 @@
 
 package org.apache.ozone.erasurecode.rawcoder;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
@@ -67,14 +67,16 @@ public class TestCoderUtil {
         smallChunk = executor.submit(() -> CoderUtil.getEmptyChunk(
             SMALL_LENGTH));
         waitUntilBlocked(workerThread);
-        assertTrue(CoderUtil.getEmptyChunk(LARGE_LENGTH).length >=
-            LARGE_LENGTH);
+        assertThat(CoderUtil.getEmptyChunk(LARGE_LENGTH).length)
+            .isGreaterThanOrEqualTo(LARGE_LENGTH);
       }
 
-      assertTrue(smallChunk.get(10, TimeUnit.SECONDS).length >= LARGE_LENGTH,
-          "concurrent caller should return the larger chunk already cached");
-      assertTrue(CoderUtil.getEmptyChunk(LARGE_LENGTH).length >= LARGE_LENGTH,
-          "empty chunk cache should not shrink");
+      assertThat(smallChunk.get(10, TimeUnit.SECONDS).length)
+          .as("concurrent caller should return the larger chunk already cached")
+          .isGreaterThanOrEqualTo(LARGE_LENGTH);
+      assertThat(CoderUtil.getEmptyChunk(LARGE_LENGTH).length)
+          .as("empty chunk cache should not shrink")
+          .isGreaterThanOrEqualTo(LARGE_LENGTH);
     } finally {
       executor.shutdownNow();
     }

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCoderUtil.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCoderUtil.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.erasurecode.rawcoder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for raw coder utility methods.
+ */
+public class TestCoderUtil {
+
+  private static final int INITIAL_LENGTH = 4096;
+  private static final int SMALL_LENGTH = INITIAL_LENGTH + 1;
+  private static final int LARGE_LENGTH = SMALL_LENGTH * 2;
+
+  @BeforeEach
+  public void resetEmptyChunk() throws Exception {
+    Field emptyChunk = CoderUtil.class.getDeclaredField("emptyChunk");
+    emptyChunk.setAccessible(true);
+    synchronized (CoderUtil.class) {
+      emptyChunk.set(null, new byte[INITIAL_LENGTH]);
+    }
+  }
+
+  @Test
+  // HDDS-15341: This can reproduce the race that can make getEmptyChunk()
+  // return a buffer shorter than requested, which later causes
+  // ArrayIndexOutOfBoundsException when resetBuffer() passes that buffer
+  // to System.arraycopy().
+  public void getEmptyChunkDoesNotShrinkWhenCacheGrowsConcurrently()
+      throws Exception {
+    AtomicReference<Thread> workerThread = new AtomicReference<>();
+    ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+      Thread thread = new Thread(r, "get-empty-chunk-small");
+      workerThread.set(thread);
+      return thread;
+    });
+
+    try {
+      Future<byte[]> smallChunk;
+      synchronized (CoderUtil.class) {
+        smallChunk = executor.submit(() -> CoderUtil.getEmptyChunk(
+            SMALL_LENGTH));
+        waitUntilBlocked(workerThread);
+        assertTrue(CoderUtil.getEmptyChunk(LARGE_LENGTH).length >=
+            LARGE_LENGTH);
+      }
+
+      assertTrue(smallChunk.get(10, TimeUnit.SECONDS).length >= LARGE_LENGTH,
+          "concurrent caller should return the larger chunk already cached");
+      assertTrue(CoderUtil.getEmptyChunk(LARGE_LENGTH).length >= LARGE_LENGTH,
+          "empty chunk cache should not shrink");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void waitUntilBlocked(AtomicReference<Thread> threadRef)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (System.nanoTime() < deadline) {
+      Thread thread = threadRef.get();
+      if (thread != null && thread.getState() == Thread.State.BLOCKED) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+
+    Thread thread = threadRef.get();
+    fail("small getEmptyChunk caller did not block on CoderUtil.class; state="
+        + (thread == null ? "not started" : thread.getState()));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a race in `CoderUtil.getEmptyChunk()` that can cause EC writes to fail with `ArrayIndexOutOfBoundsException` during parity encoding.

### Problem

This can be hit when multiple EC key output streams in the same client JVM use the Java raw EC encoder concurrently with different encode/reset lengths. Each `ECKeyOutputStream` has its own encoder, but all Java encoders share the static `CoderUtil.emptyChunk` cache. *If native ISA-L is unavailable or not selected*, the Java `RSRawEncoder` clears parity output buffers through `CoderUtil.resetOutputBuffers()`. Under concurrent close/flush paths, especially with partial final stripes of different sizes, one stream can grow the shared zero buffer for a larger encode while another smaller encode races and shrinks it, causing the larger encode’s later `System.arraycopy()` to throw `ArrayIndexOutOfBoundsException`.

This issue is avoided if native lib (ISA-L) is in-use. The issue can only be hit when fallback builtin-java codec is being used, where you may see messages like this printed on the client:

> W20260513 08:22:52.526697  4325 ErasureCodeNative.java:55] 854bfd7fdbf38f0c:f3db82230000000c] ISA-L support is not available in your platform... using builtin-java codec where applicable

---

`CoderUtil.resetBuffer(byte[] buffer, int offset, int len)` gets a shared zero-filled buffer from `getEmptyChunk(len)` and then calls:

```java
System.arraycopy(empty, 0, buffer, offset, len);
```

The old getEmptyChunk() implementation checked emptyChunk.length before entering the synchronized block, unconditionally replaced the shared static buffer inside the lock, and returned the shared static field after leaving the lock. This allowed a smaller concurrent caller to shrink the shared cached buffer after a larger caller had grown it.

```
ArrayIndexOutOfBoundsException: java.lang.ArrayIndexOutOfBoundsException
	at java.lang.System.arraycopy(Native Method)
	at org.apache.ozone.erasurecode.rawcoder.CoderUtil.resetBuffer(CoderUtil.java:76)
	at org.apache.ozone.erasurecode.rawcoder.CoderUtil.resetOutputBuffers(CoderUtil.java:96)
	at org.apache.ozone.erasurecode.rawcoder.RSRawEncoder.doEncode(RSRawEncoder.java:69)
	at org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder.encode(RawErasureEncoder.java:88)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.generateParityCells(ECKeyOutputStream.java:305)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.close(ECKeyOutputStream.java:475)
	at org.apache.hadoop.ozone.client.io.OzoneOutputStream.close(OzoneOutputStream.java:105)
	at org.apache.hadoop.fs.ozone.OzoneFSOutputStream.close(OzoneFSOutputStream.java:70)
	at org.apache.hadoop.fs.FSDataOutputStream$PositionCache.close(FSDataOutputStream.java:77)
	at org.apache.hadoop.fs.FSDataOutputStream.close(FSDataOutputStream.java:106)
```

An interleaving that repros the issue:

1. emptyChunk starts as byte[4096].
1. Thread A calls getEmptyChunk(4097) and blocks before entering the synchronized block.
1. Thread B calls getEmptyChunk(8194), enters the synchronized block, and sets emptyChunk = byte[8194].
1. Thread A resumes and unconditionally sets emptyChunk = byte[4097].
1. Thread B returns the shared static emptyChunk, now byte[4097].
1. System.arraycopy(..., len=8194) throws ArrayIndexOutOfBoundsException.

This is a TOCTOU-style race on the shared emptyChunk cache.

#### With buggy code

```mermaid
sequenceDiagram
    participant S as Small caller<br/>getEmptyChunk(4097)
    participant L as Large caller<br/>getEmptyChunk(8194)
    participant C as static emptyChunk

    Note over C: initial length = 4096

    S->>C: read length 4096 < 4097
    Note over S: pauses before synchronized block

    L->>C: read length 4096 < 8194
    L->>C: synchronized: emptyChunk = byte[8194]
    Note over L: pauses before final return emptyChunk

    S->>C: synchronized: emptyChunk = byte[4097]
    S-->>S: returns byte[4097]

    L->>C: final return reads static emptyChunk
    C-->>L: returns byte[4097]

    L->>L: resetBuffer(..., len=8194)
    L->>L: System.arraycopy(src byte[4097], len 8194)
    Note over L: ArrayIndexOutOfBoundsException
```

#### After this fix

```mermaid
sequenceDiagram
    participant S as Small caller<br/>getEmptyChunk(4097)
    participant L as Large caller<br/>resetBuffer(..., len=8194)
    participant C as static emptyChunk

    Note over C: initial length = 4096

    S->>C: chunk = emptyChunk<br/>length 4096 < 4097
    Note over S: pauses before synchronized block

    L->>C: getEmptyChunk(8194)<br/>chunk length 4096 < 8194
    L->>C: synchronized: re-read chunk
    L->>C: emptyChunk = byte[8194]
    C-->>L: return local chunk byte[8194]

    S->>C: synchronized: re-read chunk
    C-->>S: sees byte[8194]
    S-->>S: return byte[8194]

    L->>L: System.arraycopy(empty byte[8194], 0,<br/>buffer, offset, len 8194)
    Note over L: succeeds because source length >= len
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15341

## How was this patch tested?

- Added a deterministic unit test that reproduces (w/o the fix) the stale-check/shrink interleaving without Byteman or additional dependencies. The test blocks a smaller caller on CoderUtil.class, grows the cache with a larger caller, then releases the smaller caller and verifies the cache is not shrunk.