### PR TITLE
HDDS-15357. Fix MappedBufferManager WeakReference races

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/MappedBufferManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/MappedBufferManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.keyvalue.impl;
 import com.google.common.util.concurrent.Striped;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
@@ -57,10 +58,14 @@ public class MappedBufferManager {
         CompletableFuture.runAsync(() -> {
           int p = 0;
           try {
-            for (String key : mappedBuffers.keySet()) {
-              ByteBuffer buf = mappedBuffers.get(key).get();
-              if (buf == null) {
-                mappedBuffers.remove(key);
+            // remove(key, value) only counts entries we observed cleared,
+            // so a concurrent put() that replaced the WeakReference is not
+            // miscounted as freed.
+            for (Map.Entry<String, WeakReference<ByteBuffer>> entry
+                : mappedBuffers.entrySet()) {
+              final WeakReference<ByteBuffer> ref = entry.getValue();
+              if (ref.get() == null
+                  && mappedBuffers.remove(entry.getKey(), ref)) {
                 p++;
               }
             }
@@ -93,14 +98,16 @@ public class MappedBufferManager {
     Lock fileLock = lock.get(key);
     fileLock.lock();
     try {
-      WeakReference<ByteBuffer> refer = mappedBuffers.get(key);
-      if (refer != null && refer.get() != null) {
-        // reuse the mapped buffer
+      // Hold a strong reference for the rest of this method so GC cannot
+      // clear the WeakReference between the null check and the return.
+      final WeakReference<ByteBuffer> refer = mappedBuffers.get(key);
+      final ByteBuffer cached = refer != null ? refer.get() : null;
+      if (cached != null) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("find buffer for key {}", key);
         }
         releaseQuota(1);
-        return refer.get();
+        return cached;
       }
 
       ByteBuffer buffer = supplier.get();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MappedBufferManager` caches mapped buffers as `WeakReference<ByteBuffer>` and tracks in-flight quota via a `Semaphore`. Two races on master:

1. `computeIfAbsent` GC race: The cache-hit branch reads `refer.get()` once for a null check and a second time at the return. Between the two reads, the `WeakReference` is the only handle to the buffer. GC may clear it, the second read returns `null`, and `ChunkUtils.readData` then dereferences a null `IOException` (`throw null`).

2. Cleanup-loop races in `getQuota`: The async loop walks `mappedBuffers.keySet()` and re-looks up each key. A concurrent `remove()` makes the lookup return `null` and the chained `.get()` NPEs. A concurrent `put()` that replaces the `WeakReference` makes the unconditional `mappedBuffers.remove(key)` drop someone else's fresh entry. `p` is incremented for it, and `releaseQuota(p)` over-releases the semaphore.

### Fix

* `computeIfAbsent` resolves `refer.get()` once into a local `final ByteBuffer cached` and returns that. The stack-local strong reference keeps the buffer reachable until the method returns.
* The cleanup loop iterates entries directly (no key-then-get re-lookup, no NPE) and uses `ConcurrentHashMap.remove(key, value)` so a concurrent `put()` that replaced the `WeakReference` returns `false` from the conditional remove and is not counted as freed quota.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15357

## How was this patch tested?

- Existing tests