### PR TITLE
HDDS-15269. Avoid 30s shutdown wait in ReconTaskController

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -88,6 +88,7 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   private final ReconTaskStatusUpdaterManager taskStatusUpdaterManager;
   private final OMUpdateEventBuffer eventBuffer;
   private ExecutorService eventProcessingExecutor;
+  private volatile boolean running = false;
   private final AtomicBoolean tasksFailed = new AtomicBoolean(false);
   private volatile ReconOMMetadataManager currentOMMetadataManager;
   private final OzoneConfiguration configuration;
@@ -359,6 +360,7 @@ public class ReconTaskControllerImpl implements ReconTaskController {
             .build());
     
     // Start async event processing thread
+    running = true;
     eventProcessingExecutor = Executors.newSingleThreadExecutor(
         new ThreadFactoryBuilder().setNameFormat("ReconEventProcessor-%d")
             .build());
@@ -369,6 +371,9 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   @Override
   public synchronized void stop() {
     LOG.info("Stopping Recon Task Controller.");
+    // Signal the event processing loop to exit on its next poll cycle so the
+    // graceful shutdown below can complete without waiting out the timeout.
+    running = false;
     shutdownExecutorGracefully(this.executorService, "main task executor");
     shutdownExecutorGracefully(this.eventProcessingExecutor, "event processing executor");
   }
@@ -481,7 +486,7 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   private void processBufferedEventsAsync() {
     LOG.info("Started async buffered event processing thread");
     
-    while (!Thread.currentThread().isInterrupted()) {
+    while (running && !Thread.currentThread().isInterrupted()) {
       try {
         ReconEvent event = eventBuffer.poll(1000); // 1 second timeout
         if (event != null) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
 import org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdater;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdaterManager;
+import org.apache.hadoop.util.Time;
 import org.apache.ozone.recon.schema.generated.tables.daos.ReconTaskStatusDao;
 import org.apache.ozone.recon.schema.generated.tables.pojos.ReconTaskStatus;
 import org.apache.ozone.test.GenericTestUtils;
@@ -93,6 +94,19 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
         reconTaskStatusUpdaterManagerMock, reconDbProvider, reconContainerMgr, nsSummaryManager,
         reconGlobalStatsManager, reconFileMetadataManager);
     reconTaskController.start();
+  }
+
+  @Test
+  public void testStopCompletesPromptly() {
+    // stop() must not block on the graceful shutdown timeout. The event
+    // processing loop only exits on interrupt, so a plain shutdown() can never
+    // drain it and awaitTermination would otherwise burn the full 30s timeout.
+    long start = Time.monotonicNow();
+    reconTaskController.stop();
+    long elapsed = Time.monotonicNow() - start;
+    assertThat(elapsed)
+        .as("stop() should return promptly, not wait out the shutdown timeout")
+        .isLessThan(5000L);
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -610,9 +610,11 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
         .thenReturn(false)  // First call fails
         .thenReturn(true);  // Second call succeeds
     
-    // Stop async processing to control event processing manually
-    controllerSpy.stop();
-    
+    // Stop async processing on the real controller so we can drive event
+    // processing manually. Stopping controllerSpy would only flip the flag on
+    // the Mockito copy, not the live event-processing thread.
+    controllerImpl.stop();
+
     // Create and manually process a reinitialization event
     ReconTaskReInitializationEvent reinitEvent = new ReconTaskReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.TASK_FAILURES,
@@ -746,9 +748,11 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     when(controllerSpy.reInitializeTasks(any(ReconOMMetadataManager.class), any()))
         .thenReturn(true);  // Succeed
     
-    // Stop async processing to control event processing manually
-    controllerSpy.stop();
-    
+    // Stop async processing on the real controller so we can drive event
+    // processing manually. Stopping controllerSpy would only flip the flag on
+    // the Mockito copy, not the live event-processing thread.
+    controllerImpl.stop();
+
     // Create reinitialization event with checkpointed manager
     ReconTaskReInitializationEvent reinitEvent = new ReconTaskReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestReconTaskControllerImpl` took ~145s to run 17 tests. Profiling each method
showed the time was not spread out: four tests each blocked for almost exactly
**30 seconds** inside `ReconTaskController.stop()`.

### Root cause

`ReconTaskControllerImpl` runs a single background thread
(`processBufferedEventsAsync`) that loops on an interruptible
`eventBuffer.poll(...)` and only exits when the thread is **interrupted**:

```java
while (!Thread.currentThread().isInterrupted()) {
    ReconEvent event = eventBuffer.poll(1000);
    ...
}
```

When this loop was introduced (HDDS-13576), `stop()` used `shutdownNow()`, which
interrupts the thread, so it exited immediately. A later reliability change
(HDDS-13956) replaced that with a graceful shutdown:

```java
executor.shutdown();                       // does NOT interrupt running tasks
executor.awaitTermination(30, SECONDS);    // waits the full timeout
executor.shutdownNow();                     // only now interrupts
```

`shutdown()` stops accepting new work but never interrupts the running thread,
and the loop has no non-interrupt exit path. So the graceful phase can never
drain the loop: `awaitTermination` always burns its full 30s timeout before the
fallback `shutdownNow()` finally stops it. Every `stop()` therefore costs ~30s.
This is not test-only: in production it delays Recon shutdown by ~30s and logs a
misleading "did not terminate within 30 seconds" warning on every shutdown.

### Fix (production)

Give the loop a cooperative exit path: a `volatile boolean running` flag set in
`start()` and cleared in `stop()`. The loop checks it each iteration, so after
`stop()` it exits on the next poll cycle and the existing graceful shutdown
completes promptly.

I chose the cooperative flag over simply reverting to `shutdownNow()` because it
**preserves the intent of HDDS-13956**: an in-flight event is still allowed to
finish instead of being interrupted mid-processing. The 30s `awaitTermination`
stays as a genuine safety net rather than the normal path.

### Fix (test)

Two tests (`testProcessReInitializationEventWith*`) call `stop()` on a Mockito
`spy(controller)` to quiesce the background loop. A spy is a shallow copy, so it
flips the `running` flag on the copy while the live thread (started on the
original controller in `setUp`) keeps running, still hitting the 30s timeout.
They now stop the original controller. This does not change what the tests
assert; `stop()` there is only setup to avoid a race with the background loop.

### Scope

Kept intentionally small to fix only the critical issue (the 30s production
shutdown hang). Two unrelated, lower-impact test-only slowdowns remain and are
left for a follow-up to avoid scope creep:
- `testNewRetryLogicWithMaxRetriesExceeded` and `testFailedTaskRetryLogic` use
  real-clock `Thread.sleep` to wait out `RETRY_DELAY_MS`; speeding these up needs
  the retry delay to be injectable.

### Result

`TestReconTaskControllerImpl`: **~145s → ~26s**, all tests pass, checkstyle clean.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15269

## How was this patch tested?

- Added `testStopCompletesPromptly`, which fails (~31s) before the fix and passes
  (~1s) after, guarding against regression.
- Ran the full `TestReconTaskControllerImpl` class: 18 tests, 0 failures,
  ~26s (down from ~145s).
- `mvn -pl hadoop-ozone/recon checkstyle:check`: 0 violations.
