### PR TITLE
HDDS-15486 Remove excessive debug logging in BlockOutputStream and Bu…

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -359,7 +359,6 @@ public class BlockOutputStream extends OutputStream {
 
   private void writeChunkIfNeeded() throws IOException {
     if (currentBufferRemaining == 0) {
-      LOG.debug("WriteChunk from write(), buffer = {}", currentBuffer);
       clientMetrics.getWriteChunksDuringWrite().incr();
       writeChunk(currentBuffer);
       updateWriteChunkLength();
@@ -427,8 +426,6 @@ public class BlockOutputStream extends OutputStream {
       try {
         currentBuffer = bufferPool.allocateBuffer(config.getBufferIncrement());
         currentBufferRemaining = currentBuffer.remaining();
-        LOG.debug("Allocated new buffer {}, used = {}, capacity = {}", currentBuffer,
-            bufferPool.getNumberOfUsedBuffers(), bufferPool.getCapacity());
       } catch (InterruptedException e) {
         handleInterruptedException(e, false);
       }
@@ -460,10 +457,6 @@ public class BlockOutputStream extends OutputStream {
     // the BufferPool. For each pending buffers in the BufferPool, we sequentially flush it and wait synchronously.
 
     List<ChunkBuffer> allocatedBuffers = bufferPool.getAllocatedBuffers();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("{}: Retrying write length {} on target blockID {}, {} buffers", this, len, blockID,
-          allocatedBuffers.size());
-    }
     Preconditions.checkArgument(len <= streamBufferArgs.getStreamBufferMaxSize());
     int count = 0;
     while (len > 0) {
@@ -474,7 +467,6 @@ public class BlockOutputStream extends OutputStream {
       writtenDataLength += writeLen;
       updateWriteChunkLength();
       updatePutBlockLength();
-      LOG.debug("Write chunk on retry buffer = {}", buffer);
       CompletableFuture<PutBlockResult> putBlockFuture;
       if (allowPutBlockPiggybacking) {
         putBlockFuture = writeChunkAndPutBlock(buffer, false);
@@ -533,17 +525,14 @@ public class BlockOutputStream extends OutputStream {
       throw new FlushRuntimeException(e);
     }
 
-    LOG.debug("Entering watchForCommit commitIndex = {}", commitIndex);
     final long start = Time.monotonicNowNanos();
     return sendWatchForCommit(commitIndex)
         .thenAccept(this::checkReply)
         .exceptionally(e -> {
           throw new FlushRuntimeException(setIoException(e));
         })
-        .whenComplete((r, e) -> {
-          LOG.debug("Leaving watchForCommit commitIndex = {}", commitIndex);
-          clientMetrics.getHsyncWatchForCommitNs().add(Time.monotonicNowNanos() - start);
-        });
+        .whenComplete((r, e) ->
+            clientMetrics.getHsyncWatchForCommitNs().add(Time.monotonicNowNanos() - start));
   }
 
   private void checkReply(XceiverClientReply reply) {
@@ -613,10 +602,6 @@ public class BlockOutputStream extends OutputStream {
         }
         return e;
       }, responseExecutor).exceptionally(e -> {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("putBlock failed for blockID {} with exception {}",
-                  blockID, e.getLocalizedMessage());
-        }
         CompletionException ce =  new CompletionException(e);
         setIoException(ce);
         throw ce;
@@ -666,7 +651,6 @@ public class BlockOutputStream extends OutputStream {
 
   private CompletableFuture<PutBlockResult> writeChunkAndPutBlock(ChunkBuffer buffer, boolean close)
       throws IOException {
-    LOG.debug("WriteChunk and Putblock from flush, buffer={}", buffer);
     writeChunkCommon(buffer);
     return writeChunkToContainer(buffer.duplicate(0, buffer.position()), true, close);
   }
@@ -699,12 +683,10 @@ public class BlockOutputStream extends OutputStream {
   private void handleFlushInternal(boolean close)
       throws IOException, InterruptedException, ExecutionException {
     checkOpen();
-    LOG.debug("Start handleFlushInternal close={}", close);
     CompletableFuture<Void> toWaitFor = captureLatencyNs(clientMetrics.getHsyncSynchronizedWorkNs(),
         () -> handleFlushInternalSynchronized(close));
 
     if (toWaitFor != null) {
-      LOG.debug("Waiting for flush");
       try {
         long startWaiting = Time.monotonicNowNanos();
         toWaitFor.get();
@@ -716,7 +698,6 @@ public class BlockOutputStream extends OutputStream {
           throw ex;
         }
       }
-      LOG.debug("Flush done.");
     }
 
     if (close) {
@@ -773,8 +754,6 @@ public class BlockOutputStream extends OutputStream {
       // data since latest flush - we need to send the "EOF" flag
       updatePutBlockLength();
       putBlockResultFuture = executePutBlock(true, true);
-    } else {
-      LOG.debug("Flushing without data");
     }
     if (putBlockResultFuture != null) {
       recordWatchForCommitAsync(putBlockResultFuture);
@@ -825,11 +804,6 @@ public class BlockOutputStream extends OutputStream {
     if (ioe == null) {
       IOException exception =  new IOException(EXCEPTION_MSG + e.toString(), e);
       ioException.compareAndSet(null, exception);
-      LOG.debug("Exception: for block ID: " + blockID,  e);
-    } else {
-      LOG.debug("Previous request had already failed with {} " +
-              "so subsequent request also encounters " +
-              "Storage Container Exception {}", ioe, e);
     }
     return getIoException();
   }
@@ -916,11 +890,6 @@ public class BlockOutputStream extends OutputStream {
 
     long flushPos = totalWriteChunkLength;
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Writing chunk {} length {} at offset {}",
-          chunkInfo.getChunkName(), effectiveChunkSize, offset);
-    }
-
     final ChunkInfo previous = previousChunkInfo.getAndSet(chunkInfo);
     final long expectedOffset = previous == null ? 0
         : chunkInfo.getChunkName().equals(previous.getChunkName()) ?
@@ -952,7 +921,6 @@ public class BlockOutputStream extends OutputStream {
         Objects.requireNonNull(byteBufferList, "byteBufferList == null");
 
         blockData = containerBlockData.build();
-        LOG.debug("piggyback chunk list {}", blockData);
 
         if (supportIncrementalChunkList) {
           // remove any chunks in the containerBlockData list.
@@ -982,7 +950,6 @@ public class BlockOutputStream extends OutputStream {
       }, responseExecutor).exceptionally(e -> {
         String msg = "Failed to write chunk " + chunkInfo.getChunkName() +
             " into block " + blockID;
-        LOG.debug("{}, exception: {}", msg, e.getLocalizedMessage());
         CompletionException ce = new CompletionException(msg, e);
         setIoException(ce);
         throw ce;
@@ -1010,13 +977,6 @@ public class BlockOutputStream extends OutputStream {
         .equals(responseBlockID.getContainerBlockID()));
     // updates the bcsId of the block
     blockID.set(responseBlockID);
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "Adding index " + asyncReply.getLogIndex() + " flushLength "
-              + flushPos + " numBuffers " + byteBufferList.size()
-              + " blockID " + blockID + " bufferPool size " + bufferPool
-              .getSize());
-    }
     // for standalone protocol, logIndex will always be 0.
     updateCommitInfo(asyncReply, byteBufferList);
   }
@@ -1039,12 +999,6 @@ public class BlockOutputStream extends OutputStream {
     // So remove it.
     removeLastPartialChunk();
     chunk.rewind();
-    LOG.debug("Adding chunk pos {} limit {} remaining {}." +
-            "lastChunkBuffer pos {} limit {} remaining {} lastChunkOffset = {}",
-        chunk.position(), chunk.limit(), chunk.remaining(),
-        lastChunkBuffer.position(), lastChunkBuffer.limit(),
-        lastChunkBuffer.remaining(), lastChunkOffset);
-
     // Append the chunk to the last chunk buffer.
     // if the resulting size exceeds limit (4MB),
     // drop the full chunk and keep the rest.
@@ -1060,8 +1014,6 @@ public class BlockOutputStream extends OutputStream {
       appendLastChunkBuffer(chunk, remainingBufferSize,
           chunk.remaining() - remainingBufferSize);
     }
-    LOG.debug("after append, lastChunkBuffer={} lastChunkOffset={}",
-        lastChunkBuffer, lastChunkOffset);
 
     updateBlockDataWithLastChunkBuffer();
   }
@@ -1070,7 +1022,6 @@ public class BlockOutputStream extends OutputStream {
       throws OzoneChecksumException {
     // create chunk info for lastChunkBuffer
     ChunkInfo lastChunkInfo = createChunkInfo(lastChunkOffset);
-    LOG.debug("lastChunkInfo = {}", lastChunkInfo);
     long lastChunkSize = lastChunkInfo.getLen();
     addToBlockData(lastChunkInfo);
     // Set ByteBuffer limit to capacity, pos to 0. Does not erase data
@@ -1087,8 +1038,6 @@ public class BlockOutputStream extends OutputStream {
 
   private void appendLastChunkBuffer(ChunkBuffer chunkBuffer, int offset,
       int length) {
-    LOG.debug("copying to last chunk buffer offset={} length={}",
-        offset, length);
     int pos = 0;
     int uncopied = length;
     for (ByteBuffer bb : chunkBuffer.asByteBufferList()) {
@@ -1096,8 +1045,6 @@ public class BlockOutputStream extends OutputStream {
         int copyStart = offset < pos ? 0 : offset - pos;
         int copyLen = Math.min(uncopied, bb.remaining());
         try {
-          LOG.debug("put into last chunk buffer start = {} len = {}",
-              copyStart, copyLen);
           int origPos = bb.position();
           int origLimit = bb.limit();
           bb.position(copyStart).limit(copyStart + copyLen);
@@ -1167,11 +1114,9 @@ public class BlockOutputStream extends OutputStream {
   }
 
   private void addToBlockData(ChunkInfo revisedChunkInfo) {
-    LOG.debug("containerBlockData chunk: {}", containerBlockData);
     if (containerBlockData.getChunksCount() > 0) {
       ChunkInfo lastChunk = containerBlockData.getChunks(
           containerBlockData.getChunksCount() - 1);
-      LOG.debug("revisedChunkInfo chunk: {}", revisedChunkInfo);
       Preconditions.checkState(lastChunk.getOffset() + lastChunk.getLen() ==
           revisedChunkInfo.getOffset(),
             "lastChunk.getOffset() + lastChunk.getLen() " +

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A bounded pool implementation that provides {@link ChunkBuffer}s. This pool allows allocating and releasing
@@ -42,8 +40,6 @@ import org.slf4j.LoggerFactory;
  * wait until a allocated buffer is released.
  */
 public class BufferPool {
-  private static final Logger LOG = LoggerFactory.getLogger(BufferPool.class);
-
   private static final BufferPool EMPTY = new BufferPool(0, 0);
   private final int bufferSize;
   private final int capacity;
@@ -90,7 +86,6 @@ public class BufferPool {
           "Total created buffer must not exceed capacity.");
 
       while (allocated.size() == capacity) {
-        LOG.debug("Allocation needs to wait the pool is at capacity (allocated = capacity = {}).", capacity);
         notFull.await();
       }
       // Get a buffer to allocate, preferably from the released ones.
@@ -99,8 +94,6 @@ public class BufferPool {
       allocated.add(buffer);
       currentBuffer = buffer;
 
-      LOG.debug("Allocated new buffer {}, number of used buffers {}, capacity {}.",
-          buffer, allocated.size(), capacity);
       return buffer;
     } finally {
       lock.unlock();
@@ -108,7 +101,6 @@ public class BufferPool {
   }
 
   void releaseBuffer(ChunkBuffer buffer) {
-    LOG.debug("Releasing buffer {}", buffer);
     lock.lock();
     try {
       Preconditions.assertTrue(removeByIdentity(allocated, buffer), "Releasing unknown buffer");

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BenchmarkMockXceiverClient.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BenchmarkMockXceiverClient.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetCommittedBlockLengthResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutBlockResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.XceiverClientReply;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.ClientVersion;
+
+/**
+ * In-memory xceiver client for {@link BlockOutputStreamWriteBenchmark}.
+ */
+final class BenchmarkMockXceiverClient extends XceiverClientSpi {
+
+  private final Pipeline pipeline;
+  private final AtomicLong logIndex = new AtomicLong();
+
+  BenchmarkMockXceiverClient(Pipeline pipeline) {
+    this.pipeline = pipeline;
+  }
+
+  @Override
+  public void connect() {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public Pipeline getPipeline() {
+    return pipeline;
+  }
+
+  @Override
+  public XceiverClientReply sendCommandAsync(ContainerCommandRequestProto request) {
+    if (!request.hasVersion()) {
+      request = ContainerCommandRequestProto.newBuilder(request)
+          .setVersion(ClientVersion.CURRENT.toProtoValue()).build();
+    }
+    final ContainerCommandResponseProto.Builder builder =
+        ContainerCommandResponseProto.newBuilder()
+            .setResult(Result.SUCCESS)
+            .setCmdType(request.getCmdType());
+    if (request.getCmdType() == Type.PutBlock) {
+      builder.setPutBlock(PutBlockResponseProto.newBuilder()
+          .setCommittedBlockLength(
+              GetCommittedBlockLengthResponseProto.newBuilder()
+                  .setBlockID(request.getPutBlock().getBlockData().getBlockID())
+                  .setBlockLength(request.getPutBlock().getBlockData().getSize())
+                  .build())
+          .build());
+    }
+    final XceiverClientReply reply = new XceiverClientReply(
+        CompletableFuture.completedFuture(builder.build()));
+    reply.setLogIndex(logIndex.incrementAndGet());
+    return reply;
+  }
+
+  @Override
+  public ReplicationType getPipelineType() {
+    return pipeline.getType();
+  }
+
+  @Override
+  public CompletableFuture<XceiverClientReply> watchForCommit(long index) {
+    final ContainerCommandResponseProto response =
+        ContainerCommandResponseProto.newBuilder()
+            .setCmdType(Type.WriteChunk)
+            .setResult(Result.SUCCESS)
+            .build();
+    final XceiverClientReply reply =
+        new XceiverClientReply(CompletableFuture.completedFuture(response));
+    reply.setLogIndex(index);
+    return CompletableFuture.completedFuture(reply);
+  }
+
+  @Override
+  public long getReplicatedMinCommitIndex() {
+    return logIndex.get();
+  }
+
+  @Override
+  public Map<DatanodeDetails, ContainerCommandResponseProto> sendCommandOnAllNodes(
+      ContainerCommandRequestProto request) {
+    return null;
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStreamWriteBenchmark.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStreamWriteBenchmark.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.text.DecimalFormat;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.hdds.scm.ContainerClientMetrics;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.StreamBufferArgs;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.ozone.test.GenericTestUtils;
+import org.slf4j.event.Level;
+
+/**
+ * Client-side {@link RatisBlockOutputStream} write benchmark using the
+ * {@code BlockOutputStream} and {@code BufferPool} sources currently in the workspace.
+ *
+ * <p>Mocked container RPCs ({@link BenchmarkMockXceiverClient}) keep datanode I/O out of
+ * the measurement. Run twice and compare offline:
+ * <ol>
+ *   <li>On current workspace sources (after HDDS-15486)</li>
+ *   <li>After temporarily checking out pre-HDDS-15486 {@code BlockOutputStream} and
+ *       {@code BufferPool} (see {@code dev-support/run-block-output-stream-write-benchmark.sh})</li>
+ * </ol>
+ *
+ * <p>Run from the repo root:
+ * <pre>
+ *   mvn -pl hadoop-hdds/client -q test-compile exec:java \
+ *     -Dexec.mainClass=org.apache.hadoop.hdds.scm.storage.BlockOutputStreamWriteBenchmark \
+ *     -Dexec.classpathScope=test
+ * </pre>
+ *
+ * <p>Or use the helper script for both runs with automatic restore:
+ * <pre>
+ *   hadoop-hdds/client/dev-support/run-block-output-stream-write-benchmark.sh
+ * </pre>
+ */
+public final class BlockOutputStreamWriteBenchmark {
+
+  private static final int WARMUP_SECONDS = 10;
+  private static final int BENCHMARK_SECONDS = 20;
+  private static final int WRITE_SIZE = 4 * 1024;
+  private static final int STREAM_BUFFER_SIZE = 4 * 1024 * 1024;
+  private static final int POOL_CAPACITY = 8;
+  private static final int WRITES_PER_BLOCK = STREAM_BUFFER_SIZE / WRITE_SIZE;
+
+  private static final DecimalFormat MBPS = new DecimalFormat("#,##0.0");
+  private static final DecimalFormat NS = new DecimalFormat("#,##0");
+  private static final DecimalFormat COUNT = new DecimalFormat("#,##0");
+
+  private BlockOutputStreamWriteBenchmark() {
+  }
+
+  public static void main(String[] args) throws Exception {
+    GenericTestUtils.setLogLevel(BufferPool.class, Level.INFO);
+    GenericTestUtils.setLogLevel(BlockOutputStream.class, Level.INFO);
+
+    final String label = System.getProperty("benchmark.label", "workspace");
+
+    System.out.println("BlockOutputStream client write benchmark (mocked container RPCs)");
+    System.out.println("Profile: " + label);
+    System.out.println("Git: " + gitHeadShort());
+    System.out.println("Log level: INFO for BufferPool and BlockOutputStream");
+    System.out.println("JVM: " + System.getProperty("java.version")
+        + " on " + System.getProperty("os.arch"));
+    System.out.printf("Write=%dKB streamBuffer=%dMB poolCapacity=%d writes/block=%d%n",
+        WRITE_SIZE / 1024, STREAM_BUFFER_SIZE / (1024 * 1024), POOL_CAPACITY,
+        WRITES_PER_BLOCK);
+    System.out.println();
+
+    final byte[] writeBuffer = new byte[WRITE_SIZE];
+    ThreadLocalRandom.current().nextBytes(writeBuffer);
+
+    try (BenchmarkSession session = BenchmarkSession.open()) {
+      runTimedWrite(session, writeBuffer, WARMUP_SECONDS, "warmup");
+      final Result result = runTimedWrite(session, writeBuffer, BENCHMARK_SECONDS, "benchmark");
+
+      System.out.printf("elapsed: %.2fs%n", result.elapsedSeconds);
+      System.out.printf("bytes written: %s%n", COUNT.format(result.bytesWritten));
+      System.out.printf("write ops (%dKB): %s%n", WRITE_SIZE / 1024, COUNT.format(result.writeOps));
+      System.out.printf("blocks written: %s%n", COUNT.format(result.blocksWritten));
+      System.out.printf("throughput: %s MB/s%n", MBPS.format(result.mbPerSec));
+      System.out.printf("ns/write: %s%n", NS.format(result.nsPerWrite));
+      System.out.printf("writeChunks metric: %s%n",
+          COUNT.format(result.writeChunksDuringWrite));
+      System.out.printf("flushes metric: %s%n",
+          COUNT.format(result.flushesDuringWrite));
+    }
+  }
+
+  private static String gitHeadShort() {
+    try {
+      final Process process = new ProcessBuilder("git", "rev-parse", "--short", "HEAD")
+          .redirectErrorStream(true)
+          .start();
+      try (BufferedReader reader = new BufferedReader(
+          new InputStreamReader(process.getInputStream()))) {
+        final String line = reader.readLine();
+        if (process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0 && line != null) {
+          return line.trim();
+        }
+      }
+    } catch (IOException | InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    return "unknown";
+  }
+
+  private static Result runTimedWrite(BenchmarkSession session, byte[] writeBuffer,
+      int seconds, String phase) throws Exception {
+    final long start = System.nanoTime();
+    final long deadline = start + seconds * 1_000_000_000L;
+    long bytesWritten = 0;
+    long writeOps = 0;
+    long blocksWritten = 0;
+
+    final long writeChunksBefore = session.metrics.getWriteChunksDuringWrite().value();
+    final long flushesBefore = session.metrics.getFlushesDuringWrite().value();
+
+    while (System.nanoTime() < deadline) {
+      try (BlockOutputStream stream = session.newStream()) {
+        for (int i = 0; i < WRITES_PER_BLOCK && System.nanoTime() < deadline; i++) {
+          stream.write(writeBuffer, 0, writeBuffer.length);
+          bytesWritten += writeBuffer.length;
+          writeOps++;
+        }
+      }
+      blocksWritten++;
+    }
+
+    final long elapsedNanos = System.nanoTime() - start;
+    final double elapsedSeconds = elapsedNanos / 1_000_000_000.0;
+    System.out.printf("%s complete (%.2fs)%n", phase, elapsedSeconds);
+
+    return new Result(
+        bytesWritten,
+        writeOps,
+        blocksWritten,
+        elapsedSeconds,
+        bytesWritten / elapsedSeconds / (1024.0 * 1024.0),
+        (double) elapsedNanos / writeOps,
+        session.metrics.getWriteChunksDuringWrite().value() - writeChunksBefore,
+        session.metrics.getFlushesDuringWrite().value() - flushesBefore);
+  }
+
+  private static final class BenchmarkSession implements AutoCloseable {
+    private final Pipeline pipeline;
+    private final ContainerClientMetrics metrics;
+    private final BufferPool bufferPool;
+    private final OzoneClientConfig config;
+    private final StreamBufferArgs streamBufferArgs;
+    private final XceiverClientManager xceiverClientManager;
+    private final ExecutorService responseExecutor;
+
+    private BenchmarkSession(Pipeline pipeline, ContainerClientMetrics metrics,
+        BufferPool bufferPool, OzoneClientConfig config, StreamBufferArgs streamBufferArgs,
+        XceiverClientManager xceiverClientManager, ExecutorService responseExecutor) {
+      this.pipeline = pipeline;
+      this.metrics = metrics;
+      this.bufferPool = bufferPool;
+      this.config = config;
+      this.streamBufferArgs = streamBufferArgs;
+      this.xceiverClientManager = xceiverClientManager;
+      this.responseExecutor = responseExecutor;
+    }
+
+    static BenchmarkSession open() throws IOException {
+      final Pipeline pipeline = MockPipeline.createRatisPipeline();
+      final XceiverClientManager xcm = mock(XceiverClientManager.class);
+      when(xcm.acquireClient(any())).thenReturn(new BenchmarkMockXceiverClient(pipeline));
+
+      final OzoneClientConfig config = new OzoneClientConfig();
+      config.setStreamBufferSize(STREAM_BUFFER_SIZE);
+      config.setStreamBufferMaxSize(32 * 1024 * 1024);
+      config.setStreamBufferFlushDelay(false);
+      config.setStreamBufferFlushSize(16 * 1024 * 1024);
+      config.setChecksumType(ChecksumType.NONE);
+      config.setBytesPerChecksum(256 * 1024);
+
+      final StreamBufferArgs streamBufferArgs =
+          StreamBufferArgs.getDefaultStreamBufferArgs(pipeline.getReplicationConfig(), config);
+
+      return new BenchmarkSession(
+          pipeline,
+          ContainerClientMetrics.acquire(),
+          new BufferPool(STREAM_BUFFER_SIZE, POOL_CAPACITY),
+          config,
+          streamBufferArgs,
+          xcm,
+          newFixedThreadPool(4));
+    }
+
+    BlockOutputStream newStream() throws IOException {
+      return new RatisBlockOutputStream(
+          new BlockID(1L, 1L),
+          -1,
+          xceiverClientManager,
+          pipeline,
+          bufferPool,
+          config,
+          null,
+          metrics,
+          streamBufferArgs,
+          () -> responseExecutor);
+    }
+
+    @Override
+    public void close() {
+      bufferPool.clearBufferPool();
+      responseExecutor.shutdownNow();
+    }
+  }
+
+  private static final class Result {
+    private final long bytesWritten;
+    private final long writeOps;
+    private final long blocksWritten;
+    private final double elapsedSeconds;
+    private final double mbPerSec;
+    private final double nsPerWrite;
+    private final long writeChunksDuringWrite;
+    private final long flushesDuringWrite;
+
+    private Result(long bytesWritten, long writeOps, long blocksWritten, double elapsedSeconds,
+        double mbPerSec, double nsPerWrite, long writeChunksDuringWrite,
+        long flushesDuringWrite) {
+      this.bytesWritten = bytesWritten;
+      this.writeOps = writeOps;
+      this.blocksWritten = blocksWritten;
+      this.elapsedSeconds = elapsedSeconds;
+      this.mbPerSec = mbPerSec;
+      this.nsPerWrite = nsPerWrite;
+      this.writeChunksDuringWrite = writeChunksDuringWrite;
+      this.flushesDuringWrite = flushesDuringWrite;
+    }
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStreamWriteBenchmark.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStreamWriteBenchmark.java
@@ -22,13 +22,10 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.text.DecimalFormat;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.scm.ContainerClientMetrics;
@@ -70,8 +67,10 @@ public final class BlockOutputStreamWriteBenchmark {
   private static final int BENCHMARK_SECONDS = 20;
   private static final int WRITE_SIZE = 4 * 1024;
   private static final int STREAM_BUFFER_SIZE = 4 * 1024 * 1024;
+  /** User read buffer; one stream write cycle fills this buffer at advancing offsets. */
+  private static final int SOURCE_BUFFER_SIZE = STREAM_BUFFER_SIZE;
   private static final int POOL_CAPACITY = 8;
-  private static final int WRITES_PER_BLOCK = STREAM_BUFFER_SIZE / WRITE_SIZE;
+  private static final int WRITES_PER_STREAM = SOURCE_BUFFER_SIZE / WRITE_SIZE;
 
   private static final DecimalFormat MBPS = new DecimalFormat("#,##0.0");
   private static final DecimalFormat NS = new DecimalFormat("#,##0");
@@ -88,21 +87,22 @@ public final class BlockOutputStreamWriteBenchmark {
 
     System.out.println("BlockOutputStream client write benchmark (mocked container RPCs)");
     System.out.println("Profile: " + label);
-    System.out.println("Git: " + gitHeadShort());
     System.out.println("Log level: INFO for BufferPool and BlockOutputStream");
     System.out.println("JVM: " + System.getProperty("java.version")
         + " on " + System.getProperty("os.arch"));
-    System.out.printf("Write=%dKB streamBuffer=%dMB poolCapacity=%d writes/block=%d%n",
-        WRITE_SIZE / 1024, STREAM_BUFFER_SIZE / (1024 * 1024), POOL_CAPACITY,
-        WRITES_PER_BLOCK);
+    System.out.printf("Write=%dKB sourceBuffer=%dMB streamBuffer=%dMB poolCapacity=%d "
+            + "writes/stream=%d%n",
+        WRITE_SIZE / 1024, SOURCE_BUFFER_SIZE / (1024 * 1024),
+        STREAM_BUFFER_SIZE / (1024 * 1024), POOL_CAPACITY,
+        WRITES_PER_STREAM);
     System.out.println();
 
-    final byte[] writeBuffer = new byte[WRITE_SIZE];
-    ThreadLocalRandom.current().nextBytes(writeBuffer);
+    final byte[] sourceBuffer = new byte[SOURCE_BUFFER_SIZE];
+    ThreadLocalRandom.current().nextBytes(sourceBuffer);
 
     try (BenchmarkSession session = BenchmarkSession.open()) {
-      runTimedWrite(session, writeBuffer, WARMUP_SECONDS, "warmup");
-      final Result result = runTimedWrite(session, writeBuffer, BENCHMARK_SECONDS, "benchmark");
+      runTimedWrite(session, sourceBuffer, WARMUP_SECONDS, "warmup");
+      final Result result = runTimedWrite(session, sourceBuffer, BENCHMARK_SECONDS, "benchmark");
 
       System.out.printf("elapsed: %.2fs%n", result.elapsedSeconds);
       System.out.printf("bytes written: %s%n", COUNT.format(result.bytesWritten));
@@ -117,25 +117,7 @@ public final class BlockOutputStreamWriteBenchmark {
     }
   }
 
-  private static String gitHeadShort() {
-    try {
-      final Process process = new ProcessBuilder("git", "rev-parse", "--short", "HEAD")
-          .redirectErrorStream(true)
-          .start();
-      try (BufferedReader reader = new BufferedReader(
-          new InputStreamReader(process.getInputStream()))) {
-        final String line = reader.readLine();
-        if (process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0 && line != null) {
-          return line.trim();
-        }
-      }
-    } catch (IOException | InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-    return "unknown";
-  }
-
-  private static Result runTimedWrite(BenchmarkSession session, byte[] writeBuffer,
+  private static Result runTimedWrite(BenchmarkSession session, byte[] sourceBuffer,
       int seconds, String phase) throws Exception {
     final long start = System.nanoTime();
     final long deadline = start + seconds * 1_000_000_000L;
@@ -148,9 +130,10 @@ public final class BlockOutputStreamWriteBenchmark {
 
     while (System.nanoTime() < deadline) {
       try (BlockOutputStream stream = session.newStream()) {
-        for (int i = 0; i < WRITES_PER_BLOCK && System.nanoTime() < deadline; i++) {
-          stream.write(writeBuffer, 0, writeBuffer.length);
-          bytesWritten += writeBuffer.length;
+        for (int offset = 0; offset + WRITE_SIZE <= sourceBuffer.length
+            && System.nanoTime() < deadline; offset += WRITE_SIZE) {
+          stream.write(sourceBuffer, offset, WRITE_SIZE);
+          bytesWritten += WRITE_SIZE;
           writeOps++;
         }
       }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
@@ -30,21 +30,12 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
-import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.event.Level;
 
 /**
  * Test for {@link BufferPool}.
  */
 class TestBufferPool {
-
-  @BeforeAll
-  static void init() {
-    GenericTestUtils.setLogLevel(BufferPool.class, Level.DEBUG);
-  }
 
   @Test
   void testBufferPool() throws Exception {
@@ -63,11 +54,11 @@ class TestBufferPool {
     assertAllocationBlockedUntilReleased(pool, buffers);
   }
 
-  private void assertAllocationBlockedUntilReleased(BufferPool pool, Deque<ChunkBuffer> buffers) throws Exception {
+  private void assertAllocationBlockedUntilReleased(BufferPool pool, Deque<ChunkBuffer> buffers)
+      throws Exception {
     // As the pool is full, allocation will need to wait until a buffer is released.
     assertFull(pool);
 
-    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.class);
     AtomicReference<ChunkBuffer> allocated = new AtomicReference<>();
     AtomicBoolean allocatorStarted = new AtomicBoolean();
     Thread allocator = new Thread(() -> {
@@ -94,14 +85,12 @@ class TestBufferPool {
     releaser.start();
     allocator.join();
     assertEquals(toRelease, allocated.get());
-    assertTrue(logCapturer.getOutput().contains("Allocation needs to wait the pool is at capacity"));
   }
 
   private void assertAllocationBlocked(BufferPool pool) throws Exception {
     // As the pool is full, new allocation will be blocked interruptably if no allocated buffer is released.
     assertFull(pool);
 
-    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.class);
     AtomicBoolean allocatorStarted = new AtomicBoolean();
     AtomicBoolean interrupted = new AtomicBoolean(false);
     Thread allocator = new Thread(() -> {
@@ -128,7 +117,6 @@ class TestBufferPool {
     allocator.interrupt();
     allocator.join();
     assertTrue(interrupted.get());
-    assertTrue(logCapturer.getOutput().contains("Allocation needs to wait the pool is at capacity"));
   }
 
   private static void testBufferPool(final int capacity, final int bufferSize) throws Exception {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
@@ -59,6 +59,8 @@ class TestBufferPool {
     // As the pool is full, allocation will need to wait until a buffer is released.
     assertFull(pool);
 
+    assertEquals(buffers.size(), pool.getAllocatedBuffers().size());
+
     AtomicReference<ChunkBuffer> allocated = new AtomicReference<>();
     AtomicBoolean allocatorStarted = new AtomicBoolean();
     Thread allocator = new Thread(() -> {
@@ -81,9 +83,9 @@ class TestBufferPool {
         throw new RuntimeException(e);
       }
     }
-
     releaser.start();
     allocator.join();
+    assertEquals(buffers.size() + 1, pool.getAllocatedBuffers().size());
     assertEquals(toRelease, allocated.get());
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -44,7 +44,7 @@ public final class IOUtils {
    * Close the Closeable objects and <b>ignore</b> any {@link Throwable} or
    * null pointers. Must only be used for cleanup in exception handlers.
    *
-   * @param logger     the log to record problems to at debug level. Can be
+   * @param logger     the log to record problems to at warn level. Can be
    *                   null.
    * @param closeables the objects to close
    */
@@ -58,7 +58,7 @@ public final class IOUtils {
           c.close();
         } catch (Throwable e) {
           if (logger != null) {
-            logger.debug("Exception in closing {}", c, e);
+            logger.warn("Exception in closing {}", c, e);
           }
         }
       }


### PR DESCRIPTION
Remove excessive debug logging in BlockOutputStream and BufferPool

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15486

## How was this patch tested?

Added benchmark that simulates the write to the output stream from the client using mock for RPCs. Run it with changes and without changes, the benchmark shows 4% throughput improvement (18,505.3 MB/s vs 17,774.9 MB/s).

Baseline results:
```
mvn -pl hadoop-hdds/client -q clean test-compile exec:java \
  -Dexec.mainClass=org.apache.hadoop.hdds.scm.storage.BlockOutputStreamWriteBenchmark \
  -Dexec.classpathScope=test \
  -Dbenchmark.label=pre-fix
Log level: INFO for BufferPool and BlockOutputStream
JVM: 17 on aarch64
Write=4KB sourceBuffer=4MB streamBuffer=4MB poolCapacity=8 writes/stream=1024

OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
warmup complete (10.00s)
benchmark complete (20.00s)
elapsed: 20.00s
bytes written: 372,768,309,248
write ops (4KB): 91,007,888
blocks written: 88,875
throughput: 17,774.9 MB/s
ns/write: 220
writeChunks metric: 88,874
flushes metric: 0
```

After the fix:
```
mvn -pl hadoop-hdds/client -q clean test-compile exec:java \
  -Dexec.mainClass=org.apache.hadoop.hdds.scm.storage.BlockOutputStreamWriteBenchmark \
  -Dexec.classpathScope=test \
  -Dbenchmark.label=current
JVM: 17 on aarch64
Write=4KB sourceBuffer=4MB streamBuffer=4MB poolCapacity=8 writes/stream=1024

OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
warmup complete (10.00s)
benchmark complete (20.00s)
elapsed: 20.00s
bytes written: 388,086,366,208
write ops (4KB): 94,747,648
blocks written: 92,527
throughput: 18,505.3 MB/s
ns/write: 211
writeChunks metric: 92,527
flushes metric: 0
```

