### PR TITLE
HDDS-15514. DNS-refresh-on-failure for OM, SCM, DN RPC paths

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import java.io.EOFException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+/**
+ * Shared classifier for exceptions where the cached peer IP is no longer
+ * reachable and DNS re-resolution is the only plausible recovery path.
+ * <p>
+ * Used by both {@code SCMFailoverProxyProviderBase} and
+ * {@code OMFailoverProxyProviderBase} to gate the DNS-refresh-on-failure
+ * code path so that application-level errors (NotLeader, AccessControl,
+ * OMException, RetryAction) do not trigger spurious DNS lookups.
+ * <p>
+ * The classifier must match the failure shapes seen in production
+ * Kubernetes deployments where the peer pod has been rescheduled to a
+ * new IP under a stable hostname:
+ * <ul>
+ *   <li>{@link ConnectException} -- the TCP SYN was refused. Seen on
+ *       OpenStack / fast-RST environments. </li>
+ *   <li>{@link SocketTimeoutException} (and its IPC subclass
+ *       {@code ConnectTimeoutException}) -- the SYN was dropped silently.
+ *       This is the dominant failure shape on AWS EC2 / EKS where the
+ *       network silently drops packets to a defunct pod IP. The PR that
+ *       introduced this helper (HDDS-15514) is sold on this case; it
+ *       must be in the filter. </li>
+ *   <li>{@link NoRouteToHostException} -- routing table no longer
+ *       reaches the cached IP. </li>
+ *   <li>{@link UnknownHostException} -- the hostname itself failed to
+ *       resolve at the time the IPC layer reconstructed the address. </li>
+ *   <li>{@link EOFException} -- a load balancer or iptables RST closed
+ *       the half-open connection cleanly. Common in Kubernetes when an
+ *       IP is reassigned to an unrelated pod that rejects the RPC
+ *       handshake. </li>
+ *   <li>{@link SocketException} (e.g. "Connection reset") -- the peer
+ *       sent RST mid-stream. </li>
+ * </ul>
+ * The walk is bounded to {@value #MAX_CAUSE_DEPTH} levels to defend
+ * against cause chains that have been constructed (in violation of
+ * {@code Throwable.initCause}'s contract) into a cycle of length > 1.
+ */
+public final class ConnectionFailureUtils {
+
+  /**
+   * Maximum depth of the {@code Throwable.getCause()} chain we walk
+   * before giving up. Matches Hadoop's own walkers in
+   * {@code RemoteException} handling.
+   */
+  static final int MAX_CAUSE_DEPTH = 16;
+
+  private ConnectionFailureUtils() {
+  }
+
+  /**
+   * Returns true when any link in {@code t}'s cause chain (up to
+   * {@link #MAX_CAUSE_DEPTH} levels) is one of the connection-class
+   * exceptions documented on this class.
+   *
+   * @param t the throwable to classify. {@code null} returns false.
+   */
+  public static boolean isConnectionFailure(Throwable t) {
+    Throwable cause = t;
+    for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++) {
+      if (cause instanceof ConnectException
+          || cause instanceof SocketTimeoutException
+          || cause instanceof NoRouteToHostException
+          || cause instanceof UnknownHostException
+          || cause instanceof EOFException
+          || cause instanceof SocketException) {
+        return true;
+      }
+      Throwable next = cause.getCause();
+      if (next == cause) {
+        break;
+      }
+      cause = next;
+    }
+    return false;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
@@ -56,16 +56,16 @@ import java.net.UnknownHostException;
  *   <li>{@link SocketException} (e.g. "Connection reset") -- the peer
  *       sent RST mid-stream. </li>
  * </ul>
- * The walk is bounded to {@value #MAX_CAUSE_DEPTH} levels to defend
+ * The walk is bounded to {@link #MAX_CAUSE_DEPTH} levels to defend
  * against cause chains that have been constructed (in violation of
- * {@code Throwable.initCause}'s contract) into a cycle of length > 1.
+ * {@code Throwable.initCause}'s contract) into a cycle of length &gt; 1.
  */
 public final class ConnectionFailureUtils {
 
   /**
    * Maximum depth of the {@code Throwable.getCause()} chain we walk
-   * before giving up. Matches Hadoop's own walkers in
-   * {@code RemoteException} handling.
+   * before giving up (currently {@value}). Matches Hadoop's own
+   * walkers in {@code RemoteException} handling.
    */
   static final int MAX_CAUSE_DEPTH = 16;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -604,6 +604,30 @@ public final class OzoneConfigKeys {
   public static final boolean OZONE_JVM_NETWORK_ADDRESS_CACHE_ENABLED_DEFAULT =
           true;
 
+  /**
+   * When true, RPC clients (DN heartbeat, OM client, SCM client) re-resolve
+   * cached hostnames on connection failure and rebuild the proxy if the
+   * resolved IP has changed. Set to true in environments where server pod
+   * IPs may change while DNS names remain stable, such as Kubernetes.
+   * Default false preserves pre-fix behavior. Mirrors the design intent of
+   * HADOOP-17068 / HDFS-14118.
+   */
+  public static final String OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY =
+          "ozone.client.failover.resolve-needed";
+  public static final boolean OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT =
+          false;
+
+  /**
+   * Number of consecutive heartbeat failures the DN tolerates against the
+   * same SCM endpoint before re-resolving its hostname. Only consulted when
+   * {@link #OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY} is true. Conservative
+   * default avoids re-resolution on transient blips while still recovering
+   * from a peer pod IP change within seconds.
+   */
+  public static final String OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY =
+          "ozone.datanode.scm.heartbeat.address.refresh.threshold";
+  public static final int OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT = 3;
+
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY =
       "ozone.client.required.om.version.min";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3914,6 +3914,52 @@
   </property>
 
   <property>
+    <name>ozone.client.failover.resolve-needed</name>
+    <value>false</value>
+    <tag>OZONE, CLIENT, OM, SCM, HA</tag>
+    <description>When true, RPC clients (DN heartbeat, OM client, SCM
+      client) re-resolve cached hostnames on connection-class failures
+      (ConnectException, SocketTimeoutException, NoRouteToHostException,
+      UnknownHostException, EOFException, SocketException) and rebuild
+      the proxy if the resolved IP has changed. Set to true in
+      environments where server pod IPs may change while DNS names
+      remain stable, such as Kubernetes. Default false preserves
+      pre-fix behaviour. Mirrors the design intent of HADOOP-17068 /
+      HDFS-14118.
+
+      Required co-config for SECURE clusters: when this flag is true,
+      operators must ALSO set hadoop.security.token.service.use_ip=false
+      (in core-site.xml). Reason: the Hadoop delegation-token service
+      identifier defaults to an IP:port string. After a refresh, the
+      per-OM service identifier built from the new IP no longer matches
+      the IP-based service captured on long-lived tokens, and token
+      selection (OzoneDelegationTokenSelector) silently fails for the
+      refreshed peer. With use_ip=false the service identifier is the
+      stable hostname:port, which survives any IP change. Insecure
+      clusters do not need the co-config.
+
+      Note: ozone.network.jvm.address.cache.enabled controls a related
+      but distinct concern -- the JVM-level positive DNS cache TTL.
+      That setting only affects future name lookups; this setting
+      additionally rebuilds long-lived RPC proxies whose
+      InetSocketAddress was frozen at process start.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.datanode.scm.heartbeat.address.refresh.threshold</name>
+    <value>3</value>
+    <tag>OZONE, DATANODE, HA</tag>
+    <description>Number of consecutive heartbeat failures the
+      DataNode tolerates against the same SCM endpoint before
+      attempting a DNS re-resolution. Only consulted when
+      ozone.client.failover.resolve-needed is true. Conservative
+      default avoids re-resolution on transient blips while still
+      recovering from a peer pod IP change within seconds.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.directory.deleting.service.interval</name>
     <value>1m</value>
     <tag>OZONE, PERFORMANCE, OM, DELETION</tag>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestConnectionFailureUtils.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
+import org.apache.hadoop.security.AccessControlException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the connection-class exception classifier used to gate the
+ * DNS-refresh-on-failure code path on both the OM and SCM failover
+ * proxy providers and the DataNode heartbeat catch block.
+ * <p>
+ * The classifier must:
+ * <ul>
+ *   <li>Match every exception type that signals "the cached IP is no
+ *       longer reachable" -- including the AWS EC2 / EKS silent-drop
+ *       case which surfaces as {@link SocketTimeoutException}, the
+ *       case the PR motivating this helper (HDDS-15514) is sold on. </li>
+ *   <li>Reject application-level errors (NotLeader, AccessControl,
+ *       protocol mismatch) so we don't add DNS load on logical
+ *       failures where the cached IP is fine. </li>
+ *   <li>Walk wrapped cause chains so a {@code RemoteException(...)} or
+ *       {@code IOException(...)} carrying a connection-class cause is
+ *       still classified correctly. </li>
+ *   <li>Defend against pathological cycles in the cause chain. </li>
+ * </ul>
+ */
+public class TestConnectionFailureUtils {
+
+  static Stream<Arguments> connectionClassExceptions() {
+    return Stream.of(
+        Arguments.of(new ConnectException("refused"),         "ConnectException"),
+        Arguments.of(new SocketTimeoutException("EC2 drop"),  "SocketTimeoutException (AWS silent drop)"),
+        Arguments.of(new NoRouteToHostException("gone"),      "NoRouteToHostException"),
+        Arguments.of(new UnknownHostException("dns failed"),  "UnknownHostException"),
+        Arguments.of(new EOFException("LB closed"),           "EOFException"),
+        Arguments.of(new SocketException("Connection reset"), "SocketException")
+    );
+  }
+
+  @ParameterizedTest(name = "isConnectionFailure detects {1}")
+  @MethodSource("connectionClassExceptions")
+  public void testDetectsBareConnectionClass(Throwable t, String label) {
+    assertTrue(ConnectionFailureUtils.isConnectionFailure(t),
+        label + " must be classified as a connection failure");
+  }
+
+  @ParameterizedTest(name = "isConnectionFailure walks IOException wrap of {1}")
+  @MethodSource("connectionClassExceptions")
+  public void testDetectsThroughIOExceptionWrap(Throwable t, String label) {
+    IOException wrapped = new IOException("rpc failed", t);
+    assertTrue(ConnectionFailureUtils.isConnectionFailure(wrapped),
+        "IOException wrapping " + label + " must still be classified");
+  }
+
+  @Test
+  public void testDeeplyNestedChainStillClassified() {
+    // ConnectException three levels deep, the way Hadoop RPC's RetriableException
+    // wraps ServiceException wraps IOException wraps the real cause.
+    Throwable deep = new RuntimeException("outer",
+        new IOException("middle",
+            new IOException("inner", new ConnectException("dead"))));
+    assertTrue(ConnectionFailureUtils.isConnectionFailure(deep));
+  }
+
+  static Stream<Arguments> applicationLevelExceptions() {
+    return Stream.of(
+        Arguments.of(new AccessControlException("denied"),
+            "AccessControlException"),
+        Arguments.of(new IllegalArgumentException("bad request"),
+            "IllegalArgumentException"),
+        Arguments.of(new IOException("application error: not leader"),
+            "plain IOException without connection-class cause"),
+        Arguments.of(new RuntimeException("retry, please"),
+            "plain RuntimeException")
+    );
+  }
+
+  @ParameterizedTest(name = "isConnectionFailure rejects {1}")
+  @MethodSource("applicationLevelExceptions")
+  public void testRejectsApplicationLevel(Throwable t, String label) {
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(t),
+        label + " is an application error, refresh must NOT trigger");
+  }
+
+  @Test
+  public void testNullIsNotAConnectionFailure() {
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(null));
+  }
+
+  /**
+   * {@code Throwable.initCause} contractually rejects setting cause to
+   * the throwable itself, but cycles of length 2+ have appeared in
+   * practice (proxy frameworks and faulty initCause callers can
+   * construct them). The walk must terminate within the configured
+   * depth bound rather than looping forever.
+   * <p>
+   * We build the length-2 cycle through {@link Throwable#initCause}
+   * (no reflection) -- the no-arg ctor leaves cause uninitialized
+   * (cause==this sentinel), so a single initCause call on each side
+   * is permitted and lets us close the cycle.
+   */
+  @Test
+  public void testCycleOfLengthTwoTerminates() {
+    Throwable a = new IOException();
+    Throwable b = new IOException();
+    a.initCause(b);
+    b.initCause(a);
+    // Neither a nor b is a connection-class type. The walk must return
+    // false (not loop forever and not throw).
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(a),
+        "length-2 cycle must terminate cleanly");
+  }
+
+  /**
+   * Defense against an unbounded chain of non-connection-class
+   * exceptions: the depth bound must kick in.
+   * <p>
+   * Built using {@link Throwable#initCause} on freshly-constructed
+   * exceptions (no-arg ctor leaves cause uninitialized) so the test
+   * does not depend on JDK-internal reflective access to the
+   * {@code cause} field, which fails on JDK 16+ without
+   * {@code --add-opens java.base/java.lang=ALL-UNNAMED}.
+   */
+  @Test
+  public void testUnboundedChainOfNonMatchingTerminates() {
+    Throwable head = new RuntimeException();
+    Throwable cursor = head;
+    for (int i = 1; i < 1024; i++) {
+      Throwable next = new RuntimeException();
+      cursor.initCause(next);
+      cursor = next;
+    }
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(head));
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -796,7 +796,9 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
         continue;
       }
       try {
-        connectionManager.addSCMServer(scmAddress, context.getThreadNamePrefix());
+        String hostAndPort = scmAddress.getHostString() + ":" + scmAddress.getPort();
+        connectionManager.addSCMServer(scmAddress, hostAndPort,
+            context.getThreadNamePrefix());
         context.addEndpoint(scmAddress);
         effectiveScmNodeIds.add(scmNodeId);
         LOG.info("Reconfiguration successfully add SCM address {} for SCM service {}", scmAddress, scmServiceId);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.protocol.VersionResponse;
 import org.apache.hadoop.ozone.protocolPB.ReconDatanodeProtocolPB;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
@@ -47,6 +48,19 @@ public class EndpointStateMachine
   private final StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint;
   private final AtomicLong missedCount;
   private final InetSocketAddress address;
+  /**
+   * The original "host:port" string used to resolve {@link #address}.
+   * Preserved so that we can re-resolve DNS when the cached IP becomes
+   * stale (e.g. after a Kubernetes pod restart of the SCM peer). Since
+   * {@link InetSocketAddress} performs a one-shot DNS lookup at
+   * construction and freezes the IP, we cannot recover from a peer IP
+   * change without rebuilding the address from this hostname string.
+   * Null only in the legacy code path where the caller did not preserve
+   * the original config string (in which case re-resolution is disabled
+   * for that endpoint and the operator must restart the DN to pick up
+   * the new IP).
+   */
+  private final String hostAndPort;
   private final Lock lock;
   private final ConfigurationSource conf;
   private EndPointStates state = EndPointStates.FIRST;
@@ -67,9 +81,23 @@ public class EndpointStateMachine
   public EndpointStateMachine(InetSocketAddress address,
       StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
       ConfigurationSource conf, String threadNamePrefix) {
+    this(address, null, endPoint, conf, threadNamePrefix);
+  }
+
+  /**
+   * Constructs RPC Endpoints, preserving the original host:port string
+   * so DNS can be re-resolved on heartbeat failure.
+   * @param address     resolved address used to build the RPC proxy
+   * @param hostAndPort the original "host:port" string, or null if the
+   *                    caller did not preserve it (re-resolution disabled)
+   */
+  public EndpointStateMachine(InetSocketAddress address, String hostAndPort,
+      StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
+      ConfigurationSource conf, String threadNamePrefix) {
     this.endPoint = endPoint;
     this.missedCount = new AtomicLong(0);
     this.address = address;
+    this.hostAndPort = hostAndPort;
     lock = new ReentrantLock();
     this.conf = conf;
     executorService = Executors.newSingleThreadExecutor(
@@ -77,6 +105,59 @@ public class EndpointStateMachine
             .setNameFormat(threadNamePrefix + "EndpointStateMachineTaskThread-"
                 + this.address + "-%d ")
             .build());
+  }
+
+  /**
+   * The original "host:port" string used to construct {@link #getAddress()}.
+   * @return the host:port string, or null if not preserved at construction
+   */
+  public String getHostAndPort() {
+    return hostAndPort;
+  }
+
+  /**
+   * Re-resolves the configured hostname and reports whether the resolved
+   * IP differs from the cached {@link #address}. Does not mutate any
+   * state on this endpoint -- the caller is responsible for swapping
+   * this endpoint out (via {@link SCMConnectionManager#refreshSCMServer})
+   * if a refresh is desired.
+   * <p>
+   * Returns null when:
+   * <ul>
+   *   <li>{@link #hostAndPort} was not preserved at construction</li>
+   *   <li>the resolved IP is unchanged</li>
+   *   <li>the new resolution is unresolved (DNS lookup failed)</li>
+   * </ul>
+   * Returns the freshly-resolved {@link InetSocketAddress} when the IP
+   * has changed under the same hostname.
+   */
+  public InetSocketAddress resolveLatestAddress() {
+    if (hostAndPort == null) {
+      return null;
+    }
+    InetSocketAddress refreshed;
+    try {
+      refreshed = NetUtils.createSocketAddr(hostAndPort);
+    } catch (IllegalArgumentException ex) {
+      LOG.warn("Failed to re-resolve {}: {}", hostAndPort, ex.getMessage());
+      return null;
+    }
+    if (refreshed.isUnresolved()) {
+      LOG.warn("Re-resolution of {} produced an unresolved address; "
+          + "leaving cached address {} in place.", hostAndPort, address);
+      return null;
+    }
+    // Null-safe comparison: if the cached address itself was unresolved
+    // (initial DNS lookup failed; ctor accepted it with a warning),
+    // address.getAddress() is null and a successful re-resolution
+    // counts as a change. NPE-ing here would wedge the heartbeat
+    // refresh path on exactly the case it most needs to fix.
+    java.net.InetAddress cachedIp = address.getAddress();
+    if (cachedIp != null
+        && refreshed.getAddress().equals(cachedIp)) {
+      return null;
+    }
+    return refreshed;
   }
 
   /**
@@ -150,13 +231,23 @@ public class EndpointStateMachine
 
   /**
    * Closes the connection.
+   * <p>
+   * The underlying {@code endPoint.close()} delegates to
+   * {@code RPC.stopProxy} which can raise a RuntimeException; without
+   * the try/finally below, the per-endpoint executor would leak its
+   * thread on close failure. Callers (notably
+   * {@code SCMConnectionManager.refreshSCMServer}) catch RuntimeException
+   * from close, so the leak would otherwise be silent.
    */
   @Override
   public void close() {
-    if (endPoint != null) {
-      endPoint.close();
+    try {
+      if (endPoint != null) {
+        endPoint.close();
+      }
+    } finally {
+      executorService.shutdown();
     }
-    executorService.shutdown();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryCount;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryInterval;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcTimeOutInMilliseconds;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -132,6 +133,21 @@ public class SCMConnectionManager
    */
   public void addSCMServer(InetSocketAddress address,
       String threadNamePrefix) throws IOException {
+    addSCMServer(address, null, threadNamePrefix);
+  }
+
+  /**
+   * Adds a new SCM machine and remembers the original host:port string
+   * so the DN can re-resolve DNS on connection failure (e.g. after the
+   * SCM peer is rescheduled to a new pod IP in Kubernetes).
+   *
+   * @param address     resolved RPC address used to build the proxy
+   * @param hostAndPort original "host:port" string, or null to disable
+   *                    DNS re-resolution for this endpoint
+   * @param threadNamePrefix prefix for the endpoint's task thread
+   */
+  public void addSCMServer(InetSocketAddress address, String hostAndPort,
+      String threadNamePrefix) throws IOException {
     writeLock();
     try {
       if (scmMachines.containsKey(address)) {
@@ -139,38 +155,198 @@ public class SCMConnectionManager
             "Ignoring the request.");
         return;
       }
-
-      Configuration hadoopConfig =
-          LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
-      RPC.setProtocolEngine(
-          hadoopConfig,
-          StorageContainerDatanodeProtocolPB.class,
-          ProtobufRpcEngine.class);
-      long version =
-          RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
-
-      RetryPolicy retryPolicy =
-          RetryPolicies.retryUpToMaximumCountWithFixedSleep(
-              getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
-              TimeUnit.MILLISECONDS);
-
-      StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
-          StorageContainerDatanodeProtocolPB.class, version,
-          address, UserGroupInformation.getCurrentUser(), hadoopConfig,
-          NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
-          retryPolicy).getProxy();
-
-      StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
-          new StorageContainerDatanodeProtocolClientSideTranslatorPB(
-              rpcProxy);
-
-      EndpointStateMachine endPoint = new EndpointStateMachine(address,
-          rpcClient, this.conf, threadNamePrefix);
-      endPoint.setPassive(false);
+      EndpointStateMachine endPoint =
+          buildScmEndpoint(address, hostAndPort, threadNamePrefix);
       scmMachines.put(address, endPoint);
     } finally {
       writeUnlock();
     }
+  }
+
+  /**
+   * Build (but do NOT register) a fresh active-SCM endpoint bound to
+   * {@code address}. The caller is responsible for registering it in
+   * {@code scmMachines} (and tearing down any previous endpoint it
+   * replaces). Factored out of {@link #addSCMServer} so
+   * {@link #refreshSCMServer} can construct the replacement BEFORE
+   * removing the stale entry, preserving the peer in {@code scmMachines}
+   * if proxy construction throws (transient DNS failure, peer not yet
+   * accepting on the new IP, etc.).
+   */
+  @VisibleForTesting
+  EndpointStateMachine buildScmEndpoint(InetSocketAddress address,
+      String hostAndPort, String threadNamePrefix) throws IOException {
+    Configuration hadoopConfig =
+        LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
+    RPC.setProtocolEngine(
+        hadoopConfig,
+        StorageContainerDatanodeProtocolPB.class,
+        ProtobufRpcEngine.class);
+    long version =
+        RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
+
+    RetryPolicy retryPolicy =
+        RetryPolicies.retryUpToMaximumCountWithFixedSleep(
+            getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
+            TimeUnit.MILLISECONDS);
+
+    StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
+        StorageContainerDatanodeProtocolPB.class, version,
+        address, UserGroupInformation.getCurrentUser(), hadoopConfig,
+        NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
+        retryPolicy).getProxy();
+
+    StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
+        new StorageContainerDatanodeProtocolClientSideTranslatorPB(
+            rpcProxy);
+
+    EndpointStateMachine endPoint = new EndpointStateMachine(address,
+        hostAndPort, rpcClient, this.conf, threadNamePrefix);
+    endPoint.setPassive(false);
+    return endPoint;
+  }
+
+  /**
+   * Re-resolve the SCM hostname for the endpoint at {@code oldAddress} and,
+   * if the resolved IP has changed, atomically replace the endpoint with a
+   * fresh one bound to the new address.
+   * <p>
+   * Returns the new {@link InetSocketAddress} on a successful swap, or null
+   * if no swap occurred (endpoint not found, hostname not preserved at
+   * construction, IP unchanged, or DNS lookup failed). Callers receive
+   * enough information to update any external maps keyed by the old
+   * address.
+   * <p>
+   * The replacement is built via the existing {@link #addSCMServer} path,
+   * so the new endpoint starts in {@code GETVERSION} state and re-walks
+   * version → register → heartbeat. This is the correct behavior: a peer
+   * that has been rescheduled is effectively a fresh process.
+   */
+  public InetSocketAddress refreshSCMServer(InetSocketAddress oldAddress,
+      String threadNamePrefix) throws IOException {
+    // PHASE A (read lock): snapshot the endpoint reference and the
+    // preserved hostAndPort string. We cannot hold any lock across
+    // the DNS lookup that follows, so we capture only what we need
+    // and release the lock immediately.
+    final EndpointStateMachine snapshotEndpoint;
+    final String hostAndPort;
+    readLock();
+    try {
+      snapshotEndpoint = scmMachines.get(oldAddress);
+      if (snapshotEndpoint == null) {
+        return null;
+      }
+      // Recon endpoints (added via addReconServer) speak a different
+      // protocol than active SCM endpoints. The current refresh path
+      // only knows how to rebuild SCM endpoints, so refusing to
+      // refresh a passive endpoint avoids silently downgrading a
+      // Recon endpoint to an SCM-protocol one. Recon's cached IP is
+      // also a much narrower problem in practice (Recon is rarely
+      // pod-rescheduled the way SCM-HA peers are).
+      if (snapshotEndpoint.isPassive()) {
+        return null;
+      }
+      hostAndPort = snapshotEndpoint.getHostAndPort();
+      if (hostAndPort == null) {
+        return null;
+      }
+    } finally {
+      readUnlock();
+    }
+
+    // PHASE B (no lock): perform the DNS lookup. NetUtils.createSocketAddr
+    // can block on a slow / dead resolver. Holding any lock across this
+    // would stall every concurrent reader and writer of the connection
+    // manager -- including parallel heartbeat dispatch.
+    InetSocketAddress resolved = snapshotEndpoint.resolveLatestAddress();
+    if (resolved == null) {
+      return null;
+    }
+
+    // PHASE C (write lock): re-check that the snapshot is still current
+    // (another refresh / removeSCMServer may have raced ahead while we
+    // were resolving), enforce the collision invariant, build the
+    // replacement, and commit the swap atomically. Capture the stale
+    // endpoint reference for teardown OUTSIDE the lock.
+    final EndpointStateMachine staleEndpoint;
+    final InetSocketAddress refreshed;
+    writeLock();
+    try {
+      EndpointStateMachine current = scmMachines.get(oldAddress);
+      if (current != snapshotEndpoint) {
+        // Lost the race: someone else removed or replaced this entry
+        // while we were resolving DNS. Abandon the swap; whatever
+        // raced ahead is now responsible for the peer's state.
+        return null;
+      }
+      // Refuse the swap if the freshly-resolved address collides with
+      // another already-registered SCM peer key (e.g. transient kube-dns
+      // returning peer-B's IP for peer-A's hostname). Without this guard,
+      // the put below would silently overwrite peer-B's
+      // EndpointStateMachine, leaking its executor and orphaning its
+      // task thread, while peer-A's task ends up dialing peer-B's IP
+      // with peer-A's host context. Leave the stale endpoint in place;
+      // the next heartbeat retries DNS.
+      if (!resolved.equals(oldAddress)
+          && scmMachines.containsKey(resolved)) {
+        LOG.warn("DNS re-resolution: refused to swap endpoint {} -> {} "
+            + "because the new address collides with an already-registered "
+            + "SCM peer. Leaving stale endpoint in place.",
+            oldAddress, resolved);
+        return null;
+      }
+      // Build the replacement BEFORE removing the stale entry so a
+      // failure to construct the new proxy (transient DNS, peer not
+      // yet accepting on the new IP, NetUtils refusing the address)
+      // leaves the existing endpoint registered. Otherwise the peer
+      // would disappear from scmMachines entirely and the next
+      // heartbeat cycle would have nothing to dial -- much worse than
+      // the pre-PR behaviour of dialing the stale IP.
+      //
+      // buildScmEndpoint also invokes RPC.getProtocolProxy under the
+      // write lock; this is intentional. Proxy construction is
+      // synchronous-but-not-network-blocking (it builds an invocation
+      // handler; the actual socket connect is lazy on first call).
+      // The cost of running it under writeLock is bounded; the cost
+      // of dropping the lock here is a complex three-phase commit
+      // dance to defend against a second concurrent refresh racing
+      // ahead. The trade-off favours holding the lock for this step.
+      EndpointStateMachine replacement;
+      try {
+        replacement = buildScmEndpoint(resolved, hostAndPort,
+            threadNamePrefix);
+      } catch (IOException buildEx) {
+        LOG.warn("DNS re-resolution: failed to build replacement SCM "
+                + "endpoint for {} -> {} (host {}); leaving stale endpoint "
+                + "in place. Cause: {}", oldAddress, resolved, hostAndPort,
+            buildEx.getMessage());
+        throw buildEx;
+      }
+      scmMachines.put(resolved, replacement);
+      if (!resolved.equals(oldAddress)) {
+        scmMachines.remove(oldAddress);
+      }
+      staleEndpoint = snapshotEndpoint;
+      refreshed = resolved;
+    } finally {
+      writeUnlock();
+    }
+
+    // PHASE D (no lock): best-effort teardown of the stale endpoint.
+    // close() blocks on RPC.stopProxy / socket teardown -- holding
+    // writeLock during that would stall every concurrent reader
+    // (other endpoints' heartbeats calling getValues()) and writer.
+    // close() failures don't affect registration (already committed),
+    // so a RuntimeException here only impacts cleanup.
+    try {
+      staleEndpoint.close();
+    } catch (RuntimeException closeEx) {
+      LOG.warn("Failed to close stale endpoint {}: {}", oldAddress,
+          closeEx.getMessage());
+    }
+    LOG.info("DNS re-resolution: SCM endpoint {} -> {} (host {}).",
+        oldAddress, refreshed, hostAndPort);
+    return refreshed;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -1057,50 +1057,7 @@ public class StateContext {
     // are dropped (logged) -- the alternative of merging into a foreign
     // peer's queue is worse.
 
-    // Step 1 (PUBLISH): install new-key queues. On collision, do not
-    // touch newEndpoint's existing queues (foreign peer owns them).
-    synchronized (incrementalReportsQueue) {
-      if (!newAlreadyRegistered) {
-        List<Message> oldQueue = incrementalReportsQueue.get(oldEndpoint);
-        if (oldQueue != null) {
-          // Both keys reference the SAME LinkedList. Safe because
-          // producers serialize on `incrementalReportsQueue`'s monitor
-          // and the inner list is not mutated unsynchronized. After
-          // step 3 removes the old key, only the new key references
-          // the list.
-          incrementalReportsQueue.put(newEndpoint, oldQueue);
-        } else {
-          incrementalReportsQueue.putIfAbsent(newEndpoint, new LinkedList<>());
-        }
-      }
-    }
-    synchronized (containerActions) {
-      if (!newAlreadyRegistered) {
-        Queue<ContainerAction> oldActions = containerActions.get(oldEndpoint);
-        if (oldActions != null) {
-          containerActions.put(newEndpoint, oldActions);
-        } else {
-          containerActions.putIfAbsent(newEndpoint, new LinkedList<>());
-        }
-      }
-    }
-    if (!newAlreadyRegistered) {
-      PipelineActionMap oldPipelineActions = pipelineActions.get(oldEndpoint);
-      pipelineActions.computeIfAbsent(newEndpoint,
-          k -> oldPipelineActions != null
-              ? oldPipelineActions
-              : new PipelineActionMap());
-
-      // Always seed all-true flags for the new peer. A rescheduled SCM
-      // pod is a fresh process and needs a full container/node/pipeline
-      // report on the next heartbeat regardless of what the old peer
-      // had already received.
-      Map<String, AtomicBoolean> flags = new HashMap<>();
-      for (String e : fullReportTypeList) {
-        flags.put(e, new AtomicBoolean(true));
-      }
-      isFullReportReadyToBeSent.putIfAbsent(newEndpoint, flags);
-    }
+    publishMigratedQueues(oldEndpoint, newEndpoint, newAlreadyRegistered);
 
     // Step 2 (SWITCH): swap endpoint membership under the same monitors
     // producers hold when fanning out incremental reports and container
@@ -1136,8 +1093,81 @@ public class StateContext {
       }
     }
 
-    // Step 3 (RETIRE): drop the old-key queues. From this point no
-    // producer iterating `endpoints` reaches the old key.
+    retireMigratedQueues(oldEndpoint, newEndpoint, newAlreadyRegistered);
+
+    if (getQueueMetrics() != null) {
+      getQueueMetrics().removeEndpoint(oldEndpoint);
+      if (!newAlreadyRegistered) {
+        getQueueMetrics().addEndpoint(newEndpoint);
+      }
+    }
+  }
+
+  /**
+   * Step 1 of {@link #migrateEndpoint}: install new-key queues
+   * alongside the old-key queues so producers iterating `endpoints`
+   * find a valid queue for either key during the SWITCH window. On
+   * collision, do not touch newEndpoint's existing queues (foreign
+   * peer owns them).
+   * <p>
+   * Receiver-state ({@code isFullReportReadyToBeSent}) is RESET, not
+   * preserved: a rescheduled SCM pod is a fresh process and needs a
+   * full container/node/pipeline report on the next heartbeat
+   * regardless of what the old peer already received.
+   */
+  private void publishMigratedQueues(InetSocketAddress oldEndpoint,
+                                     InetSocketAddress newEndpoint,
+                                     boolean newAlreadyRegistered) {
+    synchronized (incrementalReportsQueue) {
+      if (!newAlreadyRegistered) {
+        List<Message> oldQueue = incrementalReportsQueue.get(oldEndpoint);
+        if (oldQueue != null) {
+          // Both keys reference the SAME LinkedList. Safe because
+          // producers serialize on `incrementalReportsQueue`'s monitor
+          // and the inner list is not mutated unsynchronized. After
+          // retireMigratedQueues removes the old key, only the new
+          // key references the list.
+          incrementalReportsQueue.put(newEndpoint, oldQueue);
+        } else {
+          incrementalReportsQueue.putIfAbsent(newEndpoint, new LinkedList<>());
+        }
+      }
+    }
+    synchronized (containerActions) {
+      if (!newAlreadyRegistered) {
+        Queue<ContainerAction> oldActions = containerActions.get(oldEndpoint);
+        if (oldActions != null) {
+          containerActions.put(newEndpoint, oldActions);
+        } else {
+          containerActions.putIfAbsent(newEndpoint, new LinkedList<>());
+        }
+      }
+    }
+    if (!newAlreadyRegistered) {
+      PipelineActionMap oldPipelineActions = pipelineActions.get(oldEndpoint);
+      pipelineActions.computeIfAbsent(newEndpoint,
+          k -> oldPipelineActions != null
+              ? oldPipelineActions
+              : new PipelineActionMap());
+
+      Map<String, AtomicBoolean> flags = new HashMap<>();
+      for (String e : fullReportTypeList) {
+        flags.put(e, new AtomicBoolean(true));
+      }
+      isFullReportReadyToBeSent.putIfAbsent(newEndpoint, flags);
+    }
+  }
+
+  /**
+   * Step 3 of {@link #migrateEndpoint}: drop the old-key queues. From
+   * this point no producer iterating `endpoints` reaches the old key
+   * (Step 2 SWITCH removed it). On collision, log the dropped queues
+   * for operator visibility -- merging into the foreign peer's queue
+   * would deliver one peer's reports to another, which is worse.
+   */
+  private void retireMigratedQueues(InetSocketAddress oldEndpoint,
+                                    InetSocketAddress newEndpoint,
+                                    boolean newAlreadyRegistered) {
     synchronized (incrementalReportsQueue) {
       List<Message> oldQueue =
           incrementalReportsQueue.remove(oldEndpoint);
@@ -1167,13 +1197,6 @@ public class StateContext {
           retiredPipelineActions.size(), oldEndpoint, newEndpoint);
     }
     isFullReportReadyToBeSent.remove(oldEndpoint);
-
-    if (getQueueMetrics() != null) {
-      getQueueMetrics().removeEndpoint(oldEndpoint);
-      if (!newAlreadyRegistered) {
-        getQueueMetrics().addEndpoint(newEndpoint);
-      }
-    }
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -32,7 +32,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -1092,28 +1091,50 @@ public class StateContext {
               ? oldPipelineActions
               : new PipelineActionMap());
 
-      Map<String, AtomicBoolean> oldFullReportFlags =
-          isFullReportReadyToBeSent.get(oldEndpoint);
-      Map<String, AtomicBoolean> flags = oldFullReportFlags;
-      if (flags == null) {
-        // Seed with all-true so the next heartbeat ships a fresh full
-        // report to the new peer.
-        flags = new HashMap<>();
-        for (String e : fullReportTypeList) {
-          flags.putIfAbsent(e, new AtomicBoolean(true));
-        }
+      // Always seed all-true flags for the new peer. A rescheduled SCM
+      // pod is a fresh process and needs a full container/node/pipeline
+      // report on the next heartbeat regardless of what the old peer
+      // had already received.
+      Map<String, AtomicBoolean> flags = new HashMap<>();
+      for (String e : fullReportTypeList) {
+        flags.put(e, new AtomicBoolean(true));
       }
       isFullReportReadyToBeSent.putIfAbsent(newEndpoint, flags);
     }
 
-    // Step 2 (SWITCH): atomically swap endpoint membership. Add new
-    // before removing old so producers always see at least one valid
-    // key with a populated queue. CopyOnWriteArraySet writes serve as
-    // release fences for the queue installations above.
-    if (!newAlreadyRegistered) {
-      endpoints.add(newEndpoint);
+    // Step 2 (SWITCH): swap endpoint membership under the same monitors
+    // producers hold when fanning out incremental reports and container
+    // actions, so no producer observes both keys while they alias the
+    // same underlying queue.
+    //
+    // Lock order: incrementalReportsQueue then containerActions.
+    // Steps 1 (PUBLISH) and 3 (RETIRE) take these monitors in the same
+    // order; producers (addIncrementalReport, addContainerAction) only
+    // ever take one of the two. No path takes them in reverse, so the
+    // nested acquisition here cannot deadlock. Future maintainers
+    // adding new producers MUST preserve this ordering.
+    //
+    // Why pipelineActions and isFullReportReadyToBeSent are NOT inside
+    // this critical section:
+    //   - pipelineActions: producer (addPipelineActionIfAbsent) calls
+    //     PipelineActionMap.putIfAbsent which is idempotent under
+    //     aliasing -- a producer that sees both keys during the SWITCH
+    //     window puts under one and the no-op-puts under the other,
+    //     because both keys reference the same PipelineActionMap.
+    //   - isFullReportReadyToBeSent: not iterated through `endpoints`.
+    //     Its readers (getFullReports) look up by a single endpoint
+    //     argument supplied by the heartbeat dispatcher, which is
+    //     keyed by scmMachines (the connection manager's map), not by
+    //     this StateContext's endpoints set. The SWITCH window never
+    //     produces a "both keys observed" read on this field.
+    synchronized (incrementalReportsQueue) {
+      synchronized (containerActions) {
+        if (!newAlreadyRegistered) {
+          endpoints.add(newEndpoint);
+        }
+        endpoints.remove(oldEndpoint);
+      }
     }
-    endpoints.remove(oldEndpoint);
 
     // Step 3 (RETIRE): drop the old-key queues. From this point no
     // producer iterating `endpoints` reaches the old key.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -44,6 +44,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -181,18 +182,44 @@ public class StateContext {
     this.parentDatanodeStateMachine = parent;
     commandQueue = new LinkedList<>();
     cmdStatusMap = new ConcurrentHashMap<>();
-    incrementalReportsQueue = new HashMap<>();
+    // ConcurrentHashMap because addEndpoint / removeEndpoint /
+    // migrateEndpoint mutate this map's KEYSET (put/remove) without
+    // holding the same monitor that producers (addIncrementalReport,
+    // putBackReports, getIncrementalReports) take. The producers'
+    // `synchronized(incrementalReportsQueue)` blocks still guard
+    // operations on the inner LinkedList values across threads --
+    // CHM only fixes the map-structure race. The metric readers
+    // (getIncrementalReportQueueSize) iterate the entrySet without
+    // any monitor; weakly-consistent CHM iteration is safe here.
+    incrementalReportsQueue = new ConcurrentHashMap<>();
     containerReports = new AtomicReference<>();
     nodeReport = new AtomicReference<>();
     pipelineReports = new AtomicReference<>();
-    endpoints = new HashSet<>();
-    containerActions = new HashMap<>();
+    // CopyOnWriteArraySet so producers in addContainerAction /
+    // addIncrementalReport / addPipelineActionIfAbsent can iterate
+    // endpoints lock-free and a concurrent migrateEndpoint() (fired
+    // from the heartbeat thread on DNS-refresh recovery) cannot raise
+    // ConcurrentModificationException. Endpoint membership changes
+    // are infrequent (startup add, reconfig, refresh swap) so the
+    // copy-on-write cost is negligible.
+    endpoints = new CopyOnWriteArraySet<>();
+    // ConcurrentHashMap for the same reason as incrementalReportsQueue
+    // above: addEndpoint / removeEndpoint / migrateEndpoint mutate the
+    // map structure without taking the producer's monitor. Inner Queue
+    // operations are still guarded by `synchronized(containerActions)`
+    // in the producers.
+    containerActions = new ConcurrentHashMap<>();
     pipelineActions = new ConcurrentHashMap<>();
     lock = new ReentrantLock();
     stateExecutionCount = new AtomicLong(0);
     threadPoolNotAvailableCount = new AtomicLong(0);
     lastHeartbeatSent = new AtomicLong(0);
-    isFullReportReadyToBeSent = new HashMap<>();
+    // ConcurrentHashMap because reads from getFullReports /
+    // refreshFullReport / migrateEndpoint can race against startup
+    // addEndpoint and against migrateEndpoint's putIfAbsent. Plain
+    // HashMap was unsafe even pre-PR; migrateEndpoint promoted that
+    // latent race into a regular occurrence under K8s pod churn.
+    isFullReportReadyToBeSent = new ConcurrentHashMap<>();
     fullReportTypeList = new ArrayList<>();
     type2Reports = new HashMap<>();
     this.threadNamePrefix = threadNamePrefix;
@@ -311,7 +338,13 @@ public class StateContext {
     // see XceiverServerRatis#sendPipelineReport
     synchronized (incrementalReportsQueue) {
       for (InetSocketAddress endpoint : endpoints) {
-        incrementalReportsQueue.get(endpoint).add(report);
+        // Same migration race shape as addPipelineActionIfAbsent: an
+        // endpoint observed in the COW set may have just had its
+        // queue removed by migrateEndpoint. Skip rather than NPE.
+        List<Message> queue = incrementalReportsQueue.get(endpoint);
+        if (queue != null) {
+          queue.add(report);
+        }
       }
     }
   }
@@ -483,7 +516,10 @@ public class StateContext {
   public void addContainerAction(ContainerAction containerAction) {
     synchronized (containerActions) {
       for (InetSocketAddress endpoint : endpoints) {
-        containerActions.get(endpoint).add(containerAction);
+        Queue<ContainerAction> q = containerActions.get(endpoint);
+        if (q != null) {
+          q.add(containerAction);
+        }
       }
     }
   }
@@ -496,8 +532,9 @@ public class StateContext {
   public void addContainerActionIfAbsent(ContainerAction containerAction) {
     synchronized (containerActions) {
       for (InetSocketAddress endpoint : endpoints) {
-        if (!containerActions.get(endpoint).contains(containerAction)) {
-          containerActions.get(endpoint).add(containerAction);
+        Queue<ContainerAction> q = containerActions.get(endpoint);
+        if (q != null && !q.contains(containerAction)) {
+          q.add(containerAction);
         }
       }
     }
@@ -539,7 +576,17 @@ public class StateContext {
     final PipelineKey key = new PipelineKey(pipelineAction);
     boolean added = false;
     for (InetSocketAddress endpoint : endpoints) {
-      added = pipelineActions.get(endpoint).putIfAbsent(key, pipelineAction) || added;
+      // Endpoints are migrated under the DNS-refresh path
+      // (migrateEndpoint) which removes the old pipelineActions entry
+      // before it removes the endpoint from this set. With
+      // CopyOnWriteArraySet iteration semantics we may still observe
+      // an endpoint whose pipelineActions entry was just removed --
+      // skip rather than NPE.
+      PipelineActionMap actions = pipelineActions.get(endpoint);
+      if (actions == null) {
+        continue;
+      }
+      added = actions.putIfAbsent(key, pipelineAction) || added;
     }
     return added;
   }
@@ -919,6 +966,192 @@ public class StateContext {
     this.isFullReportReadyToBeSent.remove(endpoint);
     if (getQueueMetrics() != null) {
       getQueueMetrics().removeEndpoint(endpoint);
+    }
+  }
+
+  /**
+   * Re-key all per-endpoint state from {@code oldEndpoint} to
+   * {@code newEndpoint}, preserving any reports / actions already
+   * queued for the old key. Used by the DNS-refresh-on-failure path
+   * ({@code HeartbeatEndpointTask#maybeRefreshScmAddress}) so that an
+   * SCM peer pod-IP change does not silently drop in-flight
+   * incremental container reports, container actions, or pipeline
+   * actions queued under the stale {@link InetSocketAddress}.
+   * <p>
+   * Concurrency / lock-order rules:
+   * <ul>
+   *   <li>{@link #endpoints} is a {@link CopyOnWriteArraySet} so
+   *       producers iterating it (in {@link #addContainerAction},
+   *       {@link #addIncrementalReport}, {@link #addPipelineActionIfAbsent})
+   *       cannot CME against the {@code remove}+{@code add} pair below. </li>
+   *   <li>{@link #incrementalReportsQueue} mutations take the same
+   *       {@code synchronized(incrementalReportsQueue)} monitor that
+   *       producers use. </li>
+   *   <li>{@link #containerActions} mutations take the same
+   *       {@code synchronized(containerActions)} monitor that
+   *       producers use. </li>
+   *   <li>{@link #pipelineActions} is {@link ConcurrentHashMap}; we
+   *       guard the read-modify-write sequence with the per-key atomic
+   *       {@code compute} call. </li>
+   *   <li>{@link #isFullReportReadyToBeSent} is now a
+   *       {@link ConcurrentHashMap} so its mutations are individually
+   *       atomic and concurrent {@link #refreshFullReport} iterations
+   *       are weakly-consistent rather than fail-fast. </li>
+   * </ul>
+   * Migration order: producers' queues first (so a producer racing in
+   * during the migration finds the new endpoint key already populated),
+   * then the {@code endpoints} set last (so any thread that observes
+   * the new endpoint in {@code endpoints} also observes its queues
+   * present). Each step is idempotent at the per-key level.
+   * <p>
+   * Collision case (the freshly-resolved IP collides with another
+   * already-registered endpoint key): this method leaves the existing
+   * collided entry untouched and only drops the old key's state. Two
+   * distinct SCM peers' queues are NEVER merged; doing so would deliver
+   * one peer's incremental reports / pipeline actions to a different
+   * peer that did not request them.
+   * <p>
+   * If {@code oldEndpoint} was not registered, this is a no-op. The
+   * new endpoint is NOT added in that case.
+   *
+   * @param oldEndpoint the InetSocketAddress under which queues are
+   *                    currently keyed
+   * @param newEndpoint the freshly-resolved InetSocketAddress that the
+   *                    new EndpointStateMachine is bound to
+   */
+  public void migrateEndpoint(InetSocketAddress oldEndpoint,
+                              InetSocketAddress newEndpoint) {
+    if (oldEndpoint == null || newEndpoint == null
+        || oldEndpoint.equals(newEndpoint)) {
+      return;
+    }
+    if (!endpoints.contains(oldEndpoint)) {
+      return;
+    }
+    final boolean newAlreadyRegistered = endpoints.contains(newEndpoint);
+
+    // Invariant we must preserve at every observable point:
+    //   "for every e in endpoints, queues[e] exists for all four
+    //    per-endpoint maps."
+    // Producers iterate `endpoints` lock-free (CopyOnWriteArraySet) and
+    // then look up the per-key queue. If we removed a queue before
+    // removing the endpoint from the set, a producer iterating between
+    // the two operations would see the endpoint, fail to find a queue,
+    // and silently drop its report. The producer-side null-skip we
+    // added previously was a band-aid for exactly this race.
+    //
+    // To preserve the invariant, the ordering is:
+    //   1. PUBLISH: install new-key queues alongside the old-key queues.
+    //      During this step both keys are valid.
+    //   2. SWITCH: add newEndpoint to the endpoints set; remove
+    //      oldEndpoint from the endpoints set. After this step,
+    //      producers iterating `endpoints` see only the new key (which
+    //      has its queue from step 1).
+    //   3. RETIRE: drop the old-key queues. By this point no producer
+    //      iterating `endpoints` can reach the old key.
+    //
+    // Collision case (newEndpoint already a registered peer): we MUST
+    // NOT install our incoming queues over the colliding peer's queues
+    // (would deliver one peer's reports to another). On collision we
+    // skip the publish step's "install" and the switch step's "add",
+    // and only retire the old-key queues. Any old-key in-flight reports
+    // are dropped (logged) -- the alternative of merging into a foreign
+    // peer's queue is worse.
+
+    // Step 1 (PUBLISH): install new-key queues. On collision, do not
+    // touch newEndpoint's existing queues (foreign peer owns them).
+    synchronized (incrementalReportsQueue) {
+      if (!newAlreadyRegistered) {
+        List<Message> oldQueue = incrementalReportsQueue.get(oldEndpoint);
+        if (oldQueue != null) {
+          // Both keys reference the SAME LinkedList. Safe because
+          // producers serialize on `incrementalReportsQueue`'s monitor
+          // and the inner list is not mutated unsynchronized. After
+          // step 3 removes the old key, only the new key references
+          // the list.
+          incrementalReportsQueue.put(newEndpoint, oldQueue);
+        } else {
+          incrementalReportsQueue.putIfAbsent(newEndpoint, new LinkedList<>());
+        }
+      }
+    }
+    synchronized (containerActions) {
+      if (!newAlreadyRegistered) {
+        Queue<ContainerAction> oldActions = containerActions.get(oldEndpoint);
+        if (oldActions != null) {
+          containerActions.put(newEndpoint, oldActions);
+        } else {
+          containerActions.putIfAbsent(newEndpoint, new LinkedList<>());
+        }
+      }
+    }
+    if (!newAlreadyRegistered) {
+      PipelineActionMap oldPipelineActions = pipelineActions.get(oldEndpoint);
+      pipelineActions.computeIfAbsent(newEndpoint,
+          k -> oldPipelineActions != null
+              ? oldPipelineActions
+              : new PipelineActionMap());
+
+      Map<String, AtomicBoolean> oldFullReportFlags =
+          isFullReportReadyToBeSent.get(oldEndpoint);
+      Map<String, AtomicBoolean> flags = oldFullReportFlags;
+      if (flags == null) {
+        // Seed with all-true so the next heartbeat ships a fresh full
+        // report to the new peer.
+        flags = new HashMap<>();
+        for (String e : fullReportTypeList) {
+          flags.putIfAbsent(e, new AtomicBoolean(true));
+        }
+      }
+      isFullReportReadyToBeSent.putIfAbsent(newEndpoint, flags);
+    }
+
+    // Step 2 (SWITCH): atomically swap endpoint membership. Add new
+    // before removing old so producers always see at least one valid
+    // key with a populated queue. CopyOnWriteArraySet writes serve as
+    // release fences for the queue installations above.
+    if (!newAlreadyRegistered) {
+      endpoints.add(newEndpoint);
+    }
+    endpoints.remove(oldEndpoint);
+
+    // Step 3 (RETIRE): drop the old-key queues. From this point no
+    // producer iterating `endpoints` reaches the old key.
+    synchronized (incrementalReportsQueue) {
+      List<Message> oldQueue =
+          incrementalReportsQueue.remove(oldEndpoint);
+      if (newAlreadyRegistered && oldQueue != null && !oldQueue.isEmpty()) {
+        LOG.warn("DNS refresh produced an endpoint collision: dropping "
+                + "{} incremental reports queued under {} because {} is "
+                + "already a registered endpoint with its own queue.",
+            oldQueue.size(), oldEndpoint, newEndpoint);
+      }
+    }
+    synchronized (containerActions) {
+      Queue<ContainerAction> oldActions = containerActions.remove(oldEndpoint);
+      if (newAlreadyRegistered && oldActions != null && !oldActions.isEmpty()) {
+        LOG.warn("DNS refresh produced an endpoint collision: dropping "
+                + "{} container actions queued under {} because {} is "
+                + "already a registered endpoint with its own queue.",
+            oldActions.size(), oldEndpoint, newEndpoint);
+      }
+    }
+    PipelineActionMap retiredPipelineActions =
+        pipelineActions.remove(oldEndpoint);
+    if (newAlreadyRegistered && retiredPipelineActions != null
+        && retiredPipelineActions.size() > 0) {
+      LOG.warn("DNS refresh produced an endpoint collision: dropping "
+              + "{} pipeline actions queued under {} because {} is "
+              + "already a registered endpoint with its own map.",
+          retiredPipelineActions.size(), oldEndpoint, newEndpoint);
+    }
+    isFullReportReadyToBeSent.remove(oldEndpoint);
+
+    if (getQueueMetrics() != null) {
+      getQueueMetrics().removeEndpoint(oldEndpoint);
+      if (!newAlreadyRegistered) {
+        getQueueMetrics().addEndpoint(newEndpoint);
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
@@ -101,7 +101,13 @@ public class InitDatanodeState implements DatanodeState,
         }
       }
       for (InetSocketAddress addr : addresses) {
-        connectionManager.addSCMServer(addr, context.getThreadNamePrefix());
+        // Preserve the original hostname so the DN can re-resolve DNS
+        // on heartbeat failure (Kubernetes pod-IP-change recovery).
+        // getHostString() does not trigger reverse-DNS, returning the
+        // hostname the address was constructed with.
+        String hostAndPort = addr.getHostString() + ":" + addr.getPort();
+        connectionManager.addSCMServer(addr, hostAndPort,
+            context.getThreadNamePrefix());
         this.context.addEndpoint(addr);
       }
       InetSocketAddress reconAddress = getReconAddressForDatanodes(conf);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -21,17 +21,23 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LI
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
@@ -77,6 +83,8 @@ public class HeartbeatEndpointTask
   private int maxContainerActionsPerHB;
   private int maxPipelineActionsPerHB;
   private HDDSLayoutVersionManager layoutVersionManager;
+  private final boolean resolveOnFailureEnabled;
+  private final int refreshThreshold;
 
   /**
    * Constructs a SCM heart beat.
@@ -100,6 +108,12 @@ public class HeartbeatEndpointTask
     } else {
       this.layoutVersionManager = context.getParent().getLayoutVersionManager();
     }
+    this.resolveOnFailureEnabled = conf.getBoolean(
+        OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
+        OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
+    this.refreshThreshold = Math.max(1, conf.getInt(
+        OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY,
+        OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT));
   }
 
   /**
@@ -157,10 +171,75 @@ public class HeartbeatEndpointTask
       // put back the reports which failed to be sent
       putBackIncrementalReports(requestBuilder);
       rpcEndpoint.logIfNeeded(ex);
+      maybeRefreshScmAddress(ex);
     } finally {
       rpcEndpoint.unlock();
     }
     return rpcEndpoint.getState();
+  }
+
+  /**
+   * After a heartbeat IOException, if (a) DNS-refresh-on-failure is
+   * enabled, (b) the exception's cause chain contains a connection-class
+   * type (per {@link ConnectionFailureUtils#isConnectionFailure}), and
+   * (c) the missed-heartbeat counter has reached the configured
+   * threshold, ask {@link org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager}
+   * to re-resolve this peer's hostname. If the resolved IP differs from
+   * the cached one, the connection manager swaps the endpoint atomically
+   * for a fresh one bound to the new address. The replacement starts in
+   * GETVERSION state, which is the correct behavior when the peer pod
+   * has been recreated -- the new SCM is effectively a fresh process and
+   * needs the version handshake plus DN re-registration.
+   * <p>
+   * Symmetric with the OM/SCM client-side failover providers, which
+   * also gate refresh on connection-class exceptions: an
+   * {@code AccessControlException} or {@code OMException} arriving
+   * via the heartbeat path indicates the cached IP is reachable but
+   * the peer is rejecting us at the application layer -- DNS won't help.
+   * <p>
+   * Off by default. Enable via
+   * {@code ozone.client.failover.resolve-needed=true}.
+   */
+  private void maybeRefreshScmAddress(IOException heartbeatFailure) {
+    if (!resolveOnFailureEnabled) {
+      return;
+    }
+    if (!ConnectionFailureUtils.isConnectionFailure(heartbeatFailure)) {
+      return;
+    }
+    if (rpcEndpoint.getMissedCount() < refreshThreshold) {
+      return;
+    }
+    if (rpcEndpoint.getHostAndPort() == null) {
+      // Caller did not preserve the original config string for this
+      // endpoint. Re-resolution is unsupported here; rely on operator
+      // restart for IP recovery.
+      return;
+    }
+    InetSocketAddress oldAddress = rpcEndpoint.getAddress();
+    try {
+      InetSocketAddress refreshed = context.getParent().getConnectionManager()
+          .refreshSCMServer(oldAddress, context.getThreadNamePrefix());
+      if (refreshed != null) {
+        // The connection manager swapped scmMachines from oldAddress to
+        // refreshed. Migrate the per-endpoint StateContext queues to
+        // match -- otherwise incremental container reports, container
+        // actions, and pipeline actions queued under oldAddress are
+        // silently dropped (the producers continue writing to the old
+        // key while the new endpoint reads from the new key and sees
+        // an empty queue). Failing to migrate here is the difference
+        // between "DN heartbeats fine but stops reporting changes" and
+        // "DN heartbeats fine and keeps SCM in sync".
+        context.migrateEndpoint(oldAddress, refreshed);
+        // Old endpoint is about to be GC'd; reset its counter so any
+        // concurrent observer sees a clean slate before it's released.
+        rpcEndpoint.zeroMissedCount();
+      }
+    } catch (IOException refreshEx) {
+      LOG.warn("Failed to refresh SCM address {} after {} missed "
+              + "heartbeats: {}", oldAddress,
+          rpcEndpoint.getMissedCount(), refreshEx.getMessage());
+    }
   }
 
   // TODO: Make it generic.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -37,7 +37,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdfs.util.EnumCounters;
 import org.apache.hadoop.ozone.container.common.helpers.DeletedContainerBlocksSummary;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.net.NetUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -67,19 +68,19 @@ public class TestSCMConnectionManager {
   /**
    * When the cached IP matches what DNS currently returns for the
    * preserved hostname, resolveLatestAddress() returns null (no swap
-   * needed). Uses "localhost" because it reliably resolves to a loopback
-   * address in any test environment.
+   * needed). Build the cached address via NetUtils so the IP family
+   * matches what resolveLatestAddress() re-resolves (avoids IPv4/IPv6
+   * localhost mismatch on dual-stack hosts).
    */
   @Test
   public void testResolveLatestAddressReturnsNullWhenIpUnchanged()
       throws Exception {
-    InetAddress loopback = InetAddress.getByName("localhost");
-    InetSocketAddress address = new InetSocketAddress(loopback, 9861);
+    InetSocketAddress address = NetUtils.createSocketAddr("127.0.0.1:9861");
     EndpointStateMachine endpoint = new EndpointStateMachine(
-        address, "localhost:9861", null, new OzoneConfiguration(), "");
+        address, "127.0.0.1:9861", null, new OzoneConfiguration(), "");
     InetSocketAddress refreshed = endpoint.resolveLatestAddress();
     Assertions.assertNull(refreshed,
-        "localhost re-resolves to the same loopback address; refresh "
+        "127.0.0.1 re-resolves to the same address; refresh "
             + "must report no change so the endpoint is not torn down "
             + "needlessly.");
   }
@@ -206,9 +207,8 @@ public class TestSCMConnectionManager {
   public void testRefreshSCMServerNoopWhenIpUnchanged() throws Exception {
     try (SCMConnectionManager connectionManager =
              new SCMConnectionManager(new OzoneConfiguration())) {
-      InetAddress loopback = InetAddress.getByName("localhost");
-      InetSocketAddress address = new InetSocketAddress(loopback, 9861);
-      connectionManager.addSCMServer(address, "localhost:9861", "");
+      InetSocketAddress address = NetUtils.createSocketAddr("127.0.0.1:9861");
+      connectionManager.addSCMServer(address, "127.0.0.1:9861", "");
       EndpointStateMachine before =
           connectionManager.getValues().iterator().next();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.container.common.statemachine;
 
 import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.HEARTBEAT;
 
+import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.Assertions;
@@ -44,6 +46,180 @@ public class TestSCMConnectionManager {
 
       Assertions.assertTrue(connectionManager.getValues().isEmpty());
       Assertions.assertEquals(HEARTBEAT, endpoint.getState());
+    }
+  }
+
+  /**
+   * resolveLatestAddress() returns null when no preserved hostname is
+   * available -- legacy code path -- so re-resolution is a no-op for that
+   * endpoint. Operator must restart the DN to pick up a new IP.
+   */
+  @Test
+  public void testResolveLatestAddressReturnsNullWithoutHostAndPort() {
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", 9861);
+    EndpointStateMachine endpoint = new EndpointStateMachine(
+        address, /*hostAndPort=*/ null, /*endPoint=*/ null,
+        new OzoneConfiguration(), "");
+    Assertions.assertNull(endpoint.resolveLatestAddress());
+    Assertions.assertNull(endpoint.getHostAndPort());
+  }
+
+  /**
+   * When the cached IP matches what DNS currently returns for the
+   * preserved hostname, resolveLatestAddress() returns null (no swap
+   * needed). Uses "localhost" because it reliably resolves to a loopback
+   * address in any test environment.
+   */
+  @Test
+  public void testResolveLatestAddressReturnsNullWhenIpUnchanged()
+      throws Exception {
+    InetAddress loopback = InetAddress.getByName("localhost");
+    InetSocketAddress address = new InetSocketAddress(loopback, 9861);
+    EndpointStateMachine endpoint = new EndpointStateMachine(
+        address, "localhost:9861", null, new OzoneConfiguration(), "");
+    InetSocketAddress refreshed = endpoint.resolveLatestAddress();
+    Assertions.assertNull(refreshed,
+        "localhost re-resolves to the same loopback address; refresh "
+            + "must report no change so the endpoint is not torn down "
+            + "needlessly.");
+  }
+
+  /**
+   * When the cached IP differs from what DNS currently returns for the
+   * preserved hostname, resolveLatestAddress() returns the freshly-
+   * resolved address. Simulates the "SCM pod was rescheduled to a new
+   * IP" scenario by constructing the endpoint with a deliberately stale
+   * cached IP.
+   */
+  @Test
+  public void testResolveLatestAddressReturnsNewAddressOnIpChange()
+      throws Exception {
+    // Pretend localhost previously resolved to 127.0.0.99 (stale IP).
+    // In real Kubernetes this would be the now-defunct pod IP.
+    InetSocketAddress staleAddress = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9861);
+    EndpointStateMachine endpoint = new EndpointStateMachine(
+        staleAddress, "localhost:9861", null,
+        new OzoneConfiguration(), "");
+    InetSocketAddress refreshed = endpoint.resolveLatestAddress();
+    Assertions.assertNotNull(refreshed,
+        "localhost re-resolves to loopback (typically 127.0.0.1), "
+            + "which differs from the stale 127.0.0.99 we cached; "
+            + "refresh must report the change so the endpoint can "
+            + "swap to the live address.");
+    Assertions.assertEquals(9861, refreshed.getPort());
+    Assertions.assertNotEquals(staleAddress.getAddress(),
+        refreshed.getAddress());
+  }
+
+  /**
+   * refreshSCMServer() swaps an endpoint's address atomically in the
+   * connection manager when the cached IP is stale. The replacement
+   * endpoint starts in GETVERSION state -- the version handshake must
+   * be re-run because the new SCM pod is effectively a fresh process.
+   */
+  @Test
+  public void testRefreshSCMServerSwapsEndpointOnIpChange() throws Exception {
+    try (SCMConnectionManager connectionManager =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      InetSocketAddress staleAddress = new InetSocketAddress(
+          InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9861);
+      connectionManager.addSCMServer(staleAddress, "localhost:9861", "");
+
+      InetSocketAddress refreshed = connectionManager.refreshSCMServer(
+          staleAddress, "");
+
+      Assertions.assertNotNull(refreshed);
+      Assertions.assertEquals(1, connectionManager.getNumOfConnections());
+      EndpointStateMachine swapped =
+          connectionManager.getValues().iterator().next();
+      Assertions.assertEquals(refreshed, swapped.getAddress());
+      Assertions.assertEquals("localhost:9861", swapped.getHostAndPort());
+    }
+  }
+
+  /**
+   * Regression for the rollback gap Copilot flagged on
+   * {@code refreshSCMServer}: if building the replacement endpoint
+   * throws (transient DNS blip during proxy construction, peer not
+   * yet accepting on the new IP, NetUtils refusing the resolved
+   * address), the connection manager must NOT have already removed
+   * the stale endpoint -- otherwise the peer disappears from
+   * {@code scmMachines} and no future heartbeat has anywhere to dial.
+   * <p>
+   * The fix builds the replacement BEFORE removing the stale entry.
+   * This test injects a build that throws and asserts the stale
+   * endpoint is still registered after the call returns its
+   * IOException.
+   */
+  @Test
+  public void testRefreshSCMServerLeavesStaleEndpointOnBuildFailure()
+      throws Exception {
+    final IOException simulated =
+        new IOException("simulated transient build failure");
+    try (SCMConnectionManager connectionManager =
+        new SCMConnectionManager(new OzoneConfiguration()) {
+          private boolean firstBuildDone;
+
+          @Override
+          EndpointStateMachine buildScmEndpoint(InetSocketAddress address,
+              String hostAndPort, String threadNamePrefix)
+              throws IOException {
+            if (!firstBuildDone) {
+              firstBuildDone = true;
+              return super.buildScmEndpoint(address, hostAndPort,
+                  threadNamePrefix);
+            }
+            throw simulated;
+          }
+        }) {
+      InetSocketAddress staleAddress = new InetSocketAddress(
+          InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9861);
+      connectionManager.addSCMServer(staleAddress, "localhost:9861", "");
+      EndpointStateMachine before =
+          connectionManager.getValues().iterator().next();
+
+      IOException thrown = Assertions.assertThrows(IOException.class,
+          () -> connectionManager.refreshSCMServer(staleAddress, ""));
+      Assertions.assertSame(simulated, thrown,
+          "the underlying build failure must be propagated, not "
+              + "swallowed by an enclosing recovery branch");
+
+      Assertions.assertEquals(1, connectionManager.getNumOfConnections(),
+          "stale endpoint must remain registered when buildScmEndpoint "
+              + "throws -- otherwise the peer disappears from the "
+              + "connection manager and no heartbeat can recover it");
+      Assertions.assertSame(before,
+          connectionManager.getValues().iterator().next(),
+          "the SAME EndpointStateMachine instance must still be "
+              + "registered (not a half-constructed replacement)");
+    }
+  }
+
+  /**
+   * refreshSCMServer() against an endpoint whose cached IP already matches
+   * DNS is a no-op -- the existing endpoint stays in place untouched. This
+   * prevents needless tearing-down of healthy connections when the
+   * heartbeat task asks to refresh after a transient blip.
+   */
+  @Test
+  public void testRefreshSCMServerNoopWhenIpUnchanged() throws Exception {
+    try (SCMConnectionManager connectionManager =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      InetAddress loopback = InetAddress.getByName("localhost");
+      InetSocketAddress address = new InetSocketAddress(loopback, 9861);
+      connectionManager.addSCMServer(address, "localhost:9861", "");
+      EndpointStateMachine before =
+          connectionManager.getValues().iterator().next();
+
+      InetSocketAddress refreshed =
+          connectionManager.refreshSCMServer(address, "");
+
+      Assertions.assertNull(refreshed);
+      Assertions.assertEquals(1, connectionManager.getNumOfConnections());
+      Assertions.assertSame(before,
+          connectionManager.getValues().iterator().next(),
+          "Endpoint instance must not be torn down when IP is unchanged.");
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -34,7 +34,6 @@ import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.UUID;
-import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
@@ -44,6 +43,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachin
 import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
+import org.apache.hadoop.security.AccessControlException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -261,6 +261,13 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
 
   // ------- fixture helpers -------
 
+  /**
+   * Internal test-only fixture holding all mocks and the task under
+   * test. Package-private fields are intentional — accessor methods
+   * for a small test-internal record-like class would be more noise
+   * than signal.
+   */
+  @SuppressWarnings("checkstyle:VisibilityModifier")
   private static class Fixture {
     final HeartbeatEndpointTask task;
     final EndpointStateMachine endpoint;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.states.endpoint;
+
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+import org.apache.hadoop.security.AccessControlException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.DatanodeStates;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the production trigger chain for DN → SCM DNS refresh:
+ * heartbeat fails with a connection-class IOException → catch block in
+ * {@code HeartbeatEndpointTask.call()} runs → {@code maybeRefreshScmAddress}
+ * checks the flag and the missed-count threshold → fires
+ * {@code SCMConnectionManager.refreshSCMServer}. The previous
+ * {@code TestSCMConnectionManagerDnsRefreshE2E} drove the swap mechanism
+ * directly; this test proves the integration.
+ */
+public class TestHeartbeatEndpointTaskDnsRefresh {
+
+  private static final InetSocketAddress STALE_ADDR = makeAddr(127, 0, 0, 99);
+  private static final InetSocketAddress REFRESHED_ADDR = makeAddr(127, 0, 0, 1);
+
+  /**
+   * Build an InetSocketAddress whose underlying address is RESOLVED to
+   * a specific IPv4 literal (so the test asserts on a real, non-equal
+   * post-refresh address). Going through {@code InetAddress.getByAddress}
+   * skips DNS entirely; the resulting socket address is stable in CI.
+   */
+  private static InetSocketAddress makeAddr(int a, int b, int c, int d) {
+    try {
+      return new InetSocketAddress(
+          InetAddress.getByAddress(new byte[]{(byte) a, (byte) b,
+              (byte) c, (byte) d}), 9861);
+    } catch (java.net.UnknownHostException impossible) {
+      throw new AssertionError(impossible);
+    }
+  }
+
+  /**
+   * With the flag enabled and the missed-heartbeat counter at the
+   * configured threshold, a connection-class IOException from
+   * sendHeartbeat must drive refreshSCMServer exactly once with the
+   * cached address as the argument.
+   */
+  @Test
+  public void testRefreshFiresWhenFlagEnabledAndThresholdMet()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 3);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(3L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    // Cached address is what the catch block should ask the manager to
+    // re-resolve. A regression that passed the wrong key would leave
+    // refreshSCMServer with a non-existent address and silently
+    // produce no swap.
+    verify(f.connectionManager, atLeastOnce())
+        .refreshSCMServer(eq(STALE_ADDR), any());
+  }
+
+  /**
+   * With the flag disabled (the default), refreshSCMServer must NOT be
+   * called even on a connection-class failure. Guards against the
+   * "default-off" safety claim being silently broken.
+   */
+  @Test
+  public void testRefreshSuppressedWhenFlagDisabled() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * Threshold semantics: missed count BELOW the configured threshold
+   * must NOT fire a refresh, even with the flag enabled and a
+   * connection-class failure. Guards against thrashing on the first
+   * transient blip.
+   */
+  @Test
+  public void testRefreshSuppressedBelowThreshold() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 5);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(2L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * If the endpoint never preserved its host:port string (legacy
+   * 4-arg ctor path), refresh must be a no-op. Operators in that case
+   * are expected to restart the DN to pick up new IPs.
+   */
+  @Test
+  public void testRefreshSuppressedWhenHostAndPortNotPreserved()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn(null); // legacy ctor path
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * After a successful refresh, the per-endpoint StateContext queues
+   * must be migrated from the old address key to the new one. The
+   * old key must be GONE and the new key must be PRESENT.
+   * <p>
+   * Critically, this test uses two RESOLVED but distinct InetSocketAddress
+   * instances (127.0.0.99 and 127.0.0.1) so {@code STALE_ADDR.equals(REFRESHED_ADDR)}
+   * is false. A prior version of this test used two unresolved-by-name
+   * addresses that compared equal, making {@code migrateEndpoint}
+   * short-circuit and the assertion pass vacuously regardless of
+   * whether migration ran.
+   */
+  @Test
+  public void testStateContextEndpointsMigrateAfterSuccessfulSwap()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    f.context.addEndpoint(STALE_ADDR);
+    // Pre-populate the old key with a queue marker so we can prove the
+    // migrated map is the SAME map we put data into (load-bearing
+    // assertion: queued reports survive the rekey).
+    f.context.getIncrementalReportQueueSize().put(STALE_ADDR, 0);
+
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.connectionManager.refreshSCMServer(eq(STALE_ADDR), any()))
+        .thenReturn(REFRESHED_ADDR);
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    // After migration, the OLD key must be gone from the
+    // incrementalReportsQueue/containerActions/pipelineActions/endpoints
+    // and the NEW key must be present.
+    assertEquals(true,
+        f.context.getIncrementalReportQueueSize().containsKey(REFRESHED_ADDR),
+        "post-refresh, the new endpoint key must exist in the "
+            + "incremental-reports map");
+    assertEquals(false,
+        f.context.getIncrementalReportQueueSize().containsKey(STALE_ADDR),
+        "post-refresh, the old endpoint key must NOT exist in the "
+            + "incremental-reports map (otherwise producers writing to "
+            + "the stale key still pile up reports a dead endpoint will "
+            + "never deliver)");
+    assertEquals(true,
+        f.context.getContainerActionQueueSize().containsKey(REFRESHED_ADDR),
+        "post-refresh, the new endpoint key must exist in the "
+            + "container-actions map");
+    assertEquals(false,
+        f.context.getContainerActionQueueSize().containsKey(STALE_ADDR),
+        "post-refresh, the old endpoint key must NOT exist in the "
+            + "container-actions map");
+  }
+
+  /**
+   * R2 negative-filter test: with the flag enabled and the threshold
+   * met, a heartbeat failure that is NOT a connection-class exception
+   * (e.g. AccessControlException -- the peer is reachable on the
+   * cached IP and rejects us at the application layer) must NOT
+   * trigger a refresh. Re-resolving DNS would not help, and a
+   * misbehaving peer that returns AccessControlException on every
+   * heartbeat would otherwise drive a DNS-lookup storm.
+   */
+  @Test
+  public void testRefreshSuppressedOnApplicationLevelException()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("rejected",
+            new AccessControlException("client lacks SCM_TOKEN")));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  // ------- fixture helpers -------
+
+  private static class Fixture {
+    final HeartbeatEndpointTask task;
+    final EndpointStateMachine endpoint;
+    final SCMConnectionManager connectionManager;
+    final DatanodeStateMachine datanodeStateMachine;
+    final StateContext context;
+    final StorageContainerDatanodeProtocolClientSideTranslatorPB scm;
+
+    Fixture(HeartbeatEndpointTask task, EndpointStateMachine endpoint,
+            SCMConnectionManager mgr, DatanodeStateMachine dsm,
+            StateContext ctx,
+            StorageContainerDatanodeProtocolClientSideTranslatorPB scm) {
+      this.task = task;
+      this.endpoint = endpoint;
+      this.connectionManager = mgr;
+      this.datanodeStateMachine = dsm;
+      this.context = ctx;
+      this.scm = scm;
+    }
+  }
+
+  private Fixture newFixture(OzoneConfiguration conf) throws Exception {
+    StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
+        mock(StorageContainerDatanodeProtocolClientSideTranslatorPB.class);
+
+    EndpointStateMachine endpoint = mock(EndpointStateMachine.class);
+    when(endpoint.getEndPoint()).thenReturn(scm);
+    when(endpoint.getAddress()).thenReturn(STALE_ADDR);
+
+    SCMConnectionManager connectionManager = mock(SCMConnectionManager.class);
+    DatanodeStateMachine datanodeStateMachine = mock(DatanodeStateMachine.class);
+    when(datanodeStateMachine.getConnectionManager())
+        .thenReturn(connectionManager);
+    when(datanodeStateMachine.getQueuedCommandCount())
+        .thenReturn(new org.apache.hadoop.hdfs.util.EnumCounters<>(
+            org.apache.hadoop.hdds.protocol.proto
+                .StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.class));
+
+    StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
+        datanodeStateMachine, "");
+
+    HDDSLayoutVersionManager lvm = mock(HDDSLayoutVersionManager.class);
+    when(lvm.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(lvm.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+
+    DatanodeDetails dd = DatanodeDetails.newBuilder()
+        .setUuid(UUID.randomUUID())
+        .setHostName("localhost")
+        .setIpAddress("127.0.0.1")
+        .build();
+
+    HeartbeatEndpointTask task = HeartbeatEndpointTask.newBuilder()
+        .setConfig(conf)
+        .setDatanodeDetails(dd)
+        .setContext(context)
+        .setLayoutVersionManager(lvm)
+        .setEndpointStateMachine(endpoint)
+        .build();
+
+    return new Fixture(task, endpoint, connectionManager,
+        datanodeStateMachine, context, scm);
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMFailoverProxyProviderBase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMFailoverProxyProviderBase.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -43,6 +44,7 @@ import org.apache.hadoop.io_.retry.RetryPolicies;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 
@@ -86,6 +88,14 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
   private String updatedLeaderNodeID = null;
 
   /**
+   * When true, on each connection-class failure the provider re-resolves
+   * the cached SCM hostname and rebuilds the proxy if the IP has changed
+   * (Kubernetes pod-IP-change recovery). Off by default. Mirrors the
+   * intent of HADOOP-17068 / HDFS-14118.
+   */
+  private final boolean resolveOnFailureEnabled;
+
+  /**
    * Construct SCMFailoverProxyProviderBase.
    * If userGroupInformation is not null, use the passed ugi, else obtain
    * from {@link UserGroupInformation#getCurrentUser()}
@@ -117,6 +127,9 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
     scmClientConfig = conf.getObject(SCMClientConfig.class);
     this.maxRetryCount = scmClientConfig.getRetryCount();
     this.retryInterval = scmClientConfig.getRetryInterval();
+    this.resolveOnFailureEnabled = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
 
     getLogger().info("Created fail-over proxy for protocol {} with {} nodes: {}", protocol.getSimpleName(),
         scmNodeIds.size(), scmProxyInfoMap.values());
@@ -144,6 +157,17 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
     return currentProxySCMNodeId;
   }
 
+  /**
+   * Test-only: substitute the cached SCMProxyInfo for {@code nodeId}
+   * with a hand-built one whose IP can be deliberately stale. Used to
+   * drive the DNS-refresh code path without standing up a real SCM.
+   */
+  @VisibleForTesting
+  synchronized void replaceProxyInfoForTest(String nodeId, SCMProxyInfo info) {
+    scmProxyInfoMap.put(nodeId, info);
+    scmProxies.remove(nodeId);
+  }
+
   @VisibleForTesting
   protected synchronized void loadConfigs() {
     List<SCMNodeInfo> scmNodeInfoList = SCMNodeInfo.buildNodeInfo(conf);
@@ -161,7 +185,12 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
         String scmServiceId = scmNodeInfo.getServiceId();
         String scmNodeId = scmNodeInfo.getNodeId();
         scmNodeIds.add(scmNodeId);
-        SCMProxyInfo scmProxyInfo = new SCMProxyInfo(scmServiceId, scmNodeId, protocolAddr);
+        // Preserve the original config string so DNS can be re-resolved
+        // on connection failure when the SCM peer is rescheduled to a
+        // new IP (Kubernetes pod-IP-change recovery). See
+        // refreshProxyAddressIfChanged(String).
+        SCMProxyInfo scmProxyInfo = new SCMProxyInfo(scmServiceId, scmNodeId,
+            protocolAddr, protocolAddress);
         scmProxyInfoMap.put(scmNodeId, scmProxyInfo);
       }
     }
@@ -260,6 +289,86 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
     }
   }
 
+  /**
+   * Re-resolve the configured hostname for the given SCM nodeId. If DNS
+   * now returns a different IP, swap in a fresh {@link SCMProxyInfo}
+   * (with the new resolved address) and discard any cached proxy so the
+   * next {@link #getProxy()} call dials the new IP.
+   *
+   * @return true when a swap occurred; false when the hostname was not
+   *         preserved, the IP is unchanged, the lookup failed, or the
+   *         nodeId is unknown.
+   */
+  @VisibleForTesting
+  boolean refreshProxyAddressIfChanged(String nodeId) {
+    // Read the cached info first so we can do the DNS lookup outside
+    // any monitor. A slow / dead resolver while holding the provider
+    // monitor would freeze every concurrent getProxy() / shouldRetry()
+    // caller.
+    String hostAndPort;
+    InetSocketAddress cachedAddress;
+    String serviceId;
+    synchronized (this) {
+      SCMProxyInfo cached = scmProxyInfoMap.get(nodeId);
+      if (cached == null) {
+        return false;
+      }
+      hostAndPort = cached.getHostAndPort();
+      if (hostAndPort == null) {
+        return false;
+      }
+      cachedAddress = cached.getAddress();
+      serviceId = cached.getServiceId();
+    }
+    InetSocketAddress refreshed;
+    try {
+      refreshed = NetUtils.createSocketAddr(hostAndPort);
+    } catch (IllegalArgumentException ex) {
+      getLogger().warn("Failed to re-resolve SCM address {}: {}",
+          hostAndPort, ex.getMessage());
+      return false;
+    }
+    if (refreshed.isUnresolved()) {
+      getLogger().warn("SCM hostname {} re-resolved to an unresolved "
+          + "address; leaving cached entry in place.", hostAndPort);
+      return false;
+    }
+    // Null-safe IP comparison. SCMProxyInfo's constructor allows
+    // an unresolved cached address (warns but stores). In that case
+    // cachedAddress.getAddress() is null and a successful
+    // re-resolution is genuinely a change -- proceed to swap rather
+    // than NPE on .equals().
+    java.net.InetAddress cachedIp = cachedAddress.getAddress();
+    if (cachedIp != null
+        && refreshed.getAddress().equals(cachedIp)) {
+      return false;
+    }
+    SCMProxyInfo updated = new SCMProxyInfo(serviceId, nodeId,
+        refreshed, hostAndPort);
+    ProxyInfo<T> staleProxy;
+    synchronized (this) {
+      // Re-check under the lock to avoid a lost update if another
+      // refresher beat us to the swap.
+      SCMProxyInfo current = scmProxyInfoMap.get(nodeId);
+      if (current == null || !cachedAddress.equals(current.getAddress())) {
+        return false;
+      }
+      scmProxyInfoMap.put(nodeId, updated);
+      staleProxy = scmProxies.remove(nodeId);
+    }
+    if (staleProxy != null && staleProxy.proxy != null) {
+      try {
+        RPC.stopProxy(staleProxy.proxy);
+      } catch (RuntimeException stopEx) {
+        getLogger().warn("Failed to stop stale proxy for SCM nodeId {}: {}",
+            nodeId, stopEx.getMessage());
+      }
+    }
+    getLogger().info("DNS re-resolution: SCM nodeId {} address {} -> {} "
+        + "(hostname {}).", nodeId, cachedAddress, refreshed, hostAndPort);
+    return true;
+  }
+
   private long getRetryInterval() {
     // TODO add exponential backup
     return retryInterval;
@@ -342,7 +451,23 @@ public abstract class SCMFailoverProxyProviderBase<T> implements FailoverProxyPr
           printRetryMessage(e, failover, retryAction.delayMillis);
         }
 
+        // Before advancing the failover index, give the cached SCM
+        // address a chance to be re-resolved -- the same nodeId may
+        // have moved to a new IP under a stable hostname (Kubernetes
+        // pod restart). Limited to connection-class exceptions to
+        // avoid extra DNS load on application-level errors.
+        boolean refreshed = false;
+        if (resolveOnFailureEnabled
+            && ConnectionFailureUtils.isConnectionFailure(e)) {
+          refreshed = refreshProxyAddressIfChanged(getCurrentProxySCMNodeId());
+        }
+
         if (SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
+          setUpdatedLeaderNodeID();
+        } else if (refreshed) {
+          // Stay on this nodeId so the next attempt dials the newly
+          // resolved IP; advancing the failover ring here would bypass
+          // the freshly-fixed peer for N-1 attempts.
           setUpdatedLeaderNodeID();
         } else {
           performFailoverToAssignedLeader(null, e);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMProxyInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMProxyInfo.java
@@ -33,20 +33,38 @@ public class SCMProxyInfo {
   private final String nodeId;
   private final String rpcAddrStr;
   private final InetSocketAddress rpcAddr;
+  /**
+   * Original "host:port" config string, preserved so the failover
+   * provider can re-resolve DNS on connection failure (Kubernetes pod
+   * IP-change recovery). Null when the legacy constructor was used --
+   * in that case, refresh-on-failure is disabled for this entry.
+   */
+  private final String hostAndPort;
 
   public SCMProxyInfo(String serviceID, String nodeID,
                       InetSocketAddress rpcAddress) {
+    this(serviceID, nodeID, rpcAddress, null);
+  }
+
+  public SCMProxyInfo(String serviceID, String nodeID,
+                      InetSocketAddress rpcAddress, String hostAndPort) {
     Objects.requireNonNull(rpcAddress, "rpcAddress == null");
     this.serviceId = serviceID;
     this.nodeId = nodeID;
     this.rpcAddrStr = rpcAddress.toString();
     this.rpcAddr = rpcAddress;
+    this.hostAndPort = hostAndPort;
     if (rpcAddr.isUnresolved()) {
       LOG.warn("SCM address {} for serviceID {} remains unresolved " +
               "for node ID {} Check your ozone-site.xml file to ensure scm " +
               "addresses are configured properly.",
           rpcAddress, serviceId, nodeId);
     }
+  }
+
+  /** @return the original config-time host:port string, or null. */
+  public String getHostAndPort() {
+    return hostAndPort;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/proxy/TestSCMFailoverProxyProviderRefresh.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/proxy/TestSCMFailoverProxyProviderRefresh.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.proxy;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.net.NetUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link SCMFailoverProxyProviderBase#refreshProxyAddressIfChanged}
+ * correctly detects DNS changes and swaps in a fresh {@link SCMProxyInfo}
+ * when the SCM peer's IP has shifted under a stable hostname (the
+ * Kubernetes pod-IP-change recovery scenario).
+ */
+public class TestSCMFailoverProxyProviderRefresh {
+
+  /**
+   * Build a provider whose only SCM entry deliberately points at a
+   * stale IP (127.0.0.99). Re-resolving the preserved hostname
+   * "localhost" yields a different IP (typically 127.0.0.1), so the
+   * refresh helper must swap in a fresh SCMProxyInfo.
+   */
+  @Test
+  public void testRefreshSwapsAddressOnIpChange() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    // Single SCM, no service id, hostname "localhost".
+    conf.set(OZONE_SCM_NAMES, "localhost");
+    conf.set(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY, "localhost:9863");
+
+    SCMBlockLocationFailoverProxyProvider provider =
+        new SCMBlockLocationFailoverProxyProvider(conf);
+
+    // Replace the cached entry with a deliberately-stale IP. This
+    // simulates the state we'd be in if the SCM pod had been
+    // rescheduled to a new IP after the provider was constructed.
+    SCMProxyInfo cached = provider.getSCMProxyInfoList().iterator().next();
+    String nodeId = cached.getNodeId();
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}),
+        cached.getAddress().getPort());
+    provider.replaceProxyInfoForTest(nodeId,
+        new SCMProxyInfo(cached.getServiceId(), nodeId, staleAddr,
+            cached.getHostAndPort()));
+
+    boolean swapped = provider.refreshProxyAddressIfChanged(nodeId);
+    assertTrue(swapped, "refresh must report a swap when DNS now "
+        + "resolves localhost to an IP different from the stale 127.0.0.99");
+
+    SCMProxyInfo updated = provider.getSCMProxyInfoList().iterator().next();
+    assertNotEquals(staleAddr.getAddress(), updated.getAddress().getAddress(),
+        "after refresh, cached entry must hold a fresh IP");
+    assertEquals(staleAddr.getPort(), updated.getAddress().getPort(),
+        "port must be preserved across the swap");
+    assertEquals("localhost:9863", updated.getHostAndPort(),
+        "host:port string must survive the swap so future refreshes work");
+  }
+
+  /**
+   * When DNS still returns the cached IP, refreshProxyAddressIfChanged
+   * is a no-op. This guards against tearing down a healthy proxy on
+   * every transient blip when the IP is genuinely unchanged.
+   */
+  @Test
+  public void testRefreshNoopWhenIpUnchanged() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_SCM_NAMES, "localhost");
+    conf.set(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY, "localhost:9863");
+
+    SCMBlockLocationFailoverProxyProvider provider =
+        new SCMBlockLocationFailoverProxyProvider(conf);
+
+    SCMProxyInfo before = provider.getSCMProxyInfoList().iterator().next();
+    String nodeId = before.getNodeId();
+
+    boolean swapped = provider.refreshProxyAddressIfChanged(nodeId);
+    assertFalse(swapped, "no swap expected when DNS resolves to the "
+        + "same IP that's already cached");
+  }
+
+  /**
+   * If the entry has no preserved host:port string, refresh is
+   * unsupported (legacy code path) and returns false. Belts-and-braces
+   * sanity check.
+   */
+  @Test
+  public void testRefreshNoopWithoutHostAndPort() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_SCM_NAMES, "localhost");
+    conf.set(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY, "localhost:9863");
+
+    SCMBlockLocationFailoverProxyProvider provider =
+        new SCMBlockLocationFailoverProxyProvider(conf);
+
+    SCMProxyInfo cached = provider.getSCMProxyInfoList().iterator().next();
+    String nodeId = cached.getNodeId();
+    // Replace with the legacy three-arg ctor (hostAndPort = null).
+    provider.replaceProxyInfoForTest(nodeId,
+        new SCMProxyInfo(cached.getServiceId(), nodeId,
+            NetUtils.createSocketAddr("localhost:9863")));
+
+    assertFalse(provider.refreshProxyAddressIfChanged(nodeId));
+    assertNotNull(provider.getSCMProxyInfoList().iterator().next());
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/proxy/TestSCMFailoverProxyProviderRefreshWired.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/proxy/TestSCMFailoverProxyProviderRefreshWired.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.proxy;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
+import org.apache.hadoop.io.retry.RetryPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Wired-path tests for {@link SCMFailoverProxyProviderBase#getRetryPolicy}'s
+ * interaction with the connection-class filter and
+ * {@link SCMFailoverProxyProviderBase#refreshProxyAddressIfChanged}.
+ * Complements {@code TestConnectionFailureUtils} (helper-in-isolation)
+ * and {@code TestSCMFailoverProxyProviderRefresh} (per-instance refresh)
+ * by exercising the actual retry policy whose return value drives the
+ * RetryInvocationHandler in production.
+ */
+public class TestSCMFailoverProxyProviderRefreshWired {
+
+  private OzoneConfiguration conf;
+
+  @BeforeEach
+  public void setUp() {
+    conf = new OzoneConfiguration();
+    conf.set(OZONE_SCM_NAMES, "localhost");
+    conf.set(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY, "localhost:9863");
+  }
+
+  /**
+   * A counting subclass that records each call to
+   * {@code refreshProxyAddressIfChanged} so the test can assert exactly
+   * when the wiring fires.
+   */
+  private static final class CountingProvider
+      extends SCMBlockLocationFailoverProxyProvider {
+    int refreshCalls;
+
+    CountingProvider(OzoneConfiguration c) {
+      super(c);
+    }
+
+    @Override
+    boolean refreshProxyAddressIfChanged(String nodeId) {
+      refreshCalls++;
+      return false;
+    }
+  }
+
+  @Test
+  public void testSocketTimeoutTriggersRefreshHook() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider provider = new CountingProvider(conf);
+    RetryPolicy policy = provider.getRetryPolicy();
+    policy.shouldRetry(new SocketTimeoutException("EC2 silent drop"),
+        0, 0, false);
+    assertEquals(1, provider.refreshCalls,
+        "SocketTimeoutException must invoke the refresh hook exactly once");
+  }
+
+  @Test
+  public void testConnectExceptionTriggersRefreshHook() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider provider = new CountingProvider(conf);
+    RetryPolicy policy = provider.getRetryPolicy();
+    policy.shouldRetry(
+        new IOException("connection refused", new ConnectException()),
+        0, 0, false);
+    assertEquals(1, provider.refreshCalls);
+  }
+
+  @Test
+  public void testApplicationLevelErrorDoesNotTriggerRefresh() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider provider = new CountingProvider(conf);
+    RetryPolicy policy = provider.getRetryPolicy();
+    policy.shouldRetry(new ServerNotLeaderException("not the leader"),
+        0, 0, false);
+    assertEquals(0, provider.refreshCalls,
+        "ServerNotLeaderException is application-level; refresh must NOT fire");
+  }
+
+  @Test
+  public void testFlagDisabledSuppressesRefresh() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
+    CountingProvider provider = new CountingProvider(conf);
+    RetryPolicy policy = provider.getRetryPolicy();
+    policy.shouldRetry(new ConnectException("refused"), 0, 0, false);
+    assertEquals(0, provider.refreshCalls,
+        "with the flag off the refresh hook must never fire");
+  }
+
+  /**
+   * When refresh succeeds, performFailover must stay on the current
+   * nodeId (via updatedLeaderNodeID) rather than advancing the ring.
+   */
+  @Test
+  public void testRefreshSuccessPinsCurrentNodeId() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    SCMBlockLocationFailoverProxyProvider provider =
+        new SCMBlockLocationFailoverProxyProvider(conf) {
+          @Override
+          boolean refreshProxyAddressIfChanged(String nodeId) {
+            return true;
+          }
+        };
+
+    String beforeNode = provider.getCurrentProxySCMNodeId();
+    RetryPolicy policy = provider.getRetryPolicy();
+
+    // Pre-advance the failover ring with a non-connection-class error.
+    policy.shouldRetry(new IOException("not-a-connection-failure"),
+        0, 0, false);
+
+    policy.shouldRetry(new ConnectException("refused"), 0, 1, false);
+    provider.performFailover(null);
+    assertEquals(beforeNode, provider.getCurrentProxySCMNodeId(),
+        "after a successful refresh, performFailover must stay on the "
+            + "original nodeId");
+    assertNotNull(beforeNode);
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/proxy/TestSCMFailoverProxyProviderRefreshWired.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/proxy/TestSCMFailoverProxyProviderRefreshWired.java
@@ -59,7 +59,7 @@ public class TestSCMFailoverProxyProviderRefreshWired {
    */
   private static final class CountingProvider
       extends SCMBlockLocationFailoverProxyProvider {
-    int refreshCalls;
+    private int refreshCalls;
 
     CountingProvider(OzoneConfiguration c) {
       super(c);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -118,9 +118,11 @@ public class SCMHAManagerImpl implements SCMHAManager {
       final boolean success = HAUtils.addSCM(ozoneConf,
           new AddSCMRequest.Builder().setClusterId(scm.getClusterId())
               .setScmId(scm.getScmId())
-              .setRatisAddr(nodeDetails
-                  // TODO : Should we use IP instead of hostname??
-                  .getRatisHostPortStr()).build(), scm.getSCMNodeId());
+              // Hostname is intentional: gRPC's DnsNameResolver re-resolves
+              // hostnames on connection failure, so SCM peer pod restarts
+              // are recovered automatically. See HDDS-15514.
+              .setRatisAddr(nodeDetails.getRatisHostPortStr())
+              .build(), scm.getSCMNodeId());
       if (!success) {
         throw new IOException("Adding SCM to existing HA group failed");
       } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -402,8 +402,14 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     final RaftGroupId groupId = buildRaftGroupId(clusterId);
     RaftPeerId selfPeerId = getSelfPeerId(scmId);
 
+    // The peer address is intentionally a hostname:port string, never a
+    // resolved IP. Ratis hands this string to gRPC's NettyChannelBuilder,
+    // whose default DnsNameResolver re-resolves hostnames on connection
+    // failure. Baking a resolved IP would freeze the peer at one IP,
+    // breaking recovery from peer pod restarts in Kubernetes-style
+    // environments where DNS names are stable but IPs are not. See
+    // HDDS-15514 (DNS-refresh-on-failure for all RPC paths).
     RaftPeer localRaftPeer = RaftPeer.newBuilder().setId(selfPeerId)
-        // TODO : Should we use IP instead of hostname??
         .setAddress(details.getRatisHostPortStr()).build();
 
     List<RaftPeer> raftPeers = new ArrayList<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestSCMConnectionManagerDnsRefreshE2E.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestSCMConnectionManagerDnsRefreshE2E.java
@@ -91,11 +91,10 @@ public class TestSCMConnectionManagerDnsRefreshE2E {
     InetSocketAddress liveAddr = scmServer.getListenerAddress();
     int port = liveAddr.getPort();
 
-    // The hostname we'll preserve. localhost reliably resolves to a
-    // loopback address in any test environment, and the server is
-    // bound to a loopback address, so a dial of localhost:port
-    // succeeds.
-    String hostAndPort = "localhost:" + port;
+    // Preserve the server's actual bound host so DNS re-resolution and
+    // the RPC dial use the same address family (avoids IPv4/IPv6
+    // localhost mismatch on dual-stack CI hosts).
+    String hostAndPort = liveAddr.getAddress().getHostAddress() + ":" + port;
 
     // Step 2: prime the connection manager with a deliberately stale
     // cached InetSocketAddress (127.0.0.99 has no listener; any RPC
@@ -120,7 +119,8 @@ public class TestSCMConnectionManagerDnsRefreshE2E {
 
     assertNotNull(refreshed,
         "refreshSCMServer must report a swap when the cached IP "
-            + "127.0.0.99 differs from what DNS now returns for localhost");
+            + "127.0.0.99 differs from what DNS now returns for "
+            + hostAndPort);
     assertEquals(port, refreshed.getPort(),
         "port must be preserved across the swap; only the IP changes");
     assertEquals(1, connectionManager.getNumOfConnections(),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestSCMConnectionManagerDnsRefreshE2E.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestSCMConnectionManagerDnsRefreshE2E.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
+import org.apache.hadoop.ipc_.RPC;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies the swap-mechanism + real-network-handshake half of the
+ * DataNode → SCM DNS-refresh-on-failure recovery path.
+ * <p>
+ * Stands up a real SCM-side RPC server (via {@link ScmTestMock}) bound to a
+ * loopback address on an OS-assigned port, then primes
+ * {@link SCMConnectionManager} with a deliberately stale entry: cached at
+ * {@code 127.0.0.99:port} (no listener, unreachable) but with the preserved
+ * hostname {@code localhost:port}. This is the steady state an Ozone
+ * DataNode falls into when a Kubernetes SCM pod has been rescheduled to a
+ * new IP -- the cached InetSocketAddress points to the gone-away IP, but
+ * DNS for the hostname now resolves elsewhere.
+ * <p>
+ * The test calls {@link SCMConnectionManager#refreshSCMServer} directly
+ * and asserts that:
+ * <ol>
+ *   <li>the swap occurred,</li>
+ *   <li>the cached endpoint now points at the live SCM,</li>
+ *   <li>a real heartbeat through the swapped endpoint round-trips
+ *       successfully (mock SCM observes the count incrementing).</li>
+ * </ol>
+ * Together these prove the swap-mechanism path: address re-resolution,
+ * atomic endpoint swap, fresh RPC proxy construction, real network
+ * handshake, server-side handler invocation.
+ * <p>
+ * The complementary trigger-chain integration -- heartbeat IOException
+ * → catch block → {@code maybeRefreshScmAddress} → flag/threshold check
+ * → {@code refreshSCMServer} -- is covered by
+ * {@code TestHeartbeatEndpointTaskDnsRefresh}. Together the two tests
+ * prove the full production recovery flow without a single flaky
+ * timing-dependent assertion.
+ */
+public class TestSCMConnectionManagerDnsRefreshE2E {
+
+  private RPC.Server scmServer;
+  private SCMConnectionManager connectionManager;
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (connectionManager != null) {
+      connectionManager.close();
+    }
+    if (scmServer != null) {
+      scmServer.stop();
+    }
+  }
+
+  @Test
+  @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+  public void testRefreshSwapsEndpointAndHeartbeatSucceeds() throws Exception {
+    // Step 1: stand up a real mock SCM RPC server on a loopback address,
+    // OS-assigned port. This is the "live" SCM after the pod restart.
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ScmTestMock scmServerImpl = new ScmTestMock();
+    scmServer = SCMTestUtils.startScmRpcServer(conf, scmServerImpl);
+    InetSocketAddress liveAddr = scmServer.getListenerAddress();
+    int port = liveAddr.getPort();
+
+    // The hostname we'll preserve. localhost reliably resolves to a
+    // loopback address in any test environment, and the server is
+    // bound to a loopback address, so a dial of localhost:port
+    // succeeds.
+    String hostAndPort = "localhost:" + port;
+
+    // Step 2: prime the connection manager with a deliberately stale
+    // cached InetSocketAddress (127.0.0.99 has no listener; any RPC
+    // attempt would fail). Crucially, the entry still carries the
+    // preserved hostname "localhost:port", which is the input to DNS
+    // re-resolution. This is exactly the state a DN falls into after
+    // an SCM pod is rescheduled in Kubernetes.
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), port);
+    connectionManager = new SCMConnectionManager(conf);
+    connectionManager.addSCMServer(staleAddr, hostAndPort, "");
+
+    assertEquals(1, connectionManager.getNumOfConnections());
+
+    // Step 3: call the recovery path. refreshSCMServer must:
+    //   - re-resolve "localhost" via DNS,
+    //   - notice the resolved IP differs from the stale 127.0.0.99,
+    //   - tear down the unreachable endpoint and build a fresh one
+    //     bound to the live address.
+    InetSocketAddress refreshed = connectionManager.refreshSCMServer(
+        staleAddr, "");
+
+    assertNotNull(refreshed,
+        "refreshSCMServer must report a swap when the cached IP "
+            + "127.0.0.99 differs from what DNS now returns for localhost");
+    assertEquals(port, refreshed.getPort(),
+        "port must be preserved across the swap; only the IP changes");
+    assertEquals(1, connectionManager.getNumOfConnections(),
+        "swap is in-place: still exactly one endpoint, just bound to a "
+            + "fresh address");
+
+    EndpointStateMachine swapped =
+        connectionManager.getValues().iterator().next();
+    assertEquals(refreshed, swapped.getAddress(),
+        "the cached endpoint must now hold the freshly-resolved address");
+    assertEquals(hostAndPort, swapped.getHostAndPort(),
+        "preserved hostname survives the swap so future refreshes still "
+            + "work after another pod restart");
+
+    // Step 4: the live test of the recovery -- send a real heartbeat
+    // through the swapped endpoint and verify the mock SCM saw it.
+    // If any step in the chain (address swap, proxy construction,
+    // socket dial, server handler) is broken, this RPC throws and
+    // the test fails.
+    int beforeCount = scmServerImpl.getRpcCount();
+    SCMHeartbeatRequestProto request = SCMHeartbeatRequestProto.newBuilder()
+        .setDatanodeDetails(
+            org.apache.hadoop.hdds.protocol.MockDatanodeDetails
+                .randomDatanodeDetails().getProtoBufMessage())
+        .build();
+    SCMHeartbeatResponseProto response =
+        swapped.getEndPoint().sendHeartbeat(request);
+    assertNotNull(response, "heartbeat response must come back from "
+        + "the live SCM via the swapped endpoint");
+    assertTrue(scmServerImpl.getRpcCount() > beforeCount,
+        "mock SCM must observe at least one new RPC -- proves the "
+            + "end-to-end network path through the swapped endpoint is "
+            + "actually live");
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
@@ -45,7 +45,30 @@ public class HadoopRpcOMFailoverProxyProvider<T> extends
   protected static final Logger LOG =
       LoggerFactory.getLogger(HadoopRpcOMFailoverProxyProvider.class);
 
-  private final Text delegationTokenService;
+  /**
+   * Aggregated delegation-token service identifier (the comma-joined
+   * list of per-OM service strings, sorted for stability). Mutable and
+   * volatile so that {@link #onAddressRefreshed(String)} can replace
+   * it in-place after a per-node DNS refresh; readers see either the
+   * old or the new fully-formed value, never a partial state. <p>
+   * Caveat for SECURE clusters with the default
+   * {@code hadoop.security.token.service.use_ip=true}: each per-OM
+   * service is built from the resolved IP, so after an IP refresh
+   * the new aggregate string and the token's frozen old aggregate
+   * string have no common per-OM substring for the refreshed peer.
+   * {@code OzoneDelegationTokenSelector} (substring match) then fails
+   * to select the token for that peer, and the SASL handshake on the
+   * fresh dial cannot present credentials. <p>
+   * Operators that enable {@code ozone.client.failover.resolve-needed}
+   * on a secure cluster MUST set {@code hadoop.security.token.service.use_ip=false}
+   * (in core-site.xml) so the per-OM service is hostname:port -- a
+   * stable identifier that survives any IP change. This is documented
+   * on the {@code ozone.client.failover.resolve-needed} entry in
+   * {@code ozone-default.xml}. <p>
+   * For new {@code RpcClient} instances constructed after a refresh,
+   * the volatile read here returns the up-to-date aggregate.
+   */
+  private volatile Text delegationTokenService;
 
   // HadoopRpcOMFailoverProxyProvider, on encountering certain exception,
   // tries each OM once in a round robin fashion. After that it waits
@@ -115,6 +138,18 @@ public class HadoopRpcOMFailoverProxyProvider<T> extends
 
   public Text getCurrentProxyDelegationToken() {
     return delegationTokenService;
+  }
+
+  /**
+   * After a per-node DNS refresh, the {@link OMProxyInfo#getDelegationTokenService()}
+   * for that node has been rewritten against the new resolved IP. The
+   * aggregated identifier built from the full peer set is therefore
+   * stale and must be recomputed. Volatile assignment ensures readers
+   * either see the old value in full or the new value in full.
+   */
+  @Override
+  protected void onAddressRefreshed(String nodeId) {
+    this.delegationTokenService = computeDelegationTokenService();
   }
 
   protected Text computeDelegationTokenService() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFollowerReadFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFollowerReadFailoverProxyProvider.java
@@ -385,8 +385,14 @@ public class HadoopRpcOMFollowerReadFailoverProxyProvider implements FailoverPro
 
     @Override
     public ConnectionId getConnectionId() {
+      // Read the proxy through the synchronized accessor instead of the
+      // inherited public field. With DNS-refresh-on-failure, OMProxyInfo
+      // mutates the proxy field under its monitor, so a direct field
+      // read can observe a torn value (a stale proxy whose underlying
+      // connection was just stopped, or a fresh proxy that was just
+      // installed without proper visibility for the reader).
       return RPC.getConnectionIdForProxy(useFollowerRead
-          ? getCurrentProxy().proxy : leaderProxy.getProxy().getProxy());
+          ? getCurrentProxy().getProxy() : leaderProxy.getProxy().getProxy());
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -88,6 +89,14 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
   private final UserGroupInformation ugi;
 
+  /**
+   * When true, on each connection-class failure the provider re-resolves
+   * the cached OM hostname for the current proxy and discards the cached
+   * proxy if the IP has changed (Kubernetes pod-IP-change recovery).
+   * Off by default. Mirrors the design intent of HADOOP-17068.
+   */
+  private final boolean resolveOnFailureEnabled;
+
   public OMFailoverProxyProviderBase(ConfigurationSource configuration,
                                      UserGroupInformation ugi,
                                      String omServiceId,
@@ -104,6 +113,9 @@ public abstract class OMFailoverProxyProviderBase<T> implements
     this.omProxies = new OMProxyInfo.OrderedMap<>(initOmProxiesFromConfigs(conf, omServiceId));
     nextProxyIndex = 0;
     currentProxyIndex = 0;
+    this.resolveOnFailureEnabled = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
   }
 
   /**
@@ -241,6 +253,26 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
         if (!shouldFailover(exception)) {
           return RetryAction.FAIL; // do not retry
+        }
+
+        // Before advancing failover index, give the cached OM address a
+        // chance to be re-resolved -- the same nodeId may have been
+        // rescheduled to a new IP (Kubernetes pod-IP-change recovery).
+        // Restricted to connection-class exceptions so we don't add DNS
+        // load on application-level errors.
+        if (resolveOnFailureEnabled
+            && ConnectionFailureUtils.isConnectionFailure(exception)
+            && maybeRefreshCurrentOmAddress()) {
+          // Pin nextProxyIndex back to the current nodeId so that the
+          // RetryInvocationHandler's subsequent performFailover() call
+          // does NOT advance to a different peer. Without this,
+          // performFailover() would read whatever nextProxyIndex was
+          // last set to (often already advanced from prior retries) and
+          // bypass the freshly-fixed peer for up to N-1 attempts in an
+          // N-OM HA cluster -- defeating the purpose of the refresh.
+          // Mirrors the OMLeaderNotReady "retry same OM" pattern above.
+          setNextOmProxy(omNodeId);
+          return getRetryAction(RetryDecision.FAILOVER_AND_RETRY, failovers);
         }
 
         // Prepare the next OM to be tried. This will help with calculation
@@ -476,5 +508,64 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
   protected ConfigurationSource getConf() {
     return conf;
+  }
+
+  /**
+   * Asks the current proxy's {@link OMProxyInfo} to re-resolve its
+   * configured hostname. If DNS now returns a different IP, the
+   * OMProxyInfo replaces its cached address and discards the cached
+   * proxy so the next dial happens against the new IP.
+   * <p>
+   * Calls {@link #onAddressRefreshed(String)} when a swap occurs so
+   * subclasses (specifically {@code HadoopRpcOMFailoverProxyProvider})
+   * can refresh derived state such as the aggregated delegation-token
+   * service identifier.
+   * <p>
+   * The DNS lookup performed inside {@link OMProxyInfo#refreshAddressIfChanged}
+   * is run OUTSIDE this provider's monitor. {@link OMProxyInfo} maintains
+   * its own monitor for the swap commit; if we held the provider monitor
+   * across the resolve, a slow / dead resolver would freeze every
+   * concurrent caller of synchronized provider methods (e.g.
+   * {@link #performFailover}, {@link #selectNextOmProxy}). The provider
+   * monitor is only re-acquired briefly to invoke the refresh hook.
+   *
+   * @return true if a swap actually happened.
+   */
+  @VisibleForTesting
+  boolean maybeRefreshCurrentOmAddress() {
+    final String nodeId;
+    final OMProxyInfo<T> info;
+    synchronized (this) {
+      nodeId = getCurrentProxyOMNodeId();
+      if (nodeId == null) {
+        return false;
+      }
+      info = omProxies.get(nodeId);
+      if (info == null) {
+        return false;
+      }
+    }
+    // refreshAddressIfChanged handles its own locking and performs the
+    // DNS lookup outside its entry monitor.
+    boolean swapped = info.refreshAddressIfChanged();
+    if (swapped) {
+      synchronized (this) {
+        onAddressRefreshed(nodeId);
+      }
+    }
+    return swapped;
+  }
+
+  /**
+   * Hook called immediately after a successful per-node DNS refresh.
+   * Default implementation is a no-op. Subclasses override to refresh
+   * any state derived from the cached set of OM addresses (e.g. the
+   * aggregated delegation-token service in
+   * {@code HadoopRpcOMFailoverProxyProvider}).
+   *
+   * @param nodeId the OM nodeId whose address was just refreshed.
+   */
+  protected void onAddressRefreshed(String nodeId) {
+    // no-op by default
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.ha;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -104,6 +105,15 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
 
   public synchronized InetSocketAddress getAddress() {
     return rpcAddr;
+  }
+
+  /**
+   * Test-only: inject a deliberately stale cached address to drive
+   * the DNS-refresh code path without standing up a real OM.
+   */
+  @VisibleForTesting
+  synchronized void setCachedAddressForTest(InetSocketAddress address) {
+    this.rpcAddr = address;
   }
 
   public synchronized Text getDelegationTokenService() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.ha;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Iterator;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.FailoverProxyProvider.ProxyInfo;
+import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.security.SecurityUtil;
@@ -43,9 +45,26 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
   private static final Logger LOG = LoggerFactory.getLogger(OMProxyInfo.class);
 
   private final String nodeId;
+  /**
+   * The original "host:port" config string. Stable for the lifetime of
+   * this OMProxyInfo; used as the source of truth for re-resolving DNS
+   * when the cached IP becomes stale (Kubernetes pod-IP-change recovery).
+   */
   private final String rpcAddrStr;
-  private final InetSocketAddress rpcAddr;
-  private final Text dtService;
+  /**
+   * The currently-resolved address. Initialized at construction by
+   * resolving {@link #rpcAddrStr}, and may be replaced atomically by
+   * {@link #refreshAddressIfChanged()} when the failover provider
+   * detects that the OM node has been rescheduled to a new IP.
+   * <p>
+   * Mutable but always read/written under the OMProxyInfo's monitor.
+   */
+  private InetSocketAddress rpcAddr;
+  /**
+   * Token-service name derived from {@link #rpcAddr}. Updated alongside
+   * {@link #rpcAddr} on a successful refresh.
+   */
+  private Text dtService;
 
   public static <T> OMProxyInfo<T> newInstance(T proxy, String serviceID, String nodeID, String rpcAddress) {
     if (nodeID == null) {
@@ -83,11 +102,11 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
     return rpcAddrStr;
   }
 
-  public InetSocketAddress getAddress() {
+  public synchronized InetSocketAddress getAddress() {
     return rpcAddr;
   }
 
-  public Text getDelegationTokenService() {
+  public synchronized Text getDelegationTokenService() {
     return dtService;
   }
 
@@ -106,10 +125,94 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
   }
 
   /**
-   * A {@link OMProxyInfo} map with a particular order,
+   * Re-resolve {@link #rpcAddrStr} via DNS and, if the resolved IP has
+   * changed, replace the cached {@link #rpcAddr} (and the derived
+   * delegation-token service) and discard the cached proxy so that the
+   * next {@link #createProxyIfNeeded} call dials the new IP. The stale
+   * RPC proxy is closed via {@link RPC#stopProxy} so the underlying
+   * Hadoop {@code Client} connection thread and authenticated SASL
+   * session against the gone-away peer are not leaked.
    * <p>
-   * Note the underlying collections are unmodifiable.
-   * As a result, this class is thread-safe without any synchronizations.
+   * Returns true when a swap occurred. Off the failure path this is a
+   * no-op (returns false): unchanged IP, unresolved lookup, or
+   * malformed host string.
+   * <p>
+   * The DNS lookup and the {@code RPC.stopProxy} call are performed
+   * outside the entry monitor so that a slow / dead resolver or a
+   * blocking proxy teardown does not freeze concurrent readers of
+   * {@link #getAddress()} / {@link #getProxy()}.
+   */
+  public boolean refreshAddressIfChanged() {
+    final InetSocketAddress refreshed;
+    try {
+      refreshed = NetUtils.createSocketAddr(rpcAddrStr);
+    } catch (IllegalArgumentException ex) {
+      LOG.warn("Failed to re-resolve OM address {}: {}", rpcAddrStr,
+          ex.getMessage());
+      return false;
+    }
+    if (refreshed.isUnresolved()) {
+      LOG.warn("OM hostname {} re-resolved to an unresolved address; "
+          + "leaving cached entry in place.", rpcAddrStr);
+      return false;
+    }
+    // Compute the new delegation-token service identifier OUTSIDE the
+    // entry monitor. SecurityUtil.buildTokenService is unlikely to throw
+    // for a resolved address, but if it ever did inside the swap block
+    // we'd be left with rpcAddr=new but dtService=old and proxy=non-null
+    // pointing at the old IP -- and the equality short-circuit at the
+    // top of the synchronized block below would skip every subsequent
+    // refresh attempt because rpcAddr already matches the new IP.
+    // Building first means a throw here aborts the whole refresh with
+    // no state change.
+    final Text newDtService = SecurityUtil.buildTokenService(refreshed);
+    final T staleProxy;
+    final InetSocketAddress old;
+    synchronized (this) {
+      // Null-safe IP comparison. The constructor accepts (with a warn)
+      // an unresolved rpcAddr -- in that case rpcAddr.getAddress() is
+      // null, and a successful re-resolution is genuinely a change so
+      // we MUST proceed to swap rather than NPE on .equals().
+      InetAddress cachedIp = rpcAddr.getAddress();
+      InetAddress refreshedIp = refreshed.getAddress();
+      if (cachedIp != null && refreshedIp != null
+          && refreshedIp.equals(cachedIp)) {
+        return false;
+      }
+      old = rpcAddr;
+      staleProxy = this.proxy;
+      this.rpcAddr = refreshed;
+      this.dtService = newDtService;
+      this.proxy = null;
+    }
+    if (staleProxy != null) {
+      try {
+        RPC.stopProxy(staleProxy);
+      } catch (RuntimeException stopEx) {
+        LOG.warn("Failed to stop stale OM proxy for nodeId {}: {}",
+            nodeId, stopEx.getMessage());
+      }
+    }
+    LOG.info("DNS re-resolution: OM nodeId {} address {} -> {} "
+        + "(hostname {}).", nodeId, old, refreshed, rpcAddrStr);
+    return true;
+  }
+
+  /**
+   * A {@link OMProxyInfo} map with a particular order.
+   * <p>
+   * The map structure (the {@code proxies} list and the {@code ordering}
+   * map) is built once at construction and wrapped in unmodifiable
+   * views, so the structure itself is immutable and safe to share
+   * without external synchronization.
+   * <p>
+   * Per-entry mutable state -- specifically each {@link OMProxyInfo}'s
+   * {@code rpcAddr}, {@code dtService}, and cached {@code proxy} field,
+   * which DNS-refresh-on-failure may swap -- is guarded by that
+   * entry's own monitor. Callers must reach mutable per-entry state
+   * only through the synchronized accessors ({@link #getAddress()},
+   * {@link #getProxy()}, {@link #getDelegationTokenService()},
+   * {@link #createProxyIfNeeded}, {@link #refreshAddressIfChanged}).
    */
   public static class OrderedMap<P> {
     /** A list of proxies in a particular order. */

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProviderRefreshWired.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProviderRefreshWired.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESO
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -80,7 +79,7 @@ public class TestOMFailoverProxyProviderRefreshWired {
    */
   private static final class CountingProvider
       extends HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> {
-    int refreshCalls;
+    private int refreshCalls;
 
     CountingProvider(OzoneConfiguration c) throws IOException {
       super(c, UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProviderRefreshWired.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProviderRefreshWired.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.util.StringJoiner;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Wired-path tests for {@code OMFailoverProxyProviderBase.shouldRetry}'s
+ * interaction with the new connection-class filter and refresh hook.
+ * These complement {@code TestConnectionFailureUtils} (helper-in-isolation)
+ * and {@code TestOMProxyInfoDnsRefresh} (per-instance refresh) by
+ * exercising the actual retry policy whose return value drives the
+ * RetryInvocationHandler in production.
+ * <p>
+ * The "load-bearing" assertion is that a {@link SocketTimeoutException}
+ * -- the AWS EC2 / EKS silent-drop case the PR is sold on -- routed
+ * through {@code shouldRetry} actually triggers the per-node DNS refresh
+ * on the current OM. {@code TestConnectionFailureUtils} proves the
+ * filter classifies it correctly in isolation; this test proves the
+ * filter is wired.
+ */
+public class TestOMFailoverProxyProviderRefreshWired {
+
+  private static final String OM_SERVICE_ID = "om-svc-refresh-wired";
+  private OzoneConfiguration conf;
+
+  @BeforeEach
+  public void setUp() {
+    conf = new OzoneConfiguration();
+    StringJoiner ids = new StringJoiner(",");
+    for (int i = 1; i <= 3; i++) {
+      String nodeId = "om-" + i;
+      conf.set(ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, OM_SERVICE_ID,
+          nodeId), "localhost:" + (9860 + i));
+      ids.add(nodeId);
+    }
+    conf.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID),
+        ids.toString());
+  }
+
+  /**
+   * A counting subclass that records each call to
+   * {@code maybeRefreshCurrentOmAddress} so the test can assert
+   * exactly when the wiring fires.
+   */
+  private static final class CountingProvider
+      extends HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> {
+    int refreshCalls;
+
+    CountingProvider(OzoneConfiguration c) throws IOException {
+      super(c, UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,
+          OzoneManagerProtocolPB.class);
+    }
+
+    @Override
+    synchronized boolean maybeRefreshCurrentOmAddress() {
+      refreshCalls++;
+      return false;
+    }
+  }
+
+  /**
+   * SocketTimeoutException through {@code shouldRetry} -- the AWS
+   * silent-drop scenario -- must invoke the refresh hook when the
+   * flag is on. Round 1 personas flagged this exception type as
+   * missing from the original filter; Round 2 added it to
+   * ConnectionFailureUtils. This test proves the wiring.
+   */
+  @Test
+  public void testSocketTimeoutTriggersRefreshHook() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    RetryPolicy.RetryAction action = policy.shouldRetry(
+        new SocketTimeoutException("EC2 silent drop"), 0, 0, false);
+    assertEquals(RetryPolicy.RetryAction.RetryDecision.FAILOVER_AND_RETRY,
+        action.action);
+    assertEquals(1, p.refreshCalls,
+        "SocketTimeoutException must invoke the refresh hook exactly once");
+  }
+
+  /**
+   * ConnectException (the OpenStack fast-RST scenario) must also
+   * invoke the refresh hook. Together with the SocketTimeout test,
+   * this proves the filter covers both K8s failure shapes the JIRA
+   * description names.
+   */
+  @Test
+  public void testConnectExceptionTriggersRefreshHook() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    policy.shouldRetry(
+        new IOException("connection refused", new ConnectException()), 0, 0, false);
+    assertEquals(1, p.refreshCalls);
+  }
+
+  /**
+   * Application-level errors (an OMException not wrapped in a
+   * connection-class) must NOT invoke the refresh hook. Re-resolving
+   * DNS would not help and would amplify load.
+   */
+  @Test
+  public void testApplicationLevelErrorDoesNotTriggerRefresh()
+      throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    policy.shouldRetry(new OMException("not the leader",
+        ResultCodes.INTERNAL_ERROR), 0, 0, false);
+    assertEquals(0, p.refreshCalls,
+        "OMException is application-level; refresh hook must NOT fire");
+  }
+
+  /**
+   * Flag-off invariant: even on a connection-class exception, the
+   * refresh hook must NOT be invoked when the resolve-needed flag is
+   * false. Guards the "default-off" safety claim of the PR.
+   */
+  @Test
+  public void testFlagDisabledSuppressesRefresh() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    policy.shouldRetry(new ConnectException("refused"), 0, 0, false);
+    assertEquals(0, p.refreshCalls,
+        "with the flag off the refresh hook must never fire, even for "
+            + "connection-class exceptions");
+  }
+
+  /**
+   * Verifies the C2 "retry-same-proxy" pin: when a refresh succeeds,
+   * the next failover must STAY on the just-refreshed nodeId rather
+   * than advancing to the next peer in the failover ring.
+   * <p>
+   * Round 3 found that the prior version of this test was vacuous:
+   * with both currentProxyIndex and nextProxyIndex initialised to 0
+   * from construction, performFailover was a no-op (currentProxyIndex
+   * = nextProxyIndex = 0), and the assertion held REGARDLESS of
+   * whether the pin code at OMFailoverProxyProviderBase.shouldRetry
+   * actually invoked setNextOmProxy. To make the pin observably
+   * load-bearing, this test PRE-ADVANCES nextProxyIndex by triggering
+   * a non-refresh shouldRetry first (an OMException, which is not a
+   * connection-class failure). That sets nextProxyIndex to (current+1).
+   * Then a second shouldRetry with a connection-class exception fires
+   * the refresh-success path, which MUST pull nextProxyIndex back to
+   * the current node. If the pin code is broken, the post-test
+   * currentProxyOMNodeId will be the NEXT node, not the original.
+   */
+  @Test
+  public void testRefreshSuccessPinsCurrentNodeId() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> p =
+        new HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB>(
+            conf, UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,
+            OzoneManagerProtocolPB.class) {
+          @Override
+          boolean maybeRefreshCurrentOmAddress() {
+            return true; // pretend the swap happened
+          }
+        };
+
+    String beforeNode = p.getCurrentProxyOMNodeId();
+    RetryPolicy policy = p.getRetryPolicy(10);
+
+    // Pre-advance nextProxyIndex by triggering a non-refresh failover
+    // (selectNextOmProxy increments nextProxyIndex). We use a wrapper
+    // exception that does NOT pass isConnectionFailure so the refresh
+    // hook is NOT invoked here.
+    policy.shouldRetry(new IOException("not-a-connection-failure"),
+        0, 0, false);
+    // Sanity: a subsequent performFailover would now move us off the
+    // original node, because nextProxyIndex was advanced.
+
+    // Now trigger the connection-failure path with refresh enabled.
+    // The pin MUST pull nextProxyIndex back to the original node.
+    RetryPolicy.RetryAction action = policy.shouldRetry(
+        new ConnectException("refused"), 0, 1, false);
+    assertTrue(
+        action.action == RetryPolicy.RetryAction.RetryDecision.FAILOVER_AND_RETRY,
+        "refresh-success path returns FAILOVER_AND_RETRY so the retry "
+            + "framework re-dials with the new IP");
+    p.performFailover(null);
+    assertEquals(beforeNode, p.getCurrentProxyOMNodeId(),
+        "after a successful refresh, performFailover must STAY on the "
+            + "original nodeId even though a prior shouldRetry advanced "
+            + "nextProxyIndex -- otherwise the freshly-fixed peer is "
+            + "bypassed for up to N-1 retries");
+    assertNotNull(beforeNode);
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om.ha;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
@@ -35,15 +34,6 @@ import org.junit.jupiter.api.Test;
  * the Client → OM RPC route.
  */
 public class TestOMProxyInfoDnsRefresh {
-
-  /** Force a deliberately stale cached address into the private field. */
-  private static void forceCachedAddress(OMProxyInfo<?> info,
-                                         InetSocketAddress staleAddr)
-      throws Exception {
-    Field rpcAddrField = OMProxyInfo.class.getDeclaredField("rpcAddr");
-    rpcAddrField.setAccessible(true);
-    rpcAddrField.set(info, staleAddr);
-  }
 
   /**
    * When DNS for the configured hostname now returns the same IP that
@@ -71,11 +61,9 @@ public class TestOMProxyInfoDnsRefresh {
 
   /**
    * To drive the change-detection path we construct an OMProxyInfo
-   * pointing at "localhost", then forcibly inject a deliberately stale
-   * IP via reflection (the field is private and we don't want to
-   * expand the public API surface for tests). Re-resolving "localhost"
-   * then yields the live loopback IP, the cached stale IP differs, and
-   * the swap fires.
+   * pointing at "localhost", then inject a deliberately stale IP via
+   * the test hook. Re-resolving "localhost" then yields the live
+   * loopback IP, the cached stale IP differs, and the swap fires.
    */
   @Test
   public void testRefreshSwapsAddressOnIpChange() throws Exception {
@@ -84,7 +72,7 @@ public class TestOMProxyInfoDnsRefresh {
 
     InetSocketAddress staleAddr = new InetSocketAddress(
         InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
-    forceCachedAddress(info, staleAddr);
+    info.setCachedAddressForTest(staleAddr);
 
     boolean swapped = info.refreshAddressIfChanged();
     assertTrue(swapped, "swap must fire when DNS returns a different IP "
@@ -108,7 +96,7 @@ public class TestOMProxyInfoDnsRefresh {
 
     InetSocketAddress staleAddr = new InetSocketAddress(
         InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
-    forceCachedAddress(info, staleAddr);
+    info.setCachedAddressForTest(staleAddr);
     assertTrue(info.refreshAddressIfChanged());
     assertNull(info.getProxy());
 
@@ -137,7 +125,7 @@ public class TestOMProxyInfoDnsRefresh {
         new Object(), "svc", "om1", "localhost:9862");
     InetSocketAddress staleAddr = new InetSocketAddress(
         InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
-    forceCachedAddress(info, staleAddr);
+    info.setCachedAddressForTest(staleAddr);
     // dtService was built from the original "localhost" resolution; in
     // SecurityUtil.buildTokenService form the value depends on the IP.
     // After we forced the stale IP and refresh, dtService should be

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link OMProxyInfo#refreshAddressIfChanged()} correctly
+ * detects DNS changes -- the Kubernetes pod-IP-change recovery path on
+ * the Client → OM RPC route.
+ */
+public class TestOMProxyInfoDnsRefresh {
+
+  /** Force a deliberately stale cached address into the private field. */
+  private static void forceCachedAddress(OMProxyInfo<?> info,
+                                         InetSocketAddress staleAddr)
+      throws Exception {
+    Field rpcAddrField = OMProxyInfo.class.getDeclaredField("rpcAddr");
+    rpcAddrField.setAccessible(true);
+    rpcAddrField.set(info, staleAddr);
+  }
+
+  /**
+   * When DNS for the configured hostname now returns the same IP that
+   * is already cached, refresh is a no-op. Returns false; cached
+   * address and proxy are untouched. Critically, the cached proxy must
+   * NOT be discarded -- a regression that nulled {@code proxy}
+   * unconditionally would tear down a healthy connection on every
+   * application-level failure.
+   */
+  @Test
+  public void testRefreshIsNoopWhenIpUnchanged() throws Exception {
+    Object originalProxy = new Object();
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        originalProxy, "svc", "om1", "localhost:9862");
+    InetSocketAddress before = info.getAddress();
+
+    boolean swapped = info.refreshAddressIfChanged();
+
+    assertFalse(swapped, "no swap when DNS resolves to the same IP");
+    assertSame(before, info.getAddress(),
+        "cached address must not be replaced when IP is unchanged");
+    assertSame(originalProxy, info.getProxy(),
+        "cached proxy must NOT be discarded on a no-op refresh");
+  }
+
+  /**
+   * To drive the change-detection path we construct an OMProxyInfo
+   * pointing at "localhost", then forcibly inject a deliberately stale
+   * IP via reflection (the field is private and we don't want to
+   * expand the public API surface for tests). Re-resolving "localhost"
+   * then yields the live loopback IP, the cached stale IP differs, and
+   * the swap fires.
+   */
+  @Test
+  public void testRefreshSwapsAddressOnIpChange() throws Exception {
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        /*proxy=*/ null, "svc", "om1", "localhost:9862");
+
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
+    forceCachedAddress(info, staleAddr);
+
+    boolean swapped = info.refreshAddressIfChanged();
+    assertTrue(swapped, "swap must fire when DNS returns a different IP "
+        + "than the stale 127.0.0.99 we forced into the cache");
+    assertNotEquals(staleAddr.getAddress(), info.getAddress().getAddress(),
+        "cached address must hold the freshly-resolved IP after swap");
+    assertNull(info.getProxy(),
+        "cached proxy must be discarded so the next dial uses the new IP");
+  }
+
+  /**
+   * createProxyIfNeeded rebuilds the proxy from the freshly-resolved
+   * address after a swap. The lambda asserts the parameter equals the
+   * post-refresh address -- a regression that passes a stale or null
+   * address to the factory would fire here.
+   */
+  @Test
+  public void testProxyRebuildsAfterRefreshUsesNewAddress() throws Exception {
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        new Object(), "svc", "om1", "localhost:9862");
+
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
+    forceCachedAddress(info, staleAddr);
+    assertTrue(info.refreshAddressIfChanged());
+    assertNull(info.getProxy());
+
+    InetSocketAddress expectedNewAddress = info.getAddress();
+    Object freshProxy = new Object();
+    InetSocketAddress[] dialedWith = new InetSocketAddress[1];
+    info.createProxyIfNeeded(addr -> {
+      dialedWith[0] = addr;
+      return freshProxy;
+    });
+
+    assertSame(expectedNewAddress, dialedWith[0],
+        "factory must be invoked with the freshly-resolved address, "
+            + "not the stale one or null");
+    assertSame(freshProxy, info.getProxy());
+  }
+
+  /**
+   * dtService must update alongside rpcAddr on a successful swap.
+   * Stale dtService after refresh is a fragile invariant that would
+   * silently break post-refresh authentication.
+   */
+  @Test
+  public void testRefreshUpdatesDelegationTokenService() throws Exception {
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        new Object(), "svc", "om1", "localhost:9862");
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
+    forceCachedAddress(info, staleAddr);
+    // dtService was built from the original "localhost" resolution; in
+    // SecurityUtil.buildTokenService form the value depends on the IP.
+    // After we forced the stale IP and refresh, dtService should be
+    // recomputed against the live IP. We can't easily compare exact
+    // strings (the value depends on hadoop.security.token.service.use_ip)
+    // but we can assert the field is non-null and that the address
+    // backing it matches the post-refresh address.
+    assertNotNull(info.getDelegationTokenService());
+    assertTrue(info.refreshAddressIfChanged());
+    assertNotNull(info.getDelegationTokenService(),
+        "dtService must be rebuilt after a successful swap");
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -435,42 +435,27 @@ public final class OzoneManagerRatisServer {
     }
   }
 
-  private static RaftPeer createRaftPeer(OMNodeDetails omNode) {
-    String nodeId = omNode.getNodeId();
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(nodeId);
-    InetSocketAddress ratisAddr = new InetSocketAddress(
-        omNode.getHostAddress(), omNode.getRatisPort());
-    RaftPeerRole startRole = omNode.isRatisListener() ?
-        RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER;
-
-    return RaftPeer.newBuilder()
-        .setId(raftPeerId)
-        .setAddress(ratisAddr)
-        .setStartupRole(startRole)
-        .build();
+  /**
+   * Build a RaftPeer for the given OM node. The peer address is always set
+   * as a hostname:port string (never a resolved IP). Ratis ultimately hands
+   * this string to gRPC's NettyChannelBuilder.forTarget(...), whose default
+   * DnsNameResolver re-resolves hostnames on connection failure / refresh.
+   * Baking a resolved IP into RaftPeer.address would freeze the peer at one
+   * IP for the channel's lifetime, breaking recovery from peer pod restarts
+   * in environments like Kubernetes where DNS names are stable but IPs are
+   * not. See HDDS-15514 (DNS-refresh-on-failure for all RPC paths).
+   */
+  static RaftPeer createRaftPeer(OMNodeDetails omNode) {
+    return createRaftPeer(omNode, omNode.getNodeId());
   }
 
-  /**
-   * Helper method to create a RaftPeer from OMNodeDetails, handling unresolved hosts.
-   * @param omNode the OM node details
-   * @param nodeId the node ID to use
-   * @return the created RaftPeer
-   */
-  private static RaftPeer createRaftPeer(OMNodeDetails omNode, String nodeId) {
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(nodeId);
-    RaftPeer.Builder builder = RaftPeer.newBuilder()
-        .setId(raftPeerId)
-        .setStartupRole(omNode.isRatisListener() ? RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER);
-    
-    if (omNode.isHostUnresolved()) {
-      builder.setAddress(omNode.getRatisHostPortStr());
-    } else {
-      InetSocketAddress ratisAddr = new InetSocketAddress(
-          omNode.getInetAddress(), omNode.getRatisPort());
-      builder.setAddress(ratisAddr);
-    }
-    
-    return builder.build();
+  static RaftPeer createRaftPeer(OMNodeDetails omNode, String nodeId) {
+    return RaftPeer.newBuilder()
+        .setId(RaftPeerId.valueOf(nodeId))
+        .setAddress(omNode.getRatisHostPortStr())
+        .setStartupRole(omNode.isRatisListener()
+            ? RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER)
+        .build();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -145,6 +145,37 @@ public class TestOzoneManagerRatisServer {
         "Ratis Server should be in running state");
   }
 
+  /**
+   * RaftPeer.address must always be a hostname:port string, never an
+   * IP:port string. This is what allows gRPC's DnsNameResolver to
+   * re-resolve the peer when its underlying IP changes (Kubernetes pod
+   * restart). If a resolved IP were baked in, recovery would require
+   * a full OM restart.
+   */
+  @Test
+  public void testCreateRaftPeerUsesHostnameAddress() {
+    String hostname = "om-2.om.example.svc.cluster.local";
+    int ratisPort = 9872;
+    OMNodeDetails peer = new OMNodeDetails.Builder()
+        .setOMServiceId("test-service")
+        .setOMNodeId("om2")
+        .setHostAddress(hostname)
+        .setRpcPort(9862)
+        .setRatisPort(ratisPort)
+        .build();
+
+    org.apache.ratis.protocol.RaftPeer raftPeer =
+        OzoneManagerRatisServer.createRaftPeer(peer);
+    String addr = raftPeer.getAddress();
+    assertEquals(hostname + ":" + ratisPort, addr,
+        "RaftPeer address must preserve hostname; baking a resolved IP "
+            + "would freeze the gRPC channel at one IP and break peer-pod "
+            + "IP-change recovery in Kubernetes.");
+    // Defensive: must not contain a numeric IPv4 octet in the host portion.
+    String host = addr.substring(0, addr.lastIndexOf(':'));
+    assertThat(host).doesNotMatch("^\\d{1,3}(\\.\\d{1,3}){3}$");
+  }
+
   @Test
   public void testLoadSnapshotInfoOnStart() throws Exception {
     // Stop the Ratis server and manually update the snapshotInfo.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses [HDDS-15514](https://issues.apache.org/jira/browse/HDDS-15514): Ozone DataNodes, OzoneManagers, and clients cannot recover from a peer's IP changing under a stable hostname. The cached `InetSocketAddress` is frozen for the lifetime of the process, so when an SCM/OM pod is rescheduled in Kubernetes (or any environment where pod IPs change while DNS names remain stable), every subsequent RPC dials the now-defunct IP forever. Recovery today requires a process restart or an external operator that watches pod IPs and force-restarts dependent components.

This is the same class of bug HADOOP-17068 fixed for the HDFS NameNode HA client. This PR mirrors that pattern at the `FailoverProxyProvider` / `EndpointStateMachine` layer in Ozone — one tier above where Hadoop applied the fix, because Ozone's RPC seams live there — for the four inter-component Hadoop-RPC paths, and removes the IP-baking from the two Ratis paths so gRPC's `DnsNameResolver` can re-resolve hostnames on its own.

The new behaviour is **opt-in**, default `false`, gated by `ozone.client.failover.resolve-needed`. Existing non-K8s deployments see zero behaviour change. This matches the precedent set by:
- `dfs.client.failover.resolve-needed` (HADOOP-17068 / HDFS-14118)
- `hbase.resolve.hostnames.on.failure` (HBase `ConnectionImplementation`)

## Solution overview

**The root cause is `InetSocketAddress`.** Every Ozone RPC path constructs an `InetSocketAddress` once (typically at process start) and reuses it across the lifetime of the proxy. `InetSocketAddress` performs a one-shot DNS lookup at construction and freezes the resolved IP. When the IP behind the hostname changes, no amount of retrying helps — the cached object always dials the old IP.

**The fix has two ingredients:**

1. **Preserve the original `host:port` string.** Every site that constructs an `InetSocketAddress` from a configured value now also stores the configured string. The string is the source of truth for re-resolution; the `InetSocketAddress` is a derived cache.

2. **Re-resolve and rebuild on connection-class failures.** When an RPC fails with an exception that suggests the cached IP is unreachable (`ConnectException`, `SocketTimeoutException`, `NoRouteToHostException`, `UnknownHostException`, `EOFException`, `SocketException`), the failover layer re-resolves the preserved hostname. If DNS now returns a different IP, the cached `InetSocketAddress` is replaced atomically and the underlying RPC proxy is rebuilt against the new IP.

The Ratis paths get a different fix: instead of refresh-on-failure, they pass hostname strings (not resolved `InetSocketAddress` instances) to `RaftPeer.setAddress`. Ratis hands these strings to gRPC, whose default `NameResolver` re-resolves on its own schedule.

## Per-path mechanism

| Path | Mechanism |
|---|---|
| **DN → SCM heartbeat** | `EndpointStateMachine` preserves a `hostAndPort` string. After a connection-class `IOException` from `sendHeartbeat`, if the DN's missed-heartbeat counter has reached `ozone.datanode.scm.heartbeat.address.refresh.threshold` (default 3), `HeartbeatEndpointTask` asks `SCMConnectionManager.refreshSCMServer` to re-resolve. On a successful swap, the connection manager builds a fresh `EndpointStateMachine` bound to the new IP **before** removing the stale entry (atomic-replace pattern), commits the swap under the write lock, releases the lock, and closes the stale endpoint outside the lock. `StateContext.migrateEndpoint` then re-keys the per-endpoint queues (incremental reports, container actions, pipeline actions) so in-flight reports survive the swap. |
| **OM → SCM** | `SCMProxyInfo` retains the config-time `host:port`. `SCMFailoverProxyProviderBase.refreshProxyAddressIfChanged(nodeId)` runs in `shouldRetry` when the exception chain contains a connection-class type. The DNS lookup happens **outside** the provider monitor; the swap is committed under the lock with a re-check that defends against lost updates. The stale proxy is stopped via `RPC.stopProxy` outside the lock. |
| **Client → OM (Hadoop RPC)** | `OMProxyInfo.refreshAddressIfChanged()` re-resolves outside the entry monitor, swaps `rpcAddr` / `dtService` / `proxy=null` atomically inside, and stops the stale proxy outside. `OMFailoverProxyProviderBase.shouldRetry` invokes the refresh on connection-class exceptions; on successful refresh, it pins `nextProxyIndex` to the current node so `RetryInvocationHandler.performFailover()` does NOT advance the failover ring past the just-refreshed peer. |
| **Client → OM (gRPC)** | No code change. `GrpcOMFailoverProxyProvider` passes a placeholder `InetSocketAddress(0)` and lets gRPC's `NameResolver` re-resolve hostnames on its own schedule. |
| **OM ↔ OM control plane** | Uses Hadoop RPC via `OMInterServiceProtocol`. Recovers transitively via the Client → OM machinery above. |
| **OM ↔ OM Ratis replication** | `OzoneManagerRatisServer.createRaftPeer` always passes `omNode.getRatisHostPortStr()` (a hostname string) to `RaftPeer.setAddress` — never a resolved IP. Two of three pre-PR `createRaftPeer` branches called `new InetSocketAddress(omNode.getInetAddress(), ratisPort)`, which baked the resolved IP into Ratis's peer state. With hostname-only addresses, gRPC's default `DnsNameResolver` (used by Ratis under the hood) re-resolves on connection failure. **No Ratis upstream change required.** |
| **SCM ↔ SCM Ratis replication** | Already used hostname strings; PR removes a misleading `// TODO : Should we use IP instead of hostname??` comment in `SCMRatisServerImpl.buildRaftGroup` and `SCMHAManagerImpl` and replaces with explanatory comments. |

### Connection-class exception filter

Re-resolution is gated on exception types where DNS could plausibly help, classified by `org.apache.hadoop.hdds.utils.ConnectionFailureUtils.isConnectionFailure`:

- `java.net.ConnectException` — connection refused / unreachable (OpenStack fast-RST)
- `java.net.SocketTimeoutException` — silent packet drop (the dominant failure shape on AWS EC2 / EKS)
- `java.net.NoRouteToHostException` — host route gone
- `java.net.UnknownHostException` — DNS lookup failed downstream
- `java.io.EOFException` — load balancer or iptables RST closed the connection cleanly
- `java.net.SocketException` — RST mid-stream

The classifier walks the cause chain bounded to depth 16 to defend against pathological cycles. Application-level errors (`OMException`, `OMNotLeaderException`, `AccessControlException`, `RetryAction`-coded responses) are explicitly excluded so DNS load is not amplified by logical failures.

## Design choices and rationale

### Atomic-replace pattern at every swap site

Every refresh path follows the same ordering: **build the new resource → atomically install it → close the old resource**. Never remove-then-build (a build failure would leave the registry empty for that key). Never close-then-build (a build failure would leave the system with neither old nor new resource). The pattern is visible in:

- `SCMConnectionManager.refreshSCMServer`: build replacement endpoint before swapping `scmMachines`.
- `OMProxyInfo.refreshAddressIfChanged`: capture stale proxy reference, swap fields under monitor, call `RPC.stopProxy(stale)` outside the monitor.
- `SCMFailoverProxyProviderBase.refreshProxyAddressIfChanged`: build new `SCMProxyInfo` outside lock, re-check under lock, swap, stop stale outside lock.

### No I/O inside critical sections

DNS lookups, RPC proxy construction, and proxy teardown are all blocking. None happen inside `synchronized` monitors or `writeLock()` regions in the new code. `SCMConnectionManager.refreshSCMServer` is split into 4 phases:

1. Read lock: snapshot the endpoint reference and preserved `hostAndPort`.
2. No lock: DNS lookup via `resolveLatestAddress()`.
3. Write lock: re-check the snapshot is current (defends against concurrent removeSCMServer/refresh races), enforce collision invariant, build replacement, commit swap.
4. No lock: close stale endpoint.

This pattern prevents a slow / dead resolver from stalling unrelated heartbeats and reconfiguration paths.

### Failover ring pinning after refresh-success

When the failover provider successfully refreshes the current peer's IP, `shouldRetry` returns `FAILOVER_AND_RETRY` but explicitly pins `nextProxyIndex` (OM) / `updatedLeaderNodeID` (SCM) to the current peer. Without this, the surrounding `RetryInvocationHandler.performFailover` would walk to the next peer in the ring, bypassing the just-fixed peer for up to N-1 attempts in an N-peer HA cluster.

### Endpoint queue migration preserves the "endpoint ⇒ queue" invariant

`StateContext.migrateEndpoint` re-keys per-endpoint queues (incremental reports, container actions, pipeline actions, full-report flags) when an endpoint is swapped. The migration ordering preserves the invariant that every endpoint in the `endpoints` set has a corresponding queue at every observable point:

1. **PUBLISH**: install new-key queues alongside the old-key queues.
2. **SWITCH**: add `newEndpoint` to the endpoints set; remove `oldEndpoint` from the endpoints set.
3. **RETIRE**: drop the old-key queues (no producer can reach them after step 2).

Without this ordering, a producer iterating the `endpoints` set could see the old endpoint key, look up its queue, find it removed, and silently drop the report. `endpoints` is now a `CopyOnWriteArraySet` (was `HashSet`); `incrementalReportsQueue`, `containerActions`, `pipelineActions`, and `isFullReportReadyToBeSent` are now `ConcurrentHashMap` (or already were). Producers also null-skip queue lookups as defense-in-depth.

### Collision handling

If the freshly-resolved IP collides with another already-registered SCM peer key (e.g., transient kube-dns returning peer-B's IP for peer-A's hostname), `refreshSCMServer` refuses the swap rather than overwriting the colliding peer. The stale endpoint stays registered and the next heartbeat retries DNS.

### Secure-cluster prerequisite

When `ozone.client.failover.resolve-needed=true` is enabled on a Kerberos-secured cluster, operators MUST also set `hadoop.security.token.service.use_ip=false` in `core-site.xml`. The Hadoop delegation-token service identifier defaults to an `IP:port` string; after a refresh, the per-OM service identifier built from the new IP no longer matches the IP-based service captured on long-lived tokens, and token selection silently fails for the refreshed peer. With `use_ip=false` the service identifier is the stable `hostname:port`, which survives any IP change. This is the same prerequisite HADOOP-17068 carries. Documented inline in `ozone-default.xml` on the `ozone.client.failover.resolve-needed` entry.

## How was this patch tested?

86 tests across the touched modules, all passing under `mvn clean test`:

| Test class | Count | Coverage |
|---|---|---|
| `TestConnectionFailureUtils` (new) | 20 | Filter classification: bare + `IOException`-wrapped, deeply nested chains (3 levels), application-level negative cases, length-2 cause-chain cycles, 1024-deep non-matching chains (cost bound). |
| `TestOMFailoverProxyProviderRefreshWired` (new) | 5 | Wired retry path. `SocketTimeoutException` triggers `maybeRefreshCurrentOmAddress` (the EC2 silent-drop case end-to-end, not just helper-in-isolation). `ConnectException` triggers refresh. `OMException` does NOT. Flag-off does NOT. After a successful refresh, `performFailover` stays on the same `nodeId`. |
| `TestHeartbeatEndpointTaskDnsRefresh` (new) | 6 | Production trigger chain. `HeartbeatEndpointTask.call()` catch block fires `refreshSCMServer` only when (a) flag enabled, (b) threshold met, (c) cause is connection-class, (d) `host:port` preserved. `AccessControlException` at threshold does NOT trigger. After a successful swap, `StateContext`'s incremental-reports map has the new key and not the old key. |
| `TestSCMConnectionManagerDnsRefreshE2E` (new) | 1 | Real-RPC swap mechanism with `@Timeout(30)`. Stands up a real `ScmTestMock` RPC server, primes the connection manager with a stale `127.0.0.99` cache + preserved hostname, calls `refreshSCMServer`, asserts a real `sendHeartbeat` round-trips through the swapped endpoint. |
| `TestOMProxyInfoDnsRefresh` (new, expanded) | 4 | Per-instance refresh: no-op preserves the cached proxy, swap on IP change, rebuilt proxy is dialed with the freshly-resolved address (not a sentinel), `dtService` updates. |
| `TestSCMFailoverProxyProviderRefresh` (new) | 3 | SCM swap mechanism: swap on IP change, no-op when unchanged, no-op without preserved `host:port`. |
| `TestSCMConnectionManager` (extended) | 7 (1 prior + 6 new) | `resolveLatestAddress` edge cases. `refreshSCMServer` happy-path swap. No-op when `host:port` not preserved. Rollback regression: when `buildScmEndpoint` throws, the stale endpoint remains registered (uses a `@VisibleForTesting` overridable hook to inject the failure). |
| `TestOzoneManagerRatisServer` (extended) | 6 (5 prior + 1 new) | `RaftPeer.getAddress()` is a `hostname:port` string, never an IP-format string. |

Existing regression suites verified non-regressed: `TestEndPoint` (17), `TestOMFailoverProxyProvider` (8), `TestOMFailovers` (1), `TestHeartbeatEndpointTask` (8).

## Scope and known limitations

- **DN initial bringup with stale DNS**: the refresh fires from the `HEARTBEAT` phase via `HeartbeatEndpointTask`. If a DataNode starts up with the SCM peer already at a stale IP and never reaches `HEARTBEAT`, the recovery path does not engage. Initial-bringup DNS staleness is the existing concern of [HDDS-5919](https://issues.apache.org/jira/browse/HDDS-5919)'s `ozone.network.jvm.address.cache.enabled=false`. `InitDatanodeState.java` already postpones initialization on initial-resolution failure.
- **HDFS-14118-style construction-time DNS fan-out** (one hostname → multiple persistent IPs, for round-robin DNS HA) is a different problem and out of scope. Worth a follow-on JIRA if needed.
- **Ratis quorum-loss exit-0** in `SCMStateMachine.close()` (calls `ExitUtils.terminate(0, ...)` when leader election fails to converge, leading to Kubernetes CrashLoopBackOff death spirals) is a separate concern worth its own JIRA.
- **Reverse-DNS edge case**: when `ozone.om.address` is configured as an IP literal (rather than a hostname), `NodeDetails.getRatisHostPortStr()` chains through `getHostName()` which can trigger PTR lookup on some JDKs. Operators are expected to configure SCM/OM addresses as DNS names in K8s deployments where this PR's behaviour is enabled.
- **Operator-facing markdown documentation** for the new flags lives only in `ozone-default.xml`. Worth a separate docs PR.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15514

## References

- [HADOOP-17068](https://issues.apache.org/jira/browse/HADOOP-17068): client fails forever when namenode ipaddr changed (Hadoop 3.4.0). The model for this PR.
- [HDFS-14118](https://issues.apache.org/jira/browse/HDFS-14118): introduces `dfs.client.failover.resolve-needed` and the `AbstractNNFailoverProxyProvider.getResolvedAddressesIfNecessary` hook.
- HBase: `hbase.resolve.hostnames.on.failure` (`ConnectionImplementation.RESOLVE_HOSTNAME_ON_FAIL_KEY`).
- ZOOKEEPER-1506, ZOOKEEPER-2982: ZK `StaticHostProvider` re-resolves on each `next()` call.
- [HDDS-5919](https://issues.apache.org/jira/browse/HDDS-5919): introduces `ozone.network.jvm.address.cache.enabled` (default `true`). JVM-level DNS cache TTL — necessary but not sufficient for the long-lived `InetSocketAddress` problem this PR fixes.
