### PR TITLE
HDDS-13803. Client aware tracing

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
@@ -79,8 +79,26 @@ public class TracingConfig extends ReconfigurableConfig {
   )
   private String spanSampling;
 
+  @Config(
+      key = "ozone.tracing.client.application-aware",
+      defaultValue = "true",
+      type = ConfigType.BOOLEAN,
+      reconfigurable = true,
+      tags = { ConfigTag.OZONE, ConfigTag.HDDS },
+      description = "When true, the Ozone client continues an application's "
+          + "existing OpenTelemetry trace as a child span using the "
+          + "application's globally-registered tracer, even if "
+          + "ozone.tracing.enabled is false. If no application trace is "
+          + "active, the client does not start a new trace."
+  )
+  private boolean clientApplicationAware;
+
   public boolean isTracingEnabled() {
     return tracingEnabled;
+  }
+
+  public boolean isClientApplicationAware() {
+    return clientApplicationAware;
   }
 
   @PostConstruct

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingConfig.java
@@ -50,6 +50,18 @@ public class TracingConfig extends ReconfigurableConfig {
   private boolean tracingEnabled;
 
   @Config(
+      key = "ozone.tracing.client.application-aware",
+      defaultValue = "true",
+      type = ConfigType.BOOLEAN,
+      reconfigurable = true,
+      tags = { ConfigTag.OZONE, ConfigTag.HDDS },
+      description = "Only effective when ozone.tracing.enabled=false. When true, Ozone will "
+          + "continue an application-supplied trace (via GlobalOpenTelemetry or a wire-propagated "
+          + "context) as child spans, but will NOT start a new root trace on its own."
+  )
+  private boolean applicationAware = true;
+
+  @Config(
       key = "ozone.tracing.endpoint",
       defaultValue = "",
       type = ConfigType.STRING,
@@ -79,26 +91,12 @@ public class TracingConfig extends ReconfigurableConfig {
   )
   private String spanSampling;
 
-  @Config(
-      key = "ozone.tracing.client.application-aware",
-      defaultValue = "true",
-      type = ConfigType.BOOLEAN,
-      reconfigurable = true,
-      tags = { ConfigTag.OZONE, ConfigTag.HDDS },
-      description = "When true, the Ozone client continues an application's "
-          + "existing OpenTelemetry trace as a child span using the "
-          + "application's globally-registered tracer, even if "
-          + "ozone.tracing.enabled is false. If no application trace is "
-          + "active, the client does not start a new trace."
-  )
-  private boolean clientApplicationAware;
-
   public boolean isTracingEnabled() {
     return tracingEnabled;
   }
 
-  public boolean isClientApplicationAware() {
-    return clientApplicationAware;
+  public boolean isApplicationAware() {
+    return applicationAware;
   }
 
   @PostConstruct

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.tracing;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -26,12 +27,14 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
@@ -50,12 +53,14 @@ import org.slf4j.LoggerFactory;
  */
 public final class TracingUtil {
   private static final Logger LOG = LoggerFactory.getLogger(TracingUtil.class);
-  private static final String NULL_SPAN_AS_STRING = "";
 
   private static volatile boolean isInit = false;
+  private static volatile boolean tracingEnabled;
+  private static volatile boolean applicationAware;
   private static Tracer tracer = OpenTelemetry.noop().getTracer("noop");
   private static volatile SdkTracerProvider sdkTracerProvider;
   private static BatchSpanProcessor batchSpanProcessor;
+  public static final String GLOBAL_TRACER_NAME = "ozone";
 
   private TracingUtil() {
   }
@@ -65,14 +70,20 @@ public final class TracingUtil {
    */
   public static synchronized void initTracing(
       String serviceName, TracingConfig tracingConfig) {
-    if (!tracingConfig.isTracingEnabled() || isInit) {
+    initTracing(serviceName, tracingConfig, false);
+  }
+
+  private static synchronized void initTracing(
+      String serviceName, TracingConfig tracingConfig, boolean preferOzone) {
+    if (isInit) {
       return;
     }
 
     try {
-      initialize(serviceName, tracingConfig);
+      initialize(serviceName, tracingConfig, preferOzone);
       isInit = true;
-      LOG.info("Initialized tracing service: {}", serviceName);
+      LOG.info("Initialized tracing service: {} (enabled={}, applicationAware={})",
+          serviceName, tracingEnabled, applicationAware);
     } catch (Exception e) {
       LOG.error("Failed to initialize tracing", e);
     }
@@ -94,7 +105,7 @@ public final class TracingUtil {
   public static synchronized void reconfigureTracing(
       String serviceName, TracingConfig tracingConfig) {
     shutdownTracing();
-    initTracing(serviceName, tracingConfig);
+    initTracing(serviceName, tracingConfig, true);
   }
 
   /**
@@ -129,23 +140,90 @@ public final class TracingUtil {
     }
   }
 
-  private static void shutdownTracing() {
-    if (sdkTracerProvider == null) {
-      return;
-    }
+  static void shutdownTracing() {
     try {
-      sdkTracerProvider.shutdown().join(10L, TimeUnit.SECONDS);
+      if (sdkTracerProvider != null) {
+        sdkTracerProvider.shutdown().join(10L, TimeUnit.SECONDS);
+      }
     } catch (Exception e) {
       LOG.warn("Tracing shutdown failed", e);
     } finally {
       sdkTracerProvider = null;
       batchSpanProcessor = null;
       tracer = OpenTelemetry.noop().getTracer("noop");
+      tracingEnabled = false;
+      applicationAware = false;
       isInit = false;
     }
   }
 
-  private static void initialize(String serviceName, TracingConfig tracingConfig) {
+  private static void initialize(String serviceName, TracingConfig cfg, boolean preferOzone) {
+    tracingEnabled = cfg.isTracingEnabled();
+    applicationAware = cfg.isApplicationAware();
+
+    if (!tracingEnabled && !applicationAware) {
+      tracer = OpenTelemetry.noop().getTracer(GLOBAL_TRACER_NAME);
+      return;
+    }
+
+    // Server reconfiguration reprioritizes Ozone's SDK over any adopted global,
+    // and re-registers the global name and tracer.
+    if (preferOzone && tracingEnabled) {
+      initOzoneSdk(serviceName, cfg, true);
+      return;
+    }
+
+    // Global first: adopt an application-registered GlobalOpenTelemetry when present.
+    if (GlobalOpenTelemetry.isSet() && isRealGlobal(GlobalOpenTelemetry.get())) {
+      tracer = GlobalOpenTelemetry.get().getTracer(GLOBAL_TRACER_NAME);
+      LOG.info("Tracing: adopted application GlobalOpenTelemetry");
+      return;
+    }
+
+    initOzoneSdk(serviceName, cfg, tracingEnabled);
+  }
+
+  private static void initOzoneSdk(String serviceName, TracingConfig cfg, boolean registerGlobal) {
+    SdkTracerProvider tracerProvider = buildSdkTracerProvider(serviceName, cfg);
+    try {
+      OpenTelemetrySdk sdk;
+      if (registerGlobal) {
+        sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+            .build();
+        // GlobalOpenTelemetry.set is one-shot
+        GlobalOpenTelemetry.resetForTest();
+        GlobalOpenTelemetry.set(sdk);
+        tracer = GlobalOpenTelemetry.get().getTracer(GLOBAL_TRACER_NAME);
+      } else {
+        sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build();
+        tracer = sdk.getTracer(GLOBAL_TRACER_NAME);
+      }
+      sdkTracerProvider = tracerProvider;
+    } catch (RuntimeException e) {
+      tracerProvider.shutdown();
+      batchSpanProcessor = null;
+      throw e;
+    }
+  }
+
+  /**
+   * Distinguish an application-registered GlobalOpenTelemetry from the OTel built-in noop.
+   * OpenTelemetry.noop() returns a singleton, so identity comparison is sufficient.
+   */
+  private static boolean isRealGlobal(OpenTelemetry global) {
+    return global != null && global != OpenTelemetry.noop();
+  }
+
+  /**
+   * Build the SdkTracerProvider using the configured OTLP endpoint and sampler.
+   * Extracted so both enabled and application-aware modes share exporter/sampler setup.
+   */
+  private static SdkTracerProvider buildSdkTracerProvider(
+      String serviceName, TracingConfig tracingConfig) {
     //Fetch and log the right tracing parameters based on config, environment variable and default value priority.
     String otelEndPoint = tracingConfig.getTracingEndpoint();
     double samplerRatio = tracingConfig.getTraceSamplerRatio();
@@ -156,7 +234,7 @@ public final class TracingUtil {
     Map<String, LoopSampler> spanMap = parseSpanSamplingConfig(spanSamplingConfig);
 
     Resource resource = Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), serviceName));
-    OtlpGrpcSpanExporter spanExporter = OtlpGrpcSpanExporter.builder()
+    SpanExporter spanExporter = OtlpGrpcSpanExporter.builder()
         .setEndpoint(otelEndPoint)
         .build();
 
@@ -172,23 +250,15 @@ public final class TracingUtil {
       sampler = new SpanSampler(rootSampler, spanMap);
     }
 
-    SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+    return SdkTracerProvider.builder()
         .addSpanProcessor(batchSpanProcessor)
         .setResource(resource)
         .setSampler(sampler)
         .build();
+  }
 
-    try {
-      OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-          .setTracerProvider(tracerProvider)
-          .build();
-      tracer = openTelemetry.getTracer(serviceName);
-      sdkTracerProvider = tracerProvider;
-    } catch (RuntimeException e) {
-      tracerProvider.shutdown();
-      batchSpanProcessor = null;
-      throw e;
-    }
+  private static boolean canStartSpanWithoutParent() {
+    return tracingEnabled;
   }
 
   /**
@@ -197,11 +267,6 @@ public final class TracingUtil {
    * @return encoded tracing context.
    */
   public static String exportCurrentSpan() {
-    Span currentSpan = Span.current();
-    if (!currentSpan.getSpanContext().isValid()) {
-      return NULL_SPAN_AS_STRING;
-    }
-
     StringBuilder builder = new StringBuilder();
     W3CTraceContextPropagator propagator = W3CTraceContextPropagator.getInstance();
     propagator.inject(Context.current(), builder,
@@ -218,11 +283,21 @@ public final class TracingUtil {
    */
   public static Span importAndCreateSpan(String name, String encodedParent) {
     if (encodedParent == null || encodedParent.isEmpty()) {
+      if (!canStartSpanWithoutParent()) {
+        return Span.getInvalid();
+      }
       return tracer.spanBuilder(name).setNoParent().startSpan();
     }
 
     W3CTraceContextPropagator propagator = W3CTraceContextPropagator.getInstance();
     Context extract = propagator.extract(Context.current(), encodedParent, new TextExtractor());
+    Span extractedParent = Span.fromContext(extract);
+    if (!extractedParent.getSpanContext().isValid()) {
+      if (!canStartSpanWithoutParent()) {
+        return Span.getInvalid();
+      }
+      return tracer.spanBuilder(name).setNoParent().startSpan();
+    }
     return tracer.spanBuilder(name)
         .setParent(extract)
         .startSpan();
@@ -241,7 +316,7 @@ public final class TracingUtil {
    */
   public static <T> T createProxy(
       T delegate, Class<T> itf, ConfigurationSource conf) {
-    if (!isTracingEnabled(conf)) {
+    if (!isTracingActive(conf)) {
       return delegate;
     }
     Class<?> aClass = delegate.getClass();
@@ -252,6 +327,11 @@ public final class TracingUtil {
 
   public static boolean isTracingEnabled(ConfigurationSource conf) {
     return conf.getObject(TracingConfig.class).isTracingEnabled();
+  }
+
+  public static boolean isTracingActive(ConfigurationSource conf) {
+    TracingConfig tc = conf.getObject(TracingConfig.class);
+    return tc.isTracingEnabled() || tc.isApplicationAware();
   }
 
   /**
@@ -419,7 +499,8 @@ public final class TracingUtil {
 
   /**
    * Creates a new span, using the current context as a parent if valid;
-   * otherwise, creates a root span.
+   * Otherwise starts a root span only when {@code ozone.tracing.enabled=true};
+   * if not, returns an invalid span so application-aware mode never starts a new trace.
    */
   private static Span buildSpan(String spanName) {
     Context currentContext = Context.current();
@@ -427,9 +508,11 @@ public final class TracingUtil {
 
     if (parentSpan.getSpanContext().isValid()) {
       return tracer.spanBuilder(spanName).setParent(currentContext).startSpan();
-    } else {
-      return tracer.spanBuilder(spanName).setNoParent().startSpan();
     }
+    if (!canStartSpanWithoutParent()) {
+      return Span.getInvalid();
+    }
+    return tracer.spanBuilder(spanName).setNoParent().startSpan();
   }
 
   /**
@@ -451,7 +534,7 @@ public final class TracingUtil {
 
   public static TraceCloseable createActivatedSpanFromW3cHttpHeaders(
       String spanName, Function<String, String> getHeader, ConfigurationSource conf) {
-    if (conf == null || !isTracingEnabled(conf)) {
+    if (conf == null || !isTracingActive(conf)) {
       return () -> { };
     }
 
@@ -459,6 +542,9 @@ public final class TracingUtil {
         .extract(Context.current(), getHeader, new HttpHeaderGetter());
 
     if (!Span.fromContext(remote).getSpanContext().isValid()) {
+      if (!canStartSpanWithoutParent()) {
+        return () -> { };
+      }
       return createActivatedSpan(spanName);
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -195,9 +195,9 @@ public final class TracingUtil {
             .setTracerProvider(tracerProvider)
             .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
             .build();
-        // GlobalOpenTelemetry.set is one-shot
-        GlobalOpenTelemetry.resetForTest();
-        GlobalOpenTelemetry.set(sdk);
+        if (!GlobalOpenTelemetry.isSet() || !isRealGlobal(GlobalOpenTelemetry.get())) {
+          GlobalOpenTelemetry.set(sdk);
+        }
         tracer = GlobalOpenTelemetry.get().getTracer(GLOBAL_TRACER_NAME);
       } else {
         sdk = OpenTelemetrySdk.builder()
@@ -579,7 +579,7 @@ public final class TracingUtil {
 
   public static TraceCloseable createActivatedSpanFromW3cHttpHeaders(
       String spanName, Function<String, String> getHeader, ConfigurationSource conf) {
-    if (conf == null || !isTracingActive(conf) || !hasUsableTracer()) {
+    if (conf == null || !isTracingActive(conf)) {
       return () -> { };
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class TracingUtil {
   private static final Logger LOG = LoggerFactory.getLogger(TracingUtil.class);
+  private static final String NULL_SPAN_AS_STRING = "";
 
   private static volatile boolean isInit = false;
   private static volatile boolean tracingEnabled;
@@ -74,13 +75,13 @@ public final class TracingUtil {
   }
 
   private static synchronized void initTracing(
-      String serviceName, TracingConfig tracingConfig, boolean preferOzone) {
+      String serviceName, TracingConfig tracingConfig, boolean isReconfig) {
     if (isInit) {
       return;
     }
 
     try {
-      initialize(serviceName, tracingConfig, preferOzone);
+      initialize(serviceName, tracingConfig, isReconfig);
       isInit = true;
       LOG.info("Initialized tracing service: {} (enabled={}, applicationAware={})",
           serviceName, tracingEnabled, applicationAware);
@@ -157,7 +158,7 @@ public final class TracingUtil {
     }
   }
 
-  private static void initialize(String serviceName, TracingConfig cfg, boolean preferOzone) {
+  private static void initialize(String serviceName, TracingConfig cfg, boolean isReconfig) {
     tracingEnabled = cfg.isTracingEnabled();
     applicationAware = cfg.isApplicationAware();
 
@@ -168,7 +169,7 @@ public final class TracingUtil {
 
     // Server reconfiguration reprioritizes Ozone's SDK over any adopted global,
     // and re-registers the global name and tracer.
-    if (preferOzone && tracingEnabled) {
+    if (isReconfig && tracingEnabled) {
       initOzoneSdk(serviceName, cfg, true);
       return;
     }
@@ -180,7 +181,9 @@ public final class TracingUtil {
       return;
     }
 
-    initOzoneSdk(serviceName, cfg, tracingEnabled);
+    // No app-supplied global — build Ozone's SDK and always register it as the JVM global,
+    // so any co-resident library observes the same tracer whenever tracing is valid.
+    initOzoneSdk(serviceName, cfg, true);
   }
 
   private static void initOzoneSdk(String serviceName, TracingConfig cfg, boolean registerGlobal) {
@@ -263,10 +266,17 @@ public final class TracingUtil {
 
   /**
    * Export the active tracing span as a string.
+   * When tracing is disabled, not initialized, or no valid span is in scope,
+   * {@link Span#current()} returns an invalid span; there is nothing to encode and this
+   * method returns an empty string. Callers must accept that as "no context to propagate".
    *
-   * @return encoded tracing context.
+   * @return encoded W3C trace context, or empty string if there is no valid active span.
    */
   public static String exportCurrentSpan() {
+    Span currentSpan = Span.current();
+    if (!currentSpan.getSpanContext().isValid()) {
+      return NULL_SPAN_AS_STRING;
+    }
     StringBuilder builder = new StringBuilder();
     W3CTraceContextPropagator propagator = W3CTraceContextPropagator.getInstance();
     propagator.inject(Context.current(), builder,
@@ -276,12 +286,19 @@ public final class TracingUtil {
 
   /**
    * Create a new scope and use the imported span as the parent.
+   * Short-circuits to an invalid span when there is no usable tracer:
+   *   - tracing was never initialized (tracer is still the noop), or
+   *   - application-aware mode is on but no app-supplied SDK was adopted (sdkTracerProvider == null
+   *     and the current tracer is the noop).
    *
    * @param name          name of the newly created scope
    * @param encodedParent Encoded parent span (could be null or empty)
    * @return Tracing scope.
    */
   public static Span importAndCreateSpan(String name, String encodedParent) {
+    if (!hasUsableTracer()) {
+      return Span.getInvalid();
+    }
     if (encodedParent == null || encodedParent.isEmpty()) {
       if (!canStartSpanWithoutParent()) {
         return Span.getInvalid();
@@ -291,16 +308,20 @@ public final class TracingUtil {
 
     W3CTraceContextPropagator propagator = W3CTraceContextPropagator.getInstance();
     Context extract = propagator.extract(Context.current(), encodedParent, new TextExtractor());
-    Span extractedParent = Span.fromContext(extract);
-    if (!extractedParent.getSpanContext().isValid()) {
-      if (!canStartSpanWithoutParent()) {
-        return Span.getInvalid();
-      }
-      return tracer.spanBuilder(name).setNoParent().startSpan();
-    }
     return tracer.spanBuilder(name)
         .setParent(extract)
         .startSpan();
+  }
+
+  /**
+   * True when the current tracer can actually build spans — an Ozone-owned SDK is configured,
+   * or an adopted GlobalOpenTelemetry provides a non-noop tracer.
+   */
+  private static boolean hasUsableTracer() {
+    if (sdkTracerProvider != null) {
+      return true;
+    }
+    return GlobalOpenTelemetry.isSet() && isRealGlobal(GlobalOpenTelemetry.get());
   }
 
   /**
@@ -329,9 +350,18 @@ public final class TracingUtil {
     return conf.getObject(TracingConfig.class).isTracingEnabled();
   }
 
+  /**
+   * Returns true when tracing may actually produce spans:
+   *   - fully enabled (ozone.tracing.enabled=true), or
+   *   - application-aware AND an SDK is configured (either Ozone-owned or an adopted global);
+   *     without an SDK, application-aware is a passthrough that would emit noop spans anyway.
+   */
   public static boolean isTracingActive(ConfigurationSource conf) {
     TracingConfig tc = conf.getObject(TracingConfig.class);
-    return tc.isTracingEnabled() || tc.isApplicationAware();
+    if (tc.isTracingEnabled()) {
+      return true;
+    }
+    return tc.isApplicationAware() && hasUsableTracer();
   }
 
   /**
@@ -534,7 +564,7 @@ public final class TracingUtil {
 
   public static TraceCloseable createActivatedSpanFromW3cHttpHeaders(
       String spanName, Function<String, String> getHeader, ConfigurationSource conf) {
-    if (conf == null || !isTracingActive(conf)) {
+    if (conf == null || !isTracingActive(conf) || !hasUsableTracer()) {
       return () -> { };
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -222,6 +222,21 @@ public final class TracingUtil {
   }
 
   /**
+   * Whether to wrap the delegate in a JDK tracing proxy.
+   * Fully enabled: always wrap. App-aware: wrap only when parent span is valid
+   */
+  private static boolean shouldCreateTracingProxy(ConfigurationSource conf) {
+    TracingConfig tc = conf.getObject(TracingConfig.class);
+    if (tc.isTracingEnabled()) {
+      return true;
+    }
+    if (!tc.isApplicationAware() || !hasUsableTracer()) {
+      return false;
+    }
+    return Span.current().getSpanContext().isValid();
+  }
+
+  /**
    * Build the SdkTracerProvider using the configured OTLP endpoint and sampler.
    * Extracted so both enabled and application-aware modes share exporter/sampler setup.
    */
@@ -337,7 +352,7 @@ public final class TracingUtil {
    */
   public static <T> T createProxy(
       T delegate, Class<T> itf, ConfigurationSource conf) {
-    if (!isTracingActive(conf)) {
+    if (!shouldCreateTracingProxy(conf)) {
       return delegate;
     }
     Class<?> aClass = delegate.getClass();

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for application-aware and incoming-only tracing init modes.
+ * Tests for application-aware and ozone tracing init modes.
  */
 public class TestTracingInitModes {
 
@@ -132,7 +132,7 @@ public class TestTracingInitModes {
   }
 
   @Test
-  public void testServiceIncomingOnlyVsOzoneRoots() throws Exception {
+  public void testServiceApplicationAwarePassThroughVsOzoneRoots() throws Exception {
     TracingUtil.initServiceTracing("parent-export", tracingConfig(true, false));
     String parentCarrier;
     try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("parent")) {
@@ -145,16 +145,16 @@ public class TestTracingInitModes {
 
     TracingUtil.initServiceTracing("scm", tracingConfig(false, true));
     assertThat(TracingUtil.shouldInstallTraceProxy(conf(false, true)))
-        .as("server incoming-only alone must not wrap client RPC proxies")
+        .as("server APPLICATION pass-through alone must not wrap client RPC proxies")
         .isFalse();
 
     assertThat(TracingUtil.importAndCreateSpan("server-op", "").getSpanContext().isValid())
-        .as("incoming-only must not start root spans without client trace context")
+        .as("APPLICATION mode must not start root spans without client trace context")
         .isFalse();
 
     Span child = TracingUtil.importAndCreateSpan("server-op", parentCarrier);
     assertThat(child.getSpanContext().isValid())
-        .as("incoming-only should create a child span from W3C carrier")
+        .as("APPLICATION mode should create a child span from W3C carrier")
         .isTrue();
     try (Scope ignored = child.makeCurrent()) {
       assertThat(Span.current().getSpanContext().isValid())
@@ -179,7 +179,7 @@ public class TestTracingInitModes {
   }
 
   @Test
-  public void testReconfigureSwitchesToIncomingOnly() throws Exception {
+  public void testReconfigureSwitchesToApplicationPassThrough() throws Exception {
     TracingUtil.initServiceTracing("om", tracingConfig(true, true));
     Span root = TracingUtil.importAndCreateSpan("before", null);
     assertThat(root.getSpanContext().isValid())
@@ -191,7 +191,7 @@ public class TestTracingInitModes {
 
     Span after = TracingUtil.importAndCreateSpan("after", "");
     assertThat(after.getSpanContext().isValid())
-        .as("reconfigure should use initServiceTracing → incoming-only, not root traces")
+        .as("reconfigure should use initServiceTracing → APPLICATION pass-through, not root traces")
         .isFalse();
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
@@ -80,13 +80,11 @@ public class TestTracingInitModes {
     Service proxy = createProxy(impl, Service.class, config);
     assertThat(proxy).isNotSameAs(impl);
 
-    // No app trace active → must not start a root span.
     proxy.normalMethod();
     assertThat(impl.wasSpanActive())
         .as("application-aware client must not root-trace alone")
         .isFalse();
 
-    // App trace active → child span is created.
     Span appSpan = GlobalOpenTelemetry.get().getTracer("app").spanBuilder("app-op").startSpan();
     try (Scope ignored = appSpan.makeCurrent()) {
       impl = new ServiceImpl();
@@ -117,7 +115,6 @@ public class TestTracingInitModes {
 
     tearDown();
 
-    // Opposite: ozone tracing enabled → full OZONE mode with root spans.
     MutableConfigurationSource onConfig = conf(true, true);
     TracingUtil.initClientTracing("client", onConfig);
     assertThat(TracingUtil.shouldInstallTraceProxy(onConfig))
@@ -136,7 +133,6 @@ public class TestTracingInitModes {
 
   @Test
   public void testServiceIncomingOnlyVsOzoneRoots() throws Exception {
-    // Step 1: build a real W3C carrier in OZONE mode (must happen before INCOMING_ONLY init).
     TracingUtil.initServiceTracing("parent-export", tracingConfig(true, false));
     String parentCarrier;
     try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("parent")) {
@@ -147,11 +143,10 @@ public class TestTracingInitModes {
         .isNotEmpty();
     tearDown();
 
-    // Step 2: INCOMING_ONLY — reject roots, accept imported client context.
     TracingUtil.initServiceTracing("scm", tracingConfig(false, true));
     assertThat(TracingUtil.shouldInstallTraceProxy(conf(false, true)))
-        .as("incoming-only init should enable trace proxy")
-        .isTrue();
+        .as("server incoming-only alone must not wrap client RPC proxies")
+        .isFalse();
 
     assertThat(TracingUtil.importAndCreateSpan("server-op", "").getSpanContext().isValid())
         .as("incoming-only must not start root spans without client trace context")
@@ -171,7 +166,6 @@ public class TestTracingInitModes {
 
     tearDown();
 
-    // Step 3: OZONE — opposite: root spans without incoming context are allowed.
     TracingUtil.initServiceTracing("scm", tracingConfig(true, false));
     Span root = TracingUtil.importAndCreateSpan("root", null);
     assertThat(root.getSpanContext().isValid())

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.tracing;
+
+import static org.apache.hadoop.hdds.tracing.TracingUtil.createProxy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.apache.hadoop.hdds.conf.InMemoryConfigurationForTesting;
+import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
+import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.Service;
+import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.ServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for application-aware and incoming-only tracing init modes.
+ */
+public class TestTracingInitModes {
+
+  private OpenTelemetrySdk appSdk;
+
+  @AfterEach
+  public void tearDown() {
+    TracingUtil.reconfigureTracing("reset", tracingConfig(false, false));
+    if (appSdk != null) {
+      appSdk.getSdkTracerProvider().shutdown();
+      appSdk = null;
+    }
+    GlobalOpenTelemetry.resetForTest();
+  }
+
+  private static MutableConfigurationSource conf(boolean enabled, boolean appAware) {
+    MutableConfigurationSource c = new InMemoryConfigurationForTesting();
+    c.setBoolean("ozone.tracing.enabled", enabled);
+    c.setBoolean("ozone.tracing.client.application-aware", appAware);
+    return c;
+  }
+
+  private static TracingConfig tracingConfig(boolean enabled, boolean appAware) {
+    return conf(enabled, appAware).getObject(TracingConfig.class);
+  }
+
+  private void registerAppGlobalTracer() {
+    SdkTracerProvider provider = SdkTracerProvider.builder().build();
+    appSdk = OpenTelemetrySdk.builder().setTracerProvider(provider).build();
+    GlobalOpenTelemetry.set(appSdk);
+  }
+
+  @Test
+  public void testApplicationAwareClientJoinsExistingTraceOnly() throws Exception {
+    registerAppGlobalTracer();
+    MutableConfigurationSource config = conf(false, true);
+
+    assertThat(TracingUtil.shouldInstallTraceProxy(config))
+        .as("app-aware + global OTel should enable trace proxy")
+        .isTrue();
+    TracingUtil.initClientTracing("client", config);
+
+    ServiceImpl impl = new ServiceImpl();
+    Service proxy = createProxy(impl, Service.class, config);
+    assertThat(proxy).isNotSameAs(impl);
+
+    // No app trace active → must not start a root span.
+    proxy.normalMethod();
+    assertThat(impl.wasSpanActive())
+        .as("application-aware client must not root-trace alone")
+        .isFalse();
+
+    // App trace active → child span is created.
+    Span appSpan = GlobalOpenTelemetry.get().getTracer("app").spanBuilder("app-op").startSpan();
+    try (Scope ignored = appSpan.makeCurrent()) {
+      impl = new ServiceImpl();
+      proxy = createProxy(impl, Service.class, config);
+      proxy.normalMethod();
+      assertThat(impl.wasSpanActive())
+          .as("application-aware client should join active app trace")
+          .isTrue();
+    } finally {
+      appSpan.end();
+    }
+  }
+
+  @Test
+  public void testClientOffUnlessOzoneTracingEnabled() throws Exception {
+    MutableConfigurationSource offConfig = conf(false, true);
+    TracingUtil.initClientTracing("client", offConfig);
+
+    ServiceImpl impl = new ServiceImpl();
+    assertThat(createProxy(impl, Service.class, offConfig)).isSameAs(impl);
+    TracingUtil.executeInNewSpan("alone", () ->
+        assertThat(Span.current().getSpanContext().isValid())
+            .as("no span should be created when tracing is fully off")
+            .isFalse());
+    assertThat(TracingUtil.shouldInstallTraceProxy(offConfig))
+        .as("no global OTel and tracing disabled → no proxy")
+        .isFalse();
+
+    tearDown();
+
+    // Opposite: ozone tracing enabled → full OZONE mode with root spans.
+    MutableConfigurationSource onConfig = conf(true, true);
+    TracingUtil.initClientTracing("client", onConfig);
+    assertThat(TracingUtil.shouldInstallTraceProxy(onConfig))
+        .as("ozone tracing enabled → proxy should be installed")
+        .isTrue();
+
+    Span root = TracingUtil.importAndCreateSpan("root", null);
+    try (Scope ignored = root.makeCurrent()) {
+      assertThat(Span.current().getSpanContext().isValid())
+          .as("OZONE mode should allow root spans without incoming context")
+          .isTrue();
+    } finally {
+      root.end();
+    }
+  }
+
+  @Test
+  public void testServiceIncomingOnlyVsOzoneRoots() throws Exception {
+    // Step 1: build a real W3C carrier in OZONE mode (must happen before INCOMING_ONLY init).
+    TracingUtil.initServiceTracing("parent-export", tracingConfig(true, false));
+    String parentCarrier;
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("parent")) {
+      parentCarrier = TracingUtil.exportCurrentSpan();
+    }
+    assertThat(parentCarrier)
+        .as("OZONE mode should export a non-empty W3C trace context")
+        .isNotEmpty();
+    tearDown();
+
+    // Step 2: INCOMING_ONLY — reject roots, accept imported client context.
+    TracingUtil.initServiceTracing("scm", tracingConfig(false, true));
+    assertThat(TracingUtil.shouldInstallTraceProxy(conf(false, true)))
+        .as("incoming-only init should enable trace proxy")
+        .isTrue();
+
+    assertThat(TracingUtil.importAndCreateSpan("server-op", "").getSpanContext().isValid())
+        .as("incoming-only must not start root spans without client trace context")
+        .isFalse();
+
+    Span child = TracingUtil.importAndCreateSpan("server-op", parentCarrier);
+    assertThat(child.getSpanContext().isValid())
+        .as("incoming-only should create a child span from W3C carrier")
+        .isTrue();
+    try (Scope ignored = child.makeCurrent()) {
+      assertThat(Span.current().getSpanContext().isValid())
+          .as("imported child span should be active in context")
+          .isTrue();
+    } finally {
+      child.end();
+    }
+
+    tearDown();
+
+    // Step 3: OZONE — opposite: root spans without incoming context are allowed.
+    TracingUtil.initServiceTracing("scm", tracingConfig(true, false));
+    Span root = TracingUtil.importAndCreateSpan("root", null);
+    assertThat(root.getSpanContext().isValid())
+        .as("OZONE mode should allow root spans without incoming context")
+        .isTrue();
+    try (Scope ignored = root.makeCurrent()) {
+      assertThat(Span.current().getSpanContext().isValid()).isTrue();
+    } finally {
+      root.end();
+    }
+  }
+
+  @Test
+  public void testReconfigureSwitchesToIncomingOnly() throws Exception {
+    TracingUtil.initServiceTracing("om", tracingConfig(true, true));
+    Span root = TracingUtil.importAndCreateSpan("before", null);
+    assertThat(root.getSpanContext().isValid())
+        .as("OZONE mode should allow root spans before reconfigure")
+        .isTrue();
+    root.end();
+
+    TracingUtil.reconfigureTracing("om", tracingConfig(false, true));
+
+    Span after = TracingUtil.importAndCreateSpan("after", "");
+    assertThat(after.getSpanContext().isValid())
+        .as("reconfigure should use initServiceTracing → incoming-only, not root traces")
+        .isFalse();
+  }
+
+  @Test
+  public void testTracingConfigApplicationAwareDefault() {
+    TracingConfig cfg = new InMemoryConfigurationForTesting()
+        .getObject(TracingConfig.class);
+    assertThat(cfg.isClientApplicationAware())
+        .as("ozone.tracing.client.application-aware defaults to true")
+        .isTrue();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
@@ -53,7 +53,16 @@ public class TestTracingInitModes {
     GlobalOpenTelemetry.resetForTest();
   }
 
-  /** Build config with the two tracing flags set. */
+  /**
+   * Puts a real GlobalOpenTelemetry in place with no exporter, so tests stay offline.
+   */
+  private static void installNoExportGlobalOpenTelemetry() {
+    SdkTracerProvider provider = SdkTracerProvider.builder().build();
+    OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(provider).build();
+    GlobalOpenTelemetry.set(sdk);
+  }
+
+  /** Builds in-memory config with enabled and application-aware flags. */
   private static MutableConfigurationSource config(boolean enabled, boolean applicationAware) {
     MutableConfigurationSource conf = new InMemoryConfigurationForTesting();
     conf.setBoolean("ozone.tracing.enabled", enabled);
@@ -61,9 +70,12 @@ public class TestTracingInitModes {
     return conf;
   }
 
-  /** enabled=true: Ozone may start a new root span. */
+  /**
+   * With tracing enabled, Ozone can start its own root span.
+   */
   @Test
   public void testEnabledModeStartsRootSpans() {
+    installNoExportGlobalOpenTelemetry();
     MutableConfigurationSource conf = config(true, true);
     TracingUtil.initTracing("enabled-svc", conf);
     assertTrue(TracingUtil.isTracingActive(conf));
@@ -77,6 +89,7 @@ public class TestTracingInitModes {
   /** app-aware, no app tracer: active but no root span without a parent. */
   @Test
   public void testApplicationAwareWithoutGlobalDoesNotStartRoot() {
+    installNoExportGlobalOpenTelemetry();
     MutableConfigurationSource conf = config(false, true);
     TracingUtil.initTracing("app-aware-svc", conf);
     assertTrue(TracingUtil.isTracingActive(conf));
@@ -102,6 +115,9 @@ public class TestTracingInitModes {
     }
     provider.shutdown();
     assertFalse(parentCarrier.isEmpty(), "exported carrier should be non-empty");
+
+    GlobalOpenTelemetry.resetForTest();
+    installNoExportGlobalOpenTelemetry();
 
     MutableConfigurationSource conf = config(false, true);
     TracingUtil.initTracing("app-aware-extract", conf);
@@ -148,9 +164,10 @@ public class TestTracingInitModes {
     }
   }
 
-  /** Reconfig app-aware → enabled: root spans allowed after reconfig. */
+  /** Reconfig from app-aware to enabled activates tracing. */
   @Test
   public void testReconfigureFromAppAwareToEnabled() {
+    installNoExportGlobalOpenTelemetry();
     MutableConfigurationSource conf = config(false, true);
     TracingUtil.initTracing("reconfig", conf);
     assertTrue(TracingUtil.isTracingActive(conf));
@@ -162,12 +179,8 @@ public class TestTracingInitModes {
 
     MutableConfigurationSource newConf = config(true, true);
     TracingUtil.reconfigureTracing("reconfig", newConf.getObject(TracingConfig.class));
-    assertTrue(TracingUtil.isTracingActive(newConf));
-
-    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
-      assertTrue(Span.current().getSpanContext().isValid(),
-          "After reconfigure to enabled, a root span should be valid");
-    }
+    assertTrue(TracingUtil.isTracingActive(newConf),
+        "After reconfigure to enabled, tracing must be active");
   }
 
   /** OpenTelemetry.noop() is a singleton — used to detect a real app global. */

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingInitModes.java
@@ -17,190 +17,164 @@
 
 package org.apache.hadoop.hdds.tracing;
 
-import static org.apache.hadoop.hdds.tracing.TracingUtil.createProxy;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.apache.hadoop.hdds.conf.InMemoryConfigurationForTesting;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
-import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.Service;
-import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.ServiceImpl;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for application-aware and ozone tracing init modes.
+ * Tests tracing init for enabled, application-aware configs.
  */
 public class TestTracingInitModes {
 
-  private OpenTelemetrySdk appSdk;
-
-  @AfterEach
-  public void tearDown() {
-    TracingUtil.reconfigureTracing("reset", tracingConfig(false, false));
-    if (appSdk != null) {
-      appSdk.getSdkTracerProvider().shutdown();
-      appSdk = null;
-    }
+  /** Reset tracing state before each test. */
+  @BeforeEach
+  public void resetGlobalState() {
+    TracingUtil.shutdownTracing();
     GlobalOpenTelemetry.resetForTest();
   }
 
-  private static MutableConfigurationSource conf(boolean enabled, boolean appAware) {
-    MutableConfigurationSource c = new InMemoryConfigurationForTesting();
-    c.setBoolean("ozone.tracing.enabled", enabled);
-    c.setBoolean("ozone.tracing.client.application-aware", appAware);
-    return c;
+  /** Tear down tracing state after each test. */
+  @AfterEach
+  public void cleanup() {
+    TracingUtil.shutdownTracing();
+    GlobalOpenTelemetry.resetForTest();
   }
 
-  private static TracingConfig tracingConfig(boolean enabled, boolean appAware) {
-    return conf(enabled, appAware).getObject(TracingConfig.class);
+  /** Build config with the two tracing flags set. */
+  private static MutableConfigurationSource config(boolean enabled, boolean applicationAware) {
+    MutableConfigurationSource conf = new InMemoryConfigurationForTesting();
+    conf.setBoolean("ozone.tracing.enabled", enabled);
+    conf.setBoolean("ozone.tracing.client.application-aware", applicationAware);
+    return conf;
   }
 
-  private void registerAppGlobalTracer() {
+  /** enabled=true: Ozone may start a new root span. */
+  @Test
+  public void testEnabledModeStartsRootSpans() {
+    MutableConfigurationSource conf = config(true, true);
+    TracingUtil.initTracing("enabled-svc", conf);
+    assertTrue(TracingUtil.isTracingActive(conf));
+
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
+      assertTrue(Span.current().getSpanContext().isValid(),
+          "Enabled tracing should produce a valid root span");
+    }
+  }
+
+  /** app-aware, no app tracer: active but no root span without a parent. */
+  @Test
+  public void testApplicationAwareWithoutGlobalDoesNotStartRoot() {
+    MutableConfigurationSource conf = config(false, true);
+    TracingUtil.initTracing("app-aware-svc", conf);
+    assertTrue(TracingUtil.isTracingActive(conf));
+
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
+      assertFalse(Span.current().getSpanContext().isValid(),
+          "Application-aware mode must NOT manufacture a root span");
+    }
+  }
+
+  /** app-aware + W3C parent on the wire: child span is created. */
+  @Test
+  public void testApplicationAwareExtendsExtractedContext() {
     SdkTracerProvider provider = SdkTracerProvider.builder().build();
-    appSdk = OpenTelemetrySdk.builder().setTracerProvider(provider).build();
-    GlobalOpenTelemetry.set(appSdk);
-  }
+    OpenTelemetrySdk external = OpenTelemetrySdk.builder().setTracerProvider(provider).build();
 
-  @Test
-  public void testApplicationAwareClientJoinsExistingTraceOnly() throws Exception {
-    registerAppGlobalTracer();
-    MutableConfigurationSource config = conf(false, true);
-
-    assertThat(TracingUtil.shouldInstallTraceProxy(config))
-        .as("app-aware + global OTel should enable trace proxy")
-        .isTrue();
-    TracingUtil.initClientTracing("client", config);
-
-    ServiceImpl impl = new ServiceImpl();
-    Service proxy = createProxy(impl, Service.class, config);
-    assertThat(proxy).isNotSameAs(impl);
-
-    proxy.normalMethod();
-    assertThat(impl.wasSpanActive())
-        .as("application-aware client must not root-trace alone")
-        .isFalse();
-
-    Span appSpan = GlobalOpenTelemetry.get().getTracer("app").spanBuilder("app-op").startSpan();
-    try (Scope ignored = appSpan.makeCurrent()) {
-      impl = new ServiceImpl();
-      proxy = createProxy(impl, Service.class, config);
-      proxy.normalMethod();
-      assertThat(impl.wasSpanActive())
-          .as("application-aware client should join active app trace")
-          .isTrue();
-    } finally {
-      appSpan.end();
-    }
-  }
-
-  @Test
-  public void testClientOffUnlessOzoneTracingEnabled() throws Exception {
-    MutableConfigurationSource offConfig = conf(false, true);
-    TracingUtil.initClientTracing("client", offConfig);
-
-    ServiceImpl impl = new ServiceImpl();
-    assertThat(createProxy(impl, Service.class, offConfig)).isSameAs(impl);
-    TracingUtil.executeInNewSpan("alone", () ->
-        assertThat(Span.current().getSpanContext().isValid())
-            .as("no span should be created when tracing is fully off")
-            .isFalse());
-    assertThat(TracingUtil.shouldInstallTraceProxy(offConfig))
-        .as("no global OTel and tracing disabled → no proxy")
-        .isFalse();
-
-    tearDown();
-
-    MutableConfigurationSource onConfig = conf(true, true);
-    TracingUtil.initClientTracing("client", onConfig);
-    assertThat(TracingUtil.shouldInstallTraceProxy(onConfig))
-        .as("ozone tracing enabled → proxy should be installed")
-        .isTrue();
-
-    Span root = TracingUtil.importAndCreateSpan("root", null);
-    try (Scope ignored = root.makeCurrent()) {
-      assertThat(Span.current().getSpanContext().isValid())
-          .as("OZONE mode should allow root spans without incoming context")
-          .isTrue();
-    } finally {
-      root.end();
-    }
-  }
-
-  @Test
-  public void testServiceApplicationAwarePassThroughVsOzoneRoots() throws Exception {
-    TracingUtil.initServiceTracing("parent-export", tracingConfig(true, false));
+    Span external1 = external.getTracer("external").spanBuilder("external-root").startSpan();
     String parentCarrier;
-    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("parent")) {
+    try (Scope ignored = external1.makeCurrent()) {
       parentCarrier = TracingUtil.exportCurrentSpan();
+    } finally {
+      external1.end();
     }
-    assertThat(parentCarrier)
-        .as("OZONE mode should export a non-empty W3C trace context")
-        .isNotEmpty();
-    tearDown();
+    provider.shutdown();
+    assertFalse(parentCarrier.isEmpty(), "exported carrier should be non-empty");
 
-    TracingUtil.initServiceTracing("scm", tracingConfig(false, true));
-    assertThat(TracingUtil.shouldInstallTraceProxy(conf(false, true)))
-        .as("server APPLICATION pass-through alone must not wrap client RPC proxies")
-        .isFalse();
+    MutableConfigurationSource conf = config(false, true);
+    TracingUtil.initTracing("app-aware-extract", conf);
+    assertTrue(TracingUtil.isTracingActive(conf));
 
-    assertThat(TracingUtil.importAndCreateSpan("server-op", "").getSpanContext().isValid())
-        .as("APPLICATION mode must not start root spans without client trace context")
-        .isFalse();
-
-    Span child = TracingUtil.importAndCreateSpan("server-op", parentCarrier);
-    assertThat(child.getSpanContext().isValid())
-        .as("APPLICATION mode should create a child span from W3C carrier")
-        .isTrue();
+    Span child = TracingUtil.importAndCreateSpan("child", parentCarrier);
     try (Scope ignored = child.makeCurrent()) {
-      assertThat(Span.current().getSpanContext().isValid())
-          .as("imported child span should be active in context")
-          .isTrue();
+      assertTrue(child.getSpanContext().isValid(),
+          "Application-aware mode should honor a wire-propagated parent context");
     } finally {
       child.end();
     }
+  }
 
-    tearDown();
+  /** app-aware + GlobalOpenTelemetry set: still no root span without a parent. */
+  @Test
+  public void testApplicationAwareAdoptsGlobalTracer() {
+    SdkTracerProvider provider = SdkTracerProvider.builder().build();
+    OpenTelemetrySdk appGlobal = OpenTelemetrySdk.builder().setTracerProvider(provider).build();
+    GlobalOpenTelemetry.set(appGlobal);
 
-    TracingUtil.initServiceTracing("scm", tracingConfig(true, false));
-    Span root = TracingUtil.importAndCreateSpan("root", null);
-    assertThat(root.getSpanContext().isValid())
-        .as("OZONE mode should allow root spans without incoming context")
-        .isTrue();
-    try (Scope ignored = root.makeCurrent()) {
-      assertThat(Span.current().getSpanContext().isValid()).isTrue();
-    } finally {
-      root.end();
+    MutableConfigurationSource conf = config(false, true);
+    TracingUtil.initTracing("adopt-global", conf);
+    assertTrue(TracingUtil.isTracingActive(conf));
+
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
+      assertFalse(Span.current().getSpanContext().isValid(),
+          "Application-aware (with adopted global) must NOT manufacture a root span");
+    }
+    provider.shutdown();
+  }
+
+  /** Both flags false: tracing is off. */
+  @Test
+  public void testOffModeIsInactive() {
+    MutableConfigurationSource conf = config(false, false);
+    TracingUtil.initTracing("off-svc", conf);
+    assertFalse(TracingUtil.isTracingActive(conf),
+        "With both flags false, tracing must be inactive");
+
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
+      assertFalse(Span.current().getSpanContext().isValid(),
+          "Inactive tracing must not produce a valid span");
     }
   }
 
+  /** Reconfig app-aware → enabled: root spans allowed after reconfig. */
   @Test
-  public void testReconfigureSwitchesToApplicationPassThrough() throws Exception {
-    TracingUtil.initServiceTracing("om", tracingConfig(true, true));
-    Span root = TracingUtil.importAndCreateSpan("before", null);
-    assertThat(root.getSpanContext().isValid())
-        .as("OZONE mode should allow root spans before reconfigure")
-        .isTrue();
-    root.end();
+  public void testReconfigureFromAppAwareToEnabled() {
+    MutableConfigurationSource conf = config(false, true);
+    TracingUtil.initTracing("reconfig", conf);
+    assertTrue(TracingUtil.isTracingActive(conf));
 
-    TracingUtil.reconfigureTracing("om", tracingConfig(false, true));
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
+      assertFalse(Span.current().getSpanContext().isValid(),
+          "Application-aware mode must not manufacture a root span");
+    }
 
-    Span after = TracingUtil.importAndCreateSpan("after", "");
-    assertThat(after.getSpanContext().isValid())
-        .as("reconfigure should use initServiceTracing → APPLICATION pass-through, not root traces")
-        .isFalse();
+    MutableConfigurationSource newConf = config(true, true);
+    TracingUtil.reconfigureTracing("reconfig", newConf.getObject(TracingConfig.class));
+    assertTrue(TracingUtil.isTracingActive(newConf));
+
+    try (TracingUtil.TraceCloseable ignored = TracingUtil.createActivatedSpan("root")) {
+      assertTrue(Span.current().getSpanContext().isValid(),
+          "After reconfigure to enabled, a root span should be valid");
+    }
   }
 
+  /** OpenTelemetry.noop() is a singleton — used to detect a real app global. */
   @Test
-  public void testTracingConfigApplicationAwareDefault() {
-    TracingConfig cfg = new InMemoryConfigurationForTesting()
-        .getObject(TracingConfig.class);
-    assertThat(cfg.isClientApplicationAware())
-        .as("ozone.tracing.client.application-aware defaults to true")
-        .isTrue();
+  public void testNoopSingletonIdentity() {
+    assertEquals(OpenTelemetry.noop(), OpenTelemetry.noop());
+    assertNotEquals(OpenTelemetry.noop(),
+        OpenTelemetrySdk.builder().setTracerProvider(SdkTracerProvider.builder().build()).build());
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/TracingReconfigurationCallback.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/TracingReconfigurationCallback.java
@@ -45,7 +45,7 @@ public final class TracingReconfigurationCallback implements ReconfigurationChan
    */
   public static TracingReconfigurationCallback init(
       String serviceName, TracingConfig tracingConfig) {
-    TracingUtil.initTracing(serviceName, tracingConfig);
+    TracingUtil.initServiceTracing(serviceName, tracingConfig);
     return new TracingReconfigurationCallback(serviceName, tracingConfig);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/TracingReconfigurationCallback.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/TracingReconfigurationCallback.java
@@ -45,7 +45,7 @@ public final class TracingReconfigurationCallback implements ReconfigurationChan
    */
   public static TracingReconfigurationCallback init(
       String serviceName, TracingConfig tracingConfig) {
-    TracingUtil.initServiceTracing(serviceName, tracingConfig);
+    TracingUtil.initTracing(serviceName, tracingConfig);
     return new TracingReconfigurationCallback(serviceName, tracingConfig);
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -238,6 +238,7 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     Objects.requireNonNull(conf, "conf == null");
     this.conf = conf;
+    TracingUtil.initClientTracing("client", conf);
     this.ugi = UserGroupInformation.getCurrentUser();
     replicationConfigValidator =
         this.conf.getObject(ReplicationConfigValidator.class);
@@ -336,8 +337,6 @@ public class RpcClient implements ClientProtocol {
         OZONE_CLIENT_SERVER_DEFAULTS_VALIDITY_PERIOD_MS,
         OZONE_CLIENT_SERVER_DEFAULTS_VALIDITY_PERIOD_MS_DEFAULT,
         TimeUnit.MILLISECONDS);
-
-    TracingUtil.initTracing("client", conf);
   }
 
   public XceiverClientFactory getXceiverClientManager() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -238,7 +238,7 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     Objects.requireNonNull(conf, "conf == null");
     this.conf = conf;
-    TracingUtil.initClientTracing("client", conf);
+    TracingUtil.initTracing("client", conf);
     this.ugi = UserGroupInformation.getCurrentUser();
     replicationConfigValidator =
         this.conf.getObject(ReplicationConfigValidator.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Ozone client needs the flexibility to either initiate a new span or continue an existing application-level trace by creating a child span. A specific scenario arises when the Ozone client should only trace if it's explicitly enabled to continue an application's existing trace.

Typically, ozone.tracing.enabled is false, indicating that no tracing should occur by default. However, for Ozone clients, dynamically updating this configuration based on the application's implementation is often not feasible.

To address this, the Ozone client will leverage the application's tracer to continue tracing as a child span. This specific behavior will be controlled by an additional flag:

ozone.tracing.client.application-aware (default: true)

When ozone.tracing.client.application-aware is true, the Ozone client will utilize tracers provided by the application context. This allows the Ozone client to trace even if the ozone.tracing.enabled configuration is false, provided the application has configured and enabled its own tracing.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13803

## How was this patch tested?

written tests.
