### PR TITLE
HDDS-15371. [DiskBalancer] DiskBalancer should use monotonic time for delayed replica deletion.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -634,7 +634,7 @@ public class DiskBalancerService extends BackgroundService {
         }
         if (moveSucceeded && newContainer != null) {
           // Add current old container to pendingDeletionContainers.
-          pendingDeletionContainers.put(System.currentTimeMillis() + replicaDeletionDelay, container);
+          pendingDeletionContainers.put(Time.monotonicNow() + replicaDeletionDelay, container);
           ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
               destVolume, containerSize, Time.monotonicNow() - startTime);
         }
@@ -691,7 +691,7 @@ public class DiskBalancerService extends BackgroundService {
   private boolean tryCleanupOnePendingDeletionContainer() {
     Map.Entry<Long, Container> entry = pendingDeletionContainers.pollFirstEntry();
     if (entry != null) {
-      if (entry.getKey() <= System.currentTimeMillis()) {
+      if (entry.getKey() <= Time.monotonicNow()) {
         // entry container is expired
         deleteContainer(entry.getValue());
         return true;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -59,6 +60,7 @@ import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.hdds.utils.FaultInjector;
+import org.apache.hadoop.hdds.utils.SlidingWindow;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
@@ -94,6 +96,7 @@ public class DiskBalancerService extends BackgroundService {
 
   private OzoneContainer ozoneContainer;
   private final ConfigurationSource conf;
+  private final Clock clock;
 
   private double threshold;
   private long bandwidthInMB;
@@ -135,10 +138,19 @@ public class DiskBalancerService extends BackgroundService {
   public DiskBalancerService(OzoneContainer ozoneContainer,
       long serviceCheckInterval, long serviceCheckTimeout, TimeUnit timeUnit,
       int workerSize, ConfigurationSource conf) throws IOException {
+    this(ozoneContainer, serviceCheckInterval, serviceCheckTimeout, timeUnit,
+        workerSize, conf, new SlidingWindow.MonotonicClock());
+  }
+
+  DiskBalancerService(OzoneContainer ozoneContainer,
+      long serviceCheckInterval, long serviceCheckTimeout, TimeUnit timeUnit,
+      int workerSize, ConfigurationSource conf, Clock clock)
+      throws IOException {
     super("DiskBalancerService", serviceCheckInterval, timeUnit, workerSize,
         serviceCheckTimeout);
     this.ozoneContainer = ozoneContainer;
     this.conf = conf;
+    this.clock = Objects.requireNonNull(clock, "clock");
 
     String diskBalancerInfoPath = getDiskBalancerInfoPath();
     Objects.requireNonNull(diskBalancerInfoPath);
@@ -634,7 +646,8 @@ public class DiskBalancerService extends BackgroundService {
         }
         if (moveSucceeded && newContainer != null) {
           // Add current old container to pendingDeletionContainers.
-          pendingDeletionContainers.put(Time.monotonicNow() + replicaDeletionDelay, container);
+          pendingDeletionContainers.put(clock.millis() + replicaDeletionDelay,
+              container);
           ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
               destVolume, containerSize, Time.monotonicNow() - startTime);
         }
@@ -691,7 +704,7 @@ public class DiskBalancerService extends BackgroundService {
   private boolean tryCleanupOnePendingDeletionContainer() {
     Map.Entry<Long, Container> entry = pendingDeletionContainers.pollFirstEntry();
     if (entry != null) {
-      if (entry.getKey() <= Time.monotonicNow()) {
+      if (entry.getKey() <= clock.millis()) {
         // entry container is expired
         deleteContainer(entry.getValue());
         return true;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerServiceTestImpl.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.diskbalancer;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +45,13 @@ public class DiskBalancerServiceTestImpl extends DiskBalancerService {
       throws IOException {
     super(container, serviceInterval, SERVICE_TIMEOUT_IN_MILLISECONDS,
         TimeUnit.MILLISECONDS, threadCount, conf);
+  }
+
+  public DiskBalancerServiceTestImpl(OzoneContainer container,
+      int serviceInterval, ConfigurationSource conf, int threadCount,
+      Clock clock) throws IOException {
+    super(container, serviceInterval, SERVICE_TIMEOUT_IN_MILLISECONDS,
+        TimeUnit.MILLISECONDS, threadCount, conf, clock);
   }
 
   public void runBalanceTasks() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -80,9 +80,9 @@ import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocat
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
-import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
+import org.apache.ozone.test.TestClock;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -113,6 +113,7 @@ public class TestDiskBalancerTask {
   private HddsVolume sourceVolume;
   private HddsVolume destVolume;
   private DiskBalancerServiceTestImpl diskBalancerService;
+  private TestClock clock;
 
   private static final long CONTAINER_ID = 1L;
   private static final long CONTAINER_SIZE = 1024L * 1024L; // 1 MB
@@ -243,8 +244,9 @@ public class TestDiskBalancerTask {
     DiskBalancerConfiguration diskBalancerConfiguration = conf.getObject(DiskBalancerConfiguration.class);
     diskBalancerConfiguration.setDiskBalancerShouldRun(true);
     conf.setFromObject(diskBalancerConfiguration);
+    clock = TestClock.newInstance();
     diskBalancerService = new DiskBalancerServiceTestImpl(ozoneContainer,
-        100, conf, 1);
+        100, conf, 1, clock);
     diskBalancerService.setReplicaDeletionDelay(0);
     KeyValueContainer.setInjector(kvFaultInjector);
   }
@@ -599,10 +601,8 @@ public class TestDiskBalancerTask {
     // create another container to trigger the deletion of old replicas
     createContainer(CONTAINER_ID + 1, sourceVolume, State.CLOSED);
     task = getTask();
-    // Wait until the delayed deletion is eligible, then trigger cleanup.
-    long deletionEligibleAt = Time.monotonicNow() + delay;
-    GenericTestUtils.waitFor(
-        () -> Time.monotonicNow() >= deletionEligibleAt, 50, 12_000);
+    // Advance the injected clock until the delayed deletion is eligible.
+    clock.fastForward(delay);
     task.call();
     // Verify that the old container is deleted
     assertFalse(oldContainerDir.exists());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -81,6 +81,7 @@ import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocat
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.assertj.core.api.Fail;
@@ -600,9 +601,9 @@ public class TestDiskBalancerTask {
     createContainer(CONTAINER_ID + 1, sourceVolume, State.CLOSED);
     task = getTask();
     // Wait until the delayed deletion is eligible, then trigger cleanup.
-    long deletionEligibleAt = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delay);
+    long deletionEligibleAt = Time.monotonicNow() + delay;
     GenericTestUtils.waitFor(
-        () -> System.nanoTime() >= deletionEligibleAt, 50, 12_000);
+        () -> Time.monotonicNow() >= deletionEligibleAt, 50, 12_000);
     task.call();
     // Verify that the old container is deleted
     assertFalse(oldContainerDir.exists());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -47,7 +47,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;


### PR DESCRIPTION
## What changes were proposed in this pull request?

DiskBalancer uses System.currentTimeMillis() to schedule and check delayed deletion of old replicas after a successful container move.

The delayed deletion is based on a relative delay configured by replicaDeletionDelay. Since System.currentTimeMillis() is wall-clock time, it can be affected by system clock changes such as NTP adjustment, manual time changes, or VM time drift.

If the system clock moves forward, old replicas may become eligible for deletion earlier than expected. If the system clock moves backward, old replicas may remain in the pending deletion queue longer than expected.

DiskBalancer already uses Time.monotonicNow() for other relative-time logic, such as bandwidth throttling with nextAvailableTime. The pending deletion delay should follow the same pattern and use monotonic time for both deadline calculation and expiration checks.

This makes delayed replica deletion independent of wall-clock changes and consistent with other DiskBalancer delay/elapsed-time logic.

## What is the link to the Apache JIRA

HDDS-15371. DiskBalancer should use monotonic time for delayed replica deletion.

## How was this patch tested?

Exists Unit Test.
