### PR TITLE
HDDS-15338. Fix affinity executor queue assignment skew

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/FixedThreadPoolWithAffinityExecutor.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/FixedThreadPoolWithAffinityExecutor.java
@@ -145,7 +145,7 @@ public class FixedThreadPoolWithAffinityExecutor<P, Q>
     // For messages that need to be routed to the same thread need to
     // implement hashCode to match the messages. This should be safe for
     // other messages that implement the native hash.
-    int index = message.hashCode() & (workQueues.size() - 1);
+    int index = Math.floorMod(message.hashCode(), workQueues.size());
     BlockingQueue<Q> queue = workQueues.get(index);
     queue.add((Q) message);
     if (queue instanceof IQueueMetrics) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -123,6 +125,34 @@ public class TestEventQueue {
     eventExecutor.close();
   }
 
+  @Test
+  public void fixedThreadPoolExecutorUsesAllQueuesWithNonPowerOfTwoQueueCount() {
+    Set<Integer> selectedQueues = new HashSet<>();
+    List<BlockingQueue<Integer>> queues = new ArrayList<>();
+    for (int i = 0; i < 10; ++i) {
+      queues.add(new TrackingQueue<>(i, selectedQueues));
+    }
+    Map<String, FixedThreadPoolWithAffinityExecutor> reportExecutorMap
+        = new ConcurrentHashMap<>();
+    FixedThreadPoolWithAffinityExecutor<Integer, Integer>
+        executor = new FixedThreadPoolWithAffinityExecutor<>(
+            "non-power-of-two-queue-count", (payload, publisher) -> { },
+            queues, queue, Integer.class,
+            FixedThreadPoolWithAffinityExecutor.initializeExecutorPool(queues),
+            reportExecutorMap);
+
+    try {
+      for (int hash = 0; hash < queues.size(); ++hash) {
+        executor.onMessage((payload, publisher) -> { }, hash, queue);
+      }
+
+      assertThat(selectedQueues).containsExactlyInAnyOrder(
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    } finally {
+      executor.close();
+    }
+  }
+
   /**
    * Event handler used in tests.
    */
@@ -135,6 +165,22 @@ public class TestEventQueue {
         Thread.currentThread().interrupt();
       }
       eventTotal.getAndAdd((long) payload);
+    }
+  }
+
+  private static class TrackingQueue<T> extends LinkedBlockingQueue<T> {
+    private final int index;
+    private final Set<Integer> selectedQueues;
+
+    TrackingQueue(int index, Set<Integer> selectedQueues) {
+      this.index = index;
+      this.selectedQueues = selectedQueues;
+    }
+
+    @Override
+    public boolean add(T payload) {
+      selectedQueues.add(index);
+      return super.add(payload);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the implementation of hash for FixedThreadPoolWithAffinityExecutor (used to group the container reports to the ContainerReportQueue based on the Datanode UUID) is as follow

```java
    // For messages that need to be routed to the same thread need to
    // implement hashCode to match the messages. This should be safe for
    // other messages that implement the native hash.
    int index = message.hashCode() & (workQueues.size() - 1);
    BlockingQueue<Q> queue = workQueues.get(index);
```

However, this might cause skew when the queueCount is not a power of two (like the when the default is 10)

For queueCount = 10

```
queueCount - 1 = 9
9 in binary = 1001
```

So the routing becomes:

```
queueIndex = hash & 9
```

That means only the bits represented by 1001 are kept. The possible results are only:

```
0  -> 0000
1  -> 0001
8  -> 1000
9  -> 1001
```

So with 10 queues, only queues 0, 1, 8, and 9 can be selected. Queues 2, 3, 4, 5, 6, 7 are effectively unused.

Example

```
hash 0  -> 0000 & 1001 = 0000 = queue 0
hash 1  -> 0001 & 1001 = 0001 = queue 1
hash 2  -> 0010 & 1001 = 0000 = queue 0
hash 3  -> 0011 & 1001 = 0001 = queue 1
hash 4  -> 0100 & 1001 = 0000 = queue 0
hash 5  -> 0101 & 1001 = 0001 = queue 1
hash 8  -> 1000 & 1001 = 1000 = queue 8
hash 9  -> 1001 & 1001 = 1001 = queue 9
hash 10 -> 1010 & 1001 = 1000 = queue 8
hash 11 -> 1011 & 1001 = 1001 = queue 9
```

*So the configured pool says “10 FCR processing queues”, but in practice it behaves closer to 4 active queues.*

This is observed in the MAT tool check in HDDS-15330 (see that there are only 4 ContainerReportQueue with large sizes).

If the queue count were 16:

```
queueCount - 1 = 15
15 in binary = 1111
queueIndex = hash & 15
```

Then possible queue indexes are 0..15, so all 16 queues can be used.

Currently, we can set the queue count to power of two (e.g. 16).

However, to fix the skew entirely, we can use modulo instead

For example,
```
index = Math.floorMod(hash, queueCount);
```

Hopefully through this we can ensure FCR is processed quickly and SCM memory can be freed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15338

## How was this patch tested?

UT. Clean CI: https://github.com/ivandika3/ozone/actions/runs/26219992864
