### PR TITLE
HDDS-15490. [DiskBalancer] Align batch CLI success messages with HEALTHY IN_SERVICE datanode selection.

### DIFF
--- a/hadoop-hdds/docs/content/design/diskbalancer.md
+++ b/hadoop-hdds/docs/content/design/diskbalancer.md
@@ -69,7 +69,7 @@ Administrators use the `ozone admin datanode diskbalancer` CLI to manage and mon
   - Update configuration parameters
   - Query DiskBalancer status and volume density reports
 * Each datanode performs its own **authentication** (via RPC) and **authorization** checks (using `OzoneAdmins` based on `ozone.administrators` configuration).
-* For batch operations, clients can use the `--in-service-datanodes` flag to automatically query SCM for all IN_SERVICE datanodes and execute commands on all of them.
+* For batch operations, clients can use the `--in-service-datanodes` flag to automatically query SCM for all IN_SERVICE and HEALTHY datanodes and execute commands on all of them.
 
 **DN - DiskBalancer Service:**
 
@@ -81,7 +81,7 @@ A daemon thread, the **Scheduler**, runs periodically on each Datanode.
 from the most over-utilized disk (source) to the least utilized disk (destination).
 3.  The scheduler dispatches these move tasks to a pool of **Worker** threads for parallel execution.
 
-**Note:** SCM is used **only** for datanode discovery when using the `--in-service-datanodes` flag. SCM provides a list of IN_SERVICE datanodes for batch operations but
+**Note:** SCM is used **only** for datanode discovery when using the `--in-service-datanodes` flag. SCM provides a list of IN_SERVICE and HEALTHY datanodes for batch operations but
 does **not** participate in DiskBalancer control operations (start/stop/update/status/report). All DiskBalancer operations are performed directly between client and datanode.
 
 ## Container Move Process

--- a/hadoop-hdds/docs/content/feature/DiskBalancer.md
+++ b/hadoop-hdds/docs/content/feature/DiskBalancer.md
@@ -154,7 +154,7 @@ ozone admin datanode diskbalancer report [<datanode-address> ...] [--in-service-
 | Option                              | Description                                                                                                                                                                                                                                                                                                                                                           | Example                                        |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
 | `<datanode-address>`                | One or more datanode addresses as positional arguments. Addresses can be:<br>- Hostname (e.g., `DN-1`) - uses default CLIENT_RPC port (19864)<br>- Hostname with port (e.g., `DN-1:19864`)<br>- IP address (e.g., `192.168.1.10`)<br>- IP address with port (e.g., `192.168.1.10:19864`)<br>- Stdin (`-`) - reads datanode addresses from standard input, one per line | `DN-1`<br>`DN-1:19864`<br>`192.168.1.10`<br>`-` |
-| `--in-service-datanodes`            | It queries SCM for all IN_SERVICE datanodes and executes the command on all of them.                                                                                                                                                                                                                                                                                  | `--in-service-datanodes`                       |
+| `--in-service-datanodes`            | It queries SCM for all IN_SERVICE and HEALTHY datanodes and executes the command on all of them.                                                                                                                                                                                                                                                                     | `--in-service-datanodes`                       |
 | `--json`                            | Format output as JSON.                                                                                                                                                                                                                                                                                                                                                | `--json`                                       |
 | `-t/--threshold-percentage`        | Volume density threshold percentage (default: 10.0). Used with `start` and `update` commands.                                                                                                                                                                                                                                                                         | `-t 5`<br>`--threshold-percentage 5.0`         |
 | `-b/--bandwidth-in-mb`              | Maximum disk bandwidth in MB/s (default: 10). Used with `start` and `update` commands.                                                                                                                                                                                                                                                                                | `-b 20`<br>`--bandwidth-in-mb 50`              |
@@ -169,7 +169,7 @@ ozone admin datanode diskbalancer report [<datanode-address> ...] [--in-service-
 # Start DiskBalancer on multiple datanodes
 ozone admin datanode diskbalancer start DN-1 DN-2 DN-3
 
-# Start DiskBalancer on all IN_SERVICE datanodes
+# Start DiskBalancer on all IN_SERVICE and HEALTHY datanodes
 ozone admin datanode diskbalancer start --in-service-datanodes
 
 # Start DiskBalancer with configuration parameters
@@ -189,7 +189,7 @@ ozone admin datanode diskbalancer start DN-1 --json
 # Stop DiskBalancer on multiple datanodes
 ozone admin datanode diskbalancer stop DN-1 DN-2 DN-3
 
-# Stop DiskBalancer on all IN_SERVICE datanodes
+# Stop DiskBalancer on all IN_SERVICE and HEALTHY datanodes
 ozone admin datanode diskbalancer stop --in-service-datanodes
 
 # Stop DiskBalancer with json output
@@ -202,7 +202,7 @@ ozone admin datanode diskbalancer stop DN-1 --json
 # Update multiple parameters
 ozone admin datanode diskbalancer update DN-1 -t 5 -b 50 -p 10
 
-# Update on all IN_SERVICE datanodes
+# Update on all IN_SERVICE and HEALTHY datanodes
 ozone admin datanode diskbalancer update --in-service-datanodes -t 5
 # Or using the long form:
 ozone admin datanode diskbalancer update --in-service-datanodes --threshold-percentage 5
@@ -216,7 +216,7 @@ ozone admin datanode diskbalancer update DN-1 -b 50 --json
 # Get status from multiple datanodes
 ozone admin datanode diskbalancer status DN-1 DN-2 DN-3
 
-# Get status from all IN_SERVICE datanodes
+# Get status from all IN_SERVICE and HEALTHY datanodes
 ozone admin datanode diskbalancer status --in-service-datanodes
 
 # Get status as JSON
@@ -228,7 +228,7 @@ ozone admin datanode diskbalancer status --in-service-datanodes --json
 # Get report from multiple datanodes
 ozone admin datanode diskbalancer report DN-1 DN-2 DN-3
 
-# Get report from all IN_SERVICE datanodes
+# Get report from all IN_SERVICE and HEALTHY datanodes
 ozone admin datanode diskbalancer report --in-service-datanodes
 
 # Get report as JSON

--- a/hadoop-hdds/docs/content/feature/DiskBalancer.zh.md
+++ b/hadoop-hdds/docs/content/feature/DiskBalancer.zh.md
@@ -149,7 +149,7 @@ ozone admin datanode diskbalancer report [<datanode-address> ...] [--in-service-
 | Option                              | Description                                                                                                                                                                                                      | Example                                        |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
 | `<datanode-address>`                | 一个或多个数据节点地址作为位置参数。地址可以是：<br>- 主机名（例如，`DN-1`）- 使用默认的 CLIENT_RPC 端口 (19864)<br>- 带端口的主机名（例如，`DN-1:19864`）<br>- IP 地址（例如，`192.168.1.10`）<br>- 带端口的 IP 地址（例如，`192.168.1.10:19864`）<br>- 标准输入 (`-`) - 从标准输入读取数据节点地址，每行一个 | `DN-1`<br>`DN-1:19864`<br>`192.168.1.10`<br>`-` |
-| `--in-service-datanodes`            | 它向 SCM 查询所有 IN_SERVICE 数据节点，并在所有这些数据节点上执行该命令。                                                                                                                                                                    | `--in-service-datanodes`                       |
+| `--in-service-datanodes`            | 它向 SCM 查询所有 IN_SERVICE 且 HEALTHY 的数据节点，并在所有这些数据节点上执行该命令。                                                                                                                                                                    | `--in-service-datanodes`                       |
 | `--json`                            | 输出格式设置为JSON。                                                                                                                                                                                                     | `--json`                                       |
 | `-t/--threshold-percentage`         | 磁盘使用率阈值百分比（默认值：10.0）。与 `start` 和 `update` 命令一起使用。                                                                                                                                                                 | `-t 5`<br>`--threshold-percentage 5.0`        |
 | `-b/--bandwidth-in-mb`              | 最大磁盘带宽，单位为 MB/s（默认值：10）。与 `start` 和 `update` 命令一起使用。                                                                                                                                                             | `-b 20`<br>`--bandwidth-in-mb 50`              |
@@ -164,7 +164,7 @@ ozone admin datanode diskbalancer report [<datanode-address> ...] [--in-service-
 # 在多个数据节点上启动 DiskBalancer
 ozone admin datanode diskbalancer start DN-1 DN-2 DN-3
 
-# 在所有运行中的数据节点上启动 DiskBalancer
+# 在所有 IN_SERVICE 且 HEALTHY 的数据节点上启动 DiskBalancer
 ozone admin datanode diskbalancer start --in-service-datanodes
 
 # 使用配置参数启动 DiskBalancer
@@ -183,7 +183,7 @@ ozone admin datanode diskbalancer start DN-1 --json
 # 在多个数据节点上停止 DiskBalancer
 ozone admin datanode diskbalancer stop DN-1 DN-2 DN-3
 
-# 在所有运行中的数据节点上停止 DiskBalancer
+# 在所有 IN_SERVICE 且 HEALTHY 的数据节点上停止 DiskBalancer
 ozone admin datanode diskbalancer stop --in-service-datanodes
 
 # 停止 DiskBalancer 并输出 JSON 信息
@@ -195,7 +195,7 @@ ozone admin datanode diskbalancer stop DN-1 --json
 # 更新多个参数
 ozone admin datanode diskbalancer update DN-1 -t 5 -b 50 -p 10
 
-# 更新所有 IN_SERVICE 数据节点
+# 更新所有 IN_SERVICE 且 HEALTHY 的数据节点
 ozone admin datanode diskbalancer update --in-service-datanodes -t 5
 
 # 更新并输出 JSON 格式
@@ -208,7 +208,7 @@ ozone admin datanode diskbalancer update DN-1 -b 50 --json
 # 从多个数据节点获取状态
 ozone admin datanode diskbalancer status DN-1 DN-2 DN-3
 
-# 从所有处于服务状态的数据节点获取状态
+# 从所有 IN_SERVICE 且 HEALTHY 的数据节点获取状态
 ozone admin datanode diskbalancer status --in-service-datanodes
 
 # 以 JSON 格式获取状态
@@ -220,7 +220,7 @@ ozone admin datanode diskbalancer status --in-service-datanodes --json
 # 从多个数据节点获取报告
 ozone admin datanode diskbalancer report DN-1 DN-2 DN-3
 
-# 从所有处于服务状态的数据节点获取报告
+# 从所有 IN_SERVICE 且 HEALTHY 的数据节点获取报告
 ozone admin datanode diskbalancer report --in-service-datanodes
 
 # 以 JSON 格式获取报告

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommands.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerCommands.java
@@ -35,9 +35,9 @@ import picocli.CommandLine.Command;
  *      [--in-service-datanodes]   Send requests to all available DataNodes in HEALTHY
  *                                  and IN_SERVICE operational state. When this option
  *                                  is used, specific datanode addresses are not required.
- *                                  Note: Commands will only be sent to IN_SERVICE datanodes,
- *                                  excluding DECOMMISSIONING, DECOMMISSIONED, and nodes
- *                                  in maintenance states.
+ *                                  Note: Commands will only be sent to HEALTHY datanodes
+ *                                  in IN_SERVICE operational state, excluding non-HEALTHY,
+ *                                  DECOMMISSIONING, DECOMMISSIONED, and nodes in maintenance states.
  *
  * To start:
  *      ozone admin datanode diskbalancer start {@literal <host[:port]>} [{@literal <host[:port]>} ...]
@@ -77,7 +77,7 @@ import picocli.CommandLine.Command;
  *        Start balancer on all IN_SERVICE and HEALTHY datanodes
  *
  *      ozone admin datanode diskbalancer start --in-service-datanodes --json
- *        Start balancer on all IN_SERVICE datanodes and output results in JSON format
+ *        Start balancer on all IN_SERVICE and HEALTHY datanodes and output results in JSON format
  *
  * To stop:
  *      ozone admin datanode diskbalancer stop {@literal <host[:port]>} [{@literal <host[:port]>} ...]
@@ -111,7 +111,7 @@ import picocli.CommandLine.Command;
  *        Update diskbalancer threshold to 10% on DN-1
  *
  *      ozone admin datanode diskbalancer update --in-service-datanodes -t 10
- *        Update diskbalancer threshold to 10% on all IN_SERVICE datanodes
+ *        Update diskbalancer threshold to 10% on all IN_SERVICE and HEALTHY datanodes
  *
  *      ozone admin datanode diskbalancer update DN-1 -t 10 --json
  *        Update diskbalancer threshold to 10% on DN-1 and output result in JSON format

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStartSubcommand.java
@@ -123,7 +123,7 @@ public class DiskBalancerStartSubcommand extends AbstractDiskBalancerSubCommand 
                 .map(this::formatDatanodeDisplayName)
                 .collect(toList())));
       } else {
-        System.out.println("Started DiskBalancer on all IN_SERVICE nodes.");
+        System.out.println("Started DiskBalancer on all IN_SERVICE and HEALTHY nodes.");
       }
     } else {
       // Detailed message for specific nodes

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStopSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStopSubcommand.java
@@ -69,7 +69,7 @@ public class DiskBalancerStopSubcommand extends AbstractDiskBalancerSubCommand {
                 .map(this::formatDatanodeDisplayName)
                 .collect(toList())));
       } else {
-        System.out.println("Stopped DiskBalancer on all IN_SERVICE nodes.");
+        System.out.println("Stopped DiskBalancer on all IN_SERVICE and HEALTHY nodes.");
       }
     } else {
       // Detailed message for specific nodes

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerSubCommandUtil.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerSubCommandUtil.java
@@ -75,7 +75,7 @@ final class DiskBalancerSubCommandUtil {
   }
 
   /**
-   * Retrieves all IN_SERVICE datanode addresses with their hostnames from SCM.
+   * Retrieves all IN_SERVICE and HEALTHY datanode addresses with their hostnames from SCM.
    * Used for batch operations with --in-service-datanodes flag.
    *
    * @param scmClient the SCM client

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerUpdateSubcommand.java
@@ -133,7 +133,7 @@ public class DiskBalancerUpdateSubcommand extends AbstractDiskBalancerSubCommand
                 .map(this::formatDatanodeDisplayName)
                 .collect(toList())));
       } else {
-        System.out.println("Updated DiskBalancer configuration on all IN_SERVICE nodes.");
+        System.out.println("Updated DiskBalancer configuration on all IN_SERVICE and HEALTHY nodes.");
       }
     } else {
       // Detailed message for specific nodes

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -192,7 +192,7 @@ public class TestDiskBalancerSubCommands {
 
       String output = outContent.toString(DEFAULT_ENCODING);
 
-      Pattern p = Pattern.compile("Started DiskBalancer on all IN_SERVICE nodes\\.");
+      Pattern p = Pattern.compile("Started DiskBalancer on all IN_SERVICE and HEALTHY nodes\\.");
       Matcher m = p.matcher(output);
       assertTrue(m.find());
     }
@@ -323,7 +323,7 @@ public class TestDiskBalancerSubCommands {
       c.parseArgs("--in-service-datanodes");
       cmd.call();
 
-      Pattern p = Pattern.compile("Stopped DiskBalancer on all IN_SERVICE nodes\\.");
+      Pattern p = Pattern.compile("Stopped DiskBalancer on all IN_SERVICE and HEALTHY nodes\\.");
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
       assertTrue(m.find());
     }
@@ -378,7 +378,7 @@ public class TestDiskBalancerSubCommands {
       c.parseArgs("--in-service-datanodes", "-t", "0.005", "-b", "100");
       cmd.call();
 
-      Pattern p = Pattern.compile("Updated DiskBalancer configuration on all IN_SERVICE nodes\\.");
+      Pattern p = Pattern.compile("Updated DiskBalancer configuration on all IN_SERVICE and HEALTHY nodes\\.");
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
       assertTrue(m.find());
     }
@@ -885,4 +885,3 @@ public class TestDiskBalancerSubCommands {
         .build();
   }
 }
-

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -885,3 +885,4 @@ public class TestDiskBalancerSubCommands {
         .build();
   }
 }
+

--- a/hadoop-ozone/dist/src/main/smoketest/diskbalancer/testdiskbalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/diskbalancer/testdiskbalancer.robot
@@ -46,11 +46,11 @@ Check failure with non-admin user to start, stop and update diskbalancer with --
 Check success with admin user for start, stop and update diskbalancer with --in-service-datanodes
     Run Keyword         Kinit test user                 testuser                testuser.keytab
     ${result} =         Execute                         ozone admin datanode diskbalancer start --in-service-datanodes
-                        Should Contain                  ${result}                Started DiskBalancer on all IN_SERVICE nodes.
+                        Should Contain                  ${result}                Started DiskBalancer on all IN_SERVICE and HEALTHY nodes.
     ${result} =         Execute                         ozone admin datanode diskbalancer stop --in-service-datanodes
-                        Should Contain                  ${result}                Stopped DiskBalancer on all IN_SERVICE nodes.
+                        Should Contain                  ${result}                Stopped DiskBalancer on all IN_SERVICE and HEALTHY nodes.
     ${result} =         Execute                         ozone admin datanode diskbalancer update -t 0.0002 --in-service-datanodes
-                        Should Contain                  ${result}                Updated DiskBalancer configuration on all IN_SERVICE nodes.
+                        Should Contain                  ${result}                Updated DiskBalancer configuration on all IN_SERVICE and HEALTHY nodes.
 
 Check success with non-admin user for status and report diskbalancer with --in-service-datanodes
     Run Keyword         Kinit test user                 testuser2               testuser2.keytab


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aligns DiskBalancer batch-mode success messages with the actual datanode selection criteria used by `--in-service-datanodes`.

The `--in-service-datanodes` option queries SCM for datanodes that are both in the IN_SERVICE operational state and HEALTHY node state. However, the success messages for the `start`, `stop`, and `update` subcommands previously said "all IN_SERVICE nodes", which did not mention the HEALTHY state filter.

This PR updates the batch-mode success messages to say "all IN_SERVICE and HEALTHY nodes" for:
- `ozone admin datanode diskbalancer start --in-service-datanodes`
- `ozone admin datanode diskbalancer stop --in-service-datanodes`
- `ozone admin datanode diskbalancer update --in-service-datanodes`

The corresponding CLI unit test expectations and DiskBalancer acceptance test assertions are updated to match the corrected output.

## What is the link to the Apache JIRA

JIRA: HDDS-15490. Align DiskBalancer batch CLI success messages with HEALTHY IN_SERVICE datanode selection.

## How was this patch tested?

Add Junit Test.