### PR TITLE
HDDS-15313. Increase snapshot diff default thresholds.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4726,7 +4726,7 @@
 
   <property>
     <name>ozone.om.snapshot.diff.max.page.size</name>
-    <value>1000</value>
+    <value>5000</value>
     <tag>OZONE, OM</tag>
     <description>
        Maximum number of entries to be returned in a single page of snap diff report.
@@ -4812,7 +4812,7 @@
 
   <property>
     <name>ozone.om.snapshot.diff.max.allowed.keys.changed.per.job</name>
-    <value>10000000</value>
+    <value>1000000000</value>
     <tag>OZONE, OM</tag>
     <description>
       Max numbers of keys changed allowed for a snapshot diff job.

--- a/hadoop-hdds/docs/content/feature/Snapshot-Configuration-Properties.md
+++ b/hadoop-hdds/docs/content/feature/Snapshot-Configuration-Properties.md
@@ -42,10 +42,10 @@ These parameters, defined in `ozone-site.xml`, control how Ozone manages snapsho
     *   `ozone.om.snapshot.diff.db.dir`: Directory for SnapshotDiff job data. Defaults to OM metadata dir. Use a spacious location for large diffs.
     *   `ozone.om.snapshot.force.full.diff`: Force a full diff for all snapshot diff jobs (Default: false).
     *   `ozone.om.snapshot.diff.disable.native.libs`: Disable native libraries for snapshot diff (Default: false).
-    *   `ozone.om.snapshot.diff.max.page.size`: Maximum page size for snapshot diff (Default: 1000).
+    *   `ozone.om.snapshot.diff.max.page.size`: Maximum page size for snapshot diff (Default: 5000).
     *   `ozone.om.snapshot.diff.thread.pool.size`: Thread pool size for snapshot diff (Default: 10).
     *   `ozone.om.snapshot.diff.job.default.wait.time`: Default wait time for a snapshot diff job (Default: 1m).
-    *   `ozone.om.snapshot.diff.max.allowed.keys.changed.per.job`: Maximum number of keys allowed to be changed per snapshot diff job (Default: 10000000).
+    *   `ozone.om.snapshot.diff.max.allowed.keys.changed.per.job`: Maximum number of keys allowed to be changed per snapshot diff job (Default: 1000000000).
 
 *   **Snapshot Compaction and Cleanup**
     *   `ozone.snapshot.key.deleting.limit.per.task`: The maximum number of keys scanned by the snapshot deleting service in a single run (Default: 20000).

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -67,7 +67,7 @@ public class SnapshotDiffHandler extends Handler {
           "Note the effective page size will also be bound by " +
           "the server-side page size limit, see config:%n" +
           "  ozone.om.snapshot.diff.max.page.size",
-      defaultValue = "1000",
+      defaultValue = "5000",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS
   )
   private int pageSize;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -591,7 +591,7 @@ public final class OMConfigKeys {
   public static final int OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT
       = 100;
   public static final int OZONE_OM_SNAPSHOT_DIFF_REPORT_MAX_PAGE_SIZE_DEFAULT
-      = 1000;
+      = 5000;
 
   public static final String OZONE_OM_SNAPSHOT_DIFF_THREAD_POOL_SIZE
       = "ozone.om.snapshot.diff.thread.pool.size";
@@ -638,7 +638,7 @@ public final class OMConfigKeys {
       = "ozone.om.snapshot.diff.max.allowed.keys.changed.per.job";
   public static final long
       OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB_DEFAULT
-      = 10_000_000;
+      = 1_000_000_000L;
 
   public static final String OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE
       = "ozone.om.upgrade.quota.recalculate.enabled";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOU
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_CACHE_CLEANUP_SERVICE_RUN_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DISABLE_NATIVE_LIBS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_REPORT_MAX_PAGE_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_FORCE_FULL_DIFF;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.DELIMITER;
@@ -1445,7 +1446,7 @@ public abstract class TestOmSnapshot {
             snap7, "400000000000000000003", 0, forceFullSnapshotDiff, disableNativeDiff));
     assertThat(ioException.getMessage()).contains("Index (given: 3) " +
         "should be a number >= 0 and < totalDiffEntries: 2. Page size " +
-        "(given: 1000) should be a positive number > 0.");
+        "(given: " + OZONE_OM_SNAPSHOT_DIFF_REPORT_MAX_PAGE_SIZE_DEFAULT + ") should be a positive number > 0.");
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increasing the following snapshot diff thresholds because these medium jobs have run into these limit pretty quickly during observation. 

- Increasing `ozone.om.snapshot.diff.max.allowed.keys.changed.per.job=1000000000`(current default os 10M) because this only represents an estimated number of keys to iterate which is just the sum of number of entries in the delta SST files. It's not the actual number of key we iterate with the bucket prefix to calculate the diff or the actual diff size. 
- Increasing `ozone.om.snapshot.diff.max.page.size=5000`(current default is 1000) because currently both default page size and max page size have the same limit. It makes sense to have max > default so that default can be increased without having to change max too often.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15313

## How was this patch tested?

Existing tests to should run successfully.
