### PR TITLE
HDDS-15467. Do not fall back to the OM starter user in OMClientRequest

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -115,7 +115,7 @@ public abstract class OMClientRequest implements RequestAuditor {
         .setVersion(ozoneManager.getVersionManager().getMetadataLayoutVersion())
         .build();
     omRequest = getOmRequest().toBuilder()
-        .setUserInfo(getUserIfNotExists(ozoneManager))
+        .setUserInfo(getUserInfo())
         .setLayoutVersion(layoutVersion).build();
     return omRequest;
   }
@@ -193,39 +193,16 @@ public abstract class OMClientRequest implements RequestAuditor {
         && grpcContextClientIpAddress != null) {
       userInfo.setHostName(grpcContextClientHostname);
       userInfo.setRemoteAddress(grpcContextClientIpAddress);
+    } else if (omRequest.hasUserInfo()
+        && omRequest.getUserInfo().hasRemoteAddress()) {
+      // For non-RPC internal service requests (e.g. the Trash emptier) that
+      // populate their own UserInfo, preserve the supplied host/address since
+      // there is no RPC or gRPC client context to derive it from.
+      userInfo.setHostName(omRequest.getUserInfo().getHostName());
+      userInfo.setRemoteAddress(omRequest.getUserInfo().getRemoteAddress());
     }
 
     return userInfo.build();
-  }
-
-  /**
-   * For non-rpc internal calls Server.getRemoteUser()
-   * and Server.getRemoteIp() will be null.
-   * Passing getCurrentUser() and Ip of the Om node that started it.
-   * @return User Info.
-   */
-  public OzoneManagerProtocolProtos.UserInfo getUserIfNotExists(
-      OzoneManager ozoneManager) throws IOException {
-    OzoneManagerProtocolProtos.UserInfo userInfo = getUserInfo();
-    if (!userInfo.hasRemoteAddress() || !userInfo.hasUserName()) {
-      OzoneManagerProtocolProtos.UserInfo.Builder newuserInfo =
-          OzoneManagerProtocolProtos.UserInfo.newBuilder();
-      UserGroupInformation user;
-      InetAddress remoteAddress;
-      try {
-        user = UserGroupInformation.getCurrentUser();
-        remoteAddress = ozoneManager.getOmRpcServerAddr()
-            .getAddress();
-      } catch (Exception e) {
-        LOG.debug("Couldn't get om Rpc server address", e);
-        return getUserInfo();
-      }
-      newuserInfo.setUserName(user.getUserName());
-      newuserInfo.setHostName(remoteAddress.getHostName());
-      newuserInfo.setRemoteAddress(remoteAddress.getHostAddress());
-      return newuserInfo.build();
-    }
-    return getUserInfo();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -105,7 +105,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     //  BlockOutputStreamEntryPool, so we are fine for now. But if one some
     //  one uses direct omclient we might be in trouble.
 
-    UserInfo userInfo = getUserInfo();
+    UserInfo userInfo = getOmRequest().getUserInfo();
     ReplicationConfig repConfig = ReplicationConfig.fromProto(keyArgs.getType(),
         keyArgs.getFactor(), keyArgs.getEcReplicationConfig());
     // To allocate atleast one block passing requested size and scmBlockSize
@@ -142,7 +142,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     newAllocatedBlockRequest.setKeyLocation(
         omKeyLocationInfoList.get(0).getProtobuf(getOmRequest().getVersion()));
 
-    return getOmRequest().toBuilder().setUserInfo(userInfo)
+    return getOmRequest().toBuilder()
         .setAllocateBlockRequest(newAllocatedBlockRequest).build();
 
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -105,7 +105,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     //  BlockOutputStreamEntryPool, so we are fine for now. But if one some
     //  one uses direct omclient we might be in trouble.
 
-    UserInfo userInfo = getUserIfNotExists(ozoneManager);
+    UserInfo userInfo = getUserInfo();
     ReplicationConfig repConfig = ReplicationConfig.fromProto(keyArgs.getType(),
         keyArgs.getFactor(), keyArgs.getEcReplicationConfig());
     // To allocate atleast one block passing requested size and scmBlockSize

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -92,7 +92,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     return getOmRequest().toBuilder()
         .setDeleteKeyRequest(deleteKeyRequest.toBuilder()
             .setKeyArgs(resolvedArgs))
-        .setUserInfo(getUserInfo()).build();
+        .build();
   }
 
   protected KeyArgs resolveBucketAndCheckAcls(OzoneManager ozoneManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -92,7 +92,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     return getOmRequest().toBuilder()
         .setDeleteKeyRequest(deleteKeyRequest.toBuilder()
             .setKeyArgs(resolvedArgs))
-        .setUserInfo(getUserIfNotExists(ozoneManager)).build();
+        .setUserInfo(getUserInfo()).build();
   }
 
   protected KeyArgs resolveBucketAndCheckAcls(OzoneManager ozoneManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -95,7 +95,7 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     return getOmRequest().toBuilder()
         .setRenameKeyRequest(renameKeyRequest.toBuilder().setToKeyName(dstKey)
             .setKeyArgs(resolvedArgs))
-        .setUserInfo(getUserInfo()).build();
+        .build();
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -95,7 +95,7 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     return getOmRequest().toBuilder()
         .setRenameKeyRequest(renameKeyRequest.toBuilder().setToKeyName(dstKey)
             .setKeyArgs(resolvedArgs))
-        .setUserInfo(getUserIfNotExists(ozoneManager)).build();
+        .setUserInfo(getUserInfo()).build();
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMClientRequestUserInfoFallback.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMClientRequestUserInfoFallback.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request;
+
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto;
+import org.apache.hadoop.ipc_.Server;
+import org.apache.hadoop.ozone.om.request.bucket.OMBucketCreateRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserInfo;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Tests that {@link OMClientRequest} does not silently fall back to the OM
+ * starter/login user when a request carries no user information (HDDS-15467).
+ */
+public class TestOMClientRequestUserInfoFallback {
+
+  private OMRequest newBucketRequest(UserInfo userInfo) {
+    BucketInfo.Builder bucketInfo = newBucketInfoBuilder(
+        UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        .setIsVersionEnabled(true)
+        .setStorageType(StorageTypeProto.DISK);
+    OMRequest.Builder builder = newCreateBucketRequest(bucketInfo);
+    if (userInfo != null) {
+      builder.setUserInfo(userInfo);
+    }
+    return builder.build();
+  }
+
+  /**
+   * With no RPC/gRPC context and no UserInfo on the request, getUserInfo() must
+   * not manufacture an identity from the OM starter user; createUGI() then
+   * fails closed instead of silently escalating.
+   */
+  @Test
+  public void noFallbackToServerUserWhenUserInfoMissing() throws Exception {
+    try (MockedStatic<Server> mockedRpcServer = mockStatic(Server.class)) {
+      mockedRpcServer.when(Server::getRemoteUser).thenReturn(null);
+      mockedRpcServer.when(Server::getRemoteIp).thenReturn(null);
+
+      OMRequest omRequest = newBucketRequest(null);
+      OMClientRequest request = new OMBucketCreateRequest(omRequest);
+
+      UserInfo userInfo = request.getUserInfo();
+      assertFalse(userInfo.hasUserName());
+      assertFalse(userInfo.hasRemoteAddress());
+
+      OMClientRequest withUserInfo = new OMBucketCreateRequest(
+          omRequest.toBuilder().setUserInfo(userInfo).build());
+      assertThrows(AuthenticationException.class, withUserInfo::createUGI);
+    }
+  }
+
+  /**
+   * An internal service (e.g. the Trash emptier) populates its own UserInfo.
+   * With no RPC/gRPC context, getUserInfo() must preserve that identity rather
+   * than replacing it with the OM starter user.
+   */
+  @Test
+  public void internalServiceUserInfoIsPreserved() throws Exception {
+    try (MockedStatic<Server> mockedRpcServer = mockStatic(Server.class)) {
+      mockedRpcServer.when(Server::getRemoteUser).thenReturn(null);
+      mockedRpcServer.when(Server::getRemoteIp).thenReturn(null);
+
+      UserInfo serviceUserInfo = UserInfo.newBuilder()
+          .setUserName("trash-service-user")
+          .setHostName("om-host")
+          .setRemoteAddress("10.0.0.9")
+          .build();
+
+      OMClientRequest request =
+          new OMBucketCreateRequest(newBucketRequest(serviceUserInfo));
+
+      UserInfo result = request.getUserInfo();
+      assertEquals("trash-service-user", result.getUserName());
+      assertEquals("10.0.0.9", result.getRemoteAddress());
+      assertEquals("om-host", result.getHostName());
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OMClientRequest#getUserIfNotExists()` rebuilt the request `UserInfo` from
`UserGroupInformation.getCurrentUser()` — the OM starter/login user — whenever
the derived `UserInfo` was missing a username or a remote address. Because the
result feeds `createUGI()` and the ACL check, this is a *fail-open* to an
often-privileged identity: any request reaching `preExecute()` without complete
user info would silently run as the OM service user. The escalation is latent
today (real RPC and gRPC clients always carry user info), but a future change in
`getUserInfo()` that dropped the username or remote address for a client path
would silently grant the OM identity.

The only caller that relies on this fallback is the Trash emptier
(`TrashOzoneFileSystem`), and it already populates a complete `UserInfo`
(service user + OM address) on the request it builds. The fallback merely
re-derived the same values, because `getUserInfo()` did not carry the
caller-supplied host/address over when there was no RPC/gRPC context.

### Dataflow

Before — every write request, on missing user info, is rebuilt as the OM
starter user:

```
preExecute() -> setUserInfo(getUserIfNotExists(om))
                  getUserInfo()                      // may be incomplete
                  if (!hasRemoteAddress() || !hasUserName())   // OR
                      userName = getCurrentUser()    // OM starter (admin)
                      address  = OM node address
                  -> createUGI() -> UGI(admin) -> checkAcls    // fail-open
```

After — no `getCurrentUser()` fallback; identity is either derived from the
client context, preserved from a request that already carries it (Trash), or
the request fails closed:

```
client request                         internal service (Trash)
  preExecute()                           builds request with its own UserInfo
   -> setUserInfo(getUserInfo())          (service user + OM address)
        userName <- RPC user / S3 id       userName <- omRequest.UserInfo
        address  <- RPC ip / gRPC ctx      address  <- omRequest.UserInfo (new branch)
   -> createUGI()                        -> createUGI() -> UGI(service user)
        userName present -> UGI(user)
        userName missing -> UNAUTHORIZED  // fail-closed, no admin escalation
```

So this PR:
* makes `getUserInfo()` preserve the host/address already present on the request
  when neither an RPC nor a gRPC client context is available (mirroring how the
  username is already carried over for gRPC s3g requests);
* removes the now-redundant `getUserIfNotExists()` and the
  `getCurrentUser()`/admin fallback;
* points `preExecute()` and the `OMKeyDeleteRequest` / `OMKeyRenameRequest` /
  `OMAllocateBlockRequest` callers at `getUserInfo()`.

Requests that genuinely have no identity now fail closed in `createUGI()`
(`UNAUTHORIZED`) instead of being granted the OM starter user. Real client
paths are unchanged (they always carry user info), and the Trash emptier keeps
its explicit service identity.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15467

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/27190426330