### PR TITLE
HDDS-15426. Include snapshot IDs in OM snapshot lifecycle logs

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -220,12 +220,12 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
         snapshotInfo.toAuditMap(), exception, userInfo));
 
     if (exception == null) {
-      LOG.info("Created snapshot: '{}' with snapshotId: '{}' under path '{}'",
+      LOG.info("Created snapshot '{}' (snapshotId='{}') under path '{}'",
           snapshotName, snapshotInfo.getSnapshotId(), snapshotPath);
       omMetrics.incNumSnapshotActive();
     } else {
       omMetrics.incNumSnapshotCreateFails();
-      LOG.error("Failed to create snapshot '{}' with snapshotId: '{}' under " +
+      LOG.error("Failed to create snapshot '{}' (snapshotId='{}') under " +
               "path '{}'",
           snapshotName, snapshotInfo.getSnapshotId(), snapshotPath);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -228,12 +228,12 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
     if (exception == null) {
       omMetrics.decNumSnapshotActive();
       omMetrics.incNumSnapshotDeleted();
-      LOG.info("Deleted snapshot '{}' under path '{}'",
-          snapshotName, snapshotPath);
+      LOG.info("Deleted snapshot '{}' (snapshotId='{}') under path '{}'",
+          snapshotName, snapshotInfo.getSnapshotId(), snapshotPath);
     } else {
       omMetrics.incNumSnapshotDeleteFails();
-      LOG.error("Failed to delete snapshot '{}' under path '{}'",
-          snapshotName, snapshotPath);
+      LOG.error("Failed to delete snapshot '{}' (snapshotId='{}') under path '{}'",
+          snapshotName, snapshotInfo.getSnapshotId(), snapshotPath);
     }
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.request.snapshot;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -93,6 +94,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
         .getSnapshotDBKeysList();
     TransactionInfo transactionInfo = TransactionInfo.valueOf(context.getTermIndex());
     try {
+      List<String> purgedSnapshotsForLog = new ArrayList<>();
 
       // Each snapshot purge operation does three things:
       //  1. Update the deep clean flag for the next active snapshot (So that it can be
@@ -109,6 +111,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
               "Snapshot purge request.", snapTableKey);
           continue;
         }
+        purgedSnapshotsForLog.add(formatSnapshotForLog(fromSnapshot));
         SnapshotInfo nextSnapshot = SnapshotUtils.getNextSnapshot(ozoneManager, snapshotChainManager, fromSnapshot);
         SnapshotInfo nextToNextSnapshot = nextSnapshot == null ? null : SnapshotUtils.getNextSnapshot(ozoneManager,
             snapshotChainManager, nextSnapshot);
@@ -133,8 +136,8 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
           transactionInfo);
 
       omSnapshotIntMetrics.incNumSnapshotPurges();
-      LOG.info("Successfully executed snapshotPurgeRequest: {{}} along with updating snapshots:{}.",
-          snapshotPurgeRequest, updatedSnapshotInfos);
+      LOG.info("Successfully executed snapshotPurgeRequest for snapshots: {} along with updating snapshots:{}.",
+          purgedSnapshotsForLog, updatedSnapshotInfos);
       if (LOG.isDebugEnabled()) {
         Map<String, String> auditParams = new LinkedHashMap<>();
         auditParams.put(AUDIT_PARAM_SNAPSHOT_DB_KEYS, snapshotDbKeys.toString());
@@ -254,5 +257,9 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
       }
     }
     return snapshotInfo;
+  }
+
+  private static String formatSnapshotForLog(SnapshotInfo snapshotInfo) {
+    return snapshotInfo.getTableKey() + " (snapshotId='" + snapshotInfo.getSnapshotId() + "')";
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -136,7 +136,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
           transactionInfo);
 
       omSnapshotIntMetrics.incNumSnapshotPurges();
-      LOG.info("Successfully executed snapshotPurgeRequest for snapshots: {} along with updating snapshots:{}.",
+      LOG.info("Successfully executed snapshotPurgeRequest for snapshots: {} along with updating snapshots: {}.",
           purgedSnapshotsForLog, updatedSnapshotInfos);
       if (LOG.isDebugEnabled()) {
         Map<String, String> auditParams = new LinkedHashMap<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -140,25 +140,25 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
           SnapshotInfo snapInfo = SnapshotUtils.getSnapshotInfo(ozoneManager, chainManager, iterator.next());
           if (shouldIgnoreSnapshot(snapInfo)) {
             LOG.debug("Skipping Snapshot Deletion processing because " +
-                "the snapshot is active or DB changes are not flushed: {}", snapInfo.getTableKey());
+                "the snapshot is active or DB changes are not flushed: {}", formatSnapshotForLog(snapInfo));
             continue;
           }
-          LOG.info("Started Snapshot Deletion Processing for snapshot : {}", snapInfo.getTableKey());
+          LOG.info("Started Snapshot Deletion Processing for snapshot : {}", formatSnapshotForLog(snapInfo));
           SnapshotInfo nextSnapshot = SnapshotUtils.getNextSnapshot(ozoneManager, chainManager, snapInfo);
           // Continue if the next snapshot is not active. This is to avoid unnecessary copies from one snapshot to
           // another.
           if (nextSnapshot != null &&
               nextSnapshot.getSnapshotStatus() != SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE) {
             LOG.info("Skipping Snapshot Deletion processing for : {} because the next snapshot is DELETED.",
-                snapInfo.getTableKey());
+                formatSnapshotForLog(snapInfo));
             continue;
           }
           // nextSnapshot = null means entries would be moved to AOS.
           if (nextSnapshot == null) {
-            LOG.info("Snapshot: {} entries will be moved to AOS.", snapInfo.getTableKey());
+            LOG.info("Snapshot: {} entries will be moved to AOS.", formatSnapshotForLog(snapInfo));
           } else {
             LOG.info("Snapshot: {} entries will be moved to next active snapshot: {}",
-                snapInfo.getTableKey(), nextSnapshot.getTableKey());
+                formatSnapshotForLog(snapInfo), formatSnapshotForLog(nextSnapshot));
           }
           lockIds.clear();
           lockIds.add(snapInfo.getSnapshotId());
@@ -458,5 +458,9 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
 
   public long getSuccessfulRunCount() {
     return successRunCount.get();
+  }
+
+  private static String formatSnapshotForLog(SnapshotInfo snapshotInfo) {
+    return snapshotInfo.getTableKey() + " (snapshotId='" + snapshotInfo.getSnapshotId() + "')";
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.getTableKey;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.createSnapshotRequest;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateSnapshot;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -57,6 +58,7 @@ import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -178,6 +180,7 @@ public class TestOMSnapshotCreateRequest extends TestSnapshotRequestAndResponse 
     assertNull(getOmMetadataManager().getSnapshotInfoTable().get(key));
 
     // Run validateAndUpdateCache.
+    LogCapturer logCapturer = LogCapturer.captureLogs(OMSnapshotCreateRequest.class);
     OMClientResponse omClientResponse =
         omSnapshotCreateRequest.validateAndUpdateCache(getOzoneManager(), 1);
 
@@ -211,6 +214,10 @@ public class TestOMSnapshotCreateRequest extends TestSnapshotRequestAndResponse 
     assertEquals(0, getOmMetrics().getNumSnapshotCreateFails());
     assertEquals(1, getOmMetrics().getNumSnapshotActive());
     assertEquals(1, getOmMetrics().getNumSnapshotCreates());
+    assertThat(logCapturer.getOutput()).contains(String.format(
+        "Created snapshot '%s' (snapshotId='%s') under path '%s'",
+        snapshotName1, snapshotInfoInCache.getSnapshotId(),
+        snapshotInfoInCache.getSnapshotPath()));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.util.Time;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -160,6 +161,7 @@ public class TestOMSnapshotDeleteRequest extends TestSnapshotRequestAndResponse 
         new CacheKey<>(key),
         CacheValue.get(1L, snapshotInfo));
 
+    LogCapturer logCapturer = LogCapturer.captureLogs(OMSnapshotDeleteRequest.class);
     // Trigger validateAndUpdateCache
     OMClientResponse omClientResponse =
         omSnapshotDeleteRequest.validateAndUpdateCache(getOzoneManager(), 2L);
@@ -180,6 +182,9 @@ public class TestOMSnapshotDeleteRequest extends TestSnapshotRequestAndResponse 
     assertEquals(-1, getOmMetrics().getNumSnapshotActive());
     assertEquals(1, getOmMetrics().getNumSnapshotDeleted());
     assertEquals(0, getOmMetrics().getNumSnapshotDeleteFails());
+    assertThat(logCapturer.getOutput()).contains(String.format(
+        "Deleted snapshot '%s' (snapshotId='%s') under path '%s'",
+        snapshotName, snapshotInfo.getSnapshotId(), snapshotInfo.getSnapshotPath()));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -209,6 +209,8 @@ public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAn
       assertThat(logCapturer.getOutput()).contains(
           snapshotInfo.getTableKey() + " (snapshotId='" + snapshotInfo.getSnapshotId() + "')");
     }
+    assertThat(logCapturer.getOutput()).contains(
+        "along with updating snapshots: {");
 
     assertEquals(initialSnapshotPurgeCount + 1, getOmSnapshotIntMetrics().getNumSnapshotPurges());
     assertEquals(initialSnapshotPurgeFailCount, getOmSnapshotIntMetrics().getNumSnapshotPurgeFails());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.request.snapshot;
 
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.INTERNAL_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -57,6 +58,7 @@ import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotPurgeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -177,6 +179,7 @@ public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAn
 
     OMSnapshotPurgeRequest omSnapshotPurgeRequest = preExecute(snapshotPurgeRequest);
     TransactionInfo transactionInfo = TransactionInfo.valueOf(TransactionInfo.getTermIndex(200L));
+    LogCapturer logCapturer = LogCapturer.captureLogs(OMSnapshotPurgeRequest.class);
     OMSnapshotPurgeResponse omSnapshotPurgeResponse = (OMSnapshotPurgeResponse)
         omSnapshotPurgeRequest.validateAndUpdateCache(getOzoneManager(), transactionInfo.getTransactionIndex());
 
@@ -203,6 +206,8 @@ public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAn
                snapshotLocalDataManager.getOmSnapshotLocalData(snapshotInfo)) {
         assertEquals(transactionInfo, snapProvider.getSnapshotLocalData().getTransactionInfo());
       }
+      assertThat(logCapturer.getOutput()).contains(
+          snapshotInfo.getTableKey() + " (snapshotId='" + snapshotInfo.getSnapshotId() + "')");
     }
 
     assertEquals(initialSnapshotPurgeCount + 1, getOmSnapshotIntMetrics().getNumSnapshotPurges());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
@@ -17,8 +17,10 @@
 
 package org.apache.hadoop.ozone.om.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -42,15 +44,20 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
+import org.apache.hadoop.ozone.om.lock.OMLockDetails;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotMoveKeyInfos;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -204,6 +211,51 @@ public class TestSnapshotDeletingService {
 
     // Verify no orphan entries (all items accounted for)
     assertEquals(totalExpected, totalDeletedKeysProcessed + totalRenamedKeysProcessed + totalDeletedDirsProcessed);
+  }
+
+  @Test
+  public void testSnapshotDeletingTaskLogsSnapshotId() throws Exception {
+    IOzoneManagerLock lock = Mockito.mock(IOzoneManagerLock.class);
+    UUID snapshotId = UUID.randomUUID();
+    SnapshotInfo snapshotInfo = SnapshotInfo.newBuilder()
+        .setSnapshotId(snapshotId)
+        .setVolumeName("vol1")
+        .setBucketName("bucket1")
+        .setName("snap1")
+        .setSnapshotStatus(SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)
+        .setLastTransactionInfo(TransactionInfo.valueOf(1, 1).toByteString())
+        .build();
+
+    Mockito.when(omMetadataManager.getSnapshotChainManager()).thenReturn(chainManager);
+    Mockito.when(omMetadataManager.getLock()).thenReturn(lock);
+    Mockito.when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
+    Mockito.when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    Mockito.when(ozoneManager.getConfiguration()).thenReturn(conf);
+    Mockito.when(ozoneManager.isLeaderReady()).thenReturn(true);
+    Mockito.when(chainManager.iterator(true)).thenReturn(List.of(snapshotId).iterator());
+    Mockito.when(lock.acquireWriteLocks(any(), any()))
+        .thenReturn(OMLockDetails.EMPTY_DETAILS_LOCK_NOT_ACQUIRED);
+
+    SnapshotDeletingService service = new SnapshotDeletingService(sdsRunInterval, sdsServiceTimeout, ozoneManager);
+    LogCapturer logCapturer = LogCapturer.captureLogs(SnapshotDeletingService.class);
+
+    try (MockedStatic<SnapshotUtils> snapshotUtils = mockStatic(SnapshotUtils.class);
+         MockedStatic<OmSnapshotManager> omSnapshotManagerStatic = mockStatic(OmSnapshotManager.class)) {
+      snapshotUtils.when(() -> SnapshotUtils.getSnapshotInfo(ozoneManager, chainManager, snapshotId))
+          .thenReturn(snapshotInfo);
+      snapshotUtils.when(() -> SnapshotUtils.getNextSnapshot(ozoneManager, chainManager, snapshotInfo))
+          .thenReturn(null);
+      omSnapshotManagerStatic.when(() -> OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager,
+          snapshotInfo)).thenReturn(true);
+
+      service.new SnapshotDeletingTask().call();
+    }
+
+    String expectedLogLabel = snapshotInfo.getTableKey() + " (snapshotId='" + snapshotInfo.getSnapshotId() + "')";
+    assertThat(logCapturer.getOutput()).contains(
+        "Started Snapshot Deletion Processing for snapshot : " + expectedLogLabel);
+    assertThat(logCapturer.getOutput()).contains(
+        "Snapshot: " + expectedLogLabel + " entries will be moved to AOS.");
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mockStatic;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -186,13 +187,13 @@ public class TestSnapshotDeletingService {
         "All entries should be submitted");
 
     // Verify multiple batches were created (since data should exceed buffer)
-    assertTrue(capturedRequests.size() > 1);
+    assertThat(capturedRequests).hasSizeGreaterThan(1);
 
     for (OMRequest omRequest : capturedRequests) {
       assertEquals(OzoneManagerProtocolProtos.Type.SnapshotMoveTableKeys, omRequest.getCmdType());
 
       int requestSize = omRequest.getSerializedSize();
-      assertTrue(requestSize <= ratisBufferLimit);
+      assertThat(requestSize).isLessThanOrEqualTo(ratisBufferLimit);
     }
 
     int totalDeletedKeysProcessed = capturedRequests.stream()
@@ -232,7 +233,8 @@ public class TestSnapshotDeletingService {
     Mockito.when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     Mockito.when(ozoneManager.getConfiguration()).thenReturn(conf);
     Mockito.when(ozoneManager.isLeaderReady()).thenReturn(true);
-    Mockito.when(chainManager.iterator(true)).thenReturn(List.of(snapshotId).iterator());
+    Mockito.when(chainManager.iterator(true)).thenReturn(
+        Collections.singletonList(snapshotId).iterator());
     Mockito.when(lock.acquireWriteLocks(any(), any()))
         .thenReturn(OMLockDetails.EMPTY_DETAILS_LOCK_NOT_ACQUIRED);
 
@@ -256,6 +258,65 @@ public class TestSnapshotDeletingService {
         "Started Snapshot Deletion Processing for snapshot : " + expectedLogLabel);
     assertThat(logCapturer.getOutput()).contains(
         "Snapshot: " + expectedLogLabel + " entries will be moved to AOS.");
+  }
+
+  @Test
+  public void testSnapshotDeletingTaskLogsNextActiveSnapshotId()
+      throws Exception {
+    IOzoneManagerLock lock = Mockito.mock(IOzoneManagerLock.class);
+    UUID snapshotId = UUID.randomUUID();
+    SnapshotInfo snapshotInfo = SnapshotInfo.newBuilder()
+        .setSnapshotId(snapshotId)
+        .setVolumeName("vol1")
+        .setBucketName("bucket1")
+        .setName("snap1")
+        .setSnapshotStatus(SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)
+        .setLastTransactionInfo(TransactionInfo.valueOf(1, 1).toByteString())
+        .build();
+    SnapshotInfo nextSnapshotInfo = SnapshotInfo.newBuilder()
+        .setSnapshotId(UUID.randomUUID())
+        .setVolumeName("vol1")
+        .setBucketName("bucket1")
+        .setName("snap2")
+        .setSnapshotStatus(SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE)
+        .setLastTransactionInfo(TransactionInfo.valueOf(1, 1).toByteString())
+        .build();
+
+    Mockito.when(omMetadataManager.getSnapshotChainManager()).thenReturn(chainManager);
+    Mockito.when(omMetadataManager.getLock()).thenReturn(lock);
+    Mockito.when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
+    Mockito.when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    Mockito.when(ozoneManager.getConfiguration()).thenReturn(conf);
+    Mockito.when(ozoneManager.isLeaderReady()).thenReturn(true);
+    Mockito.when(chainManager.iterator(true)).thenReturn(
+        Collections.singletonList(snapshotId).iterator());
+    Mockito.when(lock.acquireWriteLocks(any(), any()))
+        .thenReturn(OMLockDetails.EMPTY_DETAILS_LOCK_NOT_ACQUIRED);
+
+    SnapshotDeletingService service =
+        new SnapshotDeletingService(sdsRunInterval, sdsServiceTimeout, ozoneManager);
+    LogCapturer logCapturer = LogCapturer.captureLogs(SnapshotDeletingService.class);
+
+    try (MockedStatic<SnapshotUtils> snapshotUtils = mockStatic(SnapshotUtils.class);
+         MockedStatic<OmSnapshotManager> omSnapshotManagerStatic = mockStatic(OmSnapshotManager.class)) {
+      snapshotUtils.when(() -> SnapshotUtils.getSnapshotInfo(ozoneManager, chainManager, snapshotId))
+          .thenReturn(snapshotInfo);
+      snapshotUtils.when(() -> SnapshotUtils.getNextSnapshot(ozoneManager, chainManager, snapshotInfo))
+          .thenReturn(nextSnapshotInfo);
+      omSnapshotManagerStatic.when(() -> OmSnapshotManager.areSnapshotChangesFlushedToDB(
+          omMetadataManager, snapshotInfo)).thenReturn(true);
+
+      service.new SnapshotDeletingTask().call();
+    }
+
+    String expectedLogLabel = snapshotInfo.getTableKey() + " (snapshotId='"
+        + snapshotInfo.getSnapshotId() + "')";
+    String expectedNextSnapshotLogLabel = nextSnapshotInfo.getTableKey()
+        + " (snapshotId='" + nextSnapshotInfo.getSnapshotId() + "')";
+    assertThat(logCapturer.getOutput()).contains(
+        "Snapshot: " + expectedLogLabel
+            + " entries will be moved to next active snapshot: "
+            + expectedNextSnapshotLogLabel);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `snapshotId` to key OM snapshot lifecycle (create, delete, purge) log lines so the snapshot name/table key and UUID appear in the same message for create, delete, purge, and snapshot-deletion flows. To make debugging easier.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15426

## How was this patch tested?

- Added testSnapshotDeletingTaskLogsSnapshotId
- Amended existing test cases to assert logging additions