### PR TITLE
HDDS-15405. BackgroundService pool size unchanged by reconfiguration

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -41,7 +41,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -267,13 +266,7 @@ public class DiskBalancerService extends BackgroundService {
     setStopAfterDiskEven(validated.isStopAfterDiskEven());
     setVersion(diskBalancerInfo.getVersion());
     setContainerStates(validated.getMovableContainerStates());
-
-    // Default executorService is ScheduledThreadPoolExecutor, so we can
-    // update the poll size by setting corePoolSize.
-    if ((getExecutorService() instanceof ScheduledThreadPoolExecutor)) {
-      ((ScheduledThreadPoolExecutor) getExecutorService())
-          .setCorePoolSize(parallelThread);
-    }
+    setPoolSize(parallelThread);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -46,7 +46,7 @@ public abstract class BackgroundService {
   private long interval;
   private volatile long serviceTimeoutInNanos;
   private TimeUnit unit;
-  private final int threadPoolSize;
+  private int threadPoolSize;
   private final String threadNamePrefix;
   private final PeriodicalTask service;
   private CompletableFuture<Void> future;
@@ -89,6 +89,7 @@ public abstract class BackgroundService {
     // the corePoolSize will always less maximumPoolSize.
     // So we can directly set the corePoolSize
     exec.setCorePoolSize(size);
+    threadPoolSize = size;
   }
 
   public synchronized void setServiceTimeoutInNanos(long newTimeout) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.utils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -77,7 +76,7 @@ public abstract class BackgroundService {
   }
 
   @VisibleForTesting
-  public synchronized ExecutorService getExecutorService() {
+  public synchronized ScheduledThreadPoolExecutor getExecutorService() {
     return this.exec;
   }
 
@@ -126,7 +125,7 @@ public abstract class BackgroundService {
     this.unit = newUnit;
   }
 
-  protected synchronized long getIntervalMillis() {
+  public synchronized long getIntervalMillis() {
     return this.unit.toMillis(interval);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -204,7 +204,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     });
   }
 
-  private synchronized void updateAndRestart(OzoneConfiguration conf) {
+  synchronized void updateAndRestart(OzoneConfiguration conf) {
     long newInterval = conf.getTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL,
         OZONE_DIR_DELETING_SERVICE_INTERVAL_DEFAULT, TimeUnit.SECONDS);
     int newCorePoolSize = conf.getInt(OZONE_THREAD_NUMBER_DIR_DELETION,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -228,6 +229,34 @@ public class TestDirectoryDeletingService {
     } finally {
       ozoneManager.stop();
     }
+  }
+
+  @Test
+  void testUpdateAndRestart() throws Exception {
+    int threadCount = 2;
+    OzoneConfiguration conf = createConfAndInitValues(threadCount);
+    OmTestManagers omTestManagers = new OmTestManagers(conf);
+    om = omTestManagers.getOzoneManager();
+    DirectoryDeletingService subject = om.getKeyManager().getDirDeletingService();
+
+    OzoneConfiguration updatedConf = new OzoneConfiguration(conf);
+    int newThreadCount = threadCount + 1;
+    Duration newInterval = Duration.ofSeconds(5);
+    updatedConf.setInt(OZONE_THREAD_NUMBER_DIR_DELETION, newThreadCount);
+    updatedConf.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, newInterval.toMillis(), TimeUnit.MILLISECONDS);
+
+    assertThat(subject.getExecutorService().getCorePoolSize())
+        .as("initial thread pool size")
+        .isEqualTo(threadCount);
+
+    subject.updateAndRestart(updatedConf);
+
+    assertThat(subject.getExecutorService().getCorePoolSize())
+        .as("thread pool size after restart")
+        .isEqualTo(newThreadCount);
+    assertThat(subject.getIntervalMillis())
+        .as("interval after restart")
+        .isEqualTo(newInterval.toMillis());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`BlockDeletingService` and `DirectoryDeletingService` support reconfiguring pool size, but the reconfigured executor is thrown away and new one is created with the original size.

https://issues.apache.org/jira/browse/HDDS-15405

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/ozone/actions/runs/26569768472