### PR TITLE
HDDS-15265. Speed up TestStorageDistributionEndpoint testcases

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -87,7 +87,7 @@ public final class BlockDeletingServiceMetrics {
   private BlockDeletingServiceMetrics() {
   }
 
-  public static BlockDeletingServiceMetrics create() {
+  public static synchronized BlockDeletingServiceMetrics create() {
     if (instance == null) {
       MetricsSystem ms = DefaultMetricsSystem.instance();
       instance = ms.register(SOURCE_NAME, "BlockDeletingService",
@@ -100,7 +100,7 @@ public final class BlockDeletingServiceMetrics {
   /**
    * Unregister the metrics instance.
    */
-  public static void unRegister() {
+  public static synchronized void unRegister() {
     instance = null;
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(SOURCE_NAME);

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractTestStorageDistributionEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractTestStorageDistributionEndpoint.java
@@ -156,7 +156,7 @@ public abstract class AbstractTestStorageDistributionEndpoint {
     conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
 
     DatanodeConfiguration dnConf = conf.getObject(DatanodeConfiguration.class);
-    dnConf.setBlockDeletionInterval(Duration.ofMillis(30000));
+    dnConf.setBlockDeletionInterval(Duration.ofMillis(5000));
     conf.setFromObject(dnConf);
 
     recon = new ReconService(conf);
@@ -212,6 +212,7 @@ public abstract class AbstractTestStorageDistributionEndpoint {
 
   protected boolean verifyStorageDistributionAfterKeyCreation() {
     try {
+      syncDataFromOM();
       StringBuilder urlBuilder = new StringBuilder();
       urlBuilder.append(getReconWebAddress(conf)).append(STORAGE_DIST_ENDPOINT);
       String response = TestReconEndpointUtil.makeHttpCall(conf, urlBuilder);

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointEC.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointEC.java
@@ -83,11 +83,11 @@ public class TestStorageDistributionEndpointEC extends AbstractTestStorageDistri
     closeAllContainers();
     getFs().delete(dir1, true);
     GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOm, 1000, 30000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 2000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 1000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 1000, 60000);
     GenericTestUtils.waitFor(() -> Objects.requireNonNull(
             getScm().getClientProtocolServer().getDeletedBlockSummary()).getTotalBlockCount() == 0,
         1000, 30000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 2000, 60000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 2000, 60000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 1000, 60000);
   }
 }

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointRatis.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestStorageDistributionEndpointRatis.java
@@ -88,13 +88,13 @@ public class TestStorageDistributionEndpointRatis extends AbstractTestStorageDis
     closeAllContainers();
     getFs().delete(dir1, true);
     GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOm, 1000, 30000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 2000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionScm, 1000, 30000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 1000, 60000);
     GenericTestUtils.waitFor(() -> Objects.requireNonNull(
             getScm().getClientProtocolServer().getDeletedBlockSummary()).getTotalBlockCount() == 0,
         1000, 30000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionDn, 2000, 60000);
-    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 2000, 60000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionClearsAtDn, 1000, 60000);
     getCluster().getHddsDatanodes().get(0).stop();
-    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOnDnFailure, 2000, 60000);
+    GenericTestUtils.waitFor(this::verifyPendingDeletionAfterKeyDeletionOnDnFailure, 1000, 60000);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request synchronizes the creation of BlockDeletingServiceMetrics and optimizes integration tests for the Recon storage distribution endpoint by reducing block deletion intervals and adjusting wait times.

## What is the link to the Apache JIRA

HDDS-15265

## How was this patch tested?

Tested using CI  - https://github.com/priyeshkaratha/ozone/actions/runs/26841456183

Execution time reduced to 

```
[INFO] Running org.apache.hadoop.ozone.recon.TestStorageDistributionEndpointEC
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 67.64 s -- in org.apache.hadoop.ozone.recon.TestStorageDistributionEndpointEC
[INFO] Running org.apache.hadoop.ozone.recon.TestStorageDistributionEndpointRatis
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 65.61 s -- in org.apache.hadoop.ozone.recon.TestStorageDistributionEndpointRatis
```
