### PR TITLE
HDDS-15498. optimize Container Safemode refresh to use DELETED state

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRule.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,14 +91,8 @@ public abstract class AbstractContainerSafeModeRule extends SafeModeExitRule<Nod
     // Since ContainerSafeModeRule is updated with container list notified during DN registration only,
     // So its not required to add newly created container after DN registration.
     int oldContainerCount = containers.size();
-    Set<ContainerID> containerInfoSet = containerManager.getContainers(getContainerType()).stream()
-        .filter(this::isClosed)
-        .filter(c -> c.getNumberOfKeys() > 0)
-        .filter(c -> containers.containsKey(ContainerID.valueOf(c.getContainerID())))
-        .map(c -> ContainerID.valueOf(c.getContainerID()))
-        .collect(Collectors.toSet());
-    // remove deleted containers from containers list
-    containers.keySet().removeIf(c -> !containerInfoSet.contains(c));
+    List<ContainerInfo> deletedContainers = containerManager.getContainers(LifeCycleState.DELETED);
+    deletedContainers.forEach(info -> containers.remove(ContainerID.valueOf(info.getContainerID())));
     // update new total with reducing removed containers
     totalContainers.set(totalContainers.get() - (oldContainerCount - containers.size()));
     final long cutOff = (long) Math.ceil(getTotalNumberOfContainers() * getSafeModeCutoff());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
@@ -55,6 +55,7 @@ import org.mockito.ArgumentCaptor;
  * Abstract base class for container safe mode rule tests.
  */
 public abstract class AbstractContainerSafeModeRuleTest {
+  private final List<ContainerInfo> deletedContainers = new ArrayList<>();
   private List<ContainerInfo> containers;
   private SCMSafeModeManager safeModeManager;
   private ConfigurationSource conf;
@@ -74,6 +75,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
     when(safeModeManager.getSafeModeMetrics()).thenReturn(safeModeMetrics);
     containers = new ArrayList<>();
     when(containerManager.getContainers(getReplicationType())).thenReturn(containers);
+    when(containerManager.getContainers(LifeCycleState.DELETED)).thenReturn(deletedContainers);
     when(containerManager.getContainer(any(ContainerID.class))).thenAnswer(invocation -> {
       ContainerID id = invocation.getArgument(0);
       return containers.stream()
@@ -98,7 +100,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
     containers.add(mockContainer(LifeCycleState.OPEN, 3L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 4L));
     containers.removeIf(c -> c.containerID().equals(ContainerID.valueOf(8L)));
-    containers.add(mockContainer(LifeCycleState.DELETED, 8L));
+    deletedContainers.add(mockContainer(LifeCycleState.DELETED, 8L));
     rule.refresh(true);
 
     assertEquals(0.0, rule.getCurrentContainerThreshold());
@@ -110,6 +112,9 @@ public abstract class AbstractContainerSafeModeRuleTest {
       names = {"OPEN", "CLOSING", "QUASI_CLOSED", "CLOSED", "DELETING", "DELETED", "RECOVERING"})
   public void testValidateReturnsTrueAndFalse(LifeCycleState state) {
     containers.add(mockContainer(state, 1L));
+    if (state == LifeCycleState.DELETED) {
+      deletedContainers.add(mockContainer(state, 1L));
+    }
     AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of getting all container to remove DELETED containers, it can pickup only DELETED state container which will be a small sub-set of all containers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15498

## How was this patch tested?

- updated testcase
