### PR TITLE
HDDS-15351. Display datanode UUID in Datanode web UI

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/DNMXBean.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/DNMXBean.java
@@ -34,6 +34,13 @@ public interface DNMXBean extends ServiceRuntimeInfo {
   String getHostname();
 
   /**
+   * Gets the datanode UUID.
+   *
+   * @return the datanode UUID for the datanode.
+   */
+  String getDatanodeUuid();
+
+  /**
    * Gets the client rpc port.
    *
    * @return the client rpc port

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/DNMXBeanImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/DNMXBeanImpl.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.utils.VersionInfo;
 public class DNMXBeanImpl extends ServiceRuntimeInfoImpl implements DNMXBean {
 
   private String hostName;
+  private String datanodeUuid;
   private String clientRpcPort;
   private String httpPort;
   private String httpsPort;
@@ -37,6 +38,11 @@ public class DNMXBeanImpl extends ServiceRuntimeInfoImpl implements DNMXBean {
   @Override
   public String getHostname() {
     return hostName;
+  }
+
+  @Override
+  public String getDatanodeUuid() {
+    return datanodeUuid;
   }
 
   @Override
@@ -60,6 +66,10 @@ public class DNMXBeanImpl extends ServiceRuntimeInfoImpl implements DNMXBean {
 
   public void setHostName(String hostName) {
     this.hostName = hostName;
+  }
+
+  public void setDatanodeUuid(String datanodeUuid) {
+    this.datanodeUuid = datanodeUuid;
   }
 
   public void setClientRpcPort(String rpcPort) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -248,6 +248,7 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
       datanodeDetails = initializeDatanodeDetails();
       datanodeDetails.setHostName(hostname);
       serviceRuntimeInfo.setHostName(hostname);
+      serviceRuntimeInfo.setDatanodeUuid(datanodeDetails.getUuidString());
       datanodeDetails.validateDatanodeIpAddress();
       datanodeDetails.setVersion(
           HddsVersionInfo.HDDS_VERSION_INFO.getVersion());

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -17,6 +17,11 @@
 <html>
 <head><title>DataNode UI</title></head>
 <body>
+<table class="table table-bordered table-striped" class="col-md-6">
+    <tbody>
+    </tbody>
+</table>
+
 <h2>HeartBeat Information</h2>
 <table class="table" class="col-md-6">
     <thead>

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -19,6 +19,14 @@
 <body>
 <table class="table table-bordered table-striped" class="col-md-6">
     <tbody>
+    <tr>
+        <td>Datanode UUID</td>
+        <td>{{$ctrl.overview.jmx.DatanodeUuid}}</td>
+    </tr>
+    <tr>
+        <td>HostName</td>
+        <td>{{$ctrl.overview.jmx.Hostname}}</td>
+    </tr>
     </tbody>
 </table>
 

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -17,19 +17,6 @@
 <html>
 <head><title>DataNode UI</title></head>
 <body>
-<table class="table table-bordered table-striped" class="col-md-6">
-    <tbody>
-    <tr>
-        <td>Datanode UUID</td>
-        <td>{{$ctrl.overview.jmx.DatanodeUuid}}</td>
-    </tr>
-    <tr>
-        <td>HostName</td>
-        <td>{{$ctrl.overview.jmx.Hostname}}</td>
-    </tr>
-    </tbody>
-</table>
-
 <h2>HeartBeat Information</h2>
 <table class="table" class="col-md-6">
     <thead>

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -31,10 +31,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -53,6 +56,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
 import org.apache.hadoop.util.ServicePlugin;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -156,6 +160,27 @@ public class TestHddsDatanodeService {
         hddsVolume.getDeletedContainerDir().listFiles();
     assertNotNull(deletedContainersAfterShutdown);
     assertEquals(0, deletedContainersAfterShutdown.length);
+  }
+
+  @Test
+  public void testDatanodeUuidInMXBean() throws Exception {
+    try {
+      service.start(conf);
+
+      ObjectName bean = new ObjectName(
+          "Hadoop:service=HddsDatanodeService,"
+              + "name=HddsDatanodeServiceInfo,"
+              + "component=ServerRuntime");
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      String datanodeUuid = (String) mbs.getAttribute(bean, "DatanodeUuid");
+
+      assertEquals(service.getDatanodeDetails().getUuidString(), datanodeUuid);
+    } finally {
+      service.stop();
+      service.join();
+      service.close();
+      DefaultMetricsSystem.shutdown();
+    }
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/framework/src/main/resources/webapps/static/templates/overview.html
+++ b/hadoop-hdds/framework/src/main/resources/webapps/static/templates/overview.html
@@ -21,6 +21,10 @@
         <th>Namespace:</th>
         <td>{{$ctrl.jmx.Namespace}}</td>
     </tr>
+    <tr ng-if="$ctrl.jmx.DatanodeUuid">
+        <th>Datanode UUID:</th>
+        <td>{{$ctrl.jmx.DatanodeUuid}}</td>
+    </tr>
     <tr>
         <th>Started:</th>
         <td>{{$ctrl.jmx.StartedTimeInMillis | date : 'medium'}}</td>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes the DataNode web UI display the DataNode UUID.

Some operational commands (e.g. decommission) require the DataNode UUID, but previously there was no easy way to look it up from the web UI. This change exposes the UUID through the DataNode's JMX MXBean and renders it on the DataNode overview page.

Changes:
- `DNMXBean` / `DNMXBeanImpl`: add a `datanodeUuid` field with a getter/setter, following the existing `hostName` pattern. This exposes the UUID as the JMX attribute `DatanodeUuid`.
- `HddsDatanodeService`: during startup, set the UUID on the MXBean from `datanodeDetails.getUuidString()` (after the DataNode details are initialized, so the value is always present).
- `overview.html` (the shared framework overview template): add a Datanode UUID row, guarded by `ng-if="$ctrl.jmx.DatanodeUuid"` so it only renders on the DataNode UI. SCM/OM do not expose that JMX attribute, so the row is hidden there.

Note: **the SCM web UI already shows the UUID (Node Status -> UUID column)**, so only the DataNode side needed changes here. 

<img width="2539" height="1317" alt="Screenshot 2026-05-25 at 9 48 33 PM" src="https://github.com/user-attachments/assets/997a7968-87f3-40e6-97f8-2ddd33131544" />


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15351

## How was this patch tested?

Unit test: Added `TestHddsDatanodeService#testDatanodeUuidInMXBean`, which starts the service, reads the `DatanodeUuid` attribute from the JMX MXBean, and asserts it matches `datanodeDetails.getUuidString()`.

Manual UI verification:

```bash
# from repo root
mvn clean install -DskipTests

cd hadoop-ozone/dist/target/ozone-*/compose/ozone
docker compose up -d --scale datanode=3
```
- DataNode UI (ports are dynamically mapped):
  ```bash
  docker compose ps datanode
  # or compose v2:
  docker compose port --index 1 datanode 19864
  ```
  Open the returned host/port (e.g. `http://localhost:<mapped-port>`). The overview table now shows the new row Datanode UUID.

<img width="2548" height="1322" alt="Screenshot 2026-05-25 at 10 09 14 PM" src="https://github.com/user-attachments/assets/72b6fde2-4d09-4634-811f-d12f48a0379b" />
