### PR TITLE
HDDS-15367. Shell completion knows too few commands

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -24,6 +24,7 @@
   <packaging>jar</packaging>
   <name>Apache Ozone Distribution</name>
   <properties>
+    <classpath.skip>false</classpath.skip>
     <!-- Hadoop Docker image for current version; multi-arch Hadoop only available from ghcr.io currently -->
     <docker.hadoop.image>ghcr.io/apache/hadoop</docker.hadoop.image>
     <!-- suffix appended to Hadoop version to get Docker image version -->
@@ -40,6 +41,7 @@
     <maven.test.skip>true</maven.test.skip>
     <!-- rpm usage-->
     <rpm.needArch>true</rpm.needArch>
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <dependencies>
@@ -158,6 +160,11 @@
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-vapor</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -104,7 +104,7 @@ function ozonecmd_case
     ;;
     completion)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.utils.AutoCompletion;
-      OZONE_RUN_ARTIFACT_NAME="ozone-tools"
+      OZONE_RUN_ARTIFACT_NAME="ozone-dist"
     ;;
     datanode)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
@@ -287,6 +287,7 @@ function check_running_ozone_services
 function ozone_suppress_shell_log
 {
   if [[ "${OZONE_RUN_ARTIFACT_NAME}" =~ ozone-cli-.* ]] \
+      || [[ "${OZONE_RUN_ARTIFACT_NAME}" == "ozone-dist" ]] \
       || [[ "${OZONE_RUN_ARTIFACT_NAME}" == "ozone-tools" ]]; then
     if [[ -z "${OZONE_ORIGINAL_LOGLEVEL}" ]] \
         && [[ -z "${OZONE_ORIGINAL_ROOT_LOGGER}" ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -2255,7 +2255,7 @@
             <goals>
               <goal>build-classpath</goal>
             </goals>
-            <phase>prepare-package</phase>
+            <phase>generate-resources</phase>
             <configuration>
               <outputFile>${project.build.outputDirectory}/${project.artifactId}.classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shell completion, implemented in HDDS-12811, knows about only very few commands:

```bash
$ ozone completion bash | grep 'local cmds'
  local cmds0=(genconf)
  local cmds1=(getconf)
  local cmds2=(completion)
  local cmds3=(ratis)
  local cmds4=(getconf confKey)
  local cmds5=(getconf -confKey)
  local cmds6=(getconf storagecontainermanagers)
  local cmds7=(getconf -storagecontainermanagers)
  local cmds8=(getconf ozonemanagers)
  local cmds9=(getconf -ozonemanagers)
  local cmds10=(completion bash)
  local cmds11=(completion zsh)
```

It was broken by HDDS-14595, which removed `ozone-cli-shell` etc. from classpath of `ozone-tools`.

This PR changes `ozone completion` to run in `ozone-dist`, the module which depends on all other Ozone modules.  This makes all `ozone` subcommands available on the classpath.

https://issues.apache.org/jira/browse/HDDS-15367

## How was this patch tested?

```
$ ozone completion bash | grep 'local cmds' | wc -l
344
```

Also tested completion after:

```bash
$ source <(ozone completion bash)
$ ozone <TAB><TAB>
admin       completion  debug       freon       genconf     getconf     ratis       repair      s3          sh          tenant      vapor       
$ ozone debug <TAB><TAB>
auditparser  checknative  datanode     kerberos     ldb          log          om           ratis        replicas     version      
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/26406422556