### PR TITLE
HDDS-10237. Dynamic reconfiguration of replication supervisor thread pool

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -710,8 +710,11 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
   }
 
   private String reconfigReplicationStreamsLimit(String value) {
+    int poolSize = Integer.parseInt(value);
     getDatanodeStateMachine().getContainer().getReplicationServer()
-        .setPoolSize(Integer.parseInt(value));
+        .setPoolSize(poolSize);
+    getDatanodeStateMachine().getSupervisor()
+        .setReplicationMaxStreams(poolSize);
     return value;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -346,21 +346,31 @@ public final class ReplicationSupervisor {
 
   public void nodeStateUpdated(HddsProtos.NodeOperationalState newState) {
     if (state.getAndSet(newState) != newState) {
-      int threadCount = replicationConfig.getReplicationMaxStreams();
-      int newMaxQueueSize = datanodeConfig.getCommandQueueLimit();
-
-      if (isMaintenance(newState) || isDecommission(newState)) {
-        threadCount = replicationConfig.scaleOutOfServiceLimit(threadCount);
-        newMaxQueueSize =
-            replicationConfig.scaleOutOfServiceLimit(newMaxQueueSize);
-      }
-
-      LOG.info("Node state updated to {}, scaling executor pool size to {}",
-          newState, threadCount);
-
-      maxQueueSize = newMaxQueueSize;
-      executorThreadUpdater.accept(threadCount);
+      resize(newState);
     }
+  }
+
+  public void setReplicationMaxStreams(int replicationMaxStreams) {
+    replicationConfig.setReplicationMaxStreams(replicationMaxStreams);
+    resize(state.get());
+  }
+
+  private void resize(HddsProtos.NodeOperationalState nodeState) {
+    int threadCount = replicationConfig.getReplicationMaxStreams();
+    int newMaxQueueSize = datanodeConfig.getCommandQueueLimit();
+
+    if (isMaintenance(nodeState) || isDecommission(nodeState)) {
+      threadCount = replicationConfig.scaleOutOfServiceLimit(threadCount);
+      newMaxQueueSize =
+          replicationConfig.scaleOutOfServiceLimit(newMaxQueueSize);
+    }
+
+    LOG.info("Scaling replication supervisor for node state {} to executor " +
+        "pool size {} and queue size {}", nodeState, threadCount,
+        newMaxQueueSize);
+
+    maxQueueSize = newMaxQueueSize;
+    executorThreadUpdater.accept(threadCount);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -1162,10 +1162,10 @@ public class TestReplicationSupervisor {
     assertEquals(7, threadPoolSize.get());
 
     rs.nodeStateUpdated(DECOMMISSIONING);
-    assertEquals(14, threadPoolSize.get());
+    assertEquals(repConf.scaleOutOfServiceLimit(7), threadPoolSize.get());
 
     rs.setReplicationMaxStreams(3);
-    assertEquals(6, threadPoolSize.get());
+    assertEquals(repConf.scaleOutOfServiceLimit(3), threadPoolSize.get());
 
     rs.nodeStateUpdated(IN_SERVICE);
     assertEquals(3, threadPoolSize.get());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.replication;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
@@ -1137,6 +1138,37 @@ public class TestReplicationSupervisor {
     } finally {
       subject.stop();
     }
+  }
+
+  @ContainerLayoutTestInfo.ContainerTest
+  public void poolSizeCanBeUpdatedByReplicationStreamsLimitReconfiguration() {
+    final int replicationMaxStreams = 5;
+    ReplicationServer.ReplicationConfig repConf =
+        new ReplicationServer.ReplicationConfig();
+    repConf.setReplicationMaxStreams(replicationMaxStreams);
+
+    AtomicInteger threadPoolSize = new AtomicInteger();
+
+    ReplicationSupervisor rs = ReplicationSupervisor.newBuilder()
+        .executor(new DiscardingExecutorService())
+        .executorThreadUpdater(threadPoolSize::set)
+        .replicationConfig(repConf)
+        .build();
+
+    rs.nodeStateUpdated(IN_SERVICE);
+    assertEquals(replicationMaxStreams, threadPoolSize.get());
+
+    rs.setReplicationMaxStreams(7);
+    assertEquals(7, threadPoolSize.get());
+
+    rs.nodeStateUpdated(DECOMMISSIONING);
+    assertEquals(14, threadPoolSize.get());
+
+    rs.setReplicationMaxStreams(3);
+    assertEquals(6, threadPoolSize.get());
+
+    rs.nodeStateUpdated(IN_SERVICE);
+    assertEquals(3, threadPoolSize.get());
   }
 
   @ContainerLayoutTestInfo.ContainerTest


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Update `ReplicationSupervisor` when `hdds.datanode.replication.streams.limit` is reconfigured dynamically.
* Extract the supervisor resize logic so both node state changes and stream limit reconfiguration use the same scaling behavior.
* Preserve out-of-service scaling for decommissioning and maintenance datanodes when the replication stream limit changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10237

## How was this patch tested?

* Added unit test coverage for `ReplicationSupervisor` resize on stream limit reconfiguration.
* `mvn -pl hadoop-hdds/container-service -Dtest=TestReplicationSupervisor test`
* All CI Test passed