### PR TITLE
HDDS-15461. Move ACL check in Bucket requests to preExecute

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -76,9 +76,9 @@ public class OMBucketDeleteRequest extends OMClientRequest {
 
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
-    super.preExecute(ozoneManager);
+    OMRequest request = super.preExecute(ozoneManager);
     DeleteBucketRequest deleteBucketRequest =
-        getOmRequest().getDeleteBucketRequest();
+        request.getDeleteBucketRequest();
     String volumeName = deleteBucketRequest.getVolumeName();
     String bucketName = deleteBucketRequest.getBucketName();
 
@@ -95,14 +95,12 @@ public class OMBucketDeleteRequest extends OMClientRequest {
         auditMap.put(OzoneConsts.BUCKET, bucketName);
         markForAudit(ozoneManager.getAuditLogger(),
             buildAuditMessage(OMAction.DELETE_BUCKET, auditMap, ex,
-                getOmRequest().getUserInfo()));
+                request.getUserInfo()));
         throw ex;
       }
     }
 
-    return getOmRequest().toBuilder()
-        .setUserInfo(getUserIfNotExists(ozoneManager))
-        .build();
+    return request;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.V
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -74,6 +75,37 @@ public class OMBucketDeleteRequest extends OMClientRequest {
   }
 
   @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    super.preExecute(ozoneManager);
+    DeleteBucketRequest deleteBucketRequest =
+        getOmRequest().getDeleteBucketRequest();
+    String volumeName = deleteBucketRequest.getVolumeName();
+    String bucketName = deleteBucketRequest.getBucketName();
+
+    // ACL check during preExecute
+    if (ozoneManager.getAclsEnabled()) {
+      try {
+        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
+            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.DELETE,
+            volumeName, bucketName, null);
+      } catch (IOException ex) {
+        // Ensure audit log captures preExecute failures
+        Map<String, String> auditMap = new LinkedHashMap<>();
+        auditMap.put(OzoneConsts.VOLUME, volumeName);
+        auditMap.put(OzoneConsts.BUCKET, bucketName);
+        markForAudit(ozoneManager.getAuditLogger(),
+            buildAuditMessage(OMAction.DELETE_BUCKET, auditMap, ex,
+                getOmRequest().getUserInfo()));
+        throw ex;
+      }
+    }
+
+    return getOmRequest().toBuilder()
+        .setUserInfo(getUserIfNotExists(ozoneManager))
+        .build();
+  }
+
+  @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, ExecutionContext context) {
     final long transactionLogIndex = context.getIndex();
     OMMetrics omMetrics = ozoneManager.getMetrics();
@@ -101,13 +133,6 @@ public class OMBucketDeleteRequest extends OMClientRequest {
     boolean success = true;
     OMClientResponse omClientResponse = null;
     try {
-      // check Acl
-      if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
-            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.DELETE,
-            volumeName, bucketName, null);
-      }
-
       // acquire lock
       mergeOmLockDetails(
           omMetadataManager.getLock().acquireReadLock(VOLUME_LOCK, volumeName));
@@ -265,7 +290,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
 
   /**
    * Validates bucket delete requests.
-   * Handles the cases where an older client attempts to delete a bucket
+   * Handles the cases where an older client attempts to delete a bucket with
    * a new bucket layout.
    * We do not want to allow this to happen, since this would cause the client
    * to be able to delete buckets it cannot understand.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.B
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -63,15 +64,40 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager)
       throws IOException {
+    super.preExecute(ozoneManager);
+
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.SetBucketPropertyRequest.Builder
         setBucketPropertyRequestBuilder = getOmRequest()
         .getSetBucketPropertyRequest().toBuilder()
         .setModificationTime(modificationTime);
 
+    SetBucketPropertyRequest setBucketPropertyRequest =
+        getOmRequest().getSetBucketPropertyRequest();
+    BucketArgs bucketArgs = setBucketPropertyRequest.getBucketArgs();
+    String volumeName = bucketArgs.getVolumeName();
+    String bucketName = bucketArgs.getBucketName();
+
+    // ACL check during preExecute
+    if (ozoneManager.getAclsEnabled()) {
+      try {
+        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
+            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
+            volumeName, bucketName, null);
+      } catch (IOException ex) {
+        // Ensure audit log captures preExecute failures
+        OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
+        Map<String, String> auditMap = omBucketArgs.toAuditMap();
+        markForAudit(ozoneManager.getAuditLogger(),
+            buildAuditMessage(OMAction.SET_OWNER, auditMap, ex,
+                getOmRequest().getUserInfo()));
+        throw ex;
+      }
+    }
+
     return getOmRequest().toBuilder()
         .setSetBucketPropertyRequest(setBucketPropertyRequestBuilder)
-        .setUserInfo(getUserInfo())
+        .setUserInfo(getUserIfNotExists(ozoneManager))
         .build();
   }
 
@@ -109,13 +135,6 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
     boolean acquiredBucketLock = false, success = true;
     OMClientResponse omClientResponse = null;
     try {
-      // check Acl
-      if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
-            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
-            volumeName, bucketName, null);
-      }
-
       // acquire lock.
       mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
           BUCKET_LOCK, volumeName, bucketName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
@@ -64,16 +64,16 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager)
       throws IOException {
-    super.preExecute(ozoneManager);
+    OMRequest request = super.preExecute(ozoneManager);
 
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.SetBucketPropertyRequest.Builder
-        setBucketPropertyRequestBuilder = getOmRequest()
+        setBucketPropertyRequestBuilder = request
         .getSetBucketPropertyRequest().toBuilder()
         .setModificationTime(modificationTime);
 
     SetBucketPropertyRequest setBucketPropertyRequest =
-        getOmRequest().getSetBucketPropertyRequest();
+        request.getSetBucketPropertyRequest();
     BucketArgs bucketArgs = setBucketPropertyRequest.getBucketArgs();
     String volumeName = bucketArgs.getVolumeName();
     String bucketName = bucketArgs.getBucketName();
@@ -90,14 +90,13 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
         Map<String, String> auditMap = omBucketArgs.toAuditMap();
         markForAudit(ozoneManager.getAuditLogger(),
             buildAuditMessage(OMAction.SET_OWNER, auditMap, ex,
-                getOmRequest().getUserInfo()));
+                request.getUserInfo()));
         throw ex;
       }
     }
 
-    return getOmRequest().toBuilder()
+    return request.toBuilder()
         .setSetBucketPropertyRequest(setBucketPropertyRequestBuilder)
-        .setUserInfo(getUserIfNotExists(ozoneManager))
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -80,16 +80,16 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager)
       throws IOException {
-    super.preExecute(ozoneManager);
+    OMRequest request = super.preExecute(ozoneManager);
 
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.SetBucketPropertyRequest.Builder
-        setBucketPropertyRequestBuilder = getOmRequest()
+        setBucketPropertyRequestBuilder = request
         .getSetBucketPropertyRequest().toBuilder()
         .setModificationTime(modificationTime);
 
     BucketArgs bucketArgs =
-        getOmRequest().getSetBucketPropertyRequest().getBucketArgs();
+        request.getSetBucketPropertyRequest().getBucketArgs();
 
     if (bucketArgs.hasBekInfo()) {
       KeyProviderCryptoExtension kmsProvider = ozoneManager.getKmsProvider();
@@ -112,14 +112,13 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
         Map<String, String> auditMap = omBucketArgs.toAuditMap();
         markForAudit(ozoneManager.getAuditLogger(),
             buildAuditMessage(OMAction.UPDATE_BUCKET, auditMap, ex,
-                getOmRequest().getUserInfo()));
+                request.getUserInfo()));
         throw ex;
       }
     }
 
-    return getOmRequest().toBuilder()
+    return request.toBuilder()
         .setSetBucketPropertyRequest(setBucketPropertyRequestBuilder)
-        .setUserInfo(getUserIfNotExists(ozoneManager))
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.B
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
@@ -79,6 +80,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager)
       throws IOException {
+    super.preExecute(ozoneManager);
+
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.SetBucketPropertyRequest.Builder
         setBucketPropertyRequestBuilder = getOmRequest()
@@ -97,9 +100,26 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       setBucketPropertyRequestBuilder.setBucketArgs(bucketArgsBuilder.build());
     }
 
+    // ACL check during preExecute
+    if (ozoneManager.getAclsEnabled()) {
+      String volumeName = bucketArgs.getVolumeName();
+      String bucketName = bucketArgs.getBucketName();
+      try {
+        checkAclPermission(ozoneManager, volumeName, bucketName);
+      } catch (IOException ex) {
+        // Ensure audit log captures preExecute failures
+        OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
+        Map<String, String> auditMap = omBucketArgs.toAuditMap();
+        markForAudit(ozoneManager.getAuditLogger(),
+            buildAuditMessage(OMAction.UPDATE_BUCKET, auditMap, ex,
+                getOmRequest().getUserInfo()));
+        throw ex;
+      }
+    }
+
     return getOmRequest().toBuilder()
         .setSetBucketPropertyRequest(setBucketPropertyRequestBuilder)
-        .setUserInfo(getUserInfo())
+        .setUserInfo(getUserIfNotExists(ozoneManager))
         .build();
   }
 
@@ -132,11 +152,6 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     boolean acquiredBucketLock = false, success = true;
     OMClientResponse omClientResponse = null;
     try {
-      // check Acl
-      if (ozoneManager.getAclsEnabled()) {
-        checkAclPermission(ozoneManager, volumeName, bucketName);
-      }
-
       // acquire lock.
       mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
           BUCKET_LOCK, volumeName, bucketName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -54,6 +54,7 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
 
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    super.preExecute(ozoneManager);
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.SetAclRequest.Builder setAclRequestBuilder =
         getOmRequest().getSetAclRequest().toBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?
  This patch moves ACL authorization checks for bucket operations from validateAndUpdateCache to preExecute in the Ozone Manager request handlers. The affected request classes are:

  • OMBucketDeleteRequest — DELETE ACL check on bucket
  • OMBucketSetOwnerRequest — WRITE_ACL check on bucket
  • OMBucketSetPropertyRequest — WRITE_ACL/WRITE check on bucket
  • OMBucketAclRequest (covers add, remove, set ACL operations) — WRITE_ACL check on bucket

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15461

## How was this patch tested?
UT with additional integration test in PR https://github.com/apache/ozone/pull/10331
Made with [Cursor](https://cursor.com)