### PR TITLE
HDDS-15346. DiskBalancer should update delta sizes atomically.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -443,7 +443,7 @@ public class DiskBalancerService extends BackgroundService {
               destVolume);
           queue.add(task);
           inProgressContainers.add(ContainerID.valueOf(toBalanceContainer.getContainerID()));
-          reserveDeltaSize(sourceVolume, toBalanceContainer.getBytesUsed());
+          deltaSizes.merge(sourceVolume, -toBalanceContainer.getBytesUsed(), Long::sum);
         }
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -491,44 +491,6 @@ public class DiskBalancerService extends BackgroundService {
     return false;
   }
 
-  /**
-   * Atomically reserves bytes to be moved from a source volume.
-   *
-   * <p>Multiple DiskBalancer tasks can update the delta size of the same
-   * source volume concurrently.  When the resulting delta becomes zero, the
-   * volume is removed from the delta size map.</p>
-   *
-   * @param sourceVolume the volume from which bytes will be moved
-   * @param bytes the number of bytes to reserve
-   */
-  private void reserveDeltaSize(HddsVolume sourceVolume, long bytes) {
-    deltaSizes.compute(sourceVolume, (volume, current) -> {
-      long updated = (current == null ? 0L : current) - bytes;
-      return updated == 0L ? null : updated;
-    });
-  }
-
-  /**
-   * Atomically releases bytes previously reserved for a source volume.
-   *
-   * <p>When the resulting delta becomes zero, the volume is removed from the
-   * delta size map.</p>
-   *
-   * @param sourceVolume the volume from which bytes were moved
-   * @param bytes the number of bytes to release
-   */
-  private void releaseDeltaSize(HddsVolume sourceVolume, long bytes) {
-    deltaSizes.compute(sourceVolume, (volume, current) -> {
-      if (current == null) {
-        LOG.warn("No reserved delta size found for source volume {} when "
-            + "releasing {} bytes.", sourceVolume, bytes);
-        return null;
-      }
-      long updated = current + bytes;
-      return updated == 0L ? null : updated;
-    });
-  }
-
   protected class DiskBalancerTask implements BackgroundTask {
 
     private HddsVolume sourceVolume;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -443,8 +443,7 @@ public class DiskBalancerService extends BackgroundService {
               destVolume);
           queue.add(task);
           inProgressContainers.add(ContainerID.valueOf(toBalanceContainer.getContainerID()));
-          deltaSizes.put(sourceVolume, deltaSizes.getOrDefault(sourceVolume, 0L)
-              - toBalanceContainer.getBytesUsed());
+          reserveDeltaSize(sourceVolume, toBalanceContainer.getBytesUsed());
         }
       }
     }
@@ -490,6 +489,30 @@ public class DiskBalancerService extends BackgroundService {
           bytesBalanced / megaByte, delayInMillisec, delayInMillisec / 1000);
     }
     return false;
+  }
+
+  private void reserveDeltaSize(HddsVolume sourceVolume, long bytes) {
+    // deltaSizes can be updated by multiple DiskBalancer tasks for the same
+    // source volume. Use compute to avoid lost updates from a non-atomic
+    // get/put sequence.
+    deltaSizes.compute(sourceVolume, (volume, current) -> {
+      long updated = (current == null ? 0L : current) - bytes;
+      return updated == 0L ? null : updated;
+    });
+  }
+
+  private void releaseDeltaSize(HddsVolume sourceVolume, long bytes) {
+    // Match reserveDeltaSize and release the previously reserved bytes
+    // atomically when a DiskBalancer task completes.
+    deltaSizes.compute(sourceVolume, (volume, current) -> {
+      if (current == null) {
+        LOG.warn("No reserved delta size found for source volume {} when "
+            + "releasing {} bytes.", sourceVolume, bytes);
+        return null;
+      }
+      long updated = current + bytes;
+      return updated == 0L ? null : updated;
+    });
   }
 
   protected class DiskBalancerTask implements BackgroundTask {
@@ -654,8 +677,7 @@ public class DiskBalancerService extends BackgroundService {
 
     private void postCall(boolean success, long startTime) {
       inProgressContainers.remove(ContainerID.valueOf(containerData.getContainerID()));
-      deltaSizes.put(sourceVolume, deltaSizes.get(sourceVolume) +
-          containerData.getBytesUsed());
+      releaseDeltaSize(sourceVolume, containerData.getBytesUsed());
       destVolume.incCommittedBytes(0 - containerData.getBytesUsed());
       long endTime = Time.monotonicNow();
       if (success) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -691,7 +691,7 @@ public class DiskBalancerService extends BackgroundService {
 
     private void postCall(boolean success, long startTime) {
       inProgressContainers.remove(ContainerID.valueOf(containerData.getContainerID()));
-      releaseDeltaSize(sourceVolume, containerData.getBytesUsed());
+      deltaSizes.merge(sourceVolume, containerData.getBytesUsed(), Long::sum);
       destVolume.incCommittedBytes(0 - containerData.getBytesUsed());
       long endTime = Time.monotonicNow();
       if (success) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -491,19 +491,33 @@ public class DiskBalancerService extends BackgroundService {
     return false;
   }
 
+  /**
+   * Atomically reserves bytes to be moved from a source volume.
+   *
+   * <p>Multiple DiskBalancer tasks can update the delta size of the same
+   * source volume concurrently.  When the resulting delta becomes zero, the
+   * volume is removed from the delta size map.</p>
+   *
+   * @param sourceVolume the volume from which bytes will be moved
+   * @param bytes the number of bytes to reserve
+   */
   private void reserveDeltaSize(HddsVolume sourceVolume, long bytes) {
-    // deltaSizes can be updated by multiple DiskBalancer tasks for the same
-    // source volume. Use compute to avoid lost updates from a non-atomic
-    // get/put sequence.
     deltaSizes.compute(sourceVolume, (volume, current) -> {
       long updated = (current == null ? 0L : current) - bytes;
       return updated == 0L ? null : updated;
     });
   }
 
+  /**
+   * Atomically releases bytes previously reserved for a source volume.
+   *
+   * <p>When the resulting delta becomes zero, the volume is removed from the
+   * delta size map.</p>
+   *
+   * @param sourceVolume the volume from which bytes were moved
+   * @param bytes the number of bytes to release
+   */
   private void releaseDeltaSize(HddsVolume sourceVolume, long bytes) {
-    // Match reserveDeltaSize and release the previously reserved bytes
-    // atomically when a DiskBalancer task completes.
     deltaSizes.compute(sourceVolume, (volume, current) -> {
       if (current == null) {
         LOG.warn("No reserved delta size found for source volume {} when "

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -36,19 +36,24 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -87,6 +92,7 @@ import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -312,6 +318,37 @@ public class TestDiskBalancerTask {
     containerIterator = destVolume.getContainerIterator();
     assertTrue(containerIterator.hasNext());
     assertEquals(CONTAINER_ID, containerIterator.next());
+  }
+
+  @Test
+  public void concurrentPostCallRestoresDeltaSizeAtomically()
+      throws Exception {
+    Method postCall = DiskBalancerService.DiskBalancerTask.class
+        .getDeclaredMethod("postCall", boolean.class, long.class);
+    postCall.setAccessible(true);
+
+    RacingDeltaMap deltaSizes = new RacingDeltaMap(sourceVolume);
+    setDeltaSizes(deltaSizes);
+    deltaSizes.put(sourceVolume, -2 * CONTAINER_SIZE);
+    destVolume.incCommittedBytes(2 * CONTAINER_SIZE);
+
+    DiskBalancerService.DiskBalancerTask task1 =
+        newTask(CONTAINER_ID + 1);
+    DiskBalancerService.DiskBalancerTask task2 =
+        newTask(CONTAINER_ID + 2);
+
+    deltaSizes.enableRacingGets();
+    CompletableFuture<Void> first = CompletableFuture.runAsync(
+        () -> invokePostCall(postCall, task1));
+    CompletableFuture<Void> second = CompletableFuture.runAsync(
+        () -> invokePostCall(postCall, task2));
+
+    first.get(5, TimeUnit.SECONDS);
+    second.get(5, TimeUnit.SECONDS);
+
+    deltaSizes.disableRacingGets();
+    assertEquals(0L, deltaSizes.getOrDefault(sourceVolume, 0L));
+    assertEquals(0L, destVolume.getCommittedBytes());
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -677,6 +714,99 @@ public class TestDiskBalancerTask {
 
     // Verify delta sizes are restored
     assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+  }
+
+  private DiskBalancerService.DiskBalancerTask newTask(long containerId) {
+    KeyValueContainerData containerData = new KeyValueContainerData(
+        containerId, ContainerLayoutVersion.FILE_PER_BLOCK, CONTAINER_SIZE,
+        UUID.randomUUID().toString(), datanodeUuid);
+    containerData.getStatistics().setBlockBytesForTesting(CONTAINER_SIZE);
+    return diskBalancerService.new DiskBalancerTask(containerData,
+        sourceVolume, destVolume);
+  }
+
+  private void invokePostCall(Method postCall,
+      DiskBalancerService.DiskBalancerTask task) {
+    try {
+      postCall.invoke(task, false, TimeUnit.MILLISECONDS.toMillis(1));
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private void setDeltaSizes(Map<HddsVolume, Long> deltaSizes)
+      throws ReflectiveOperationException {
+    Field field = DiskBalancerService.class.getDeclaredField("deltaSizes");
+    field.setAccessible(true);
+    field.set(diskBalancerService, deltaSizes);
+  }
+
+  private static final class RacingDeltaMap
+      extends AbstractMap<HddsVolume, Long> {
+    private final Map<HddsVolume, Long> entries = new HashMap<>();
+    private final HddsVolume racedVolume;
+    private final CountDownLatch concurrentGets = new CountDownLatch(2);
+    private volatile boolean raceGets;
+
+    private RacingDeltaMap(HddsVolume racedVolume) {
+      this.racedVolume = racedVolume;
+    }
+
+    private void enableRacingGets() {
+      raceGets = true;
+    }
+
+    private void disableRacingGets() {
+      raceGets = false;
+    }
+
+    @Override
+    public Long get(Object key) {
+      Long value;
+      synchronized (this) {
+        value = entries.get(key);
+      }
+      if (raceGets && key == racedVolume) {
+        concurrentGets.countDown();
+        try {
+          if (!concurrentGets.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("Timed out waiting for concurrent gets");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError(e);
+        }
+      }
+      return value;
+    }
+
+    @Override
+    public synchronized Long put(HddsVolume key, Long value) {
+      return entries.put(key, value);
+    }
+
+    @Override
+    public synchronized Long remove(Object key) {
+      return entries.remove(key);
+    }
+
+    @Override
+    public synchronized Long compute(HddsVolume key,
+        BiFunction<? super HddsVolume, ? super Long, ? extends Long>
+            remappingFunction) {
+      Long newValue = remappingFunction.apply(key, entries.get(key));
+      if (newValue == null) {
+        entries.remove(key);
+      } else {
+        entries.put(key, newValue);
+      }
+      return newValue;
+    }
+
+    @Override
+    public synchronized Set<Entry<HddsVolume, Long>> entrySet() {
+      return entries.entrySet();
+    }
   }
 
   private KeyValueContainer createContainer(long containerId, HddsVolume vol, State state)

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -280,8 +280,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
 
     Container container = createContainer(CONTAINER_ID, sourceVolume, containerState);
     State originalState = container.getContainerState();
@@ -311,7 +310,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getSuccessCount());
     assertEquals(CONTAINER_SIZE, diskBalancerService.getMetrics().getSuccessBytes());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
-    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
 
     containerIterator = sourceVolume.getContainerIterator();
     assertFalse(containerIterator.hasNext());
@@ -360,8 +359,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
 
     // verify temp container directory doesn't exist before task execution
@@ -400,7 +398,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -412,8 +410,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
     Path tempDir = destVolume.getTmpDir().toPath()
         .resolve(DISK_BALANCER_DIR)
@@ -464,7 +461,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -476,8 +473,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
     Path destDirPath = Paths.get(
         KeyValueContainerLocationUtil.getBaseContainerLocation(
@@ -529,7 +525,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -540,8 +536,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
 
     // Use a static mock for the KeyValueContainer utility class
     try (MockedStatic<KeyValueContainerUtil> mockedUtil =
@@ -578,7 +573,7 @@ public class TestDiskBalancerTask {
           destVolume.getCurrentUsage().getUsedSpace());
       assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
       assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-      assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+      assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
     }
   }
 
@@ -590,8 +585,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
 
     GenericTestUtils.LogCapturer serviceLog = GenericTestUtils.LogCapturer.captureLogs(DiskBalancerService.class);
     DiskBalancerService.DiskBalancerTask task = getTask();
@@ -612,7 +606,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -659,8 +653,7 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
-        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
+    long initialSourceDelta = getDeltaSize(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
 
     // Verify temp container directory doesn't exist before task execution
@@ -713,7 +706,7 @@ public class TestDiskBalancerTask {
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
 
     // Verify delta sizes are restored
-    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
   }
 
   private DiskBalancerService.DiskBalancerTask newTask(long containerId) {
@@ -739,6 +732,10 @@ public class TestDiskBalancerTask {
     Field field = DiskBalancerService.class.getDeclaredField("deltaSizes");
     field.setAccessible(true);
     field.set(diskBalancerService, deltaSizes);
+  }
+
+  private long getDeltaSize(HddsVolume volume) {
+    return diskBalancerService.getDeltaSizes().getOrDefault(volume, 0L);
   }
 
   private static final class RacingDeltaMap

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -36,24 +36,19 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BiFunction;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -92,7 +87,6 @@ import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -280,7 +274,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
 
     Container container = createContainer(CONTAINER_ID, sourceVolume, containerState);
     State originalState = container.getContainerState();
@@ -310,44 +305,13 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getSuccessCount());
     assertEquals(CONTAINER_SIZE, diskBalancerService.getMetrics().getSuccessBytes());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
-    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
+    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
 
     containerIterator = sourceVolume.getContainerIterator();
     assertFalse(containerIterator.hasNext());
     containerIterator = destVolume.getContainerIterator();
     assertTrue(containerIterator.hasNext());
     assertEquals(CONTAINER_ID, containerIterator.next());
-  }
-
-  @Test
-  public void concurrentPostCallRestoresDeltaSizeAtomically()
-      throws Exception {
-    Method postCall = DiskBalancerService.DiskBalancerTask.class
-        .getDeclaredMethod("postCall", boolean.class, long.class);
-    postCall.setAccessible(true);
-
-    RacingDeltaMap deltaSizes = new RacingDeltaMap(sourceVolume);
-    setDeltaSizes(deltaSizes);
-    deltaSizes.put(sourceVolume, -2 * CONTAINER_SIZE);
-    destVolume.incCommittedBytes(2 * CONTAINER_SIZE);
-
-    DiskBalancerService.DiskBalancerTask task1 =
-        newTask(CONTAINER_ID + 1);
-    DiskBalancerService.DiskBalancerTask task2 =
-        newTask(CONTAINER_ID + 2);
-
-    deltaSizes.enableRacingGets();
-    CompletableFuture<Void> first = CompletableFuture.runAsync(
-        () -> invokePostCall(postCall, task1));
-    CompletableFuture<Void> second = CompletableFuture.runAsync(
-        () -> invokePostCall(postCall, task2));
-
-    first.get(5, TimeUnit.SECONDS);
-    second.get(5, TimeUnit.SECONDS);
-
-    deltaSizes.disableRacingGets();
-    assertEquals(0L, deltaSizes.getOrDefault(sourceVolume, 0L));
-    assertEquals(0L, destVolume.getCommittedBytes());
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -359,7 +323,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
 
     // verify temp container directory doesn't exist before task execution
@@ -398,7 +363,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
+    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -410,7 +375,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
     Path tempDir = destVolume.getTmpDir().toPath()
         .resolve(DISK_BALANCER_DIR)
@@ -461,7 +427,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
+    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -473,7 +439,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
     Path destDirPath = Paths.get(
         KeyValueContainerLocationUtil.getBaseContainerLocation(
@@ -525,7 +492,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
+    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -536,7 +503,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
 
     // Use a static mock for the KeyValueContainer utility class
     try (MockedStatic<KeyValueContainerUtil> mockedUtil =
@@ -573,7 +541,7 @@ public class TestDiskBalancerTask {
           destVolume.getCurrentUsage().getUsedSpace());
       assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
       assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-      assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
+      assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
     }
   }
 
@@ -585,7 +553,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
 
     GenericTestUtils.LogCapturer serviceLog = GenericTestUtils.LogCapturer.captureLogs(DiskBalancerService.class);
     DiskBalancerService.DiskBalancerTask task = getTask();
@@ -606,7 +575,7 @@ public class TestDiskBalancerTask {
     assertEquals(1, diskBalancerService.getMetrics().getFailureCount());
     assertEquals(initialDestCommitted, destVolume.getCommittedBytes());
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
-    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
+    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -653,7 +622,8 @@ public class TestDiskBalancerTask {
     long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
     long initialDestUsed = destVolume.getCurrentUsage().getUsedSpace();
     long initialDestCommitted = destVolume.getCommittedBytes();
-    long initialSourceDelta = getDeltaSize(sourceVolume);
+    long initialSourceDelta = diskBalancerService.getDeltaSizes().get(sourceVolume) == null ?
+        0L : diskBalancerService.getDeltaSizes().get(sourceVolume);
     String oldContainerPath = container.getContainerData().getContainerPath();
 
     // Verify temp container directory doesn't exist before task execution
@@ -706,106 +676,7 @@ public class TestDiskBalancerTask {
     assertFalse(diskBalancerService.getInProgressContainers().contains(ContainerID.valueOf(CONTAINER_ID)));
 
     // Verify delta sizes are restored
-    assertEquals(initialSourceDelta, getDeltaSize(sourceVolume));
-  }
-
-  private DiskBalancerService.DiskBalancerTask newTask(long containerId) {
-    KeyValueContainerData containerData = new KeyValueContainerData(
-        containerId, ContainerLayoutVersion.FILE_PER_BLOCK, CONTAINER_SIZE,
-        UUID.randomUUID().toString(), datanodeUuid);
-    containerData.getStatistics().setBlockBytesForTesting(CONTAINER_SIZE);
-    return diskBalancerService.new DiskBalancerTask(containerData,
-        sourceVolume, destVolume);
-  }
-
-  private void invokePostCall(Method postCall,
-      DiskBalancerService.DiskBalancerTask task) {
-    try {
-      postCall.invoke(task, false, TimeUnit.MILLISECONDS.toMillis(1));
-    } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
-    }
-  }
-
-  private void setDeltaSizes(Map<HddsVolume, Long> deltaSizes)
-      throws ReflectiveOperationException {
-    Field field = DiskBalancerService.class.getDeclaredField("deltaSizes");
-    field.setAccessible(true);
-    field.set(diskBalancerService, deltaSizes);
-  }
-
-  private long getDeltaSize(HddsVolume volume) {
-    return diskBalancerService.getDeltaSizes().getOrDefault(volume, 0L);
-  }
-
-  private static final class RacingDeltaMap
-      extends AbstractMap<HddsVolume, Long> {
-    private final Map<HddsVolume, Long> entries = new HashMap<>();
-    private final HddsVolume racedVolume;
-    private final CountDownLatch concurrentGets = new CountDownLatch(2);
-    private volatile boolean raceGets;
-
-    private RacingDeltaMap(HddsVolume racedVolume) {
-      this.racedVolume = racedVolume;
-    }
-
-    private void enableRacingGets() {
-      raceGets = true;
-    }
-
-    private void disableRacingGets() {
-      raceGets = false;
-    }
-
-    @Override
-    public Long get(Object key) {
-      Long value;
-      synchronized (this) {
-        value = entries.get(key);
-      }
-      if (raceGets && key == racedVolume) {
-        concurrentGets.countDown();
-        try {
-          if (!concurrentGets.await(5, TimeUnit.SECONDS)) {
-            throw new AssertionError("Timed out waiting for concurrent gets");
-          }
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new AssertionError(e);
-        }
-      }
-      return value;
-    }
-
-    @Override
-    public synchronized Long put(HddsVolume key, Long value) {
-      return entries.put(key, value);
-    }
-
-    @Override
-    public synchronized Long remove(Object key) {
-      return entries.remove(key);
-    }
-
-    @Override
-    public synchronized Long merge(HddsVolume key, Long value,
-        BiFunction<? super Long, ? super Long, ? extends Long>
-            remappingFunction) {
-      Long current = entries.get(key);
-      Long newValue = current == null ? value :
-          remappingFunction.apply(current, value);
-      if (newValue == null) {
-        entries.remove(key);
-      } else {
-        entries.put(key, newValue);
-      }
-      return newValue;
-    }
-
-    @Override
-    public synchronized Set<Entry<HddsVolume, Long>> entrySet() {
-      return entries.entrySet();
-    }
+    assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
   }
 
   private KeyValueContainer createContainer(long containerId, HddsVolume vol, State state)

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -788,10 +788,12 @@ public class TestDiskBalancerTask {
     }
 
     @Override
-    public synchronized Long compute(HddsVolume key,
-        BiFunction<? super HddsVolume, ? super Long, ? extends Long>
+    public synchronized Long merge(HddsVolume key, Long value,
+        BiFunction<? super Long, ? super Long, ? extends Long>
             remappingFunction) {
-      Long newValue = remappingFunction.apply(key, entries.get(key));
+      Long current = entries.get(key);
+      Long newValue = current == null ? value :
+          remappingFunction.apply(current, value);
       if (newValue == null) {
         entries.remove(key);
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR updates DiskBalancer delta size tracking to use atomic map updates.

DiskBalancer uses `deltaSizes` to track scheduled bytes per source volume. Previously, some updates were done with separate read and write operations, such as `getOrDefault(...)` followed by `put(...)`. These operations are not atomic, so concurrent DiskBalancer tasks updating the same source volume could overwrite each other and leave an incorrect delta size.

This change introduces helper methods to reserve and release delta size using `ConcurrentHashMap.compute(...)`, so each per-volume update is applied atomically. It also removes zero-value entries after the reserved bytes are fully released.

A unit test is added to cover concurrent task completion and verify that the delta size is restored correctly.


## What is the link to the Apache JIRA

JIRA: HDDS-15346. DiskBalancer should update delta sizes atomically.

## How was this patch tested?

Added unit test.