### PR TITLE
HDDS-15369. Fix datanode shutdown on ozone.scm.nodes reconfig

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates;
 import org.apache.hadoop.ozone.protocolPB.ReconDatanodeProtocolPB;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolPB;
@@ -234,7 +233,9 @@ public class SCMConnectionManager
             "Ignoring the request.");
         return;
       }
-      endPoint.setState(EndPointStates.SHUTDOWN);
+      // This is a normal reconfiguration removal. Do not set the endpoint to
+      // SHUTDOWN, as an in-flight task may report that state as a DN fatal
+      // shutdown.
       endPoint.close();
     } finally {
       writeUnlock();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.statemachine;
+
+import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.HEARTBEAT;
+
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for SCMConnectionManager.
+ */
+public class TestSCMConnectionManager {
+
+  @Test
+  public void testRemoveSCMServerDoesNotMarkEndpointShutdown()
+      throws Exception {
+    try (SCMConnectionManager connectionManager =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      InetSocketAddress address = new InetSocketAddress("127.0.0.1", 9861);
+      connectionManager.addSCMServer(address, "");
+      EndpointStateMachine endpoint =
+          connectionManager.getValues().iterator().next();
+      endpoint.setState(HEARTBEAT);
+
+      connectionManager.removeSCMServer(address);
+
+      Assertions.assertTrue(connectionManager.getValues().isEmpty());
+      Assertions.assertEquals(HEARTBEAT, endpoint.getState());
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Issue
1. When reconfiguring and removing SCM, the `connectionManager.removeSCMServer` is called, in the `removeSCMServer`, the endpoint State will be set to `SHUTDOWN` 
2. However, the rule for `RunningDatanodeState` is: whenever any endpoint task returns `SHUTDOWN`, the entire DN state machine switches to `SHUTDOWN`, this will cause the DN exceptional shutdown.

### FIx
Do not set the endpoint to be removed to the `SHUTDOWN` state

## What is the link to the Apache JIRA
[HDDS-15369
](https://issues.apache.org/jira/browse/HDDS-15369)

## How was this patch tested?
unit test

