### PR TITLE
HDDS-15515. Support object Content-Type end-to-end in S3 Gateway

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -118,6 +118,12 @@ import org.slf4j.LoggerFactory;
 public abstract class EndpointBase {
 
   protected static final String ETAG_CUSTOM = "etag-custom";
+  // Metadata key under which the object's Content-Type is stored in the OM key
+  // metadata (the standard Content-Type header name).
+  protected static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE;
+  // Key used to preserve a user-supplied "x-amz-meta-content-type" so it does
+  // not collide with the object's Content-Type stored under CONTENT_TYPE.
+  protected static final String CONTENT_TYPE_CUSTOM = "content-type-custom";
 
   private static final ThreadLocal<MessageDigest> MD5_PROVIDER;
   private static final ThreadLocal<MessageDigest> SHA_256_PROVIDER;
@@ -319,20 +325,33 @@ public abstract class EndpointBase {
       }
     }
 
-    // If the request contains a custom metadata header "x-amz-meta-ETag",
-    // replace the metadata key to "etag-custom" to prevent key metadata collision with
-    // the ETag calculated by hashing the object when storing the key in OM table.
-    // The custom ETag metadata header will be rebuilt during the headObject operation.
-    if (customMetadata.containsKey(HttpHeaders.ETAG)
-        || customMetadata.containsKey(HttpHeaders.ETAG.toLowerCase())) {
-      String customETag = customMetadata.get(HttpHeaders.ETAG) != null ?
-          customMetadata.get(HttpHeaders.ETAG) : customMetadata.get(HttpHeaders.ETAG.toLowerCase());
-      customMetadata.remove(HttpHeaders.ETAG);
-      customMetadata.remove(HttpHeaders.ETAG.toLowerCase());
-      customMetadata.put(ETAG_CUSTOM, customETag);
-    }
+    // A user-supplied x-amz-meta-{etag,content-type} would collide with the
+    // system ETag / Content-Type stored under the same key in the OM key
+    // metadata. Remap them to dedicated custom keys; they are rebuilt on read
+    // in addCustomMetadataHeaders().
+    remapReservedMetadataKey(customMetadata, HttpHeaders.ETAG, ETAG_CUSTOM);
+    remapReservedMetadataKey(customMetadata, CONTENT_TYPE, CONTENT_TYPE_CUSTOM);
 
     return customMetadata;
+  }
+
+  /**
+   * If {@code metadata} contains a user-supplied value under {@code headerName}
+   * (in either the canonical or lower-case form), move it to {@code customKey}
+   * so it does not collide with the system value stored under
+   * {@code headerName}. The original header is rebuilt on read in
+   * {@link #addCustomMetadataHeaders}.
+   */
+  private static void remapReservedMetadataKey(Map<String, String> metadata,
+      String headerName, String customKey) {
+    String lowerName = headerName.toLowerCase();
+    if (metadata.containsKey(headerName) || metadata.containsKey(lowerName)) {
+      String value = metadata.get(headerName) != null
+          ? metadata.get(headerName) : metadata.get(lowerName);
+      metadata.remove(headerName);
+      metadata.remove(lowerName);
+      metadata.put(customKey, value);
+    }
   }
 
   protected void addCustomMetadataHeaders(
@@ -343,10 +362,18 @@ public abstract class EndpointBase {
       if (entry.getKey().equals(ETAG)) {
         continue;
       }
+      // The object's Content-Type is returned as the standard Content-Type
+      // response header, not as a user-metadata header.
+      if (entry.getKey().equals(CONTENT_TYPE)) {
+        continue;
+      }
       String metadataKey = entry.getKey();
       if (metadataKey.equals(ETAG_CUSTOM)) {
         // Rebuild the ETag custom metadata header
         metadataKey = ETAG.toLowerCase();
+      } else if (metadataKey.equals(CONTENT_TYPE_CUSTOM)) {
+        // Rebuild the user-supplied content-type custom metadata header
+        metadataKey = CONTENT_TYPE.toLowerCase();
       }
       responseBuilder
           .header(CUSTOM_METADATA_HEADER_PREFIX + metadataKey,

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -48,6 +48,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.validateMultiChunksUpload;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.validateSignatureHeader;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -118,12 +119,22 @@ import org.slf4j.LoggerFactory;
 public abstract class EndpointBase {
 
   protected static final String ETAG_CUSTOM = "etag-custom";
-  // Metadata key under which the object's Content-Type is stored in the OM key
-  // metadata (the standard Content-Type header name).
-  protected static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE;
-  // Key used to preserve a user-supplied "x-amz-meta-content-type" so it does
-  // not collide with the object's Content-Type stored under CONTENT_TYPE.
   protected static final String CONTENT_TYPE_CUSTOM = "content-type-custom";
+
+  // System metadata key -> custom key. A user x-amz-meta-{etag,content-type}
+  // collides with the system ETag / Content-Type stored under the same key, so
+  // it is remapped on write and rebuilt on read; the system value is returned
+  // via its own ETag / Content-Type response header.
+  private static final Map<String, String> RESERVED_METADATA_KEYS =
+      ImmutableMap.of(
+          ETAG, ETAG_CUSTOM,
+          HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_CUSTOM);
+
+  // Custom key -> lower-cased header, to rebuild remapped user metadata on read.
+  private static final Map<String, String> REBUILT_RESERVED_KEYS =
+      RESERVED_METADATA_KEYS.entrySet().stream()
+          .collect(ImmutableMap.toImmutableMap(
+              Map.Entry::getValue, e -> e.getKey().toLowerCase()));
 
   private static final ThreadLocal<MessageDigest> MD5_PROVIDER;
   private static final ThreadLocal<MessageDigest> SHA_256_PROVIDER;
@@ -325,22 +336,16 @@ public abstract class EndpointBase {
       }
     }
 
-    // A user-supplied x-amz-meta-{etag,content-type} would collide with the
-    // system ETag / Content-Type stored under the same key in the OM key
-    // metadata. Remap them to dedicated custom keys; they are rebuilt on read
-    // in addCustomMetadataHeaders().
-    remapReservedMetadataKey(customMetadata, HttpHeaders.ETAG, ETAG_CUSTOM);
-    remapReservedMetadataKey(customMetadata, CONTENT_TYPE, CONTENT_TYPE_CUSTOM);
+    // Remap user values that collide with a reserved system key.
+    RESERVED_METADATA_KEYS.forEach((headerName, customKey) ->
+        remapReservedMetadataKey(customMetadata, headerName, customKey));
 
     return customMetadata;
   }
 
   /**
-   * If {@code metadata} contains a user-supplied value under {@code headerName}
-   * (in either the canonical or lower-case form), move it to {@code customKey}
-   * so it does not collide with the system value stored under
-   * {@code headerName}. The original header is rebuilt on read in
-   * {@link #addCustomMetadataHeaders}.
+   * Move a user value under {@code headerName} (canonical or lower-case) to
+   * {@code customKey} so it does not collide with the system value.
    */
   private static void remapReservedMetadataKey(Map<String, String> metadata,
       String headerName, String customKey) {
@@ -359,22 +364,13 @@ public abstract class EndpointBase {
 
     Map<String, String> metadata = key.getMetadata();
     for (Map.Entry<String, String> entry : metadata.entrySet()) {
-      if (entry.getKey().equals(ETAG)) {
-        continue;
-      }
-      // The object's Content-Type is returned as the standard Content-Type
-      // response header, not as a user-metadata header.
-      if (entry.getKey().equals(CONTENT_TYPE)) {
-        continue;
-      }
       String metadataKey = entry.getKey();
-      if (metadataKey.equals(ETAG_CUSTOM)) {
-        // Rebuild the ETag custom metadata header
-        metadataKey = ETAG.toLowerCase();
-      } else if (metadataKey.equals(CONTENT_TYPE_CUSTOM)) {
-        // Rebuild the user-supplied content-type custom metadata header
-        metadataKey = CONTENT_TYPE.toLowerCase();
+      // System ETag / Content-Type are returned via their own response header.
+      if (RESERVED_METADATA_KEYS.containsKey(metadataKey)) {
+        continue;
       }
+      // Rebuild a remapped user value (e.g. content-type-custom -> content-type).
+      metadataKey = REBUILT_RESERVED_KEYS.getOrDefault(metadataKey, metadataKey);
       responseBuilder
           .header(CUSTOM_METADATA_HEADER_PREFIX + metadataKey,
               entry.getValue());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -133,7 +133,6 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
   public ObjectEndpoint() {
     overrideQueryParameter = ImmutableMap.<String, String>builder()
-        .put(HttpHeaders.CONTENT_TYPE, "response-content-type")
         .put(HttpHeaders.CONTENT_LANGUAGE, "response-content-language")
         .put(HttpHeaders.EXPIRES, "response-expires")
         .put(HttpHeaders.CACHE_CONTROL, "response-cache-control")
@@ -464,15 +463,16 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       MultivaluedMap<String, String> queryParams =
           getContext().getUriInfo().getQueryParameters();
 
+      // Content-Type comes from the stored object, not the request header;
+      // response-content-type still overrides it.
+      String contentType = queryParams.getFirst("response-content-type");
+      if (contentType == null) {
+        contentType = contentTypeOf(keyDetails);
+      }
+      responseBuilder.header(HttpHeaders.CONTENT_TYPE, contentType);
+
       for (Map.Entry<String, String> entry : overrideQueryParameter.entrySet()) {
         String headerValue = getHeaders().getHeaderString(entry.getKey());
-        // Default the response Content-Type to the object's stored Content-Type
-        // (or the standard default) so it is always returned; a
-        // response-content-type query parameter still overrides it below.
-        if (headerValue == null
-            && HttpHeaders.CONTENT_TYPE.equals(entry.getKey())) {
-          headerValue = contentTypeOf(keyDetails);
-        }
         String queryValue = queryParams.getFirst(entry.getValue());
         if (queryValue != null) {
           headerValue = queryValue;
@@ -508,21 +508,20 @@ public class ObjectEndpoint extends ObjectOperationHandler {
   }
 
   /**
-   * Store the request's Content-Type in the key metadata so it can be returned
-   * on GET/HEAD and propagated on copy. The original value is preserved by
-   * {@link HeaderPreprocessor} as {@code X-Ozone-Original-Content-Type}.
+   * Store the request's Content-Type (preserved by {@link HeaderPreprocessor}
+   * as {@code X-Ozone-Original-Content-Type}) in the key metadata.
    */
   private void putContentType(Map<String, String> metadata) {
     String contentType =
         getHeaders().getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE);
     if (contentType != null) {
-      metadata.put(CONTENT_TYPE, contentType);
+      metadata.put(HttpHeaders.CONTENT_TYPE, contentType);
     }
   }
 
   /** Returns the object's stored Content-Type, or the default if absent. */
   private static String contentTypeOf(OzoneKey key) {
-    String contentType = key.getMetadata().get(CONTENT_TYPE);
+    String contentType = key.getMetadata().get(HttpHeaders.CONTENT_TYPE);
     return contentType != null ? contentType : DEFAULT_CONTENT_TYPE;
   }
 
@@ -1119,8 +1118,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       } else if (metadataCopyDirective.equals(CopyDirective.REPLACE.name())) {
         // Replace the metadata with the metadata form the request headers
         customMetadata = getCustomMetadataFromHeaders(getHeaders().getRequestHeaders());
-        // With REPLACE, the Content-Type comes from the copy request (if any),
-        // not from the source object.
+        // REPLACE: Content-Type comes from the request, not the source.
         putContentType(customMetadata);
       } else {
         OS3Exception ex = newError(INVALID_ARGUMENT, metadataCopyDirective);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -119,6 +119,8 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
   private static final String BUCKET = "bucket";
   private static final String PATH = "path";
+  // Default Content-Type for objects stored without one, matching S3.
+  private static final String DEFAULT_CONTENT_TYPE = "binary/octet-stream";
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ObjectEndpoint.class);
@@ -267,6 +269,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       Map<String, String> customMetadata =
           getCustomMetadataFromHeaders(getHeaders().getRequestHeaders());
+      putContentType(customMetadata);
       Map<String, String> tags = getTaggingFromHeaders(getHeaders());
 
       long putLength;
@@ -463,6 +466,13 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       for (Map.Entry<String, String> entry : overrideQueryParameter.entrySet()) {
         String headerValue = getHeaders().getHeaderString(entry.getKey());
+        // Default the response Content-Type to the object's stored Content-Type
+        // (or the standard default) so it is always returned; a
+        // response-content-type query parameter still overrides it below.
+        if (headerValue == null
+            && HttpHeaders.CONTENT_TYPE.equals(entry.getKey())) {
+          headerValue = contentTypeOf(keyDetails);
+        }
         String queryValue = queryParams.getFirst(entry.getValue());
         if (queryValue != null) {
           headerValue = queryValue;
@@ -495,6 +505,25 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     responseBuilder
         .header(HttpHeaders.LAST_MODIFIED,
             RFC1123Util.FORMAT.format(lastModificationTime));
+  }
+
+  /**
+   * Store the request's Content-Type in the key metadata so it can be returned
+   * on GET/HEAD and propagated on copy. The original value is preserved by
+   * {@link HeaderPreprocessor} as {@code X-Ozone-Original-Content-Type}.
+   */
+  private void putContentType(Map<String, String> metadata) {
+    String contentType =
+        getHeaders().getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE);
+    if (contentType != null) {
+      metadata.put(CONTENT_TYPE, contentType);
+    }
+  }
+
+  /** Returns the object's stored Content-Type, or the default if absent. */
+  private static String contentTypeOf(OzoneKey key) {
+    String contentType = key.getMetadata().get(CONTENT_TYPE);
+    return contentType != null ? contentType : DEFAULT_CONTENT_TYPE;
   }
 
   static void addTagCountIfAny(
@@ -572,7 +601,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
     ResponseBuilder response = Response.ok().status(HttpStatus.SC_OK)
         .header(HttpHeaders.CONTENT_LENGTH, key.getDataSize())
-        .header(HttpHeaders.CONTENT_TYPE, "binary/octet-stream")
+        .header(HttpHeaders.CONTENT_TYPE, contentTypeOf(key))
         .header(STORAGE_CLASS_HEADER, s3StorageType.toString());
     addEntityTagHeader(response, key);
 
@@ -675,6 +704,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       Map<String, String> customMetadata =
           getCustomMetadataFromHeaders(getHeaders().getRequestHeaders());
+      putContentType(customMetadata);
 
       Map<String, String> tags = getTaggingFromHeaders(getHeaders());
 
@@ -1089,6 +1119,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       } else if (metadataCopyDirective.equals(CopyDirective.REPLACE.name())) {
         // Replace the metadata with the metadata form the request headers
         customMetadata = getCustomMetadataFromHeaders(getHeaders().getRequestHeaders());
+        // With REPLACE, the Content-Type comes from the copy request (if any),
+        // not from the source object.
+        putContentType(customMetadata);
       } else {
         OS3Exception ex = newError(INVALID_ARGUMENT, metadataCopyDirective);
         ex.setErrorMessage("An error occurred (InvalidArgument) " +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -41,6 +41,7 @@ import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest.Part;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
@@ -120,6 +121,23 @@ public class TestMultipartUploadComplete {
 
     assertEquals("custom-value1", headResponse.getHeaderString(CUSTOM_METADATA_HEADER_PREFIX + "custom-key1"));
     assertEquals("custom-value2", headResponse.getHeaderString(CUSTOM_METADATA_HEADER_PREFIX + "custom-key2"));
+  }
+
+  @Test
+  public void testMultipartStoresContentType() throws Exception {
+    String key = UUID.randomUUID().toString();
+
+    // Content-Type set on CreateMultipartUpload is preserved as
+    // ORIGINAL_CONTENT_TYPE and must survive to the completed object.
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn("video/webm");
+
+    String uploadID = initiateMultipartUpload(key);
+    Part part1 = uploadPart(rest, OzoneConsts.S3_BUCKET, key, 1, uploadID, "Multipart Upload 1");
+    completeMultipartUpload(rest, OzoneConsts.S3_BUCKET, key, uploadID, singletonList(part1));
+
+    assertEquals("video/webm", rest.head(OzoneConsts.S3_BUCKET, key)
+        .getHeaderString(HttpHeaders.CONTENT_TYPE));
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -217,7 +217,8 @@ public class TestObjectGet {
 
     Response response = get(rest, BUCKET_NAME, KEY_NAME);
 
-    assertEquals(CONTENT_TYPE1,
+    // Content-Type is not inherited from the request; key1 has none stored.
+    assertEquals("binary/octet-stream",
         response.getHeaderString("Content-Type"));
     assertEquals(CONTENT_LANGUAGE1,
         response.getHeaderString("Content-Language"));
@@ -302,14 +303,14 @@ public class TestObjectGet {
   @Test
   public void getAndHeadReturnStoredContentType()
       throws IOException, OS3Exception {
-    // PUT an object whose Content-Type is preserved as ORIGINAL_CONTENT_TYPE.
+    // Store a Content-Type, then read with no request Content-Type.
     when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
         .thenReturn(CONTENT_TYPE1);
     assertSucceeds(() -> put(rest, BUCKET_NAME, "typed-key", CONTENT));
     when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
         .thenReturn(null);
 
-    // GET and HEAD return the stored Content-Type when the request carries none.
+    // GET and HEAD return the stored Content-Type.
     assertEquals(CONTENT_TYPE1,
         get(rest, BUCKET_NAME, "typed-key").getHeaderString("Content-Type"));
     assertEquals(CONTENT_TYPE1,
@@ -320,6 +321,32 @@ public class TestObjectGet {
         get(rest, BUCKET_NAME, KEY_NAME).getHeaderString("Content-Type"));
     assertEquals("binary/octet-stream",
         rest.head(BUCKET_NAME, KEY_NAME).getHeaderString("Content-Type"));
+  }
+
+  @Test
+  public void getIgnoresRequestContentTypeUsesStored()
+      throws IOException, OS3Exception {
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn(CONTENT_TYPE1);
+    assertSucceeds(() -> put(rest, BUCKET_NAME, "typed-key", CONTENT));
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn(null);
+
+    // A request Content-Type is ignored; the stored value is returned.
+    doReturn(CONTENT_TYPE2).when(headers).getHeaderString("Content-Type");
+    assertEquals(CONTENT_TYPE1,
+        get(rest, BUCKET_NAME, "typed-key").getHeaderString("Content-Type"));
+
+    // No stored Content-Type: request still ignored, default returned.
+    assertEquals("binary/octet-stream",
+        get(rest, BUCKET_NAME, KEY_NAME).getHeaderString("Content-Type"));
+
+    // response-content-type still overrides.
+    MultivaluedMap<String, String> queryParameter =
+        rest.getContext().getUriInfo().getQueryParameters();
+    queryParameter.putSingle("response-content-type", CONTENT_TYPE2);
+    assertEquals(CONTENT_TYPE2,
+        get(rest, BUCKET_NAME, "typed-key").getHeaderString("Content-Type"));
   }
 
   private void setDefaultHeader() {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneClientTestUtils;
+import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.util.RFC1123Util;
 import org.junit.jupiter.api.BeforeEach;
@@ -296,6 +297,29 @@ public class TestObjectGet {
     assertEquals(response.getStatus(),
         Response.Status.PARTIAL_CONTENT.getStatusCode());
     assertNull(response.getHeaderString(TAG_COUNT_HEADER));
+  }
+
+  @Test
+  public void getAndHeadReturnStoredContentType()
+      throws IOException, OS3Exception {
+    // PUT an object whose Content-Type is preserved as ORIGINAL_CONTENT_TYPE.
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn(CONTENT_TYPE1);
+    assertSucceeds(() -> put(rest, BUCKET_NAME, "typed-key", CONTENT));
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn(null);
+
+    // GET and HEAD return the stored Content-Type when the request carries none.
+    assertEquals(CONTENT_TYPE1,
+        get(rest, BUCKET_NAME, "typed-key").getHeaderString("Content-Type"));
+    assertEquals(CONTENT_TYPE1,
+        rest.head(BUCKET_NAME, "typed-key").getHeaderString("Content-Type"));
+
+    // An object stored without a Content-Type falls back to the default.
+    assertEquals("binary/octet-stream",
+        get(rest, BUCKET_NAME, KEY_NAME).getHeaderString("Content-Type"));
+    assertEquals("binary/octet-stream",
+        rest.head(BUCKET_NAME, KEY_NAME).getHeaderString("Content-Type"));
   }
 
   private void setDefaultHeader() {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertStatus
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertSucceeds;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_NONE_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_UNMODIFIED_SINCE_HEADER;
@@ -42,6 +43,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -49,6 +52,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.util.RFC1123Util;
 import org.apache.http.HttpStatus;
@@ -229,6 +233,37 @@ public class TestObjectHead {
     assertNotNull(response.getHeaderString(TAG_COUNT_HEADER),
         "HeadObject must include x-amz-tagging-count when object has tags (AWS TagCount)");
     assertEquals("2", response.getHeaderString(TAG_COUNT_HEADER));
+  }
+
+  @Test
+  public void testHeadSeparatesUserContentTypeMetadataFromObjectContentType()
+      throws Exception {
+    String keyName = "typed-with-user-meta";
+    String objectContentType = "image/jpeg";
+    String userContentType = "user/custom-type";
+
+    // PUT with both the object's Content-Type and a colliding user
+    // x-amz-meta-content-type.
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn(objectContentType);
+    MultivaluedMap<String, String> requestHeaders = new MultivaluedHashMap<>();
+    requestHeaders.putSingle(
+        CUSTOM_METADATA_HEADER_PREFIX + "content-type", userContentType);
+    when(headers.getRequestHeaders()).thenReturn(requestHeaders);
+    assertSucceeds(() -> put(keyEndpoint, bucketName, keyName, "head-content"));
+
+    // The user value is remapped, so the object's Content-Type is preserved.
+    assertEquals(objectContentType,
+        bucket.getKey(keyName).getMetadata().get(HttpHeaders.CONTENT_TYPE));
+
+    // HEAD returns the object Content-Type as the standard header and the user
+    // value as x-amz-meta-content-type.
+    Response response = keyEndpoint.head(bucketName, keyName);
+    assertEquals(HttpStatus.SC_OK, response.getStatus());
+    assertEquals(objectContentType,
+        response.getHeaderString(HttpHeaders.CONTENT_TYPE));
+    assertEquals(userContentType,
+        response.getHeaderString(CUSTOM_METADATA_HEADER_PREFIX + "content-type"));
   }
 
   private byte[] createKey(String keyPath) throws IOException {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -83,6 +83,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
@@ -379,6 +380,42 @@ class TestObjectPut {
         BUCKET_NAME + "/" + urlEncode(NONEXISTENT_BUCKET));
     assertErrorResponse(NO_SUCH_BUCKET,
         () -> put(objectEndpoint, "nonexistent", KEY_NAME, CONTENT));
+  }
+
+  @Test
+  void testContentTypeStoredAndCopied() throws Exception {
+    // PUT with an explicit Content-Type (preserved by HeaderPreprocessor).
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn("audio/mpeg");
+
+    assertSucceeds(() -> putObject(CONTENT));
+    OzoneKeyDetails source = bucket.getKey(KEY_NAME);
+    assertEquals("audio/mpeg",
+        source.getMetadata().get(HttpHeaders.CONTENT_TYPE));
+
+    // COPY directive: destination keeps the source Content-Type, ignoring the
+    // Content-Type on the copy request.
+    when(headers.getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER))
+        .thenReturn("COPY");
+    when(headers.getHeaderString(COPY_SOURCE_HEADER))
+        .thenReturn(BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn("text/plain");
+
+    assertSucceeds(() -> put(objectEndpoint, DEST_BUCKET_NAME, DEST_KEY, CONTENT));
+    assertEquals("audio/mpeg",
+        destBucket.getKey(DEST_KEY).getMetadata().get(HttpHeaders.CONTENT_TYPE));
+
+    // REPLACE directive: destination takes the Content-Type from the request.
+    when(headers.getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER))
+        .thenReturn("REPLACE");
+    when(headers.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+    when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))
+        .thenReturn("application/json");
+
+    assertSucceeds(() -> put(objectEndpoint, DEST_BUCKET_NAME, DEST_KEY, CONTENT));
+    assertEquals("application/json",
+        destBucket.getKey(DEST_KEY).getMetadata().get(HttpHeaders.CONTENT_TYPE));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

The S3 Gateway never persisted an object's `Content-Type`. The request
`Content-Type` was only forwarded to `HeaderPreprocessor` for SigV4 signing
(`X-Ozone-Original-Content-Type`) and was never stored in the OM key metadata;
`GetObject` did not set it from the object and `HeadObject` hard-coded
`binary/octet-stream`. Because the value is never stored, `CopyObject` /
`UploadPartCopy` cannot preserve or replace it, so copied (and plain) objects
consistently default to octet-stream.

This is an end-to-end gap, not a copy-only issue. This PR adds object
`Content-Type` support across the read/write/copy paths, aligning with AWS S3:

* **PutObject / CreateMultipartUpload** — store the request `Content-Type` in
  the OM key metadata, mirroring the existing ETag-in-metadata convention.
* **GetObject / HeadObject** — return the stored `Content-Type`, defaulting to
  `binary/octet-stream` when absent (the `response-content-type` query
  parameter still overrides).
* **CopyObject** metadata directive — `COPY` (default) preserves the source
  object's `Content-Type` (it rides along in the copied source metadata);
  `REPLACE` applies the `Content-Type` from the copy request.
* A user-supplied `x-amz-meta-content-type` is remapped to a dedicated key so
  it does not collide with the object's stored `Content-Type`. The reserved-key
  remap/rebuild that previously existed only for ETag is now factored into a
  shared helper and reused for both.

Before vs after (response):

| Path | Before | After |
| --- | --- | --- |
| PUT/MPU | Content-Type not persisted | stored in key metadata |
| GET | only set from request header / `response-content-type` | falls back to stored Content-Type |
| HEAD | hard-coded `binary/octet-stream` | stored Content-Type (or default) |
| COPY (COPY) | dest defaults to octet-stream | keeps source Content-Type |
| COPY (REPLACE) | dest defaults to octet-stream | uses request Content-Type |

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15515

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/27210927693