### PR TITLE
HDDS-15513. Bind cluster services to localhost for MiniOzoneCluster

### DIFF
--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -428,10 +428,6 @@ public abstract class GenericTestUtils {
     public static String localhostWithFreePort() {
       return HOST_ADDRESS + ":" + getFreePort();
     }
-
-    public static String anyHostWithFreePort() {
-      return "0.0.0.0:" + getFreePort();
-    }
   }
 
   /**

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -710,6 +710,13 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
           localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
           localhostWithFreePort());
+      // Bind SCM servers to 127.0.0.1 instead of the default 0.0.0.0.
+      // Without this, the bind address (0.0.0.0) leaks into OZONE_SCM_NAMES
+      // via updateListenAddress/getSCMAddresses, causing DataNodes to connect
+      // to 0.0.0.0 which gets routed to unreachable addresses on VPN.
+      conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY, "127.0.0.1");
+      conf.set(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY, "127.0.0.1");
+      conf.set(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY, "127.0.0.1");
       conf.set(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
           "3s");
       conf.setInt(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY, getFreePort());

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/UniformDatanodesFactory.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/UniformDatanodesFactory.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HOST_NAME_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_INITIAL_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_RECON_INITIAL_HEARTBEAT_INTERVAL;
@@ -33,8 +34,8 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATAS
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_IPC_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_SERVER_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_RATIS_LEADER_FIRST_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -123,8 +124,9 @@ public class UniformDatanodesFactory implements MiniOzoneCluster.DatanodeFactory
   }
 
   private void configureDatanodePorts(ConfigurationTarget conf) {
-    conf.set(HDDS_DATANODE_HTTP_ADDRESS_KEY, anyHostWithFreePort());
-    conf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY, anyHostWithFreePort());
+    conf.set(HDDS_DATANODE_HOST_NAME_KEY, "127.0.0.1");
+    conf.set(HDDS_DATANODE_HTTP_ADDRESS_KEY, localhostWithFreePort());
+    conf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY, localhostWithFreePort());
     conf.setInt(HDDS_CONTAINER_IPC_PORT, getFreePort());
     conf.setInt(HDDS_CONTAINER_RATIS_IPC_PORT, getFreePort());
     conf.setInt(HDDS_CONTAINER_RATIS_ADMIN_PORT, getFreePort());


### PR DESCRIPTION
## What changes were proposed in this pull request?
When any VPN is enabled, MiniOzoneCluster setup is stuck with the following logs
```
  2026-06-08 21:27:39,275 [2e356ac8-c8fe-422b-ab07-b38cf90f4ac5@group-D0937D61FBB5-StateMachineUpdater] INFO  SCMHATransactionMonitor (BackgroundSCMService.java:notifyStatusChanged(78)) - Service SCMHATransactionMonitor transitions to RUNNING.
  2026-06-08 21:27:58,720 [main] INFO  ipc_.Client (Client.java:handleConnectionTimeout(861)) - Retrying connect to server: 0.0.0.0/0.0.0.0:15001. Already tried 0 time(s); maxRetries=45
  2026-06-08 21:28:18,724 [main] INFO  ipc_.Client (Client.java:handleConnectionTimeout(861)) - Retrying connect to server: 0.0.0.0/0.0.0.0:15001. Already tried 1 time(s); maxRetries=45
  2026-06-08 21:28:38,727 [main] INFO  ipc_.Client (Client.java:handleConnectionTimeout(861)) - Retrying connect to server: 0.0.0.0/0.0.0.0:15001. Already tried 2 time(s); maxRetries=45
  2026-06-08 21:28:58,730 [main] INFO  ipc_.Client (Client.java:handleConnectionTimeout(861)) - Retrying connect to server: 0.0.0.0/0.0.0.0:15001. Already tried 3 time(s); maxRetries=45 
```
The problem is that the bind address for SCM is never set. As a result it defaults to 0.0.0.0. This reroutes to localhost/127.0.0.1 when no VPN is enabled but it is rerouted to a random IP when VPN is enabled. 

Without VPN:
```
rpatel@GQ2V5HK6NX ~ % lsof -i :15001
COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
java    21703 rpatel  406u  IPv4 0x61ad94e3040c8c85      0t0  TCP *:15001 (LISTEN)
java    21703 rpatel  504u  IPv4 0xda4ec39b5b69c9c1      0t0  TCP mac:57747->mac:15001 (ESTABLISHED)
java    21703 rpatel  505u  IPv4 0x970351ac8a67ab7c      0t0  TCP mac:15001->mac:57747 (ESTABLISHED) 
```
With VPN:
```
rpatel@GQ2V5HK6NX ~ % lsof -i :15001
COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
java    21382 rpatel  406u  IPv4 0xbe6aafab2e6f769a      0t0  TCP *:15001 (LISTEN)
java    21382 rpatel  504u  IPv4 0x5febf36e5f0f5a7e      0t0  TCP 10.19.13.105:57618->192.168.4.44:15001 (SYN_SENT) 
```

With VPN and after applying the PR:
```
rpatel@GQ2V5HK6NX ~ % lsof -i :15001
COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
java    32513 rpatel  406u  IPv4 0x9ff01ec7a29075f7      0t0  TCP localhost:15001 (LISTEN)
java    32513 rpatel  504u  IPv4 0xf968e5ff22fc6491      0t0  TCP localhost:58189->localhost:15001 (ESTABLISHED)
java    32513 rpatel  505u  IPv4 0x206a62e061704db4      0t0  TCP localhost:15001->localhost:58189 (ESTABLISHED)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15513

## How was this patch tested?

CI: https://github.com/ptlrs/ozone/actions/runs/27187591995