### PR TITLE
HDDS-15449. Avoid leaked event-processing thread and async work outliving tests in TestReconTaskControllerImpl

### DIFF
--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -585,7 +585,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     // Iterations 1-6: should return RETRY_LATER and increment retry count
     for (int i = 1; i <= 6; i++) {
       if (i > 1) {
-        Thread.sleep(2500); // Wait for retry delay
+        Thread.sleep(2100); // Wait for retry delay
       }
       result = controllerSpy.queueReInitializationEvent(
           ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
@@ -596,7 +596,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     
     // Iteration 7: should return MAX_RETRIES_EXCEEDED (eventProcessRetryCount is now 6,
     // which >= MAX_EVENT_PROCESS_RETRIES)
-    Thread.sleep(2500); // Wait for retry delay
+    Thread.sleep(2100); // Wait for retry delay
     result = controllerSpy.queueReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
     assertEquals(ReconTaskController.ReInitializationResult.MAX_RETRIES_EXCEEDED, result,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.util.Time;
 import org.apache.ozone.recon.schema.generated.tables.daos.ReconTaskStatusDao;
 import org.apache.ozone.recon.schema.generated.tables.pojos.ReconTaskStatus;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -96,6 +97,13 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     reconTaskController.start();
   }
 
+  @AfterEach
+  public void tearDown() {
+    if (reconTaskController != null) {
+      reconTaskController.stop();
+    }
+  }
+
   @Test
   public void testStopCompletesPromptly() {
     // stop() must not block on the graceful shutdown timeout. The event
@@ -122,15 +130,10 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
 
   @Test
   public void testConsumeOMEvents() throws Exception {
-    // Use CountDownLatch to wait for async processing
-    CountDownLatch taskCompletionLatch = new CountDownLatch(1);
-    
     ReconOmTask reconOmTaskMock = getMockTask("MockTask");
     when(reconOmTaskMock.process(any(OMUpdateEventBatch.class), anyMap()))
-        .thenAnswer(invocation -> {
-          taskCompletionLatch.countDown(); // Signal task completion
-          return new ReconOmTask.TaskResult.Builder().setTaskName("MockTask").setTaskSuccess(true).build();
-        });
+        .thenReturn(new ReconOmTask.TaskResult.Builder()
+            .setTaskName("MockTask").setTaskSuccess(true).build());
     reconTaskController.registerTask(reconOmTaskMock);
     
     OMUpdateEventBatch omUpdateEventBatchMock = mock(OMUpdateEventBatch.class);
@@ -145,10 +148,17 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
         omUpdateEventBatchMock,
         mock(OMMetadataManager.class));
 
-    // Wait for async processing to complete using latch
-    boolean completed = taskCompletionLatch.await(10, TimeUnit.SECONDS);
-    assertThat(completed).isTrue();
-    
+    GenericTestUtils.waitFor(() -> {
+      try {
+        ReconTaskStatus status = reconTaskStatusDao.findById("MockTask");
+        return status != null
+            && status.getLastTaskRunStatus() == 0
+            && status.getLastUpdatedSeqNumber() == 100L;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 100, 5000);
+
     verify(reconOmTaskMock, times(1))
         .process(any(), anyMap());
     long endTime = System.currentTimeMillis();
@@ -236,9 +246,17 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     reconTaskController.consumeOMEvents(omUpdateEventBatchMock,
         mock(OMMetadataManager.class));
     
-    // Wait for async processing to complete
-    Thread.sleep(3000); // Increase timeout for retry logic
-    
+    GenericTestUtils.waitFor(() -> {
+      try {
+        ReconTaskStatus status = reconTaskStatusDao.findById(taskName);
+        return status != null
+            && status.getLastTaskRunStatus() == 0
+            && status.getLastUpdatedSeqNumber() == 100L;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 100, 5000);
+
     assertThat(reconTaskController.getRegisteredTasks()).isNotEmpty();
     assertEquals(dummyReconDBTask, reconTaskController.getRegisteredTasks()
         .get(dummyReconDBTask.getTaskName()));
@@ -350,6 +368,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     when(mockCheckpoint.getCheckpointLocation()).thenReturn(mockCheckpointPath);
     
     reconTaskController.updateOMMetadataManager(mockOMMetadataManager);
+    reconTaskController.stop();
     
     // Test successful queueing - the checkpoint creation should work with proper mocks
     ReconTaskController.ReInitializationResult result = reconTaskController.queueReInitializationEvent(
@@ -377,6 +396,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     when(mockCheckpoint.getCheckpointLocation()).thenReturn(mockCheckpointPath);
     
     reconTaskController.updateOMMetadataManager(mockOMMetadataManager);
+    reconTaskController.stop();
     
     // Create a spy of the controller to mock checkpoint creation failure
     ReconTaskControllerImpl controllerSpy = spy((ReconTaskControllerImpl) reconTaskController);
@@ -471,6 +491,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     
     // Update with first manager
     reconTaskController.updateOMMetadataManager(mockManager1);
+    reconTaskController.stop();
     
     // Test that the manager was updated correctly by attempting to queue a reinitialization event
     ReconTaskController.ReInitializationResult result = reconTaskController.queueReInitializationEvent(
@@ -495,6 +516,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     when(mockCheckpoint.getCheckpointLocation()).thenReturn(mockCheckpointPath);
     
     reconTaskController.updateOMMetadataManager(mockOMMetadataManager);
+    reconTaskController.stop();
     
     // This test verifies the successful path - in practice, queue failure after clear is very rare
     // since we clear the buffer before queueing the reinitialization event
@@ -524,6 +546,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     
     ReconTaskControllerImpl controllerImpl = (ReconTaskControllerImpl) reconTaskController;
     controllerImpl.updateOMMetadataManager(mockOMMetadataManager);
+    controllerImpl.stop();
     
     // Reset any previous retry state
     controllerImpl.resetRetryCounters();
@@ -545,6 +568,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     ReconOMMetadataManager mockOMMetadataManager = mock(ReconOMMetadataManager.class);
     ReconTaskControllerImpl controllerImpl = (ReconTaskControllerImpl) reconTaskController;
     controllerImpl.updateOMMetadataManager(mockOMMetadataManager);
+    controllerImpl.stop();
     
     // Reset any previous retry state
     controllerImpl.resetRetryCounters();
@@ -561,7 +585,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     // Iterations 1-6: should return RETRY_LATER and increment retry count
     for (int i = 1; i <= 6; i++) {
       if (i > 1) {
-        Thread.sleep(2100); // Wait for retry delay
+        Thread.sleep(2500); // Wait for retry delay
       }
       result = controllerSpy.queueReInitializationEvent(
           ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
@@ -572,7 +596,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     
     // Iteration 7: should return MAX_RETRIES_EXCEEDED (eventProcessRetryCount is now 6,
     // which >= MAX_EVENT_PROCESS_RETRIES)
-    Thread.sleep(2100); // Wait for retry delay
+    Thread.sleep(2500); // Wait for retry delay
     result = controllerSpy.queueReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
     assertEquals(ReconTaskController.ReInitializationResult.MAX_RETRIES_EXCEEDED, result,


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Added teardown in `TestReconTaskControllerImpl` to stop the task controller after each test.
* Updated queue-only reinitialization tests to stop the background event processor before enqueueing events.
* Replaced async wait logic with deterministic waits for task status updates so test work does not outlive the test method.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15449

## How was this patch tested?
* All CI test passed