### PR TITLE
HDDS-15470. Disk usage refresh thread name has newline

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -261,7 +261,7 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
 
     return Executors.newScheduledThreadPool(1,
         new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("DiskUsage-" + params.getPath() + "-%n")
+            .setNameFormat("DiskUsage-" + params.getPath() + "-%d")
             .build());
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -26,6 +26,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
@@ -259,9 +260,13 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
       return null;
     }
 
-    return Executors.newScheduledThreadPool(1,
-        new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("DiskUsage-" + params.getPath() + "-%d")
-            .build());
+    return Executors.newScheduledThreadPool(1, threadFactoryFor(params));
+  }
+
+  static ThreadFactory threadFactoryFor(SpaceUsageCheckParams params) {
+    return new ThreadFactoryBuilder()
+        .setDaemon(true)
+        .setNameFormat("DiskUsage-" + params.getPath() + "-%d")
+        .build();
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.fs;
 
 import static org.apache.hadoop.hdds.fs.MockSpaceUsageCheckParams.newBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
@@ -31,6 +32,7 @@ import java.io.File;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.RandomUtils;
@@ -215,6 +217,19 @@ class TestCachingSpaceUsageSource {
     assertEquals(original.getAvailable(), subject.getAvailable());
     assertEquals(original.getCapacity(), subject.getCapacity());
     assertSnapshotIsUpToDate(subject);
+  }
+
+  @Test
+  void testThreadName() {
+    SpaceUsageCheckParams params = paramsBuilder(new AtomicLong(50))
+        .build();
+    ThreadFactory subject = CachingSpaceUsageSource.threadFactoryFor(params);
+
+    for (int i = 0; i < 3; i++) {
+      assertThat(subject.newThread(() -> { }).getName())
+          .doesNotContain("\n")
+          .endsWith("-" + i);
+    }
   }
 
   private static void assertSnapshotIsUpToDate(SpaceUsageSource subject) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix unintended newline in `DiskUsage` thread name:

```
2026-05-15 02:36:19,987 [DiskUsage-/home/runner/work/ozone/ozone/hadoop-ozone/integration-test-recon/target/test-dir/MiniOzoneClusterImpl-6e6bc084-e2c8-4bcf-ad5c-b93a846d5de6/ozone-metadata/datanode-1/data-0-
] INFO  fs.DUOptimized (DUOptimized.java:getUsedSpace(49)) - Disk metaPath du usages 4382720, container data usages 0
```

https://issues.apache.org/jira/browse/HDDS-15470

## How was this patch tested?

Added unit test.

```
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.398 s -- in org.apache.hadoop.hdds.fs.TestCachingSpaceUsageSource
```

https://github.com/adoroszlai/ozone/actions/runs/26868112520