### PR TITLE
HDDS-15414. Cache some Java 8 dependencies

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -88,6 +88,17 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: mvn $BUILD_ARGS $MAVEN_ARGS --no-transfer-progress --show-version -Pgo-offline clean verify
 
+      - name: Setup Java 8
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - name: Fetch dependencies for Java 8
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: mvn $MAVEN_ARGS --no-transfer-progress --show-version -Pgo-offline -DskipRecon -DskipShade test-compile
+
       - name: Delete Ozone jars from repo
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: rm -fr ~/.m2/repository/org/apache/ozone


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-15279 changed `populate-cache` to use Java 21, just like most of regular CI.  `basic` checks still use Java 8, and now `findbugs` encounters intermittent error:

```
Could not transfer artifact org.aspectj:aspectjrt:pom:1.9.7 from/to central (https://repo.maven.apache.org/maven2): Connection reset
```

This change tweaks `populate-cache` to also get dependencies for Java 8.  It adds about 1 minute of runtime for the workflow.

https://issues.apache.org/jira/browse/HDDS-15414

## How was this patch tested?

Verified that both versions of `aspectj` (1.9.7 and 1.9.24) are cached:

https://github.com/adoroszlai/ozone/actions/runs/26626034728/job/78462892344#step:12:3587