### PR TITLE
HDDS-15518. Selective checks: skip acceptance for test-utils changes

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -187,6 +187,28 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=false
 }
 
+@test "mini-cluster" {
+  run dev-support/ci/selective_ci_checks.sh f0388a195411e68aac360de8ab95735b2eb295de
+
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compile=true
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-integration-tests=true
+  assert_output -p needs-kubernetes-tests=false
+}
+
+@test "test-utils" {
+  run dev-support/ci/selective_ci_checks.sh 60e4ab121853c182e1272b04fd1a93d55b12cfc7
+
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compile=true
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-integration-tests=true
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "native only" {
   run dev-support/ci/selective_ci_checks.sh 5b1319a8c2
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -260,6 +260,7 @@ function get_count_doc_files() {
 function get_count_integration_files() {
     start_end::group_start "Count integration test files"
     local pattern_array=(
+        "^hadoop-hdds/test-utils"
         "^hadoop-ozone/dev-support/checks/_mvn_unit_report.sh"
         "^hadoop-ozone/dev-support/checks/integration.sh"
         "^hadoop-ozone/dev-support/checks/junit.sh"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes in `hdds-test-utils` only affect JUnit tests, acceptance/kubernetes checks can be skipped.

https://issues.apache.org/jira/browse/HDDS-15518

## How was this patch tested?

Added test case.

https://github.com/adoroszlai/ozone/actions/runs/27255109861/job/80487643970