### PR TITLE
HDDS-15469. Duplicate license sections.

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -264,21 +264,6 @@ CDDL 1.1 + GPLv2 with classpath exception
 
 Apache License 2.0
 =====================
-   com.squareup.okhttp3:okhttp
-   com.squareup.okhttp3:okhttp-sse
-   com.squareup.okio:okio
-   com.squareup.retrofit2:converter-jackson
-   com.squareup.retrofit2:retrofit
-   dev.ai4j:openai4j
-   dev.langchain4j:langchain4j-anthropic
-   dev.langchain4j:langchain4j-core
-   dev.langchain4j:langchain4j-open-ai
-   org.jetbrains.kotlin:kotlin-stdlib-common
-   org.jetbrains.kotlin:kotlin-stdlib-jdk7
-   org.jetbrains.kotlin:kotlin-stdlib-jdk8
-
-Apache License 2.0
-=====================
 
    ch.qos.reload4j:reload4j
    com.amazonaws:aws-java-sdk-core
@@ -317,8 +302,13 @@ Apache License 2.0
    com.jolbox:bonecp
    com.lmax:disruptor
    com.nimbusds:nimbus-jose-jwt
+   com.squareup.okhttp3:okhttp
    com.squareup.okhttp3:okhttp-jvm
+   com.squareup.okhttp3:okhttp-sse
+   com.squareup.okio:okio
    com.squareup.okio:okio-jvm
+   com.squareup.retrofit2:converter-jackson
+   com.squareup.retrofit2:retrofit
    commons-beanutils:commons-beanutils
    commons-cli:commons-cli
    commons-codec:commons-codec
@@ -328,6 +318,10 @@ Apache License 2.0
    commons-net:commons-net
    commons-validator:commons-validator
    commons-fileupload:commons-fileupload
+   dev.ai4j:openai4j
+   dev.langchain4j:langchain4j-anthropic
+   dev.langchain4j:langchain4j-core
+   dev.langchain4j:langchain4j-open-ai
    info.picocli:picocli
    info.picocli:picocli-shell-jline3
    io.airlift:aircompressor
@@ -469,6 +463,9 @@ Apache License 2.0
    org.jboss.weld.servlet:weld-servlet-shaded
    org.jetbrains:annotations
    org.jetbrains.kotlin:kotlin-stdlib
+   org.jetbrains.kotlin:kotlin-stdlib-common
+   org.jetbrains.kotlin:kotlin-stdlib-jdk7
+   org.jetbrains.kotlin:kotlin-stdlib-jdk8
    org.jheaps:jheaps
    org.jooq:jooq
    org.jooq:jooq-codegen
@@ -485,13 +482,10 @@ Apache License 2.0
 
 MIT
 =====================
-   com.knuddels:jtokkit
-
-MIT
-=====================
 
    com.bettercloud:vault-java-driver
    com.github.jnr:jnr-x86asm
+   com.knuddels:jtokkit
    com.kstruct:gethostname4j
    org.bouncycastle:bcpkix-jdk18on
    org.bouncycastle:bcprov-jdk18on


### PR DESCRIPTION
## What changes were proposed in this pull request?
When the Recon chatbot work (HDDS-14816) added new libraries (LangChain4j, OkHttp, Kotlin, etc.), those dependencies were listed in `LICENSE.txt` under **new** “Apache License 2.0” and “MIT” sections. That left **two** Apache sections and **two** MIT sections for the same license types.

**This PR:**

1. **Removes the extra section headers** so there is one Apache 2.0 block and one MIT block again.
2. **Moves the new dependency names** into those existing blocks in the right place (e.g. okhttp, retrofit, langchain4j, kotlin libs under Apache; `jtokkit` under MIT).
3. **Does not add or remove libraries** - only reorganizes how they are documented for legal/compliance checks.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15469

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
