### PR TITLE
HDDS-15354. Fix nested tab completion in ozone interactive

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
@@ -26,7 +26,7 @@ import picocli.CommandLine;
 /**
  * Ozone Admin Command line tool.
  */
-@CommandLine.Command(name = "ozone admin",
+@CommandLine.Command(name = "ozone admin", aliases = "admin",
     description = "Developer tools for Ozone Admin operations",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -26,7 +26,7 @@ import picocli.CommandLine;
 /**
  * Ozone Debug Command line tool.
  */
-@CommandLine.Command(name = "ozone debug",
+@CommandLine.Command(name = "ozone debug", aliases = "debug",
         description = "Developer tools for Ozone Debug operations",
         versionProvider = HddsVersionProvider.class,
         mixinStandardHelpOptions = true)

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Command;
 /**
  * Shell commands for native rpc object manipulation.
  */
-@Command(name = "ozone sh",
+@Command(name = "ozone sh", aliases = "sh",
     description = "Shell for Ozone object store",
     subcommands = {
         BucketCommands.class,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.Command;
 /**
  * Shell for s3 related operations.
  */
-@Command(name = "ozone s3",
+@Command(name = "ozone s3", aliases = "s3",
     description = "Shell for S3 specific operations",
     subcommands = {
         GetS3SecretHandler.class,

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.Command;
 /**
  * Shell for multi-tenant related operations.
  */
-@Command(name = "ozone tenant",
+@Command(name = "ozone tenant", aliases = "tenant",
     description = "Shell for multi-tenant specific operations",
     subcommands = {
         TenantCreateHandler.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15354. Fix nested tab completion in ozone interactive

After [HDDS-15185](https://github.com/apache/ozone/pull/10348) introduced the top-level ozone interactive entry point (ozone-cli-interactive), users can reach nested CLIs with short names such as sh, s3, tenant, admin, and debug. Tab completion worked for those top-level tokens but failed for deeper input (for example sh vol, sh vol create).

This change adds Picocli aliases on the nested CLI root commands so the names registered by OzoneInteractiveShell match what the JLine/picocli completer uses when resolving subcommands.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15354

## How was this patch tested?

Manual — ozone interactive (cluster or compose env with Ozone CLI built from this branch):
Start ozone interactive.
Tab-complete top-level: sh, s3, tenant, admin, debug.
Tab-complete nested paths, e.g. sh → vol / bucket / key, and at least one deeper level (e.g. sh vol → subcommands).
Confirm behavior matches ozone sh --interactive for nested completion where applicable.

CI - Passed 