### PR TITLE
HDDS-15362. [DiskBalancer] Handle zero-capacity volumes in status report.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -743,15 +743,13 @@ public class DiskBalancerService extends BackgroundService {
     List<VolumeReportProto> result = new ArrayList<>();
     for (VolumeFixedUsage v : volumeSet) {
       HddsVolume volume = v.getVolume();
-      double utilization = v.getUsage().getCapacity() == 0
-          ? 0.0 : v.getUtilization();
       VolumeReportProto.Builder builder = VolumeReportProto.newBuilder()
           .setStorageId(volume.getStorageID())
           .setTotalCapacity(v.getUsage().getCapacity())
           .setUsedSpace(v.getUsage().getUsedSpace())
           .setCommittedBytes(volume.getCommittedBytes())
           .setEffectiveUsedSpace(v.getEffectiveUsed())
-          .setUtilization(utilization);
+          .setUtilization(v.getUtilization());
       if (volume.getStorageDir() != null) {
         builder.setStoragePath(volume.getStorageDir().getPath());
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -743,13 +743,15 @@ public class DiskBalancerService extends BackgroundService {
     List<VolumeReportProto> result = new ArrayList<>();
     for (VolumeFixedUsage v : volumeSet) {
       HddsVolume volume = v.getVolume();
+      double utilization = v.getUsage().getCapacity() == 0
+          ? 0.0 : v.getUtilization();
       VolumeReportProto.Builder builder = VolumeReportProto.newBuilder()
           .setStorageId(volume.getStorageID())
           .setTotalCapacity(v.getUsage().getCapacity())
           .setUsedSpace(v.getUsage().getUsedSpace())
           .setCommittedBytes(volume.getCommittedBytes())
           .setEffectiveUsedSpace(v.getEffectiveUsed())
-          .setUtilization(v.getUtilization());
+          .setUtilization(utilization);
       if (volume.getStorageDir() != null) {
         builder.setStoragePath(volume.getStorageDir().getPath());
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java
@@ -174,7 +174,7 @@ public final class DiskBalancerVolumeCalculation {
       this.effectiveUsed = computeEffectiveUsage(usage, volume.getCommittedBytes(), delta);
       this.utilization = usage.getCapacity() > 0
           ? computeUtilization(usage, volume.getCommittedBytes(), delta)
-          : 1.0;
+          : 0.0;
     }
 
     public HddsVolume getVolume() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerVolumeCalculation.java
@@ -22,7 +22,6 @@ import static org.apache.ratis.util.Preconditions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -167,13 +166,15 @@ public final class DiskBalancerVolumeCalculation {
     private final HddsVolume volume;
     private final SpaceUsageSource.Fixed usage;
     private final long effectiveUsed;
-    private final Double utilization;
+    private final double utilization;
 
     private VolumeFixedUsage(HddsVolume volume, long delta) {
       this.volume = volume;
       this.usage = volume.getCurrentUsage();
       this.effectiveUsed = computeEffectiveUsage(usage, volume.getCommittedBytes(), delta);
-      this.utilization = usage.getCapacity() > 0 ? computeUtilization(usage, volume.getCommittedBytes(), delta) : null;
+      this.utilization = usage.getCapacity() > 0
+          ? computeUtilization(usage, volume.getCommittedBytes(), delta)
+          : 1.0;
     }
 
     public HddsVolume getVolume() {
@@ -189,7 +190,7 @@ public final class DiskBalancerVolumeCalculation {
     }
 
     public double getUtilization() {
-      return Objects.requireNonNull(utilization,  "utilization == null");
+      return utilization;
     }
 
     public long computeUsableSpace() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
@@ -84,6 +84,17 @@ class TestDiskBalancerVolumeCalculation {
   }
 
   @Test
+  void buildVolumeReportProtoReportsZeroUtilizationForZeroCapacityVolume()
+      throws IOException {
+    HddsVolume volume = createVolume("zero-capacity-report", 0, 0);
+
+    assertEquals(0.0, DiskBalancerService.buildVolumeReportProto(
+        Collections.singletonList(
+            DiskBalancerVolumeCalculation.newVolumeFixedUsage(volume, null)))
+        .get(0).getUtilization());
+  }
+
+  @Test
   void getIdealUsageRejectsNegativeCapacity() throws IOException {
     HddsVolume negativeCapacityVolume = createVolume(
         "negative-capacity", -1, 0);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
@@ -84,11 +84,20 @@ class TestDiskBalancerVolumeCalculation {
   }
 
   @Test
-  void buildVolumeReportProtoReportsZeroUtilizationForZeroCapacityVolume()
+  void getUtilizationReturnsFullUtilizationForZeroCapacityVolume()
+      throws IOException {
+    HddsVolume volume = createVolume("zero-capacity-utilization", 0, 0);
+
+    assertEquals(1.0, DiskBalancerVolumeCalculation.newVolumeFixedUsage(
+        volume, null).getUtilization());
+  }
+
+  @Test
+  void buildVolumeReportProtoReportsFullUtilizationForZeroCapacityVolume()
       throws IOException {
     HddsVolume volume = createVolume("zero-capacity-report", 0, 0);
 
-    assertEquals(0.0, DiskBalancerService.buildVolumeReportProto(
+    assertEquals(1.0, DiskBalancerService.buildVolumeReportProto(
         Collections.singletonList(
             DiskBalancerVolumeCalculation.newVolumeFixedUsage(volume, null)))
         .get(0).getUtilization());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerVolumeCalculation.java
@@ -84,20 +84,20 @@ class TestDiskBalancerVolumeCalculation {
   }
 
   @Test
-  void getUtilizationReturnsFullUtilizationForZeroCapacityVolume()
+  void getUtilizationReturnsZeroForZeroCapacityVolume()
       throws IOException {
     HddsVolume volume = createVolume("zero-capacity-utilization", 0, 0);
 
-    assertEquals(1.0, DiskBalancerVolumeCalculation.newVolumeFixedUsage(
+    assertEquals(0.0, DiskBalancerVolumeCalculation.newVolumeFixedUsage(
         volume, null).getUtilization());
   }
 
   @Test
-  void buildVolumeReportProtoReportsFullUtilizationForZeroCapacityVolume()
+  void buildVolumeReportProtoReportsZeroUtilizationForZeroCapacityVolume()
       throws IOException {
     HddsVolume volume = createVolume("zero-capacity-report", 0, 0);
 
-    assertEquals(1.0, DiskBalancerService.buildVolumeReportProto(
+    assertEquals(0.0, DiskBalancerService.buildVolumeReportProto(
         Collections.singletonList(
             DiskBalancerVolumeCalculation.newVolumeFixedUsage(volume, null)))
         .get(0).getUtilization());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request fixes a possible `NullPointerException` in the DiskBalancer status/report generation path when a datanode contains a zero-capacity volume.

`VolumeFixedUsage` does not calculate utilization for a volume whose capacity is 0, leaving its utilization value as `null`. However, `DiskBalancerService.buildVolumeReportProto()` previously attempted to retrieve utilization for every volume while constructing status report entries. As a result, a zero-capacity volume could cause DiskBalancer status reporting to fail with `NullPointerException: utilization == null`.

This change keeps zero-capacity volumes in the generated report and reports their utilization as 0.0. Normal volumes continue to use their calculated utilization values. This allows status/report requests to complete successfully while preserving useful information about zero-capacity volumes.

A regression unit test is added to verify that a zero-capacity volume can be included in the volume report with utilization set to 0.0.

## What is the link to the Apache JIRA

HDDS-15362. [DiskBalancer] Handle zero-capacity volumes in status report.

## How was this patch tested?

Added a unit test.

CI: https://github.com/slfan1989/ozone/actions/runs/26357147502