### PR TITLE
HDDS-15459. Speed up TestKeyPathLock

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/lock/TestKeyPathLock.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/lock/TestKeyPathLock.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Tests OzoneManagerLock.Resource.KEY_PATH_LOCK.
  */
-class TestKeyPathLock extends TestOzoneManagerLock {
+class TestKeyPathLock {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyPathLock.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestKeyPathLock extends TestOzoneManagerLock` unnecessarily, running all test cases from the parent class without any change.

```
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.77 s -- in org.apache.hadoop.ozone.om.lock.TestOzoneManagerLock
[INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.22 s -- in org.apache.hadoop.ozone.om.lock.TestKeyPathLock
```

https://issues.apache.org/jira/browse/HDDS-15459

## How was this patch tested?

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.762 s -- in org.apache.hadoop.ozone.om.lock.TestKeyPathLock
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.74 s -- in org.apache.hadoop.ozone.om.lock.TestOzoneManagerLock
```

https://github.com/adoroszlai/ozone/actions/runs/26820582416