### PR TITLE
HDDS-15468. Replace langchain4j-bom, guice-bom due to leaked dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,13 +242,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId>
-        <artifactId>langchain4j-bom</artifactId>
-        <version>${langchain4j.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
         <version>${io.grpc.version}</version>
@@ -521,6 +514,21 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-anthropic</artifactId>
+        <version>${langchain4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-core</artifactId>
+        <version>${langchain4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-open-ai</artifactId>
+        <version>${langchain4j.version}</version>
       </dependency>
       <dependency>
         <groupId>info.picocli</groupId>
@@ -1610,17 +1618,6 @@
         <version>${jooq.version}</version>
       </dependency>
       <dependency>
-        <!-- langchain4j-bom pins JUnit 5.10.0; override to keep Ozone on ${junit5.version}. -->
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit5.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit5.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.kohsuke.metainf-services</groupId>
         <artifactId>metainf-services</artifactId>
         <version>${metainf-services.version}</version>
@@ -1674,57 +1671,6 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
-      </dependency>
-      <dependency>
-        <!-- langchain4j-bom pins AWS SDK 2.21.44; override to keep Ozone on ${aws-java-sdk2.version}. -->
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>apache-client</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>auth</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>aws-core</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>http-client-spi</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>identity-spi</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>regions</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>s3</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>s3-transfer-manager</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>sdk-core</artifactId>
-        <version>${aws-java-sdk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>utils</artifactId>
-        <version>${aws-java-sdk2.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -235,13 +235,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice-bom</artifactId>
-        <version>${guice.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
         <version>${io.grpc.version}</version>
@@ -432,6 +425,21 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-servlet</artifactId>
+        <version>${guice.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`langchain4j-bom` and `guice-bom` leak transitive dependencies defined in their parent POMs.

- https://github.com/langchain4j/langchain4j/blob/0.35.0/langchain4j-bom/pom.xml#L8
- https://github.com/langchain4j/langchain4j/blob/0.35.0/langchain4j-parent/pom.xml#L92-L126
- https://github.com/langchain4j/langchain4j/blob/0.35.0/langchain4j-parent/pom.xml#L158-L433
- https://github.com/google/guice/blob/6.0.0/bom/pom.xml#L8
- https://github.com/google/guice/blob/6.0.0/pom.xml#L127-L199

This overrides some of Ozone's own dependencies.  Example for production dependency:

```
$ cd hadoop-ozone/dist/target/ozone-2.2.0-SNAPSHOT/share/ozone/lib
$ ls slf4j*
slf4j-api-2.0.7.jar
slf4j-reload4j-2.0.17.jar
```

Some test artifacts are also overridden, which was previously worked around by adding these dependencies again, despite having been imported from their own BOMs:

https://github.com/apache/ozone/blob/891cf0e86fe9b0bec15f86be60db28d1b553c1d3/pom.xml#L1613
https://github.com/apache/ozone/blob/891cf0e86fe9b0bec15f86be60db28d1b553c1d3/pom.xml#L1679

This change replaces usage of these two BOMs with individual artifacts.

https://issues.apache.org/jira/browse/HDDS-15468

## How was this patch tested?

Verified `slf4j-api` version after build.

```
$ cd hadoop-ozone/dist/target/ozone-2.2.0-SNAPSHOT/share/ozone/lib
$ ls slf4j*
slf4j-api-2.0.17.jar
slf4j-reload4j-2.0.17.jar
```

Compared effective POM before/after the change.  Effective POM (with BOMs imported, properties substituted etc.) can be generated as:

```bash
mvn -N help:effective-pom -Doutput=effective.xml
```

https://github.com/adoroszlai/ozone/actions/runs/26864255402