### PR TITLE
HDDS-15349. Remove the non-ignorePipeline codec from OmKeyInfo.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -59,8 +59,7 @@ public final class OmKeyInfo extends WithParentObjectId
     implements CopyObject<OmKeyInfo>, WithTags {
   private static final Logger LOG = LoggerFactory.getLogger(OmKeyInfo.class);
 
-  private static final Codec<OmKeyInfo> CODEC_TRUE = newCodec(true);
-  private static final Codec<OmKeyInfo> CODEC_FALSE = newCodec(false);
+  private static final Codec<OmKeyInfo> CODEC = newCodec();
   /**
    * Metadata key flag to indicate whether a deleted key was a committed key.
    * The flag is set when a committed key is deleted from AOS but still held in
@@ -131,17 +130,16 @@ public final class OmKeyInfo extends WithParentObjectId
     this.expectedDataGeneration = b.expectedDataGeneration;
   }
 
-  private static Codec<OmKeyInfo> newCodec(boolean ignorePipeline) {
+  private static Codec<OmKeyInfo> newCodec() {
     return new DelegatedCodec<>(
         Proto2Codec.get(KeyInfo.getDefaultInstance()),
         OmKeyInfo::getFromProtobuf,
-        k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION),
+        k -> k.getProtobuf(true, ClientVersion.CURRENT_VERSION),
         OmKeyInfo.class);
   }
 
-  public static Codec<OmKeyInfo> getCodec(boolean ignorePipeline) {
-    LOG.debug("OmKeyInfo.getCodec ignorePipeline = {}", ignorePipeline);
-    return ignorePipeline ? CODEC_TRUE : CODEC_FALSE;
+  public static Codec<OmKeyInfo> getCodec() {
+    return CODEC;
   }
 
   public String getVolumeName() {

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
@@ -35,11 +35,12 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.hadoop.io.MD5Hash;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test {@link OmKeyInfo#getCodec(boolean)} .
+ * Test {@link OmKeyInfo#getCodec()} .
  */
 public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
   private static final String VOLUME = "hadoop";
@@ -51,7 +52,7 @@ public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
 
   @Override
   public Codec<OmKeyInfo> getCodec() {
-    return OmKeyInfo.getCodec(false);
+    return OmKeyInfo.getCodec();
   }
 
   private static FileChecksum createEmptyChecksum() {
@@ -102,7 +103,7 @@ public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
 
   public void testOmKeyInfoCodecWithoutPipeline(int chunkNum)
       throws IOException {
-    final Codec<OmKeyInfo> codec = OmKeyInfo.getCodec(true);
+    final Codec<OmKeyInfo> codec = OmKeyInfo.getCodec();
     OmKeyInfo originKey = getKeyInfo(chunkNum);
     byte[] rawData = codec.toPersistedFormat(originKey);
     OmKeyInfo key = codec.fromPersistedFormat(rawData);
@@ -115,11 +116,11 @@ public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
   }
 
   public void testOmKeyInfoCodecCompatibility(int chunkNum) throws IOException {
-    final Codec<OmKeyInfo> codecWithoutPipeline = OmKeyInfo.getCodec(true);
-    final Codec<OmKeyInfo> codecWithPipeline = OmKeyInfo.getCodec(false);
+    final Codec<OmKeyInfo> codec = OmKeyInfo.getCodec();
     OmKeyInfo originKey = getKeyInfo(chunkNum);
-    byte[] rawData = codecWithPipeline.toPersistedFormat(originKey);
-    OmKeyInfo key = codecWithoutPipeline.fromPersistedFormat(rawData);
+    byte[] rawData = originKey
+        .getProtobuf(false, ClientVersion.CURRENT_VERSION).toByteArray();
+    OmKeyInfo key = codec.fromPersistedFormat(rawData);
     System.out.println("Chunk number = " + chunkNum +
         ", Serialized key size with pipeline = " + rawData.length);
     assertNotNull(key.getLatestVersionLocations().getLocationList().get(0)

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.hadoop.io.MD5Hash;
-import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
@@ -97,8 +96,6 @@ public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
   public void test() throws IOException {
     testOmKeyInfoCodecWithoutPipeline(1);
     testOmKeyInfoCodecWithoutPipeline(2);
-    testOmKeyInfoCodecCompatibility(1);
-    testOmKeyInfoCodecCompatibility(2);
   }
 
   public void testOmKeyInfoCodecWithoutPipeline(int chunkNum)
@@ -113,17 +110,5 @@ public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
         .getPipeline());
     assertNotNull(key.getFileChecksum());
     assertEquals(key.getFileChecksum(), checksum);
-  }
-
-  public void testOmKeyInfoCodecCompatibility(int chunkNum) throws IOException {
-    final Codec<OmKeyInfo> codec = OmKeyInfo.getCodec();
-    OmKeyInfo originKey = getKeyInfo(chunkNum);
-    byte[] rawData = originKey
-        .getProtobuf(false, ClientVersion.CURRENT_VERSION).toByteArray();
-    OmKeyInfo key = codec.fromPersistedFormat(rawData);
-    System.out.println("Chunk number = " + chunkNum +
-        ", Serialized key size with pipeline = " + rawData.length);
-    assertNotNull(key.getLatestVersionLocations().getLocationList().get(0)
-        .getPipeline());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -208,7 +208,7 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> KEY_TABLE_DEF
       = new DBColumnFamilyDefinition<>(KEY_TABLE,
           StringCodec.get(),
-          OmKeyInfo.getCodec(true));
+          OmKeyInfo.getCodec());
 
   public static final String DELETED_TABLE = "deletedTable";
   /** deletedTable: /volume/bucket/key :- RepeatedKeyInfo. */
@@ -222,7 +222,7 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> OPEN_KEY_TABLE_DEF
       = new DBColumnFamilyDefinition<>(OPEN_KEY_TABLE,
           StringCodec.get(),
-          OmKeyInfo.getCodec(true));
+          OmKeyInfo.getCodec());
 
   public static final String MULTIPART_INFO_TABLE = "multipartInfoTable";
   /** multipartInfoTable: /volume/bucket/key/uploadId :- parts. */
@@ -245,14 +245,14 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> FILE_TABLE_DEF
       = new DBColumnFamilyDefinition<>(FILE_TABLE,
           StringCodec.get(),
-          OmKeyInfo.getCodec(true));
+          OmKeyInfo.getCodec());
 
   public static final String OPEN_FILE_TABLE = "openFileTable";
   /** openFileTable: /volumeId/bucketId/parentId/fileName/id :- KeyInfo. */
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> OPEN_FILE_TABLE_DEF
       = new DBColumnFamilyDefinition<>(OPEN_FILE_TABLE,
           StringCodec.get(),
-          OmKeyInfo.getCodec(true));
+          OmKeyInfo.getCodec());
 
   public static final String DIRECTORY_TABLE = "directoryTable";
   /** directoryTable: /volumeId/bucketId/parentId/dirName :- DirInfo. */
@@ -266,7 +266,7 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> DELETED_DIR_TABLE_DEF
       = new DBColumnFamilyDefinition<>(DELETED_DIR_TABLE,
           StringCodec.get(),
-          OmKeyInfo.getCodec(true));
+          OmKeyInfo.getCodec());
 
   //---------------------------------------------------------------------------
   // S3 Multi-Tenancy Tables


### PR DESCRIPTION
## What changes were proposed in this pull request?
The ignorePipeline parameter is always true except for tests. Let's remove it in order to simplify the code.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15349

## How was this patch tested?
CI (https://github.com/YutaLin/ozone/actions/runs/26421165778)