### PR TITLE
HDDS-15460. Move ACL checks for key and prefix requests to preExecute

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1367,6 +1367,7 @@ message RenameKeysArgs {
     required string volumeName = 1;
     required string bucketName = 2;
     repeated RenameKeysMap renameKeysMap = 3;
+    repeated RenameKeysMap aclDeniedRenameKeys = 4;
 }
 
 message RenameKeysMap {
@@ -1400,6 +1401,7 @@ message DeleteKeyArgs {
     required string volumeName = 1;
     required string bucketName = 2;
     repeated string keys = 3;
+    repeated string aclDeniedKeys = 4;
 }
 
 message DeleteKeyError {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -109,11 +109,14 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     List<String> keysPassingAcl = new ArrayList<>();
     List<String> aclDeniedKeys = new ArrayList<>();
     if (ozoneManager.getAclsEnabled()) {
+      OMPerformanceMetrics perfMetrics = ozoneManager.getPerfMetrics();
       for (String keyName : keys) {
         try {
+          long startNanosAclCheck = Time.monotonicNowNanos();
           checkKeyAcls(ozoneManager, resolvedVolume, resolvedBucket, keyName,
               IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
               volumeOwner);
+          perfMetrics.setDeleteKeysAclCheckLatencyNs(Time.monotonicNowNanos() - startNanosAclCheck);
           keysPassingAcl.add(keyName);
         } catch (IOException ex) {
           LOG.warn("ACL check failed for key {} during preExecute: {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -88,6 +88,65 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     super(omRequest, bucketLayout);
   }
 
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    super.preExecute(ozoneManager);
+
+    DeleteKeysRequest deleteKeysRequest = getOmRequest().getDeleteKeysRequest();
+    DeleteKeyArgs deleteKeyArgs = deleteKeysRequest.getDeleteKeys();
+
+    String volumeName = deleteKeyArgs.getVolumeName();
+    String bucketName = deleteKeyArgs.getBucketName();
+    List<String> keys = deleteKeyArgs.getKeysList();
+
+    ResolvedBucket resolvedBucketObj = ozoneManager.resolveBucketLink(
+        Pair.of(volumeName, bucketName));
+    String resolvedVolume = resolvedBucketObj.realVolume();
+    String resolvedBucket = resolvedBucketObj.realBucket();
+
+    String volumeOwner = getVolumeOwner(ozoneManager.getMetadataManager(), resolvedVolume);
+
+    List<String> keysPassingAcl = new ArrayList<>();
+    List<String> aclDeniedKeys = new ArrayList<>();
+    if (ozoneManager.getAclsEnabled()) {
+      for (String keyName : keys) {
+        try {
+          checkKeyAcls(ozoneManager, resolvedVolume, resolvedBucket, keyName,
+              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
+              volumeOwner);
+          keysPassingAcl.add(keyName);
+        } catch (IOException ex) {
+          LOG.warn("ACL check failed for key {} during preExecute: {}",
+              keyName, ex.getMessage());
+          aclDeniedKeys.add(keyName);
+          Map<String, String> auditMap = new LinkedHashMap<>();
+          auditMap.put(VOLUME, resolvedVolume);
+          auditMap.put(BUCKET, resolvedBucket);
+          auditMap.put(KEY, keyName);
+          markForAudit(ozoneManager.getAuditLogger(),
+              buildAuditMessage(DELETE_KEYS, auditMap, ex,
+                  getOmRequest().getUserInfo()));
+        }
+      }
+    } else {
+      keysPassingAcl.addAll(keys);
+    }
+
+    DeleteKeyArgs.Builder modifiedArgs = deleteKeyArgs.toBuilder()
+        .clearKeys()
+        .addAllKeys(keysPassingAcl)
+        .clearAclDeniedKeys()
+        .addAllAclDeniedKeys(aclDeniedKeys);
+
+    DeleteKeysRequest.Builder modifiedRequest = deleteKeysRequest.toBuilder()
+        .setDeleteKeys(modifiedArgs);
+
+    return getOmRequest().toBuilder()
+        .setDeleteKeysRequest(modifiedRequest)
+        .setUserInfo(getUserIfNotExists(ozoneManager))
+        .build();
+  }
+
   @Override @SuppressWarnings("methodlength")
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, ExecutionContext context) {
     final long trxnLogIndex = context.getIndex();
@@ -147,7 +206,13 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       acquiredLock = getOmLockDetails().isLockAcquired();
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-      String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
+
+      for (String deniedKey : deleteKeyArgs.getAclDeniedKeysList()) {
+        deleteStatus = false;
+        unDeletedKeys.addKeys(deniedKey);
+        keyToError.put(deniedKey,
+            new ErrorInfo(OMException.ResultCodes.ACCESS_DENIED.name(), "ACL check failed"));
+      }
 
       for (indexFailed = 0; indexFailed < length; indexFailed++) {
         String keyName = deleteKeyArgs.getKeys(indexFailed);
@@ -166,25 +231,11 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           continue;
         }
 
-        try {
-          // check Acl
-          long startNanosDeleteKeysAclCheckLatency = Time.monotonicNowNanos();
-          checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
-              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
-          perfMetrics.setDeleteKeysAclCheckLatencyNs(Time.monotonicNowNanos() - startNanosDeleteKeysAclCheckLatency);
-          OzoneFileStatus fileStatus = getOzoneKeyStatus(
-              ozoneManager, omMetadataManager, volumeName, bucketName, keyName);
-          addKeyToAppropriateList(omKeyInfoList, omKeyInfo, dirList,
-              fileStatus);
-          deleteKeysInfo.add(omKeyInfo);
-        } catch (Exception ex) {
-          deleteStatus = false;
-          LOG.error("Acl check failed for Key: {}", objectKey, ex);
-          deleteKeys.remove(keyName);
-          unDeletedKeys.addKeys(keyName);
-          keyToError.put(keyName, new ErrorInfo(OMException.ResultCodes.ACCESS_DENIED.name(), "ACL check failed"));
-        }
+        OzoneFileStatus fileStatus = getOzoneKeyStatus(
+            ozoneManager, omMetadataManager, volumeName, bucketName, keyName);
+        addKeyToAppropriateList(omKeyInfoList, omKeyInfo, dirList,
+            fileStatus);
+        deleteKeysInfo.add(omKeyInfo);
       }
 
       OmBucketInfo omBucketInfo =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -17,8 +17,12 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import static org.apache.hadoop.ozone.OzoneConsts.BUCKET;
+import static org.apache.hadoop.ozone.OzoneConsts.DST_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.RENAMED_KEYS_MAP;
+import static org.apache.hadoop.ozone.OzoneConsts.SRC_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.UNRENAMED_KEYS_MAP;
+import static org.apache.hadoop.ozone.OzoneConsts.VOLUME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_RENAME;
@@ -78,6 +82,76 @@ public class OMKeysRenameRequest extends OMKeyRequest {
   }
 
   @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    super.preExecute(ozoneManager);
+
+    RenameKeysRequest renameKeysRequest = getOmRequest().getRenameKeysRequest();
+    RenameKeysArgs renameKeysArgs = renameKeysRequest.getRenameKeysArgs();
+
+    String volumeName = renameKeysArgs.getVolumeName();
+    String bucketName = renameKeysArgs.getBucketName();
+
+    ResolvedBucket resolvedBucketObj = ozoneManager.resolveBucketLink(
+        Pair.of(volumeName, bucketName));
+    String resolvedVolume = resolvedBucketObj.realVolume();
+    String resolvedBucket = resolvedBucketObj.realBucket();
+
+    String volumeOwner = getVolumeOwner(ozoneManager.getMetadataManager(), resolvedVolume);
+
+    List<RenameKeysMap> keyPairsPassingAcl = new ArrayList<>();
+    List<RenameKeysMap> aclDeniedPairs = new ArrayList<>();
+    if (ozoneManager.getAclsEnabled()) {
+      for (RenameKeysMap renameKey : renameKeysArgs.getRenameKeysMapList()) {
+        String fromKeyName = renameKey.getFromKeyName();
+        String toKeyName = renameKey.getToKeyName();
+
+        if (fromKeyName.isEmpty() || toKeyName.isEmpty()) {
+          keyPairsPassingAcl.add(renameKey);
+          continue;
+        }
+
+        try {
+          checkKeyAcls(ozoneManager, resolvedVolume, resolvedBucket, fromKeyName,
+              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
+              volumeOwner);
+          checkKeyAcls(ozoneManager, resolvedVolume, resolvedBucket, toKeyName,
+              IAccessAuthorizer.ACLType.CREATE, OzoneObj.ResourceType.KEY,
+              volumeOwner);
+          keyPairsPassingAcl.add(renameKey);
+        } catch (IOException ex) {
+          LOG.warn("ACL check failed for rename {} -> {} during preExecute: {}",
+              fromKeyName, toKeyName, ex.getMessage());
+          aclDeniedPairs.add(renameKey);
+          Map<String, String> auditMap = new LinkedHashMap<>();
+          auditMap.put(VOLUME, resolvedVolume);
+          auditMap.put(BUCKET, resolvedBucket);
+          auditMap.put(SRC_KEY, fromKeyName);
+          auditMap.put(DST_KEY, toKeyName);
+          markForAudit(ozoneManager.getAuditLogger(),
+              buildAuditMessage(OMAction.RENAME_KEYS, auditMap, ex,
+                  getOmRequest().getUserInfo()));
+        }
+      }
+    } else {
+      keyPairsPassingAcl.addAll(renameKeysArgs.getRenameKeysMapList());
+    }
+
+    RenameKeysArgs.Builder modifiedArgs = renameKeysArgs.toBuilder()
+        .clearRenameKeysMap()
+        .addAllRenameKeysMap(keyPairsPassingAcl)
+        .clearAclDeniedRenameKeys()
+        .addAllAclDeniedRenameKeys(aclDeniedPairs);
+
+    RenameKeysRequest.Builder modifiedRequest = renameKeysRequest.toBuilder()
+        .setRenameKeysArgs(modifiedArgs);
+
+    return getOmRequest().toBuilder()
+        .setRenameKeysRequest(modifiedRequest)
+        .setUserInfo(getUserIfNotExists(ozoneManager))
+        .build();
+  }
+
+  @Override
   @SuppressWarnings("methodlength")
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, ExecutionContext context) {
     final long trxnLogIndex = context.getIndex();
@@ -125,7 +199,12 @@ public class OMKeysRenameRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-      String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
+
+      for (RenameKeysMap deniedPair : renameKeysArgs.getAclDeniedRenameKeysList()) {
+        renameStatus = false;
+        unRenamedKeys.add(deniedPair);
+      }
+
       for (RenameKeysMap renameKey : renameKeysArgs.getRenameKeysMapList()) {
 
         fromKeyName = renameKey.getFromKeyName();
@@ -139,25 +218,6 @@ public class OMKeysRenameRequest extends OMKeyRequest {
                   .build());
           LOG.error("Key name is empty fromKeyName {} toKeyName {}",
               fromKeyName, toKeyName);
-          continue;
-        }
-
-        try {
-          // check Acls to see if user has access to perform delete operation
-          // on old key and create operation on new key
-          checkKeyAcls(ozoneManager, volumeName, bucketName, fromKeyName,
-              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
-          checkKeyAcls(ozoneManager, volumeName, bucketName, toKeyName,
-              IAccessAuthorizer.ACLType.CREATE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
-        } catch (Exception ex) {
-          renameStatus = false;
-          unRenamedKeys.add(
-              unRenameKey.setFromKeyName(fromKeyName).setToKeyName(toKeyName)
-                  .build());
-          LOG.error("Acl check failed for fromKeyName {} toKeyName {}",
-              fromKeyName, toKeyName, ex);
           continue;
         }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -21,11 +21,13 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.B
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
@@ -62,6 +64,46 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
   }
 
   @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    OMRequest omRequest = super.preExecute(ozoneManager);
+
+    // ACL check during preExecute
+    if (ozoneManager.getAclsEnabled()) {
+      try {
+        ObjectParser objectParser = new ObjectParser(getPath(),
+            ObjectType.KEY);
+        ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
+            Pair.of(objectParser.getVolume(), objectParser.getBucket()));
+        String volume = resolvedBucket.realVolume();
+        String bucket = resolvedBucket.realBucket();
+        String key = objectParser.getKey();
+
+        checkAcls(ozoneManager, OzoneObj.ResourceType.KEY,
+            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
+            volume, bucket, key);
+      } catch (IOException ex) {
+        // Ensure audit log captures preExecute failures
+        Map<String, String> auditMap = new LinkedHashMap<>();
+        OzoneObj obj = getObject();
+        auditMap.putAll(obj.toAuditMap());
+        // Determine which action based on request type
+        OMAction action = OMAction.SET_ACL;
+        if (omRequest.hasAddAclRequest()) {
+          action = OMAction.ADD_ACL;
+        } else if (omRequest.hasRemoveAclRequest()) {
+          action = OMAction.REMOVE_ACL;
+        }
+        markForAudit(ozoneManager.getAuditLogger(),
+            buildAuditMessage(action, auditMap, ex,
+                omRequest.getUserInfo()));
+        throw ex;
+      }
+    }
+
+    return omRequest;
+  }
+
+  @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, ExecutionContext context) {
     final long trxnLogIndex = context.getIndex();
 
@@ -87,12 +129,6 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       bucket = resolvedBucket.realBucket();
       key = objectParser.getKey();
 
-      // check Acl
-      if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.KEY,
-            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
-            volume, bucket, key);
-      }
       mergeOmLockDetails(
           omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK, volume,
               bucket));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
@@ -55,13 +55,17 @@ public class OMKeyAddAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   @Override
   public OzoneManagerProtocolProtos.OMRequest preExecute(
       OzoneManager ozoneManager) throws IOException {
+    // Call parent's preExecute to perform ACL checks
+    OzoneManagerProtocolProtos.OMRequest omRequest =
+        super.preExecute(ozoneManager);
+
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.AddAclRequest.Builder addAclRequestBuilder =
-        getOmRequest().getAddAclRequest().toBuilder()
+        omRequest.getAddAclRequest().toBuilder()
             .setModificationTime(modificationTime);
 
-    return getOmRequest().toBuilder().setAddAclRequest(addAclRequestBuilder)
-        .setUserInfo(getUserInfo()).build();
+    return omRequest.toBuilder().setAddAclRequest(addAclRequestBuilder)
+        .build();
   }
 
   public OMKeyAddAclRequestWithFSO(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
@@ -55,14 +55,18 @@ public class OMKeyRemoveAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   @Override
   public OzoneManagerProtocolProtos.OMRequest preExecute(
       OzoneManager ozoneManager) throws IOException {
+    // Call parent's preExecute to perform ACL checks
+    OzoneManagerProtocolProtos.OMRequest omRequest =
+        super.preExecute(ozoneManager);
+
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.RemoveAclRequest.Builder
         removeAclRequestBuilder =
-        getOmRequest().getRemoveAclRequest().toBuilder()
+        omRequest.getRemoveAclRequest().toBuilder()
             .setModificationTime(modificationTime);
 
-    return getOmRequest().toBuilder()
-        .setRemoveAclRequest(removeAclRequestBuilder).setUserInfo(getUserInfo())
+    return omRequest.toBuilder()
+        .setRemoveAclRequest(removeAclRequestBuilder)
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
@@ -56,13 +56,17 @@ public class OMKeySetAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   @Override
   public OzoneManagerProtocolProtos.OMRequest preExecute(
       OzoneManager ozoneManager) throws IOException {
+    // Call parent's preExecute to perform ACL checks
+    OzoneManagerProtocolProtos.OMRequest omRequest =
+        super.preExecute(ozoneManager);
+
     long modificationTime = Time.now();
     OzoneManagerProtocolProtos.SetAclRequest.Builder setAclRequestBuilder =
-        getOmRequest().getSetAclRequest().toBuilder()
+        omRequest.getSetAclRequest().toBuilder()
             .setModificationTime(modificationTime);
 
-    return getOmRequest().toBuilder().setSetAclRequest(setAclRequestBuilder)
-        .setUserInfo(getUserInfo()).build();
+    return omRequest.toBuilder().setSetAclRequest(setAclRequestBuilder)
+        .build();
   }
 
   public OMKeySetAclRequestWithFSO(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Move ACL authorization checks for **key** bulk operations (`DeleteKeys`, `RenameKeys`) from `validateAndUpdateCache` to `preExecute`
- Move ACL checks for key and prefix ACL operations (`OMKeyAclRequest`, `OMKeyAclRequestWithFSO`, `OMPrefixAclRequest`, and FSO add/remove/set variants) from `validateAndUpdateCache` to `preExecute`
- For bulk operations, keys denied by ACL are collected in new proto fields (`aclDeniedKeys` / `aclDeniedRenameKeys`) and removed from the batch, so permitted keys in the same request can still be processed
- Proto: add `aclDeniedKeys` to `DeleteKeyArgs` and `aclDeniedRenameKeys` to `RenameKeysArgs`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15460

## How was this patch tested?

By existing tests, more tests would be added in a separate PR https://github.com/apache/ozone/pull/10331 

Made with [Cursor](https://cursor.com)