### PR TITLE
HDDS-15429. Fix updateAndRestart deadlock with BackgroundService.PeriodicalTask

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -123,7 +123,7 @@ public class BlockDeletingService extends BackgroundService {
     });
   }
 
-  public synchronized void updateAndRestart(OzoneConfiguration ozoneConf) {
+  public void updateAndRestart(OzoneConfiguration ozoneConf) {
     long newInterval = ozoneConf.getTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL,
         OZONE_BLOCK_DELETING_SERVICE_INTERVAL_DEFAULT, TimeUnit.SECONDS);
     int newCorePoolSize = ozoneConf.getInt(OZONE_BLOCK_DELETING_SERVICE_WORKERS,
@@ -134,11 +134,15 @@ public class BlockDeletingService extends BackgroundService {
             ", core pool size {} and timeout {} {}",
         newInterval, TimeUnit.SECONDS.name().toLowerCase(), newCorePoolSize, newTimeout,
         TimeUnit.NANOSECONDS.name().toLowerCase());
+    // shutdown() awaits the executor; do not hold this monitor (same object as
+    // BackgroundService.PeriodicalTask) or the pool thread can deadlock.
     shutdown();
-    setInterval(newInterval, TimeUnit.SECONDS);
-    setPoolSize(newCorePoolSize);
-    setServiceTimeoutInNanos(newTimeout);
-    start();
+    synchronized (this) {
+      setInterval(newInterval, TimeUnit.SECONDS);
+      setPoolSize(newCorePoolSize);
+      setServiceTimeoutInNanos(newTimeout);
+      start();
+    }
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -190,7 +190,11 @@ public abstract class BackgroundService {
     }
   }
 
-  // shutdown and make sure all threads are properly released.
+  /**
+   * Shuts down the scheduled executor and waits for pool threads to finish.
+   * DO NOT call while holding the monitor on this instance. {@link PeriodicalTask}
+   * uses the same lock and can deadlock during {@code awaitTermination}.
+   */
   public void shutdown() {
     LOG.info("Shutting down service {}", this.serviceName);
     final ScheduledThreadPoolExecutor current;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -204,7 +204,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     });
   }
 
-  synchronized void updateAndRestart(OzoneConfiguration conf) {
+  void updateAndRestart(OzoneConfiguration conf) {
     long newInterval = conf.getTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL,
         OZONE_DIR_DELETING_SERVICE_INTERVAL_DEFAULT, TimeUnit.SECONDS);
     int newCorePoolSize = conf.getInt(OZONE_THREAD_NUMBER_DIR_DELETION,
@@ -212,11 +212,15 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     LOG.info("Updating and restarting DirectoryDeletingService with interval {} {}" +
             " and core pool size {}",
         newInterval, TimeUnit.SECONDS.name().toLowerCase(), newCorePoolSize);
+    // shutdown() awaits the executor; do not hold this monitor (same object as
+    // BackgroundService.PeriodicalTask) or the pool thread can deadlock.
     shutdown();
-    setInterval(newInterval, TimeUnit.SECONDS);
-    setPoolSize(newCorePoolSize);
-    this.numberOfParallelThreadsPerStore.set(newCorePoolSize);
-    start();
+    synchronized (this) {
+      setInterval(newInterval, TimeUnit.SECONDS);
+      setPoolSize(newCorePoolSize);
+      this.numberOfParallelThreadsPerStore.set(newCorePoolSize);
+      start();
+    }
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Any thread that calls shutdown() also can't hold the monitor lock on BackgroundService instance, in this case updateAndRestart. Otherwise, it can deadlock. This is a follow-up to HDDS-14645.

Context: https://github.com/apache/ozone/pull/10378#discussion_r3328231014

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15429

## How was this patch tested?

- n/a