### PR TITLE
HDDS-15453. [Recon] Refresh all capacity APIs on auto refresh

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -113,15 +113,7 @@ const Capacity: React.FC<object> = () => {
     })
   }
 
-  const loadDNData = () => {
-    dnPendingDeletes.refetch();
-    setState({
-      isDNPending: dnPendingDeletes.data.status !== "FINISHED",
-      lastUpdated: Number(moment())
-    })
-  } 
-
-  const autoReload = useAutoReload(loadDNData, PENDING_POLL_INTERVAL);
+  const autoReload = useAutoReload(loadData);
 
   const selectedDNDetails: DataNodeUsage & { pendingBlockSize: number } = React.useMemo(() => {
     const selected = storageDistribution.data.dataNodeUsage.find(datanode => datanode.hostName === selectedDatanode)
@@ -192,24 +184,22 @@ const Capacity: React.FC<object> = () => {
     }
   };
 
-  // Poll every 5s until status is FINISHED, then stop
+  // Poll DN pending deletion every 5s until status is FINISHED
   React.useEffect(() => {
-    if (dnPendingDeletes.data.status !== "FINISHED") {
-      if (!autoReload.isPolling) {
-        autoReload.startPolling(PENDING_POLL_INTERVAL);
-      }
+    if (dnPendingDeletes.data.status === "FINISHED") {
       return;
     }
 
-    if (autoReload.isPolling) {
-      autoReload.stopPolling();
-    }
-  }, [
-    dnPendingDeletes.data.status,
-    autoReload.isPolling,
-    autoReload.startPolling,
-    autoReload.stopPolling
-  ]);
+    dnPendingDeletes.refetch();
+
+    const intervalId = window.setInterval(() => {
+      dnPendingDeletes.refetch();
+    }, PENDING_POLL_INTERVAL);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [dnPendingDeletes.data.status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dnReportStatus = (
     (dnPendingDeletes.data.totalNodeQueriesFailed ?? 0) > 0

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -38,6 +38,7 @@ import { useApiData } from '@/v2/hooks/useAPIData.hook';
 import * as CONSTANTS from '@/v2/constants/capacity.constants';
 import { UtilizationResponse, SCMPendingDeletion, OMPendingDeletion, DNPendingDeletion, DataNodeUsage } from '@/v2/types/capacity.types';
 import { useAutoReload } from '@/v2/hooks/useAutoReload.hook';
+import { AUTO_RELOAD_INTERVAL_DEFAULT } from '@/constants/autoReload.constants';
 
 type CapacityState = {
   isDNPending: boolean;
@@ -184,22 +185,19 @@ const Capacity: React.FC<object> = () => {
     }
   };
 
-  // Poll DN pending deletion every 5s until status is FINISHED
+  // Adjust the polling interval based on DN scan status:
+  // fast (5s) while a scan is running, normal (60s) once finished.
+  // Honors the auto-reload toggle: if polling is OFF, do nothing.
   React.useEffect(() => {
-    if (dnPendingDeletes.data.status === "FINISHED") {
+    if (!autoReload.isPolling) {
       return;
     }
-
-    dnPendingDeletes.refetch();
-
-    const intervalId = window.setInterval(() => {
-      dnPendingDeletes.refetch();
-    }, PENDING_POLL_INTERVAL);
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [dnPendingDeletes.data.status]); // eslint-disable-line react-hooks/exhaustive-deps
+    autoReload.startPolling(
+      dnPendingDeletes.data.status === "FINISHED"
+        ? AUTO_RELOAD_INTERVAL_DEFAULT
+        : PENDING_POLL_INTERVAL
+    );
+  }, [dnPendingDeletes.data.status, autoReload.isPolling]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dnReportStatus = (
     (dnPendingDeletes.data.totalNodeQueriesFailed ?? 0) > 0

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -41,7 +41,6 @@ import { useAutoReload } from '@/v2/hooks/useAutoReload.hook';
 import { AUTO_RELOAD_INTERVAL_DEFAULT } from '@/constants/autoReload.constants';
 
 type CapacityState = {
-  isDNPending: boolean;
   lastUpdated: number;
 };
 
@@ -52,7 +51,6 @@ const Capacity: React.FC<object> = () => {
   const DOWNLOAD_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 
   const [state, setState] = React.useState<CapacityState>({
-    isDNPending: true,
     lastUpdated: 0
   });
 
@@ -108,7 +106,6 @@ const Capacity: React.FC<object> = () => {
     omPendingDeletes.refetch();
     dnPendingDeletes.refetch();
     setState({
-      isDNPending: dnPendingDeletes.data.status !== "FINISHED",
       lastUpdated: Number(moment())
     })
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -88,7 +88,6 @@ const Capacity: React.FC<object> = () => {
     CONSTANTS.DEFAULT_DN_PENDING_DELETION,
     {
       retryAttempts: 2,
-      initialFetch: false,
       onError: (error) => showDataFetchError(error)
     }
   );
@@ -114,7 +113,19 @@ const Capacity: React.FC<object> = () => {
     })
   }
 
-  const autoReload = useAutoReload(loadData);
+  const loadDataIfIdle = () => {
+    if (
+      storageDistribution.loading ||
+      scmPendingDeletes.loading ||
+      omPendingDeletes.loading ||
+      dnPendingDeletes.loading
+    ) {
+      return;
+    }
+    loadData();
+  };
+
+  const autoReload = useAutoReload(loadDataIfIdle);
 
   const selectedDNDetails: DataNodeUsage & { pendingBlockSize: number } = React.useMemo(() => {
     const selected = storageDistribution.data.dataNodeUsage.find(datanode => datanode.hostName === selectedDatanode)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the Auto Refresh toggle to reload all capacity APIs on the default 60s interval. Poll the DN pending deletion API separately every 5s until the scan status is FINISHED, so fast DN updates no longer override full-page refresh behavior.

The earlier concern was regarding whether auto refresh cause unnecessary API calls for long running tasks. But additionally, there is a 30-second delay between metric collection cycles. After a collection completes, the next collection will not start for at least 30 seconds. This ensures that users can view stable results for a reasonable period before a new collection begins.

## What is the link to the Apache JIRA

HDDS-15453

## How was this patch tested?

Tested manually

