### PR TITLE
HDDS-10310. Speed up TestOMRatisSnapshots

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -804,6 +804,24 @@ public class TestOMRatisSnapshots {
     assertLogCapture(logCapture, msg);
     assertLogCapture(logCapture, "Install Checkpoint is finished");
 
+    // All newKeys writes have completed (writeFuture.get() above), so the
+    // leader must already contain them.
+    OMMetadataManager leaderOmMetaMgr = leaderOM.getMetadataManager();
+    for (String key : newKeys) {
+      assertNotNull(leaderOmMetaMgr.getKeyTable(
+          TEST_BUCKET_LAYOUT)
+          .get(leaderOmMetaMgr.getOzoneKey(volumeName, bucketName, key)));
+    }
+
+    // Wait for the follower to apply everything the leader has applied; all
+    // writes have completed on the leader, so after this no further snapshot
+    // install (and DB reload) can occur and the follower DB reads below are
+    // safe from "Rocks Database is closed" races.
+    long leaderApplied = leaderOM.getOmRatisServer()
+        .getLastAppliedTermIndex().getIndex();
+    GenericTestUtils.waitFor(() -> followerOM.getOmRatisServer()
+        .getLastAppliedTermIndex().getIndex() >= leaderApplied, 100, 30_000);
+
     long followerOMLastAppliedIndex =
         followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex();
     assertThat(followerOMLastAppliedIndex).isGreaterThanOrEqualTo(leaderOMSnapshotIndex - 1);
@@ -829,19 +847,6 @@ public class TestOMRatisSnapshots {
           TEST_BUCKET_LAYOUT)
           .get(followerOMMetaMgr.getOzoneKey(volumeName, bucketName, key)));
     }
-    OMMetadataManager leaderOmMetaMgr = leaderOM.getMetadataManager();
-    for (String key : newKeys) {
-      assertNotNull(leaderOmMetaMgr.getKeyTable(
-          TEST_BUCKET_LAYOUT)
-          .get(followerOMMetaMgr.getOzoneKey(volumeName, bucketName, key)));
-    }
-    // Wait for the follower to apply all transactions the leader has applied;
-    // by this point every write has completed on the leader, so reaching the
-    // leader's applied index implies all newKeys are visible on the follower.
-    long leaderApplied = leaderOM.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex();
-    GenericTestUtils.waitFor(() -> followerOM.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex() >= leaderApplied, 100, 30_000);
     followerOMMetaMgr = followerOM.getMetadataManager();
     for (String key : newKeys) {
       assertNotNull(followerOMMetaMgr.getKeyTable(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -789,9 +789,6 @@ public class TestOMRatisSnapshots {
     });
     List<String> newKeys = writeFuture.get();
 
-    // Wait checkpoint installation to finish
-    Thread.sleep(5000);
-
     // The recently started OM should be lagging behind the leader OM.
     // Wait & for follower to update transactions to leader snapshot index.
     // Timeout error if follower does not load update within 3s
@@ -836,7 +833,16 @@ public class TestOMRatisSnapshots {
           TEST_BUCKET_LAYOUT)
           .get(followerOMMetaMgr.getOzoneKey(volumeName, bucketName, key)));
     }
-    Thread.sleep(5000);
+    OMMetadataManager catchUpMetaMgr = followerOM.getMetadataManager();
+    String lastNewKey = newKeys.get(newKeys.size() - 1);
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return catchUpMetaMgr.getKeyTable(TEST_BUCKET_LAYOUT)
+            .get(catchUpMetaMgr.getOzoneKey(volumeName, bucketName, lastNewKey)) != null;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 100, 30_000);
     followerOMMetaMgr = followerOM.getMetadataManager();
     for (String key : newKeys) {
       assertNotNull(followerOMMetaMgr.getKeyTable(
@@ -931,8 +937,6 @@ public class TestOMRatisSnapshots {
           .get(followerOMMetaMngr.getOzoneKey(volumeName, bucketName, key)));
     }
 
-    // Wait installation finish
-    Thread.sleep(5000);
     // Verify checkpoint installation was happened.
     assertLogCapture(logCapture, "Reloaded OM state");
     assertLogCapture(logCapture, "Install Checkpoint is finished");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1187,7 +1187,6 @@ public class TestOMRatisSnapshots {
     long logIndex = omRatisServer.getLastAppliedTermIndex().getIndex();
     while (logIndex < targetLogIndex) {
       keys.add(createKey(ozoneBucket));
-      Thread.sleep(100);
       logIndex = omRatisServer.getLastAppliedTermIndex().getIndex();
     }
     return keys;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -977,6 +977,13 @@ public class TestOMRatisSnapshots {
     writeKeysToIncreaseLogIndex(followerOM.getOmRatisServer(),
         leaderCheckpointTermIndex.getIndex() + 100);
 
+    // Wait for the follower to finish applying in-flight transactions, so
+    // that the TermIndex read below matches what installCheckpoint observes.
+    long leaderAppliedIndex = leaderOM.getOmRatisServer()
+        .getLastAppliedTermIndex().getIndex();
+    GenericTestUtils.waitFor(() -> followerRatisServer
+        .getLastAppliedTermIndex().getIndex() >= leaderAppliedIndex, 100, 10_000);
+
     // Install the old checkpoint on the follower OM. This should fail as the
     // followerOM is already ahead of that transactionLogIndex and the OM
     // state should be reloaded.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -791,6 +791,15 @@ public class TestOMRatisSnapshots {
     });
     List<String> newKeys = writeFuture.get();
 
+    // All newKeys writes have completed (writeFuture.get() above), so the
+    // leader must already contain them.
+    OMMetadataManager leaderOmMetaMgr = leaderOM.getMetadataManager();
+    for (String key : newKeys) {
+      assertNotNull(leaderOmMetaMgr.getKeyTable(
+          TEST_BUCKET_LAYOUT)
+          .get(leaderOmMetaMgr.getOzoneKey(volumeName, bucketName, key)));
+    }
+
     // The recently started OM should be lagging behind the leader OM.
     // Wait & for follower to update transactions to leader snapshot index.
     // Timeout error if follower does not load update within 3s
@@ -803,15 +812,6 @@ public class TestOMRatisSnapshots {
     String msg = "Reloaded OM state";
     assertLogCapture(logCapture, msg);
     assertLogCapture(logCapture, "Install Checkpoint is finished");
-
-    // All newKeys writes have completed (writeFuture.get() above), so the
-    // leader must already contain them.
-    OMMetadataManager leaderOmMetaMgr = leaderOM.getMetadataManager();
-    for (String key : newKeys) {
-      assertNotNull(leaderOmMetaMgr.getKeyTable(
-          TEST_BUCKET_LAYOUT)
-          .get(leaderOmMetaMgr.getOzoneKey(volumeName, bucketName, key)));
-    }
 
     // Wait for the follower to apply everything the leader has applied; all
     // writes have completed on the leader, so after this no further snapshot

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -835,16 +835,13 @@ public class TestOMRatisSnapshots {
           TEST_BUCKET_LAYOUT)
           .get(followerOMMetaMgr.getOzoneKey(volumeName, bucketName, key)));
     }
-    OMMetadataManager catchUpMetaMgr = followerOM.getMetadataManager();
-    String lastNewKey = newKeys.get(newKeys.size() - 1);
-    GenericTestUtils.waitFor(() -> {
-      try {
-        return catchUpMetaMgr.getKeyTable(TEST_BUCKET_LAYOUT)
-            .get(catchUpMetaMgr.getOzoneKey(volumeName, bucketName, lastNewKey)) != null;
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }, 100, 30_000);
+    // Wait for the follower to apply all transactions the leader has applied;
+    // by this point every write has completed on the leader, so reaching the
+    // leader's applied index implies all newKeys are visible on the follower.
+    long leaderApplied = leaderOM.getOmRatisServer()
+        .getLastAppliedTermIndex().getIndex();
+    GenericTestUtils.waitFor(() -> followerOM.getOmRatisServer()
+        .getLastAppliedTermIndex().getIndex() >= leaderApplied, 100, 30_000);
     followerOMMetaMgr = followerOM.getMetadataManager();
     for (String key : newKeys) {
       assertNotNull(followerOMMetaMgr.getKeyTable(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -169,11 +169,13 @@ public class TestOMRatisSnapshots {
     clientConfig.setRpcTimeOut(TimeUnit.SECONDS.toMillis(5));
     conf.setFromObject(clientConfig);
 
-    cluster = MiniOzoneCluster.newHABuilder(conf)
-        .setOMServiceId("om-service-test1")
+    MiniOzoneHAClusterImpl.Builder clusterBuilder =
+        MiniOzoneCluster.newHABuilder(conf);
+    clusterBuilder.setOMServiceId("om-service-test1")
         .setNumOfOzoneManagers(NUM_OF_OMS)
         .setNumOfActiveOMs(2)
-        .build();
+        .setNumDatanodes(1);
+    cluster = clusterBuilder.build();
     cluster.waitForClusterToBeReady();
     client = OzoneClientFactory.getRpcClient(OM_SERVICE_ID, conf);
     objectStore = client.getObjectStore();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test-only change: speeds up `TestOMRatisSnapshots`. Profiling the run shows that a large share of the time is spent on fixed sleeps and on the oversized cluster setup rather than on the code under test.

This PR removes the dead time without weakening any assertion:

1. **Remove the per-key `Thread.sleep(100)` in `writeKeysToIncreaseLogIndex`.** Each `createKey()` is a synchronous RPC producing 2 Ratis transactions, so the loop converges without sleeping; callers only require reaching at least the target index. Sleep was introduced without a documented rationale in the HDDS-3741 refactor (the original HDDS-1649 loop had no sleep). This alone was ~40s of pure sleep per parameter run.
2. **Replace/remove three hardcoded `Thread.sleep(5000)`.** Two were redundant (each immediately followed by a 30s polling assertion). The third is replaced by waiting for the follower's applied index to reach the leader's. (Polling the follower's key table by name was tried first, but it races with the DB reload during snapshot install, see 4.)
3. **Use a single datanode.** All key writes in this class use `ReplicationFactor.ONE`, so 3 DNs only add startup/teardown cost for each of the 12 cluster instances. (`setNumDatanodes` returns the base builder type, hence the builder chain is split.)
4. **Fix two pre-existing races that the removed sleeps used to mask**, by waiting for the follower to catch up to the leader's applied index before reading follower state:
   - `testInstallOldCheckpointFailure` asserts a log message containing an exact TermIndex; trailing applies could advance the index between the test's read and the one inside `installCheckpoint` (observed: expected i:202, OM logged i:203).
   - `testInstallSnapshotWithClientWrite` read the follower's RocksDB while a second snapshot install could still reload the DB underneath it ("Rocks Database is closed").

Why faster writes cannot break the forced InstallSnapshot: Ratis snapshots and log purges are triggered by applied-index thresholds (50 here) on the same thread that advances the index polled by the write loop, and OM defaults `ozone.om.ratis.log.purge.upto.snapshot.index=true`, so purging does not wait for the down follower. Several purge cycles therefore complete during the write loop itself, before `startInactiveOM` finishes.

Follow-up: HDDS-15493 will limit the class-level parameterization to the checkpoint-transfer tests, which roughly halves the remaining cost.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10310

## How was this patch tested?

Full `TestOMRatisSnapshots` class run locally with both parameters:

```
mvn -pl hadoop-ozone/integration-test test -Dtest=TestOMRatisSnapshots
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```

Three consecutive full-class runs to check for flakiness: 12/12 passed on each. The class total (~480-525s) is dominated by `testInstallSnapshot`, which this PR intentionally does not touch (deferred to HDDS-15493), so totals are noisy; the affected tests improve consistently:

| Test | Before | After |
| --- | --- | --- |
| testInstallSnapshotWithClientWrite | 50-55s | 33-39s |
| testInstallSnapshotWithClientRead | 44s | 26-37s |
| testInstallOldCheckpointFailure | 33-37s | 23-28s |

`checkstyle`, `rat`, and `author` checks pass on the module.


CI comparison, `integration (om)` job (the class runs as two parameterized forks):

| | master (3 recent runs) | this branch | delta |
| --- | --- | --- | --- |
| fork 1 | 234.3s / 238.6s / 247.2s | 205.9s | ~-34s |
| fork 2 | 221.9s / 224.5s / 234.5s | 193.7s | ~-33s |
| total | 456.3s / 463.1s / 481.7s | **399.7s** | **~-67s (-14%)** |

12/12 pass in CI as well. Branch run: https://github.com/chihsuan/ozone/actions/runs/27062244125. Master baselines: [HDDS-14643](https://github.com/apache/ozone/actions/runs/27005420089), [HDDS-14356](https://github.com/apache/ozone/actions/runs/26989182526), [HDDS-10308](https://github.com/apache/ozone/actions/runs/26968877542).
