### PR TITLE
HDDS-15419. Write HTTP request log to access.log only for daemons

### DIFF
--- a/hadoop-hdds/common/src/main/conf/ozone-env.sh
+++ b/hadoop-hdds/common/src/main/conf/ozone-env.sh
@@ -206,6 +206,15 @@ export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
 # Java property: hadoop.root.logger
 # export OZONE_DAEMON_ROOT_LOGGER=INFO,RFA
 
+# Default log4j setting for the HTTP request log of interactive commands
+# Java property: ozone.http.request.logger
+# export OZONE_HTTP_REQUEST_LOGGER=INFO,console
+
+# Default log4j setting for the HTTP request log of daemons spawned explicitly by
+# --daemon option of ozone command.
+# Java property: ozone.http.request.logger
+# export OZONE_DAEMON_HTTP_REQUEST_LOGGER=INFO,HttpAccess
+
 # Default log level and output location for security-related messages.
 # You will almost certainly want to change this on a per-daemon basis via
 # the Java property (i.e., -Dhadoop.security.logger=foo).

--- a/hadoop-ozone/dist/src/shell/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/shell/conf/log4j.properties
@@ -18,6 +18,7 @@
 hadoop.root.logger=INFO,console
 hadoop.log.dir=.
 hadoop.log.file=hadoop.log
+ozone.http.request.logger=INFO,console
 
 # Define the root logger to the system property "hadoop.root.logger".
 log4j.rootLogger=${hadoop.root.logger}
@@ -151,8 +152,11 @@ log4j.appender.HttpAccess.DatePattern=.yyyy-MM-dd
 log4j.appender.HttpAccess.layout=org.apache.log4j.PatternLayout
 log4j.appender.HttpAccess.layout.ConversionPattern=%m%n
 
+# Define the HTTP request logger to the system property "ozone.http.request.logger".
+# Only daemons write to the HttpAccess file appender (see ozone-functions.sh);
+# other commands default to console to avoid creating the log directory.
 log4j.additivity.http.requests=false
-log4j.logger.http.requests=INFO,HttpAccess
+log4j.logger.http.requests=${ozone.http.request.logger}
 # Create separate appender for each co-hosted component if needed, then enable distinct logger configs:
 #log4j.logger.http.requests.hddsDatanode=INFO,HttpAccess
 #log4j.logger.http.requests.ozoneManager=INFO,HttpAccess

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -890,6 +890,8 @@ function ozone_basic_init
   OZONE_PID_DIR=${OZONE_PID_DIR:-/tmp}
   OZONE_ROOT_LOGGER=${OZONE_ROOT_LOGGER:-${OZONE_LOGLEVEL},console}
   OZONE_DAEMON_ROOT_LOGGER=${OZONE_DAEMON_ROOT_LOGGER:-${OZONE_LOGLEVEL},RFA}
+  OZONE_HTTP_REQUEST_LOGGER=${OZONE_HTTP_REQUEST_LOGGER:-INFO,console}
+  OZONE_DAEMON_HTTP_REQUEST_LOGGER=${OZONE_DAEMON_HTTP_REQUEST_LOGGER:-INFO,HttpAccess}
   OZONE_SECURITY_LOGGER=${OZONE_SECURITY_LOGGER:-INFO,NullAppender}
   OZONE_SSH_OPTS=${OZONE_SSH_OPTS-"-o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10s"}
   OZONE_SECURE_LOG_DIR=${OZONE_SECURE_LOG_DIR:-${OZONE_LOG_DIR}}
@@ -1599,6 +1601,7 @@ function ozone_finalize_opts
   ozone_add_param OZONE_OPTS hadoop.home.dir "-Dhadoop.home.dir=${OZONE_HOME}"
   ozone_add_param OZONE_OPTS hadoop.id.str "-Dhadoop.id.str=${OZONE_IDENT_STRING}"
   ozone_add_param OZONE_OPTS hadoop.root.logger "-Dhadoop.root.logger=${OZONE_ROOT_LOGGER}"
+  ozone_add_param OZONE_OPTS ozone.http.request.logger "-Dozone.http.request.logger=${OZONE_HTTP_REQUEST_LOGGER}"
   ozone_add_param OZONE_OPTS hadoop.policy.file "-Dhadoop.policy.file=${OZONE_POLICYFILE}"
   ozone_add_param OZONE_OPTS hadoop.security.logger "-Dhadoop.security.logger=${OZONE_SECURITY_LOGGER}"
 }
@@ -2730,6 +2733,7 @@ function ozone_generic_java_subcmd_handler
   # if yes, use the daemon logger and the appropriate log file.
   if [[ "${OZONE_DAEMON_MODE}" != "default" ]]; then
     OZONE_ROOT_LOGGER="${OZONE_DAEMON_ROOT_LOGGER}"
+    OZONE_HTTP_REQUEST_LOGGER="${OZONE_DAEMON_HTTP_REQUEST_LOGGER}"
     if [[ "${OZONE_SUBCMD_SECURESERVICE}" = true ]]; then
       OZONE_LOGFILE="ozone-${OZONE_SECURE_USER}-${OZONE_IDENT_STRING}-${OZONE_SUBCMD}-${HOSTNAME}.log"
     else

--- a/hadoop-ozone/dist/src/test/shell/http_request_logger.bats
+++ b/hadoop-ozone/dist/src/test/shell/http_request_logger.bats
@@ -21,14 +21,14 @@
 
 load ozone-functions_test_helper
 
-@test "HTTP request logger: client default is propagated to OZONE_OPTS" {
-  export OZONE_HTTP_REQUEST_LOGGER="INFO,console"
+@test "HTTP request logger: value is propagated to OZONE_OPTS" {
+  export OZONE_HTTP_REQUEST_LOGGER="ERROR,console"
   export OZONE_OPTS=""
 
   ozone_finalize_opts
 
   echo "$OZONE_OPTS"
-  [[ "$OZONE_OPTS" =~ "-Dozone.http.request.logger=INFO,console" ]]
+  [[ "$OZONE_OPTS" =~ "-Dozone.http.request.logger=ERROR,console" ]]
 }
 
 @test "HTTP request logger: defaults are set by ozone_basic_init" {

--- a/hadoop-ozone/dist/src/test/shell/http_request_logger.bats
+++ b/hadoop-ozone/dist/src/test/shell/http_request_logger.bats
@@ -31,12 +31,12 @@ load ozone-functions_test_helper
   [[ "$OZONE_OPTS" =~ "-Dozone.http.request.logger=INFO,console" ]]
 }
 
-@test "HTTP request logger: daemon value is propagated to OZONE_OPTS" {
-  export OZONE_HTTP_REQUEST_LOGGER="INFO,HttpAccess"
-  export OZONE_OPTS=""
+@test "HTTP request logger: defaults are set by ozone_basic_init" {
+  unset OZONE_HTTP_REQUEST_LOGGER
+  unset OZONE_DAEMON_HTTP_REQUEST_LOGGER
 
-  ozone_finalize_opts
+  ozone_basic_init
 
-  echo "$OZONE_OPTS"
-  [[ "$OZONE_OPTS" =~ "-Dozone.http.request.logger=INFO,HttpAccess" ]]
+  [[ "$OZONE_HTTP_REQUEST_LOGGER" == "INFO,console" ]]
+  [[ "$OZONE_DAEMON_HTTP_REQUEST_LOGGER" == "INFO,HttpAccess" ]]
 }

--- a/hadoop-ozone/dist/src/test/shell/http_request_logger.bats
+++ b/hadoop-ozone/dist/src/test/shell/http_request_logger.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Can be executed with bats (https://github.com/bats-core/bats-core)
+# bats http_request_logger.bats
+#
+
+load ozone-functions_test_helper
+
+@test "HTTP request logger: client default is propagated to OZONE_OPTS" {
+  export OZONE_HTTP_REQUEST_LOGGER="INFO,console"
+  export OZONE_OPTS=""
+
+  ozone_finalize_opts
+
+  echo "$OZONE_OPTS"
+  [[ "$OZONE_OPTS" =~ "-Dozone.http.request.logger=INFO,console" ]]
+}
+
+@test "HTTP request logger: daemon value is propagated to OZONE_OPTS" {
+  export OZONE_HTTP_REQUEST_LOGGER="INFO,HttpAccess"
+  export OZONE_OPTS=""
+
+  ozone_finalize_opts
+
+  echo "$OZONE_OPTS"
+  [[ "$OZONE_OPTS" =~ "-Dozone.http.request.logger=INFO,HttpAccess" ]]
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes an issue where Ozone CLI commands print log4j errors if the log directory isn’t writable or doesn’t exist (e.g., on package installs with restricted permissions). Previously, all commands tried to write `access.log` due to an unconditional `HttpAccess` appender in `log4j.properties`, causing errors even for CLI tools that don't generate HTTP logs.

**Solution:**  

Creating `/opt/ozone/logs` at package install time (as suggested in the Jira) would not be enough: if the directory exists but is not writable by the user running the CLI, the same error is raised with `(Permission denied)`, and tarball installs would still be affected.

To address this, the log destination for HTTP access logs can now be configured using the `ozone.http.request.logger` system property, following a pattern similar to `hadoop.root.logger`. Specifically:
- By default, CLI logging is set to `INFO,console`, directing output to the console and avoiding interaction with `access.log`.
- When the CLI is started with the `--daemon` flag, logging uses `INFO,HttpAccess`, so `access.log` is created and written as before.

These are controllable with the new `OZONE_HTTP_REQUEST_LOGGER` and `OZONE_DAEMON_HTTP_REQUEST_LOGGER` environment variables (documented in `ozone-env.sh`).

**Note on foreground daemons:** services started without `--daemon` (e.g. docker compose / k8s, where the command is `ozone om`) now emit HTTP request logs to stdout instead of `access.log`. This matches how the root logger already behaves in foreground mode and keeps container logs self-contained. This is also why the non-daemon default is `INFO,console` rather than `INFO,NullAppender` (the `OZONE_SECURITY_LOGGER` precedent): a null appender would silently discard access logs in such deployments. No test or script depends on `access.log`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15419

## How was this patch tested?

- Reproduced the exact error from the Jira with `bin/ozone s3` and `OZONE_LOG_DIR` under a non-writable parent; with this change the error is gone
- `ozone --daemon start om` still passes `INFO,HttpAccess` and creates `access.log` as before
- Added bats tests for the default values and the variable propagation; `bats.sh`, `rat.sh`, `author.sh` pass locally; `shellcheck` output on `ozone-functions.sh` is unchanged compared to master
