### PR TITLE
HDDS-15466. Make RocksDB bottommost level compaction options configurable for CLI tools

### DIFF
--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
@@ -62,6 +62,13 @@ public class RocksDBManualCompaction extends RepairTool {
       description = "Column family name")
   private String columnFamilyName;
 
+  @CommandLine.Option(names = {"--bottommost-level-compaction", "--blc"},
+      description = "BottommostLevelCompaction option for RocksDB compaction." +
+          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce)." +
+          " Default: 0 (kSkip).",
+      defaultValue = "0")
+  private int bottommostLevelCompaction;
+
   private String getConsoleReadLineWithFormat() {
     err().printf(WARNING_TO_STOP_SERVICE);
     return getScanner().nextLine().trim();
@@ -96,11 +103,14 @@ public class RocksDBManualCompaction extends RepairTool {
             " is not in a column family in DB for the given path.");
       }
 
-      info("Running compaction on " + columnFamilyName);
+      ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
+          getBottommostLevelCompaction(bottommostLevelCompaction);
+      info("Running compaction on " + columnFamilyName +
+          " with BottommostLevelCompaction=" + blcOption.name());
       long startTime = Time.monotonicNow();
       if (!isDryRun()) {
         ManagedCompactRangeOptions compactOptions = new ManagedCompactRangeOptions();
-        compactOptions.setBottommostLevelCompaction(ManagedCompactRangeOptions.BottommostLevelCompaction.kForce);
+        compactOptions.setBottommostLevelCompaction(blcOption);
         db.get().compactRange(cfh, null, null, compactOptions);
       }
       long duration = Time.monotonicNow() - startTime;
@@ -116,5 +126,16 @@ public class RocksDBManualCompaction extends RepairTool {
       IOUtils.closeQuietly(dbOptions);
       IOUtils.closeQuietly(cfHandleList);
     }
+  }
+
+  /**
+   * Converts the given rocksId to a
+   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum.
+   * Defaults to kSkip if the value is invalid.
+   */
+  static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(int rocksId) {
+    ManagedCompactRangeOptions.BottommostLevelCompaction blc =
+        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(rocksId);
+    return blc != null ? blc : ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
   }
 }

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
@@ -65,9 +65,9 @@ public class RocksDBManualCompaction extends RepairTool {
 
   @CommandLine.Option(names = {"--bottommost-level-compaction", "--blc"},
       description = "BottommostLevelCompaction option for RocksDB compaction." +
-          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce)." +
-          " Default: 0 (kSkip).",
-      defaultValue = "0")
+          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce), 3 (kForceOptimized).",
+      defaultValue = "0",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
   private int bottommostLevelCompaction;
 
   private String getConsoleReadLineWithFormat() {
@@ -107,7 +107,7 @@ public class RocksDBManualCompaction extends RepairTool {
       ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
           CompactDBUtil.getBottommostLevelCompaction(bottommostLevelCompaction);
       info("Running compaction on " + columnFamilyName +
-          " with BottommostLevelCompaction=" + blcOption.name());
+          " with bottommost level compaction: " + blcOption.name());
       long startTime = Time.monotonicNow();
       if (!isDryRun()) {
         ManagedCompactRangeOptions compactOptions = new ManagedCompactRangeOptions();

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/ldb/RocksDBManualCompaction.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedConfigOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.debug.RocksDBUtils;
+import org.apache.hadoop.ozone.om.service.CompactDBUtil;
 import org.apache.hadoop.ozone.repair.RepairTool;
 import org.apache.hadoop.util.Time;
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -104,7 +105,7 @@ public class RocksDBManualCompaction extends RepairTool {
       }
 
       ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
-          getBottommostLevelCompaction(bottommostLevelCompaction);
+          CompactDBUtil.getBottommostLevelCompaction(bottommostLevelCompaction);
       info("Running compaction on " + columnFamilyName +
           " with BottommostLevelCompaction=" + blcOption.name());
       long startTime = Time.monotonicNow();
@@ -126,16 +127,5 @@ public class RocksDBManualCompaction extends RepairTool {
       IOUtils.closeQuietly(dbOptions);
       IOUtils.closeQuietly(cfHandleList);
     }
-  }
-
-  /**
-   * Converts the given rocksId to a
-   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum.
-   * Defaults to kSkip if the value is invalid.
-   */
-  static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(int rocksId) {
-    ManagedCompactRangeOptions.BottommostLevelCompaction blc =
-        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(rocksId);
-    return blc != null ? blc : ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
   }
 }

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
@@ -61,9 +61,10 @@ public class CompactOMDB extends RepairTool {
   private String nodeId;
 
   @CommandLine.Option(names = {"--bottommost-level-compaction", "--blc"},
-      required = true,
       description = "BottommostLevelCompaction option for RocksDB compaction." +
-          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce).")
+          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce), 3 (kForceOptimized).",
+      defaultValue = "0",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
   private int bottommostLevelCompaction;
 
   @Override
@@ -79,8 +80,8 @@ public class CompactOMDB extends RepairTool {
                OMAdminProtocolClientSideImpl.createProxyForSingleOM(conf,
                    UserGroupInformation.getCurrentUser(), omNodeDetails)) {
         omAdminProtocolClient.compactOMDB(columnFamilyName, blcOption.getValue());
-        info("Compaction request issued for om.db of om node: %s, column-family: %s," +
-            " BottommostLevelCompaction=%s.", nodeId, columnFamilyName, blcOption.name());
+        info("Compaction request issued for om.db of om node: %s, column-family: %s" +
+            " with bottommost level compaction: %s.", nodeId, columnFamilyName, blcOption.name());
         info("Please check role logs of %s for completion status.", nodeId);
       } catch (IOException ex) {
         error("Couldn't compact column %s. \nException: %s", columnFamilyName, ex);

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.repair.om;
 import java.io.IOException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
 import org.apache.hadoop.ozone.repair.RepairTool;
@@ -58,22 +59,43 @@ public class CompactOMDB extends RepairTool {
   )
   private String nodeId;
 
+  @CommandLine.Option(names = {"--bottommost-level-compaction", "--blc"},
+      description = "BottommostLevelCompaction option for RocksDB compaction." +
+          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce)." +
+          " Default: 0 (kSkip).",
+      defaultValue = "0")
+  private int bottommostLevelCompaction;
+
   @Override
   public void execute() throws Exception {
 
     OzoneConfiguration conf = getOzoneConf();
     OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
         conf, omServiceId, nodeId);
+    ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
+        getBottommostLevelCompaction(bottommostLevelCompaction);
     if (!isDryRun()) {
       try (OMAdminProtocolClientSideImpl omAdminProtocolClient =
                OMAdminProtocolClientSideImpl.createProxyForSingleOM(conf,
                    UserGroupInformation.getCurrentUser(), omNodeDetails)) {
-        omAdminProtocolClient.compactOMDB(columnFamilyName);
-        info("Compaction request issued for om.db of om node: %s, column-family: %s.", nodeId, columnFamilyName);
+        omAdminProtocolClient.compactOMDB(columnFamilyName, blcOption.getValue());
+        info("Compaction request issued for om.db of om node: %s, column-family: %s," +
+            " BottommostLevelCompaction=%s.", nodeId, columnFamilyName, blcOption.name());
         info("Please check role logs of %s for completion status.", nodeId);
       } catch (IOException ex) {
         error("Couldn't compact column %s. \nException: %s", columnFamilyName, ex);
       }
     }
+  }
+
+  /**
+   * Converts the given rocksId to a
+   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum.
+   * Defaults to kSkip if the value is invalid.
+   */
+  static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(int rocksId) {
+    ManagedCompactRangeOptions.BottommostLevelCompaction blc =
+        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(rocksId);
+    return blc != null ? blc : ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
   }
 }

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
+import org.apache.hadoop.ozone.om.service.CompactDBUtil;
 import org.apache.hadoop.ozone.repair.RepairTool;
 import org.apache.hadoop.security.UserGroupInformation;
 import picocli.CommandLine;
@@ -60,10 +61,9 @@ public class CompactOMDB extends RepairTool {
   private String nodeId;
 
   @CommandLine.Option(names = {"--bottommost-level-compaction", "--blc"},
+      required = true,
       description = "BottommostLevelCompaction option for RocksDB compaction." +
-          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce)." +
-          " Default: 0 (kSkip).",
-      defaultValue = "0")
+          " Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce).")
   private int bottommostLevelCompaction;
 
   @Override
@@ -73,7 +73,7 @@ public class CompactOMDB extends RepairTool {
     OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
         conf, omServiceId, nodeId);
     ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
-        getBottommostLevelCompaction(bottommostLevelCompaction);
+        CompactDBUtil.getBottommostLevelCompaction(bottommostLevelCompaction);
     if (!isDryRun()) {
       try (OMAdminProtocolClientSideImpl omAdminProtocolClient =
                OMAdminProtocolClientSideImpl.createProxyForSingleOM(conf,
@@ -86,16 +86,5 @@ public class CompactOMDB extends RepairTool {
         error("Couldn't compact column %s. \nException: %s", columnFamilyName, ex);
       }
     }
-  }
-
-  /**
-   * Converts the given rocksId to a
-   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum.
-   * Defaults to kSkip if the value is invalid.
-   */
-  static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(int rocksId) {
-    ManagedCompactRangeOptions.BottommostLevelCompaction blc =
-        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(rocksId);
-    return blc != null ? blc : ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
   }
 }

--- a/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
+++ b/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/ldb/TestLdbRepair.java
@@ -125,7 +125,8 @@ public class TestLdbRepair {
     CommandLine cmd = new CommandLine(compactionTool);
     String[] args = {
         "--db", dbPath.toString(),
-        "--column-family", TEST_CF_NAME
+        "--column-family", TEST_CF_NAME,
+        "--blc", "2"
     };
     // Pass two "y" inputs - one for user confirmation and the other for warning to stop service
     int exitCode = withTextFromSystemIn("y", "y")

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -682,6 +682,16 @@ public final class OMConfigKeys {
       "keyTable,fileTable,directoryTable,deletedTable,deletedDirectoryTable,multipartInfoTable,multipartPartsTable";
 
   /**
+   * Bottommost level compaction type for manual compaction.
+   * Invalid values will default to kSkip.
+   * Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce), 3 (kForceOptimized).
+   * Refer to {@code org.rocksdb.CompactRangeOptions.BottommostLevelCompaction}.
+   */
+  public static final String OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION =
+      "ozone.om.compaction.service.bottommostlevelcompaction";
+  public static final int OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION_DEFAULT = 0;
+
+  /**
    * Configuration to enable/disable non-snapshot diff table compaction when snapshots are evicted from cache.
    */
   public static final String OZONE_OM_SNAPSHOT_COMPACT_NON_SNAPSHOT_DIFF_TABLES = 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -682,16 +682,6 @@ public final class OMConfigKeys {
       "keyTable,fileTable,directoryTable,deletedTable,deletedDirectoryTable,multipartInfoTable,multipartPartsTable";
 
   /**
-   * Bottommost level compaction type for manual compaction.
-   * Invalid values will default to kSkip.
-   * Valid values: 0 (kSkip), 1 (kIfHaveCompactionFilter), 2 (kForce), 3 (kForceOptimized).
-   * Refer to {@code org.rocksdb.CompactRangeOptions.BottommostLevelCompaction}.
-   */
-  public static final String OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION =
-      "ozone.om.compaction.service.bottommostlevelcompaction";
-  public static final int OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION_DEFAULT = 0;
-
-  /**
    * Configuration to enable/disable non-snapshot diff table compaction when snapshots are evicted from cache.
    */
   public static final String OZONE_OM_SNAPSHOT_COMPACT_NON_SNAPSHOT_DIFF_TABLES = 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
@@ -47,6 +47,18 @@ public interface OMAdminProtocol extends Closeable {
   void compactOMDB(String columnFamily) throws IOException;
 
   /**
+   * Requests compaction of a column family of om.db with the specified
+   * BottommostLevelCompaction option.
+   *
+   * @param columnFamily              column family name
+   * @param bottommostLevelCompaction rocksId of BottommostLevelCompaction
+   *                                  (0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce)
+   */
+  default void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException {
+    compactOMDB(columnFamily);
+  }
+
+  /**
    * Triggers the Snapshot Defragmentation Service to run immediately.
    * @param noWait if true, return immediately without waiting for completion
    * @return true if defragmentation completed successfully (when noWait is false),

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
@@ -46,7 +46,7 @@ public interface OMAdminProtocol extends Closeable {
    *
    * @param columnFamily              column family name
    * @param bottommostLevelCompaction rocksId of BottommostLevelCompaction
-   *                                  (0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce)
+   *                                  (0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce, 3=kForceOptimized)
    */
   void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
@@ -41,12 +41,6 @@ public interface OMAdminProtocol extends Closeable {
   void decommission(OMNodeDetails removeOMNode) throws IOException;
 
   /**
-   * Requests compaction of a column family of om.db.
-   * @param columnFamily
-   */
-  void compactOMDB(String columnFamily) throws IOException;
-
-  /**
    * Requests compaction of a column family of om.db with the specified
    * BottommostLevelCompaction option.
    *
@@ -54,9 +48,7 @@ public interface OMAdminProtocol extends Closeable {
    * @param bottommostLevelCompaction rocksId of BottommostLevelCompaction
    *                                  (0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce)
    */
-  default void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException {
-    compactOMDB(columnFamily);
-  }
+  void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException;
 
   /**
    * Triggers the Snapshot Defragmentation Service to run immediately.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
@@ -216,11 +216,6 @@ public final class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
   }
 
   @Override
-  public void compactOMDB(String columnFamily) throws IOException {
-    compactOMDB(columnFamily, 0);
-  }
-
-  @Override
   public void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException {
     CompactRequest compactRequest = CompactRequest.newBuilder()
         .setColumnFamily(columnFamily)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
@@ -217,8 +217,14 @@ public final class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
 
   @Override
   public void compactOMDB(String columnFamily) throws IOException {
+    compactOMDB(columnFamily, 0);
+  }
+
+  @Override
+  public void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException {
     CompactRequest compactRequest = CompactRequest.newBuilder()
         .setColumnFamily(columnFamily)
+        .setBottommostLevelCompaction(bottommostLevelCompaction)
         .build();
     CompactResponse response;
     try {

--- a/hadoop-ozone/dist/src/main/smoketest/repair/om-compact.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/repair/om-compact.robot
@@ -34,7 +34,7 @@ Get OM DB SST Files Size
 
 Compact OM DB Column Family
     [Arguments]        ${column_family}
-    Execute    ozone repair om compact --cf=${column_family} --service-id ${OM_SERVICE_ID} --node-id om1
+    Execute    ozone repair om compact --cf=${column_family} --service-id ${OM_SERVICE_ID} --node-id om1 --blc 2
 
 *** Test Cases ***
 Testing OM DB Size Reduction After Compaction

--- a/hadoop-ozone/interface-client/src/main/proto/OMAdminProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OMAdminProtocol.proto
@@ -72,6 +72,9 @@ message DecommissionOMResponse {
 
 message CompactRequest {
     required string columnFamily = 1;
+  // BottommostLevelCompaction option: 0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce.
+  // Defaults to kSkip (0) if not set.
+  optional int32 bottommostLevelCompaction = 2 [default = 0];
 }
 
 message CompactResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OMAdminProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OMAdminProtocol.proto
@@ -72,7 +72,8 @@ message DecommissionOMResponse {
 
 message CompactRequest {
     required string columnFamily = 1;
-  // BottommostLevelCompaction option: 0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce.
+  // BottommostLevelCompaction option:
+  // 0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce, 3=kForceOptimized.
   // Defaults to kSkip (0) if not set.
   optional int32 bottommostLevelCompaction = 2 [default = 0];
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -5643,10 +5643,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
   }
 
-  public void compactOMDB(String columnFamily) throws IOException {
+  public void compactOMDB(String columnFamily,
+      ManagedCompactRangeOptions.BottommostLevelCompaction bottommostLevelCompaction) throws IOException {
     checkAdminUserPrivilege("compact column family " + columnFamily);
-    ManagedCompactRangeOptions.BottommostLevelCompaction bottommostLevelCompaction =
-        CompactDBUtil.getBottommostLevelCompaction(configuration);
     CompletableFuture<Void> compactFuture =
         CompactDBUtil.compactTableAsync(metadataManager, columnFamily, bottommostLevelCompaction);
     compactFuture.whenComplete((result, throwable) -> {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -221,6 +221,7 @@ import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
@@ -5643,11 +5644,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public void compactOMDB(String columnFamily) throws IOException {
-    compactOMDB(columnFamily, 0);
-  }
-
-  public void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException {
     checkAdminUserPrivilege("compact column family " + columnFamily);
+    ManagedCompactRangeOptions.BottommostLevelCompaction bottommostLevelCompaction =
+        CompactDBUtil.getBottommostLevelCompaction(configuration);
     CompletableFuture<Void> compactFuture =
         CompactDBUtil.compactTableAsync(metadataManager, columnFamily, bottommostLevelCompaction);
     compactFuture.whenComplete((result, throwable) -> {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -5643,9 +5643,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public void compactOMDB(String columnFamily) throws IOException {
+    compactOMDB(columnFamily, 0);
+  }
+
+  public void compactOMDB(String columnFamily, int bottommostLevelCompaction) throws IOException {
     checkAdminUserPrivilege("compact column family " + columnFamily);
     CompletableFuture<Void> compactFuture =
-        CompactDBUtil.compactTableAsync(metadataManager, columnFamily);
+        CompactDBUtil.compactTableAsync(metadataManager, columnFamily, bottommostLevelCompaction);
     compactFuture.whenComplete((result, throwable) -> {
       if (throwable == null) {
         LOG.info("Compaction request for column family \"{}\" completed successfully.",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
@@ -40,11 +40,19 @@ public final class CompactDBUtil {
 
   public static void compactTable(OMMetadataManager omMetadataManager,
                                   String tableName) throws IOException {
+    compactTable(omMetadataManager, tableName, 0);
+  }
+
+  public static void compactTable(OMMetadataManager omMetadataManager,
+      String tableName,
+      int bottommostLevelCompaction) throws IOException {
     long startTime = Time.monotonicNow();
-    LOG.info("Compacting column family: {}", tableName);
+    ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
+        getBottommostLevelCompaction(bottommostLevelCompaction);
+    LOG.info("Compacting column family: {} with BottommostLevelCompaction={}",
+        tableName, blcOption.name());
     try (ManagedCompactRangeOptions options = new ManagedCompactRangeOptions()) {
-      options.setBottommostLevelCompaction(
-          ManagedCompactRangeOptions.BottommostLevelCompaction.kForce);
+      options.setBottommostLevelCompaction(blcOption);
       options.setExclusiveManualCompaction(true);
       RocksDatabase rocksDatabase =
           ((RDBStore) omMetadataManager.getStore()).getDb();
@@ -63,13 +71,33 @@ public final class CompactDBUtil {
   }
 
   public static CompletableFuture<Void> compactTableAsync(OMMetadataManager metadataManager, String tableName) {
+    return compactTableAsync(metadataManager, tableName, 0);
+  }
+
+  public static CompletableFuture<Void> compactTableAsync(
+      OMMetadataManager metadataManager, String tableName, int bottommostLevelCompaction) {
     return CompletableFuture.runAsync(() -> {
       try {
-        compactTable(metadataManager, tableName);
+        compactTable(metadataManager, tableName, bottommostLevelCompaction);
       } catch (Exception e) {
         LOG.warn("Failed to compact column family: {}", tableName, e);
         throw new CompletionException("Compaction failed for column family: " + tableName, e);
       }
     });
+  }
+
+  /**
+   * Converts the given rocksId to a
+   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum.
+   * Defaults to kSkip if the value is invalid.
+   */
+  static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(int rocksId) {
+    ManagedCompactRangeOptions.BottommostLevelCompaction blc =
+        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(rocksId);
+    if (blc == null) {
+      LOG.warn("Invalid BottommostLevelCompaction value: {}. Defaulting to kSkip.", rocksId);
+      return ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
+    }
+    return blc;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.ozone.om.service;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
@@ -38,21 +40,13 @@ public final class CompactDBUtil {
   private CompactDBUtil() {
   }
 
-  public static void compactTable(OMMetadataManager omMetadataManager,
-                                  String tableName) throws IOException {
-    compactTable(omMetadataManager, tableName, 0);
-  }
-
-  public static void compactTable(OMMetadataManager omMetadataManager,
-      String tableName,
-      int bottommostLevelCompaction) throws IOException {
+  public static void compactTable(OMMetadataManager omMetadataManager, String tableName,
+      ManagedCompactRangeOptions.BottommostLevelCompaction compactionType) throws IOException {
     long startTime = Time.monotonicNow();
-    ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
-        getBottommostLevelCompaction(bottommostLevelCompaction);
-    LOG.info("Compacting column family: {} with BottommostLevelCompaction={}",
-        tableName, blcOption.name());
     try (ManagedCompactRangeOptions options = new ManagedCompactRangeOptions()) {
-      options.setBottommostLevelCompaction(blcOption);
+      options.setBottommostLevelCompaction(compactionType);
+      LOG.info("Compacting column family: {} with {} bottommost level compaction",
+          tableName, options.bottommostLevelCompaction());
       options.setExclusiveManualCompaction(true);
       RocksDatabase rocksDatabase =
           ((RDBStore) omMetadataManager.getStore()).getDb();
@@ -70,15 +64,11 @@ public final class CompactDBUtil {
     }
   }
 
-  public static CompletableFuture<Void> compactTableAsync(OMMetadataManager metadataManager, String tableName) {
-    return compactTableAsync(metadataManager, tableName, 0);
-  }
-
-  public static CompletableFuture<Void> compactTableAsync(
-      OMMetadataManager metadataManager, String tableName, int bottommostLevelCompaction) {
+  public static CompletableFuture<Void> compactTableAsync(OMMetadataManager metadataManager, String tableName,
+      ManagedCompactRangeOptions.BottommostLevelCompaction compactionType) {
     return CompletableFuture.runAsync(() -> {
       try {
-        compactTable(metadataManager, tableName, bottommostLevelCompaction);
+        compactTable(metadataManager, tableName, compactionType);
       } catch (Exception e) {
         LOG.warn("Failed to compact column family: {}", tableName, e);
         throw new CompletionException("Compaction failed for column family: " + tableName, e);
@@ -86,18 +76,18 @@ public final class CompactDBUtil {
     });
   }
 
-  /**
-   * Converts the given rocksId to a
-   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum.
-   * Defaults to kSkip if the value is invalid.
-   */
-  static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(int rocksId) {
-    ManagedCompactRangeOptions.BottommostLevelCompaction blc =
-        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(rocksId);
-    if (blc == null) {
-      LOG.warn("Invalid BottommostLevelCompaction value: {}. Defaulting to kSkip.", rocksId);
-      return ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
+  public static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(
+      OzoneConfiguration configuration) {
+    int compactionType = configuration.getInt(
+        OMConfigKeys.OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION,
+        OMConfigKeys.OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION_DEFAULT);
+    ManagedCompactRangeOptions.BottommostLevelCompaction level =
+        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(compactionType);
+    if (level == null) {
+      compactionType = OMConfigKeys.OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION_DEFAULT;
+      level = ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(compactionType);
+      LOG.warn("Invalid bottommost level compaction type. Using default value: {}", level);
     }
-    return blc;
+    return level;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
@@ -20,11 +20,9 @@ package org.apache.hadoop.ozone.om.service;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
@@ -76,17 +74,21 @@ public final class CompactDBUtil {
     });
   }
 
+  /**
+   * Converts the given RocksDB id to a
+   * {@link ManagedCompactRangeOptions.BottommostLevelCompaction} enum value.
+   * Defaults to {@code kSkip} if the id is invalid.
+   *
+   * @param bottommostLevelCompaction RocksDB id
+   *                                  (0=kSkip, 1=kIfHaveCompactionFilter, 2=kForce, 3=kForceOptimized).
+   */
   public static ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction(
-      OzoneConfiguration configuration) {
-    int compactionType = configuration.getInt(
-        OMConfigKeys.OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION,
-        OMConfigKeys.OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION_DEFAULT);
+      int bottommostLevelCompaction) {
     ManagedCompactRangeOptions.BottommostLevelCompaction level =
-        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(compactionType);
+        ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(bottommostLevelCompaction);
     if (level == null) {
-      compactionType = OMConfigKeys.OZONE_OM_COMPACTION_SERVICE_BOTTOMMOSTLEVELCOMPACTION_DEFAULT;
-      level = ManagedCompactRangeOptions.BottommostLevelCompaction.fromRocksId(compactionType);
-      LOG.warn("Invalid bottommost level compaction type. Using default value: {}", level);
+      LOG.warn("Invalid bottommost level compaction id: {}. Using default: kSkip.", bottommostLevelCompaction);
+      return ManagedCompactRangeOptions.BottommostLevelCompaction.kSkip;
     }
     return level;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactionService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactionService.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.slf4j.Logger;
@@ -53,6 +54,7 @@ public class CompactionService extends BackgroundService {
   private final AtomicBoolean suspended;
   // list of tables that can be compacted
   private final List<String> compactableTables;
+  private final ManagedCompactRangeOptions.BottommostLevelCompaction bottommostLevelCompaction;
 
   public CompactionService(OzoneManager ozoneManager, TimeUnit unit, long interval, long timeout,
                            List<String> tables) {
@@ -65,6 +67,7 @@ public class CompactionService extends BackgroundService {
     this.numCompactions = new AtomicLong(0);
     this.suspended = new AtomicBoolean(false);
     this.compactableTables = validateTables(tables);
+    this.bottommostLevelCompaction = CompactDBUtil.getBottommostLevelCompaction(ozoneManager.getConfiguration());
   }
 
   private List<String> validateTables(List<String> tables) {
@@ -108,6 +111,11 @@ public class CompactionService extends BackgroundService {
     return compactableTables;
   }
 
+  @VisibleForTesting
+  public ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction() {
+    return bottommostLevelCompaction;
+  }
+
   /**
    * Returns the number of manual compactions performed.
    *
@@ -141,11 +149,11 @@ public class CompactionService extends BackgroundService {
    * @return CompletableFuture that completes when compaction finishes
    */
   public CompletableFuture<Void> compactTableAsync(String tableName) {
-    return CompactDBUtil.compactTableAsync(omMetadataManager, tableName);
+    return CompactDBUtil.compactTableAsync(omMetadataManager, tableName, bottommostLevelCompaction);
   }
 
   protected void compactFully(String tableName) throws IOException {
-    CompactDBUtil.compactTable(omMetadataManager, tableName);
+    CompactDBUtil.compactTable(omMetadataManager, tableName, bottommostLevelCompaction);
   }
 
   private class CompactTask implements BackgroundTask {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactionService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactionService.java
@@ -54,7 +54,6 @@ public class CompactionService extends BackgroundService {
   private final AtomicBoolean suspended;
   // list of tables that can be compacted
   private final List<String> compactableTables;
-  private final ManagedCompactRangeOptions.BottommostLevelCompaction bottommostLevelCompaction;
 
   public CompactionService(OzoneManager ozoneManager, TimeUnit unit, long interval, long timeout,
                            List<String> tables) {
@@ -67,7 +66,6 @@ public class CompactionService extends BackgroundService {
     this.numCompactions = new AtomicLong(0);
     this.suspended = new AtomicBoolean(false);
     this.compactableTables = validateTables(tables);
-    this.bottommostLevelCompaction = CompactDBUtil.getBottommostLevelCompaction(ozoneManager.getConfiguration());
   }
 
   private List<String> validateTables(List<String> tables) {
@@ -111,11 +109,6 @@ public class CompactionService extends BackgroundService {
     return compactableTables;
   }
 
-  @VisibleForTesting
-  public ManagedCompactRangeOptions.BottommostLevelCompaction getBottommostLevelCompaction() {
-    return bottommostLevelCompaction;
-  }
-
   /**
    * Returns the number of manual compactions performed.
    *
@@ -149,11 +142,13 @@ public class CompactionService extends BackgroundService {
    * @return CompletableFuture that completes when compaction finishes
    */
   public CompletableFuture<Void> compactTableAsync(String tableName) {
-    return CompactDBUtil.compactTableAsync(omMetadataManager, tableName, bottommostLevelCompaction);
+    return CompactDBUtil.compactTableAsync(omMetadataManager, tableName,
+        ManagedCompactRangeOptions.BottommostLevelCompaction.kForce);
   }
 
   protected void compactFully(String tableName) throws IOException {
-    CompactDBUtil.compactTable(omMetadataManager, tableName, bottommostLevelCompaction);
+    CompactDBUtil.compactTable(omMetadataManager, tableName,
+        ManagedCompactRangeOptions.BottommostLevelCompaction.kForce);
   }
 
   private class CompactTask implements BackgroundTask {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
@@ -25,12 +25,14 @@ import com.google.protobuf.ServiceException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.om.service.CompactDBUtil;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.CompactRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.CompactResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.DecommissionOMRequest;
@@ -121,7 +123,9 @@ public class OMAdminProtocolServerSideImpl implements OMAdminProtocolPB {
     try {
       // check if table exists. IOException is thrown if table is not found.
       ozoneManager.getMetadataManager().getStore().getTable(compactRequest.getColumnFamily());
-      ozoneManager.compactOMDB(compactRequest.getColumnFamily());
+      ManagedCompactRangeOptions.BottommostLevelCompaction bottommostLevelCompaction =
+          CompactDBUtil.getBottommostLevelCompaction(compactRequest.getBottommostLevelCompaction());
+      ozoneManager.compactOMDB(compactRequest.getColumnFamily(), bottommostLevelCompaction);
     } catch (IOException ex) {
       return CompactResponse.newBuilder()
           .setSuccess(false)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
@@ -121,7 +121,7 @@ public class OMAdminProtocolServerSideImpl implements OMAdminProtocolPB {
     try {
       // check if table exists. IOException is thrown if table is not found.
       ozoneManager.getMetadataManager().getStore().getTable(compactRequest.getColumnFamily());
-      ozoneManager.compactOMDB(compactRequest.getColumnFamily(), compactRequest.getBottommostLevelCompaction());
+      ozoneManager.compactOMDB(compactRequest.getColumnFamily());
     } catch (IOException ex) {
       return CompactResponse.newBuilder()
           .setSuccess(false)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
@@ -121,7 +121,7 @@ public class OMAdminProtocolServerSideImpl implements OMAdminProtocolPB {
     try {
       // check if table exists. IOException is thrown if table is not found.
       ozoneManager.getMetadataManager().getStore().getTable(compactRequest.getColumnFamily());
-      ozoneManager.compactOMDB(compactRequest.getColumnFamily());
+      ozoneManager.compactOMDB(compactRequest.getColumnFamily(), compactRequest.getBottommostLevelCompaction());
     } catch (IOException ex) {
       return CompactResponse.newBuilder()
           .setSuccess(false)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR updates `org.apache.hadoop.ozone.repair.ldb.RocksDBManualCompaction` and `org.apache.hadoop.ozone.om.service.CompactDBUtil`
- Sets default compaction style to kSkip
- Makes the compaction style configurable
- Updates related protos

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15466

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/26923017311