### PR TITLE
HDDS-15491. [DiskBalancer] Preserve datanode order in status command output.

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.DiskBalancerProtocol;
@@ -83,7 +84,10 @@ public class DiskBalancerStatusSubcommand extends AbstractDiskBalancerSubCommand
     // Display consolidated status for successful nodes
     if (!successNodes.isEmpty() && !statuses.isEmpty()) {
       List<DatanodeDiskBalancerInfoProto> statusList =
-          new ArrayList<>(statuses.values());
+          successNodes.stream()
+              .map(statuses::get)
+              .filter(Objects::nonNull)
+              .collect(toList());
       System.out.println(generateStatus(statusList));
     }
   }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.DiskBalancerProtocol;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -44,7 +43,7 @@ public class DiskBalancerStatusSubcommand extends AbstractDiskBalancerSubCommand
 
   // Store statuses for non-JSON mode consolidation
   private final Map<String, DatanodeDiskBalancerInfoProto> statuses =
-      new ConcurrentHashMap<>();
+      new LinkedHashMap<>();
 
   @Override
   protected Object executeCommand(String hostName) throws IOException {

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -528,8 +528,8 @@ public class TestDiskBalancerSubCommands {
       String output = outContent.toString(DEFAULT_ENCODING);
       int host2Index = output.indexOf("host-2");
       int host1Index = output.indexOf("host-1");
-      assertTrue(host2Index >= 0);
-      assertTrue(host1Index > host2Index, output);
+      assertThat(host2Index).isGreaterThanOrEqualTo(0);
+      assertThat(host1Index).isGreaterThan(host2Index);
     }
   }
 
@@ -573,8 +573,10 @@ public class TestDiskBalancerSubCommands {
 
       String output = outContent.toString(DEFAULT_ENCODING);
       assertTrue(output.contains("Status result"));
-      assertTrue(output.contains("host-1"));
-      assertTrue(output.contains("host-2"));
+      int host1Index = output.indexOf("host-1");
+      int host2Index = output.indexOf("host-2");
+      assertThat(host1Index).isGreaterThanOrEqualTo(0);
+      assertThat(host2Index).isGreaterThan(host1Index);
     }
   }
 
@@ -887,4 +889,3 @@ public class TestDiskBalancerSubCommands {
         .build();
   }
 }
-

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -513,8 +513,8 @@ public class TestDiskBalancerSubCommands {
   public void testStatusDiskBalancerWithMultipleNodes() throws Exception {
     DiskBalancerStatusSubcommand cmd = new DiskBalancerStatusSubcommand();
     
-    DatanodeDiskBalancerInfoProto statusProto1 = generateRandomStatusProto("host-1");
-    DatanodeDiskBalancerInfoProto statusProto2 = generateRandomStatusProto("host-2");
+    DatanodeDiskBalancerInfoProto statusProto1 = generateRandomStatusProto("host-2");
+    DatanodeDiskBalancerInfoProto statusProto2 = generateRandomStatusProto("host-1");
     
     when(mockProtocol.getDiskBalancerInfo())
         .thenReturn(statusProto1, statusProto2);
@@ -522,12 +522,14 @@ public class TestDiskBalancerSubCommands {
     try (DiskBalancerMocks mocks = setupAllMocks()) {
 
       CommandLine c = new CommandLine(cmd);
-      c.parseArgs("host-1", "host-2");
+      c.parseArgs("host-2", "host-1");
       cmd.call();
 
       String output = outContent.toString(DEFAULT_ENCODING);
-      assertTrue(output.contains("host-1"));
-      assertTrue(output.contains("host-2"));
+      int host2Index = output.indexOf("host-2");
+      int host1Index = output.indexOf("host-1");
+      assertTrue(host2Index >= 0);
+      assertTrue(host1Index > host2Index, output);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR preserves the datanode order in the non-JSON output of the DiskBalancer status command.

The DiskBalancer status command executes requests in the order provided by the user, or in the order resolved by `--in-service-datanodes`. However, the non-JSON status output previously collected successful responses from `ConcurrentHashMap.values()`, which does not guarantee iteration order.

As a result, the displayed status rows could appear in a different order from the input datanode list. This PR updates the rendering path to build the status result list according to the ordered `successNodes` list instead.

The PR also updates the CLI unit test to verify that status output preserves the requested datanode order.

## What is the link to the Apache JIRA

HDDS-15491. [DiskBalancer] Preserve datanode order in status command output.

## How was this patch tested?

Add Junit Test.

CI: https://github.com/slfan1989/ozone/actions/runs/27052253038


For example, with input order:

```bash
ozone admin datanode diskbalancer status host-2 host-1
```

Before the fix, non-JSON status output could follow map iteration order instead of the user input order:

```
Status result:
Datanode                                                     Status       Threshold(%)    BandwidthInMB   Threads      StopAfterDiskEven    ContainerStates                          SuccessMove  FailureMove  BytesMoved(MB)  EstBytesToMove(MB) EstTimeLeft(min)
host-1 (127.0.0.1:19864)                                     RUNNING      10.0000         100             5            true                                                          1            0            50              100                1
host-2 (127.0.0.1:19864)                                     RUNNING      10.0000         100             5            true                                                          2            0            100             200                1
```

After the fix, the output follows the input order:

```
Status result:
Datanode                                                     Status       Threshold(%)    BandwidthInMB   Threads      StopAfterDiskEven    ContainerStates                          SuccessMove  FailureMove  BytesMoved(MB)  EstBytesToMove(MB) EstTimeLeft(min)
host-2 (127.0.0.1:19864)                                     RUNNING      10.0000         100             5            true                                                          2            0            100             200                1
host-1 (127.0.0.1:19864)                                     RUNNING      10.0000         100             5            true                                                          1            0            50              100                1
```