### PR TITLE
HDDS-15347. Move virtual-host test out of smoketest/s3

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/ec-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/ec-test.sh
@@ -17,8 +17,7 @@
 
 start_docker_env 5
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-execute_robot_test scm -v BUCKET:erasure --exclude virtual-host s3
+execute_robot_test scm -v BUCKET:erasure s3
 
 execute_robot_test scm ec/rewrite.robot
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test-haproxy-s3g.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test-haproxy-s3g.sh
@@ -30,11 +30,9 @@ source "$COMPOSE_DIR/../testlib.sh"
 
 start_docker_env
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-exclude="--exclude virtual-host"
+exclude=""
 for bucket in generated; do
   execute_robot_test ${SCM} -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
   # some tests are independent of the bucket type, only need to be run once
-  ## Exclude awss3virtualhost.robot
-  exclude="--exclude virtual-host --exclude no-bucket-type"
+  exclude="--exclude no-bucket-type"
 done

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -37,13 +37,12 @@ execute_robot_test ${SCM} basic/links.robot
 
 execute_robot_test ${SCM} -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-ofs-link ozonefs/ozonefs.robot
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-exclude="--exclude virtual-host"
+exclude=""
 for bucket in generated; do
   for layout in OBJECT_STORE LEGACY FILE_SYSTEM_OPTIMIZED; do
     execute_robot_test ${SCM} -v BUCKET:${bucket} -v BUCKET_LAYOUT:${layout} -N s3-${layout}-${bucket} ${exclude} s3
     # some tests are independent of the bucket type, only need to be run once
-    exclude="--exclude virtual-host --exclude no-bucket-type"
+    exclude="--exclude no-bucket-type"
   done
 done
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-haproxy-s3g.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-haproxy-s3g.sh
@@ -35,11 +35,9 @@ start_docker_env
 
 execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-exclude="--exclude virtual-host"
+exclude=""
 for bucket in encrypted; do
   execute_robot_test recon -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
   # some tests are independent of the bucket type, only need to be run once
-  ## Exclude virtual-host.robot
-  exclude="--exclude virtual-host --exclude no-bucket-type"
+  exclude="--exclude no-bucket-type"
 done

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-s3g-virtual-host.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-s3g-virtual-host.sh
@@ -33,4 +33,4 @@ source "$COMPOSE_DIR/../testlib.sh"
 start_docker_env
 
 ## Run virtual host test cases
-execute_robot_test s3g -N s3-virtual-host s3/awss3virtualhost.robot
+execute_robot_test s3g -N s3-virtual-host awss3virtualhost.robot

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -46,13 +46,11 @@ execute_robot_test s3g -v SCHEME:o3fs -v BUCKET_TYPE:link -N ozonefs-o3fs-link o
 
 execute_robot_test s3g basic/links.robot
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-exclude="--exclude virtual-host"
+exclude=""
 for bucket in link; do
   execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
   # some tests are independent of the bucket type, only need to be run once
-  ## Exclude virtual-host.robot
-  exclude="--exclude virtual-host --exclude no-bucket-type"
+  exclude="--exclude no-bucket-type"
 done
 
 # Run Fault Injection tests at the end

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-vault.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-vault.sh
@@ -30,5 +30,4 @@ export COMPOSE_FILE=docker-compose.yaml:vault.yaml
 
 start_docker_env
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-execute_robot_test scm --exclude virtual-host s3
+execute_robot_test scm s3

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -43,13 +43,11 @@ execute_robot_test scm repair/bucket-encryption.robot
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-ofs-bucket ozonefs/ozonefs.robot
 
-## Exclude virtual-host tests. This is tested separately as it requires additional config.
-exclude="--exclude virtual-host"
+exclude=""
 for bucket in encrypted; do
   execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
   # some tests are independent of the bucket type, only need to be run once
-  ## Exclude virtual-host.robot
-  exclude="--exclude virtual-host --exclude no-bucket-type"
+  exclude="--exclude no-bucket-type"
 done
 
 #expects 4 pipelines, should be run before

--- a/hadoop-ozone/dist/src/main/smoketest/awss3virtualhost.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/awss3virtualhost.robot
@@ -17,11 +17,10 @@
 Documentation       S3 gateway test with aws cli using virtual host style address
 Library             OperatingSystem
 Library             String
-Resource            ../commonlib.robot
-Resource            ./commonawslib.robot
+Resource            commonlib.robot
+Resource            s3/commonawslib.robot
 Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
-Default Tags        virtual-host
 
 *** Variables ***
 ${ENDPOINT_URL}                http://s3g.internal:9878


### PR DESCRIPTION
## What changes were proposed in this pull request?

`smoketest/s3/awss3virtualhost.robot` requires special configuration (`ozone.s3g.domain.name`), so it does not work with most acceptance test environments.  When running all tests in `smoketest/s3`, this test currently needs to be excluded, e.g.:

https://github.com/apache/ozone/blob/c13a0c0fcb478266aec94f5aa9eb8df7265abad6/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh#L40-L41

We can avoid the need for exclusion by moving it to another directory.

https://issues.apache.org/jira/browse/HDDS-15347

## How was this patch tested?

```
s3-virtual-host :: S3 gateway test with aws cli using virtual host style ad...
==============================================================================
File upload and directory list with virtual style addressing          | PASS |
------------------------------------------------------------------------------
s3-virtual-host :: S3 gateway test with aws cli using virtual host... | PASS |
1 test, 1 passed, 0 failed
```

https://github.com/adoroszlai/ozone/actions/runs/26282681788/job/77364249255#step:13:1357

CI:
https://github.com/adoroszlai/ozone/actions/runs/26282681788