### PR TITLE
HDDS-14443. Documentation and Scripting Inconsistencies for Ozone Environment Variables

### DIFF
--- a/hadoop-hdds/common/src/main/conf/ozone-env.sh
+++ b/hadoop-hdds/common/src/main/conf/ozone-env.sh
@@ -220,16 +220,6 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # Java property: hadoop.policy.file
 # export OZONE_POLICYFILE="hadoop-policy.xml"
 
-#
-# NOTE: this is not used by default!  <-----
-# You can define variables right here and then re-use them later on.
-# For example, it is common to use the same garbage collection settings
-# for all the daemons.  So one could define:
-#
-# export OZONE_GC_SETTINGS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
-#
-# .. and then use it when setting OZONE_OM_OPTS, etc. below
-
 ###
 # Secure/privileged execution
 ###
@@ -257,13 +247,6 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # This directory contains the logs for secure and privileged processes.
 # Java property: hadoop.log.dir
 # export OZONE_SECURE_LOG_DIR=${OZONE_LOG_DIR}
-
-#
-# When running a secure daemon, the default value of OZONE_IDENT_STRING
-# ends up being a bit bogus.  Therefore, by default, the code will
-# replace OZONE_IDENT_STRING with OZONE_xx_SECURE_USER.  If one wants
-# to keep OZONE_IDENT_STRING untouched, then uncomment this line.
-# export OZONE_SECURE_IDENT_PRESERVE="true"
 
 ###
 # Ozone Manager specific parameters

--- a/hadoop-hdds/common/src/main/conf/ozone-env.sh
+++ b/hadoop-hdds/common/src/main/conf/ozone-env.sh
@@ -256,7 +256,7 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 #
 # This directory contains the logs for secure and privileged processes.
 # Java property: hadoop.log.dir
-# export OZONE_SECURE_LOG=${OZONE_LOG_DIR}
+# export OZONE_SECURE_LOG_DIR=${OZONE_LOG_DIR}
 
 #
 # When running a secure daemon, the default value of OZONE_IDENT_STRING

--- a/hadoop-hdds/common/src/main/conf/ozone-env.sh
+++ b/hadoop-hdds/common/src/main/conf/ozone-env.sh
@@ -154,6 +154,10 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # helper scripts # such as workers.sh, start-ozone.sh, etc.
 # export OZONE_WORKERS="${OZONE_CONF_DIR}/workers"
 
+# A space-separated list of worker host names, used as an alternative to the
+# OZONE_WORKERS file.  Only one of OZONE_WORKERS or OZONE_WORKER_NAMES may be set.
+# export OZONE_WORKER_NAMES=""
+
 ###
 # Options for all daemons
 ###
@@ -167,6 +171,15 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # or set differently in certain contexts (e.g., secure vs
 # non-secure)
 #
+
+# Extra Java runtime options for all Ozone server daemons (OM, SCM, DataNode,
+# S3 Gateway, Recon, HttpFS, CSI).  These get appended to OZONE_OPTS for such
+# daemons and are a convenient way to apply common options to all of them.
+# export OZONE_SERVER_OPTS=""
+
+# Simple override of the default log level used to build OZONE_ROOT_LOGGER and
+# OZONE_DAEMON_ROOT_LOGGER.  Defaults to INFO.
+# export OZONE_LOGLEVEL=INFO
 
 # Where (primarily) daemon log files are stored.
 # ${OZONE_HOME}/logs by default.
@@ -232,6 +245,9 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # protocol.  Jsvc is not required if SASL is configured for authentication of
 # data transfer protocol using non-privileged ports.
 # export JSVC_HOME=/usr/bin
+
+# Extra arguments to pass to jsvc when launching secure/privileged daemons.
+# export OZONE_DAEMON_JSVC_EXTRA_OPTS=""
 
 #
 # This directory contains pids for secure and privileged processes.

--- a/hadoop-hdds/common/src/main/conf/ozone-env.sh
+++ b/hadoop-hdds/common/src/main/conf/ozone-env.sh
@@ -277,6 +277,57 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # export OZONE_SCM_OPTS=""
 
 ###
+# S3 Gateway specific parameters
+###
+# Specify the JVM options to be used when starting the S3 Gateway.
+# These options will be appended to the options specified as OZONE_OPTS
+# and therefore may override any similar flags set in OZONE_OPTS
+#
+# export OZONE_S3G_OPTS=""
+
+###
+# Recon specific parameters
+###
+# Specify the JVM options to be used when starting Recon.
+# These options will be appended to the options specified as OZONE_OPTS
+# and therefore may override any similar flags set in OZONE_OPTS
+#
+# export OZONE_RECON_OPTS=""
+
+###
+# HttpFS Gateway specific parameters
+###
+# Specify the JVM options to be used when starting the HttpFS Gateway.
+# These options will be appended to the options specified as OZONE_OPTS
+# and therefore may override any similar flags set in OZONE_OPTS
+#
+# export OZONE_HTTPFS_OPTS=""
+
+###
+# CSI server specific parameters
+###
+# Specify the JVM options to be used when starting the CSI server.
+# These options will be appended to the options specified as OZONE_OPTS
+# and therefore may override any similar flags set in OZONE_OPTS
+#
+# export OZONE_CSI_OPTS=""
+
+###
+# Client and tool command specific parameters
+###
+# Specify the JVM options to be used when running the corresponding command
+# (ozone sh, fs, admin, debug, freon, vapor).  These options will be appended
+# to the options specified as OZONE_OPTS and therefore may override any
+# similar flags set in OZONE_OPTS
+#
+# export OZONE_SH_OPTS=""
+# export OZONE_FS_OPTS=""
+# export OZONE_ADMIN_OPTS=""
+# export OZONE_DEBUG_OPTS=""
+# export OZONE_FREON_OPTS=""
+# export OZONE_VAPOR_OPTS=""
+
+###
 # Advanced Users Only!
 ###
 

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -177,7 +177,7 @@ function ozonecmd_case
     ;;
     httpfs)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
-      OZONE_OPTS="${OZONE_OPTS} ${RATIS_OPTS} -Dhttpfs.home.dir=${OZONE_HOME} -Dhttpfs.config.dir=${OZONE_CONF_DIR} -Dhttpfs.log.dir=${OZONE_HOME}/log -Dhttpfs.temp.dir=${OZONE_HOME}/temp -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties ${OZONE_MODULE_ACCESS_ARGS}"
+      OZONE_HTTPFS_OPTS="${OZONE_HTTPFS_OPTS} ${RATIS_OPTS} -Dhttpfs.home.dir=${OZONE_HOME} -Dhttpfs.config.dir=${OZONE_CONF_DIR} -Dhttpfs.log.dir=${OZONE_HOME}/log -Dhttpfs.temp.dir=${OZONE_HOME}/temp -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_CLASSNAME='org.apache.ozone.fs.http.server.HttpFSServerWebServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-httpfsgateway"
     ;;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The environment variables used to configure and run Ozone are inconsistent between the shell scripts (`ozone`, `ozone-functions.sh`) and the file that documents them, `ozone-env.sh`. This leaves several useful variables undocumented, documents one variable under a name the scripts never read, and keeps dead examples around, all of which confuses operators. This PR aligns the documentation with the actual behavior of the scripts and makes the HttpFS gateway consistent with the other daemons.

The change is split into one commit per fix:

1. **Add `OZONE_HTTPFS_OPTS` support for the httpfs subcommand.** Previously the `httpfs)` case in the `ozone` launcher hard-coded its JVM properties directly into `OZONE_OPTS`, the only daemon to do so. It now seeds a dedicated `OZONE_HTTPFS_OPTS` variable, exactly mirroring the `recon)` and `s3g)` cases. The generic `ozone_subcommand_opts` handler then folds it into `OZONE_OPTS`, so a user-supplied `OZONE_HTTPFS_OPTS` is honored.
2. **Document the missing component `_OPTS` variables** in `ozone-env.sh`: `OZONE_S3G_OPTS`, `OZONE_RECON_OPTS`, `OZONE_HTTPFS_OPTS`, `OZONE_CSI_OPTS`, and the client/tool ones (`OZONE_SH_OPTS`, `OZONE_FS_OPTS`, `OZONE_ADMIN_OPTS`, `OZONE_DEBUG_OPTS`, `OZONE_FREON_OPTS`, `OZONE_VAPOR_OPTS`).
3. **Document other supported-but-undocumented variables**: `OZONE_SERVER_OPTS`, `OZONE_WORKER_NAMES`, `OZONE_DAEMON_JSVC_EXTRA_OPTS`, `OZONE_LOGLEVEL`.
4. **Correct the secure-log variable name** from `OZONE_SECURE_LOG` to `OZONE_SECURE_LOG_DIR`, which is what `ozone-functions.sh` actually reads. Setting the documented name previously had no effect.
5. **Remove dead examples** `OZONE_GC_SETTINGS` and `OZONE_SECURE_IDENT_PRESERVE`, which are no longer read anywhere in the scripts.

Only comments/documentation change except for fix 1, which is a one-line consistency refactor of the `httpfs)` case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14443

## How was this patch tested?

Manual testing against a locally built distribution (`mvn -Pdist -DskipTests clean install`), with the commands run under `bash` (not the macOS default shell):

**1. Syntax check the edited scripts**

```bash
bash -n hadoop-ozone/dist/src/shell/ozone/ozone
bash -n hadoop-hdds/common/src/main/conf/ozone-env.sh
```

**2. Verify the generic handler folds `OZONE_HTTPFS_OPTS` into `OZONE_OPTS`**

```bash
D=hadoop-ozone/dist/target/ozone-*-SNAPSHOT
bash -c '
  source '"$D"'/libexec/ozone-functions.sh
  OZONE_OPTS="-Dexisting=1"
  OZONE_HTTPFS_OPTS="-Dfoo=bar -Dhttpfs.home.dir=/x"
  ozone_subcommand_opts "ozone" "httpfs"
  echo "$OZONE_OPTS"
'
# => -Dexisting=1 -Dfoo=bar -Dhttpfs.home.dir=/x
```

**3. End-to-end through the launcher, using a stub `java` that echoes its args instead of starting the daemon**

```bash
D=$(ls -d hadoop-ozone/dist/target/ozone-*-SNAPSHOT)

# stub JAVA_HOME/bin/java that prints the assembled command and exits
mkdir -p /tmp/stubjava/bin
printf '#!/usr/bin/env bash\necho "JAVA-CMD: $*"\nexit 0\n' > /tmp/stubjava/bin/java
chmod +x /tmp/stubjava/bin/java

JAVA_HOME=/tmp/stubjava OZONE_HTTPFS_OPTS="-Dfoo=bar" "$D/bin/ozone" httpfs
# JAVA-CMD line contains both the user-supplied -Dfoo=bar AND the
# built-in -Dhttpfs.home.dir / -Dhttpfs.config.dir properties.

# parity: recon handles OZONE_RECON_OPTS the same way
JAVA_HOME=/tmp/stubjava OZONE_RECON_OPTS="-Dfoo=bar" "$D/bin/ozone" recon
```

Results: the user-set `OZONE_HTTPFS_OPTS` reaches the final java command while the built-in HttpFS properties are preserved, and `recon` behaves identically, confirming the intended consistency.

No new unit test was added: the changed `httpfs)` branch lives in `ozonecmd_case` in the launcher, which has no bats harness, and the sibling cases it mirrors (`recon)`, `s3g)`, `om)`) are likewise untested at that level; the append itself goes through the already-exercised `ozone_subcommand_opts`. HttpFS is covered by the `compose/httpfs` acceptance suite.
