### PR TITLE
HDDS-15363. Remove unused dependency properties-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1521,11 +1521,6 @@
         <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>${properties.maven.plugin.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>guice-bridge</artifactId>
         <version>${hk2.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1789,6 +1789,11 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>properties-maven-plugin</artifactId>
+          <version>${properties.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
           <version>${maven-clean-plugin.version}</version>
@@ -2433,11 +2438,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>${properties.maven.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven.compiler.createMissingPackageInfoClass>false</maven.compiler.createMissingPackageInfoClass>
     <maven.compiler.release>8</maven.compiler.release>
-    <maven.core.version>3.9.15</maven.core.version>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <metainf-services.version>1.11</metainf-services.version>
     <mockito.version>4.11.0</mockito.version>
@@ -2439,13 +2438,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
         <version>${properties.maven.plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven.core.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1637,11 +1637,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-        <version>${jdeb.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
         <version>${sqlite.version}</version>
@@ -2200,6 +2195,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${pmd.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.vafer</groupId>
+          <artifactId>jdeb</artifactId>
+          <version>${jdeb.version}</version>
         </plugin>
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- HDDS-13414 added `properties-maven-plugin` and `jdeb` plugins to `dependencyManagement`.  Move them to `pluginManagement`, where they belong.
- Remove custom `maven-core` version, which is no longer needed after `properties-maven-plugin` upgrade from 1.2.1 to 1.3.0.

https://issues.apache.org/jira/browse/HDDS-15363

## How was this patch tested?

`properties-maven-plugin` continues to [work](https://github.com/adoroszlai/ozone/actions/runs/26358184158/job/77588709421#step:13:1735) (same output as [previously](https://github.com/apache/ozone/actions/runs/26354578790/job/77578847487#step:13:1740)):

```
[INFO] --- properties:1.3.0:read-project-properties (read-property-from-file) @ hdds-rocks-native ---
Warning:  Unknown properties resource extension: 'txt' assume as: 'properties'
[INFO] Loading 1 properties from File: /home/runner/work/ozone/ozone/hadoop-hdds/rocks-native/target/propertyFile.txt
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/26358184158