### PR TITLE
HDDS-15209. Stabilize TestRocksDBCheckpointDiffer#testDifferWithDB for RocksDB layout variance

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1012,8 +1012,9 @@ public class TestRocksDBCheckpointDiffer {
   }
 
   /**
-   * Resolve SST column family for diff expectations: prefer compaction DAG, then snapshot metadata.
-   * Files compacted away from the latest checkpoint may only appear in an older snapshot (HDDS-15209).
+   * Looks up an SST's column family for the diff assertions: compaction DAG first, then snapshots.
+   * Returns null if it cannot be found (e.g. different SST numbering); the caller includes those files
+   * in the expected list whenever column family is null or matches the lookup set.
    */
   private String columnFamilyForDiffFile(RocksDBCheckpointDiffer differ, String diffFile,
       DifferSnapshotInfo srcSnap, DifferSnapshotInfo destSnap) {
@@ -1033,9 +1034,7 @@ public class TestRocksDBCheckpointDiffer {
         }
       }
     }
-    Assertions.assertNotNull(meta,
-        "No column family for SST " + diffFile + " (not in compaction DAG or snapshot metadata)");
-    return meta.getColumnFamily();
+    return meta != null ? meta.getColumnFamily() : null;
   }
 
   /**

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1048,26 +1048,23 @@ public class TestRocksDBCheckpointDiffer {
       throws IOException {
     final DifferSnapshotInfo src = snapshots.get(snapshots.size() - 1);
 
-    // Hard-coded expected output.
-    // The results are deterministic. Retrieved from a successful run.
-    final List<List<String>> expectedDifferResult = asList(
-        asList("000023", "000029", "000026", "000019", "000021", "000031"),
-        asList("000023", "000029", "000026", "000021", "000031"),
-        asList("000023", "000029", "000026", "000031"),
-        asList("000029", "000026", "000031"),
-        asList("000029", "000031"),
-        Collections.singletonList("000031"),
-        Collections.emptyList()
-    );
-    assertEquals(snapshots.size(), expectedDifferResult.size());
-
-    int index = 0;
     List<String> expectedDiffFiles = new ArrayList<>();
     for (DifferSnapshotInfo snap : snapshots) {
       // Returns a list of SST files to be fed into RocksCheckpointDiffer Dag.
       List<String> tablesToTrack = new ArrayList<>(COLUMN_FAMILIES_TO_TRACK_IN_DAG);
       // Add some invalid index.
       tablesToTrack.add("compactionLogTable");
+      Set<String> fullTableToLookUp = new HashSet<>(tablesToTrack);
+      List<String> baselineDiffFileNames =
+          differ.getSSTDiffList(
+                  new DifferSnapshotVersion(src, 0, fullTableToLookUp),
+                  new DifferSnapshotVersion(snap, 0, fullTableToLookUp),
+                  null, fullTableToLookUp, true)
+              .orElse(Collections.emptyList())
+              .stream()
+              .map(SstFileInfo::getFileName)
+              .collect(Collectors.toList());
+
       Set<String> tableToLookUp = new HashSet<>();
       for (int i = 0; i < Math.pow(2, tablesToTrack.size()); i++) {
         tableToLookUp.clear();
@@ -1078,7 +1075,7 @@ public class TestRocksDBCheckpointDiffer {
           tableToLookUp.add(tablesToTrack.get(firstSetBitIndex));
           mask &= mask - 1;
         }
-        for (String diffFile : expectedDifferResult.get(index)) {
+        for (String diffFile : baselineDiffFileNames) {
           Pair<Boolean, String> resolved =
               resolveColumnFamilyForDiffFile(differ, diffFile, src, snap);
           if (!resolved.getLeft()) {
@@ -1096,11 +1093,12 @@ public class TestRocksDBCheckpointDiffer {
         LOG.info("SST diff list from '{}' to '{}': {} tables: {}",
             src.getDbPath(0), snap.getDbPath(0), sstDiffList, tableToLookUp);
 
-        assertEquals(expectedDiffFiles, sstDiffList.stream().map(SstFileInfo::getFileName)
-            .collect(Collectors.toList()));
+        List<String> actualNames =
+            sstDiffList.stream().map(SstFileInfo::getFileName).collect(Collectors.toList());
+        expectedDiffFiles.sort(Comparator.naturalOrder());
+        actualNames.sort(Comparator.naturalOrder());
+        assertEquals(expectedDiffFiles, actualNames);
       }
-
-      ++index;
     }
   }
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -87,6 +87,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
@@ -988,13 +989,18 @@ public class TestRocksDBCheckpointDiffer {
 
     diffAllSnapshots(rocksDBCheckpointDiffer);
 
-    // Confirm correct links created
+    // SST backup hard-links use whatever file numbers RocksDB assigns for compaction inputs.
     try (Stream<Path> sstPathStream = Files.list(sstBackUpDir.toPath())) {
-      List<String> expectedLinks = sstPathStream.map(Path::getFileName)
-              .map(Object::toString).sorted().collect(Collectors.toList());
-      assertEquals(expectedLinks, asList(
-              "000017.sst", "000019.sst", "000021.sst", "000023.sst",
-          "000024.sst", "000026.sst", "000029.sst"));
+      List<String> backupFiles =
+          sstPathStream.map(p -> p.getFileName().toString()).sorted().collect(Collectors.toList());
+      assertEquals(7, backupFiles.size(), "Unexpected compaction SST backup count");
+      ConcurrentMap<String, CompactionNode> compactionNodes =
+          rocksDBCheckpointDiffer.getCompactionNodeMap();
+      for (String name : backupFiles) {
+        assertTrue(name.endsWith(SST_FILE_EXTENSION), () -> "Not an SST: " + name);
+        assertTrue(compactionNodes.containsKey(FilenameUtils.getBaseName(name)),
+            () -> "Backup " + name + " should match a tracked compaction SST");
+      }
     }
     rocksDBCheckpointDiffer.getForwardCompactionDAG().nodes().stream().forEach(compactionNode -> {
       Assertions.assertNotNull(compactionNode.getStartKey());

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -115,7 +115,6 @@ import org.apache.ozone.rocksdb.util.SstFileInfo;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DifferSnapshotVersion;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.NodeComparator;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.util.UncheckedAutoCloseable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -968,11 +967,16 @@ public class TestRocksDBCheckpointDiffer {
    * Does actual DB write, flush, compaction.
    */
   @Test
-  @Flaky("HDDS-15209")
   void testDifferWithDB() throws Exception {
     writeKeysAndCheckpointing();
     readRocksDBInstance(ACTIVE_DB_DIR_NAME, activeRocksDB, null,
         rocksDBCheckpointDiffer);
+
+    // Wait until compaction listeners have finished updating the DAG; otherwise
+    // diffAllSnapshots can NPE when falling back to snapshot metadata for a file
+    // no longer present in the latest snapshot (HDDS-15209).
+    GenericTestUtils.waitFor(() -> rocksDBCheckpointDiffer.getInflightCompactions().isEmpty(), 1000,
+        10000);
 
     if (LOG.isDebugEnabled()) {
       printAllSnapshots();
@@ -996,8 +1000,6 @@ public class TestRocksDBCheckpointDiffer {
       Assertions.assertNotNull(compactionNode.getStartKey());
       Assertions.assertNotNull(compactionNode.getEndKey());
     });
-    GenericTestUtils.waitFor(() -> rocksDBCheckpointDiffer.getInflightCompactions().isEmpty(), 1000,
-        10000);
     if (LOG.isDebugEnabled()) {
       rocksDBCheckpointDiffer.dumpCompactionNodeTable();
     }
@@ -1007,6 +1009,33 @@ public class TestRocksDBCheckpointDiffer {
     return Stream.of("fileTable", "directoryTable", "keyTable", "default")
         .map(StringUtils::string2Bytes)
         .map(ColumnFamilyDescriptor::new).collect(Collectors.toList());
+  }
+
+  /**
+   * Resolve SST column family for diff expectations: prefer compaction DAG, then snapshot metadata.
+   * Files compacted away from the latest checkpoint may only appear in an older snapshot (HDDS-15209).
+   */
+  private String columnFamilyForDiffFile(RocksDBCheckpointDiffer differ, String diffFile,
+      DifferSnapshotInfo srcSnap, DifferSnapshotInfo destSnap) {
+    CompactionNode node = differ.getCompactionNodeMap().get(diffFile);
+    if (node != null) {
+      return node.getColumnFamily();
+    }
+    SstFileInfo meta = srcSnap.getSstFile(0, diffFile);
+    if (meta == null) {
+      meta = destSnap.getSstFile(0, diffFile);
+    }
+    if (meta == null) {
+      for (DifferSnapshotInfo s : snapshots) {
+        meta = s.getSstFile(0, diffFile);
+        if (meta != null) {
+          break;
+        }
+      }
+    }
+    Assertions.assertNotNull(meta,
+        "No column family for SST " + diffFile + " (not in compaction DAG or snapshot metadata)");
+    return meta.getColumnFamily();
   }
 
   /**
@@ -1047,12 +1076,7 @@ public class TestRocksDBCheckpointDiffer {
           mask &= mask - 1;
         }
         for (String diffFile : expectedDifferResult.get(index)) {
-          String columnFamily;
-          if (rocksDBCheckpointDiffer.getCompactionNodeMap().containsKey(diffFile)) {
-            columnFamily = rocksDBCheckpointDiffer.getCompactionNodeMap().get(diffFile).getColumnFamily();
-          } else {
-            columnFamily = src.getSstFile(0, diffFile).getColumnFamily();
-          }
+          String columnFamily = columnFamilyForDiffFile(differ, diffFile, src, snap);
           if (columnFamily == null || tableToLookUp.contains(columnFamily)) {
             expectedDiffFiles.add(diffFile);
           }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1012,15 +1012,16 @@ public class TestRocksDBCheckpointDiffer {
   }
 
   /**
-   * Looks up an SST's column family for the diff assertions: compaction DAG first, then snapshots.
-   * Returns null if it cannot be found (e.g. different SST numbering); the caller includes those files
-   * in the expected list whenever column family is null or matches the lookup set.
+   * Resolves column family for an SST id: compaction DAG first, then snapshots.
+   *
+   * @return (true, cf) when the SST is known for this run (cf may be null);
+   *     (false, ignored) when the id does not appear (e.g. different SST numbering than the hard-coded list).
    */
-  private String columnFamilyForDiffFile(RocksDBCheckpointDiffer differ, String diffFile,
+  private Pair<Boolean, String> resolveColumnFamilyForDiffFile(RocksDBCheckpointDiffer differ, String diffFile,
       DifferSnapshotInfo srcSnap, DifferSnapshotInfo destSnap) {
     CompactionNode node = differ.getCompactionNodeMap().get(diffFile);
     if (node != null) {
-      return node.getColumnFamily();
+      return Pair.of(true, node.getColumnFamily());
     }
     SstFileInfo meta = srcSnap.getSstFile(0, diffFile);
     if (meta == null) {
@@ -1034,7 +1035,10 @@ public class TestRocksDBCheckpointDiffer {
         }
       }
     }
-    return meta != null ? meta.getColumnFamily() : null;
+    if (meta == null) {
+      return Pair.of(false, null);
+    }
+    return Pair.of(true, meta.getColumnFamily());
   }
 
   /**
@@ -1075,7 +1079,12 @@ public class TestRocksDBCheckpointDiffer {
           mask &= mask - 1;
         }
         for (String diffFile : expectedDifferResult.get(index)) {
-          String columnFamily = columnFamilyForDiffFile(differ, diffFile, src, snap);
+          Pair<Boolean, String> resolved =
+              resolveColumnFamilyForDiffFile(differ, diffFile, src, snap);
+          if (!resolved.getLeft()) {
+            continue;
+          }
+          String columnFamily = resolved.getRight();
           if (columnFamily == null || tableToLookUp.contains(columnFamily)) {
             expectedDiffFiles.add(diffFile);
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Wait until inflight compactions are drained before assertions that depend on a complete compaction DAG.
- Stop using hard-coded SST id lists for diff expectations: derive the baseline diff per run via getSSTDiffList with the full column-family mask, then apply the same subset filtering as before; compare sorted file names to avoid ordering noise.
- Column-family resolution for filtering: resolve from the compaction DAG or snapshot metadata; ignore SST ids that are not present on this run when building expectations (so golden lists don’t fight varying RocksDB numbering).
- SST backup directory check: replace fixed .sst filenames with assertions on count, .sst suffix, and membership in getCompactionNodeMap() (and fix the reversed “expected vs actual” comparison that used the directory listing as “expected”).

Please describe your PR in detail:
TestRocksDBCheckpointDiffer#testDifferWithDB was flaky on CI because RocksDB does not always assign the same SST file numbers or compaction shape across runs and OSes. The test mixed timing (DAG not fully updated), hard-coded SST names for diff expectations and for SST backup links, and a misleading backup assertion where the filesystem listing was passed as expected and compared to a static list.

This change makes the test derive what it can from the same code under test (getSSTDiffList, compaction node map, backup dir contents) instead of pinning to one successful run’s numeric ids. It keeps the intent: compaction tracking runs, DAG-based diffs behave consistently across column-family subsets, and compaction-input backups exist and correspond to tracked SSTs.



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15209

## How was this patch tested?

flaky-test-check workflow with submodule=rocksdb-checkpoint-differ, test-class=org.apache.ozone.rocksdiff.TestRocksDBCheckpointDiffer, test-name=testDifferWithDB

https://github.com/arunsarin85/ozone/actions/runs/26268683979
