### PR TITLE
HDDS-15420. Update Ozone command help menu

### DIFF
--- a/hadoop-hdds/docs/content/tools/_index.md
+++ b/hadoop-hdds/docs/content/tools/_index.md
@@ -54,7 +54,7 @@ Admin commands:
    * **classpath** - Prints the class path needed to get the hadoop jar and the
     required libraries.
    * **dtutil**    - Operations related to delegation tokens
-   * **envvars** - Display computed Hadoop environment variables.
+   * **envvars** - Display computed Ozone environment variables.
    * **getconf** -  Reads ozone config values from configuration.
    * **genconf** -  Generate minimally required ozone configs and output to
    ozone-site.xml.

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Command;
 /**
  * Shell commands for native rpc object manipulation.
  */
-@Command(name = "ozone sh", aliases = "sh",
+@Command(name = "ozone sh", aliases = {"sh", "shell"},
     description = "Shell for Ozone object store",
     subcommands = {
         BucketCommands.class,

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -53,7 +53,7 @@ function ozone_usage
   ozone_add_subcommand "httpfs" daemon "run the HTTPFS compatible REST gateway"
   ozone_add_subcommand "csi" daemon "run the standalone CSI daemon"
   ozone_add_subcommand "recon" daemon "run the Recon service"
-  ozone_add_subcommand "sh" client "command line interface for object store operations"
+  ozone_add_subcommand "sh" client "command line interface for object store operations (alias: shell)"
   ozone_add_subcommand "s3" client "command line interface for s3 related operations"
   ozone_add_subcommand "tenant" client "command line interface for multi-tenant related operations"
   ozone_add_subcommand "insight" client "tool to get runtime operation information"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -41,7 +41,7 @@ function ozone_usage
   ozone_add_subcommand "classpath" client "prints the class path needed for running ozone commands"
   ozone_add_subcommand "completion" client "generate autocompletion script for bash/zsh"
   ozone_add_subcommand "datanode" daemon "run a HDDS datanode"
-  ozone_add_subcommand "envvars" client "display computed Hadoop environment variables"
+  ozone_add_subcommand "envvars" client "display computed Ozone environment variables"
   ozone_add_subcommand "daemonlog" admin "get/set the log level for each daemon"
   ozone_add_subcommand "freon" client "runs an ozone data generator"
   ozone_add_subcommand "fs" client "run a filesystem command on Ozone file system. Equivalent to 'hadoop fs'"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -35,7 +35,7 @@ function ozone_usage
   ozone_add_option "--hosts filename" "list of hosts to use in worker mode"
   ozone_add_option "--loglevel level" "set the log4j level for this command"
   ozone_add_option "--workers" "turn on worker mode"
-  ozone_add_option "--jvmargs arguments" "append JVM options to any existing options defined in the OZONE_OPTS environment variable. Any defined in OZONE_CLIENT_OPTS will be append after these jvmargs"
+  ozone_add_option "--jvmargs arguments" "append JVM options to any existing options defined in the OZONE_OPTS environment variable. Any defined in OZONE_CLIENT_OPTS will be appended after these jvmargs"
   ozone_add_option "--validate (continue)" "validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present, command execution shall continue post validation failure if 'continue' is passed"
 
   ozone_add_subcommand "classpath" client "prints the class path needed for running ozone commands"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -36,7 +36,7 @@ function ozone_usage
   ozone_add_option "--loglevel level" "set the log4j level for this command"
   ozone_add_option "--workers" "turn on worker mode"
   ozone_add_option "--jvmargs arguments" "append JVM options to any existing options defined in the OZONE_OPTS environment variable. Any defined in OZONE_CLIENT_OPTS will be appended after these jvmargs"
-  ozone_add_option "--validate (continue)" "validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present, command execution shall continue post validation failure if 'continue' is passed"
+  ozone_add_option "--validate [continue]" "validate that all required jars are present on the classpath; with 'continue', keep running even if validation fails"
 
   ozone_add_subcommand "classpath" client "prints the class path needed for running ozone commands"
   ozone_add_subcommand "completion" client "generate autocompletion script for bash/zsh"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -48,14 +48,14 @@ function ozone_debug
 ## @replaceable yes
 function ozone_validate_classpath_usage
 {
-  description=$'The --validate flag validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present\n\n'
+  description=$'The --validate flag checks that all jars required for the command are present on the classpath\n\n'
   usage_text=$'Usage I: ozone --validate classpath <ARTIFACTNAME>\nUsage II: ozone --validate [OPTIONS] --daemon start|status|stop csi|datanode|om|recon|s3g|scm\n\n'
   options=$'  OPTIONS is none or any of:\n\ncontinue\tcommand execution shall continue even if validation fails'
   ozone_error "${description}${usage_text}${options}"
   exit 1
 }
 
-## @description Validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present
+## @description Validates that all jars required for the command are present on the classpath
 ## @audience private
 ## @stability evolving
 ## @replaceable yes

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/AutoCompletion.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/AutoCompletion.java
@@ -168,8 +168,8 @@ public final class AutoCompletion extends GenericCli {
     private String jvmargs;
 
     @Option(names = {"--validate"},
-        description = "validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath " +
-            "file are present, command execution shall continue post validation failure if 'continue' is passed")
+        description = "validate that all required jars are present on the classpath; " +
+            "with 'continue', keep running even if validation fails")
     private String validate;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/AutoCompletion.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/AutoCompletion.java
@@ -139,7 +139,7 @@ public final class AutoCompletion extends GenericCli {
     private String debug;
 
     @Option(names = {"--daemon"},
-        description = "attempt to add class files from build tree")
+        description = "operate on a daemon")
     private String daemon;
 
     @Option(names = {"--help"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ozone` command help menu (`ozone --help`) and the generated shell autocompletion contained outdated, incorrect, and confusing entries. This PR cleans them up:

- **`--jvmargs`**: fix typo "will be append" → "will be appended".
- **`--validate`**: change the ambiguous `(continue)` notation to `[continue]` (square brackets denote the optional argument), and reword the description to drop the leaky internal `OZONE_RUN_ARTIFACT_NAME` variable in favor of user-facing wording. Applied to all three copies: the shell usage menu, the autocompletion generator, and the `--validate` misuse/error message in `ozone-functions.sh`.
- **`envvars`**: refer to "Ozone" instead of "Hadoop" environment variables, in both the shell usage menu and the tools docs page.
- **`--daemon`** (autocompletion source): fix a description accidentally copy-pasted from `--buildpaths`; it now reads "operate on a daemon".
- **`shell` alias**: the `shell` alias for `sh` is accepted by the `ozone` script but was undocumented and unknown to the autocompletion generator. Note it in the usage menu and register it on the `OzoneShell` command so generated bash/zsh completion lists and dispatches `shell` as well.

Each change is a separate commit. A few items mentioned in the Jira are intentionally scoped **out** of this PR, and I'm happy to revisit if reviewers prefer otherwise:

- **`csi`**: the Jira suggests it may be legacy. But it seems currently an alpha-but-documented, shipped interface with no in-repo replacement, and deprecating a daemon feels like a separate decision (own Jira + dev-list) rather than a help-text cleanup. Left as-is here.
- **`auditparser` / `checknative`**: already deprecated and redirected with a warning; since deprecated commands are normally not advertised in the menu, I left them out, but can document them if preferred.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15420

## How was this patch tested?

Built a distribution (`mvn clean install -DskipTests -Pdist`) and verified against the running binary:

- `ozone --help` shows all four updated usage lines (`--jvmargs` appended, `--validate [continue]`, `envvars` → Ozone, `sh ... (alias: shell)`).

<details>

```bash
> ozone --help

Usage: ozone [OPTIONS] SUBCOMMAND [SUBCOMMAND OPTIONS]

  OPTIONS is none or any of:

--buildpaths                       attempt to add class files from build tree
--config dir                       Ozone config directory
--daemon (start|status|stop)       operate on a daemon
--debug                            turn on shell script debug mode
--help                             usage information
--hostnames list[,of,host,names]   hosts to use in worker mode
--hosts filename                   list of hosts to use in worker mode
--jvmargs arguments                append JVM options to any existing options defined in the OZONE_OPTS environment variable. Any defined in OZONE_CLIENT_OPTS will be appended after these jvmargs
--loglevel level                   set the log4j level for this command
--validate [continue]              validate that all required jars are present on the classpath; with 'continue', keep running even if validation fails
--workers                          turn on worker mode

  SUBCOMMAND is one of:


    Admin Commands:

daemonlog     get/set the log level for each daemon

    Client Commands:

admin         Ozone admin tool
classpath     prints the class path needed for running ozone commands
completion    generate autocompletion script for bash/zsh
debug         Ozone debug tool
dtutil        operations related to delegation tokens
envvars       display computed Ozone environment variables
freon         runs an ozone data generator
fs            run a filesystem command on Ozone file system. Equivalent to 'hadoop fs'
genconf       generate minimally required ozone configs and output to ozone-site.xml in specified path
getconf       get ozone config values from configuration
insight       tool to get runtime operation information
interactive   interactive shell for ozone commands
ratis         Ozone ratis tool
repair        Ozone repair tool
s3            command line interface for s3 related operations
sh            command line interface for object store operations (alias: shell)
tenant        command line interface for multi-tenant related operations
vapor         Ozone server simulator
version       print the version

    Daemon Commands:

csi           run the standalone CSI daemon
datanode      run a HDDS datanode
httpfs        run the HTTPFS compatible REST gateway
om            Ozone Manager
recon         run the Recon service
s3g           run the S3 compatible REST gateway
scm           run the Storage Container Manager service

SUBCOMMAND may print help when invoked w/o parameters or with -h.
```

</details>

- `ozone shell --help` routes to `OzoneShell` (the alias is functional).

<details>

```bash
> ./bin/ozone shell --help

Usage: ozone sh [-hV] [--verbose] [-conf=<configurationPath>]
                [-D=<String=String>]... [--interactive | --execute=<command>
                [--execute=<command>]...] [COMMAND]
Shell for Ozone object store
      -conf=<configurationPath>

  -D, --set=<String=String>
      --execute=<command>   Run command as part of batch
  -h, --help                Show this help message and exit.
      --interactive         Run in interactive mode
  -V, --version             Print version information and exit.
      --verbose             More verbose output. Show the stack trace of the
                              errors.
Commands:
  bucket       Bucket specific operations
  key          Key specific operations
  prefix       Prefix specific operations
  snapshot     Snapshot specific operations
  user         Tenant user management
  token        Token specific operations
  volume, vol  Volume specific operations
```

</details>

- `ozone completion bash` lists both `sh` and `shell` in the top-level candidate list and dispatcher.
- `checkstyle:check` passes on the changed modules (`hadoop-ozone/tools`, `hadoop-ozone/cli-shell`).
