### PR TITLE
HDDS-15359. Read chunks into pooled direct buffers

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.util.DirectBufferPool;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,13 +36,21 @@ public final class BufferUtils {
 
   private static final ByteBuffer[] EMPTY_BYTE_BUFFER_ARRAY = {};
 
+  /** Pool for reusing direct {@link ByteBuffer}s allocated by {@link #assignByteBuffers}. */
+  public static final DirectBufferPool BUFFER_POOL = new DirectBufferPool();
+
   /** Utility classes should not be constructed. **/
   private BufferUtils() {
 
   }
 
   /**
-   * Assign an array of ByteBuffers.
+   * Allocate an array of direct {@link ByteBuffer}s drawn from
+   * {@link #BUFFER_POOL}, sized to hold {@code totalLen} bytes split into
+   * slices of at most {@code bufferCapacity} bytes each.  Callers are
+   * responsible for returning each buffer via
+   * {@link DirectBufferPool#returnBuffer} when finished.
+   *
    * @param totalLen total length of all ByteBuffers
    * @param bufferCapacity max capacity of each ByteBuffer
    */
@@ -58,13 +67,15 @@ public final class BufferUtils {
     long allocatedLen = 0;
     // For each ByteBuffer (except the last) allocate bufferLen of capacity
     for (int i = 0; i < numBuffers - 1; i++) {
-      dataBuffers[i] = ByteBuffer.allocate(bufferCapacity);
+      dataBuffers[i] = BUFFER_POOL.getBuffer(bufferCapacity);
+      dataBuffers[i].limit(bufferCapacity);
       allocatedLen += bufferCapacity;
     }
     // For the last ByteBuffer, allocate as much space as is needed to fit
     // remaining bytes
-    dataBuffers[numBuffers - 1] = ByteBuffer.allocate(
-        Math.toIntExact(totalLen - allocatedLen));
+    final int lastLen = Math.toIntExact(totalLen - allocatedLen);
+    dataBuffers[numBuffers - 1] = BUFFER_POOL.getBuffer(lastLen);
+    dataBuffers[numBuffers - 1].limit(lastLen);
     return dataBuffers;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -202,18 +202,25 @@ public final class ChunkUtils {
   @SuppressWarnings("checkstyle:parameternumber")
   public static ChunkBuffer readData(long len, int bufferCapacity,
       File file, long off, HddsVolume volume, int readMappedBufferThreshold, boolean mmapEnabled,
-      MappedBufferManager mappedBufferManager) throws StorageContainerException {
+      MappedBufferManager mappedBufferManager, DispatcherContext dispatcherContext)
+      throws StorageContainerException {
     if (mmapEnabled && len > readMappedBufferThreshold && bufferCapacity > readMappedBufferThreshold) {
-      return readData(file, bufferCapacity, off, len, volume, mappedBufferManager);
+      return readData(file, bufferCapacity, off, len, volume, mappedBufferManager, dispatcherContext);
     } else if (len == 0) {
       return ChunkBuffer.wrap(Collections.emptyList());
+    } else {
+      final ByteBuffer[] buffers = BufferUtils.assignByteBuffers(len, bufferCapacity);
+      readData(file, off, len, c -> c.position(off).read(buffers), volume);
+      Arrays.stream(buffers).forEach(ByteBuffer::flip);
+      if (dispatcherContext != null && dispatcherContext.isReleaseSupported()) {
+        dispatcherContext.setReleaseMethod(() -> {
+          for (ByteBuffer buf : buffers) {
+            BufferUtils.BUFFER_POOL.returnBuffer(buf);
+          }
+        });
+      }
+      return ChunkBuffer.wrap(Arrays.asList(buffers));
     }
-
-    final ByteBuffer[] buffers = BufferUtils.assignByteBuffers(len,
-        bufferCapacity);
-    readData(file, off, len, c -> c.position(off).read(buffers), volume);
-    Arrays.stream(buffers).forEach(ByteBuffer::flip);
-    return ChunkBuffer.wrap(Arrays.asList(buffers));
   }
 
   private static void readData(File file, long offset, long len,
@@ -253,16 +260,23 @@ public final class ChunkUtils {
    * @return a list of {@link MappedByteBuffer} containing the data.
    */
   private static ChunkBuffer readData(File file, int chunkSize,
-      long offset, long length, HddsVolume volume, MappedBufferManager mappedBufferManager)
+      long offset, long length, HddsVolume volume, MappedBufferManager mappedBufferManager,
+      DispatcherContext dispatcherContext)
       throws StorageContainerException {
 
     final int bufferNum = Math.toIntExact((length - 1) / chunkSize) + 1;
     if (!mappedBufferManager.getQuota(bufferNum)) {
       // proceed with normal buffer
-      final ByteBuffer[] buffers = BufferUtils.assignByteBuffers(length,
-          chunkSize);
+      final ByteBuffer[] buffers = BufferUtils.assignByteBuffers(length, chunkSize);
       readData(file, offset, length, c -> c.position(offset).read(buffers), volume);
       Arrays.stream(buffers).forEach(ByteBuffer::flip);
+      if (dispatcherContext != null && dispatcherContext.isReleaseSupported()) {
+        dispatcherContext.setReleaseMethod(() -> {
+          for (ByteBuffer buf : buffers) {
+            BufferUtils.BUFFER_POOL.returnBuffer(buf);
+          }
+        });
+      }
       return ChunkBuffer.wrap(Arrays.asList(buffers));
     } else {
       try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -244,7 +244,8 @@ public class FilePerBlockStrategy implements ChunkManager {
       return ChunkUtils.readData(chunkFile, bufferCapacity, offset, len, volume, dispatcherContext);
     }
     return ChunkUtils.readData(len, bufferCapacity, chunkFile, offset, volume,
-        readMappedBufferThreshold, readMappedBufferMaxCount > 0, mappedBufferManager);
+        readMappedBufferThreshold, readMappedBufferMaxCount > 0, mappedBufferManager,
+        dispatcherContext);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -275,7 +275,8 @@ public class FilePerChunkStrategy implements ChunkManager {
             return ChunkUtils.readData(file, bufferCapacity, offset, len, volume, dispatcherContext);
           }
           return ChunkUtils.readData(len, bufferCapacity, file, offset, volume,
-              readMappedBufferThreshold, readMappedBufferMaxCount > 0, mappedBufferManager);
+              readMappedBufferThreshold, readMappedBufferMaxCount > 0, mappedBufferManager,
+              dispatcherContext);
         }
       } catch (StorageContainerException ex) {
         //UNABLE TO FIND chunk is not a problem as we will try with the

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -78,7 +78,7 @@ class TestChunkUtils {
       throws StorageContainerException {
     LOG.info("off={}, len={}", off, len);
     return ChunkUtils.readData(len, BUFFER_CAPACITY, file, off, null,
-        MAPPED_BUFFER_THRESHOLD, true, MAPPED_BUFFER_MANAGER);
+        MAPPED_BUFFER_THRESHOLD, true, MAPPED_BUFFER_MANAGER, null);
   }
 
   @Test
@@ -169,12 +169,15 @@ class TestChunkUtils {
             assertEquals(1, buffers.size());
             final ByteBuffer readBuffer = buffers.get(0);
 
+            int remaining = readBuffer.remaining();
+            byte[] readArray = new byte[remaining];
+            readBuffer.get(readArray);
             LOG.info("Read data ({}): {}", threadNumber,
-                new String(readBuffer.array(), UTF_8));
-            if (!Arrays.equals(array, readBuffer.array())) {
+                new String(readArray, UTF_8));
+            if (!Arrays.equals(array, readArray)) {
               fail.getAndIncrement();
             }
-            assertEquals(len, readBuffer.remaining());
+            assertEquals(len, remaining);
           } catch (Exception ee) {
             LOG.error("Failed to read data ({})", threadNumber, ee);
             fail.getAndIncrement();


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.7)

## What changes were proposed in this pull request?

`BufferUtils.assignByteBuffers` previously allocated heap `ByteBuffer`s for chunk reads. Reading from a `FileChannel` into a heap buffer forces the JDK to first read into a thread-local `DirectByteBuffer` (in `sun.nio.ch.IOUtil`) and then memcpy the chunk-sized payload into the user's heap buffer. So every default-config chunk read paid one extra user-space chunk-sized memcpy plus one chunk-sized heap allocation.

Two prior PRs added opt-in direct-buffer paths to skip exactly this copy:

* HDDS-7188 (Tsz-Wo Nicholas Sze, Jan 2025): `ChunkUtils.readDataNettyChunkedNioFile` via Netty `PooledByteBufAllocator.DEFAULT`
* HDDS-10488 (Sammi Chen, Sep 2024): `MappedBufferManager` mmap reads with semaphore-tracked quota

Both deliberately avoided raw `ByteBuffer.allocateDirect` because it is a known leak pattern under sustained load. Tiny wrapper objects mean GC fires rarely, the `Cleaner` that frees direct memory never runs promptly, and the native budget exhausts with `OutOfMemoryError: Direct buffer memory`. Neither PR updated the default `assignByteBuffers` path, so the heap allocation stayed.

This change uses Hadoop's `org.apache.hadoop.util.DirectBufferPool`, the same pool already used by `BlockOutputStream` and `KeyValueContainerCheck`. Release plumbing lives entirely in `ChunkUtils.readData`: a release lambda is registered on `DispatcherContext.setReleaseMethod`, fires once in `GrpcXceiverService`'s `finally` block after `responseObserver.onNext` returns (the standard server marshaller is synchronous, so the response bytes are already serialized into the Netty outgoing buffer by then), and returns each buffer to the pool. Paths without a release-supporting context fall back to GC reclaim via the pool's `WeakReference` layer, so the pool degrades to plain `allocateDirect` rather than leaking. `ChunkBuffer` and `ChunkBufferImplWithByteBufferList` are unchanged from master.

A consumer audit confirmed no `.array()` usage breaks with direct buffers. `ChecksumByteBufferImpl` guards `.array()` with `hasArray()`, and `UnsafeByteOperations.unsafeWrap` of a direct `ByteBuffer` produces a zero-copy `NioByteString` without calling `.array()`. One test (`TestChunkUtils.concurrentReadWriteOfSameFile`) called `.array()` directly and was updated to use `get(byte[])`.

### Expected impact

Per chunk read:

* One chunk-sized user-space memcpy eliminated (~270 µs for a 4 MB chunk on a typical x86 server with ~15 GB/s memory bandwidth).
* One chunk-sized heap allocation eliminated (heap churn moves to bounded direct memory in the pool).

Wall-clock effect depends on storage:

| Storage | Latency per chunk | Effect |
|---|---|---|
| Page-cache hit | sub-ms total | meaningful (memcpy was a large fraction) |
| NVMe sequential | ~1 ms total | ~20 percent reduction |
| SATA SSD | ~10 ms total | a few percent |
| HDD | tens of ms total | invisible at wall-clock |

Heap-churn reduction is consistent across storage tiers: at 100 MB/s read throughput a DN sheds roughly 100 MB/s of heap allocation.

### Pool sizing and operational note

`DirectBufferPool` is unbounded by design (per `ConcurrentMap<Integer, Queue<WeakReference<ByteBuffer>>>`). Steady-state pool memory converges to peak concurrent in-flight buffers per capacity class. For default-config chunk reads (4 MB) on a 64-thread DN, that is roughly 256 MB of direct memory. Operators should ensure `-XX:MaxDirectMemorySize` accommodates this; the existing `BlockOutputStream` and `KeyValueContainerCheck` consumers of `DirectBufferPool` are already sized this way.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15359

## How was this patch tested?

- Existing tests