### PR TITLE
HDDS-14818. Recon: Add AI Assistant chat UI for natural-language cluster queries.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -117,7 +117,6 @@ public class OzoneManagerServiceProviderImpl
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerServiceProviderImpl.class);
   private URLConnectionFactory connectionFactory;
-  private final AtomicBoolean reInitializeTasksCalled = new AtomicBoolean(false);
 
   private File omSnapshotDBParentDir = null;
   private File reconDbDir = null;
@@ -712,152 +711,145 @@ public class OzoneManagerServiceProviderImpl
       try {
         long currentSequenceNumber = getCurrentOMDBSequenceNumber();
         LOG.info("Seq number of Recon's OM DB : {}", currentSequenceNumber);
-        boolean fullSnapshot = true;
+        boolean fullSnapshot = false;
 
-        if (reInitializeTasksCalled.compareAndSet(false, true)) {
-          LOG.info("Calling reprocess on Recon tasks.");
-          reconTaskController.reInitializeTasks(omMetadataManager,null);
+        if (currentSequenceNumber <= 0) {
+          fullSnapshot = true;
         } else {
-          LOG.info("reInitializeTasks already called once; skipping.");
+          // Get updates from OM and apply to local Recon OM DB and update task status in table
+          deltaReconTaskStatusUpdater.recordRunStart();
+          int loopCount = 0;
+          long fromSequenceNumber = currentSequenceNumber;
+          long diffBetweenOMDbAndReconDBSeqNumber = deltaUpdateLimit + 1;
+          /**
+           * This loop will continue to fetch and apply OM DB updates and with every
+           * OM DB fetch request, it will fetch {@code deltaUpdateLimit} count of DB updates.
+           * It continues to fetch from OM till the lag, between OM DB WAL sequence number
+           * and Recon OM DB snapshot WAL sequence number, is less than this lag threshold value.
+           * In high OM write TPS cluster, this simulates continuous pull from OM without any delay.
+           */
+          while (diffBetweenOMDbAndReconDBSeqNumber > omDBLagThreshold) {
+            try (OMDBUpdatesHandler omdbUpdatesHandler =
+                     new OMDBUpdatesHandler(omMetadataManager)) {
+
+              // If interrupt was previously signalled,
+              // we should check for it before starting delta update sync.
+              if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread interrupted during delta update.");
+              }
+              diffBetweenOMDbAndReconDBSeqNumber =
+                  getAndApplyDeltaUpdatesFromOM(currentSequenceNumber, omdbUpdatesHandler);
+              deltaReconTaskStatusUpdater.setLastTaskRunStatus(0);
+              // Keeping last updated sequence number for both full and delta tasks to be same
+              // because sequence number of DB denotes and points to same OM DB copy of Recon,
+              // even though two different tasks are updating the DB at different conditions, but
+              // it tells the sync state with actual OM DB for the same Recon OM DB copy.
+              deltaReconTaskStatusUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
+              fullSnapshotReconTaskUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
+              deltaReconTaskStatusUpdater.recordRunCompletion();
+              fullSnapshotReconTaskUpdater.updateDetails();
+              // Update the current OM metadata manager in task controller
+              reconTaskController.updateOMMetadataManager(omMetadataManager);
+
+              // Pass on DB update events to tasks that are listening.
+              reconTaskController.consumeOMEvents(new OMUpdateEventBatch(
+                  omdbUpdatesHandler.getEvents(), omdbUpdatesHandler.getLatestSequenceNumber()), omMetadataManager);
+
+              // Check if task reinitialization is needed due to buffer overflow or task failures
+              boolean bufferOverflowed = reconTaskController.hasEventBufferOverflowed();
+              boolean tasksFailed = reconTaskController.hasTasksFailed();
+
+              if (bufferOverflowed || tasksFailed) {
+                ReconTaskReInitializationEvent.ReInitializationReason reason = bufferOverflowed ?
+                    ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW :
+                    ReconTaskReInitializationEvent.ReInitializationReason.TASK_FAILURES;
+
+                LOG.warn("Detected condition for task reinitialization: {}, queueing async reinitialization event",
+                    reason);
+
+                markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
+
+                // Queue async reinitialization event - checkpoint creation and retry logic is handled internally
+                ReconTaskController.ReInitializationResult result =
+                    reconTaskController.queueReInitializationEvent(reason);
+
+                //TODO: Create a metric to track this event buffer overflow or task failure event
+                boolean triggerFullSnapshot =
+                    Optional.ofNullable(result)
+                        .map(r -> {
+                          switch (r) {
+                          case MAX_RETRIES_EXCEEDED:
+                            LOG.warn(
+                                "Reinitialization queue failures exceeded maximum retries, triggering full snapshot " +
+                                    "fallback");
+                            return true;
+
+                          case RETRY_LATER:
+                            LOG.debug("Reinitialization event queueing will be retried in next iteration");
+                            return false;
+
+                          default:
+                            LOG.info("Reinitialization event successfully queued");
+                            return false;
+                          }
+                        })
+                        .orElseGet(() -> {
+                          LOG.error(
+                              "ReInitializationResult is null, something went wrong in queueing reinitialization " +
+                                  "event");
+                          return true;
+                        });
+
+                if (triggerFullSnapshot) {
+                  fullSnapshot = true;
+                }
+              }
+              currentSequenceNumber = getCurrentOMDBSequenceNumber();
+              LOG.debug("Updated current sequence number: {}", currentSequenceNumber);
+              loopCount++;
+            } catch (InterruptedException intEx) {
+              LOG.error("OM DB Delta update sync thread was interrupted and delta sync failed.");
+              // We are updating the table even if it didn't run i.e. got interrupted beforehand
+              // to indicate that a task was supposed to run, but it didn't.
+              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
+              Thread.currentThread().interrupt();
+              // Since thread is interrupted, we do not fall back to snapshot sync.
+              // Return with sync failed status.
+              return false;
+            } catch (Exception e) {
+              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
+              LOG.warn("Unable to get and apply delta updates from OM: {}, falling back to full snapshot",
+                  e.getMessage());
+              fullSnapshot = true;
+            }
+            if (fullSnapshot) {
+              break;
+            }
+          }
+          LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
+              getCurrentOMDBSequenceNumber() - fromSequenceNumber);
         }
 
-//        if (currentSequenceNumber <= 0) {
-//          fullSnapshot = true;
-//        } else {
-//          // Get updates from OM and apply to local Recon OM DB and update task status in table
-//          deltaReconTaskStatusUpdater.recordRunStart();
-//          int loopCount = 0;
-//          long fromSequenceNumber = currentSequenceNumber;
-//          long diffBetweenOMDbAndReconDBSeqNumber = deltaUpdateLimit + 1;
-//          /**
-//           * This loop will continue to fetch and apply OM DB updates and with every
-//           * OM DB fetch request, it will fetch {@code deltaUpdateLimit} count of DB updates.
-//           * It continues to fetch from OM till the lag, between OM DB WAL sequence number
-//           * and Recon OM DB snapshot WAL sequence number, is less than this lag threshold value.
-//           * In high OM write TPS cluster, this simulates continuous pull from OM without any delay.
-//           */
-//          while (diffBetweenOMDbAndReconDBSeqNumber > omDBLagThreshold) {
-//            try (OMDBUpdatesHandler omdbUpdatesHandler =
-//                     new OMDBUpdatesHandler(omMetadataManager)) {
-//
-//              // If interrupt was previously signalled,
-//              // we should check for it before starting delta update sync.
-//              if (Thread.currentThread().isInterrupted()) {
-//                throw new InterruptedException("Thread interrupted during delta update.");
-//              }
-//              diffBetweenOMDbAndReconDBSeqNumber =
-//                  getAndApplyDeltaUpdatesFromOM(currentSequenceNumber, omdbUpdatesHandler);
-//              deltaReconTaskStatusUpdater.setLastTaskRunStatus(0);
-//              // Keeping last updated sequence number for both full and delta tasks to be same
-//              // because sequence number of DB denotes and points to same OM DB copy of Recon,
-//              // even though two different tasks are updating the DB at different conditions, but
-//              // it tells the sync state with actual OM DB for the same Recon OM DB copy.
-//              deltaReconTaskStatusUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
-//              fullSnapshotReconTaskUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
-//              deltaReconTaskStatusUpdater.recordRunCompletion();
-//              fullSnapshotReconTaskUpdater.updateDetails();
-//              // Update the current OM metadata manager in task controller
-//              reconTaskController.updateOMMetadataManager(omMetadataManager);
-//
-//              // Pass on DB update events to tasks that are listening.
-//              reconTaskController.consumeOMEvents(new OMUpdateEventBatch(
-//                  omdbUpdatesHandler.getEvents(), omdbUpdatesHandler.getLatestSequenceNumber()), omMetadataManager);
-//
-//              // Check if task reinitialization is needed due to buffer overflow or task failures
-//              boolean bufferOverflowed = reconTaskController.hasEventBufferOverflowed();
-//              boolean tasksFailed = reconTaskController.hasTasksFailed();
-//
-//              if (bufferOverflowed || tasksFailed) {
-//                ReconTaskReInitializationEvent.ReInitializationReason reason = bufferOverflowed ?
-//                    ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW :
-//                    ReconTaskReInitializationEvent.ReInitializationReason.TASK_FAILURES;
-//
-//                LOG.warn("Detected condition for task reinitialization: {}, queueing async reinitialization event",
-//                    reason);
-//
-//                markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
-//
-//                // Queue async reinitialization event - checkpoint creation and retry logic is handled internally
-//                ReconTaskController.ReInitializationResult result =
-//                    reconTaskController.queueReInitializationEvent(reason);
-//
-//                //TODO: Create a metric to track this event buffer overflow or task failure event
-//                boolean triggerFullSnapshot =
-//                    Optional.ofNullable(result)
-//                        .map(r -> {
-//                          switch (r) {
-//                          case MAX_RETRIES_EXCEEDED:
-//                            LOG.warn(
-//                                "Reinitialization queue failures exceeded maximum retries, triggering full snapshot " +
-//                                    "fallback");
-//                            return true;
-//
-//                          case RETRY_LATER:
-//                            LOG.debug("Reinitialization event queueing will be retried in next iteration");
-//                            return false;
-//
-//                          default:
-//                            LOG.info("Reinitialization event successfully queued");
-//                            return false;
-//                          }
-//                        })
-//                        .orElseGet(() -> {
-//                          LOG.error(
-//                              "ReInitializationResult is null, something went wrong in queueing reinitialization " +
-//                                  "event");
-//                          return true;
-//                        });
-//
-//                if (triggerFullSnapshot) {
-//                  fullSnapshot = true;
-//                }
-//              }
-//              currentSequenceNumber = getCurrentOMDBSequenceNumber();
-//              LOG.debug("Updated current sequence number: {}", currentSequenceNumber);
-//              loopCount++;
-//            } catch (InterruptedException intEx) {
-//              LOG.error("OM DB Delta update sync thread was interrupted and delta sync failed.");
-//              // We are updating the table even if it didn't run i.e. got interrupted beforehand
-//              // to indicate that a task was supposed to run, but it didn't.
-//              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
-//              Thread.currentThread().interrupt();
-//              // Since thread is interrupted, we do not fall back to snapshot sync.
-//              // Return with sync failed status.
-//              return false;
-//            } catch (Exception e) {
-//              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
-//              LOG.warn("Unable to get and apply delta updates from OM: {}, falling back to full snapshot",
-//                  e.getMessage());
-//              fullSnapshot = true;
-//            }
-//            if (fullSnapshot) {
-//              break;
-//            }
-//          }
-//          LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
-//              getCurrentOMDBSequenceNumber() - fromSequenceNumber);
-//        }
-
-//        if (fullSnapshot) {
-//          try {
-//            executeFullSnapshot(fullSnapshotReconTaskUpdater, deltaReconTaskStatusUpdater);
-//          } catch (InterruptedException intEx) {
-//            LOG.error("OM DB Snapshot update sync thread was interrupted.");
-//            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
-//            fullSnapshotReconTaskUpdater.recordRunCompletion();
-//            Thread.currentThread().interrupt();
-//            // Mark sync status as failed.
-//            return false;
-//          } catch (Exception e) {
-//            metrics.incrNumSnapshotRequestsFailed();
-//            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
-//            fullSnapshotReconTaskUpdater.recordRunCompletion();
-//            LOG.error("Unable to update Recon's metadata with new OM DB. ", e);
-//            // Update health status in ReconContext
-//            reconContext.updateHealthStatus(new AtomicBoolean(false));
-//            reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
-//          }
-//        }
+        if (fullSnapshot) {
+          try {
+            executeFullSnapshot(fullSnapshotReconTaskUpdater, deltaReconTaskStatusUpdater);
+          } catch (InterruptedException intEx) {
+            LOG.error("OM DB Snapshot update sync thread was interrupted.");
+            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
+            fullSnapshotReconTaskUpdater.recordRunCompletion();
+            Thread.currentThread().interrupt();
+            // Mark sync status as failed.
+            return false;
+          } catch (Exception e) {
+            metrics.incrNumSnapshotRequestsFailed();
+            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
+            fullSnapshotReconTaskUpdater.recordRunCompletion();
+            LOG.error("Unable to update Recon's metadata with new OM DB. ", e);
+            // Update health status in ReconContext
+            reconContext.updateHealthStatus(new AtomicBoolean(false));
+            reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+          }
+        }
         printOMDBMetaInfo();
       } finally {
         isSyncDataFromOMRunning.set(false);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -117,6 +117,7 @@ public class OzoneManagerServiceProviderImpl
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerServiceProviderImpl.class);
   private URLConnectionFactory connectionFactory;
+  private final AtomicBoolean reInitializeTasksCalled = new AtomicBoolean(false);
 
   private File omSnapshotDBParentDir = null;
   private File reconDbDir = null;
@@ -711,145 +712,152 @@ public class OzoneManagerServiceProviderImpl
       try {
         long currentSequenceNumber = getCurrentOMDBSequenceNumber();
         LOG.info("Seq number of Recon's OM DB : {}", currentSequenceNumber);
-        boolean fullSnapshot = false;
+        boolean fullSnapshot = true;
 
-        if (currentSequenceNumber <= 0) {
-          fullSnapshot = true;
+        if (reInitializeTasksCalled.compareAndSet(false, true)) {
+          LOG.info("Calling reprocess on Recon tasks.");
+          reconTaskController.reInitializeTasks(omMetadataManager,null);
         } else {
-          // Get updates from OM and apply to local Recon OM DB and update task status in table
-          deltaReconTaskStatusUpdater.recordRunStart();
-          int loopCount = 0;
-          long fromSequenceNumber = currentSequenceNumber;
-          long diffBetweenOMDbAndReconDBSeqNumber = deltaUpdateLimit + 1;
-          /**
-           * This loop will continue to fetch and apply OM DB updates and with every
-           * OM DB fetch request, it will fetch {@code deltaUpdateLimit} count of DB updates.
-           * It continues to fetch from OM till the lag, between OM DB WAL sequence number
-           * and Recon OM DB snapshot WAL sequence number, is less than this lag threshold value.
-           * In high OM write TPS cluster, this simulates continuous pull from OM without any delay.
-           */
-          while (diffBetweenOMDbAndReconDBSeqNumber > omDBLagThreshold) {
-            try (OMDBUpdatesHandler omdbUpdatesHandler =
-                     new OMDBUpdatesHandler(omMetadataManager)) {
-
-              // If interrupt was previously signalled,
-              // we should check for it before starting delta update sync.
-              if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread interrupted during delta update.");
-              }
-              diffBetweenOMDbAndReconDBSeqNumber =
-                  getAndApplyDeltaUpdatesFromOM(currentSequenceNumber, omdbUpdatesHandler);
-              deltaReconTaskStatusUpdater.setLastTaskRunStatus(0);
-              // Keeping last updated sequence number for both full and delta tasks to be same
-              // because sequence number of DB denotes and points to same OM DB copy of Recon,
-              // even though two different tasks are updating the DB at different conditions, but
-              // it tells the sync state with actual OM DB for the same Recon OM DB copy.
-              deltaReconTaskStatusUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
-              fullSnapshotReconTaskUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
-              deltaReconTaskStatusUpdater.recordRunCompletion();
-              fullSnapshotReconTaskUpdater.updateDetails();
-              // Update the current OM metadata manager in task controller
-              reconTaskController.updateOMMetadataManager(omMetadataManager);
-
-              // Pass on DB update events to tasks that are listening.
-              reconTaskController.consumeOMEvents(new OMUpdateEventBatch(
-                  omdbUpdatesHandler.getEvents(), omdbUpdatesHandler.getLatestSequenceNumber()), omMetadataManager);
-
-              // Check if task reinitialization is needed due to buffer overflow or task failures
-              boolean bufferOverflowed = reconTaskController.hasEventBufferOverflowed();
-              boolean tasksFailed = reconTaskController.hasTasksFailed();
-
-              if (bufferOverflowed || tasksFailed) {
-                ReconTaskReInitializationEvent.ReInitializationReason reason = bufferOverflowed ?
-                    ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW :
-                    ReconTaskReInitializationEvent.ReInitializationReason.TASK_FAILURES;
-
-                LOG.warn("Detected condition for task reinitialization: {}, queueing async reinitialization event",
-                    reason);
-
-                markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
-
-                // Queue async reinitialization event - checkpoint creation and retry logic is handled internally
-                ReconTaskController.ReInitializationResult result =
-                    reconTaskController.queueReInitializationEvent(reason);
-
-                //TODO: Create a metric to track this event buffer overflow or task failure event
-                boolean triggerFullSnapshot =
-                    Optional.ofNullable(result)
-                        .map(r -> {
-                          switch (r) {
-                          case MAX_RETRIES_EXCEEDED:
-                            LOG.warn(
-                                "Reinitialization queue failures exceeded maximum retries, triggering full snapshot " +
-                                    "fallback");
-                            return true;
-
-                          case RETRY_LATER:
-                            LOG.debug("Reinitialization event queueing will be retried in next iteration");
-                            return false;
-
-                          default:
-                            LOG.info("Reinitialization event successfully queued");
-                            return false;
-                          }
-                        })
-                        .orElseGet(() -> {
-                          LOG.error(
-                              "ReInitializationResult is null, something went wrong in queueing reinitialization " +
-                                  "event");
-                          return true;
-                        });
-
-                if (triggerFullSnapshot) {
-                  fullSnapshot = true;
-                }
-              }
-              currentSequenceNumber = getCurrentOMDBSequenceNumber();
-              LOG.debug("Updated current sequence number: {}", currentSequenceNumber);
-              loopCount++;
-            } catch (InterruptedException intEx) {
-              LOG.error("OM DB Delta update sync thread was interrupted and delta sync failed.");
-              // We are updating the table even if it didn't run i.e. got interrupted beforehand
-              // to indicate that a task was supposed to run, but it didn't.
-              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
-              Thread.currentThread().interrupt();
-              // Since thread is interrupted, we do not fall back to snapshot sync.
-              // Return with sync failed status.
-              return false;
-            } catch (Exception e) {
-              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
-              LOG.warn("Unable to get and apply delta updates from OM: {}, falling back to full snapshot",
-                  e.getMessage());
-              fullSnapshot = true;
-            }
-            if (fullSnapshot) {
-              break;
-            }
-          }
-          LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
-              getCurrentOMDBSequenceNumber() - fromSequenceNumber);
+          LOG.info("reInitializeTasks already called once; skipping.");
         }
 
-        if (fullSnapshot) {
-          try {
-            executeFullSnapshot(fullSnapshotReconTaskUpdater, deltaReconTaskStatusUpdater);
-          } catch (InterruptedException intEx) {
-            LOG.error("OM DB Snapshot update sync thread was interrupted.");
-            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
-            fullSnapshotReconTaskUpdater.recordRunCompletion();
-            Thread.currentThread().interrupt();
-            // Mark sync status as failed.
-            return false;
-          } catch (Exception e) {
-            metrics.incrNumSnapshotRequestsFailed();
-            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
-            fullSnapshotReconTaskUpdater.recordRunCompletion();
-            LOG.error("Unable to update Recon's metadata with new OM DB. ", e);
-            // Update health status in ReconContext
-            reconContext.updateHealthStatus(new AtomicBoolean(false));
-            reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
-          }
-        }
+//        if (currentSequenceNumber <= 0) {
+//          fullSnapshot = true;
+//        } else {
+//          // Get updates from OM and apply to local Recon OM DB and update task status in table
+//          deltaReconTaskStatusUpdater.recordRunStart();
+//          int loopCount = 0;
+//          long fromSequenceNumber = currentSequenceNumber;
+//          long diffBetweenOMDbAndReconDBSeqNumber = deltaUpdateLimit + 1;
+//          /**
+//           * This loop will continue to fetch and apply OM DB updates and with every
+//           * OM DB fetch request, it will fetch {@code deltaUpdateLimit} count of DB updates.
+//           * It continues to fetch from OM till the lag, between OM DB WAL sequence number
+//           * and Recon OM DB snapshot WAL sequence number, is less than this lag threshold value.
+//           * In high OM write TPS cluster, this simulates continuous pull from OM without any delay.
+//           */
+//          while (diffBetweenOMDbAndReconDBSeqNumber > omDBLagThreshold) {
+//            try (OMDBUpdatesHandler omdbUpdatesHandler =
+//                     new OMDBUpdatesHandler(omMetadataManager)) {
+//
+//              // If interrupt was previously signalled,
+//              // we should check for it before starting delta update sync.
+//              if (Thread.currentThread().isInterrupted()) {
+//                throw new InterruptedException("Thread interrupted during delta update.");
+//              }
+//              diffBetweenOMDbAndReconDBSeqNumber =
+//                  getAndApplyDeltaUpdatesFromOM(currentSequenceNumber, omdbUpdatesHandler);
+//              deltaReconTaskStatusUpdater.setLastTaskRunStatus(0);
+//              // Keeping last updated sequence number for both full and delta tasks to be same
+//              // because sequence number of DB denotes and points to same OM DB copy of Recon,
+//              // even though two different tasks are updating the DB at different conditions, but
+//              // it tells the sync state with actual OM DB for the same Recon OM DB copy.
+//              deltaReconTaskStatusUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
+//              fullSnapshotReconTaskUpdater.setLastUpdatedSeqNumber(getCurrentOMDBSequenceNumber());
+//              deltaReconTaskStatusUpdater.recordRunCompletion();
+//              fullSnapshotReconTaskUpdater.updateDetails();
+//              // Update the current OM metadata manager in task controller
+//              reconTaskController.updateOMMetadataManager(omMetadataManager);
+//
+//              // Pass on DB update events to tasks that are listening.
+//              reconTaskController.consumeOMEvents(new OMUpdateEventBatch(
+//                  omdbUpdatesHandler.getEvents(), omdbUpdatesHandler.getLatestSequenceNumber()), omMetadataManager);
+//
+//              // Check if task reinitialization is needed due to buffer overflow or task failures
+//              boolean bufferOverflowed = reconTaskController.hasEventBufferOverflowed();
+//              boolean tasksFailed = reconTaskController.hasTasksFailed();
+//
+//              if (bufferOverflowed || tasksFailed) {
+//                ReconTaskReInitializationEvent.ReInitializationReason reason = bufferOverflowed ?
+//                    ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW :
+//                    ReconTaskReInitializationEvent.ReInitializationReason.TASK_FAILURES;
+//
+//                LOG.warn("Detected condition for task reinitialization: {}, queueing async reinitialization event",
+//                    reason);
+//
+//                markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
+//
+//                // Queue async reinitialization event - checkpoint creation and retry logic is handled internally
+//                ReconTaskController.ReInitializationResult result =
+//                    reconTaskController.queueReInitializationEvent(reason);
+//
+//                //TODO: Create a metric to track this event buffer overflow or task failure event
+//                boolean triggerFullSnapshot =
+//                    Optional.ofNullable(result)
+//                        .map(r -> {
+//                          switch (r) {
+//                          case MAX_RETRIES_EXCEEDED:
+//                            LOG.warn(
+//                                "Reinitialization queue failures exceeded maximum retries, triggering full snapshot " +
+//                                    "fallback");
+//                            return true;
+//
+//                          case RETRY_LATER:
+//                            LOG.debug("Reinitialization event queueing will be retried in next iteration");
+//                            return false;
+//
+//                          default:
+//                            LOG.info("Reinitialization event successfully queued");
+//                            return false;
+//                          }
+//                        })
+//                        .orElseGet(() -> {
+//                          LOG.error(
+//                              "ReInitializationResult is null, something went wrong in queueing reinitialization " +
+//                                  "event");
+//                          return true;
+//                        });
+//
+//                if (triggerFullSnapshot) {
+//                  fullSnapshot = true;
+//                }
+//              }
+//              currentSequenceNumber = getCurrentOMDBSequenceNumber();
+//              LOG.debug("Updated current sequence number: {}", currentSequenceNumber);
+//              loopCount++;
+//            } catch (InterruptedException intEx) {
+//              LOG.error("OM DB Delta update sync thread was interrupted and delta sync failed.");
+//              // We are updating the table even if it didn't run i.e. got interrupted beforehand
+//              // to indicate that a task was supposed to run, but it didn't.
+//              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
+//              Thread.currentThread().interrupt();
+//              // Since thread is interrupted, we do not fall back to snapshot sync.
+//              // Return with sync failed status.
+//              return false;
+//            } catch (Exception e) {
+//              markDeltaTaskStatusAsFailed(deltaReconTaskStatusUpdater);
+//              LOG.warn("Unable to get and apply delta updates from OM: {}, falling back to full snapshot",
+//                  e.getMessage());
+//              fullSnapshot = true;
+//            }
+//            if (fullSnapshot) {
+//              break;
+//            }
+//          }
+//          LOG.info("Delta updates received from OM : {} loops, {} records", loopCount,
+//              getCurrentOMDBSequenceNumber() - fromSequenceNumber);
+//        }
+
+//        if (fullSnapshot) {
+//          try {
+//            executeFullSnapshot(fullSnapshotReconTaskUpdater, deltaReconTaskStatusUpdater);
+//          } catch (InterruptedException intEx) {
+//            LOG.error("OM DB Snapshot update sync thread was interrupted.");
+//            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
+//            fullSnapshotReconTaskUpdater.recordRunCompletion();
+//            Thread.currentThread().interrupt();
+//            // Mark sync status as failed.
+//            return false;
+//          } catch (Exception e) {
+//            metrics.incrNumSnapshotRequestsFailed();
+//            fullSnapshotReconTaskUpdater.setLastTaskRunStatus(-1);
+//            fullSnapshotReconTaskUpdater.recordRunCompletion();
+//            LOG.error("Unable to update Recon's metadata with new OM DB. ", e);
+//            // Update health status in ReconContext
+//            reconContext.updateHealthStatus(new AtomicBoolean(false));
+//            reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+//          }
+//        }
         printOMDBMetaInfo();
       } finally {
         isSyncDataFromOMRunning.set(false);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/.gitignore
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/.gitignore
@@ -21,3 +21,9 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Playwright
+e2e/screenshots/
+test-results/
+playwright-report/
+blob-report/

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/e2e/chatbot-errors.spec.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/e2e/chatbot-errors.spec.ts
@@ -159,7 +159,8 @@ test.describe('Recon AI Error Handling Scenarios', () => {
     await page.fill('textarea', 'Hello');
     await page.keyboard.press('Enter');
     
-    await expect(page.locator('text=An error occurred processing your request.')).toBeVisible();
+    await expect(page.locator('text=An error occurred while processing your request')).toBeVisible();
+    await expect(page.locator('text=For more details, check the Recon server logs.')).toBeVisible();
     await page.screenshot({ path: 'e2e/screenshots/chat-500-internal.png' });
   });
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/e2e/chatbot-errors.spec.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/e2e/chatbot-errors.spec.ts
@@ -1,0 +1,251 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Recon AI Error Handling Scenarios', () => {
+  
+  test('health-disabled', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({
+        status: 200,
+        json: { enabled: false, llmClientAvailable: true }
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Recon AI is Disabled')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/health-disabled.png' });
+  });
+
+  test('health-not-configured', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({
+        status: 200,
+        json: { enabled: true, llmClientAvailable: false }
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Recon AI is Not Configured')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/health-not-configured.png' });
+  });
+
+  test('empty-state', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/empty-state.png' });
+  });
+
+  test('chat-loading', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      // Delay the response to capture the loading state
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await route.fulfill({ status: 200, json: { response: 'Done', success: true } });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Hello');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('.loading-bubble')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-loading.png' });
+  });
+
+  test('chat-success', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      await route.fulfill({ 
+        status: 200, 
+        json: { 
+          response: 'This is a **Markdown** response with a table:\n\n| Col 1 | Col 2 |\n|---|---|\n| A | B |', 
+          success: true 
+        } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Show me a table');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('table')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-success.png' });
+  });
+
+  test('chat-503-busy', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      await route.fulfill({ 
+        status: 503, 
+        json: { error: 'The chatbot is currently handling too many requests. Please try again in a moment.' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Hello');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('text=The chatbot is currently handling too many requests. Please try again in a moment.')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-503-busy.png' });
+  });
+
+  test('chat-504-timeout', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      await route.fulfill({ 
+        status: 504, 
+        json: { error: 'The chatbot request timed out. The LLM or Recon API took too long to respond. Please try again or use a different model.' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Hello');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('text=The chatbot request timed out. The LLM or Recon API took too long to respond. Please try again or use a different model.')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-504-timeout.png' });
+  });
+
+  test('chat-500-internal', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      await route.fulfill({ 
+        status: 500, 
+        json: { error: 'An error occurred processing your request.' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Hello');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('text=An error occurred processing your request.')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-500-internal.png' });
+  });
+
+  test('chat-503-interrupted', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      await route.fulfill({ 
+        status: 503, 
+        json: { error: 'Request was interrupted. Please try again.' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Hello');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('text=Request was interrupted. Please try again.')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-503-interrupted.png' });
+  });
+
+  test('chat-503-disabled', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ status: 200, json: { models: ['gemini-2.5-flash'] } });
+    });
+    await page.route('**/api/v1/chatbot/chat', async route => {
+      await route.fulfill({ 
+        status: 503, 
+        json: { error: 'Chatbot service is not enabled' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    await page.fill('textarea', 'Hello');
+    await page.keyboard.press('Enter');
+    
+    await expect(page.locator('text=Chatbot service is not enabled')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/chat-503-disabled.png' });
+  });
+
+  test('models-500', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ 
+        status: 500, 
+        json: { error: 'Failed to fetch models' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    // Check that we can still use the chat with default provider
+    await expect(page.locator('text=Default Provider')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/models-500.png' });
+  });
+
+  test('models-503', async ({ page }) => {
+    await page.route('**/api/v1/chatbot/health', async route => {
+      await route.fulfill({ status: 200, json: { enabled: true, llmClientAvailable: true } });
+    });
+    await page.route('**/api/v1/chatbot/models', async route => {
+      await route.fulfill({ 
+        status: 503, 
+        json: { error: 'Chatbot service is not enabled' } 
+      });
+    });
+    
+    await page.goto('/#/Assistant');
+    await expect(page.locator('text=Welcome to Recon AI')).toBeVisible();
+    
+    // Check that we can still use the chat with default provider
+    await expect(page.locator('text=Default Provider')).toBeVisible();
+    await page.screenshot({ path: 'e2e/screenshots/models-503.png' });
+  });
+});

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/e2e/chatbot-errors.spec.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/e2e/chatbot-errors.spec.ts
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { test, expect } from '@playwright/test';
 
 test.describe('Recon AI Error Handling Scenarios', () => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
@@ -25,9 +25,11 @@
     "pretty-ms": "^5.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.14.0",
+    "react-markdown": "^8.0.7",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4",
     "react-select": "^3.2.0",
+    "remark-gfm": "^3.0.1",
     "typescript": "4.9.5"
   },
   "scripts": {
@@ -35,6 +37,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "test": "vitest",
+    "e2e": "playwright test",
     "mock:api": "json-server --watch api/db.json --routes api/routes.json --middlewares api/pagination.js --port 9888",
     "dev": "npm-run-all --parallel mock:api start",
     "lint": "eslint src/*",
@@ -56,6 +59,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.5.2",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/playwright.config.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/playwright.config.ts
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/playwright.config.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: ^16.14.0
         version: 16.14.0(react@16.14.0)
+      react-markdown:
+        specifier: ^8.0.7
+        version: 8.0.7(@types/react@16.8.15)(react@16.14.0)
       react-router:
         specifier: ^5.3.4
         version: 5.3.4(react@16.14.0)
@@ -59,10 +62,16 @@ importers:
       react-select:
         specifier: ^3.2.0
         version: 3.2.0(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      remark-gfm:
+        specifier: ^3.0.1
+        version: 3.0.1
       typescript:
         specifier: 4.9.5
         version: 4.9.5
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@testing-library/jest-dom':
         specifier: ^6.4.8
         version: 6.9.1
@@ -651,6 +660,11 @@ packages:
   '@open-draft/until@1.0.3':
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -921,6 +935,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@2.3.10':
+    resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
+
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
 
@@ -935,6 +952,9 @@ packages:
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/mdast@3.0.15':
+    resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -976,6 +996,9 @@ packages:
 
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -1355,6 +1378,9 @@ packages:
   babel-plugin-syntax-jsx@6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1432,6 +1458,9 @@ packages:
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
@@ -1443,6 +1472,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -1506,6 +1538,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1669,6 +1704,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
@@ -1710,6 +1748,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -1717,6 +1759,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1857,6 +1903,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-prettier@8.10.2:
     resolution: {integrity: sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==}
@@ -2122,6 +2172,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2281,6 +2336,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-whitespace@2.0.1:
+    resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
+
   headers-polyfill@3.2.5:
     resolution: {integrity: sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==}
 
@@ -2374,6 +2432,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+
   inquirer@8.2.7:
     resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
     engines: {node: '>=12.0.0'}
@@ -2412,6 +2473,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -2498,6 +2563,10 @@ packages:
   is-path-inside@1.0.1:
     resolution: {integrity: sha512-qhsCR/Esx4U4hg/9I19OVUAJkGWtjRYHMRgUMZE2TDdj+Ag+kttZanLupfddNyglzz50cUlmWzUaI37GDfNx/g==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2673,6 +2742,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   latest-version@5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}
     engines: {node: '>=8'}
@@ -2718,6 +2791,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2758,9 +2834,51 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-definitions@5.1.2:
+    resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
+
+  mdast-util-find-and-replace@2.2.2:
+    resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
+
+  mdast-util-from-markdown@1.3.1:
+    resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
+
+  mdast-util-gfm-autolink-literal@1.0.3:
+    resolution: {integrity: sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==}
+
+  mdast-util-gfm-footnote@1.0.2:
+    resolution: {integrity: sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==}
+
+  mdast-util-gfm-strikethrough@1.0.3:
+    resolution: {integrity: sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==}
+
+  mdast-util-gfm-table@1.0.7:
+    resolution: {integrity: sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==}
+
+  mdast-util-gfm-task-list-item@1.0.2:
+    resolution: {integrity: sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==}
+
+  mdast-util-gfm@2.0.2:
+    resolution: {integrity: sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==}
+
+  mdast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==}
+
+  mdast-util-to-hast@12.3.0:
+    resolution: {integrity: sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==}
+
+  mdast-util-to-markdown@1.5.0:
+    resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
+
+  mdast-util-to-string@3.2.0:
+    resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -2790,6 +2908,90 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@1.1.0:
+    resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
+
+  micromark-extension-gfm-autolink-literal@1.0.5:
+    resolution: {integrity: sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==}
+
+  micromark-extension-gfm-footnote@1.1.2:
+    resolution: {integrity: sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==}
+
+  micromark-extension-gfm-strikethrough@1.0.7:
+    resolution: {integrity: sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==}
+
+  micromark-extension-gfm-table@1.0.7:
+    resolution: {integrity: sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==}
+
+  micromark-extension-gfm-tagfilter@1.0.2:
+    resolution: {integrity: sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==}
+
+  micromark-extension-gfm-task-list-item@1.0.5:
+    resolution: {integrity: sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==}
+
+  micromark-extension-gfm@2.0.3:
+    resolution: {integrity: sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==}
+
+  micromark-factory-destination@1.1.0:
+    resolution: {integrity: sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==}
+
+  micromark-factory-label@1.1.0:
+    resolution: {integrity: sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==}
+
+  micromark-factory-space@1.1.0:
+    resolution: {integrity: sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==}
+
+  micromark-factory-title@1.1.0:
+    resolution: {integrity: sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==}
+
+  micromark-factory-whitespace@1.1.0:
+    resolution: {integrity: sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==}
+
+  micromark-util-character@1.2.0:
+    resolution: {integrity: sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==}
+
+  micromark-util-chunked@1.1.0:
+    resolution: {integrity: sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==}
+
+  micromark-util-classify-character@1.1.0:
+    resolution: {integrity: sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==}
+
+  micromark-util-combine-extensions@1.1.0:
+    resolution: {integrity: sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==}
+
+  micromark-util-decode-numeric-character-reference@1.1.0:
+    resolution: {integrity: sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==}
+
+  micromark-util-decode-string@1.1.0:
+    resolution: {integrity: sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==}
+
+  micromark-util-encode@1.1.0:
+    resolution: {integrity: sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==}
+
+  micromark-util-html-tag-name@1.2.0:
+    resolution: {integrity: sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==}
+
+  micromark-util-normalize-identifier@1.1.0:
+    resolution: {integrity: sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==}
+
+  micromark-util-resolve-all@1.1.0:
+    resolution: {integrity: sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==}
+
+  micromark-util-sanitize-uri@1.2.0:
+    resolution: {integrity: sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==}
+
+  micromark-util-subtokenize@1.1.0:
+    resolution: {integrity: sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==}
+
+  micromark-util-symbol@1.1.0:
+    resolution: {integrity: sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==}
+
+  micromark-util-types@1.1.0:
+    resolution: {integrity: sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==}
+
+  micromark@3.2.0:
+    resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2849,6 +3051,10 @@ packages:
   morgan@1.10.1:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -3159,6 +3365,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
 
@@ -3209,6 +3425,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@6.5.0:
+    resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -3495,6 +3714,12 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-markdown@8.0.7:
+    resolution: {integrity: sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
     peerDependencies:
@@ -3559,6 +3784,15 @@ packages:
   registry-url@5.1.0:
     resolution: {integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==}
     engines: {node: '>=8'}
+
+  remark-gfm@3.0.1:
+    resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
+
+  remark-parse@10.0.2:
+    resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
+
+  remark-rehype@10.1.0:
+    resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
 
   request@2.88.2:
     resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
@@ -3643,6 +3877,10 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -3796,6 +4034,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -3922,6 +4163,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  style-to-object@0.4.4:
+    resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4014,6 +4258,12 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -4104,9 +4354,30 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  unified@10.1.2:
+    resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+
   unique-string@1.0.0:
     resolution: {integrity: sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg==}
     engines: {node: '>=4'}
+
+  unist-util-generated@2.0.1:
+    resolution: {integrity: sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==}
+
+  unist-util-is@5.2.1:
+    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
+
+  unist-util-position@4.0.4:
+    resolution: {integrity: sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==}
+
+  unist-util-stringify-position@3.0.3:
+    resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
+
+  unist-util-visit-parents@5.1.3:
+    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
+
+  unist-util-visit@4.1.2:
+    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -4148,6 +4419,11 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  uvu@0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   v8-compile-cache@2.4.0:
     resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
 
@@ -4164,6 +4440,12 @@ packages:
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
+
+  vfile-message@3.1.4:
+    resolution: {integrity: sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==}
+
+  vfile@5.3.7:
+    resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -4411,6 +4693,9 @@ packages:
 
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4844,6 +5129,10 @@ snapshots:
 
   '@open-draft/until@1.0.3': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -5030,6 +5319,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@2.3.10':
+    dependencies:
+      '@types/unist': 2.0.11
+
   '@types/history@4.7.11': {}
 
   '@types/js-levenshtein@1.1.3': {}
@@ -5041,6 +5334,10 @@ snapshots:
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 25.3.5
+
+  '@types/mdast@3.0.15':
+    dependencies:
+      '@types/unist': 2.0.11
 
   '@types/ms@2.1.0': {}
 
@@ -5091,6 +5388,8 @@ snapshots:
   '@types/set-cookie-parser@2.4.10':
     dependencies:
       '@types/node': 25.3.5
+
+  '@types/unist@2.0.11': {}
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)':
     dependencies:
@@ -5536,6 +5835,8 @@ snapshots:
 
   babel-plugin-syntax-jsx@6.18.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -5642,6 +5943,8 @@ snapshots:
 
   caseless@0.12.0: {}
 
+  ccount@2.0.1: {}
+
   chai@4.5.0:
     dependencies:
       assertion-error: 1.1.0
@@ -5662,6 +5965,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities@2.0.2: {}
 
   chardet@2.1.1: {}
 
@@ -5728,6 +6033,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
 
@@ -5887,6 +6194,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@3.3.0:
     dependencies:
       mimic-response: 1.0.1
@@ -5942,9 +6253,13 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
 
   diff-sequences@29.6.3: {}
+
+  diff@5.2.2: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -6252,6 +6567,8 @@ snapshots:
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-prettier@8.10.2(eslint@7.32.0):
     dependencies:
@@ -6608,6 +6925,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6776,6 +7096,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-whitespace@2.0.1: {}
+
   headers-polyfill@3.2.5: {}
 
   history@4.10.1:
@@ -6870,6 +7192,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.1.1: {}
+
   inquirer@8.2.7(@types/node@25.3.5):
     dependencies:
       '@inquirer/external-editor': 1.0.3(@types/node@25.3.5)
@@ -6931,6 +7255,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@2.0.5: {}
 
   is-bun-module@2.0.0:
     dependencies:
@@ -7006,6 +7332,8 @@ snapshots:
   is-path-inside@1.0.1:
     dependencies:
       path-is-inside: 1.0.2
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7205,6 +7533,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@4.1.5: {}
+
   latest-version@5.1.0:
     dependencies:
       package-json: 6.5.0
@@ -7259,6 +7589,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -7302,7 +7634,114 @@ snapshots:
       semver: 5.7.2
     optional: true
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-definitions@5.1.2:
+    dependencies:
+      '@types/mdast': 3.0.15
+      '@types/unist': 2.0.11
+      unist-util-visit: 4.1.2
+
+  mdast-util-find-and-replace@2.2.2:
+    dependencies:
+      '@types/mdast': 3.0.15
+      escape-string-regexp: 5.0.0
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
+
+  mdast-util-from-markdown@1.3.1:
+    dependencies:
+      '@types/mdast': 3.0.15
+      '@types/unist': 2.0.11
+      decode-named-character-reference: 1.3.0
+      mdast-util-to-string: 3.2.0
+      micromark: 3.2.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-decode-string: 1.1.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      unist-util-stringify-position: 3.0.3
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@1.0.3:
+    dependencies:
+      '@types/mdast': 3.0.15
+      ccount: 2.0.1
+      mdast-util-find-and-replace: 2.2.2
+      micromark-util-character: 1.2.0
+
+  mdast-util-gfm-footnote@1.0.2:
+    dependencies:
+      '@types/mdast': 3.0.15
+      mdast-util-to-markdown: 1.5.0
+      micromark-util-normalize-identifier: 1.1.0
+
+  mdast-util-gfm-strikethrough@1.0.3:
+    dependencies:
+      '@types/mdast': 3.0.15
+      mdast-util-to-markdown: 1.5.0
+
+  mdast-util-gfm-table@1.0.7:
+    dependencies:
+      '@types/mdast': 3.0.15
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 1.3.1
+      mdast-util-to-markdown: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@1.0.2:
+    dependencies:
+      '@types/mdast': 3.0.15
+      mdast-util-to-markdown: 1.5.0
+
+  mdast-util-gfm@2.0.2:
+    dependencies:
+      mdast-util-from-markdown: 1.3.1
+      mdast-util-gfm-autolink-literal: 1.0.3
+      mdast-util-gfm-footnote: 1.0.2
+      mdast-util-gfm-strikethrough: 1.0.3
+      mdast-util-gfm-table: 1.0.7
+      mdast-util-gfm-task-list-item: 1.0.2
+      mdast-util-to-markdown: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@3.0.1:
+    dependencies:
+      '@types/mdast': 3.0.15
+      unist-util-is: 5.2.1
+
+  mdast-util-to-hast@12.3.0:
+    dependencies:
+      '@types/hast': 2.3.10
+      '@types/mdast': 3.0.15
+      mdast-util-definitions: 5.1.2
+      micromark-util-sanitize-uri: 1.2.0
+      trim-lines: 3.0.1
+      unist-util-generated: 2.0.1
+      unist-util-position: 4.0.4
+      unist-util-visit: 4.1.2
+
+  mdast-util-to-markdown@1.5.0:
+    dependencies:
+      '@types/mdast': 3.0.15
+      '@types/unist': 2.0.11
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 3.0.1
+      mdast-util-to-string: 3.2.0
+      micromark-util-decode-string: 1.1.0
+      unist-util-visit: 4.1.2
+      zwitch: 2.0.4
+
+  mdast-util-to-string@3.2.0:
+    dependencies:
+      '@types/mdast': 3.0.15
 
   media-typer@0.3.0: {}
 
@@ -7326,6 +7765,197 @@ snapshots:
       - supports-color
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@1.1.0:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-factory-destination: 1.1.0
+      micromark-factory-label: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-factory-title: 1.1.0
+      micromark-factory-whitespace: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-chunked: 1.1.0
+      micromark-util-classify-character: 1.1.0
+      micromark-util-html-tag-name: 1.2.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-subtokenize: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-extension-gfm-autolink-literal@1.0.5:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-extension-gfm-footnote@1.1.2:
+    dependencies:
+      micromark-core-commonmark: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-extension-gfm-strikethrough@1.0.7:
+    dependencies:
+      micromark-util-chunked: 1.1.0
+      micromark-util-classify-character: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-extension-gfm-table@1.0.7:
+    dependencies:
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-extension-gfm-tagfilter@1.0.2:
+    dependencies:
+      micromark-util-types: 1.1.0
+
+  micromark-extension-gfm-task-list-item@1.0.5:
+    dependencies:
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-extension-gfm@2.0.3:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 1.0.5
+      micromark-extension-gfm-footnote: 1.1.2
+      micromark-extension-gfm-strikethrough: 1.0.7
+      micromark-extension-gfm-table: 1.0.7
+      micromark-extension-gfm-tagfilter: 1.0.2
+      micromark-extension-gfm-task-list-item: 1.0.5
+      micromark-util-combine-extensions: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-factory-destination@1.1.0:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-factory-label@1.1.0:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-factory-space@1.1.0:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-types: 1.1.0
+
+  micromark-factory-title@1.1.0:
+    dependencies:
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-factory-whitespace@1.1.0:
+    dependencies:
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-util-character@1.2.0:
+    dependencies:
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-util-chunked@1.1.0:
+    dependencies:
+      micromark-util-symbol: 1.1.0
+
+  micromark-util-classify-character@1.1.0:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-util-combine-extensions@1.1.0:
+    dependencies:
+      micromark-util-chunked: 1.1.0
+      micromark-util-types: 1.1.0
+
+  micromark-util-decode-numeric-character-reference@1.1.0:
+    dependencies:
+      micromark-util-symbol: 1.1.0
+
+  micromark-util-decode-string@1.1.0:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 1.2.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-symbol: 1.1.0
+
+  micromark-util-encode@1.1.0: {}
+
+  micromark-util-html-tag-name@1.2.0: {}
+
+  micromark-util-normalize-identifier@1.1.0:
+    dependencies:
+      micromark-util-symbol: 1.1.0
+
+  micromark-util-resolve-all@1.1.0:
+    dependencies:
+      micromark-util-types: 1.1.0
+
+  micromark-util-sanitize-uri@1.2.0:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-encode: 1.1.0
+      micromark-util-symbol: 1.1.0
+
+  micromark-util-subtokenize@1.1.0:
+    dependencies:
+      micromark-util-chunked: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+
+  micromark-util-symbol@1.1.0: {}
+
+  micromark-util-types@1.1.0: {}
+
+  micromark@3.2.0:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      micromark-core-commonmark: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-chunked: 1.1.0
+      micromark-util-combine-extensions: 1.1.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-encode: 1.1.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-subtokenize: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -7381,6 +8011,8 @@ snapshots:
       on-headers: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  mri@1.2.0: {}
 
   ms@2.0.0: {}
 
@@ -7691,6 +8323,14 @@ snapshots:
       mlly: 1.8.1
       pathe: 2.0.3
 
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   please-upgrade-node@3.2.0:
     dependencies:
       semver-compare: 1.0.0
@@ -7738,6 +8378,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@6.5.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -8118,6 +8760,28 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-markdown@8.0.7(@types/react@16.8.15)(react@16.14.0):
+    dependencies:
+      '@types/hast': 2.3.10
+      '@types/prop-types': 15.7.15
+      '@types/react': 16.8.15
+      '@types/unist': 2.0.11
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 2.0.1
+      prop-types: 15.8.1
+      property-information: 6.5.0
+      react: 16.14.0
+      react-is: 18.3.1
+      remark-parse: 10.0.2
+      remark-rehype: 10.1.0
+      space-separated-tokens: 2.0.2
+      style-to-object: 0.4.4
+      unified: 10.1.2
+      unist-util-visit: 4.1.2
+      vfile: 5.3.7
+    transitivePeerDependencies:
+      - supports-color
+
   react-router-dom@5.3.4(react@16.14.0):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -8230,6 +8894,30 @@ snapshots:
   registry-url@5.1.0:
     dependencies:
       rc: 1.2.8
+
+  remark-gfm@3.0.1:
+    dependencies:
+      '@types/mdast': 3.0.15
+      mdast-util-gfm: 2.0.2
+      micromark-extension-gfm: 2.0.3
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@10.0.2:
+    dependencies:
+      '@types/mdast': 3.0.15
+      mdast-util-from-markdown: 1.3.1
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@10.1.0:
+    dependencies:
+      '@types/hast': 2.3.10
+      '@types/mdast': 3.0.15
+      mdast-util-to-hast: 12.3.0
+      unified: 10.1.2
 
   request@2.88.2:
     dependencies:
@@ -8348,6 +9036,10 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -8521,6 +9213,8 @@ snapshots:
   source-map@0.6.1:
     optional: true
 
+  space-separated-tokens@2.0.2: {}
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -8676,6 +9370,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  style-to-object@0.4.4:
+    dependencies:
+      inline-style-parser: 0.1.1
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -8764,6 +9462,10 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -8862,9 +9564,44 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  unified@10.1.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      bail: 2.0.2
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 5.3.7
+
   unique-string@1.0.0:
     dependencies:
       crypto-random-string: 1.0.0
+
+  unist-util-generated@2.0.1: {}
+
+  unist-util-is@5.2.1:
+    dependencies:
+      '@types/unist': 2.0.11
+
+  unist-util-position@4.0.4:
+    dependencies:
+      '@types/unist': 2.0.11
+
+  unist-util-stringify-position@3.0.3:
+    dependencies:
+      '@types/unist': 2.0.11
+
+  unist-util-visit-parents@5.1.3:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 5.2.1
+
+  unist-util-visit@4.1.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
 
   universalify@0.2.0: {}
 
@@ -8936,6 +9673,13 @@ snapshots:
 
   uuid@3.4.0: {}
 
+  uvu@0.5.6:
+    dependencies:
+      dequal: 2.0.3
+      diff: 5.2.2
+      kleur: 4.1.5
+      sade: 1.8.1
+
   v8-compile-cache@2.4.0: {}
 
   validate-npm-package-license@3.0.4:
@@ -8952,6 +9696,18 @@ snapshots:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+
+  vfile-message@3.1.4:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-stringify-position: 3.0.3
+
+  vfile@5.3.7:
+    dependencies:
+      '@types/unist': 2.0.11
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 3.0.3
+      vfile-message: 3.1.4
 
   vite-node@1.6.1(@types/node@25.3.5)(less@3.13.1):
     dependencies:
@@ -9214,3 +9970,5 @@ snapshots:
   zrender@5.6.1:
     dependencies:
       tslib: 2.3.0
+
+  zwitch@2.0.4: {}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/assistant/Assistant.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/assistant/Assistant.test.tsx
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import '@testing-library/react/dont-cleanup-after-each';

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/assistant/Assistant.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/assistant/Assistant.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import '@testing-library/react/dont-cleanup-after-each';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { 
+  assistantServer, 
+  mockHealthDisabled, 
+  mockHealthNotConfigured,
+  mockChatBusy,
+  mockChatTimeout,
+  mockChatError,
+  mockChatDisabled,
+  mockChatInterrupted,
+  mockHealthEnabled,
+  mockModels,
+  mockModelsError,
+  mockModelsDisabled,
+  mockChatSuccess,
+  mockChatDelayed
+} from '@tests/mocks/assistantMocks/assistantServer';
+import Assistant from '@/v2/pages/assistant/assistant';
+import { CHATBOT_ENDPOINTS } from '@/v2/constants/chatbot.constants';
+import { rest } from 'msw';
+
+const WrappedAssistantComponent = () => {
+  return (
+    <BrowserRouter>
+      <Assistant />
+    </BrowserRouter>
+  )
+}
+
+describe('Assistant Tests', () => {
+  afterEach(() => {
+    assistantServer.resetHandlers();
+    sessionStorage.clear();
+    cleanup();
+  });
+
+  beforeAll(() => {
+    assistantServer.listen();
+  });
+
+  afterAll(() => {
+    assistantServer.close();
+  });
+
+  it('renders disabled state when health check returns enabled=false', async () => {
+    assistantServer.use(mockHealthDisabled);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Recon AI is Disabled')).toBeVisible();
+    });
+  });
+
+  it('renders not configured state when health check returns llmClientAvailable=false', async () => {
+    assistantServer.use(mockHealthNotConfigured);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Recon AI is Not Configured')).toBeVisible();
+    });
+  });
+
+  it('renders empty state when enabled and configured', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+    
+    // Seed prompts should be visible
+    expect(screen.getByText('How many unhealthy containers are there?')).toBeVisible();
+  });
+
+  it('sends a message and renders markdown response', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatSuccess);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    // Type a message
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    // Click send
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    // Wait for the response
+    await waitFor(() => {
+      // Markdown bold should render as a strong tag
+      expect(screen.getByText('Markdown')).toHaveStyle('font-weight: bold');
+      // Table should render
+      expect(screen.getByRole('table')).toBeVisible();
+    });
+  });
+
+  it('shows error bubble on 503 busy', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatBusy);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('The chatbot is currently handling too many requests. Please try again in a moment.')).toBeVisible();
+    });
+  });
+
+  it('shows error bubble on 504 timeout', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatTimeout);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('The chatbot request timed out. The LLM or Recon API took too long to respond. Please try again or use a different model.')).toBeVisible();
+    });
+  });
+
+  it('shows error bubble on 500 error', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatError);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('An error occurred processing your request.')).toBeVisible();
+    });
+  });
+
+  it('shows error bubble on 503 chat disabled', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatDisabled);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Chatbot service is not enabled')).toBeVisible();
+    });
+  });
+
+  it('shows error bubble on 503 interrupted', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatInterrupted);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Request was interrupted. Please try again.')).toBeVisible();
+    });
+  });
+
+  it('handles models fetch failure gracefully', async () => {
+    assistantServer.use(mockHealthEnabled, mockModelsError);
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+    
+    // Default model should be selected or available even if fetch fails
+    expect(screen.getByText('Default Provider')).toBeVisible();
+  });
+
+  it('disables send button while in-flight', async () => {
+    // Delay the response to test in-flight state
+    assistantServer.use(
+      mockHealthEnabled,
+      mockModels,
+      mockChatDelayed
+    );
+    
+    render(<WrappedAssistantComponent />);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await userEvent.click(sendButton);
+
+    // Stop button should appear, send button should be gone or disabled
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /stop/i })).toBeVisible();
+    });
+    
+    // Wait for completion
+    await waitFor(() => {
+      expect(screen.getByText('Delayed')).toBeVisible();
+    });
+  });
+});

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/assistant/Assistant.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/assistant/Assistant.test.tsx
@@ -154,7 +154,71 @@ describe('Assistant Tests', () => {
     await userEvent.click(sendButton);
 
     await waitFor(() => {
-      expect(screen.getByText('An error occurred processing your request.')).toBeVisible();
+      expect(screen.getByText(/An error occurred while processing your request/)).toBeVisible();
+      expect(screen.getByText('For more details, check the Recon server logs.')).toBeVisible();
+    });
+  });
+
+  it('shows provider-specific error bubble on 500 error for OpenAI', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatError);
+    render(<WrappedAssistantComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    await userEvent.click(screen.getByText('Default Provider'));
+    await userEvent.click(screen.getByText('OpenAI'));
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/OpenAI could not complete this request/)).toBeVisible();
+      expect(screen.getByText('For more details, check the Recon server logs.')).toBeVisible();
+    });
+  });
+
+  it('shows provider-specific error bubble on 500 error for Gemini', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatError);
+    render(<WrappedAssistantComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    await userEvent.click(screen.getByText('Default Provider'));
+    await userEvent.click(screen.getByText('Google Gemini'));
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Google Gemini could not complete this request/)).toBeVisible();
+      expect(screen.getByText('For more details, check the Recon server logs.')).toBeVisible();
+    });
+  });
+
+  it('shows provider-specific error bubble on 500 error for Anthropic', async () => {
+    assistantServer.use(mockHealthEnabled, mockModels, mockChatError);
+    render(<WrappedAssistantComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Recon AI')).toBeVisible();
+    });
+
+    await userEvent.click(screen.getByText('Default Provider'));
+    await userEvent.click(screen.getByText('Anthropic Claude'));
+
+    const input = screen.getByPlaceholderText('Ask Recon AI about your cluster...');
+    await userEvent.type(input, 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Anthropic Claude could not complete this request/)).toBeVisible();
+      expect(screen.getByText('For more details, check the Recon server logs.')).toBeVisible();
     });
   });
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/assistantMocks/assistantServer.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/assistantMocks/assistantServer.ts
@@ -36,7 +36,7 @@ export const mockModels = rest.get(CHATBOT_ENDPOINTS.MODELS, (req, res, ctx) => 
   return res(
     ctx.status(200),
     ctx.json({
-      models: ['gemini-2.5-flash', 'gemini-2.5-pro']
+      models: ['gpt-4.1-nano', 'gemini-2.5-flash', 'gemini-2.5-pro', 'claude-opus-4-6']
     })
   );
 });

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/assistantMocks/assistantServer.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/assistantMocks/assistantServer.ts
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { CHATBOT_ENDPOINTS } from '@/v2/constants/chatbot.constants';

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/assistantMocks/assistantServer.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/assistantMocks/assistantServer.ts
@@ -1,0 +1,141 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { CHATBOT_ENDPOINTS } from '@/v2/constants/chatbot.constants';
+
+export const mockHealthEnabled = rest.get(CHATBOT_ENDPOINTS.HEALTH, (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      enabled: true,
+      llmClientAvailable: true
+    })
+  );
+});
+
+export const mockHealthDisabled = rest.get(CHATBOT_ENDPOINTS.HEALTH, (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      enabled: false,
+      llmClientAvailable: true
+    })
+  );
+});
+
+export const mockHealthNotConfigured = rest.get(CHATBOT_ENDPOINTS.HEALTH, (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      enabled: true,
+      llmClientAvailable: false
+    })
+  );
+});
+
+export const mockModels = rest.get(CHATBOT_ENDPOINTS.MODELS, (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      models: ['gemini-2.5-flash', 'gemini-2.5-pro']
+    })
+  );
+});
+
+export const mockModelsError = rest.get(CHATBOT_ENDPOINTS.MODELS, (req, res, ctx) => {
+  return res(
+    ctx.status(500),
+    ctx.json({
+      error: 'Failed to fetch models'
+    })
+  );
+});
+
+export const mockModelsDisabled = rest.get(CHATBOT_ENDPOINTS.MODELS, (req, res, ctx) => {
+  return res(
+    ctx.status(503),
+    ctx.json({
+      error: 'Chatbot service is not enabled'
+    })
+  );
+});
+
+export const mockChatSuccess = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      response: 'This is a **Markdown** response with a table:\n\n| Col 1 | Col 2 |\n|---|---|\n| A | B |',
+      success: true
+    })
+  );
+});
+
+export const mockChatDelayed = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.delay(100),
+    ctx.status(200),
+    ctx.json({
+      response: 'Delayed',
+      success: true
+    })
+  );
+});
+
+export const mockChatBusy = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(503),
+    ctx.json({
+      error: 'The chatbot is currently handling too many requests. Please try again in a moment.'
+    })
+  );
+});
+
+export const mockChatTimeout = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(504),
+    ctx.json({
+      error: 'The chatbot request timed out. The LLM or Recon API took too long to respond. Please try again or use a different model.'
+    })
+  );
+});
+
+export const mockChatError = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(500),
+    ctx.json({
+      error: 'An error occurred processing your request.'
+    })
+  );
+});
+
+export const mockChatDisabled = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(503),
+    ctx.json({
+      error: 'Chatbot service is not enabled'
+    })
+  );
+});
+
+export const mockChatInterrupted = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(503),
+    ctx.json({
+      error: 'Request was interrupted. Please try again.'
+    })
+  );
+});
+
+export const mockChatEmpty = rest.post(CHATBOT_ENDPOINTS.CHAT, (req, res, ctx) => {
+  return res(
+    ctx.status(400),
+    ctx.json({
+      error: 'Query cannot be empty'
+    })
+  );
+});
+
+export const assistantServer = setupServer(
+  mockHealthEnabled,
+  mockModels,
+  mockChatSuccess
+);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/vitest.setup.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/vitest.setup.ts
@@ -58,4 +58,6 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   })),
-})
+});
+
+window.Element.prototype.scrollIntoView = vi.fn();

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
@@ -23,7 +23,7 @@ import NavBar from './components/navBar/navBar';
 import NavBarV2 from '@/v2/components/navBar/navBar';
 import Breadcrumbs from './components/breadcrumbs/breadcrumbs';
 import BreadcrumbsV2 from '@/v2/components/breadcrumbs/breadcrumbs';
-import { HashRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
+import { HashRouter as Router, Switch, Route, Redirect, useLocation } from 'react-router-dom';
 import { routes } from '@/routes';
 import { routesV2 } from '@/v2/routes-v2';
 import { MakeRouteWithSubRoutes } from '@/makeRouteWithSubRoutes';
@@ -43,6 +43,58 @@ interface IAppState {
   enableOldUI: boolean;
 }
 
+const AppLayout = ({ enableOldUI, collapsed, onCollapse, onToggleUI }: any) => {
+  const location = useLocation();
+  const isAssistantRoute = location.pathname === '/Assistant';
+  const layoutClass = classNames('content-layout', { 'sidebar-collapsed': collapsed });
+
+  return (
+    <Layout style={{ minHeight: '100vh' }}>
+      {
+        (enableOldUI)
+          ? <NavBar collapsed={collapsed} onCollapse={onCollapse} />
+          : <NavBarV2 collapsed={collapsed} onCollapse={onCollapse} />
+      }
+      <Layout className={layoutClass}>
+        <Header>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            {(enableOldUI) ? <Breadcrumbs /> : <BreadcrumbsV2 />}
+            <span>
+              <span style={{ marginRight: '8px', color: '#515151'}}>Switch to</span>
+              <AntDSwitch
+                unCheckedChildren={<div style={{ paddingRight: '2px' }}>Old UI</div>}
+                checkedChildren={<div style={{ paddingLeft: '2px' }}>New UI</div>}
+                checked={enableOldUI}
+                onChange={onToggleUI} />
+            </span>
+          </div>
+        </Header>
+        <Content style={(enableOldUI) ? { margin: '0 16px 0', overflow: 'initial' } : (isAssistantRoute ? { display: 'flex', flexDirection: 'column', height: 'calc(100vh - 50px)', overflow: 'hidden' } : {})}>
+          <Suspense fallback={<Loader />}>
+            <Switch>
+              <Route exact path='/'>
+                <Redirect to='/Overview' />
+              </Route>
+              {(enableOldUI)
+                ? routes.map(
+                  (route, index) => <MakeRouteWithSubRoutes key={index} {...route} />
+                )
+                : routesV2.map(
+                  (route, index) => {
+                    return <MakeRouteWithSubRoutes key={index} {...route} />
+                  }
+                )
+              }
+              <Route component={NotFound} />
+            </Switch>
+          </Suspense>
+        </Content>
+        {!isAssistantRoute && <Footer style={{ textAlign: 'center' }} />}
+      </Layout>
+    </Layout>
+  );
+};
+
 class App extends React.Component<Record<string, object>, IAppState> {
   constructor(props = {}) {
     super(props);
@@ -59,63 +111,21 @@ class App extends React.Component<Record<string, object>, IAppState> {
 
   render() {
     const { collapsed, enableOldUI } = this.state;
-    const layoutClass = classNames('content-layout', { 'sidebar-collapsed': collapsed });
-
 
     return (
       <Router>
-        <Layout style={{ minHeight: '100vh' }}>
-          {
-            (enableOldUI)
-              ? <NavBar collapsed={collapsed} onCollapse={this.onCollapse} />
-              : <NavBarV2 collapsed={collapsed} onCollapse={this.onCollapse} />
-          }
-          <Layout className={layoutClass}>
-            <Header>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                {(enableOldUI) ? <Breadcrumbs /> : <BreadcrumbsV2 />}
-                <span>
-                  <span style={{ marginRight: '8px', color: '#515151'}}>Switch to</span>
-                  <AntDSwitch
-                    unCheckedChildren={<div style={{ paddingRight: '2px' }}>Old UI</div>}
-                    checkedChildren={<div style={{ paddingLeft: '2px' }}>New UI</div>}
-                    checked={this.state.enableOldUI}
-                    onChange={(checked: boolean) => {
-                      this.setState({
-                        enableOldUI: checked
-                      }, () => {
-                        // This is to persist the state of the UI between refreshes.
-                        // While using session storage to store state is an anti-pattern, provided the size of the data stored in this case
-                        // and the plan to deprecate UI v1 (old UI) in the future - this is the simplest approach/fix for persisting state.
-                        sessionStorage.setItem('enableOldUI', JSON.stringify(checked));
-                      });
-                    }} />
-                </span>
-              </div>
-            </Header>
-            <Content style={(enableOldUI) ? { margin: '0 16px 0', overflow: 'initial' } : {}}>
-              <Suspense fallback={<Loader />}>
-                <Switch>
-                  <Route exact path='/'>
-                    <Redirect to='/Overview' />
-                  </Route>
-                  {(enableOldUI)
-                    ? routes.map(
-                      (route, index) => <MakeRouteWithSubRoutes key={index} {...route} />
-                    )
-                    : routesV2.map(
-                      (route, index) => {
-                        return <MakeRouteWithSubRoutes key={index} {...route} />
-                      }
-                    )
-                  }
-                  <Route component={NotFound} />
-                </Switch>
-              </Suspense>
-            </Content>
-            <Footer style={{ textAlign: 'center' }} />
-          </Layout>
-        </Layout>
+        <AppLayout 
+          enableOldUI={enableOldUI} 
+          collapsed={collapsed} 
+          onCollapse={this.onCollapse}
+          onToggleUI={(checked: boolean) => {
+            this.setState({
+              enableOldUI: checked
+            }, () => {
+              sessionStorage.setItem('enableOldUI', JSON.stringify(checked));
+            });
+          }}
+        />
       </Router>
     );
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
@@ -48,6 +48,20 @@ export const AxiosPutHelper = (
   }
 }
 
+export const AxiosPostHelper = (
+  url: string,
+  data: any = {},
+  controller: AbortController | undefined,
+  message: string = '',  //optional
+): { request: Promise<AxiosResponse<any, any>>; controller: AbortController } => {
+  controller && controller.abort(message);
+  controller = new AbortController(); // generate new AbortController for the upcoming request
+  return {
+    request: axios.post(url, data, { signal: controller.signal }),
+    controller: controller
+  }
+}
+
 export const PromiseAllSettledGetHelper = (
   urls: string[],
   controller: AbortController | undefined,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/clipboard.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/clipboard.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copies text to the clipboard. Uses the async Clipboard API when available
+ * (secure contexts), otherwise falls back to execCommand for HTTP clusters.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to legacy copy for non-secure or denied contexts.
+    }
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return copied;
+  } catch {
+    return false;
+  }
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/navBar/navBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/navBar/navBar.tsx
@@ -28,7 +28,8 @@ import {
   FolderOpenOutlined,
   InboxOutlined,
   LayoutOutlined,
-  PieChartOutlined
+  PieChartOutlined,
+  ThunderboltOutlined
 } from '@ant-design/icons';
 import {Link, useLocation} from 'react-router-dom';
 
@@ -60,7 +61,16 @@ const NavBar: React.FC<NavBarProps> = ({
     }
   );
 
+  const { data: chatbotHealth } = useApiData<{ enabled: boolean; llmClientAvailable: boolean }>(
+    '/api/v1/chatbot/health',
+    { enabled: false, llmClientAvailable: false },
+    {
+      onError: (error) => showDataFetchError(error)
+    }
+  );
+
   const isHeatmapEnabled = !disabledFeatures.includes('HEATMAP');
+  const isChatbotEnabled = chatbotHealth.enabled;
 
   const menuItems = [(
     <Menu.Item key='/Overview'
@@ -135,6 +145,13 @@ const NavBar: React.FC<NavBarProps> = ({
         state: { isHeatmapEnabled: isHeatmapEnabled }
       }}
       />
+    </Menu.Item>
+  ),(
+    isChatbotEnabled &&
+    <Menu.Item key='/Assistant'
+      icon={<ThunderboltOutlined />}>
+      <span>Recon AI</span>
+      <Link to='/Assistant' />
     </Menu.Item>
   )]
   return (

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/navBar/navBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/navBar/navBar.tsx
@@ -37,6 +37,7 @@ import {Link, useLocation} from 'react-router-dom';
 import logo from '@/logo.png';
 import {showDataFetchError} from '@/utils/common';
 import {useApiData} from '@/v2/hooks/useAPIData.hook';
+import { CHATBOT_ENDPOINTS } from '@/v2/constants/chatbot.constants';
 
 import './navBar.less';
 
@@ -61,16 +62,19 @@ const NavBar: React.FC<NavBarProps> = ({
     }
   );
 
-  const { data: chatbotHealth } = useApiData<{ enabled: boolean; llmClientAvailable: boolean }>(
-    '/api/v1/chatbot/health',
+  const { data: chatbotHealth, success: chatbotHealthLoaded } = useApiData<{
+    enabled: boolean;
+    llmClientAvailable: boolean;
+  }>(
+    CHATBOT_ENDPOINTS.HEALTH,
     { enabled: false, llmClientAvailable: false },
     {
-      onError: (error) => showDataFetchError(error)
+      retryAttempts: 0,
     }
   );
 
   const isHeatmapEnabled = !disabledFeatures.includes('HEATMAP');
-  const isChatbotEnabled = chatbotHealth.enabled;
+  const isChatbotEnabled = chatbotHealthLoaded && chatbotHealth.enabled;
 
   const menuItems = [(
     <Menu.Item key='/Overview'

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/constants/chatbot.constants.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/constants/chatbot.constants.tsx
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const CHATBOT_ENDPOINTS = {
+  HEALTH: '/api/v1/chatbot/health',
+  MODELS: '/api/v1/chatbot/models',
+  CHAT: '/api/v1/chatbot/chat'
+};
+
+export const DEFAULT_MODEL_SENTINEL = 'default_server_model';
+
+export const PROVIDER_LABELS: Record<string, string> = {
+  openai: 'OpenAI',
+  gemini: 'Google Gemini',
+  anthropic: 'Anthropic Claude',
+  other: 'Other Models'
+};
+
+export const getProviderForModel = (model: string): string => {
+  const lower = model.toLowerCase();
+  if (lower.startsWith('gpt') || lower.startsWith('o1') || lower.startsWith('o3')) return 'openai';
+  if (lower.startsWith('gemini')) return 'gemini';
+  if (lower.startsWith('claude')) return 'anthropic';
+  return 'other';
+};
+
+export const LOADING_STAGES = [
+  { maxSeconds: 3, text: "Understanding query..." },
+  { maxSeconds: 10, text: "Searching cluster data..." },
+  { maxSeconds: 45, text: "Summarizing results..." },
+  { maxSeconds: Infinity, text: "Still working - complex queries can take a moment..." }
+];
+
+export const SEED_PROMPTS = [
+  {
+    icon: 'heart',
+    label: 'Cluster Health',
+    prompt: "How many unhealthy containers are there?"
+  },
+  {
+    icon: 'folder',
+    label: 'Browse Keys',
+    prompt: "List keys in /vol1/bucket1"
+  },
+  {
+    icon: 'pie-chart',
+    label: 'Capacity',
+    prompt: "What is the current cluster capacity?"
+  },
+  {
+    icon: 'database',
+    label: 'OM Tasks',
+    prompt: "Show me the status of OM tasks"
+  },
+  {
+    icon: 'cluster',
+    label: 'Datanodes',
+    prompt: "List the datanodes in the cluster"
+  },
+  {
+    icon: 'deployment-unit',
+    label: 'Pipelines',
+    prompt: "Show me the pipelines"
+  }
+];

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/constants/chatbot.constants.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/constants/chatbot.constants.tsx
@@ -103,9 +103,9 @@ export const SEED_PROMPTS = [
     prompt: "How many unhealthy containers are there?"
   },
   {
-    icon: 'folder',
-    label: 'Browse Keys',
-    prompt: "List keys in /vol1/bucket1"
+    icon: 'database',
+    label: 'Volumes & Buckets',
+    prompt: 'Give me a high-level summary of volumes and buckets in the cluster'
   },
   {
     icon: 'pie-chart',
@@ -113,7 +113,7 @@ export const SEED_PROMPTS = [
     prompt: "What is the current cluster capacity?"
   },
   {
-    icon: 'database',
+    icon: 'schedule',
     label: 'OM Tasks',
     prompt: "Show me the status of OM tasks"
   },

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/constants/chatbot.constants.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/constants/chatbot.constants.tsx
@@ -39,6 +39,56 @@ export const getProviderForModel = (model: string): string => {
   return 'other';
 };
 
+export const RECON_LOGS_HINT = 'For more details, check the Recon server logs.';
+
+const GENERIC_BACKEND_PROCESSING_ERROR = 'An error occurred processing your request.';
+
+export const resolveRequestProvider = (provider?: string, model?: string): string | undefined => {
+  if (provider && provider !== DEFAULT_MODEL_SENTINEL) {
+    return provider;
+  }
+  if (model && model !== DEFAULT_MODEL_SENTINEL) {
+    return getProviderForModel(model);
+  }
+  return undefined;
+};
+
+export const isMaskedLlmProcessingError = (errorText?: string): boolean => {
+  if (!errorText) {
+    return true;
+  }
+  if (errorText === GENERIC_BACKEND_PROCESSING_ERROR) {
+    return true;
+  }
+  return (
+    errorText.includes('OpenAiHttpException')
+    || errorText.includes('LLM request failed')
+    || errorText.includes('An internal error occurred while processing your request')
+  );
+};
+
+export const getLlmProviderFailureMessage = (provider?: string, model?: string): string => {
+  const resolved = resolveRequestProvider(provider, model);
+
+  let main: string;
+  switch (resolved) {
+    case 'openai':
+      main = 'OpenAI could not complete this request. Check your API key and model settings in ozone-site.xml, or try another provider such as Google Gemini.';
+      break;
+    case 'gemini':
+      main = 'Google Gemini could not complete this request. Check your API key and model settings in ozone-site.xml, or try another provider such as OpenAI.';
+      break;
+    case 'anthropic':
+      main = 'Anthropic Claude could not complete this request. Check your API key and model settings in ozone-site.xml, or try another provider such as OpenAI.';
+      break;
+    default:
+      main = 'An error occurred while processing your request. Please try again or switch to a different model or provider.';
+      break;
+  }
+
+  return `${main}\n\n${RECON_LOGS_HINT}`;
+};
+
 export const LOADING_STAGES = [
   { maxSeconds: 3, text: "Understanding query..." },
   { maxSeconds: 10, text: "Searching cluster data..." },

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
@@ -93,7 +93,7 @@ export const useChat = () => {
     startTimer();
 
     const userMessage: ChatMessage = {
-      id: Date.now().toString(),
+      id: crypto.randomUUID(),
       role: 'user',
       text: query,
       timestamp: Date.now()
@@ -135,7 +135,7 @@ export const useChat = () => {
       const data = response.data as ChatbotChatResponse;
       
       const assistantMessage: ChatMessage = {
-        id: (Date.now() + 1).toString(),
+        id: crypto.randomUUID(),
         role: 'assistant',
         text: data.response,
         timestamp: Date.now()

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
@@ -19,7 +19,13 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { AxiosPostHelper } from '@/utils/axiosRequestHelper';
 import { ChatMessage, ChatbotChatRequest, ChatbotChatResponse, ChatbotErrorResponse } from '@/v2/types/chatbot.types';
-import { CHATBOT_ENDPOINTS, DEFAULT_MODEL_SENTINEL } from '@/v2/constants/chatbot.constants';
+import {
+  CHATBOT_ENDPOINTS,
+  DEFAULT_MODEL_SENTINEL,
+  getLlmProviderFailureMessage,
+  isMaskedLlmProcessingError,
+  RECON_LOGS_HINT
+} from '@/v2/constants/chatbot.constants';
 import axios, { AxiosError } from 'axios';
 
 export const useChat = () => {
@@ -152,11 +158,10 @@ export const useChat = () => {
         } else if (status === 504) {
           displayError = errorText || 'Request timed out. The query took too long to process. Please try a different or faster model.';
         } else if (status === 500) {
-          // Clean up the OpenAI stack trace if present
-          if (errorText && errorText.includes('dev.ai4j.openai4j.OpenAiHttpException')) {
-            displayError = 'Failed to connect to OpenAI API. Please verify your API key configuration in ozone-site.xml.';
+          if (isMaskedLlmProcessingError(errorText)) {
+            displayError = getLlmProviderFailureMessage(provider, model);
           } else {
-            displayError = errorText || 'An internal error occurred while processing your request. Please try again.';
+            displayError = `${errorText}\n\n${RECON_LOGS_HINT}`;
           }
         } else if (status === 400) {
           displayError = errorText || 'Invalid request. Please check your query.';

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { AxiosPostHelper } from '@/utils/axiosRequestHelper';
+import { ChatMessage, ChatbotChatRequest, ChatbotChatResponse, ChatbotErrorResponse } from '@/v2/types/chatbot.types';
+import { CHATBOT_ENDPOINTS, DEFAULT_MODEL_SENTINEL } from '@/v2/constants/chatbot.constants';
+import axios, { AxiosError } from 'axios';
+
+export const useChat = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>(() => {
+    const saved = sessionStorage.getItem('recon_ai_messages');
+    if (saved) {
+      try {
+        return JSON.parse(saved);
+      } catch (e) {
+        console.error('Failed to parse saved chat messages', e);
+      }
+    }
+    return [];
+  });
+  const [isInFlight, setIsInFlight] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [errorBubble, setErrorBubble] = useState<string | null>(null);
+  const [currentQuery, setCurrentQuery] = useState('');
+
+  const controllerRef = useRef<AbortController | undefined>();
+  const timerRef = useRef<NodeJS.Timeout | undefined>();
+
+  useEffect(() => {
+    sessionStorage.setItem('recon_ai_messages', JSON.stringify(messages));
+  }, [messages]);
+
+  const startTimer = useCallback(() => {
+    setElapsedSeconds(0);
+    timerRef.current = setInterval(() => {
+      setElapsedSeconds(prev => prev + 1);
+    }, 1000);
+  }, []);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      stopTimer();
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+      }
+    };
+  }, [stopTimer]);
+
+  const cancelRequest = useCallback(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort('User cancelled the request');
+      controllerRef.current = undefined;
+    }
+    setIsInFlight(false);
+    stopTimer();
+  }, [stopTimer]);
+
+  const sendMessage = useCallback(async (query: string, model?: string, provider?: string) => {
+    if (!query.trim() || isInFlight) return;
+
+    setErrorBubble(null);
+    setIsInFlight(true);
+    setCurrentQuery(query);
+    startTimer();
+
+    const userMessage: ChatMessage = {
+      id: Date.now().toString(),
+      role: 'user',
+      text: query,
+      timestamp: Date.now()
+    };
+
+    setMessages(prev => {
+      // If the last message is a user message with the same text, don't append a new one
+      if (prev.length > 0) {
+        const lastMsg = prev[prev.length - 1];
+        if (lastMsg.role === 'user' && lastMsg.text === query) {
+          return prev;
+        }
+      }
+      return [...prev, userMessage];
+    });
+
+    const requestBody: ChatbotChatRequest = {
+      query: query.trim()
+    };
+
+    if (provider && provider !== DEFAULT_MODEL_SENTINEL) {
+      requestBody.provider = provider;
+    }
+
+    if (model && model !== DEFAULT_MODEL_SENTINEL) {
+      requestBody.model = model;
+    }
+
+    const { request, controller } = AxiosPostHelper(
+      CHATBOT_ENDPOINTS.CHAT,
+      requestBody,
+      controllerRef.current,
+      'New request initiated'
+    );
+    controllerRef.current = controller;
+
+    try {
+      const response = await request;
+      const data = response.data as ChatbotChatResponse;
+      
+      const assistantMessage: ChatMessage = {
+        id: (Date.now() + 1).toString(),
+        role: 'assistant',
+        text: data.response,
+        timestamp: Date.now()
+      };
+      
+      setMessages(prev => [...prev, assistantMessage]);
+      setCurrentQuery('');
+    } catch (error) {
+      if (axios.isCancel(error)) {
+        // Request was cancelled, do nothing
+      } else {
+        const axiosError = error as AxiosError<ChatbotErrorResponse>;
+        const status = axiosError.response?.status;
+        const errorText = axiosError.response?.data?.error || axiosError.message;
+        
+        let displayError = errorText;
+        if (status === 503) {
+          // Could be disabled or busy
+          displayError = errorText || 'Service is currently busy. Please retry in a moment.';
+        } else if (status === 504) {
+          displayError = errorText || 'Request timed out. The query took too long to process. Please try a different or faster model.';
+        } else if (status === 500) {
+          // Clean up the OpenAI stack trace if present
+          if (errorText && errorText.includes('dev.ai4j.openai4j.OpenAiHttpException')) {
+            displayError = 'Failed to connect to OpenAI API. Please verify your API key configuration in ozone-site.xml.';
+          } else {
+            displayError = errorText || 'An internal error occurred while processing your request. Please try again.';
+          }
+        } else if (status === 400) {
+          displayError = errorText || 'Invalid request. Please check your query.';
+        }
+
+        setErrorBubble(displayError);
+      }
+    } finally {
+      setIsInFlight(false);
+      stopTimer();
+    }
+  }, [isInFlight, startTimer, stopTimer]);
+
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+    setErrorBubble(null);
+    sessionStorage.removeItem('recon_ai_messages');
+  }, []);
+
+  return {
+    messages,
+    isInFlight,
+    elapsedSeconds,
+    errorBubble,
+    currentQuery,
+    sendMessage,
+    cancelRequest,
+    clearMessages,
+    setCurrentQuery
+  };
+};

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/hooks/useChat.hook.tsx
@@ -41,6 +41,7 @@ export const useChat = () => {
     return [];
   });
   const [isInFlight, setIsInFlight] = useState(false);
+  const isInFlightRef = useRef(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [errorBubble, setErrorBubble] = useState<string | null>(null);
   const [currentQuery, setCurrentQuery] = useState('');
@@ -81,14 +82,16 @@ export const useChat = () => {
       controllerRef.current = undefined;
     }
     setIsInFlight(false);
+    isInFlightRef.current = false;
     stopTimer();
   }, [stopTimer]);
 
   const sendMessage = useCallback(async (query: string, model?: string, provider?: string) => {
-    if (!query.trim() || isInFlight) return;
+    if (!query.trim() || isInFlightRef.current) return;
 
     setErrorBubble(null);
     setIsInFlight(true);
+    isInFlightRef.current = true;
     setCurrentQuery(query);
     startTimer();
 
@@ -96,7 +99,9 @@ export const useChat = () => {
       id: crypto.randomUUID(),
       role: 'user',
       text: query,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      model,
+      provider
     };
 
     setMessages(prev => {
@@ -171,9 +176,10 @@ export const useChat = () => {
       }
     } finally {
       setIsInFlight(false);
+      isInFlightRef.current = false;
       stopTimer();
     }
-  }, [isInFlight, startTimer, stopTimer]);
+  }, [startTimer, stopTimer]);
 
   const clearMessages = useCallback(() => {
     setMessages([]);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.less
@@ -735,7 +735,7 @@
 
 // Accessibility
 @media (prefers-reduced-motion: reduce) {
-  * {
+  .assistant-page-container * {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.less
@@ -1,0 +1,743 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Brand Tokens
+@color-teal-dark: #142329;
+@color-teal-panel: #224452;
+@color-green-brand: #4DCF4C;
+@ai-gradient: linear-gradient(135deg, @color-teal-dark 0%, @color-teal-panel 55%, @color-green-brand 140%);
+@bg-glass: rgba(255, 255, 255, 0.7);
+@bg-glass-hover: rgba(255, 255, 255, 0.9);
+@content-width: 1024px;
+
+// Keyframes
+@keyframes slideFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulseGlow {
+  0% { box-shadow: 0 0 0 0 rgba(77, 207, 76, 0.4); }
+  70% { box-shadow: 0 0 0 10px rgba(77, 207, 76, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(77, 207, 76, 0); }
+}
+
+@keyframes sparkPulse {
+  0% { transform: scale(1); filter: brightness(1); }
+  50% { transform: scale(1.1); filter: brightness(1.3); }
+  100% { transform: scale(1); filter: brightness(1); }
+}
+
+.recon-ai-mark {
+  &.active .spark-group {
+    animation: sparkPulse 1.5s ease-in-out infinite;
+  }
+}
+
+// Global container
+.assistant-page-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%; // Fill the parent container instead of fixed calc
+  background: linear-gradient(to bottom right, #e8edf0, #dce5e8);
+  overflow: hidden;
+  position: relative;
+  font-family: 'Roboto', sans-serif;
+}
+
+// Header
+.assistant-header {
+  padding: 12px 24px;
+  background: @bg-glass;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(20, 35, 41, 0.05);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 10;
+
+  .header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .header-icon-wrapper {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    background: @ai-gradient;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    box-shadow: 0 4px 12px rgba(77, 207, 76, 0.2);
+  }
+
+  .header-text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .header-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .alpha-tag {
+    border-radius: 12px;
+    background: rgba(77, 207, 76, 0.1);
+    color: #2b8a2a;
+    border: 1px solid rgba(77, 207, 76, 0.3);
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .header-title {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+    color: @color-teal-dark;
+    letter-spacing: -0.5px;
+  }
+
+  .header-subtitle {
+    font-size: 13px;
+    color: #5c737d;
+    margin-top: 2px;
+    font-weight: 400;
+  }
+  .new-chat-btn {
+    border-radius: 16px;
+    border: 1px solid @color-teal-panel;
+    background: @ai-gradient;
+    color: white;
+    font-weight: 500;
+    transition: all 0.3s ease;
+    
+    .anticon {
+      color: white;
+    }
+    
+    &:hover, &:focus {
+      background: @ai-gradient;
+      border-color: @color-green-brand;
+      color: white;
+      box-shadow: 0 4px 12px rgba(20, 35, 41, 0.25);
+    }
+    
+    &:disabled {
+      background: #f5f5f5;
+      border-color: #d9d9d9;
+      color: rgba(0, 0, 0, 0.25);
+      box-shadow: none;
+    }
+  }
+}
+
+// Chat Area
+.assistant-chat-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(20, 35, 41, 0.15);
+    border-radius: 3px;
+  }
+}
+
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: @content-width;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.memory-hint {
+  text-align: center;
+  font-size: 12px;
+  color: #5c737d;
+  margin-bottom: 16px;
+  padding: 6px 16px;
+  background: rgba(20, 35, 41, 0.04);
+  border-radius: 20px;
+  align-self: center;
+  backdrop-filter: blur(4px);
+}
+
+// Bubbles
+.message-bubble-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  animation: slideFadeIn 0.3s ease-out forwards;
+  
+  &.user-message {
+    align-items: flex-end;
+    
+    .message-bubble-content {
+      flex-direction: row-reverse;
+    }
+    
+    .message-bubble-body {
+      background: @ai-gradient;
+      color: white;
+      border-radius: 18px 18px 4px 18px;
+      box-shadow: 0 4px 12px rgba(77, 207, 76, 0.15);
+    }
+  }
+  
+  &.assistant-message {
+    align-items: flex-start;
+    
+    .message-bubble-body {
+      background: @bg-glass;
+      backdrop-filter: blur(8px);
+      color: @color-teal-dark;
+      border-radius: 18px 18px 18px 4px;
+      border: 1px solid rgba(255, 255, 255, 0.8);
+      box-shadow: 0 4px 12px rgba(20, 35, 41, 0.05);
+    }
+  }
+}
+
+.message-bubble-content {
+  display: flex;
+  gap: 16px;
+  max-width: 92%;
+}
+
+.message-avatar {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: @ai-gradient;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: bold;
+  font-size: 14px;
+  margin-top: auto;
+  box-shadow: 0 2px 8px rgba(77, 207, 76, 0.3);
+  
+  &.pulsing {
+    animation: pulseGlow 2s infinite;
+  }
+}
+
+.message-bubble-body {
+  padding: 16px 20px;
+  font-size: 15px;
+  line-height: 1.6;
+  word-break: break-word;
+}
+
+// Markdown Styling
+.message-markdown {
+  color: #0f1a1e;
+
+  p, li, td {
+    color: inherit;
+  }
+
+  strong {
+    color: @color-teal-dark;
+    font-weight: 700;
+  }
+
+  p {
+    margin-bottom: 0.8em;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+  
+  h1, h2, h3, h4, h5, h6 {
+    color: @color-teal-dark;
+    margin-top: 1.2em;
+    margin-bottom: 0.6em;
+    font-weight: 600;
+  }
+  
+  pre {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+    padding: 16px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 12px 0;
+    border-left: 4px solid @color-green-brand;
+  }
+  
+  code {
+    background-color: rgba(20, 35, 41, 0.08);
+    color: #a61e2d;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.92em;
+  }
+  
+  pre code {
+    background-color: transparent;
+    color: inherit;
+    padding: 0;
+  }
+  
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 16px 0;
+    background: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    
+    th, td {
+      border: 1px solid #f0f0f0;
+      padding: 10px 12px;
+    }
+    
+    th {
+      background-color: #fafafa;
+      font-weight: 600;
+      color: @color-teal-dark;
+    }
+    
+    tr:nth-child(even) {
+      background-color: #fafbfc;
+    }
+  }
+
+  ul, ol {
+    padding-left: 24px;
+    margin-bottom: 0.8em;
+  }
+  
+  li {
+    margin-bottom: 4px;
+  }
+}
+
+.message-actions {
+  margin-top: 6px;
+  margin-left: 52px;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+  
+  &:hover {
+    opacity: 1;
+  }
+}
+
+// Composer
+.composer-container {
+  padding: 0 24px 24px; // Remove top padding, keep bottom padding to anchor to the bottom
+  background: transparent;
+  position: relative;
+  
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: linear-gradient(to top, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0) 100%);
+    pointer-events: none;
+    z-index: 0;
+  }
+}
+
+.composer-pill {
+  position: relative;
+  z-index: 1;
+  max-width: @content-width;
+  margin: 0 auto;
+  background: @bg-glass;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255,255,255,0.8);
+  border-radius: 24px;
+  box-shadow: 0 8px 32px rgba(20, 35, 41, 0.08);
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: box-shadow 0.3s ease;
+  
+  &:focus-within {
+    box-shadow: 0 8px 32px rgba(77, 207, 76, 0.15), 0 0 0 2px rgba(77, 207, 76, 0.3);
+  }
+}
+
+.composer-toolbar {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 8px;
+  
+  .model-picker {
+    min-width: 160px;
+    .ant-select-selector {
+      background: transparent !important;
+      border: 1px solid rgba(20, 35, 41, 0.1) !important;
+      border-radius: 20px !important;
+      box-shadow: none !important;
+      color: #5c737d;
+      padding: 0 12px;
+      
+      &:hover {
+        color: @color-teal-dark;
+      }
+    }
+  }
+}
+
+.ai-picker-dropdown {
+  border-radius: 16px !important;
+  box-shadow: 0 4px 16px rgba(20, 35, 41, 0.1) !important;
+  overflow: hidden;
+}
+
+.composer-input-wrapper {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.composer-textarea {
+  border: none !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  resize: none;
+  font-size: 15px;
+  padding: 8px;
+  
+  &::placeholder {
+    color: #a0b0b5;
+  }
+}
+
+.composer-actions {
+  padding-bottom: 4px;
+  
+  .send-btn {
+    background: @ai-gradient;
+    border: none;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+    
+    &:not(:disabled):hover {
+      transform: scale(1.1);
+      box-shadow: 0 4px 12px rgba(77, 207, 76, 0.4);
+    }
+    
+    &:disabled {
+      background: #d9d9d9;
+    }
+  }
+  
+  .stop-btn {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: pulseGlow 2s infinite;
+  }
+}
+
+.composer-disclaimer {
+  text-align: center;
+  font-size: 12px;
+  color: #8c9ba1;
+  margin-top: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+// Empty State
+.empty-state-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 8vh;
+  height: 100%;
+  text-align: center;
+  padding-bottom: 24px;
+  animation: slideFadeIn 0.5s ease-out;
+  
+  .empty-state-hero {
+    margin-bottom: 40px;
+  }
+  
+  .hero-orb {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background: @ai-gradient;
+    border: none;
+    margin: 0 auto 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 8px 24px rgba(77, 207, 76, 0.25);
+    animation: pulseGlow 3s infinite;
+    color: white;
+    
+    .anticon {
+      font-size: 40px;
+      color: white;
+    }
+  }
+  
+  h2 {
+    font-size: 34px;
+    font-weight: 700;
+    margin-bottom: 12px;
+    color: @color-teal-dark;
+  }
+  
+  p {
+    color: #5c737d;
+    font-size: 16px;
+    max-width: 500px;
+    margin: 0 auto;
+  }
+}
+
+.seed-prompts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  max-width: @content-width;
+  width: 100%;
+}
+
+.seed-prompt-chip {
+  background: @bg-glass;
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255,255,255,0.8);
+  border-radius: 12px;
+  padding: 16px;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  box-shadow: 0 4px 12px rgba(20, 35, 41, 0.03);
+  
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(77, 207, 76, 0.15);
+    background: @bg-glass-hover;
+    border-color: rgba(77, 207, 76, 0.3);
+  }
+  
+  .chip-icon {
+    font-size: 20px;
+    color: @color-green-brand;
+    margin-top: 2px;
+  }
+  
+  .chip-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    
+    .chip-label {
+      font-weight: 600;
+      color: @color-teal-dark;
+      font-size: 14px;
+    }
+    
+    .chip-prompt {
+      color: #5c737d;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+  }
+
+  .chip-arrow {
+    color: @color-green-brand;
+    opacity: 0;
+    transform: translateX(-4px);
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+  }
+
+  &:hover .chip-arrow {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+// Loading Indicator Bubble
+.loading-bubble {
+  .message-bubble-body {
+    min-width: 300px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .skeleton-line {
+    height: 12px;
+    background: linear-gradient(90deg, rgba(20,35,41,0.05) 25%, rgba(20,35,41,0.1) 50%, rgba(20,35,41,0.05) 75%);
+    background-size: 200% 100%;
+    border-radius: 6px;
+    animation: shimmer 1.5s infinite linear;
+    width: 100%;
+    
+    &.short {
+      width: 60%;
+    }
+  }
+
+  .loading-status-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .loading-text {
+    color: #5c737d;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .elapsed-pill {
+    margin-left: auto;
+    background: rgba(20,35,41,0.05);
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    color: #5c737d;
+  }
+}
+
+.typing-dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  height: 24px;
+  
+  .dot {
+    width: 8px;
+    height: 8px;
+    background: @color-green-brand;
+    border-radius: 50%;
+    animation: typingBounce 1.4s infinite ease-in-out both;
+    
+    &:nth-child(1) { animation-delay: -0.32s; }
+    &:nth-child(2) { animation-delay: -0.16s; }
+  }
+}
+
+.loading-text {
+  color: #5c737d;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.loading-warning {
+  font-size: 12px;
+  color: #fa8c16;
+  background: #fff7e6;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #ffd591;
+}
+
+// Error & Disabled States
+.error-bubble {
+  .message-bubble-body {
+    background: #fff2f0 !important;
+    border-color: #ffccc7 !important;
+    color: #cf1322 !important;
+  }
+  
+  .error-content {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    
+    .error-icon {
+      font-size: 16px;
+    }
+    
+    .error-text {
+      font-size: 14px;
+      line-height: 1.5;
+    }
+  }
+}
+
+.disabled-state-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background: @bg-glass;
+  backdrop-filter: blur(12px);
+  
+  .ant-result {
+    background: white;
+    padding: 48px;
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(20, 35, 41, 0.08);
+  }
+}
+
+// Accessibility
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.less
@@ -712,6 +712,7 @@
     .error-text {
       font-size: 14px;
       line-height: 1.5;
+      white-space: pre-line;
     }
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.tsx
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useApiData } from '@/v2/hooks/useAPIData.hook';
+import { showDataFetchError } from '@/utils/common';
+import { ChatbotHealthResponse, ChatbotModelsResponse } from '@/v2/types/chatbot.types';
+import { CHATBOT_ENDPOINTS } from '@/v2/constants/chatbot.constants';
+import { useChat } from '@/v2/hooks/useChat.hook';
+import { Spin, Button, Tag } from 'antd';
+import { ClearOutlined } from '@ant-design/icons';
+
+import DisabledState from './components/DisabledState';
+import EmptyState from './components/EmptyState';
+import MessageList from './components/MessageList';
+import Composer from './components/Composer';
+
+import './assistant.less';
+
+import ReconAIMark from './components/ReconAIMark';
+
+const Assistant: React.FC = () => {
+  const [isHealthLoaded, setIsHealthLoaded] = useState(false);
+  const [isModelsLoaded, setIsModelsLoaded] = useState(false);
+
+  const healthData = useApiData<ChatbotHealthResponse>(
+    CHATBOT_ENDPOINTS.HEALTH,
+    { enabled: false, llmClientAvailable: false },
+    {
+      onSuccess: () => setIsHealthLoaded(true),
+      onError: (error) => {
+        showDataFetchError(error);
+        setIsHealthLoaded(true); // Still set loaded to show disabled state
+      }
+    }
+  );
+
+  const modelsData = useApiData<ChatbotModelsResponse>(
+    CHATBOT_ENDPOINTS.MODELS,
+    { models: [] },
+    {
+      initialFetch: false,
+      retryAttempts: 0,
+      onSuccess: () => setIsModelsLoaded(true),
+      onError: (error) => {
+        showDataFetchError(error);
+        setIsModelsLoaded(true);
+      }
+    }
+  );
+
+  const {
+    messages,
+    isInFlight,
+    elapsedSeconds,
+    errorBubble,
+    currentQuery,
+    setCurrentQuery,
+    sendMessage,
+    cancelRequest,
+    clearMessages
+  } = useChat();
+
+  useEffect(() => {
+    if (isHealthLoaded && healthData.data.enabled && healthData.data.llmClientAvailable) {
+      modelsData.execute().catch(() => {});
+    }
+  }, [isHealthLoaded, healthData.data]);
+
+  if (!isHealthLoaded || (healthData.data.enabled && healthData.data.llmClientAvailable && !isModelsLoaded)) {
+    return (
+      <div className="assistant-page-container" style={{ alignItems: 'center', justifyContent: 'center' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!healthData.data.enabled) {
+    return (
+      <div className="assistant-page-container">
+        <DisabledState reason="disabled" />
+      </div>
+    );
+  }
+
+  if (!healthData.data.llmClientAvailable) {
+    return (
+      <div className="assistant-page-container">
+        <DisabledState reason="not-configured" />
+      </div>
+    );
+  }
+
+  const handlePromptClick = (prompt: string) => {
+    setCurrentQuery(prompt);
+  };
+
+  const handleRetry = () => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        sendMessage(messages[i].text);
+        break;
+      }
+    }
+  };
+
+  const handleRegenerate = (index: number) => {
+    // Find the last user message before this assistant message
+    for (let i = index - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        sendMessage(messages[i].text);
+        break;
+      }
+    }
+  };
+
+  return (
+    <div className="assistant-page-container">
+      <div className="assistant-header">
+        <div className="header-left">
+          <div className="header-icon-wrapper">
+            <ReconAIMark size={24} active={isInFlight} />
+          </div>
+          <div className="header-text">
+            <div className="header-title-row">
+              <h1 className="header-title">Recon AI</h1>
+              <Tag className="alpha-tag">Alpha</Tag>
+            </div>
+            <div className="header-subtitle">Your intelligent cluster assistant</div>
+          </div>
+        </div>
+        {messages.length > 0 && (
+          <Button 
+            icon={<ClearOutlined />} 
+            onClick={clearMessages}
+            type="default"
+            className="new-chat-btn"
+            disabled={isInFlight}
+          >
+            New chat
+          </Button>
+        )}
+      </div>
+      <div className="assistant-chat-area">
+        {messages.length === 0 ? (
+          <EmptyState onPromptClick={handlePromptClick} />
+        ) : (
+          <MessageList 
+            messages={messages}
+            isInFlight={isInFlight}
+            elapsedSeconds={elapsedSeconds}
+            errorBubble={errorBubble}
+            onRetry={handleRetry}
+            onRegenerate={handleRegenerate}
+          />
+        )}
+      </div>
+      <Composer 
+        onSend={sendMessage}
+        onCancel={cancelRequest}
+        isInFlight={isInFlight}
+        models={modelsData.data.models}
+        currentQuery={currentQuery}
+        setCurrentQuery={setCurrentQuery}
+      />
+    </div>
+  );
+};
+
+export default Assistant;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/assistant.tsx
@@ -113,7 +113,7 @@ const Assistant: React.FC = () => {
   const handleRetry = () => {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === 'user') {
-        sendMessage(messages[i].text);
+        sendMessage(messages[i].text, messages[i].model, messages[i].provider);
         break;
       }
     }
@@ -123,7 +123,7 @@ const Assistant: React.FC = () => {
     // Find the last user message before this assistant message
     for (let i = index - 1; i >= 0; i--) {
       if (messages[i].role === 'user') {
-        sendMessage(messages[i].text);
+        sendMessage(messages[i].text, messages[i].model, messages[i].provider);
         break;
       }
     }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/Composer.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/Composer.tsx
@@ -20,7 +20,6 @@ import React, { useState, KeyboardEvent } from 'react';
 import { Input, Button } from 'antd';
 import { SendOutlined, StopOutlined } from '@ant-design/icons';
 import ModelPicker from './ModelPicker';
-import { getProviderForModel } from '@/v2/constants/chatbot.constants';
 
 interface ComposerProps {
   onSend: (query: string, model?: string, provider?: string) => void;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/Composer.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/Composer.tsx
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, KeyboardEvent } from 'react';
+import { Input, Button } from 'antd';
+import { SendOutlined, StopOutlined } from '@ant-design/icons';
+import ModelPicker from './ModelPicker';
+import { getProviderForModel } from '@/v2/constants/chatbot.constants';
+
+interface ComposerProps {
+  onSend: (query: string, model?: string, provider?: string) => void;
+  onCancel: () => void;
+  isInFlight: boolean;
+  models: string[];
+  currentQuery: string;
+  setCurrentQuery: (q: string) => void;
+}
+
+const Composer: React.FC<ComposerProps> = ({ 
+  onSend, 
+  onCancel, 
+  isInFlight, 
+  models,
+  currentQuery,
+  setCurrentQuery
+}) => {
+  const [selectedProvider, setSelectedProvider] = useState<string | undefined>();
+  const [selectedModel, setSelectedModel] = useState<string | undefined>();
+
+  const handleProviderChange = (provider: string) => {
+    setSelectedProvider(provider);
+    // Reset model when provider changes to avoid invalid combinations
+    setSelectedModel(undefined);
+  };
+
+  const handleSend = () => {
+    if (currentQuery.trim() && !isInFlight) {
+      onSend(currentQuery, selectedModel, selectedProvider);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="composer-container">
+      <div className="composer-pill">
+        <div className="composer-toolbar">
+          <ModelPicker 
+            models={models} 
+            selectedProvider={selectedProvider}
+            selectedModel={selectedModel} 
+            onProviderChange={handleProviderChange}
+            onModelChange={setSelectedModel} 
+            disabled={isInFlight} 
+          />
+        </div>
+        <div className="composer-input-wrapper">
+          <Input.TextArea
+            value={currentQuery}
+            onChange={(e) => setCurrentQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask Recon AI about your cluster..."
+            autoSize={{ minRows: 1, maxRows: 6 }}
+            disabled={isInFlight}
+            className="composer-textarea"
+            bordered={false}
+          />
+          <div className="composer-actions">
+            {isInFlight ? (
+              <Button 
+                type="primary" 
+                danger 
+                icon={<StopOutlined />} 
+                onClick={onCancel}
+                shape="circle"
+                className="stop-btn"
+              />
+            ) : (
+              <Button 
+                type="primary" 
+                icon={<SendOutlined />} 
+                onClick={handleSend}
+                disabled={!currentQuery.trim()}
+                shape="circle"
+                className="send-btn"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="composer-disclaimer">
+        Recon AI treats each query independently and may occasionally hallucinate. Please verify important cluster data.
+      </div>
+    </div>
+  );
+};
+
+export default Composer;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/DisabledState.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/DisabledState.tsx
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Result } from 'antd';
+
+interface DisabledStateProps {
+  reason: 'disabled' | 'not-configured';
+}
+
+const DisabledState: React.FC<DisabledStateProps> = ({ reason }) => {
+  if (reason === 'disabled') {
+    return (
+      <div className="disabled-state-container">
+        <Result
+          status="warning"
+          title="Recon AI is Disabled"
+          subTitle="The chatbot feature is currently disabled in the server configuration. Please contact your administrator to enable it."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="disabled-state-container">
+      <Result
+        status="warning"
+        title="Recon AI is Not Configured"
+        subTitle="The chatbot feature is enabled, but no LLM client is available. Please check your API keys and provider configuration."
+      />
+    </div>
+  );
+};
+
+export default DisabledState;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/EmptyState.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/EmptyState.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { SEED_PROMPTS } from '@/v2/constants/chatbot.constants';
+import { 
+  HeartOutlined, 
+  FolderOpenOutlined, 
+  PieChartOutlined, 
+  DatabaseOutlined, 
+  ClusterOutlined, 
+  DeploymentUnitOutlined,
+  ArrowRightOutlined
+} from '@ant-design/icons';
+import ReconAIMark from './ReconAIMark';
+
+interface EmptyStateProps {
+  onPromptClick: (prompt: string) => void;
+}
+
+const getIcon = (iconName: string) => {
+  switch (iconName) {
+    case 'heart': return <HeartOutlined />;
+    case 'folder': return <FolderOpenOutlined />;
+    case 'pie-chart': return <PieChartOutlined />;
+    case 'database': return <DatabaseOutlined />;
+    case 'cluster': return <ClusterOutlined />;
+    case 'deployment-unit': return <DeploymentUnitOutlined />;
+    default: return <ReconAIMark size={20} />;
+  }
+};
+
+const EmptyState: React.FC<EmptyStateProps> = ({ onPromptClick }) => {
+  return (
+    <div className="empty-state-container">
+      <div className="empty-state-hero">
+        <div className="hero-orb">
+          <ReconAIMark size={40} />
+        </div>
+        <h2>Welcome to Recon AI</h2>
+        <p>Ask questions about your Ozone cluster's health, capacity, and metadata.</p>
+      </div>
+      
+      <div className="seed-prompts-grid">
+        {SEED_PROMPTS.map((item, index) => (
+          <div 
+            key={index} 
+            className="seed-prompt-chip" 
+            onClick={() => onPromptClick(item.prompt)}
+          >
+            <div className="chip-icon">
+              {getIcon(item.icon)}
+            </div>
+            <div className="chip-content">
+              <span className="chip-label">{item.label}</span>
+              <span className="chip-prompt">{item.prompt}</span>
+            </div>
+            <div className="chip-arrow">
+              <ArrowRightOutlined />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/EmptyState.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/EmptyState.tsx
@@ -20,9 +20,9 @@ import React from 'react';
 import { SEED_PROMPTS } from '@/v2/constants/chatbot.constants';
 import { 
   HeartOutlined, 
-  FolderOpenOutlined, 
   PieChartOutlined, 
   DatabaseOutlined, 
+  ScheduleOutlined,
   ClusterOutlined, 
   DeploymentUnitOutlined,
   ArrowRightOutlined
@@ -36,9 +36,9 @@ interface EmptyStateProps {
 const getIcon = (iconName: string) => {
   switch (iconName) {
     case 'heart': return <HeartOutlined />;
-    case 'folder': return <FolderOpenOutlined />;
-    case 'pie-chart': return <PieChartOutlined />;
     case 'database': return <DatabaseOutlined />;
+    case 'pie-chart': return <PieChartOutlined />;
+    case 'schedule': return <ScheduleOutlined />;
     case 'cluster': return <ClusterOutlined />;
     case 'deployment-unit': return <DeploymentUnitOutlined />;
     default: return <ReconAIMark size={20} />;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/LoadingIndicator.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/LoadingIndicator.tsx
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useMemo } from 'react';
+import ReconAIMark from './ReconAIMark';
+import { LOADING_STAGES } from '@/v2/constants/chatbot.constants';
+
+interface LoadingIndicatorProps {
+  elapsedSeconds: number;
+}
+
+const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({ elapsedSeconds }) => {
+  const isLong = elapsedSeconds > 60;
+
+  const currentStageText = useMemo(() => {
+    for (const stage of LOADING_STAGES) {
+      if (elapsedSeconds <= stage.maxSeconds) {
+        return stage.text;
+      }
+    }
+    return LOADING_STAGES[LOADING_STAGES.length - 1].text;
+  }, [elapsedSeconds]);
+
+  return (
+    <div className="message-bubble-wrapper assistant-message loading-bubble">
+      <div className="message-bubble-content">
+        <div className="message-avatar">
+          <ReconAIMark size={20} active={true} />
+        </div>
+        <div className="message-bubble-body">
+          <div className="skeleton-line"></div>
+          <div className="skeleton-line"></div>
+          <div className="skeleton-line short"></div>
+          
+          <div className="loading-status-row" role="status" aria-live="polite">
+            <span className="loading-text">{currentStageText}</span>
+            <div className="typing-dots">
+              <div className="dot"></div>
+              <div className="dot"></div>
+              <div className="dot"></div>
+            </div>
+          </div>
+          
+          {isLong && (
+            <div className="loading-warning">
+              This is taking longer than usual. The request may time out after 3 minutes.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingIndicator;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageBubble.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageBubble.tsx
@@ -23,6 +23,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ChatMessage } from '@/v2/types/chatbot.types';
 import classNames from 'classnames';
+import { copyToClipboard } from '@/utils/clipboard';
 import ReconAIMark from './ReconAIMark';
 
 interface MessageBubbleProps {
@@ -32,11 +33,19 @@ interface MessageBubbleProps {
 
 const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onRegenerate }) => {
   const [copied, setCopied] = React.useState(false);
+  const [copyFailed, setCopyFailed] = React.useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(message.text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    const didCopy = await copyToClipboard(message.text);
+    if (didCopy) {
+      setCopyFailed(false);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } else {
+      setCopied(false);
+      setCopyFailed(true);
+      setTimeout(() => setCopyFailed(false), 2000);
+    }
   };
 
   const isUser = message.role === 'user';
@@ -61,7 +70,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onRegenerate }) 
       </div>
       {!isUser && (
         <div className="message-actions">
-          <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+          <Tooltip title={copied ? 'Copied!' : copyFailed ? 'Copy failed' : 'Copy'}>
             <Button 
               type="text" 
               size="small" 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageBubble.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageBubble.tsx
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Button, Tooltip } from 'antd';
+import { CopyOutlined, CheckOutlined, UserOutlined, ReloadOutlined } from '@ant-design/icons';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { ChatMessage } from '@/v2/types/chatbot.types';
+import classNames from 'classnames';
+import ReconAIMark from './ReconAIMark';
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+  onRegenerate?: () => void;
+}
+
+const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onRegenerate }) => {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(message.text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={classNames('message-bubble-wrapper', { 'user-message': isUser, 'assistant-message': !isUser })}>
+      <div className="message-bubble-content">
+        <div className="message-avatar">
+          {isUser ? <UserOutlined /> : <ReconAIMark size={20} />}
+        </div>
+        <div className="message-bubble-body">
+          {isUser ? (
+            <div className="message-text">{message.text}</div>
+          ) : (
+            <div className="message-markdown">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {message.text}
+              </ReactMarkdown>
+            </div>
+          )}
+        </div>
+      </div>
+      {!isUser && (
+        <div className="message-actions">
+          <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+            <Button 
+              type="text" 
+              size="small" 
+              icon={copied ? <CheckOutlined /> : <CopyOutlined />} 
+              onClick={handleCopy}
+            />
+          </Tooltip>
+          {onRegenerate && (
+            <Tooltip title="Regenerate">
+              <Button 
+                type="text" 
+                size="small" 
+                icon={<ReloadOutlined />} 
+                onClick={onRegenerate}
+              />
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MessageBubble;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageList.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageList.tsx
@@ -52,7 +52,7 @@ const MessageList: React.FC<MessageListProps> = ({
         <MessageBubble 
           key={msg.id} 
           message={msg} 
-          onRegenerate={() => onRegenerate(index)} 
+          onRegenerate={msg.role === 'assistant' ? () => onRegenerate(index) : undefined} 
         />
       ))}
       

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageList.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/MessageList.tsx
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import MessageBubble from './MessageBubble';
+import { ChatMessage } from '@/v2/types/chatbot.types';
+import LoadingIndicator from './LoadingIndicator';
+import { Button } from 'antd';
+import ReconAIMark from './ReconAIMark';
+
+interface MessageListProps {
+  messages: ChatMessage[];
+  isInFlight: boolean;
+  elapsedSeconds: number;
+  errorBubble: string | null;
+  onRetry: () => void;
+  onRegenerate: (index: number) => void;
+}
+
+const MessageList: React.FC<MessageListProps> = ({ 
+  messages, 
+  isInFlight, 
+  elapsedSeconds, 
+  errorBubble,
+  onRetry,
+  onRegenerate
+}) => {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, isInFlight, errorBubble]);
+
+  return (
+    <div className="message-list">
+      {messages.map((msg, index) => (
+        <MessageBubble 
+          key={msg.id} 
+          message={msg} 
+          onRegenerate={() => onRegenerate(index)} 
+        />
+      ))}
+      
+      {isInFlight && (
+        <LoadingIndicator elapsedSeconds={elapsedSeconds} />
+      )}
+      
+      {errorBubble && (
+        <div className="message-bubble-wrapper assistant-message error-bubble">
+          <div className="message-bubble-content">
+            <div className="message-avatar">
+              <ReconAIMark size={20} />
+            </div>
+            <div className="message-bubble-body">
+              <div className="error-content">
+                <span className="error-icon">⚠️</span>
+                <span className="error-text">{errorBubble}</span>
+              </div>
+              <div className="message-actions" style={{ marginLeft: 0, marginTop: '12px', opacity: 1 }}>
+                <Button size="small" onClick={onRetry} type="primary" ghost>
+                  Retry
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      
+      <div ref={bottomRef} />
+    </div>
+  );
+};
+
+export default MessageList;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/ModelPicker.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/ModelPicker.tsx
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useMemo } from 'react';
+import { Select } from 'antd';
+import { DEFAULT_MODEL_SENTINEL, getProviderForModel, PROVIDER_LABELS } from '@/v2/constants/chatbot.constants';
+
+const { Option, OptGroup } = Select;
+
+interface ModelPickerProps {
+  models: string[];
+  selectedProvider?: string;
+  selectedModel?: string;
+  onProviderChange: (provider: string) => void;
+  onModelChange: (model: string) => void;
+  disabled?: boolean;
+}
+
+const ModelPicker: React.FC<ModelPickerProps> = ({ 
+  models, 
+  selectedProvider,
+  selectedModel, 
+  onProviderChange,
+  onModelChange, 
+  disabled 
+}) => {
+  const groupedModels = useMemo(() => {
+    const groups: Record<string, string[]> = {
+      openai: [],
+      gemini: [],
+      anthropic: [],
+      other: []
+    };
+    
+    models.forEach(model => {
+      const provider = getProviderForModel(model);
+      if (groups[provider]) {
+        groups[provider].push(model);
+      }
+    });
+    
+    return groups;
+  }, [models]);
+
+  const availableProviders = useMemo(() => {
+    return Object.keys(groupedModels).filter(key => groupedModels[key].length > 0);
+  }, [groupedModels]);
+
+  const availableModelsForProvider = useMemo(() => {
+    if (!selectedProvider || selectedProvider === DEFAULT_MODEL_SENTINEL) {
+      return [];
+    }
+    return groupedModels[selectedProvider] || [];
+  }, [selectedProvider, groupedModels]);
+
+  return (
+    <div style={{ display: 'flex', gap: '8px' }}>
+      <Select
+        value={selectedProvider || DEFAULT_MODEL_SENTINEL}
+        onChange={onProviderChange}
+        disabled={disabled}
+        className="model-picker"
+        dropdownClassName="ai-picker-dropdown"
+        size="small"
+        dropdownMatchSelectWidth={false}
+      >
+        <Option value={DEFAULT_MODEL_SENTINEL}>Default Provider</Option>
+        {availableProviders.map(providerKey => (
+          <Option key={providerKey} value={providerKey}>
+            {PROVIDER_LABELS[providerKey] || providerKey}
+          </Option>
+        ))}
+      </Select>
+
+      {selectedProvider && selectedProvider !== DEFAULT_MODEL_SENTINEL && (
+        <Select
+          value={selectedModel || DEFAULT_MODEL_SENTINEL}
+          onChange={onModelChange}
+          disabled={disabled || availableModelsForProvider.length === 0}
+          className="model-picker"
+          dropdownClassName="ai-picker-dropdown"
+          size="small"
+          dropdownMatchSelectWidth={false}
+        >
+          <Option value={DEFAULT_MODEL_SENTINEL}>Default Model</Option>
+          {availableModelsForProvider.map(model => (
+            <Option key={model} value={model}>{model}</Option>
+          ))}
+        </Select>
+      )}
+    </div>
+  );
+};
+
+export default ModelPicker;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/ReconAIMark.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/assistant/components/ReconAIMark.tsx
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+interface ReconAIMarkProps {
+  size?: number;
+  active?: boolean;
+  className?: string;
+}
+
+const ReconAIMark: React.FC<ReconAIMarkProps> = ({ size = 24, active = false, className = '' }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`recon-ai-mark ${active ? 'active' : ''} ${className}`}
+      style={{ display: 'inline-block', verticalAlign: 'middle' }}
+    >
+      <defs>
+        <path id="sparkle" d="M 0 -10 C 0 -4 4 0 10 0 C 4 0 0 4 0 10 C 0 4 -4 0 -10 0 C -4 0 0 -4 0 -10 Z" />
+      </defs>
+      <g className="spark-group" style={{ transformOrigin: '12px 12px' }}>
+        {/* Main large star */}
+        <use href="#sparkle" transform="translate(8, 12) scale(0.8)" />
+        {/* Medium star right */}
+        <use href="#sparkle" transform="translate(19, 12) scale(0.4)" />
+        {/* Small star top right */}
+        <use href="#sparkle" transform="translate(14, 5) scale(0.25)" />
+        {/* Small star bottom right */}
+        <use href="#sparkle" transform="translate(14, 19) scale(0.25)" />
+      </g>
+    </svg>
+  );
+};
+
+export default ReconAIMark;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/routes-v2.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/routes-v2.tsx
@@ -28,6 +28,7 @@ const Insights = lazy(() => import('@/v2/pages/insights/insights'));
 const OMDBInsights = lazy(() => import('@/v2/pages/insights/omInsights'));
 const Capacity = lazy(() => import('@/v2/pages/capacity/capacity'));
 const Heatmap = lazy(() => import('@/v2/pages/heatmap/heatmap'));
+const Assistant = lazy(() => import('@/v2/pages/assistant/assistant'));
 
 
 export const routesV2 = [
@@ -74,5 +75,9 @@ export const routesV2 = [
   {
     path: '/Heatmap',
     component: Heatmap
+  },
+  {
+    path: '/Assistant',
+    component: Assistant
   }
 ];

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/chatbot.types.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/chatbot.types.ts
@@ -16,20 +16,34 @@
  * limitations under the License.
  */
 
-type BreadcrumbNameMap = {
-  [path: string]: string;
+export interface ChatbotHealthResponse {
+  enabled: boolean;
+  llmClientAvailable: boolean;
 }
 
-export const breadcrumbNameMap: BreadcrumbNameMap = {
-  '/Overview': 'Overview',
-  '/Volumes': 'Volumes',
-  '/Buckets': 'Buckets',
-  '/Datanodes': 'Datanodes',
-  '/Pipelines': 'Pipelines',
-  '/Containers': 'Containers',
-  '/Insights': 'Insights',
-  '/NamespaceUsage': 'Namespace Usage',
-  '/Heatmap': 'Heatmap',
-  '/Om': 'OM DB Insights',
-  '/Assistant': 'Recon AI'
-};
+export interface ChatbotModelsResponse {
+  models: string[];
+}
+
+export interface ChatbotChatRequest {
+  query: string;
+  model?: string;
+  provider?: string;
+  userId?: string;
+}
+
+export interface ChatbotChatResponse {
+  response: string;
+  success: boolean;
+}
+
+export interface ChatbotErrorResponse {
+  error: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  timestamp: number;
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/chatbot.types.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/types/chatbot.types.ts
@@ -46,4 +46,6 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   text: string;
   timestamp: number;
+  model?: string;
+  provider?: string;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a new **AI Assistant** page to the Recon web UI. It lets an operator ask questions about the cluster in plain English (for example, "How many unhealthy containers are there?" or "List keys in /vol1/bucket1") and get back a readable answer, instead of clicking through screens or calling APIs by hand.

The backend for this (added separately) takes a question, calls the right Recon APIs, and returns a single Markdown answer. This PR is the **frontend** that talks to that backend and presents it as a modern chat experience.

What it does:

- Adds a new `/Assistant` page and a nav entry, shown only when the feature is enabled.
- Checks `/api/v1/chatbot/health` first and shows the right state:
    - feature disabled → "not enabled" screen
    - enabled but no API key / provider down → "not configured" screen
    - healthy → full chat
- Sends questions to `/api/v1/chatbot/chat` and renders the Markdown reply (including tables, lists, code).
- Loads available models from `/api/v1/chatbot/models` and offers a **provider + model** picker.
- Handles the slow, no-streaming backend with a loading state, an elapsed timer, and a Stop button to cancel.
- Handles errors clearly (busy / timeout / server error) with a retry option.
- Keeps chat history in the browser session until the user clicks "New chat".
- Shows an "Alpha" label and a short disclaimer (chats are independent, AI may be wrong — verify important data).

Why: Recon already exposes a lot of cluster data, but finding it takes effort. This gives operators a faster, friendlier way to get answers, while staying inside Recon's existing look and feel (teal/green theme, rounded panels, custom Recon AI mark).

Notes / current limits:

- The backend is stateless, so there is no memory across questions (each one stands alone).
- Responses arrive all at once (no token streaming); typical answers take a few seconds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14818

## How was this patch tested?
- **Unit/component tests** (Vitest + MSW) covering the chat flow and all backend states: success, disabled, not-configured, busy (503), timeout (504), server error (500), and model-list failures.
- **End-to-end tests** (Playwright) that mock each API response and capture screenshots of every state.
- **Manual testing** against a running Recon with the chatbot backend enabled.

## UI Manual Testing Results Document - https://docs.google.com/document/d/1Ex3L9eY8oNm-73TwdDr6ZO2eDd2kQZ2WOo_8vsk45ic/edit?tab=t.0#heading=h.onx3qjujbc5t

<img width="1513" height="896" alt="image" src="https://github.com/user-attachments/assets/c4ea9e30-cf32-403e-9905-de5926fee1a7" />

https://github.com/user-attachments/assets/75318e69-b44c-415a-8af3-90e4c2d9d14e

