### PR TITLE
HDDS-15185. Create submodule ozone-cli-interactive

### DIFF
--- a/hadoop-ozone/cli-interactive/pom.xml
+++ b/hadoop-ozone/cli-interactive/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.ozone</groupId>
+    <artifactId>ozone</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>ozone-cli-interactive</artifactId>
+  <version>2.2.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Apache Ozone CLI Interactive</name>
+  <description>Apache Ozone top-level interactive CLI</description>
+
+  <properties>
+    <classpath.skip>false</classpath.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli-shell-jline3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-cli-admin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-cli-debug</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-cli-shell</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/hadoop-ozone/cli-interactive/pom.xml
+++ b/hadoop-ozone/cli-interactive/pom.xml
@@ -52,10 +52,6 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/hadoop-ozone/cli-interactive/src/main/java/org/apache/hadoop/ozone/shell/OzoneInteractiveShell.java
+++ b/hadoop-ozone/cli-interactive/src/main/java/org/apache/hadoop/ozone/shell/OzoneInteractiveShell.java
@@ -17,9 +17,10 @@
 
 package org.apache.hadoop.ozone.shell;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.hadoop.ozone.admin.OzoneAdmin;
+import org.apache.hadoop.ozone.debug.OzoneDebug;
+import org.apache.hadoop.ozone.shell.s3.S3Shell;
+import org.apache.hadoop.ozone.shell.tenant.TenantShell;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.shell.jline3.PicocliCommands.PicocliCommandsFactory;
@@ -29,8 +30,6 @@ import picocli.shell.jline3.PicocliCommands.PicocliCommandsFactory;
  */
 public final class OzoneInteractiveShell {
 
-  private static final Logger LOG = LoggerFactory.getLogger(OzoneInteractiveShell.class);
-
   private OzoneInteractiveShell() {
   }
 
@@ -38,15 +37,11 @@ public final class OzoneInteractiveShell {
     PicocliCommandsFactory factory = new PicocliCommandsFactory();
     CommandLine topCmd = new CommandLine(new TopCommand(), factory);
 
-    // Add known subcommands statically if they are in the same module.
     topCmd.addSubcommand("sh", new OzoneShell().getCmd());
-    topCmd.addSubcommand("tenant", new org.apache.hadoop.ozone.shell.tenant.TenantShell().getCmd());
-    topCmd.addSubcommand("s3", new org.apache.hadoop.ozone.shell.s3.S3Shell().getCmd());
-
-    // Dynamically add subcommands from other modules to avoid circular dependencies.
-    addDynamicSubcommand(topCmd, "admin", "org.apache.hadoop.ozone.admin.OzoneAdmin");
-    addDynamicSubcommand(topCmd, "debug", "org.apache.hadoop.ozone.debug.OzoneDebug");
-    addDynamicSubcommand(topCmd, "repair", "org.apache.hadoop.ozone.repair.OzoneRepair");
+    topCmd.addSubcommand("tenant", new TenantShell().getCmd());
+    topCmd.addSubcommand("s3", new S3Shell().getCmd());
+    topCmd.addSubcommand("admin", new OzoneAdmin().getCmd());
+    topCmd.addSubcommand("debug", new OzoneDebug().getCmd());
 
     Shell dummyShell = new Shell() {
       @Override
@@ -63,18 +58,8 @@ public final class OzoneInteractiveShell {
     new REPL(dummyShell, topCmd, factory, null);
   }
 
-  private static void addDynamicSubcommand(CommandLine topCmd, String name, String className) {
-    try {
-      Class<?> clazz = Class.forName(className);
-      GenericCli instance = (GenericCli) clazz.getDeclaredConstructor().newInstance();
-      topCmd.addSubcommand(name, instance.getCmd());
-    } catch (Exception e) {
-      LOG.debug("Subcommand {} not loaded: class {} not found or could not be instantiated", 
-          name, className, e);
-    }
-  }
-
-  @Command(name = "ozone", description = "Interactive Shell for all Ozone commands", mixinStandardHelpOptions = true)
+  @Command(name = "ozone", description = "Interactive Shell for all Ozone commands",
+      mixinStandardHelpOptions = true)
   private static class TopCommand implements Runnable {
     @Override
     public void run() {

--- a/hadoop-ozone/cli-interactive/src/main/java/org/apache/hadoop/ozone/shell/package-info.java
+++ b/hadoop-ozone/cli-interactive/src/main/java/org/apache/hadoop/ozone/shell/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Top-level interactive CLI for Ozone.
+ */
+package org.apache.hadoop.ozone.shell;

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -82,6 +82,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-cli-interactive</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-cli-repair</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -218,6 +218,7 @@ share/ozone/lib/osgi-resource-locator.jar
 share/ozone/lib/ozone-client.jar
 share/ozone/lib/ozone-cli-admin.jar
 share/ozone/lib/ozone-cli-debug.jar
+share/ozone/lib/ozone-cli-interactive.jar
 share/ozone/lib/ozone-cli-repair.jar
 share/ozone/lib/ozone-cli-shell.jar
 share/ozone/lib/ozone-common.jar

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -224,14 +224,8 @@ function ozonecmd_case
     ;;
     interactive)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneInteractiveShell
-      OZONE_RUN_ARTIFACT_NAME="ozone-cli-shell"
+      OZONE_RUN_ARTIFACT_NAME="ozone-cli-interactive"
       OZONE_OPTS="${OZONE_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
-      # Add all CLI classpaths to support all subcommands dynamically
-      for cp_file in "ozone-cli-admin" "ozone-cli-debug" "ozone-cli-repair" "ozone-tools"; do
-        if [[ -f "${OZONE_HOME}/share/ozone/classpath/${cp_file}.classpath" ]]; then
-          ozone_add_classpath_from_file "${OZONE_HOME}/share/ozone/classpath/${cp_file}.classpath"
-        fi
-      done
     ;;
     admin)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.admin.OzoneAdmin

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -27,6 +27,7 @@
   <modules>
     <module>cli-admin</module>
     <module>cli-debug</module>
+    <module>cli-interactive</module>
     <module>cli-repair</module>
     <module>cli-shell</module>
     <module>client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1236,6 +1236,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-cli-interactive</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
         <artifactId>ozone-cli-repair</artifactId>
         <version>${ozone.version}</version>
       </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15185. Create submodule ozone-cli-interactive

This change introduces a dedicated Maven module `ozone-cli-interactive` for the top-level `ozone interactive` command and refactors how subcommands are wired into the interactive shell.

Please describe your PR in detail:
[HDDS-11838](https://issues.apache.org/jira/browse/HDDS-11838) / [#10134](https://github.com/apache/ozone/pull/10134) added `OzoneInteractiveShell` under `ozone-cli-shell`. Subcommands in the same module (`sh`, `tenant`, `s3`) were registered statically, while `admin`, `debug`, and `repair` were loaded at runtime via reflection (`Class.forName`). The `ozone` launcher script also stitched additional CLI classpaths at runtime for the `interactive` subcommand. That approach works but is fragile and harder to maintain.
This PR addresses the follow-up described in [HDDS-15185](https://issues.apache.org/jira/browse/HDDS-15185) (parent: [HDDS-11825](https://issues.apache.org/jira/browse/HDDS-11825)):
* **New module `ozone-cli-interactive`** — `OzoneInteractiveShell` is moved from `ozone-cli-shell` into this module.
* **Static Maven dependencies** — the interactive module depends on `ozone-cli-shell`, `ozone-cli-admin`, and `ozone-cli-debug` (per Jira: **except repair**). Subcommands are registered with regular method calls (`new OzoneAdmin().getCmd()`, etc.); reflection and `addDynamicSubcommand()` are removed.
* **Dist and launcher** — `ozone-dist` depends on `ozone-cli-interactive`; the `interactive` branch in `hadoop-ozone/dist/src/shell/ozone/ozone` sets `OZONE_RUN_ARTIFACT_NAME=ozone-cli-interactive` and drops the loop that dynamically appended admin/debug/repair/tools classpaths.
* **License metadata** — `jar-report.txt` is updated for `ozone-cli-interactive.jar` in the distribution.
The interactive user experience (`ozone>` prompt, JLine/Picocli REPL in `REPL.java`) is unchanged; only packaging and command registration are improved.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15185

## How was this patch tested?

* CI workflow runs on the contributor fork (`will-sh/ozone`, branch `HDDS-15185`) is successful.
* Manual smoke test: build dist, start docker compose cluster, run `ozone interactive` and exercise `sh`, `admin`, and `debug` subcommands; confirm `repair` is not exposed as a top-level interactive subcommand per Jira scope.
