### PR TITLE
HDDS-15527. Cancel superseded PR runs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,10 @@ on:
 
 permissions: { }
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   title:
     runs-on: ubuntu-slim

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,8 +26,8 @@ on:
 permissions: { }
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository == 'apache/ozone', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'apache/ozone' }}
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,6 +25,10 @@ on:
 
 permissions: { }
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changes were proposed in this pull request?

> When a new commit is pushed to a PR branch, the runs triggered by earlier commits keep going, even though their results are no longer relevant. A concurrency group scoped to the PR cancels those stale runs as soon as a newer commit arrives.  Scope the group by PR number so each PR only cancels its own runs, and limit cancel-in-progress to pull_request events so pushes to release branches are never interrupted.

https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices

https://issues.apache.org/jira/browse/HDDS-15527