### PR TITLE
HDDS-15502. Update proto.lock for Ozone 2.2.0

### DIFF
--- a/hadoop-hdds/interface-admin/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-admin/src/main/resources/proto.lock
@@ -207,6 +207,18 @@
               {
                 "name": "ReconcileContainer",
                 "integer": 45
+              },
+              {
+                "name": "GetDeletedBlocksTransactionSummary",
+                "integer": 46
+              },
+              {
+                "name": "ListContainerIDs",
+                "integer": 47
+              },
+              {
+                "name": "SuppressContainer",
+                "integer": 48
               }
             ]
           },
@@ -559,6 +571,24 @@
                 "name": "reconcileContainerRequest",
                 "type": "ReconcileContainerRequestProto",
                 "optional": true
+              },
+              {
+                "id": 50,
+                "name": "getDeletedBlocksTxnSummaryRequest",
+                "type": "GetDeletedBlocksTxnSummaryRequestProto",
+                "optional": true
+              },
+              {
+                "id": 51,
+                "name": "scmListContainerIDsRequest",
+                "type": "SCMListContainerIDsRequestProto",
+                "optional": true
+              },
+              {
+                "id": 52,
+                "name": "suppressContainerRequest",
+                "type": "SuppressContainerRequestProto",
+                "optional": true
               }
             ]
           },
@@ -876,6 +906,24 @@
                 "name": "reconcileContainerResponse",
                 "type": "ReconcileContainerResponseProto",
                 "optional": true
+              },
+              {
+                "id": 50,
+                "name": "getDeletedBlocksTxnSummaryResponse",
+                "type": "GetDeletedBlocksTxnSummaryResponseProto",
+                "optional": true
+              },
+              {
+                "id": 51,
+                "name": "scmListContainerIDsResponse",
+                "type": "SCMListContainerIDsResponseProto",
+                "optional": true
+              },
+              {
+                "id": 52,
+                "name": "suppressContainerResponse",
+                "type": "SuppressContainerResponseProto",
+                "optional": true
               }
             ]
           },
@@ -1115,6 +1163,46 @@
             ]
           },
           {
+            "name": "SCMListContainerIDsRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "count",
+                "type": "uint32",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "startContainerID",
+                "type": "ContainerID",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "state",
+                "type": "LifeCycleState",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "traceID",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "SCMListContainerIDsResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerIDs",
+                "type": "ContainerID",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
             "name": "SCMListContainerRequestProto",
             "fields": [
               {
@@ -1157,6 +1245,12 @@
                 "id": 7,
                 "name": "ecReplicationConfig",
                 "type": "ECReplicationConfig",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "suppressed",
+                "type": "bool",
                 "optional": true
               }
             ]
@@ -1804,6 +1898,20 @@
             ]
           },
           {
+            "name": "GetDeletedBlocksTxnSummaryRequestProto"
+          },
+          {
+            "name": "GetDeletedBlocksTxnSummaryResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "summary",
+                "type": "DeletedBlocksTransactionSummary",
+                "optional": true
+              }
+            ]
+          },
+          {
             "name": "FinalizeScmUpgradeRequestProto",
             "fields": [
               {
@@ -2024,6 +2132,18 @@
               {
                 "id": 15,
                 "name": "excludeNodes",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 16,
+                "name": "excludeContainers",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 17,
+                "name": "includeContainers",
                 "type": "string",
                 "optional": true
               }
@@ -2323,6 +2443,34 @@
           },
           {
             "name": "ReconcileContainerResponseProto"
+          },
+          {
+            "name": "SuppressContainerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerIDs",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "suppress",
+                "type": "bool",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "SuppressContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "failedContainerIDs",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
           }
         ],
         "services": [

--- a/hadoop-hdds/interface-client/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/resources/proto.lock
@@ -98,6 +98,10 @@
               {
                 "name": "GetContainerChecksumInfo",
                 "integer": 23
+              },
+              {
+                "name": "ReadBlock",
+                "integer": 24
               }
             ]
           },
@@ -632,6 +636,12 @@
                 "name": "getContainerChecksumInfo",
                 "type": "GetContainerChecksumInfoRequestProto",
                 "optional": true
+              },
+              {
+                "id": 28,
+                "name": "readBlock",
+                "type": "ReadBlockRequestProto",
+                "optional": true
               }
             ]
           },
@@ -780,6 +790,12 @@
                 "id": 24,
                 "name": "getContainerChecksumInfo",
                 "type": "GetContainerChecksumInfoResponseProto",
+                "optional": true
+              },
+              {
+                "id": 25,
+                "name": "readBlock",
+                "type": "ReadBlockResponseProto",
                 "optional": true
               }
             ]
@@ -1176,6 +1192,58 @@
                 "name": "blockData",
                 "type": "BlockData",
                 "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ReadBlockRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "offset",
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "length",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "responseDataSize",
+                "type": "uint32",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ReadBlockResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "checksumData",
+                "type": "ChecksumData",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "offset",
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "bytes",
+                "required": true
               }
             ]
           },
@@ -1828,6 +1896,227 @@
       }
     },
     {
+      "protopath": "DiskBalancerProtocol.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "GetDiskBalancerInfoRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clientVersion",
+                "type": "uint32",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "GetDiskBalancerInfoResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "info",
+                "type": "DatanodeDiskBalancerInfoProto",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "StartDiskBalancerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "config",
+                "type": "DiskBalancerConfigurationProto",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "StartDiskBalancerResponseProto"
+          },
+          {
+            "name": "StopDiskBalancerRequestProto"
+          },
+          {
+            "name": "StopDiskBalancerResponseProto"
+          },
+          {
+            "name": "UpdateDiskBalancerConfigurationRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "config",
+                "type": "DiskBalancerConfigurationProto",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "UpdateDiskBalancerConfigurationResponseProto"
+          }
+        ],
+        "services": [
+          {
+            "name": "DiskBalancerProtocolService",
+            "rpcs": [
+              {
+                "name": "getDiskBalancerInfo",
+                "in_type": "GetDiskBalancerInfoRequestProto",
+                "out_type": "GetDiskBalancerInfoResponseProto"
+              },
+              {
+                "name": "startDiskBalancer",
+                "in_type": "StartDiskBalancerRequestProto",
+                "out_type": "StartDiskBalancerResponseProto"
+              },
+              {
+                "name": "stopDiskBalancer",
+                "in_type": "StopDiskBalancerRequestProto",
+                "out_type": "StopDiskBalancerResponseProto"
+              },
+              {
+                "name": "updateDiskBalancerConfiguration",
+                "in_type": "UpdateDiskBalancerConfigurationRequestProto",
+                "out_type": "UpdateDiskBalancerConfigurationResponseProto"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "hdds.proto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "DiskBalancerProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "IpcConnectionContext.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "UserInformationProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "effectiveUser",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "realUser",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "IpcConnectionContextProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "userInfo",
+                "type": "UserInformationProto",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "protocol",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.common"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.ipc_.protobuf"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "IpcConnectionContextProtos"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "ProtobufRpcEngine.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RequestHeaderProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "methodName",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "declaringClassProtocolName",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "clientProtocolVersion",
+                "type": "uint64",
+                "required": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.common"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.ipc_.protobuf"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ProtobufRpcEngineProtos"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "ReconfigureProtocol.proto",
       "def": {
         "messages": [
@@ -1963,6 +2252,385 @@
           {
             "name": "java_generic_services",
             "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "RpcHeader.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "RpcKindProto",
+            "enum_fields": [
+              {
+                "name": "RPC_BUILTIN"
+              },
+              {
+                "name": "RPC_WRITABLE",
+                "integer": 1
+              },
+              {
+                "name": "RPC_PROTOCOL_BUFFER",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "RpcRequestHeaderProto.OperationProto",
+            "enum_fields": [
+              {
+                "name": "RPC_FINAL_PACKET"
+              },
+              {
+                "name": "RPC_CONTINUATION_PACKET",
+                "integer": 1
+              },
+              {
+                "name": "RPC_CLOSE_CONNECTION",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "RpcResponseHeaderProto.RpcStatusProto",
+            "enum_fields": [
+              {
+                "name": "SUCCESS"
+              },
+              {
+                "name": "ERROR",
+                "integer": 1
+              },
+              {
+                "name": "FATAL",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "RpcResponseHeaderProto.RpcErrorCodeProto",
+            "enum_fields": [
+              {
+                "name": "ERROR_APPLICATION",
+                "integer": 1
+              },
+              {
+                "name": "ERROR_NO_SUCH_METHOD",
+                "integer": 2
+              },
+              {
+                "name": "ERROR_NO_SUCH_PROTOCOL",
+                "integer": 3
+              },
+              {
+                "name": "ERROR_RPC_SERVER",
+                "integer": 4
+              },
+              {
+                "name": "ERROR_SERIALIZING_RESPONSE",
+                "integer": 5
+              },
+              {
+                "name": "ERROR_RPC_VERSION_MISMATCH",
+                "integer": 6
+              },
+              {
+                "name": "FATAL_UNKNOWN",
+                "integer": 10
+              },
+              {
+                "name": "FATAL_UNSUPPORTED_SERIALIZATION",
+                "integer": 11
+              },
+              {
+                "name": "FATAL_INVALID_RPC_HEADER",
+                "integer": 12
+              },
+              {
+                "name": "FATAL_DESERIALIZING_REQUEST",
+                "integer": 13
+              },
+              {
+                "name": "FATAL_VERSION_MISMATCH",
+                "integer": 14
+              },
+              {
+                "name": "FATAL_UNAUTHORIZED",
+                "integer": 15
+              }
+            ]
+          },
+          {
+            "name": "RpcSaslProto.SaslState",
+            "enum_fields": [
+              {
+                "name": "SUCCESS"
+              },
+              {
+                "name": "NEGOTIATE",
+                "integer": 1
+              },
+              {
+                "name": "INITIATE",
+                "integer": 2
+              },
+              {
+                "name": "CHALLENGE",
+                "integer": 3
+              },
+              {
+                "name": "RESPONSE",
+                "integer": 4
+              },
+              {
+                "name": "WRAP",
+                "integer": 5
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "RPCTraceInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceId",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "parentId",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RPCCallerContextProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "context",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "signature",
+                "type": "bytes",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RpcRequestHeaderProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rpcKind",
+                "type": "RpcKindProto",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "rpcOp",
+                "type": "OperationProto",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "callId",
+                "type": "sint32",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "clientId",
+                "type": "bytes",
+                "required": true
+              },
+              {
+                "id": 5,
+                "name": "retryCount",
+                "type": "sint32",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-1"
+                  }
+                ]
+              },
+              {
+                "id": 6,
+                "name": "traceInfo",
+                "type": "RPCTraceInfoProto",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "callerContext",
+                "type": "RPCCallerContextProto",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "stateId",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RpcResponseHeaderProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "callId",
+                "type": "uint32",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "RpcStatusProto",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "serverIpcVersionNum",
+                "type": "uint32",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "exceptionClassName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "errorMsg",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "errorDetail",
+                "type": "RpcErrorCodeProto",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "clientId",
+                "type": "bytes",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "retryCount",
+                "type": "sint32",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-1"
+                  }
+                ]
+              },
+              {
+                "id": 9,
+                "name": "stateId",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RpcSaslProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "uint32",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "state",
+                "type": "SaslState",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "token",
+                "type": "bytes",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "auths",
+                "type": "SaslAuth",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "SaslAuth",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "method",
+                    "type": "string",
+                    "required": true
+                  },
+                  {
+                    "id": 2,
+                    "name": "mechanism",
+                    "type": "string",
+                    "required": true
+                  },
+                  {
+                    "id": 3,
+                    "name": "protocol",
+                    "type": "string",
+                    "optional": true
+                  },
+                  {
+                    "id": 4,
+                    "name": "serverId",
+                    "type": "string",
+                    "optional": true
+                  },
+                  {
+                    "id": 5,
+                    "name": "challenge",
+                    "type": "bytes",
+                    "optional": true
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.common"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.ipc_.protobuf"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "RpcHeaderProtos"
           },
           {
             "name": "java_generate_equals_and_hash",
@@ -2296,6 +2964,23 @@
               {
                 "name": "FINALIZATION_REQUIRED",
                 "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "DiskBalancerRunningStatus",
+            "enum_fields": [
+              {
+                "name": "RUNNING",
+                "integer": 1
+              },
+              {
+                "name": "STOPPED",
+                "integer": 2
+              },
+              {
+                "name": "PAUSED",
+                "integer": 3
               }
             ]
           }
@@ -2734,6 +3419,24 @@
                 "name": "nodeOperationalStates",
                 "type": "NodeOperationalState",
                 "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "totalVolumeCount",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "healthyVolumeCount",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "failedVolumes",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },
@@ -2796,6 +3499,24 @@
               {
                 "id": 8,
                 "name": "pipelineCount",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "reserved",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "fsCapacity",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "fsAvailable",
                 "type": "int64",
                 "optional": true
               }
@@ -2874,6 +3595,12 @@
                 "id": 12,
                 "name": "ecReplicationConfig",
                 "type": "ECReplicationConfig",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "suppressed",
+                "type": "bool",
                 "optional": true
               }
             ]
@@ -3457,6 +4184,18 @@
                 "name": "statSample",
                 "type": "KeyContainerIDList",
                 "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "sampleLimit",
+                "type": "int32",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "100"
+                  }
+                ]
               }
             ]
           },
@@ -3558,6 +4297,18 @@
                 "name": "moveReplicationTimeout",
                 "type": "int64",
                 "optional": true
+              },
+              {
+                "id": 21,
+                "name": "includeContainers",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 22,
+                "name": "includeNonStandardContainers",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -3600,6 +4351,35 @@
                 "id": 4,
                 "name": "count",
                 "type": "int32",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "DeletedBlocksTransactionSummary",
+            "fields": [
+              {
+                "id": 1,
+                "name": "totalTransactionCount",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "totalBlockCount",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "totalBlockSize",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "totalBlockReplicatedSize",
+                "type": "uint64",
                 "optional": true
               }
             ]
@@ -3756,6 +4536,159 @@
                 "id": 3,
                 "name": "childrenMap",
                 "type": "ChildrenMap",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DiskBalancerConfigurationProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "threshold",
+                "type": "double",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "diskBandwidthInMB",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "parallelThread",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "stopAfterDiskEven",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "containerStates",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "VolumeReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "storageId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "storagePath",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "totalCapacity",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "usedSpace",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "committedBytes",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "effectiveUsedSpace",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "utilization",
+                "type": "double",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "ozoneAvailable",
+                "type": "uint64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "DatanodeDiskBalancerInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node",
+                "type": "DatanodeDetailsProto",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "currentVolumeDensitySum",
+                "type": "double",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "runningStatus",
+                "type": "DiskBalancerRunningStatus",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "diskBalancerConf",
+                "type": "DiskBalancerConfigurationProto",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "successMoveCount",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "failureMoveCount",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "bytesToMove",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "bytesMoved",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "idealUsage",
+                "type": "double",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "volumeInfo",
+                "type": "VolumeReportProto",
                 "is_repeated": true
               }
             ]

--- a/hadoop-hdds/interface-server/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-server/src/main/resources/proto.lock
@@ -97,6 +97,9 @@
             "name": "RequestType",
             "enum_fields": [
               {
+                "name": "REQUEST_TYPE_UNSPECIFIED"
+              },
+              {
                 "name": "PIPELINE",
                 "integer": 1
               },
@@ -147,7 +150,7 @@
                 "id": 1,
                 "name": "name",
                 "type": "string",
-                "required": true
+                "optional": true
               },
               {
                 "id": 2,
@@ -164,13 +167,13 @@
                 "id": 1,
                 "name": "type",
                 "type": "string",
-                "required": true
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "value",
                 "type": "bytes",
-                "required": true
+                "optional": true
               }
             ]
           },
@@ -181,7 +184,7 @@
                 "id": 1,
                 "name": "type",
                 "type": "string",
-                "required": true
+                "optional": true
               },
               {
                 "id": 2,
@@ -198,13 +201,13 @@
                 "id": 1,
                 "name": "type",
                 "type": "RequestType",
-                "required": true
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "method",
                 "type": "Method",
-                "required": true
+                "optional": true
               }
             ]
           },
@@ -215,14 +218,17 @@
                 "id": 2,
                 "name": "type",
                 "type": "string",
-                "required": true
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "value",
                 "type": "bytes",
-                "required": true
+                "optional": true
               }
+            ],
+            "reserved_ids": [
+              1
             ]
           }
         ],
@@ -1430,6 +1436,36 @@
                     "value": "0"
                   }
                 ]
+              },
+              {
+                "id": 10,
+                "name": "reserved",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "fsCapacity",
+                "type": "uint64",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 12,
+                "name": "fsAvailable",
+                "type": "uint64",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
               }
             ]
           },
@@ -1969,6 +2005,24 @@
                     "value": "true"
                   }
                 ]
+              },
+              {
+                "id": 5,
+                "name": "totalBlockSize",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "totalBlockReplicatedSize",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "totalSizePerReplica",
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2889,6 +2943,24 @@
                 "id": 2,
                 "name": "blocks",
                 "type": "BlockID",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "size",
+                "type": "uint64",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "replicatedSize",
+                "type": "uint64",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "sizePerReplica",
+                "type": "uint64",
                 "is_repeated": true
               }
             ]

--- a/hadoop-ozone/interface-client/src/main/resources/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/resources/proto.lock
@@ -159,6 +159,40 @@
                 "optional": true
               }
             ]
+          },
+          {
+            "name": "TriggerSnapshotDefragRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "noWait",
+                "type": "bool",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "TriggerSnapshotDefragResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "errorMsg",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "result",
+                "type": "bool",
+                "optional": true
+              }
+            ]
           }
         ],
         "services": [
@@ -179,6 +213,11 @@
                 "name": "compactDB",
                 "in_type": "CompactRequest",
                 "out_type": "CompactResponse"
+              },
+              {
+                "name": "triggerSnapshotDefrag",
+                "in_type": "TriggerSnapshotDefragRequest",
+                "out_type": "TriggerSnapshotDefragResponse"
               }
             ]
           }
@@ -599,6 +638,10 @@
               {
                 "name": "DeleteObjectTagging",
                 "integer": 142
+              },
+              {
+                "name": "SubmitSnapshotDiff",
+                "integer": 143
               }
             ]
           },
@@ -1005,6 +1048,18 @@
               {
                 "name": "TOO_MANY_SNAPSHOTS",
                 "integer": 98
+              },
+              {
+                "name": "ETAG_MISMATCH",
+                "integer": 99
+              },
+              {
+                "name": "ETAG_NOT_AVAILABLE",
+                "integer": 100
+              },
+              {
+                "name": "ATOMIC_WRITE_CONFLICT",
+                "integer": 101
               }
             ]
           },
@@ -1258,6 +1313,10 @@
               {
                 "name": "CANCELLED",
                 "integer": 6
+              },
+              {
+                "name": "NOT_FOUND",
+                "integer": 7
               }
             ]
           },
@@ -1306,6 +1365,30 @@
                 "integer": 4
               }
             ]
+          },
+          {
+            "name": "ReadConsistencyProto",
+            "enum_fields": [
+              {
+                "name": "READ_CONSISTENCY_UNSPECIFIED"
+              },
+              {
+                "name": "DEFAULT",
+                "integer": 1
+              },
+              {
+                "name": "LINEARIZABLE_LEADER_ONLY",
+                "integer": 2
+              },
+              {
+                "name": "LINEARIZABLE_ALLOW_FOLLOWER",
+                "integer": 3
+              },
+              {
+                "name": "LOCAL_LEASE",
+                "integer": 4
+              }
+            ]
           }
         ],
         "messages": [
@@ -1346,6 +1429,12 @@
                 "id": 6,
                 "name": "layoutVersion",
                 "type": "LayoutVersion",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "readConsistencyHint",
+                "type": "ReadConsistencyHint",
                 "optional": true
               },
               {
@@ -1965,6 +2054,12 @@
                 "name": "SetSnapshotPropertyRequests",
                 "type": "SetSnapshotPropertyRequest",
                 "is_repeated": true
+              },
+              {
+                "id": 144,
+                "name": "submitSnapshotDiffRequest",
+                "type": "SubmitSnapshotDiffRequest",
+                "optional": true
               }
             ]
           },
@@ -2599,6 +2694,12 @@
                 "id": 142,
                 "name": "deleteObjectTaggingResponse",
                 "type": "DeleteObjectTaggingResponse",
+                "optional": true
+              },
+              {
+                "id": 143,
+                "name": "submitSnapshotDiffResponse",
+                "type": "SubmitSnapshotDiffResponse",
                 "optional": true
               }
             ]
@@ -3550,13 +3651,25 @@
                 "id": 11,
                 "name": "checkpointDir",
                 "type": "string",
-                "optional": true
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 12,
                 "name": "dbTxSequenceNumber",
                 "type": "int64",
-                "optional": true
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 13,
@@ -3705,6 +3818,12 @@
                 "id": 13,
                 "name": "keysProcessedPct",
                 "type": "double",
+                "optional": true
+              },
+              {
+                "id": 14,
+                "name": "largestEntryKey",
+                "type": "string",
                 "optional": true
               }
             ]
@@ -4185,6 +4304,12 @@
                 "name": "expectedDataGeneration",
                 "type": "uint64",
                 "optional": true
+              },
+              {
+                "id": 24,
+                "name": "expectedETag",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -4637,6 +4762,12 @@
               {
                 "id": 10,
                 "name": "isEncrypted",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "isFile",
                 "type": "bool",
                 "optional": true
               }
@@ -6290,7 +6421,13 @@
                 "id": 5,
                 "name": "partKeyInfoList",
                 "type": "PartKeyInfo",
-                "is_repeated": true
+                "is_repeated": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 6,
@@ -6315,6 +6452,42 @@
                 "name": "ecReplicationConfig",
                 "type": "hadoop.hdds.ECReplicationConfig",
                 "optional": true
+              },
+              {
+                "id": 10,
+                "name": "schemaVersion",
+                "type": "uint32",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "volumeName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 12,
+                "name": "bucketName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "keyName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 14,
+                "name": "ownerName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 15,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
               }
             ]
           },
@@ -6338,6 +6511,71 @@
                 "name": "partKeyInfo",
                 "type": "KeyInfo",
                 "required": true
+              }
+            ]
+          },
+          {
+            "name": "MultipartPartInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "partNumber",
+                "type": "uint32",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "eTag",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "keyLocationList",
+                "type": "KeyLocationList",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "dataSize",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "modificationTime",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "objectID",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "updateID",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "fileEncryptionInfo",
+                "type": "FileEncryptionInfoProto",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "fileChecksum",
+                "type": "FileChecksumProto",
+                "optional": true
               }
             ]
           },
@@ -7288,6 +7526,59 @@
                 "id": 7,
                 "name": "forceFullDiff",
                 "type": "bool",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 8,
+                "name": "disableNativeDiff",
+                "type": "bool",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "SubmitSnapshotDiffRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "fromSnapshot",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "toSnapshot",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "forceFullDiff",
+                "type": "bool",
                 "optional": true
               },
               {
@@ -7816,6 +8107,17 @@
             ]
           },
           {
+            "name": "SubmitSnapshotDiffResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
             "name": "CancelSnapshotDiffResponse",
             "fields": [
               {
@@ -8336,6 +8638,42 @@
           },
           {
             "name": "DeleteObjectTaggingResponse"
+          },
+          {
+            "name": "ReadConsistencyHint",
+            "fields": [
+              {
+                "id": 1,
+                "name": "readConsistency",
+                "type": "ReadConsistencyProto",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "localLeaseContext",
+                "type": "LocalLeaseContext",
+                "optional": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "LocalLeaseContext",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "logLimit",
+                    "type": "uint64",
+                    "optional": true
+                  },
+                  {
+                    "id": 2,
+                    "name": "leaseTimeMs",
+                    "type": "uint64",
+                    "optional": true
+                  }
+                ]
+              }
+            ]
           }
         ],
         "services": [


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15502. Update proto.lock for Ozone 2.2.0

Please describe your PR in detail:
The following codes generate it
`#!/usr/bin/env sh

for lock in $(find . -name proto.lock); do
  lockdir="$(dirname "$lock")"
  protoroot="$lockdir"/../proto
  if protolock status --lockdir="$lockdir" --protoroot="$protoroot"; then
    protolock commit --lockdir="$lockdir" --protoroot="$protoroot"
  else
    echo "protolock update failed for $protoroot"
  fi
done`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15502


## How was this patch tested?
No need
