### PR TITLE
HDDS-15481. Avoid re-encoding the URL safe token for each read chunk

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -79,6 +79,7 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
   private final long readTimeoutNanos;
   private final AtomicReference<Pipeline> pipelineRef = new AtomicReference<>();
   private final AtomicReference<Token<OzoneBlockTokenIdentifier>> tokenRef = new AtomicReference<>();
+  private String encodedToken;
   private XceiverClientFactory xceiverClientFactory;
   private XceiverClientGrpc xceiverClient;
 
@@ -102,6 +103,7 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
     this.blockLength = length;
     pipelineRef.set(setPipeline(pipeline));
     tokenRef.set(token);
+    this.encodedToken = token != null ? token.encodeToUrlString() : null;
     this.xceiverClientFactory = xceiverClientFactory;
     this.verifyChecksum = config.isChecksumVerify();
     this.retryPolicy = getReadRetryPolicy(config);
@@ -323,7 +325,7 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
       throw new IOException("Uninitialized StreamingReadResponse: " + blockID);
     }
     xceiverClient.streamRead(ContainerProtocolCalls.buildReadBlockCommandProto(
-        blockID, requestedLength, length, responseDataSize, tokenRef.get(), pipelineRef.get()), r);
+        blockID, requestedLength, length, responseDataSize, encodedToken, pipelineRef.get()), r);
   }
 
   private void handleExceptions(IOException cause) throws IOException {
@@ -356,6 +358,8 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
 
   private void refreshBlockInfo(IOException cause) throws IOException {
     refreshBlockInfo(cause, blockID, pipelineRef, tokenRef, refreshFunction);
+    final Token<OzoneBlockTokenIdentifier> refreshed = tokenRef.get();
+    encodedToken = refreshed != null ? refreshed.encodeToUrlString() : null;
   }
 
   private synchronized void releaseStreamResources() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -909,6 +909,14 @@ public final class ContainerProtocolCalls  {
       BlockID blockID, long offset, long length, int responseDataSize,
       Token<? extends TokenIdentifier> token, Pipeline pipeline)
       throws IOException {
+    return buildReadBlockCommandProto(blockID, offset, length, responseDataSize,
+        token != null ? token.encodeToUrlString() : null, pipeline);
+  }
+
+  public static ContainerCommandRequestProto buildReadBlockCommandProto(
+      BlockID blockID, long offset, long length, int responseDataSize,
+      String encodedToken, Pipeline pipeline)
+      throws IOException {
     final DatanodeDetails datanode = pipeline.getClosestNode();
     final DatanodeBlockID datanodeBlockID = getDatanodeBlockID(blockID, datanode, pipeline.getReplicaIndexes());
     final ReadBlockRequestProto.Builder readBlockRequest = ReadBlockRequestProto.newBuilder()
@@ -919,8 +927,8 @@ public final class ContainerProtocolCalls  {
     final ContainerCommandRequestProto.Builder builder =
         ContainerCommandRequestProto.newBuilder().setCmdType(Type.ReadBlock)
             .setContainerID(blockID.getContainerID());
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
+    if (encodedToken != null) {
+      builder.setEncodedToken(encodedToken);
     }
 
     return builder.setDatanodeUuid(datanode.getUuidString())


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a small performance improvement - the Token is re-encoded as a URL-safe base64 string on every call to readBlockImpl(), which will be called for each 1MB read.

We can cache the URL encoded value and on re-encode it if the token is refreshed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15481

## How was this patch tested?

Depends on existing tests.
