### PR TITLE
HDDS-15494. Refactor OzoneOutputStream usage to utilize try-with-resources

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -108,7 +108,7 @@ public class TestContainerStateMachine {
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 30000);
     cluster.getOzoneManager().startSecretManager();
-    //the easiest way to create an open container is creating a key
+    // The easiest way to create an open container is creating a key.
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "testcontainerstatemachinefailures";
@@ -133,12 +133,12 @@ public class TestContainerStateMachine {
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
       key.write("ratis".getBytes(UTF_8));
 
-      //get the name of a valid container
+      // Get the name of a valid container.
       KeyOutputStream groupOutputStream =
           (KeyOutputStream) key.getOutputStream();
 
@@ -147,7 +147,7 @@ public class TestContainerStateMachine {
       assertEquals(1, locationInfoList.size());
       omKeyLocationInfo = locationInfoList.get(0);
 
-      // delete the container dir
+      // Delete the container directory.
       FileUtil.fullyDelete(new File(
           cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
               .getContainer().getContainerSet()
@@ -180,7 +180,7 @@ public class TestContainerStateMachine {
               .createKey(("ratis" + i), 1024,
                   ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
                       ReplicationFactor.ONE), new HashMap<>())) {
-        // First write and flush creates a container in the datanode
+        // First write and flush creates a container in the datanode.
         key.write(("ratis" + i).getBytes(UTF_8));
         key.flush();
         key.write(("ratis" + i).getBytes(UTF_8));
@@ -205,7 +205,7 @@ public class TestContainerStateMachine {
               .createKey(("ratis" + i), 1024,
                   ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
                       ReplicationFactor.ONE), new HashMap<>())) {
-        // First write and flush creates a container in the datanode
+        // First write and flush creates a container in the datanode.
         key.write(("ratis" + i).getBytes(UTF_8));
         key.flush();
         key.write(("ratis" + i).getBytes(UTF_8));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -127,33 +127,34 @@ public class TestContainerStateMachine {
 
   @Test
   public void testContainerStateMachineFailures() throws Exception {
-    OzoneOutputStream key =
+    OmKeyLocationInfo omKeyLocationInfo;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
 
-    //get the name of a valid container
-    KeyOutputStream groupOutputStream =
-        (KeyOutputStream) key.getOutputStream();
+      //get the name of a valid container
+      KeyOutputStream groupOutputStream =
+          (KeyOutputStream) key.getOutputStream();
 
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
 
-    // delete the container dir
-    FileUtil.fullyDelete(new File(
-        cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
-            .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID()).getContainerData()
-            .getContainerPath()));
+      // delete the container dir
+      FileUtil.fullyDelete(new File(
+          cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
+              .getContainer().getContainerSet()
+              .getContainer(omKeyLocationInfo.getContainerID()).getContainerData()
+              .getContainerPath()));
+    }
 
-    key.close();
     // Make sure the container is marked unhealthy
     assertEquals(
         ContainerProtos.ContainerDataProto.State.UNHEALTHY,
@@ -174,16 +175,16 @@ public class TestContainerStateMachine {
 
     // Write 10 keys. Num snapshots should be equal to config value.
     for (int i = 1; i <= 10; i++) {
-      OzoneOutputStream key =
+      try (OzoneOutputStream key =
           objectStore.getVolume(volumeName).getBucket(bucketName)
               .createKey(("ratis" + i), 1024,
                   ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                      ReplicationFactor.ONE), new HashMap<>());
-      // First write and flush creates a container in the datanode
-      key.write(("ratis" + i).getBytes(UTF_8));
-      key.flush();
-      key.write(("ratis" + i).getBytes(UTF_8));
-      key.close();
+                      ReplicationFactor.ONE), new HashMap<>())) {
+        // First write and flush creates a container in the datanode
+        key.write(("ratis" + i).getBytes(UTF_8));
+        key.flush();
+        key.write(("ratis" + i).getBytes(UTF_8));
+      }
     }
 
     RatisServerConfiguration ratisServerConfiguration =
@@ -199,16 +200,16 @@ public class TestContainerStateMachine {
 
     // Write 10 more keys. Num Snapshots should remain the same.
     for (int i = 11; i <= 20; i++) {
-      OzoneOutputStream key =
+      try (OzoneOutputStream key =
           objectStore.getVolume(volumeName).getBucket(bucketName)
               .createKey(("ratis" + i), 1024,
                   ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                      ReplicationFactor.ONE), new HashMap<>());
-      // First write and flush creates a container in the datanode
-      key.write(("ratis" + i).getBytes(UTF_8));
-      key.flush();
-      key.write(("ratis" + i).getBytes(UTF_8));
-      key.close();
+                      ReplicationFactor.ONE), new HashMap<>())) {
+        // First write and flush creates a container in the datanode
+        key.write(("ratis" + i).getBytes(UTF_8));
+        key.flush();
+        key.write(("ratis" + i).getBytes(UTF_8));
+      }
     }
     files = parentPath.toFile().listFiles();
     assertThat(files).isNotNull();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
@@ -165,23 +165,22 @@ public class TestContainerStateMachineFailureOnRead {
     }
 
     OmKeyLocationInfo omKeyLocationInfo;
-    OzoneOutputStream key = objectStore.getVolume(volumeName)
+    try (OzoneOutputStream key = objectStore.getVolume(volumeName)
         .getBucket(bucketName)
         .createKey("ratis", 1024, ReplicationType.RATIS,
-            ReplicationFactor.THREE, new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    
-    // get the name of a valid container
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
+            ReplicationFactor.THREE, new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      
+      // get the name of a valid container
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
 
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    omKeyLocationInfo = locationInfoList.get(0);
-    key.close();
-    groupOutputStream.close();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
+    }
 
     Optional<HddsDatanodeService> leaderDn =
         cluster.getHddsDatanodes().stream().filter(dn -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
@@ -169,11 +169,11 @@ public class TestContainerStateMachineFailureOnRead {
         .getBucket(bucketName)
         .createKey("ratis", 1024, ReplicationType.RATIS,
             ReplicationFactor.THREE, new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
-      
-      // get the name of a valid container
+
+      // Get the name of a valid container.
       KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
 
       List<OmKeyLocationInfo> locationInfoList =
@@ -193,7 +193,7 @@ public class TestContainerStateMachineFailureOnRead {
         }).findFirst();
 
     assertTrue(leaderDn.isPresent());
-    // delete the container dir from leader
+    // Delete the container directory from leader.
     FileUtil.fullyDelete(new File(
         leaderDn.get().getDatanodeStateMachine()
             .getContainer().getContainerSet()
@@ -212,7 +212,7 @@ public class TestContainerStateMachineFailureOnRead {
       assertEquals(Pipeline.PipelineState.CLOSED, pipeline.getPipelineState(),
           "Pipeline " + pipeline.getId() + "should be in CLOSED state");
     } catch (PipelineNotFoundException e) {
-      // do nothing
+      // Do nothing.
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -175,7 +175,7 @@ public class TestContainerStateMachineFailures {
             .build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
-    //the easiest way to create an open container is creating a key
+    // The easiest way to create an open container is creating a key.
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     xceiverClientManager = new XceiverClientManager(conf);
@@ -318,15 +318,16 @@ public class TestContainerStateMachineFailures {
   @Order(Integer.MAX_VALUE)
   public void testContainerStateMachineFailures() throws Exception {
     byte[] testData = "ratis".getBytes(UTF_8);
-    long containerID;
-    HddsDatanodeService dn;
+    long containerID = 0;
+    HddsDatanodeService dn = null;
+    boolean injectedContainerFailure = false;
     try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write(testData);
       key.flush();
       key.write(testData);
@@ -338,17 +339,22 @@ public class TestContainerStateMachineFailures {
       OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
       dn = TestHelper.getDatanodeService(omKeyLocationInfo,
           cluster);
-      // delete the container dir
+      // Delete the container directory.
       FileUtil.fullyDelete(new File(dn.getDatanodeStateMachine()
           .getContainer().getContainerSet()
           .getContainer(omKeyLocationInfo.getContainerID()).
           getContainerData().getContainerPath()));
       containerID = omKeyLocationInfo.getContainerID();
+      injectedContainerFailure = true;
     } catch (IOException ioe) {
-      // there is only 1 datanode in the pipeline, the pipeline will be closed
-      // and allocation to new pipeline will fail as there is no other dn in
-      // the cluster
+      // There is only 1 datanode in the pipeline, the pipeline will be closed
+      // and allocation to a new pipeline will fail as there is no other DN in
+      // the cluster.
+      assertTrue(injectedContainerFailure,
+          "Unexpected IOException before closing the key");
     }
+    assertTrue(containerID > 0, "Container ID should be captured");
+    assertNotNull(dn, "Datanode should be captured");
 
     // Make sure the container is marked unhealthy
     assertSame(dn.getDatanodeStateMachine()
@@ -357,7 +363,7 @@ public class TestContainerStateMachineFailures {
         .getContainerState(), UNHEALTHY);
     OzoneContainer ozoneContainer;
 
-    // restart the hdds datanode, container should not in the regular set
+    // Restart the HDDS datanode; the container should not be in the regular set.
     OzoneConfiguration config = dn.getConf();
     final String dir = config.get(OzoneConfigKeys.
         HDDS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
@@ -373,16 +379,17 @@ public class TestContainerStateMachineFailures {
 
   @Test
   public void testUnhealthyContainer() throws Exception {
-    long containerID;
-    HddsDatanodeService dn;
-    KeyValueContainerData keyValueContainerData;
+    long containerID = 0;
+    HddsDatanodeService dn = null;
+    KeyValueContainerData keyValueContainerData = null;
+    boolean injectedContainerFailure = false;
     try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
       key.write("ratis".getBytes(UTF_8));
@@ -401,14 +408,20 @@ public class TestContainerStateMachineFailures {
               .getContainerData();
       keyValueContainerData =
           assertInstanceOf(KeyValueContainerData.class, containerData);
-      // delete the container db file
+      // Delete the container DB file.
       FileUtil.fullyDelete(new File(keyValueContainerData.getChunksPath()));
       containerID = omKeyLocationInfo.getContainerID();
+      injectedContainerFailure = true;
     } catch (IOException ioe) {
-      // there is only 1 datanode in the pipeline, the pipeline will be closed
-      // and allocation to new pipeline will fail as there is no other dn in
-      // the cluster
+      // There is only 1 datanode in the pipeline, the pipeline will be closed
+      // and allocation to a new pipeline will fail as there is no other DN in
+      // the cluster.
+      assertTrue(injectedContainerFailure,
+          "Unexpected IOException before closing the key");
     }
+    assertTrue(containerID > 0, "Container ID should be captured");
+    assertNotNull(dn, "Datanode should be captured");
+    assertNotNull(keyValueContainerData, "Container data should be captured");
 
     // Make sure the container is marked unhealthy
     assertSame(dn.getDatanodeStateMachine()
@@ -428,10 +441,10 @@ public class TestContainerStateMachineFailures {
         + UUID.randomUUID();
     config.set(OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, dir);
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
-    // restart the hdds datanode and see if the container is listed in the
-    // in the missing container set and not in the regular set
+    // Restart the HDDS datanode and see if the container is listed in the
+    // missing container set and not in the regular set.
     cluster.restartHddsDatanode(dn.getDatanodeDetails(), true);
-    // make sure the container state is still marked unhealthy after restart
+    // Make sure the container state is still marked unhealthy after restart.
     keyValueContainerData = (KeyValueContainerData) ContainerDataYaml
         .readContainerFile(containerFile);
     assertEquals(keyValueContainerData.getState(), UNHEALTHY);
@@ -468,7 +481,7 @@ public class TestContainerStateMachineFailures {
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
       key.write("ratis".getBytes(UTF_8));
@@ -494,7 +507,7 @@ public class TestContainerStateMachineFailures {
             getHddsDatanodes().get(index), omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
         (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
-    // delete the container db file
+    // Delete the container DB file.
     FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
     long bcsid = containerData.getBlockCommitSequenceId();
 
@@ -509,8 +522,8 @@ public class TestContainerStateMachineFailures {
     request.setContainerID(containerID);
     request.setCloseContainer(
         ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
-    // close container transaction will fail over Ratis and will initiate
-    // a pipeline close action
+    // The close container transaction will fail over Ratis and initiate
+    // a pipeline close action.
 
     try {
       assertThrows(IOException.class, () -> xceiverClient.sendCommand(request.build()));
@@ -528,7 +541,7 @@ public class TestContainerStateMachineFailures {
       }
     }, 100, 5000);
     try {
-      // try to take a new snapshot, ideally it should just fail
+      // Try to take a new snapshot, ideally it should just fail.
       stateMachine.takeSnapshot();
       fail("Should have thrown StateMachineException because it is UNHEALTHY");
     } catch (IOException ioe) {
@@ -542,7 +555,8 @@ public class TestContainerStateMachineFailures {
 
 
     final FileInfo snapshot = getSnapshotFileInfo(storage);
-    // when remove pipeline, group dir including snapshot will be deleted
+    // When the pipeline is removed, the group directory including the snapshot
+    // is deleted.
     LambdaTestUtils.await(10000, 500,
         () -> (!snapshot.getPath().toFile().exists()));
   }
@@ -559,7 +573,7 @@ public class TestContainerStateMachineFailures {
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
       key.write("ratis".getBytes(UTF_8));
@@ -649,7 +663,7 @@ public class TestContainerStateMachineFailures {
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
       key.write("ratis".getBytes(UTF_8));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -207,57 +207,57 @@ public class TestContainerStateMachineFailures {
     // to inject this state, it removes the pipeline by directly calling
     // the underlying method.
 
-    OzoneOutputStream key =
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("testQuasiClosed1", 1024,
                 ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                    ReplicationFactor.THREE), new HashMap<>());
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
+                    ReplicationFactor.THREE), new HashMap<>())) {
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
 
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key.
-        getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key.
+          getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
 
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+      OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
-    Set<HddsDatanodeService> datanodeSet =
-        TestHelper.getDatanodeServices(cluster,
-            omKeyLocationInfo.getPipeline());
+      Set<HddsDatanodeService> datanodeSet =
+          TestHelper.getDatanodeServices(cluster,
+              omKeyLocationInfo.getPipeline());
 
-    long containerID = omKeyLocationInfo.getContainerID();
+      long containerID = omKeyLocationInfo.getContainerID();
 
-    for (HddsDatanodeService dn : datanodeSet) {
-      XceiverServerRatis wc = (XceiverServerRatis)
-          dn.getDatanodeStateMachine().getContainer().getWriteChannel();
-      if (wc == null) {
-        // Test applicable only for RATIS based channel.
-        return;
+      for (HddsDatanodeService dn : datanodeSet) {
+        XceiverServerRatis wc = (XceiverServerRatis)
+            dn.getDatanodeStateMachine().getContainer().getWriteChannel();
+        if (wc == null) {
+          // Test applicable only for RATIS based channel.
+          return;
+        }
+        wc.notifyGroupRemove(RaftGroupId
+            .valueOf(omKeyLocationInfo.getPipeline().getId().getId()));
+        SCMCommand<?> command = new CloseContainerCommand(
+            containerID, omKeyLocationInfo.getPipeline().getId());
+        command.setTerm(
+            cluster
+                .getStorageContainerManager()
+                .getScmContext()
+                .getTermOfLeader());
+        cluster.getStorageContainerManager().getScmNodeManager()
+            .addDatanodeCommand(dn.getDatanodeDetails().getID(), command);
       }
-      wc.notifyGroupRemove(RaftGroupId
-          .valueOf(omKeyLocationInfo.getPipeline().getId().getId()));
-      SCMCommand<?> command = new CloseContainerCommand(
-          containerID, omKeyLocationInfo.getPipeline().getId());
-      command.setTerm(
-          cluster
-              .getStorageContainerManager()
-              .getScmContext()
-              .getTermOfLeader());
-      cluster.getStorageContainerManager().getScmNodeManager()
-          .addDatanodeCommand(dn.getDatanodeDetails().getID(), command);
-    }
 
 
-    for (HddsDatanodeService dn : datanodeSet) {
-      LambdaTestUtils.await(20000, 1000,
-          () -> (dn.getDatanodeStateMachine()
-              .getContainer().getContainerSet()
-              .getContainer(containerID)
-              .getContainerState().equals(QUASI_CLOSED)));
+      for (HddsDatanodeService dn : datanodeSet) {
+        LambdaTestUtils.await(20000, 1000,
+            () -> (dn.getDatanodeStateMachine()
+                .getContainer().getContainerSet()
+                .getContainer(containerID)
+                .getContainerState().equals(QUASI_CLOSED)));
+      }
     }
-    key.close();
   }
 
   @Test
@@ -317,38 +317,38 @@ public class TestContainerStateMachineFailures {
   @Test
   @Order(Integer.MAX_VALUE)
   public void testContainerStateMachineFailures() throws Exception {
-    OzoneOutputStream key =
+    byte[] testData = "ratis".getBytes(UTF_8);
+    long containerID;
+    HddsDatanodeService dn;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    byte[] testData = "ratis".getBytes(UTF_8);
-    // First write and flush creates a container in the datanode
-    key.write(testData);
-    key.flush();
-    key.write(testData);
-    KeyOutputStream groupOutputStream =
-        (KeyOutputStream) key.getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    // delete the container dir
-    FileUtil.fullyDelete(new File(dn.getDatanodeStateMachine()
-        .getContainer().getContainerSet()
-        .getContainer(omKeyLocationInfo.getContainerID()).
-        getContainerData().getContainerPath()));
-    try {
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write(testData);
+      key.flush();
+      key.write(testData);
+      KeyOutputStream groupOutputStream =
+          (KeyOutputStream) key.getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      // delete the container dir
+      FileUtil.fullyDelete(new File(dn.getDatanodeStateMachine()
+          .getContainer().getContainerSet()
+          .getContainer(omKeyLocationInfo.getContainerID()).
+          getContainerData().getContainerPath()));
+      containerID = omKeyLocationInfo.getContainerID();
+    } catch (IOException ioe) {
       // there is only 1 datanode in the pipeline, the pipeline will be closed
       // and allocation to new pipeline will fail as there is no other dn in
       // the cluster
-      key.close();
-    } catch (IOException ioe) {
     }
-    long containerID = omKeyLocationInfo.getContainerID();
 
     // Make sure the container is marked unhealthy
     assertSame(dn.getDatanodeStateMachine()
@@ -373,42 +373,42 @@ public class TestContainerStateMachineFailures {
 
   @Test
   public void testUnhealthyContainer() throws Exception {
-    OzoneOutputStream key =
+    long containerID;
+    HddsDatanodeService dn;
+    KeyValueContainerData keyValueContainerData;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key
-        .getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    ContainerData containerData =
-        dn.getDatanodeStateMachine()
-            .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID())
-            .getContainerData();
-    KeyValueContainerData keyValueContainerData =
-        assertInstanceOf(KeyValueContainerData.class, containerData);
-    // delete the container db file
-    FileUtil.fullyDelete(new File(keyValueContainerData.getChunksPath()));
-    try {
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key
+          .getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      ContainerData containerData =
+          dn.getDatanodeStateMachine()
+              .getContainer().getContainerSet()
+              .getContainer(omKeyLocationInfo.getContainerID())
+              .getContainerData();
+      keyValueContainerData =
+          assertInstanceOf(KeyValueContainerData.class, containerData);
+      // delete the container db file
+      FileUtil.fullyDelete(new File(keyValueContainerData.getChunksPath()));
+      containerID = omKeyLocationInfo.getContainerID();
+    } catch (IOException ioe) {
       // there is only 1 datanode in the pipeline, the pipeline will be closed
       // and allocation to new pipeline will fail as there is no other dn in
       // the cluster
-      key.close();
-    } catch (IOException ioe) {
     }
-
-    long containerID = omKeyLocationInfo.getContainerID();
 
     // Make sure the container is marked unhealthy
     assertSame(dn.getDatanodeStateMachine()
@@ -456,38 +456,44 @@ public class TestContainerStateMachineFailures {
 
   @Test
   public void testApplyTransactionFailure() throws Exception {
-    OzoneOutputStream key =
+    long containerID;
+    OmKeyLocationInfo omKeyLocationInfo;
+    KeyValueContainerData keyValueContainerData;
+    int index;
+    ContainerData containerData;
+    HddsDatanodeService dn;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key.
-        getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
-    ContainerData containerData = dn.getDatanodeStateMachine()
-        .getContainer().getContainerSet()
-        .getContainer(omKeyLocationInfo.getContainerID())
-        .getContainerData();
-    KeyValueContainerData keyValueContainerData =
-        assertInstanceOf(KeyValueContainerData.class, containerData);
-    key.close();
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key.
+          getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
+      containerData = dn.getDatanodeStateMachine()
+          .getContainer().getContainerSet()
+          .getContainer(omKeyLocationInfo.getContainerID())
+          .getContainerData();
+      keyValueContainerData =
+          assertInstanceOf(KeyValueContainerData.class, containerData);
+      containerID = omKeyLocationInfo.getContainerID();
+    }
     ContainerStateMachine stateMachine =
         (ContainerStateMachine) TestHelper.getStateMachine(cluster.
             getHddsDatanodes().get(index), omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
         (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
-    long containerID = omKeyLocationInfo.getContainerID();
     // delete the container db file
     FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
     long bcsid = containerData.getBlockCommitSequenceId();
@@ -544,29 +550,33 @@ public class TestContainerStateMachineFailures {
   @Test
   void testApplyTransactionIdempotencyWithClosedContainer()
       throws Exception {
-    OzoneOutputStream key =
+    long containerID;
+    OmKeyLocationInfo omKeyLocationInfo;
+    HddsDatanodeService dn;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    ContainerData containerData = dn.getDatanodeStateMachine()
-        .getContainer().getContainerSet()
-        .getContainer(omKeyLocationInfo.getContainerID())
-        .getContainerData();
-    assertInstanceOf(KeyValueContainerData.class, containerData);
-    key.close();
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      ContainerData containerData = dn.getDatanodeStateMachine()
+          .getContainer().getContainerSet()
+          .getContainer(omKeyLocationInfo.getContainerID())
+          .getContainerData();
+      assertInstanceOf(KeyValueContainerData.class, containerData);
+      containerID = omKeyLocationInfo.getContainerID();
+    }
     ContainerStateMachine stateMachine =
         (ContainerStateMachine) TestHelper.getStateMachine(dn,
             omKeyLocationInfo.getPipeline());
@@ -579,7 +589,6 @@ public class TestContainerStateMachineFailures {
     assertNotNull(snapshot);
     long markIndex1 = StatemachineImplTestUtil.findLatestSnapshot(storage)
         .getIndex();
-    long containerID = omKeyLocationInfo.getContainerID();
     Pipeline pipeline = cluster.getStorageContainerLocationClient()
         .getContainerWithPipeline(containerID).getPipeline();
     XceiverClientSpi xceiverClient =
@@ -631,31 +640,35 @@ public class TestContainerStateMachineFailures {
   @Test
   void testWriteStateMachineDataIdempotencyWithClosedContainer()
       throws Exception {
-    OzoneOutputStream key =
+    long containerID;
+    OmKeyLocationInfo omKeyLocationInfo;
+    HddsDatanodeService dn;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis-1", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key
-        .getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    ContainerData containerData =
-        dn.getDatanodeStateMachine()
-            .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID())
-            .getContainerData();
-    assertInstanceOf(KeyValueContainerData.class, containerData);
-    key.close();
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key
+          .getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      ContainerData containerData =
+          dn.getDatanodeStateMachine()
+              .getContainer().getContainerSet()
+              .getContainer(omKeyLocationInfo.getContainerID())
+              .getContainerData();
+      assertInstanceOf(KeyValueContainerData.class, containerData);
+      containerID = omKeyLocationInfo.getContainerID();
+    }
     ContainerStateMachine stateMachine =
         (ContainerStateMachine) TestHelper.getStateMachine(dn,
             omKeyLocationInfo.getPipeline());
@@ -668,7 +681,6 @@ public class TestContainerStateMachineFailures {
     // applyTransactions, we should see snapshots
     assertThat(parentPath.getParent().toFile().listFiles().length).isGreaterThan(0);
     assertNotNull(snapshot);
-    long containerID = omKeyLocationInfo.getContainerID();
     Pipeline pipeline = cluster.getStorageContainerLocationClient()
         .getContainerWithPipeline(containerID).getPipeline();
     XceiverClientSpi xceiverClient =
@@ -787,31 +799,31 @@ public class TestContainerStateMachineFailures {
   @Test
   void testContainerStateMachineDualFailureRetry()
       throws Exception {
-    OzoneOutputStream key =
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis2", 1024,
                 ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                    ReplicationFactor.THREE), new HashMap<>());
+                    ReplicationFactor.THREE), new HashMap<>())) {
 
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    key.write("ratis".getBytes(UTF_8));
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      key.write("ratis".getBytes(UTF_8));
 
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key.
-        getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key.
+          getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
 
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+      OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
-    induceFollowerFailure(omKeyLocationInfo, 1);
+      induceFollowerFailure(omKeyLocationInfo, 1);
 
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.close();
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+    }
     validateData("ratis1", 2, "ratisratisratisratis");
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
@@ -108,7 +108,7 @@ public class TestContainerStateMachineFlushDelay {
             .build();
     cluster.waitForClusterToBeReady();
     cluster.getOzoneManager().startSecretManager();
-    //the easiest way to create an open container is creating a key
+    // The easiest way to create an open container is creating a key.
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "testcontainerstatemachinefailures";
@@ -134,17 +134,17 @@ public class TestContainerStateMachineFlushDelay {
                 ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
       // Now ozone.client.stream.buffer.flush.delay is currently enabled
-      // by default. Here we  written data(length 110) greater than chunk
-      // Size(length 100), make sure flush will sync data.
+      // by default. Here we write data (length 110) greater than chunk
+      // size (length 100), making sure flush will sync data.
       byte[] data =
           ContainerTestHelper.getFixedLengthString(keyString, 110)
               .getBytes(UTF_8);
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write(data);
       key.flush();
       key.write("ratis".getBytes(UTF_8));
 
-      //get the name of a valid container
+      // Get the name of a valid container.
       KeyOutputStream groupOutputStream =
           (KeyOutputStream) key.getOutputStream();
 
@@ -153,7 +153,7 @@ public class TestContainerStateMachineFlushDelay {
       assertEquals(1, locationInfoList.size());
       omKeyLocationInfo = locationInfoList.get(0);
 
-      // delete the container dir
+      // Delete the container directory.
       FileUtil.fullyDelete(new File(
           cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
               .getContainer().getContainerSet()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
@@ -127,39 +127,39 @@ public class TestContainerStateMachineFlushDelay {
 
   @Test
   public void testContainerStateMachineFailures() throws Exception {
-    OzoneOutputStream key =
+    OmKeyLocationInfo omKeyLocationInfo;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // Now ozone.client.stream.buffer.flush.delay is currently enabled
-    // by default. Here we  written data(length 110) greater than chunk
-    // Size(length 100), make sure flush will sync data.
-    byte[] data =
-        ContainerTestHelper.getFixedLengthString(keyString, 110)
-            .getBytes(UTF_8);
-    // First write and flush creates a container in the datanode
-    key.write(data);
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // Now ozone.client.stream.buffer.flush.delay is currently enabled
+      // by default. Here we  written data(length 110) greater than chunk
+      // Size(length 100), make sure flush will sync data.
+      byte[] data =
+          ContainerTestHelper.getFixedLengthString(keyString, 110)
+              .getBytes(UTF_8);
+      // First write and flush creates a container in the datanode
+      key.write(data);
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
 
-    //get the name of a valid container
-    KeyOutputStream groupOutputStream =
-        (KeyOutputStream) key.getOutputStream();
+      //get the name of a valid container
+      KeyOutputStream groupOutputStream =
+          (KeyOutputStream) key.getOutputStream();
 
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
 
-    // delete the container dir
-    FileUtil.fullyDelete(new File(
-        cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
-            .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID()).getContainerData()
-            .getContainerPath()));
-
-    key.close();
+      // delete the container dir
+      FileUtil.fullyDelete(new File(
+          cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
+              .getContainer().getContainerSet()
+              .getContainer(omKeyLocationInfo.getContainerID()).getContainerData()
+              .getContainerPath()));
+    }
     // Make sure the container is marked unhealthy
     assertSame(
         cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -141,34 +141,38 @@ public class TestValidateBCSIDOnRestart {
 
   @Test
   public void testValidateBCSIDOnDnRestart() throws Exception {
-    OzoneOutputStream key =
+    long containerID;
+    OmKeyLocationInfo omKeyLocationInfo;
+    HddsDatanodeService dn;
+    KeyValueContainerData keyValueContainerData;
+    try (OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
             .createKey("ratis", 1024,
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
-                    ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis".getBytes(UTF_8));
-    key.flush();
-    key.write("ratis".getBytes(UTF_8));
-    KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
-    List<OmKeyLocationInfo> locationInfoList =
-        groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
-    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    ContainerData containerData =
-        TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
-            .getDatanodeStateMachine()
-            .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID())
-            .getContainerData();
-    KeyValueContainerData keyValueContainerData =
-        assertInstanceOf(KeyValueContainerData.class, containerData);
-    key.close();
+                    ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key.write("ratis".getBytes(UTF_8));
+      key.flush();
+      key.write("ratis".getBytes(UTF_8));
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList =
+          groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      ContainerData containerData =
+          TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
+              .getDatanodeStateMachine()
+              .getContainer().getContainerSet()
+              .getContainer(omKeyLocationInfo.getContainerID())
+              .getContainerData();
+      keyValueContainerData =
+          assertInstanceOf(KeyValueContainerData.class, containerData);
+      containerID = omKeyLocationInfo.getContainerID();
+    }
 
-    long containerID = omKeyLocationInfo.getContainerID();
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     // delete the container db file
     FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
@@ -197,26 +201,26 @@ public class TestValidateBCSIDOnRestart {
     assertThat(dispatcher.getMissingContainerSet()).isNotEmpty();
     assertThat(dispatcher.getMissingContainerSet()).contains(containerID);
     // write a new key
-    key = objectStore.getVolume(volumeName).getBucket(bucketName)
+    try (OzoneOutputStream key2 = objectStore.getVolume(volumeName).getBucket(bucketName)
         .createKey("ratis", 1024,
             ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
-                ReplicationFactor.ONE), new HashMap<>());
-    // First write and flush creates a container in the datanode
-    key.write("ratis1".getBytes(UTF_8));
-    key.flush();
-    groupOutputStream = (KeyOutputStream) key.getOutputStream();
-    locationInfoList = groupOutputStream.getLocationInfoList();
-    assertEquals(1, locationInfoList.size());
-    omKeyLocationInfo = locationInfoList.get(0);
-    key.close();
-    containerID = omKeyLocationInfo.getContainerID();
-    dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-        cluster);
-    containerData = dn.getDatanodeStateMachine()
-        .getContainer().getContainerSet()
-        .getContainer(omKeyLocationInfo.getContainerID())
-        .getContainerData();
-    keyValueContainerData = assertInstanceOf(KeyValueContainerData.class, containerData);
+                ReplicationFactor.ONE), new HashMap<>())) {
+      // First write and flush creates a container in the datanode
+      key2.write("ratis1".getBytes(UTF_8));
+      key2.flush();
+      KeyOutputStream groupOutputStream = (KeyOutputStream) key2.getOutputStream();
+      List<OmKeyLocationInfo> locationInfoList = groupOutputStream.getLocationInfoList();
+      assertEquals(1, locationInfoList.size());
+      omKeyLocationInfo = locationInfoList.get(0);
+      containerID = omKeyLocationInfo.getContainerID();
+      dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+          cluster);
+      ContainerData containerData = dn.getDatanodeStateMachine()
+          .getContainer().getContainerSet()
+          .getContainer(omKeyLocationInfo.getContainerID())
+          .getContainerData();
+      keyValueContainerData = assertInstanceOf(KeyValueContainerData.class, containerData);
+    }
     try (DBHandle db = BlockUtils.getDB(keyValueContainerData, conf)) {
 
       // modify the bcsid for the container in the ROCKS DB thereby inducing

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -122,7 +122,7 @@ public class TestValidateBCSIDOnRestart {
             .build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
-    //the easiest way to create an open container is creating a key
+    // The easiest way to create an open container is creating a key.
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "testcontainerstatemachinefailures";
@@ -151,7 +151,7 @@ public class TestValidateBCSIDOnRestart {
                 ReplicationConfig.fromTypeAndFactor(
                     ReplicationType.RATIS,
                     ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key.write("ratis".getBytes(UTF_8));
       key.flush();
       key.write("ratis".getBytes(UTF_8));
@@ -174,7 +174,7 @@ public class TestValidateBCSIDOnRestart {
     }
 
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
-    // delete the container db file
+    // Delete the container DB file.
     FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
 
     HddsDatanodeService dnService = cluster.getHddsDatanodes().get(index);
@@ -196,16 +196,16 @@ public class TestValidateBCSIDOnRestart {
     // applyTransactions, we should see snapshots
     assertThat(parentPath.getParent().toFile().listFiles().length).isGreaterThan(0);
 
-    // make sure the missing containerSet is not empty
+    // Make sure the missing containerSet is not empty.
     HddsDispatcher dispatcher = (HddsDispatcher) ozoneContainer.getDispatcher();
     assertThat(dispatcher.getMissingContainerSet()).isNotEmpty();
     assertThat(dispatcher.getMissingContainerSet()).contains(containerID);
-    // write a new key
+    // Write a new key.
     try (OzoneOutputStream key2 = objectStore.getVolume(volumeName).getBucket(bucketName)
         .createKey("ratis", 1024,
             ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
                 ReplicationFactor.ONE), new HashMap<>())) {
-      // First write and flush creates a container in the datanode
+      // First write and flush creates a container in the datanode.
       key2.write("ratis1".getBytes(UTF_8));
       key2.flush();
       KeyOutputStream groupOutputStream = (KeyOutputStream) key2.getOutputStream();
@@ -223,14 +223,14 @@ public class TestValidateBCSIDOnRestart {
     }
     try (DBHandle db = BlockUtils.getDB(keyValueContainerData, conf)) {
 
-      // modify the bcsid for the container in the ROCKS DB thereby inducing
-      // corruption
+      // Modify the BCSID for the container in RocksDB, thereby inducing
+      // corruption.
       db.getStore().getMetadataTable()
           .put(keyValueContainerData.getBcsIdKey(), 0L);
     }
-    // after the restart, there will be a mismatch in BCSID of what is recorded
-    // in the and what is there in RockSDB and hence the container would be
-    // marked unhealthy
+    // After the restart, there will be a mismatch in BCSID between what is
+    // recorded in the container file and what is in RocksDB, so the container
+    // will be marked unhealthy.
     index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     cluster.restartHddsDatanode(dn.getDatanodeDetails(), true);
     // Make sure the container is marked unhealthy

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -234,7 +234,7 @@ public class TestBlockDeletion {
     List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList =
         om.lookupKey(keyArgs).getKeyLocationVersions();
 
-    // verify key blocks were created in DN.
+    // Verify key blocks were created in DN.
     GenericTestUtils.waitFor(() -> {
       try {
         scm.getScmHAManager().asSCMHADBTransactionBuffer().flush();
@@ -263,7 +263,7 @@ public class TestBlockDeletion {
         e.getMessage().startsWith("expected: <null> but was:"));
 
     assertEquals(0L, metrics.getNumBlockDeletionTransactionsOnDatanodes());
-    // close the containers which hold the blocks for the key
+    // Close the containers which hold the blocks for the key.
     OzoneTestUtils.closeAllContainers(scm.getEventQueue(), scm);
 
     // If any container present as not closed, i.e. matches some entry
@@ -308,9 +308,9 @@ public class TestBlockDeletion {
       }
     }, 500, 10000);
 
-    // Containers in the DN and SCM should have same delete transactionIds
-    // after DN restart. The assertion is just to verify that the state of
-    // containerInfos in dn and scm is consistent after dn restart.
+    // After DN restart, containers in the DN and SCM should have same delete
+    // transactionIds. The assertion verifies that the state of containerInfos
+    // in DN and SCM is consistent after DN restart.
     cluster.restartHddsDatanode(0, true);
     matchContainerTransactionIds();
 
@@ -494,7 +494,7 @@ public class TestBlockDeletion {
     // Wait for container to close
     TestHelper.waitForContainerClose(cluster,
         containerIdList.toArray(new Long[0]));
-    // make sure the containers are closed on the dn
+    // Make sure the containers are closed on the DN.
     omKeyLocationInfoGroupList.forEach((group) -> {
       List<OmKeyLocationInfo> locationInfo = group.getLocationList();
       locationInfo.forEach(
@@ -624,7 +624,7 @@ public class TestBlockDeletion {
     // Wait for container to close
     TestHelper.waitForContainerClose(cluster,
         containerIdList.toArray(new Long[0]));
-    // make sure the containers are closed on the dn
+    // Make sure the containers are closed on the DN.
     omKeyLocationInfoGroupList.forEach((group) -> {
       List<OmKeyLocationInfo> locationInfo = group.getLocationList();
       locationInfo.forEach(
@@ -806,7 +806,7 @@ public class TestBlockDeletion {
       keys.add(keyName);
     }
 
-    // close the containers which hold the blocks for the key
+    // Close the containers which hold the blocks for the key.
     OzoneTestUtils.closeAllContainers(scm.getEventQueue(), scm);
     Thread.sleep(2000);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -220,12 +220,12 @@ public class TestBlockDeletion {
 
     String keyName = UUID.randomUUID().toString();
 
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, repConfig, new HashMap<>());
-    for (int i = 0; i < 10; i++) {
-      out.write(value.getBytes(UTF_8));
+    try (OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes(UTF_8).length, repConfig, new HashMap<>())) {
+      for (int i = 0; i < 10; i++) {
+        out.write(value.getBytes(UTF_8));
+      }
     }
-    out.close();
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
@@ -353,11 +353,11 @@ public class TestBlockDeletion {
     OzoneBucket bucket = volume.getBucket(bucketName);
 
     String keyName = UUID.randomUUID().toString();
-    OzoneOutputStream out = bucket.createKey(keyName,
+    try (OzoneOutputStream out = bucket.createKey(keyName,
         value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        ReplicationFactor.THREE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+        ReplicationFactor.THREE, new HashMap<>())) {
+      out.write(value.getBytes(UTF_8));
+    }
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
@@ -464,11 +464,11 @@ public class TestBlockDeletion {
     OzoneBucket bucket = volume.getBucket(bucketName);
 
     String keyName = UUID.randomUUID().toString();
-    OzoneOutputStream out = bucket.createKey(keyName,
+    try (OzoneOutputStream out = bucket.createKey(keyName,
         value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        ReplicationFactor.THREE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+        ReplicationFactor.THREE, new HashMap<>())) {
+      out.write(value.getBytes(UTF_8));
+    }
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
@@ -594,11 +594,11 @@ public class TestBlockDeletion {
     OzoneBucket bucket = volume.getBucket(bucketName);
 
     String keyName = UUID.randomUUID().toString();
-    OzoneOutputStream out = bucket.createKey(keyName,
+    try (OzoneOutputStream out = bucket.createKey(keyName,
         value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        ReplicationFactor.THREE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
+        ReplicationFactor.THREE, new HashMap<>())) {
+      out.write(value.getBytes(UTF_8));
+    }
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
@@ -798,11 +798,11 @@ public class TestBlockDeletion {
     List<String> keys = new ArrayList<>();
     for (int j = 0; j < keyCount; j++) {
       String keyName = UUID.randomUUID().toString();
-      OzoneOutputStream out = bucket.createKey(keyName,
+      try (OzoneOutputStream out = bucket.createKey(keyName,
           value.getBytes(UTF_8).length, ReplicationType.RATIS,
-          ReplicationFactor.THREE, new HashMap<>());
-      out.write(value.getBytes(UTF_8));
-      out.close();
+          ReplicationFactor.THREE, new HashMap<>())) {
+        out.write(value.getBytes(UTF_8));
+      }
       keys.add(keyName);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The manual `key.close()` or `out.close()` calls at the end of test cases are replaced with try-with-resources blocks. This ensures that:
- Output streams are safely and automatically closed even when test assertions fail or unexpected exceptions are thrown midway through execution.
- Potential connection, pipeline, or file descriptor leaks between test runs are eliminated.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15494

## How was this patch tested?

https://github.com/apache/ozone/actions/runs/27091454547

```bash
mvn clean test -pl hadoop-ozone/integration-test -Dtest=TestContainerStateMachine,TestContainerStateMachineFailures,TestBlockDeletion,TestValidateBCSIDOnRestart
```