### PR TITLE
HDDS-10308. Run config-independent test cases in TestOmSnapshot only once

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -224,6 +224,27 @@ public abstract class TestOmSnapshot {
     }
   }
 
+  /**
+   * Pins a config-independent heavyweight test to exactly one subclass so it
+   * runs once instead of across the whole 8-class matrix (HDDS-10308). The test
+   * fast-skips in the other 7 classes.
+   *
+   * <p>The canonical config is the FSO, non-linked bucket layout. The native
+   * lib dimension selects between the two such classes:
+   * {@code requiresNativeDiff == true} resolves to {@code
+   * TestOmSnapshotFsoWithNativeLib} (native on, {@code disableNativeDiff ==
+   * false}); {@code requiresNativeDiff == false} resolves to {@code
+   * TestOmSnapshotFsoWithoutNativeLib} (native off, {@code disableNativeDiff ==
+   * true}).
+   *
+   * @param requiresNativeDiff whether the test needs the native diff lib enabled
+   */
+  private void assumeCanonicalConfig(boolean requiresNativeDiff) {
+    assumeTrue(bucketLayout.isFileSystemOptimized()
+        && (requiresNativeDiff != disableNativeDiff)
+        && !createLinkedBucket);
+  }
+
   private void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS, enabledFileSystemPaths);
@@ -2050,6 +2071,7 @@ public abstract class TestOmSnapshot {
 
   @Test
   public void testSnapshotOpensWithDisabledAutoCompaction() throws Exception {
+    assumeCanonicalConfig(false);
     String snapPrefix = createSnapshot(volumeName, bucketName);
     try (UncheckedAutoCloseableSupplier<IOmMetadataReader> snapshotSupplier =
              cluster.getOzoneManager().getOmSnapshotManager()
@@ -2172,6 +2194,7 @@ public abstract class TestOmSnapshot {
 
   @Test
   public void testCompactionDagDisableForSnapshotMetadata() throws Exception {
+    assumeCanonicalConfig(false);
     String snapshotName = createSnapshot(volumeName, bucketName);
 
     RDBStore activeDbStore = getRdbStore();
@@ -2399,6 +2422,7 @@ public abstract class TestOmSnapshot {
   // column families are used in SST diff calculation.
   @Test
   public void testSnapshotCompactionDag() throws Exception {
+    assumeCanonicalConfig(true);
     String volume1 = "volume-1-" + RandomStringUtils.secure().nextNumeric(5);
     String bucket1 = "bucket-1-" + RandomStringUtils.secure().nextNumeric(5);
     String bucket2 = "bucket-2-" + RandomStringUtils.secure().nextNumeric(5);
@@ -2543,6 +2567,7 @@ public abstract class TestOmSnapshot {
 
   @Test
   public void testSnapshotReuseSnapName() throws Exception {
+    assumeCanonicalConfig(false);
     // start KeyManager for this test
     startKeyManager();
     String volume = "vol-" + counter.incrementAndGet();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -225,19 +225,11 @@ public abstract class TestOmSnapshot {
   }
 
   /**
-   * Pins a config-independent heavyweight test to exactly one subclass so it
-   * runs once instead of across the whole 8-class matrix (HDDS-10308). The test
-   * fast-skips in the other 7 classes.
-   *
-   * <p>The canonical config is the FSO, non-linked bucket layout. The native
-   * lib dimension selects between the two such classes:
-   * {@code requiresNativeDiff == true} resolves to {@code
-   * TestOmSnapshotFsoWithNativeLib} (native on, {@code disableNativeDiff ==
-   * false}); {@code requiresNativeDiff == false} resolves to {@code
-   * TestOmSnapshotFsoWithoutNativeLib} (native off, {@code disableNativeDiff ==
-   * true}).
-   *
-   * @param requiresNativeDiff whether the test needs the native diff lib enabled
+   * Pins a config-independent heavyweight test to exactly one subclass so it runs
+   * once instead of across the whole 8-class matrix (HDDS-10308); fast-skips in the
+   * other 7. The canonical config is FSO + non-linked. requiresNativeDiff picks
+   * between TestOmSnapshotFsoWithNativeLib (native on) and
+   * TestOmSnapshotFsoWithoutNativeLib (native off).
    */
   private void assumeCanonicalConfig(boolean requiresNativeDiff) {
     assumeTrue(bucketLayout.isFileSystemOptimized()


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem.** `TestOmSnapshot` is one of the slower integration suites, and much of that time is redundant. It runs its full suite 8 times: there are 8 subclasses, each starting its own `MiniOzoneCluster` to cover a different config combination `(bucketLayout, disableNativeDiff, createLinkedBucket, ...)`. Most tests don't depend on the config, so that 8x is paid for no extra coverage — and a few slow tests pay it the most.

**Fix.** Make the four worst offenders run **once** instead of 8 times, by adding an `assumeTrue(...)` guard so each test runs in just one subclass and skips in the other 7:

- **`testSnapshotCompactionDag`** (the big one) → runs only in `TestOmSnapshotFsoWithNativeLib`. It needs the native lib (its SST-pruning check sits behind `if (!disableNativeDiff)`), and FSO is the richest layout for it: FSO keys populate both `directoryTable` and `fileTable`, which the compaction DAG tracks, while other layouts only use `keyTable`. Native-on covers everything native-off does, so no coverage is lost.
- **`testCompactionDagDisableForSnapshotMetadata`**, **`testSnapshotOpensWithDisabledAutoCompaction`**, **`testSnapshotReuseSnapName`** → run only in `TestOmSnapshotFsoWithoutNativeLib`. They don't need the native lib, so pinning them to the native-off class keeps them running for local devs who don't have it.

A small helper, `assumeCanonicalConfig(boolean requiresNativeDiff)`, holds the two guard conditions.

No new test class and no refactoring: the four methods stay in `TestOmSnapshot` and simply skip in the classes where they no longer need to run.

**Trade-off:** `testSnapshotCompactionDag` no longer runs under OBJECT_STORE/LEGACY, and won't run locally without the native lib (its class is native-gated). CI has the native lib, so CI coverage is unchanged, and this matches how the existing `*WithNativeLib*` classes already behave locally.

**This is a first, low-risk step.** It targets only the handful of tests that dominate the cost, with no coverage impact. A bigger win is possible — running the much larger set of config-independent tests once as well — but that needs careful per-test analysis (many snapshot-diff tests genuinely exercise layout-specific code paths and must keep running across layouts). That work is more involved, so it's tracked as a follow-up in HDDS-15474.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10308

## How was this patch tested?

Test-only change: it moves *where* four methods run, not what they assert.

Verified on CI against master HEAD (same `build-branch` workflow, `integration (snapshot)` job):

- No failures or errors in either run.
- Skips moved exactly as intended: `compactionDag` now runs in one class and the three lifecycle tests in one class; everywhere else they skip.
- The `TestOmSnapshot` matrix dropped ~232s (2046.8s → 1815.3s), and the full snapshot job dropped ~3.9 min (2884s → 2651s, ~8%). `compactionDag` costs ~34s per occurrence on CI.

Also ran the native-off class locally (no native lib): the three lifecycle tests pass and `compactionDag` skips, as designed.
