### PR TITLE
HDDS-15326. Clamp outofservice.limit.factor to bounds instead of resetting to default

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -182,10 +182,10 @@ public class ReplicationServer {
     public static final int REPLICATION_MAX_STREAMS_DEFAULT = 10;
     private static final String OUTOFSERVICE_FACTOR_KEY =
         "outofservice.limit.factor";
-    private static final double OUTOFSERVICE_FACTOR_MIN = 1;
+    static final double OUTOFSERVICE_FACTOR_MIN = 1;
     static final double OUTOFSERVICE_FACTOR_DEFAULT = 2;
     private static final String OUTOFSERVICE_FACTOR_DEFAULT_VALUE = "2.0";
-    private static final double OUTOFSERVICE_FACTOR_MAX = 10;
+    static final double OUTOFSERVICE_FACTOR_MAX = 10;
     static final String REPLICATION_OUTOFSERVICE_FACTOR_KEY =
         PREFIX + "." + OUTOFSERVICE_FACTOR_KEY;
 
@@ -274,14 +274,16 @@ public class ReplicationServer {
 
       if (outOfServiceFactor < OUTOFSERVICE_FACTOR_MIN ||
           outOfServiceFactor > OUTOFSERVICE_FACTOR_MAX) {
+        double clamped = Math.min(OUTOFSERVICE_FACTOR_MAX,
+            Math.max(OUTOFSERVICE_FACTOR_MIN, outOfServiceFactor));
         LOG.warn(
-            "{} must be between {} and {} but was set to {}. Defaulting to {}",
+            "{} must be between {} and {} but was set to {}. Clamping to {}",
             REPLICATION_OUTOFSERVICE_FACTOR_KEY,
             OUTOFSERVICE_FACTOR_MIN,
             OUTOFSERVICE_FACTOR_MAX,
             outOfServiceFactor,
-            OUTOFSERVICE_FACTOR_DEFAULT);
-        outOfServiceFactor = OUTOFSERVICE_FACTOR_DEFAULT;
+            clamped);
+        outOfServiceFactor = clamped;
       }
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
@@ -99,6 +99,33 @@ public class TestReplicationConfig {
   }
 
   @Test
+  public void acceptsOutOfServiceFactorBoundaryValues() {
+    // GIVEN
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+        OUTOFSERVICE_FACTOR_MIN);
+
+    // WHEN
+    ReplicationConfig subject = conf.getObject(ReplicationConfig.class);
+
+    // THEN
+    assertEquals(OUTOFSERVICE_FACTOR_MIN,
+        subject.getOutOfServiceFactor(), 0.001);
+
+    // GIVEN
+    conf = new OzoneConfiguration();
+    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+        OUTOFSERVICE_FACTOR_MAX);
+
+    // WHEN
+    subject = conf.getObject(ReplicationConfig.class);
+
+    // THEN
+    assertEquals(OUTOFSERVICE_FACTOR_MAX,
+        subject.getOutOfServiceFactor(), 0.001);
+  }
+
+  @Test
   public void isCreatedWitDefaultValues() {
     // GIVEN
     OzoneConfiguration conf = new OzoneConfiguration();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.container.replication;
 
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.OUTOFSERVICE_FACTOR_DEFAULT;
+import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.OUTOFSERVICE_FACTOR_MAX;
+import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.OUTOFSERVICE_FACTOR_MIN;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_MAX_STREAMS_DEFAULT;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_OUTOFSERVICE_FACTOR_KEY;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_STREAMS_LIMIT_KEY;
@@ -52,14 +54,11 @@ public class TestReplicationConfig {
   }
 
   @Test
-  public void overridesInvalidValues() {
+  public void overridesInvalidReplicationLimit() {
     // GIVEN
     int invalidReplicationLimit = -5;
-    double invalidOutOfServiceFactor = 0.5;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, invalidReplicationLimit);
-    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
-        invalidOutOfServiceFactor);
 
     // WHEN
     ReplicationConfig subject = conf.getObject(ReplicationConfig.class);
@@ -67,7 +66,35 @@ public class TestReplicationConfig {
     // THEN
     assertEquals(REPLICATION_MAX_STREAMS_DEFAULT,
         subject.getReplicationMaxStreams());
-    assertEquals(OUTOFSERVICE_FACTOR_DEFAULT,
+  }
+
+  @Test
+  public void clampsOutOfServiceFactorBelowMinToMin() {
+    // GIVEN
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+        OUTOFSERVICE_FACTOR_MIN - 0.5);
+
+    // WHEN
+    ReplicationConfig subject = conf.getObject(ReplicationConfig.class);
+
+    // THEN
+    assertEquals(OUTOFSERVICE_FACTOR_MIN,
+        subject.getOutOfServiceFactor(), 0.001);
+  }
+
+  @Test
+  public void clampsOutOfServiceFactorAboveMaxToMax() {
+    // GIVEN
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+        OUTOFSERVICE_FACTOR_MAX + 10);
+
+    // WHEN
+    ReplicationConfig subject = conf.getObject(ReplicationConfig.class);
+
+    // THEN
+    assertEquals(OUTOFSERVICE_FACTOR_MAX,
         subject.getOutOfServiceFactor(), 0.001);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`hdds.datanode.replication.outofservice.limit.factor` gives more weight to maintenance and decommission replication tasks over normal replication tasks. The valid range is `[1, 10]` (`OUTOFSERVICE_FACTOR_MIN`..`OUTOFSERVICE_FACTOR_MAX`).

Previously, any out-of-range value was reset to `OUTOFSERVICE_FACTOR_DEFAULT` (2). This was unexpected: configuring a value above the maximum (e.g. 20, intending *more* weight) silently dropped the factor back to 2, giving *less* weight than the cap.

This change clamps an out-of-range value to the nearest bound instead of resetting to the default:
- below `MIN` -> `MIN` (1)
- above `MAX` -> `MAX` (10)

The warning log wording is updated from "Defaulting to" to "Clamping to" accordingly. The unrelated `replication.max.streams` invalid-value handling is unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15326

## How was this patch tested?

Unit tests in `TestReplicationConfig`:
- `clampsOutOfServiceFactorBelowMinToMin` (configured `MIN - 0.5` -> expects `MIN`).
- `clampsOutOfServiceFactorAboveMaxToMax` (configured `MAX + 10` -> expects `MAX`).
- `acceptsOutOfServiceFactorBoundaryValues` (configured exactly `MIN` / `MAX` -> accepted unchanged), guarding against a regression that would reset valid boundary values.
- Split the former `overridesInvalidValues` into `overridesInvalidReplicationLimit`, since the max-streams reset-to-default behavior is unchanged.

`mvn -pl hadoop-hdds/container-service test -Dtest=TestReplicationConfig` -> `Tests run: 6, Failures: 0, Errors: 0`. Module checkstyle passes.
