### PR TITLE
HDDS-15244 enable logLevel endpoint for secure configuration

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -843,19 +843,9 @@ public final class HttpServer2 implements FilterContainer {
    */
   protected void addDefaultServlets() {
     addServlet("stacks", "/stacks", StackServlet.class);
-    addSecuredServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
+    addServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
     addServlet("jmx", "/jmx", JMXJsonServlet.class);
     addServlet("conf", "/conf", ConfServlet.class);
-  }
-
-  /**
-   * Add a servlet that requires Kerberos (SPNEGO) authentication when security
-   * is enabled.
-   */
-  private void addSecuredServlet(String name, String pathSpec,
-      Class<? extends HttpServlet> clazz) {
-    addInternalServlet(name, pathSpec, clazz, true);
-    addFilterPathMapping(pathSpec, webAppContext);
   }
 
   public void addContext(ServletContextHandler ctxt, boolean isFiltered) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -204,6 +204,7 @@ public final class HttpServer2 implements FilterContainer {
   static final String STATE_DESCRIPTION_ALIVE = " - alive";
   static final String STATE_DESCRIPTION_NOT_LIVE = " - not live";
   private final SignerSecretProvider secretProvider;
+  private final boolean spnegoEnabled;
   private XFrameOption xFrameOption;
   private HttpServer2Metrics metrics;
   private boolean xFrameOptionIsEnabled;
@@ -632,6 +633,7 @@ public final class HttpServer2 implements FilterContainer {
 
     this.findPort = b.findPort;
     this.portRanges = b.portRanges;
+    this.spnegoEnabled = b.securityEnabled;
     initializeWebServer(b);
   }
 
@@ -840,11 +842,20 @@ public final class HttpServer2 implements FilterContainer {
    * Add default servlets.
    */
   protected void addDefaultServlets() {
-    // set up default servlets
     addServlet("stacks", "/stacks", StackServlet.class);
-    addServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
+    addSecuredServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
     addServlet("jmx", "/jmx", JMXJsonServlet.class);
     addServlet("conf", "/conf", ConfServlet.class);
+  }
+
+  /**
+   * Add a servlet that requires Kerberos (SPNEGO) authentication when security
+   * is enabled.
+   */
+  private void addSecuredServlet(String name, String pathSpec,
+      Class<? extends HttpServlet> clazz) {
+    addInternalServlet(name, pathSpec, clazz, true);
+    addFilterPathMapping(pathSpec, webAppContext);
   }
 
   public void addContext(ServletContextHandler ctxt, boolean isFiltered) {
@@ -967,7 +978,7 @@ public final class HttpServer2 implements FilterContainer {
       }
     }
 
-    if (requireAuth && UserGroupInformation.isSecurityEnabled()) {
+    if (requireAuth && spnegoEnabled) {
       LOG.info("Adding Kerberos (SPNEGO) filter to {}", name);
       ServletHandler handler = webAppContext.getServletHandler();
       FilterMapping fmap = new FilterMapping();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/LogLevelEndpointTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/LogLevelEndpointTestUtil.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
+
+/**
+ * Shared helpers for /logLevel HTTP endpoint integration tests.
+ */
+final class LogLevelEndpointTestUtil {
+
+  static final String MARKER = "<!-- OUTPUT -->";
+  static final Pattern TAG = Pattern.compile("<[^>]*>");
+  static final String EFFECTIVE_LEVEL = "Effective Level";
+  static final String SET_LEVEL = "DEBUG";
+
+  static final String OM_LOGGER = OzoneManager.class.getName();
+  static final String SCM_LOGGER = StorageContainerManager.class.getName();
+  static final String DN_LOGGER = HddsDatanodeService.class.getName();
+
+  private LogLevelEndpointTestUtil() {
+  }
+
+  /** OM HTTP address from a running {@link MiniOzoneCluster}. */
+  static String getOmHttpAddress(MiniOzoneCluster cluster) {
+    return getOmHttpAddress(cluster.getOzoneManager());
+  }
+
+  /** OM HTTP address from a running {@link OzoneManager} (non-Kerberos). */
+  static String getOmHttpAddress(OzoneManager om) {
+    return toConnectHostPort(om.getHttpServer().getHttpAddress());
+  }
+
+  /**
+   * Kerberos HTTP address for OM using the canonical hostname registered in the
+   * KDC SPNEGO principal.
+   */
+  static String getKerberosHttpAddress(String host, OzoneManager om) {
+    return host + ":" + om.getHttpServer().getHttpAddress().getPort();
+  }
+
+  /**
+   * Kerberos HTTP address using the canonical hostname and a {@code host:port}
+   * value from configuration.
+   */
+  static String getKerberosHttpAddress(String host, String configHostPort) {
+    int port = NetUtils.createSocketAddr(configHostPort).getPort();
+    return host + ":" + port;
+  }
+
+  /**
+   * SCM HTTP {@code host:port} from a running {@link MiniOzoneCluster}.
+   * SCM does not expose {@code getHttpServer()}, so the bound address is read
+   * from cluster configuration (HA uses service- and node-suffixed keys).
+   */
+  static String getScmHttpAddress(MiniOzoneCluster cluster) {
+    OzoneConfiguration conf = cluster.getConf();
+    String key = ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY;
+    String scmServiceId = HddsUtils.getScmServiceId(conf);
+    if (scmServiceId != null) {
+      String scmNodeId = conf.getTrimmed(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY);
+      key = ConfUtils.addKeySuffixes(key, scmServiceId, scmNodeId);
+    }
+    return toConnectHostPort(NetUtils.createSocketAddr(conf.get(key)));
+  }
+
+  /**
+   * DN HTTP {@code host:port} from a running {@link MiniOzoneCluster}.
+   * Datanodes do not expose {@code getHttpServer()}, so the bound address is
+   * read from the datanode configuration after startup.
+   */
+  static String getDnHttpAddress(MiniOzoneCluster cluster) {
+    HddsDatanodeService datanode = cluster.getHddsDatanodes().get(0);
+    return toConnectHostPort(NetUtils.createSocketAddr(
+        datanode.getConf().get(HddsConfigKeys.HDDS_DATANODE_HTTP_ADDRESS_KEY)));
+  }
+
+  private static String toConnectHostPort(InetSocketAddress address) {
+    return NetUtils.getHostPortString(NetUtils.getConnectAddress(address));
+  }
+
+  static HttpURLConnection openUnauthenticatedConnection(String address,
+      String logger) throws Exception {
+    return openUnauthenticatedConnection(address, logger, null);
+  }
+
+  static HttpURLConnection openUnauthenticatedConnection(String address,
+      String logger, String level) throws Exception {
+    URL url = new URL(buildLogLevelUrl(address, logger, level));
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.connect();
+    return connection;
+  }
+
+  static String getLogLevel(String address, String logger) throws Exception {
+    HttpURLConnection connection =
+        openUnauthenticatedConnection(address, logger);
+    assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode());
+    return readResponse(connection);
+  }
+
+  static String setLogLevel(String address, String logger, String level)
+      throws Exception {
+    HttpURLConnection connection =
+        openUnauthenticatedConnection(address, logger, level);
+    assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode());
+    return readResponse(connection);
+  }
+
+  static String getLogLevelWithSpnego(String address, String logger)
+      throws Exception {
+    return fetchLogLevelWithSpnego(address, logger, null);
+  }
+
+  static String setLogLevelWithSpnego(String address, String logger,
+      String level) throws Exception {
+    return fetchLogLevelWithSpnego(address, logger, level);
+  }
+
+  static String fetchLogLevelWithSpnego(String address, String logger)
+      throws Exception {
+    return fetchLogLevelWithSpnego(address, logger, null);
+  }
+
+  private static String fetchLogLevelWithSpnego(String address, String logger,
+      String level) throws Exception {
+    URL url = new URL(buildLogLevelUrl(address, logger, level));
+    AuthenticatedURL authenticatedUrl =
+        new AuthenticatedURL(new KerberosAuthenticator());
+    AuthenticatedURL.Token token = new AuthenticatedURL.Token();
+    HttpURLConnection connection = (HttpURLConnection) authenticatedUrl
+        .openConnection(url, token);
+    connection.connect();
+    assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode(),
+        "Authenticated admin must receive /logLevel content");
+    return readResponse(connection);
+  }
+
+  static void assertGetLogLevelResponse(String response, String serviceName) {
+    assertTrue(response.contains(EFFECTIVE_LEVEL),
+        serviceName + " GET /logLevel must return effective level");
+    assertTrue(!response.contains("Bad Level"),
+        serviceName + " GET /logLevel must not report bad level");
+  }
+
+  static void assertSetLogLevelResponse(String response, String serviceName,
+      String level) {
+    assertTrue(response.contains("Setting Level to " + level),
+        serviceName + " SET /logLevel must confirm level change");
+    assertEffectiveLevel(response, level, serviceName);
+  }
+
+  static void assertEffectiveLevel(String response, String level,
+      String serviceName) {
+    assertTrue(response.contains(EFFECTIVE_LEVEL + ": " + level),
+        serviceName + " response must show effective level " + level
+            + ", got: " + response);
+  }
+
+  static void enableSpnegoOnHttpClient() {
+    System.clearProperty("jdk.http.auth.tunneling.disabledSchemes");
+    System.clearProperty("jdk.http.auth.proxying.disabledSchemes");
+  }
+
+  static String readResponse(URLConnection connection) throws Exception {
+    StringBuilder body = new StringBuilder();
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.startsWith(MARKER)) {
+          body.append(TAG.matcher(line).replaceAll(""));
+        }
+      }
+    }
+    return body.toString();
+  }
+
+  static void restoreSystemProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+  private static String buildLogLevelUrl(String address, String logger,
+      String level) {
+    StringBuilder url = new StringBuilder("http://")
+        .append(address)
+        .append("/logLevel?log=")
+        .append(logger);
+    if (level != null) {
+      url.append("&level=").append(level);
+    }
+    return url.toString();
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/LogLevelEndpointTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/LogLevelEndpointTestUtil.java
@@ -33,10 +33,10 @@ import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLogLevelEndpointInsecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLogLevelEndpointInsecure.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.DN_LOGGER;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.OM_LOGGER;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.SCM_LOGGER;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.SET_LEVEL;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.assertGetLogLevelResponse;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.assertSetLogLevelResponse;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getDnHttpAddress;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getLogLevel;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getOmHttpAddress;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getScmHttpAddress;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.setLogLevel;
+
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Integration tests for the /logLevel HTTP endpoint in a non-secure cluster.
+ */
+public class TestLogLevelEndpointInsecure {
+
+  private static MiniOzoneCluster cluster;
+  private static String omHttpAddress;
+  private static String scmHttpAddress;
+  private static String dnHttpAddress;
+
+  @BeforeAll
+  static void startCluster() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    UserGroupInformation.setConfiguration(
+        LegacyHadoopConfigurationSource.asHadoopConfiguration(conf));
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(1)
+        .build();
+    cluster.waitForClusterToBeReady();
+    omHttpAddress = getOmHttpAddress(cluster);
+    scmHttpAddress = getScmHttpAddress(cluster);
+    dnHttpAddress = getDnHttpAddress(cluster);
+  }
+
+  @AfterAll
+  static void stopCluster() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+  }
+
+  @ParameterizedTest(name = "GET /logLevel on {0}")
+  @MethodSource("httpEndpoints")
+  void testGetLogLevel(String serviceName, String httpAddress, String logger)
+      throws Exception {
+    String response = getLogLevel(httpAddress, logger);
+    assertGetLogLevelResponse(response, serviceName);
+  }
+
+  @ParameterizedTest(name = "SET /logLevel on {0}")
+  @MethodSource("httpEndpoints")
+  void testSetLogLevel(String serviceName, String httpAddress, String logger)
+      throws Exception {
+    String setResponse = setLogLevel(httpAddress, logger, SET_LEVEL);
+    assertSetLogLevelResponse(setResponse, serviceName, SET_LEVEL);
+
+    String getResponse = getLogLevel(httpAddress, logger);
+    assertGetLogLevelResponse(getResponse, serviceName);
+    LogLevelEndpointTestUtil.assertEffectiveLevel(getResponse, SET_LEVEL,
+        serviceName);
+  }
+
+  static Stream<Arguments> httpEndpoints() {
+    return Stream.of(
+        Arguments.of("OM", omHttpAddress, OM_LOGGER),
+        Arguments.of("SCM", scmHttpAddress, SCM_LOGGER),
+        Arguments.of("DN", dnHttpAddress, DN_LOGGER));
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLogLevelEndpointSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLogLevelEndpointSecure.java
@@ -24,13 +24,13 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_KERBEROS_
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_KERBEROS_PRINCIPAL_KEY;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_HTTP_AUTH_TYPE;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_HTTP_AUTH_TYPE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_KERBEROS_PRINCIPAL_KEY;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HTTP_SECURITY_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLogLevelEndpointSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLogLevelEndpointSecure.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHORIZATION;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_AUTH_TYPE;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_HTTP_AUTH_TYPE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HTTP_SECURITY_ENABLED_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.DN_LOGGER;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.OM_LOGGER;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.SCM_LOGGER;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.SET_LEVEL;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.assertGetLogLevelResponse;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.assertSetLogLevelResponse;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.enableSpnegoOnHttpClient;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getDnHttpAddress;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getKerberosHttpAddress;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getLogLevelWithSpnego;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.getScmHttpAddress;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.openUnauthenticatedConnection;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.restoreSystemProperty;
+import static org.apache.hadoop.ozone.om.LogLevelEndpointTestUtil.setLogLevelWithSpnego;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_KERBEROS_KEYTAB_FILE;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.security.PrivilegedExceptionAction;
+import java.util.Properties;
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.util.ExitUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Integration tests for the /logLevel HTTP endpoint in a secure cluster.
+ *
+ * <p>After changing {@code HttpServer2}, run with {@code -am} or install
+ * {@code hadoop-hdds/framework} so tests use the updated server code.
+ */
+public class TestLogLevelEndpointSecure {
+
+  private static final String SCM_SERVICE_ID = "loglevel-scm";
+
+  @TempDir
+  private static java.io.File workDir;
+
+  private static MiniKdc miniKdc;
+  private static MiniOzoneCluster cluster;
+  private static OzoneConfiguration secureConf;
+  private static UserGroupInformation adminUgi;
+  private static String omHttpAddress;
+  private static String scmHttpAddress;
+  private static String dnHttpAddress;
+  private static String adminPrincipal;
+  private static String host;
+
+  @BeforeAll
+  static void startSecureCluster() throws Exception {
+    ExitUtils.disableSystemExit();
+    DefaultMetricsSystem.setMiniClusterMode(true);
+    secureConf = new OzoneConfiguration();
+    secureConf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "localhost");
+
+    startMiniKdc();
+    configureSecureCluster();
+    createCredentialsInKdc();
+
+    UserGroupInformation.setConfiguration(secureConf);
+    adminUgi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        adminPrincipal, secureConf.get(OZONE_OM_KERBEROS_KEYTAB_FILE_KEY));
+    secureConf.set(OZONE_ADMINISTRATORS, adminUgi.getShortUserName());
+    UserGroupInformation.setLoginUser(adminUgi);
+
+    OzoneManager.setTestSecureOmFlag(true);
+    cluster = MiniOzoneCluster.newHABuilder(secureConf)
+        .setSCMServiceId(SCM_SERVICE_ID)
+        .setNumOfStorageContainerManagers(3)
+        .setNumOfOzoneManagers(1)
+        .setNumDatanodes(1)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    omHttpAddress = getKerberosHttpAddress(host, cluster.getOzoneManager());
+    scmHttpAddress = getKerberosHttpAddress(host, getScmHttpAddress(cluster));
+    dnHttpAddress = getKerberosHttpAddress(host, getDnHttpAddress(cluster));
+  }
+
+  @AfterAll
+  static void stopSecureCluster() throws Exception {
+    if (cluster != null) {
+      cluster.close();
+    }
+    if (miniKdc != null) {
+      miniKdc.stop();
+    }
+  }
+
+  @ParameterizedTest(name = "admin GET /logLevel on {0}")
+  @MethodSource("secureHttpEndpoints")
+  void testGetLogLevelForAdminWithSpnego(
+      String serviceName, String httpAddress, String logger) throws Exception {
+    String response = runAsAdmin(
+        () -> getLogLevelWithSpnego(httpAddress, logger));
+
+    assertGetLogLevelResponse(response, serviceName);
+    assertFalse(response.contains("Unauthenticated users are not authorized"),
+        serviceName + " authenticated admin must not be rejected");
+  }
+
+  @ParameterizedTest(name = "admin SET /logLevel on {0}")
+  @MethodSource("secureHttpEndpoints")
+  void testSetLogLevelForAdminWithSpnego(
+      String serviceName, String httpAddress, String logger) throws Exception {
+    String setResponse = runAsAdmin(
+        () -> setLogLevelWithSpnego(httpAddress, logger, SET_LEVEL));
+    assertSetLogLevelResponse(setResponse, serviceName, SET_LEVEL);
+
+    String getResponse = runAsAdmin(
+        () -> getLogLevelWithSpnego(httpAddress, logger));
+    assertGetLogLevelResponse(getResponse, serviceName);
+    LogLevelEndpointTestUtil.assertEffectiveLevel(getResponse, SET_LEVEL,
+        serviceName);
+  }
+
+  @ParameterizedTest(name = "reject unauthenticated GET /logLevel on {0}")
+  @MethodSource("secureHttpEndpoints")
+  void testLogLevelRejectsUnauthenticatedRequest(
+      String serviceName, String httpAddress, String logger) throws Exception {
+    UserGroupInformation.setConfiguration(secureConf);
+    UserGroupInformation previousLoginUser = UserGroupInformation.getLoginUser();
+    String previousDisabledSchemes =
+        System.getProperty("jdk.http.auth.tunneling.disabledSchemes");
+    String previousDisabledProxySchemes =
+        System.getProperty("jdk.http.auth.proxying.disabledSchemes");
+    try {
+      UserGroupInformation.setLoginUser(
+          UserGroupInformation.createRemoteUser("nobody"));
+      System.setProperty("jdk.http.auth.tunneling.disabledSchemes",
+          "Basic,Negotiate,Kerberos");
+      System.setProperty("jdk.http.auth.proxying.disabledSchemes",
+          "Basic,Negotiate,Kerberos");
+
+      HttpURLConnection connection =
+          openUnauthenticatedConnection(httpAddress, logger);
+      int responseCode = connection.getResponseCode();
+      assertNotEquals(HttpURLConnection.HTTP_OK, responseCode,
+          serviceName + " must not allow unauthenticated /logLevel access");
+      assertTrue(responseCode == HttpURLConnection.HTTP_UNAUTHORIZED
+              || responseCode == HttpURLConnection.HTTP_FORBIDDEN,
+          serviceName + " must reject unauthenticated /logLevel, got "
+              + responseCode);
+    } finally {
+      UserGroupInformation.setLoginUser(previousLoginUser);
+      restoreSystemProperty("jdk.http.auth.tunneling.disabledSchemes",
+          previousDisabledSchemes);
+      restoreSystemProperty("jdk.http.auth.proxying.disabledSchemes",
+          previousDisabledProxySchemes);
+    }
+  }
+
+  static Stream<Arguments> secureHttpEndpoints() {
+    return Stream.of(
+        Arguments.of("OM", omHttpAddress, OM_LOGGER),
+        Arguments.of("SCM", scmHttpAddress, SCM_LOGGER),
+        Arguments.of("DN", dnHttpAddress, DN_LOGGER));
+  }
+
+  private static String runAsAdmin(PrivilegedExceptionAction<String> action)
+      throws Exception {
+    UserGroupInformation.setConfiguration(secureConf);
+    UserGroupInformation.setLoginUser(adminUgi);
+    adminUgi.setAuthenticationMethod(KERBEROS);
+    enableSpnegoOnHttpClient();
+    return adminUgi.doAs(action);
+  }
+
+  private static void startMiniKdc() throws Exception {
+    Properties securityProperties = MiniKdc.createConf();
+    miniKdc = new MiniKdc(securityProperties, workDir);
+    miniKdc.start();
+  }
+
+  private static void configureSecureCluster() throws Exception {
+    secureConf.setBoolean(OZONE_SECURITY_ENABLED_KEY, true);
+    secureConf.setBoolean(HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED, false);
+    secureConf.setBoolean(OZONE_HTTP_SECURITY_ENABLED_KEY, true);
+    secureConf.setBoolean(HADOOP_SECURITY_AUTHORIZATION, true);
+    secureConf.set(HADOOP_SECURITY_AUTHENTICATION, KERBEROS.name());
+    secureConf.set(OZONE_OM_HTTP_AUTH_TYPE, "kerberos");
+    secureConf.set(HDDS_SCM_HTTP_AUTH_TYPE, "kerberos");
+    secureConf.set(HDDS_DATANODE_HTTP_AUTH_TYPE, "kerberos");
+
+    host = InetAddress.getLocalHost().getCanonicalHostName()
+        .toLowerCase();
+    String realm = miniKdc.getRealm();
+    String hostAndRealm = host + "@" + realm;
+    String httpSpnegoPrincipal = "HTTP/_HOST@" + realm;
+    adminPrincipal = "om/" + hostAndRealm;
+
+    String scmPrincipal = "scm/" + hostAndRealm;
+    secureConf.set(HDDS_SCM_KERBEROS_PRINCIPAL_KEY, scmPrincipal);
+    secureConf.set(HDDS_SCM_HTTP_KERBEROS_PRINCIPAL_KEY, httpSpnegoPrincipal);
+    secureConf.set(OZONE_OM_KERBEROS_PRINCIPAL_KEY, scmPrincipal);
+    secureConf.set(OZONE_OM_HTTP_KERBEROS_PRINCIPAL_KEY, httpSpnegoPrincipal);
+    secureConf.set(HDDS_DATANODE_KERBEROS_PRINCIPAL_KEY, scmPrincipal);
+    secureConf.set(HDDS_DATANODE_HTTP_KERBEROS_PRINCIPAL_KEY,
+        httpSpnegoPrincipal);
+
+    File omKeytab = new File(workDir, "om.keytab");
+    File spnegoKeytab = new File(workDir, "http.keytab");
+    secureConf.set(OZONE_OM_KERBEROS_KEYTAB_FILE_KEY,
+        omKeytab.getAbsolutePath());
+    secureConf.set(OZONE_OM_HTTP_KERBEROS_KEYTAB_FILE,
+        spnegoKeytab.getAbsolutePath());
+    secureConf.set(HDDS_SCM_KERBEROS_KEYTAB_FILE_KEY,
+        omKeytab.getAbsolutePath());
+    secureConf.set(HDDS_SCM_HTTP_KERBEROS_KEYTAB_FILE_KEY,
+        spnegoKeytab.getAbsolutePath());
+    secureConf.set(HDDS_DATANODE_KERBEROS_KEYTAB_FILE_KEY,
+        omKeytab.getAbsolutePath());
+    secureConf.set(HDDS_DATANODE_HTTP_KERBEROS_KEYTAB_FILE_KEY,
+        spnegoKeytab.getAbsolutePath());
+  }
+
+  private static void createCredentialsInKdc() throws Exception {
+    String realm = miniKdc.getRealm();
+    String hostAndRealm = host + "@" + realm;
+    String httpPrincipal = "HTTP/" + hostAndRealm;
+    String scmPrincipal = "scm/" + hostAndRealm;
+    File omKeytab = new File(secureConf.get(OZONE_OM_KERBEROS_KEYTAB_FILE_KEY));
+    File spnegoKeytab =
+        new File(secureConf.get(OZONE_OM_HTTP_KERBEROS_KEYTAB_FILE));
+    miniKdc.createPrincipal(omKeytab, adminPrincipal, scmPrincipal);
+    miniKdc.createPrincipal(spnegoKeytab, httpPrincipal);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-15244 enable logLevel endpoint for secure configuration

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15244

## How was this patch tested?

Integration tests:
mvn -pl hadoop-ozone/integration-test -am  -Dtest=TestLogLevelEndpointInsecure,TestLogLevelEndpointSecure test