### PR TITLE
HDDS-10283. [WIP] Apply zero copy to Ozone client reads

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdds.HddsUtils.processForDebug;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -63,8 +64,15 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.Time;
+import org.apache.ratis.grpc.util.ZeroCopyMessageMarshaller;
+import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.thirdparty.com.google.protobuf.TextFormat;
+import org.apache.ratis.thirdparty.io.grpc.CallOptions;
+import org.apache.ratis.thirdparty.io.grpc.Channel;
+import org.apache.ratis.thirdparty.io.grpc.ClientCall;
+import org.apache.ratis.thirdparty.io.grpc.ClientInterceptor;
 import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
+import org.apache.ratis.thirdparty.io.grpc.MethodDescriptor;
 import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
@@ -91,6 +99,82 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   private static final Logger LOG = LoggerFactory.getLogger(XceiverClientGrpc.class);
   private static final int SHUTDOWN_WAIT_INTERVAL_MILLIS = 100;
   private static final int SHUTDOWN_WAIT_MAX_SECONDS = 5;
+
+  /**
+   * Zero-copy marshaller for inbound {@link ContainerCommandResponseProto}.
+   * For {@code ReadChunk} responses, the parsed proto's bytes fields alias
+   * the inbound Netty buffer (avoiding a chunk-sized memcpy); the buffer is
+   * held until {@link ChunkInputStream} releases it via
+   * {@link #releaseReceivedResponse}. Other response types are deep-copied
+   * inside the wrapping marshaller and released immediately, so callers
+   * never observe a buffer-aliased non-{@code ReadChunk} response.
+   */
+  private static final ZeroCopyMessageMarshaller<ContainerCommandResponseProto>
+      ZERO_COPY_RESPONSE_MARSHALLER = new ZeroCopyMessageMarshaller<>(
+          ContainerCommandResponseProto.getDefaultInstance());
+
+  /**
+   * Marshaller used as the response marshaller of the {@code send} method.
+   * Delegates outbound {@code stream()} to the default, and inbound
+   * {@code parse()} to the zero-copy marshaller. After a successful
+   * zero-copy parse, non-{@code ReadChunk} responses are deep-copied and
+   * the original buffer-aliased response is released, so only
+   * {@code ReadChunk} responses retain the Netty buffer until the caller
+   * is done with the chunk bytes.
+   */
+  private static final MethodDescriptor.Marshaller<ContainerCommandResponseProto>
+      RESPONSE_MARSHALLER =
+      new MethodDescriptor.Marshaller<ContainerCommandResponseProto>() {
+        @Override
+        public InputStream stream(ContainerCommandResponseProto value) {
+          return ZERO_COPY_RESPONSE_MARSHALLER.stream(value);
+        }
+
+        @Override
+        public ContainerCommandResponseProto parse(InputStream stream) {
+          ContainerCommandResponseProto resp =
+              ZERO_COPY_RESPONSE_MARSHALLER.parse(stream);
+          if (resp == null
+              || resp.getCmdType() == ContainerProtos.Type.ReadChunk) {
+            return resp;
+          }
+          // Materialize all bytes fields into byte[]-backed ByteStrings so
+          // the response is independent of the Netty inbound buffer, then
+          // release the underlying buffer back to the pool.
+          try {
+            return ContainerCommandResponseProto.parseFrom(resp.toByteArray());
+          } catch (InvalidProtocolBufferException e) {
+            throw Status.INTERNAL.withDescription("Failed to materialize response")
+                .withCause(e).asRuntimeException();
+          } finally {
+            ZERO_COPY_RESPONSE_MARSHALLER.release(resp);
+          }
+        }
+      };
+
+  /**
+   * gRPC interceptor that installs {@link #RESPONSE_MARSHALLER} as the
+   * response marshaller for the {@code send} bidi-streaming method.
+   */
+  private static final ClientInterceptor ZERO_COPY_INTERCEPTOR =
+      new ClientInterceptor() {
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method,
+            CallOptions callOptions, Channel next) {
+          if (XceiverClientProtocolServiceGrpc.getSendMethod()
+              .getFullMethodName().equals(method.getFullMethodName())) {
+            @SuppressWarnings("unchecked")
+            final MethodDescriptor.Marshaller<RespT> respMarshaller =
+                (MethodDescriptor.Marshaller<RespT>) RESPONSE_MARSHALLER;
+            method = method.toBuilder()
+                .setResponseMarshaller(respMarshaller)
+                .build();
+          }
+          return next.newCall(method, callOptions);
+        }
+      };
+
   private final Pipeline pipeline;
   private final ConfigurationSource config;
   private final XceiverClientMetrics metrics;
@@ -210,7 +294,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(dnHost, port)
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
             .proxyDetector(uri -> null)
-            .intercept(new GrpcClientInterceptor());
+            // Order matters. The zero-copy interceptor swaps the response
+            // marshaller for `send`; the tracing interceptor wraps that.
+            .intercept(new GrpcClientInterceptor())
+            .intercept(ZERO_COPY_INTERCEPTOR);
     if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
       if (trustManager != null) {
@@ -764,6 +851,15 @@ public class XceiverClientGrpc extends XceiverClientSpi {
 
   public void setTimeout(long timeout) {
     this.timeout = timeout;
+  }
+
+  @Override
+  public void releaseReceivedResponse(ContainerCommandResponseProto response) {
+    if (response != null) {
+      // Idempotent: the marshaller no-ops if `response` was never tracked
+      // (i.e., parsed via the standard fallback path).
+      ZERO_COPY_RESPONSE_MARSHALLER.release(response);
+    }
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -394,18 +394,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   @Override
   public ContainerCommandResponseProto sendCommand(
       ContainerCommandRequestProto request) throws IOException {
-    try {
-      return sendCommandWithTraceIDAndRetry(request, null, false).
-          getResponse().get();
-    } catch (ExecutionException e) {
-      throw getIOExceptionForSendCommand(request, e);
-    } catch (InterruptedException e) {
-      LOG.error("Command execution was interrupted.");
-      Thread.currentThread().interrupt();
-      throw (IOException) new InterruptedIOException(
-          "Command " + processForDebug(request) + " was interrupted.")
-          .initCause(e);
-    }
+    return sendCommandAndWait(request, null, false);
   }
 
   @Override
@@ -485,28 +474,22 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   public ContainerCommandResponseProto sendCommand(
       ContainerCommandRequestProto request, List<Validator> validators)
       throws IOException {
-    try {
-      XceiverClientReply reply =
-          sendCommandWithTraceIDAndRetry(request, validators, false);
-      return reply.getResponse().get();
-    } catch (ExecutionException e) {
-      throw getIOExceptionForSendCommand(request, e);
-    } catch (InterruptedException e) {
-      LOG.error("Command execution was interrupted.");
-      Thread.currentThread().interrupt();
-      throw (IOException) new InterruptedIOException(
-          "Command " + processForDebug(request) + " was interrupted.")
-          .initCause(e);
-    }
+    return sendCommandAndWait(request, validators, false);
   }
 
   @Override
   public ContainerCommandResponseProto sendCommandWithZeroCopy(
       ContainerCommandRequestProto request, List<Validator> validators)
       throws IOException {
+    return sendCommandAndWait(request, validators, true);
+  }
+
+  private ContainerCommandResponseProto sendCommandAndWait(
+      ContainerCommandRequestProto request, List<Validator> validators,
+      boolean zeroCopy) throws IOException {
     try {
       XceiverClientReply reply =
-          sendCommandWithTraceIDAndRetry(request, validators, true);
+          sendCommandWithTraceIDAndRetry(request, validators, zeroCopy);
       return reply.getResponse().get();
     } catch (ExecutionException e) {
       throw getIOExceptionForSendCommand(request, e);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -608,8 +608,11 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         }
         break;
       } catch (IOException e) {
+        if (responseProto != null) {
+          releaseReceivedResponse(responseProto);
+          responseProto = null;
+        }
         ioException = e;
-        responseProto = null;
         if (LOG.isDebugEnabled()) {
           LOG.debug("Failed to execute command {} on datanode {}",
               processForDebug(request), dn, e);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -71,6 +71,7 @@ import org.apache.ratis.thirdparty.io.grpc.CallOptions;
 import org.apache.ratis.thirdparty.io.grpc.Channel;
 import org.apache.ratis.thirdparty.io.grpc.ClientCall;
 import org.apache.ratis.thirdparty.io.grpc.ClientInterceptor;
+import org.apache.ratis.thirdparty.io.grpc.ClientInterceptors;
 import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
 import org.apache.ratis.thirdparty.io.grpc.MethodDescriptor;
 import org.apache.ratis.thirdparty.io.grpc.Status;
@@ -154,7 +155,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
 
   /**
    * gRPC interceptor that installs {@link #RESPONSE_MARSHALLER} as the
-   * response marshaller for the {@code send} bidi-streaming method.
+   * response marshaller for the {@code send} bidi-streaming method of the
+   * dedicated zero-copy stub.
    */
   private static final ClientInterceptor ZERO_COPY_INTERCEPTOR =
       new ClientInterceptor() {
@@ -280,7 +282,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
 
     ManagedChannel channel = createChannel(dn, port).build();
     XceiverClientProtocolServiceStub stub = XceiverClientProtocolServiceGrpc.newStub(channel);
-    return new ChannelInfo(channel, stub);
+    XceiverClientProtocolServiceStub zeroCopyStub =
+        XceiverClientProtocolServiceGrpc.newStub(
+            ClientInterceptors.intercept(channel, ZERO_COPY_INTERCEPTOR));
+    return new ChannelInfo(channel, stub, zeroCopyStub);
   }
 
   protected NettyChannelBuilder createChannel(DatanodeDetails dn, int port)
@@ -294,10 +299,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(dnHost, port)
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
             .proxyDetector(uri -> null)
-            // Order matters. The zero-copy interceptor swaps the response
-            // marshaller for `send`; the tracing interceptor wraps that.
-            .intercept(new GrpcClientInterceptor())
-            .intercept(ZERO_COPY_INTERCEPTOR);
+            .intercept(new GrpcClientInterceptor());
     if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
       if (trustManager != null) {
@@ -393,7 +395,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   public ContainerCommandResponseProto sendCommand(
       ContainerCommandRequestProto request) throws IOException {
     try {
-      return sendCommandWithTraceIDAndRetry(request, null).
+      return sendCommandWithTraceIDAndRetry(request, null, false).
           getResponse().get();
     } catch (ExecutionException e) {
       throw getIOExceptionForSendCommand(request, e);
@@ -484,7 +486,27 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       ContainerCommandRequestProto request, List<Validator> validators)
       throws IOException {
     try {
-      XceiverClientReply reply = sendCommandWithTraceIDAndRetry(request, validators);
+      XceiverClientReply reply =
+          sendCommandWithTraceIDAndRetry(request, validators, false);
+      return reply.getResponse().get();
+    } catch (ExecutionException e) {
+      throw getIOExceptionForSendCommand(request, e);
+    } catch (InterruptedException e) {
+      LOG.error("Command execution was interrupted.");
+      Thread.currentThread().interrupt();
+      throw (IOException) new InterruptedIOException(
+          "Command " + processForDebug(request) + " was interrupted.")
+          .initCause(e);
+    }
+  }
+
+  @Override
+  public ContainerCommandResponseProto sendCommandWithZeroCopy(
+      ContainerCommandRequestProto request, List<Validator> validators)
+      throws IOException {
+    try {
+      XceiverClientReply reply =
+          sendCommandWithTraceIDAndRetry(request, validators, true);
       return reply.getResponse().get();
     } catch (ExecutionException e) {
       throw getIOExceptionForSendCommand(request, e);
@@ -498,7 +520,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   }
 
   private XceiverClientReply sendCommandWithTraceIDAndRetry(
-      ContainerCommandRequestProto request, List<Validator> validators)
+      ContainerCommandRequestProto request, List<Validator> validators,
+      boolean zeroCopy)
       throws IOException {
 
     String spanName = "XceiverClientGrpc." + request.getCmdType().name();
@@ -511,7 +534,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
           if (!request.hasVersion()) {
             builder.setVersion(ClientVersion.CURRENT.toProtoValue());
           }
-          return sendCommandWithRetry(builder.build(), validators);
+          return sendCommandWithRetry(builder.build(), validators, zeroCopy);
         });
   }
 
@@ -576,7 +599,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   }
 
   private XceiverClientReply sendCommandWithRetry(
-      ContainerCommandRequestProto request, List<Validator> validators)
+      ContainerCommandRequestProto request, List<Validator> validators,
+      boolean zeroCopy)
       throws IOException {
     ContainerCommandResponseProto responseProto = null;
     IOException ioException = null;
@@ -596,7 +620,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         // sendCommandAsyncCall will create a new channel and async stub
         // in case these don't exist for the specific datanode.
         reply.addDatanode(dn);
-        responseProto = sendCommandAsync(request, dn).getResponse().get();
+        responseProto = (zeroCopy
+            ? sendCommandAsync(request, dn, true)
+            : sendCommandAsync(request, dn)).getResponse().get();
         if (validators != null && !validators.isEmpty()) {
           for (Validator validator : validators) {
             validator.accept(request, responseProto);
@@ -776,11 +802,19 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   public XceiverClientReply sendCommandAsync(
       ContainerCommandRequestProto request, DatanodeDetails dn)
       throws IOException, InterruptedException {
+    return sendCommandAsync(request, dn, false);
+  }
+
+  @VisibleForTesting
+  protected XceiverClientReply sendCommandAsync(
+      ContainerCommandRequestProto request, DatanodeDetails dn,
+      boolean zeroCopy)
+      throws IOException, InterruptedException {
     checkOpen(dn);
     DatanodeID dnId = dn.getID();
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Send command {} to datanode {}",
-          request.getCmdType(), dn);
+      LOG.debug("Send command {} to datanode {}{}",
+          request.getCmdType(), dn, zeroCopy ? " with zero-copy response" : "");
     }
     final CompletableFuture<ContainerCommandResponseProto> replyFuture =
         new CompletableFuture<>();
@@ -790,7 +824,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
 
     // create a new grpc message stream pair for each call.
     final StreamObserver<ContainerCommandRequestProto> requestObserver =
-        dnChannelInfoMap.get(dnId).getStub().withDeadlineAfter(timeout, TimeUnit.SECONDS)
+        (zeroCopy ? dnChannelInfoMap.get(dnId).getZeroCopyStub()
+            : dnChannelInfoMap.get(dnId).getStub())
+            .withDeadlineAfter(timeout, TimeUnit.SECONDS)
             .send(new StreamObserver<ContainerCommandResponseProto>() {
               @Override
               public void onNext(ContainerCommandResponseProto value) {
@@ -871,10 +907,13 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   private static class ChannelInfo {
     private final ManagedChannel channel;
     private final XceiverClientProtocolServiceStub stub;
+    private final XceiverClientProtocolServiceStub zeroCopyStub;
 
-    ChannelInfo(ManagedChannel channel, XceiverClientProtocolServiceStub stub) {
+    ChannelInfo(ManagedChannel channel, XceiverClientProtocolServiceStub stub,
+        XceiverClientProtocolServiceStub zeroCopyStub) {
       this.channel = channel;
       this.stub = stub;
+      this.zeroCopyStub = zeroCopyStub;
     }
 
     public ManagedChannel getChannel() {
@@ -883,6 +922,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
 
     public XceiverClientProtocolServiceStub getStub() {
       return stub;
+    }
+
+    public XceiverClientProtocolServiceStub getZeroCopyStub() {
+      return zeroCopyStub;
     }
 
     public boolean isChannelInactive() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -450,8 +450,8 @@ public class ChunkInputStream extends InputStream
       throws IOException {
 
     ContainerCommandResponseProto reply =
-        ContainerProtocolCalls.readChunk(xceiverClient, readChunkInfo, datanodeBlockID, validators,
-            tokenSupplier.get());
+        ContainerProtocolCalls.readChunkForZeroCopy(xceiverClient, readChunkInfo,
+            datanodeBlockID, validators, tokenSupplier.get());
     // The zero-copy-tracked buffer for the chunk data lives inside `reply`.
     // Stash the outer reference so releaseBuffers() can return it once the
     // chunk bytes have been fully consumed.

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -96,6 +96,13 @@ public class ChunkInputStream extends InputStream
   // retry.  Once the chunk is read, this variable is reset.
   private long chunkPosition = -1;
 
+  // Outer ContainerCommandResponseProto whose chunk data the current `buffers`
+  // view. Held until releaseBuffers() so the underlying zero-copy-tracked
+  // Netty buffer is not freed while the buffers are still in use.
+  // Null on the standard (non-zero-copy) parse path - the proto's bytes
+  // are heap-backed and need no explicit release.
+  private ContainerCommandResponseProto lastResponseToRelease;
+
   private final Supplier<Token<?>> tokenSupplier;
 
   private static final int EOF = -1;
@@ -431,14 +438,25 @@ public class ChunkInputStream extends InputStream
 
   /**
    * Send RPC call to get the chunk from the container.
+   * <p>
+   * On the zero-copy path (HDDS-10283), the returned {@link ByteBuffer}s
+   * view the underlying inbound Netty buffer of the response. Those bytes
+   * stay reachable until {@link #releaseBuffers()} releases them via
+   * {@link XceiverClientSpi#releaseReceivedResponse}, which this method
+   * registers as a side effect through {@link #lastResponseToRelease}.
    */
   @VisibleForTesting
   protected ByteBuffer[] readChunk(ChunkInfo readChunkInfo)
       throws IOException {
 
-    ReadChunkResponseProto readChunkResponse =
+    ContainerCommandResponseProto reply =
         ContainerProtocolCalls.readChunk(xceiverClient, readChunkInfo, datanodeBlockID, validators,
             tokenSupplier.get());
+    // The zero-copy-tracked buffer for the chunk data lives inside `reply`.
+    // Stash the outer reference so releaseBuffers() can return it once the
+    // chunk bytes have been fully consumed.
+    setLastResponseToRelease(reply);
+    final ReadChunkResponseProto readChunkResponse = reply.getReadChunk();
 
     if (readChunkResponse.hasData()) {
       return readChunkResponse.getData().asReadOnlyByteBufferList()
@@ -451,6 +469,16 @@ public class ChunkInputStream extends InputStream
       throw new IOException("Unexpected error while reading chunk data " +
           "from container. No data returned.");
     }
+  }
+
+  private void setLastResponseToRelease(ContainerCommandResponseProto reply) {
+    // If a previous response is still being held (e.g., readChunk called
+    // twice without an intervening releaseBuffers), release the prior one
+    // first so its Netty buffer goes back to the pool.
+    if (lastResponseToRelease != null) {
+      xceiverClient.releaseReceivedResponse(lastResponseToRelease);
+    }
+    lastResponseToRelease = reply;
   }
 
   private void validateChunk(
@@ -702,6 +730,13 @@ public class ChunkInputStream extends InputStream
     buffers = null;
     bufferIndex = 0;
     firstUnreleasedBufferIndex = 0;
+    // Release the zero-copy-tracked Netty buffer of the response that backed
+    // these ByteBuffers. Idempotent and a no-op if the response was parsed
+    // via the standard heap-backed path.
+    if (lastResponseToRelease != null) {
+      xceiverClient.releaseReceivedResponse(lastResponseToRelease);
+      lastResponseToRelease = null;
+    }
     // We should not reset bufferOffsetWrtChunkData and buffersSize here
     // because when getPos() is called in chunkStreamEOF() we use these
     // values and determine whether chunk is read completely or not.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
@@ -155,6 +155,24 @@ public abstract class XceiverClientSpi implements Closeable {
     }
   }
 
+  /**
+   * Sends a given command using an explicit zero-copy-capable response path
+   * when supported by the transport.
+   * <p>
+   * The default implementation delegates to {@link #sendCommand(
+   * ContainerCommandRequestProto, List)}, so transports without zero-copy
+   * support continue to return normal heap-backed responses.
+   *
+   * @param request Request
+   * @param validators functions to validate the response
+   * @return Response to the command
+   */
+  public ContainerCommandResponseProto sendCommandWithZeroCopy(
+      ContainerCommandRequestProto request,
+      List<Validator> validators) throws IOException {
+    return sendCommand(request, validators);
+  }
+
   public void initStreamRead(BlockID blockID, StreamingReaderSpi streamObserver) throws IOException {
     throw new UnsupportedOperationException("Stream read is not supported");
   }
@@ -222,8 +240,9 @@ public abstract class XceiverClientSpi implements Closeable {
    * marshaller, the parsed proto's {@code bytes} fields reference the
    * Netty-managed pooled buffer of the inbound message. Those buffers must
    * be released back to Netty when the caller is done with the proto;
-   * otherwise direct memory accumulates. Callers of {@code sendCommand}
-   * that retain the response past the call (e.g. {@code ReadChunk} via
+   * otherwise direct memory accumulates. Callers of
+   * {@code sendCommandWithZeroCopy} that retain the response past the call
+   * (e.g. {@code ReadChunk} via
    * {@code ContainerProtocolCalls.readChunkForZeroCopy(...)} in
    * {@code ChunkInputStream}) must invoke this method once they are done.
    * <p>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
@@ -129,12 +129,15 @@ public abstract class XceiverClientSpi implements Closeable {
       ContainerCommandRequestProto request,
       List<Validator> validators)
       throws IOException {
+    ContainerCommandResponseProto responseProto = null;
+    boolean validatorsPassed = false;
     try {
       XceiverClientReply reply = sendCommandAsync(request);
-      ContainerCommandResponseProto responseProto = reply.getResponse().get();
+      responseProto = reply.getResponse().get();
       for (Validator function : validators) {
         function.accept(request, responseProto);
       }
+      validatorsPassed = true;
       return responseProto;
     } catch (InterruptedException e) {
       // Re-interrupt the thread while catching InterruptedException
@@ -142,6 +145,13 @@ public abstract class XceiverClientSpi implements Closeable {
       throw getIOExceptionForSendCommand(request, e);
     } catch (ExecutionException e) {
       throw getIOExceptionForSendCommand(request, e);
+    } finally {
+      // If a validator threw, the caller never receives the response, so
+      // release any zero-copy-tracked buffer here. Successful responses are
+      // returned to the caller, who is responsible for releasing them.
+      if (responseProto != null && !validatorsPassed) {
+        releaseReceivedResponse(responseProto);
+      }
     }
   }
 
@@ -204,4 +214,22 @@ public abstract class XceiverClientSpi implements Closeable {
   public abstract Map<DatanodeDetails, ContainerCommandResponseProto>
       sendCommandOnAllNodes(ContainerCommandRequestProto request)
       throws IOException, InterruptedException;
+
+  /**
+   * Release the resources held on behalf of a previously-received response.
+   * <p>
+   * When the underlying transport parses a response with a zero-copy
+   * marshaller, the parsed proto's {@code bytes} fields reference the
+   * Netty-managed pooled buffer of the inbound message. Those buffers must
+   * be released back to Netty when the caller is done with the proto;
+   * otherwise direct memory accumulates. Callers of {@code sendCommand}
+   * that retain the response past the call (e.g. {@code ReadChunk} via
+   * {@code ChunkInputStream}) must invoke this method once they are done.
+   * <p>
+   * This method is idempotent and safe to call on responses that were
+   * never tracked by a zero-copy marshaller.
+   */
+  public void releaseReceivedResponse(ContainerCommandResponseProto response) {
+    // Default: transport without zero-copy support -> no-op.
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
@@ -224,6 +224,7 @@ public abstract class XceiverClientSpi implements Closeable {
    * be released back to Netty when the caller is done with the proto;
    * otherwise direct memory accumulates. Callers of {@code sendCommand}
    * that retain the response past the call (e.g. {@code ReadChunk} via
+   * {@code ContainerProtocolCalls.readChunkForZeroCopy(...)} in
    * {@code ChunkInputStream}) must invoke this method once they are done.
    * <p>
    * This method is idempotent and safe to call on responses that were

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -363,14 +363,29 @@ public final class ContainerProtocolCalls  {
       XceiverClientSpi xceiverClient, ChunkInfo chunk, DatanodeBlockID blockID,
       List<Validator> validators,
       Token<? extends TokenIdentifier> token) throws IOException {
-    ContainerCommandResponseProto reply =
-        readChunkForZeroCopy(xceiverClient, chunk, blockID, validators, token);
-    try {
-      // Detach the inner proto from any zero-copy-backed buffers before the
-      // outer response is released.
-      return ReadChunkResponseProto.parseFrom(reply.getReadChunk().toByteArray());
-    } finally {
-      xceiverClient.releaseReceivedResponse(reply);
+    ReadChunkRequestProto.Builder readChunkRequest =
+        ReadChunkRequestProto.newBuilder()
+            .setBlockID(blockID)
+            .setChunkData(chunk)
+            .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
+    ContainerCommandRequestProto.Builder builder =
+        ContainerCommandRequestProto.newBuilder().setCmdType(Type.ReadChunk)
+            .setContainerID(blockID.getContainerID())
+            .setReadChunk(readChunkRequest);
+    if (token != null) {
+      builder.setEncodedToken(token.encodeToUrlString());
+    }
+
+    try (TracingUtil.TraceCloseable ignored =
+             TracingUtil.createActivatedSpan("readChunk")) {
+      Span span = TracingUtil.getActiveSpan();
+      span.setAttribute("offset", chunk.getOffset())
+          .setAttribute("length", chunk.getLen())
+          .setAttribute("block", blockID.toString());
+      return tryEachDatanode(xceiverClient.getPipeline(),
+          d -> readChunk(xceiverClient, chunk, blockID,
+              validators, builder, d, false).getReadChunk(),
+          d -> toErrorMessage(chunk, blockID, d));
     }
   }
 
@@ -416,7 +431,7 @@ public final class ContainerProtocolCalls  {
           .setAttribute("block", blockID.toString());
       return tryEachDatanode(xceiverClient.getPipeline(),
           d -> readChunk(xceiverClient, chunk, blockID,
-              validators, builder, d),
+              validators, builder, d, true),
           d -> toErrorMessage(chunk, blockID, d));
     }
   }
@@ -425,7 +440,7 @@ public final class ContainerProtocolCalls  {
       XceiverClientSpi xceiverClient, ChunkInfo chunk, DatanodeBlockID blockID,
       List<Validator> validators,
       ContainerCommandRequestProto.Builder builder,
-      DatanodeDetails d) throws IOException {
+      DatanodeDetails d, boolean zeroCopy) throws IOException {
     ContainerCommandRequestProto.Builder requestBuilder = builder
         .setDatanodeUuid(d.getUuidString());
     String traceId = TracingUtil.exportCurrentSpan();
@@ -433,12 +448,17 @@ public final class ContainerProtocolCalls  {
       requestBuilder = requestBuilder.setTraceID(traceId);
     }
     ContainerCommandResponseProto reply =
-        xceiverClient.sendCommandWithZeroCopy(requestBuilder.build(), validators);
+        zeroCopy
+            ? xceiverClient.sendCommandWithZeroCopy(
+                requestBuilder.build(), validators)
+            : xceiverClient.sendCommand(requestBuilder.build(), validators);
     final ReadChunkResponseProto response = reply.getReadChunk();
     final long readLen = getLen(response);
     if (readLen != chunk.getLen()) {
-      // Release the zero-copy-tracked buffer before propagating the error.
-      xceiverClient.releaseReceivedResponse(reply);
+      if (zeroCopy) {
+        // Release the zero-copy-tracked buffer before propagating the error.
+        xceiverClient.releaseReceivedResponse(reply);
+      }
       throw new IOException(toErrorMessage(chunk, blockID, d)
           + ": readLen=" + readLen);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -433,7 +433,7 @@ public final class ContainerProtocolCalls  {
       requestBuilder = requestBuilder.setTraceID(traceId);
     }
     ContainerCommandResponseProto reply =
-        xceiverClient.sendCommand(requestBuilder.build(), validators);
+        xceiverClient.sendCommandWithZeroCopy(requestBuilder.build(), validators);
     final ReadChunkResponseProto response = reply.getReadChunk();
     final long readLen = getLen(response);
     if (readLen != chunk.getLen()) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -344,17 +344,24 @@ public final class ContainerProtocolCalls  {
   }
 
   /**
-   * Calls the container protocol to read a chunk.
+   * Calls the container protocol to read a chunk and returns the outer
+   * {@link ContainerCommandResponseProto}. The caller is responsible for
+   * invoking
+   * {@link XceiverClientSpi#releaseReceivedResponse(ContainerCommandResponseProto)}
+   * on the returned response once the chunk bytes are no longer needed.
+   * The outer wrapper is returned (rather than just the inner
+   * {@link ReadChunkResponseProto}) so that the caller has a stable reference
+   * for the zero-copy release.
    *
    * @param xceiverClient client to perform call
    * @param chunk information about chunk to read
    * @param blockID ID of the block
    * @param validators functions to validate the response
    * @param token a token for this block (may be null)
-   * @return container protocol read chunk response
+   * @return outer container command response containing the read chunk reply
    * @throws IOException if there is an I/O error while performing the call
    */
-  public static ContainerProtos.ReadChunkResponseProto readChunk(
+  public static ContainerCommandResponseProto readChunk(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, DatanodeBlockID blockID,
       List<Validator> validators,
       Token<? extends TokenIdentifier> token) throws IOException {
@@ -383,7 +390,7 @@ public final class ContainerProtocolCalls  {
     }
   }
 
-  private static ContainerProtos.ReadChunkResponseProto readChunk(
+  private static ContainerCommandResponseProto readChunk(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, DatanodeBlockID blockID,
       List<Validator> validators,
       ContainerCommandRequestProto.Builder builder,
@@ -399,10 +406,12 @@ public final class ContainerProtocolCalls  {
     final ReadChunkResponseProto response = reply.getReadChunk();
     final long readLen = getLen(response);
     if (readLen != chunk.getLen()) {
+      // Release the zero-copy-tracked buffer before propagating the error.
+      xceiverClient.releaseReceivedResponse(reply);
       throw new IOException(toErrorMessage(chunk, blockID, d)
           + ": readLen=" + readLen);
     }
-    return response;
+    return reply;
   }
 
   static String toErrorMessage(ChunkInfo chunk, DatanodeBlockID blockId,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -344,6 +344,37 @@ public final class ContainerProtocolCalls  {
   }
 
   /**
+   * Calls the container protocol to read a chunk and returns a detached
+   * {@link ReadChunkResponseProto}.
+   * <p>
+   * Callers that need access to the zero-copy-backed outer response should use
+   * {@link #readChunkForZeroCopy(XceiverClientSpi, ChunkInfo, DatanodeBlockID,
+   * List, Token)}.
+   *
+   * @param xceiverClient client to perform call
+   * @param chunk information about chunk to read
+   * @param blockID ID of the block
+   * @param validators functions to validate the response
+   * @param token a token for this block (may be null)
+   * @return detached read chunk response
+   * @throws IOException if there is an I/O error while performing the call
+   */
+  public static ReadChunkResponseProto readChunk(
+      XceiverClientSpi xceiverClient, ChunkInfo chunk, DatanodeBlockID blockID,
+      List<Validator> validators,
+      Token<? extends TokenIdentifier> token) throws IOException {
+    ContainerCommandResponseProto reply =
+        readChunkForZeroCopy(xceiverClient, chunk, blockID, validators, token);
+    try {
+      // Detach the inner proto from any zero-copy-backed buffers before the
+      // outer response is released.
+      return ReadChunkResponseProto.parseFrom(reply.getReadChunk().toByteArray());
+    } finally {
+      xceiverClient.releaseReceivedResponse(reply);
+    }
+  }
+
+  /**
    * Calls the container protocol to read a chunk and returns the outer
    * {@link ContainerCommandResponseProto}. The caller is responsible for
    * invoking
@@ -361,7 +392,7 @@ public final class ContainerProtocolCalls  {
    * @return outer container command response containing the read chunk reply
    * @throws IOException if there is an I/O error while performing the call
    */
-  public static ContainerCommandResponseProto readChunk(
+  public static ContainerCommandResponseProto readChunkForZeroCopy(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, DatanodeBlockID blockID,
       List<Validator> validators,
       Token<? extends TokenIdentifier> token) throws IOException {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
@@ -510,7 +510,7 @@ public class TestContainerReconciliationWithMockDatanodes {
           .build();
     }
 
-    public ContainerProtos.ReadChunkResponseProto readChunk(ContainerProtos.DatanodeBlockID blockId,
+    public ContainerProtos.ContainerCommandResponseProto readChunk(ContainerProtos.DatanodeBlockID blockId,
         ContainerProtos.ChunkInfo chunkInfo, List<XceiverClientSpi.Validator> validators) throws IOException {
       KeyValueContainer container = getContainer(blockId.getContainerID());
       ContainerProtos.ReadChunkResponseProto readChunkResponseProto =
@@ -520,11 +520,11 @@ public class TestContainerReconciliationWithMockDatanodes {
               .setData(handler.getChunkManager().readChunk(container, BlockID.getFromProtobuf(blockId),
                   ChunkInfo.getFromProtoBuf(chunkInfo), null).toByteString())
               .build();
-      verifyChecksums(readChunkResponseProto, blockId, chunkInfo, validators);
-      return readChunkResponseProto;
+      return verifyChecksums(readChunkResponseProto, blockId, chunkInfo, validators);
     }
 
-    public void verifyChecksums(ContainerProtos.ReadChunkResponseProto readChunkResponseProto,
+    public ContainerProtos.ContainerCommandResponseProto verifyChecksums(
+        ContainerProtos.ReadChunkResponseProto readChunkResponseProto,
         ContainerProtos.DatanodeBlockID blockId, ContainerProtos.ChunkInfo chunkInfo,
         List<XceiverClientSpi.Validator> validators) throws IOException {
       assertFalse(validators.isEmpty());
@@ -547,6 +547,7 @@ public class TestContainerReconciliationWithMockDatanodes {
       for (XceiverClientSpi.Validator function : validators) {
         function.accept(requestProto, responseProto);
       }
+      return responseProto;
     }
 
     public KeyValueContainer getContainer(long containerID) {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestFileChecksumHelper.java
@@ -217,9 +217,9 @@ public class TestFileChecksumHelper {
     XceiverClientGrpc xceiverClientGrpc =
         new XceiverClientGrpc(pipeline, conf) {
           @Override
-          public XceiverClientReply sendCommandAsync(
+          protected XceiverClientReply sendCommandAsync(
               ContainerProtos.ContainerCommandRequestProto request,
-              DatanodeDetails dn) {
+              DatanodeDetails dn, boolean zeroCopy) {
             return buildValidResponse(helperType);
           }
         };

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
@@ -126,9 +126,12 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
     ContainerCommandRequestProto request = createReadChunkRequest(0);
     ContainerCommandResponseProto response =
         xceiverClient.sendCommand(request);
-
-    checksum = new Checksum(ContainerProtos.ChecksumType.CRC32, chunkSize);
-    checksumReference = computeChecksum(response);
+    try {
+      checksum = new Checksum(ContainerProtos.ChecksumType.CRC32, chunkSize);
+      checksumReference = computeChecksum(response);
+    } finally {
+      xceiverClient.releaseReceivedResponse(response);
+    }
   }
 
   private void validateChunk(long stepNo) throws Exception {
@@ -138,15 +141,18 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
       try {
         ContainerCommandResponseProto response =
             xceiverClient.sendCommand(request);
+        try {
+          ChecksumData checksumOfChunk = computeChecksum(response);
 
-        ChecksumData checksumOfChunk = computeChecksum(response);
-
-        if (!checksumReference.equals(checksumOfChunk)) {
-          throw new IllegalStateException(
-              "Reference (=first) message checksum doesn't match " +
-                  "with checksum of chunk "
-                        + response.getReadChunk()
-                  .getChunkData().getChunkName());
+          if (!checksumReference.equals(checksumOfChunk)) {
+            throw new IllegalStateException(
+                "Reference (=first) message checksum doesn't match " +
+                    "with checksum of chunk "
+                          + response.getReadChunk()
+                    .getChunkData().getChunkName());
+          }
+        } finally {
+          xceiverClient.releaseReceivedResponse(response);
         }
       } catch (IOException e) {
         LOG.warn("Could not read chunk due to IOException: ", e);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -209,11 +209,12 @@ public class TestXceiverClientGrpc {
             ContainerProtocolCalls.readChunk(client, chunkInfo,
                 bid.getDatanodeBlockIDProtobuf(), null, null)
                 .getData().toByteArray());
-        assertEquals(1, releaseCount.get());
+        assertEquals(0, releaseCount.get());
       }
     }
 
-    assertEquals(1, releaseCount.get());
+    assertEquals(readChunkApi == ReadChunkApi.ZERO_COPY ? 1 : 0,
+        releaseCount.get());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -57,16 +57,15 @@ import org.junit.jupiter.params.provider.EnumSource;
  * select the closest node, and connections are re-used after a getBlock call.
  */
 public class TestXceiverClientGrpc {
+  private Pipeline pipeline;
+  private List<DatanodeDetails> dns;
+  private List<DatanodeDetails> dnsInOrder;
+  private OzoneConfiguration conf = new OzoneConfiguration();
 
   private enum ReadChunkApi {
     LEGACY,
     ZERO_COPY
   }
-
-  private Pipeline pipeline;
-  private List<DatanodeDetails> dns;
-  private List<DatanodeDetails> dnsInOrder;
-  private OzoneConfiguration conf = new OzoneConfiguration();
 
   @BeforeEach
   public void setup() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -108,9 +108,9 @@ public class TestXceiverClientGrpc {
     for (int i = 0; i < 100; i++) {
       try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
-        public XceiverClientReply sendCommandAsync(
+        protected XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
-            DatanodeDetails dn) {
+            DatanodeDetails dn, boolean zeroCopy) {
           seenDN.add(dn);
           return buildValidResponse();
         }
@@ -127,9 +127,9 @@ public class TestXceiverClientGrpc {
     assertThat(allDNs.size()).isGreaterThan(1);
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
-      public XceiverClientReply sendCommandAsync(
+      protected XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,
-          DatanodeDetails dn) throws IOException {
+          DatanodeDetails dn, boolean zeroCopy) throws IOException {
         allDNs.remove(dn);
         throw new IOException("Failed " + dn);
       }
@@ -148,9 +148,9 @@ public class TestXceiverClientGrpc {
     assertThat(allDNs.size()).isGreaterThan(1);
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
-      public XceiverClientReply sendCommandAsync(
+      protected XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,
-          DatanodeDetails dn) throws IOException {
+          DatanodeDetails dn, boolean zeroCopy) throws IOException {
         allDNs.remove(dn);
         throw new IOException("Failed " + dn);
       }
@@ -169,9 +169,9 @@ public class TestXceiverClientGrpc {
     final AtomicInteger releaseCount = new AtomicInteger();
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
-      public XceiverClientReply sendCommandAsync(
+      protected XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,
-          DatanodeDetails dn) {
+          DatanodeDetails dn, boolean zeroCopy) {
         return buildValidReadChunkResponse();
       }
 
@@ -217,6 +217,64 @@ public class TestXceiverClientGrpc {
   }
 
   @Test
+  public void testReadChunkZeroCopyIsOptInOnly() throws IOException {
+    final AtomicInteger regularCallCount = new AtomicInteger();
+    final AtomicInteger zeroCopyCallCount = new AtomicInteger();
+    final BlockID blockID = new BlockID(1, 1);
+    final ContainerProtos.ChunkInfo chunkInfo = ContainerProtos.ChunkInfo
+        .newBuilder()
+        .setChunkName("Anything")
+        .setChecksumData(ContainerProtos.ChecksumData.newBuilder()
+            .setBytesPerChecksum(1)
+            .setType(ContainerProtos.ChecksumType.CRC32)
+            .build())
+        .setLen(1)
+        .setOffset(0)
+        .build();
+    final ContainerProtos.ContainerCommandRequestProto request =
+        ContainerProtos.ContainerCommandRequestProto.newBuilder()
+            .setCmdType(ContainerProtos.Type.ReadChunk)
+            .setContainerID(blockID.getContainerID())
+            .setDatanodeUuid(pipeline.getFirstNode().getUuidString())
+            .setReadChunk(ContainerProtos.ReadChunkRequestProto.newBuilder()
+                .setBlockID(blockID.getDatanodeBlockIDProtobuf())
+                .setChunkData(chunkInfo))
+            .build();
+
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      @Override
+      protected XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request,
+          DatanodeDetails dn, boolean zeroCopy) {
+        if (zeroCopy) {
+          zeroCopyCallCount.incrementAndGet();
+        } else {
+          regularCallCount.incrementAndGet();
+        }
+        return buildValidReadChunkResponse();
+      }
+    }) {
+      assertArrayEquals(new byte[] {1},
+          client.sendCommand(request).getReadChunk().getData().toByteArray());
+      assertEquals(1, regularCallCount.get());
+      assertEquals(0, zeroCopyCallCount.get());
+
+      ContainerProtos.ContainerCommandResponseProto reply =
+          ContainerProtocolCalls.readChunkForZeroCopy(client, chunkInfo,
+              blockID.getDatanodeBlockIDProtobuf(), null, null);
+      try {
+        assertArrayEquals(new byte[] {1},
+            reply.getReadChunk().getData().toByteArray());
+      } finally {
+        client.releaseReceivedResponse(reply);
+      }
+    }
+
+    assertEquals(1, regularCallCount.get());
+    assertEquals(1, zeroCopyCallCount.get());
+  }
+
+  @Test
   public void testReadChunkValidatorFailureReleasesResponseBeforeRetry()
       throws IOException {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
@@ -244,9 +302,9 @@ public class TestXceiverClientGrpc {
 
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
-      public XceiverClientReply sendCommandAsync(
+      protected XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,
-          DatanodeDetails dn) {
+          DatanodeDetails dn, boolean zeroCopy) {
         allDNs.remove(dn);
         return buildValidReadChunkResponse();
       }
@@ -275,9 +333,9 @@ public class TestXceiverClientGrpc {
         new CompletableFuture<>();
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
-      public XceiverClientReply sendCommandAsync(
+      protected XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,
-          DatanodeDetails dn) {
+          DatanodeDetails dn, boolean zeroCopy) {
         return new XceiverClientReply(response);
       }
     }) {
@@ -305,9 +363,9 @@ public class TestXceiverClientGrpc {
     for (int i = 0; i < 100; i++) {
       try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
-        public XceiverClientReply sendCommandAsync(
+        protected XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
-            DatanodeDetails dn) {
+            DatanodeDetails dn, boolean zeroCopy) {
           seenDNs.add(dn);
           if (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
             return buildValidReadChunkResponse();
@@ -340,9 +398,9 @@ public class TestXceiverClientGrpc {
           setPersistedOpState(NodeOperationalState.IN_MAINTENANCE);
       try (XceiverClientGrpc client = new XceiverClientGrpc(randomPipeline, conf) {
         @Override
-        public XceiverClientReply sendCommandAsync(
+        protected XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
-            DatanodeDetails dn) {
+            DatanodeDetails dn, boolean zeroCopy) {
           seenDNs.add(dn);
           return buildValidResponse();
         }
@@ -366,9 +424,9 @@ public class TestXceiverClientGrpc {
       final Set<DatanodeDetails> seenDNs = new HashSet<>();
       try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
-        public XceiverClientReply sendCommandAsync(
+        protected XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
-            DatanodeDetails dn) {
+            DatanodeDetails dn, boolean zeroCopy) {
           seenDNs.add(dn);
           if (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
             return buildValidReadChunkResponse();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,12 +49,19 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * Tests for TestXceiverClientGrpc, to ensure topology aware reads work
  * select the closest node, and connections are re-used after a getBlock call.
  */
 public class TestXceiverClientGrpc {
+
+  private enum ReadChunkApi {
+    LEGACY,
+    ZERO_COPY
+  }
 
   private Pipeline pipeline;
   private List<DatanodeDetails> dns;
@@ -133,8 +141,9 @@ public class TestXceiverClientGrpc {
     assertEquals(0, allDNs.size());
   }
 
-  @Test
-  public void testReadChunkRetryAllNodes() {
+  @ParameterizedTest(name = "readChunkApi={0}")
+  @EnumSource(ReadChunkApi.class)
+  public void testReadChunkRetryAllNodes(ReadChunkApi readChunkApi) {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
     assertThat(allDNs.size()).isGreaterThan(1);
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
@@ -146,11 +155,65 @@ public class TestXceiverClientGrpc {
         throw new IOException("Failed " + dn);
       }
     }) {
-      invokeXceiverClientReadChunk(client);
+      invokeXceiverClientReadChunk(client, readChunkApi);
     } catch (IOException e) {
       e.printStackTrace();
     }
     assertEquals(0, allDNs.size());
+  }
+
+  @ParameterizedTest(name = "readChunkApi={0}")
+  @EnumSource(ReadChunkApi.class)
+  public void testReadChunkApisReturnExpectedDataAndReleaseOwnership(
+      ReadChunkApi readChunkApi) throws IOException {
+    final AtomicInteger releaseCount = new AtomicInteger();
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      @Override
+      public XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request,
+          DatanodeDetails dn) {
+        return buildValidReadChunkResponse();
+      }
+
+      @Override
+      public void releaseReceivedResponse(
+          ContainerProtos.ContainerCommandResponseProto response) {
+        releaseCount.incrementAndGet();
+      }
+    }) {
+      BlockID bid = new BlockID(1, 1);
+      bid.setBlockCommitSequenceId(1);
+      ContainerProtos.ChunkInfo chunkInfo =
+          ContainerProtos.ChunkInfo.newBuilder()
+              .setChunkName("Anything")
+              .setChecksumData(ContainerProtos.ChecksumData.newBuilder()
+                  .setBytesPerChecksum(1)
+                  .setType(ContainerProtos.ChecksumType.CRC32)
+                  .build())
+              .setLen(1)
+              .setOffset(0)
+              .build();
+      if (readChunkApi == ReadChunkApi.ZERO_COPY) {
+        ContainerProtos.ContainerCommandResponseProto reply =
+            ContainerProtocolCalls.readChunkForZeroCopy(client, chunkInfo,
+                bid.getDatanodeBlockIDProtobuf(), null, null);
+        assertEquals(0, releaseCount.get());
+        try {
+          assertArrayEquals(new byte[] {1},
+              reply.getReadChunk().getData().toByteArray());
+        } finally {
+          client.releaseReceivedResponse(reply);
+        }
+      } else {
+        assertArrayEquals(new byte[] {1},
+            ContainerProtocolCalls.readChunk(client, chunkInfo,
+                bid.getDatanodeBlockIDProtobuf(), null, null)
+                .getData().toByteArray());
+        assertEquals(1, releaseCount.get());
+      }
+    }
+
+    assertEquals(1, releaseCount.get());
   }
 
   @Test
@@ -246,6 +309,9 @@ public class TestXceiverClientGrpc {
             ContainerProtos.ContainerCommandRequestProto request,
             DatanodeDetails dn) {
           seenDNs.add(dn);
+          if (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
+            return buildValidReadChunkResponse();
+          }
           return buildValidResponse();
         }
       }) {
@@ -290,8 +356,10 @@ public class TestXceiverClientGrpc {
     }
   }
 
-  @Test
-  public void testConnectionReusedAfterGetBlock() throws IOException {
+  @ParameterizedTest(name = "readChunkApi={0}")
+  @EnumSource(ReadChunkApi.class)
+  public void testConnectionReusedAfterGetBlock(ReadChunkApi readChunkApi)
+      throws IOException {
     // With a new Client, make 100 calls. On each call, ensure that only one
     // DN is seen, indicating the same DN connection is reused.
     for (int i = 0; i < 100; i++) {
@@ -302,12 +370,15 @@ public class TestXceiverClientGrpc {
             ContainerProtos.ContainerCommandRequestProto request,
             DatanodeDetails dn) {
           seenDNs.add(dn);
+          if (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
+            return buildValidReadChunkResponse();
+          }
           return buildValidResponse();
         }
       }) {
         invokeXceiverClientGetBlock(client);
         invokeXceiverClientGetBlock(client);
-        invokeXceiverClientReadChunk(client);
+        invokeXceiverClientReadChunk(client, readChunkApi);
         invokeXceiverClientReadSmallFile(client);
       }
       assertEquals(1, seenDNs.size());
@@ -324,22 +395,30 @@ public class TestXceiverClientGrpc {
             .build()), null, client.getPipeline().getReplicaIndexes());
   }
 
-  private void invokeXceiverClientReadChunk(XceiverClientSpi client)
+  private void invokeXceiverClientReadChunk(XceiverClientSpi client,
+      ReadChunkApi readChunkApi)
       throws IOException {
     BlockID bid = new BlockID(1, 1);
     bid.setBlockCommitSequenceId(1);
-    ContainerProtocolCalls.readChunk(client,
+    ContainerProtos.ChunkInfo chunkInfo =
         ContainerProtos.ChunkInfo.newBuilder()
             .setChunkName("Anything")
             .setChecksumData(ContainerProtos.ChecksumData.newBuilder()
-                .setBytesPerChecksum(512)
+                .setBytesPerChecksum(1)
                 .setType(ContainerProtos.ChecksumType.CRC32)
                 .build())
-            .setLen(-1)
+            .setLen(1)
             .setOffset(0)
-            .build(),
-        bid.getDatanodeBlockIDProtobuf(),
-        null, null);
+            .build();
+    if (readChunkApi == ReadChunkApi.ZERO_COPY) {
+      ContainerProtos.ContainerCommandResponseProto reply =
+          ContainerProtocolCalls.readChunkForZeroCopy(client, chunkInfo,
+              bid.getDatanodeBlockIDProtobuf(), null, null);
+      client.releaseReceivedResponse(reply);
+      return;
+    }
+    ContainerProtocolCalls.readChunk(client, chunkInfo,
+        bid.getDatanodeBlockIDProtobuf(), null, null);
   }
 
   private void invokeXceiverClientReadSmallFile(XceiverClientSpi client)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -25,10 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -43,6 +45,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -148,6 +151,58 @@ public class TestXceiverClientGrpc {
       e.printStackTrace();
     }
     assertEquals(0, allDNs.size());
+  }
+
+  @Test
+  public void testReadChunkValidatorFailureReleasesResponseBeforeRetry()
+      throws IOException {
+    final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
+    final AtomicInteger releaseCount = new AtomicInteger();
+    final BlockID blockID = new BlockID(1, 1);
+    final ContainerProtos.ChunkInfo chunkInfo = ContainerProtos.ChunkInfo
+        .newBuilder()
+        .setChunkName("Anything")
+        .setChecksumData(ContainerProtos.ChecksumData.newBuilder()
+            .setBytesPerChecksum(1)
+            .setType(ContainerProtos.ChecksumType.CRC32)
+            .build())
+        .setLen(1)
+        .setOffset(0)
+        .build();
+    final ContainerProtos.ContainerCommandRequestProto request =
+        ContainerProtos.ContainerCommandRequestProto.newBuilder()
+            .setCmdType(ContainerProtos.Type.ReadChunk)
+            .setContainerID(blockID.getContainerID())
+            .setDatanodeUuid(pipeline.getFirstNode().getUuidString())
+            .setReadChunk(ContainerProtos.ReadChunkRequestProto.newBuilder()
+                .setBlockID(blockID.getDatanodeBlockIDProtobuf())
+                .setChunkData(chunkInfo))
+            .build();
+
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      @Override
+      public XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request,
+          DatanodeDetails dn) {
+        allDNs.remove(dn);
+        return buildValidReadChunkResponse();
+      }
+
+      @Override
+      public void releaseReceivedResponse(
+          ContainerProtos.ContainerCommandResponseProto response) {
+        releaseCount.incrementAndGet();
+      }
+    }) {
+      IOException ex = assertThrows(IOException.class,
+          () -> client.sendCommand(request, Collections.singletonList((req, resp) -> {
+            throw new IOException("validator failed");
+          })));
+      assertThat(ex).hasMessageContaining("validator failed");
+    }
+
+    assertEquals(0, allDNs.size());
+    assertEquals(dns.size(), releaseCount.get());
   }
 
   @Test
@@ -299,6 +354,34 @@ public class TestXceiverClientGrpc {
         ContainerProtos.ContainerCommandResponseProto.newBuilder()
             .setCmdType(ContainerProtos.Type.GetBlock)
             .setResult(ContainerProtos.Result.SUCCESS).build();
+    final CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
+        replyFuture = new CompletableFuture<>();
+    replyFuture.complete(resp);
+    return new XceiverClientReply(replyFuture);
+  }
+
+  private XceiverClientReply buildValidReadChunkResponse() {
+    ContainerProtos.ContainerCommandResponseProto resp =
+        ContainerProtos.ContainerCommandResponseProto.newBuilder()
+            .setCmdType(ContainerProtos.Type.ReadChunk)
+            .setResult(ContainerProtos.Result.SUCCESS)
+            .setReadChunk(ContainerProtos.ReadChunkResponseProto.newBuilder()
+                .setBlockID(ContainerProtos.DatanodeBlockID.newBuilder()
+                    .setContainerID(1)
+                    .setLocalID(1)
+                    .build())
+                .setChunkData(ContainerProtos.ChunkInfo.newBuilder()
+                    .setChunkName("Anything")
+                    .setChecksumData(ContainerProtos.ChecksumData.newBuilder()
+                        .setBytesPerChecksum(1)
+                        .setType(ContainerProtos.ChecksumType.CRC32)
+                        .build())
+                    .setLen(1)
+                    .setOffset(0)
+                    .build())
+                .setData(ByteString.copyFrom(new byte[] {1}))
+                .build())
+            .build();
     final CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
         replyFuture = new CompletableFuture<>();
     replyFuture.complete(resp);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -165,6 +165,11 @@ public class TestContainerCommandsEC {
   private static OzoneBucket classBucket;
   private static ReplicationConfig repConfig;
 
+  private enum ReadChunkPath {
+    LEGACY,
+    ZERO_COPY
+  }
+
   @BeforeAll
   public static void init() throws Exception {
     config = new OzoneConfiguration();
@@ -243,6 +248,10 @@ public class TestContainerCommandsEC {
             throw new RuntimeException(e);
           }
         });
+  }
+
+  private static Stream<ReadChunkPath> readChunkPaths() {
+    return Stream.of(ReadChunkPath.values());
   }
 
   @Test
@@ -443,8 +452,10 @@ public class TestContainerCommandsEC {
     }
   }
 
-  @Test
-  public void testCreateRecoveryContainer() throws Exception {
+  @ParameterizedTest(name = "readChunkPath={0}")
+  @MethodSource("readChunkPaths")
+  public void testCreateRecoveryContainer(ReadChunkPath readChunkPath)
+      throws Exception {
     try (XceiverClientManager xceiverClientManager =
         new XceiverClientManager(config)) {
       ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
@@ -514,26 +525,46 @@ public class TestContainerCommandsEC {
                 container.containerID().getProtobuf().getId(), encodedToken);
         assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
             readContainerResponseProto.getContainerData().getState());
-        ContainerProtos.ContainerCommandResponseProto readChunkReply =
-            ContainerProtocolCalls.readChunkForZeroCopy(dnClient,
-                writeChunkRequest.getWriteChunk().getChunkData(),
-                blockID.getDatanodeBlockIDProtobufBuilder().setReplicaIndex(replicaIndex).build(), null,
-                blockToken);
-        try {
-          ContainerProtos.ReadChunkResponseProto readChunkResponseProto =
-              readChunkReply.getReadChunk();
-          ByteBuffer[] readOnlyByteBuffersArray = BufferUtils
-              .getReadOnlyByteBuffersArray(
-                  readChunkResponseProto.getDataBuffers().getBuffersList());
-          assertEquals(readOnlyByteBuffersArray[0].limit(), data.length);
-          byte[] readBuff = new byte[readOnlyByteBuffersArray[0].limit()];
-          readOnlyByteBuffersArray[0].get(readBuff, 0, readBuff.length);
-          assertArrayEquals(data, readBuff);
-        } finally {
-          dnClient.releaseReceivedResponse(readChunkReply);
-        }
+        ContainerProtos.DatanodeBlockID readBlockID =
+            blockID.getDatanodeBlockIDProtobufBuilder()
+                .setReplicaIndex(replicaIndex)
+                .build();
+        assertReadChunkData(readChunkPath, dnClient,
+            writeChunkRequest.getWriteChunk().getChunkData(),
+            readBlockID, blockToken, data);
       } finally {
         xceiverClientManager.releaseClient(dnClient, false);
+      }
+    }
+  }
+
+  private void assertReadChunkData(ReadChunkPath readChunkPath,
+      XceiverClientSpi dnClient, ContainerProtos.ChunkInfo chunkInfo,
+      ContainerProtos.DatanodeBlockID blockID,
+      Token<? extends TokenIdentifier> blockToken, byte[] expectedData)
+      throws IOException {
+    ContainerProtos.ContainerCommandResponseProto readChunkReply = null;
+    ContainerProtos.ReadChunkResponseProto readChunkResponseProto;
+    if (readChunkPath == ReadChunkPath.ZERO_COPY) {
+      readChunkReply = ContainerProtocolCalls.readChunkForZeroCopy(dnClient,
+          chunkInfo, blockID, null, blockToken);
+      readChunkResponseProto = readChunkReply.getReadChunk();
+    } else {
+      readChunkResponseProto = ContainerProtocolCalls.readChunk(dnClient,
+          chunkInfo, blockID, null, blockToken);
+    }
+
+    try {
+      ByteBuffer[] readOnlyByteBuffersArray = BufferUtils
+          .getReadOnlyByteBuffersArray(
+              readChunkResponseProto.getDataBuffers().getBuffersList());
+      assertEquals(readOnlyByteBuffersArray[0].limit(), expectedData.length);
+      byte[] readBuff = new byte[readOnlyByteBuffersArray[0].limit()];
+      readOnlyByteBuffersArray[0].get(readBuff, 0, readBuff.length);
+      assertArrayEquals(expectedData, readBuff);
+    } finally {
+      if (readChunkReply != null) {
+        dnClient.releaseReceivedResponse(readChunkReply);
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -515,7 +515,7 @@ public class TestContainerCommandsEC {
         assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
             readContainerResponseProto.getContainerData().getState());
         ContainerProtos.ContainerCommandResponseProto readChunkReply =
-            ContainerProtocolCalls.readChunk(dnClient,
+            ContainerProtocolCalls.readChunkForZeroCopy(dnClient,
                 writeChunkRequest.getWriteChunk().getChunkData(),
                 blockID.getDatanodeBlockIDProtobufBuilder().setReplicaIndex(replicaIndex).build(), null,
                 blockToken);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -514,18 +514,24 @@ public class TestContainerCommandsEC {
                 container.containerID().getProtobuf().getId(), encodedToken);
         assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
             readContainerResponseProto.getContainerData().getState());
-        ContainerProtos.ReadChunkResponseProto readChunkResponseProto =
+        ContainerProtos.ContainerCommandResponseProto readChunkReply =
             ContainerProtocolCalls.readChunk(dnClient,
                 writeChunkRequest.getWriteChunk().getChunkData(),
                 blockID.getDatanodeBlockIDProtobufBuilder().setReplicaIndex(replicaIndex).build(), null,
                 blockToken);
-        ByteBuffer[] readOnlyByteBuffersArray = BufferUtils
-            .getReadOnlyByteBuffersArray(
-                readChunkResponseProto.getDataBuffers().getBuffersList());
-        assertEquals(readOnlyByteBuffersArray[0].limit(), data.length);
-        byte[] readBuff = new byte[readOnlyByteBuffersArray[0].limit()];
-        readOnlyByteBuffersArray[0].get(readBuff, 0, readBuff.length);
-        assertArrayEquals(data, readBuff);
+        try {
+          ContainerProtos.ReadChunkResponseProto readChunkResponseProto =
+              readChunkReply.getReadChunk();
+          ByteBuffer[] readOnlyByteBuffersArray = BufferUtils
+              .getReadOnlyByteBuffersArray(
+                  readChunkResponseProto.getDataBuffers().getBuffersList());
+          assertEquals(readOnlyByteBuffersArray[0].limit(), data.length);
+          byte[] readBuff = new byte[readOnlyByteBuffersArray[0].limit()];
+          readOnlyByteBuffersArray[0].get(readBuff, 0, readBuff.length);
+          assertArrayEquals(data, readBuff);
+        } finally {
+          dnClient.releaseReceivedResponse(readChunkReply);
+        }
       } finally {
         xceiverClientManager.releaseClient(dnClient, false);
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
@@ -835,35 +835,49 @@ public class TestOmContainerLocationCache {
                              byte[] data,
                              Exception exception,
                              Result errorCode) throws Exception {
-    final CompletableFuture<ContainerCommandResponseProto> response;
-    if (exception != null) {
-      response = new CompletableFuture<>();
-      response.completeExceptionally(exception);
-    } else if (errorCode != null) {
-      ContainerCommandResponseProto readChunkResp =
-          ContainerCommandResponseProto.newBuilder()
-              .setResult(errorCode)
-              .setCmdType(Type.ReadChunk)
-              .build();
-      response = completedFuture(readChunkResp);
+    final ContainerCommandResponseProto response;
+    if (errorCode != null) {
+      response = ContainerCommandResponseProto.newBuilder()
+          .setResult(errorCode)
+          .setCmdType(Type.ReadChunk)
+          .build();
+    } else if (data != null) {
+      response = ContainerCommandResponseProto.newBuilder()
+          .setReadChunk(ReadChunkResponseProto.newBuilder()
+              .setBlockID(createBlockId(containerId, localId))
+              .setChunkData(createChunkInfo(data))
+              .setData(ByteString.copyFrom(data))
+              .build()
+          )
+          .setResult(Result.SUCCESS)
+          .setCmdType(Type.ReadChunk)
+          .build();
     } else {
-      ContainerCommandResponseProto readChunkResp =
-          ContainerCommandResponseProto.newBuilder()
-              .setReadChunk(ReadChunkResponseProto.newBuilder()
-                  .setBlockID(createBlockId(containerId, localId))
-                  .setChunkData(createChunkInfo(data))
-                  .setData(ByteString.copyFrom(data))
-                  .build()
-              )
-              .setResult(Result.SUCCESS)
-              .setCmdType(Type.ReadChunk)
-              .build();
-      response = completedFuture(readChunkResp);
+      response = null;
     }
 
-    doAnswer(invocation -> new XceiverClientReply(response))
-        .when(mockDnProtocol)
-        .sendCommandAsync(argThat(matchCmd(Type.ReadChunk)), any());
+    doAnswer(invocation -> {
+      if (exception != null) {
+        ExecutionException executionException = new ExecutionException(
+            exception);
+        if (Status.fromThrowable(exception).getCode()
+            == Status.UNAUTHENTICATED.getCode()) {
+          throw new SCMSecurityException("Failed to authenticate with "
+              + "GRPC XceiverServer with Ozone block token.");
+        }
+        throw new IOException(executionException);
+      }
+
+      ContainerCommandRequestProto request = invocation.getArgument(0);
+      List<XceiverClientSpi.Validator> validators = invocation.getArgument(1);
+      if (validators != null) {
+        for (XceiverClientSpi.Validator validator : validators) {
+          validator.accept(request, response);
+        }
+      }
+      return response;
+    }).when(mockDnProtocol)
+        .sendCommandWithZeroCopy(argThat(matchCmd(Type.ReadChunk)), any());
 
   }
 


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.7)
Generated-by: Codex (GPT-5.4)

Finishing what @duongkame left off.

## What changes were proposed in this pull request?

- Add an explicit zero-copy `ReadChunk` path for client reads.
- Keep the existing `readChunk()` path unchanged for compatibility.
- Release zero-copy responses correctly on retry/validation paths, and add coverage for both legacy and zero-copy callers.

Mirrors the existing server-side request-side zero-copy pattern in GrpcXceiverService.bindServiceWithZeroCopy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10283

## How was this patch tested?

- Parameterized test cases to test zero copy path.