### PR TITLE
HDDS-15473. TestOmSnapshotObjectStore should run with createLinkedBucket=false

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotObjectStore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotObjectStore.java
@@ -25,6 +25,6 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.OBJECT_STORE;
 public class TestOmSnapshotObjectStore extends TestOmSnapshot {
 
   public TestOmSnapshotObjectStore() throws Exception {
-    super(OBJECT_STORE, false, false, false, true);
+    super(OBJECT_STORE, false, false, false, false);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestOmSnapshotObjectStore` and `TestOmSnapshotObjectStoreWithLinkedBuckets` both call `super(OBJECT_STORE, false, false, false, true). They are therefore identical, and the non-linked `OBJECT_STORE` snapshot path is no longer exercised by any test.

https://github.com/apache/ozone/blob/547ac88e42c19d0efae943e9d6b3f192712e4785/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotObjectStore.java#L25-L30

https://github.com/apache/ozone/blob/dcc6edf50d1713a6fd55de7483988103b4ae6011/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotObjectStoreWithLinkedBuckets.java#L25-L30


This was introduced in HDDS-11705 (#7434), which added `TestOmSnapshotObjectStoreWithLinkedBuckets` and converted `TestOmSnapshotObjectStore`'s constructor from 4 to 5 arguments, passing `true` for the new `createLinkedBucket` flag instead of `false`.

This PR changes `TestOmSnapshotObjectStore` to pass `createLinkedBucket=false`, restoring coverage of the non-linked path. This matches the non-linked/linked pairing that every other layout already has (`TestOmSnapshotFsoWithNativeLib` vs `...WithLinkedBuckets`, `TestOmSnapshotWithoutBucketLinkingLegacy` vs `TestOmSnapshotWithBucketLinkingLegacy`).

Noted as a side observation in HDDS-10308, but it is a coverage correctness issue, not a speedup, so address it separately.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15473

## How was this patch tested?

Existing `TestOmSnapshotObjectStore` integration test, now exercising the non-linked `OBJECT_STORE` path. Verified via the CI workflow run on the fork. https://github.com/chihsuan/ozone/actions/runs/26890673615/job/79318188405#step:13:5621
