### PR TITLE
HDDS-15472. Avoid using JBoss repository in CI

### DIFF
--- a/dev-support/ci/maven-settings.xml
+++ b/dev-support/ci/maven-settings.xml
@@ -31,5 +31,12 @@
       <url>https://repository.apache.org/content/repositories/snapshots</url>
       <blocked>true</blocked>
     </mirror>
+    <mirror>
+      <id>block-jboss</id>
+      <mirrorOf>repository.jboss.org</mirrorOf>
+      <name>Block access to JBoss</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public</url>
+      <blocked>true</blocked>
+    </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`acceptance (s3a)` check got unexpectedly long today.  Requests to `repository.jboss.org` seem to be rate limited.

Yesterday (~300 ms):

```
2026-06-02T17:36:10.5731654Z [INFO] Downloading from repository.jboss.org: https://repository.jboss.org/nexus/content/groups/public/org/bouncycastle/bcutil-jdk18on/1.82/bcutil-jdk18on-1.82.jar
2026-06-02T17:36:10.8791947Z [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar
```

Today (more than 30 sec):

```
2026-06-03T06:56:04.8241135Z [INFO] Downloading from repository.jboss.org: https://repository.jboss.org/nexus/content/groups/public/org/bouncycastle/bcutil-jdk18on/1.82/bcutil-jdk18on-1.82.jar
2026-06-03T06:56:37.1873817Z [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar
```

As the log shows, most artifacts are not found in `repository.jboss.org`.

This PR changes CI's Maven settings to block access to JBoss repository.  Its use is unnecessary, central should have all artifacts.

https://issues.apache.org/jira/browse/HDDS-15472

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/26871454788/job/79249484420