### PR TITLE
HDDS-15498. Followup. Improve test case to remove unnecessary MockContainers

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
@@ -100,6 +100,7 @@ public abstract class AbstractContainerSafeModeRuleTest {
     containers.add(mockContainer(LifeCycleState.OPEN, 3L));
     containers.add(mockContainer(LifeCycleState.CLOSED, 4L));
     containers.removeIf(c -> c.containerID().equals(ContainerID.valueOf(8L)));
+    containers.add(mockContainer(LifeCycleState.DELETED, 8L));
     deletedContainers.add(mockContainer(LifeCycleState.DELETED, 8L));
     rule.refresh(true);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
@@ -96,7 +96,6 @@ public abstract class AbstractContainerSafeModeRuleTest {
     AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
     assertEquals(2, rule.getTotalNumberOfContainers(), "Total number of containers should be 2");
-    containers.add(mockContainer(LifeCycleState.DELETED, 8L));
     deletedContainers.add(mockContainer(LifeCycleState.DELETED, 8L));
     rule.refresh(true);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/AbstractContainerSafeModeRuleTest.java
@@ -96,10 +96,6 @@ public abstract class AbstractContainerSafeModeRuleTest {
     AbstractContainerSafeModeRule rule = createRule(eventQueue, conf, containerManager, safeModeManager);
     rule.setValidateBasedOnReportProcessing(false);
     assertEquals(2, rule.getTotalNumberOfContainers(), "Total number of containers should be 2");
-    containers.add(mockContainer(LifeCycleState.CLOSED, 2L));
-    containers.add(mockContainer(LifeCycleState.OPEN, 3L));
-    containers.add(mockContainer(LifeCycleState.CLOSED, 4L));
-    containers.removeIf(c -> c.containerID().equals(ContainerID.valueOf(8L)));
     containers.add(mockContainer(LifeCycleState.DELETED, 8L));
     deletedContainers.add(mockContainer(LifeCycleState.DELETED, 8L));
     rule.refresh(true);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Following up https://github.com/apache/ozone/pull/10462, in the test case, we no longer need to add more containers to the `containers` because the `reinitializeRule` no longer access `when(containerManager.getContainers(getReplicationType())).thenReturn(containers);`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15498

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Unit test
