### PR TITLE
HDDS-15522. Make RpcClient close idempotent

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -79,6 +80,29 @@ public final class ContainerClientMetrics {
   private final Map<DatanodeID, MutableCounterLong> writeChunksCallsByLeaders;
   private final MetricsRegistry registry;
 
+  /**
+   * Handle for one ContainerClientMetrics acquisition.
+   */
+  public static final class Handle implements AutoCloseable {
+    private final ContainerClientMetrics metrics;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Handle(ContainerClientMetrics metrics) {
+      this.metrics = metrics;
+    }
+
+    public ContainerClientMetrics metrics() {
+      return metrics;
+    }
+
+    @Override
+    public void close() {
+      if (closed.compareAndSet(false, true)) {
+        release();
+      }
+    }
+  }
+
   public static synchronized ContainerClientMetrics acquire() {
     if (instance == null) {
       instanceCount++;
@@ -88,6 +112,10 @@ public final class ContainerClientMetrics {
     }
     referenceCount++;
     return instance;
+  }
+
+  public static Handle acquireHandle() {
+    return new Handle(acquire());
   }
 
   public static synchronized void release() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -220,6 +220,7 @@ public class RpcClient implements ClientProtocol {
   private final BlockInputStreamFactory blockInputStreamFactory;
   private final OzoneManagerVersion omVersion;
   private final MemoizedSupplier<ExecutorService> ecReconstructExecutor;
+  private final ContainerClientMetrics.Handle clientMetricsHandle;
   private final ContainerClientMetrics clientMetrics;
   private final MemoizedSupplier<ExecutorService> writeExecutor;
   private volatile OzoneFsServerDefaults serverDefaults;
@@ -328,7 +329,8 @@ public class RpcClient implements ClientProtocol {
     this.byteBufferPool = new BoundedElasticByteBufferPool(maxPoolSize);
     this.blockInputStreamFactory = BlockInputStreamFactoryImpl
         .getInstance(byteBufferPool, ecReconstructExecutor);
-    this.clientMetrics = ContainerClientMetrics.acquire();
+    this.clientMetricsHandle = ContainerClientMetrics.acquireHandle();
+    this.clientMetrics = clientMetricsHandle.metrics();
 
     this.serverDefaultsValidityPeriod = conf.getTimeDuration(
         OZONE_CLIENT_SERVER_DEFAULTS_VALIDITY_PERIOD_MS,
@@ -1948,16 +1950,23 @@ public class RpcClient implements ClientProtocol {
 
   @Override
   public void close() throws IOException {
-    if (ecReconstructExecutor.isInitialized()) {
-      ecReconstructExecutor.get().shutdownNow();
+    IOUtils.cleanupWithLogger(LOG,
+        () -> shutdownExecutor(ecReconstructExecutor),
+        () -> shutdownExecutor(writeExecutor),
+        ozoneManagerClient,
+        xceiverClientManager,
+        () -> {
+          keyProviderCache.invalidateAll();
+          keyProviderCache.cleanUp();
+        },
+        clientMetricsHandle);
+  }
+
+  private static void shutdownExecutor(
+      MemoizedSupplier<ExecutorService> executor) {
+    if (executor.isInitialized()) {
+      executor.get().shutdownNow();
     }
-    if (writeExecutor.isInitialized()) {
-      writeExecutor.get().shutdownNow();
-    }
-    IOUtils.cleanupWithLogger(LOG, ozoneManagerClient, xceiverClientManager);
-    keyProviderCache.invalidateAll();
-    keyProviderCache.cleanUp();
-    ContainerClientMetrics.release();
   }
 
   @Deprecated

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestRpcClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestRpcClient.java
@@ -18,17 +18,29 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import static org.apache.hadoop.ozone.client.rpc.RpcClient.validateOmVersion;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
+import org.apache.hadoop.ozone.client.MockOmTransport;
+import org.apache.hadoop.ozone.client.MockXceiverClientFactory;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.event.Level;
 
 /**
  * Run RPC Client tests.
@@ -214,5 +226,42 @@ public class TestRpcClient {
     assertThrows(
         IllegalArgumentException.class,
         () -> validateOmVersion(OzoneManagerVersion.FUTURE_VERSION, null));
+  }
+
+  @Test
+  public void testCloseTwiceDoesNotWarn() throws IOException {
+    RpcClient rpcClient = createRpcClient();
+    GenericTestUtils.setLogLevel(RpcClient.class, Level.DEBUG);
+    LogCapturer logs = LogCapturer.captureLogs(RpcClient.class);
+    logs.clearOutput();
+
+    try {
+      assertDoesNotThrow(() -> {
+        rpcClient.close();
+        rpcClient.close();
+      });
+
+      assertThat(logs.getOutput())
+          .doesNotContain("WARN")
+          .doesNotContain("This metrics class is not used.");
+    } finally {
+      logs.stopCapturing();
+    }
+  }
+
+  private static RpcClient createRpcClient() throws IOException {
+    OzoneConfiguration config = new OzoneConfiguration();
+    return new RpcClient(config, null) {
+      @Override
+      protected OmTransport createOmTransport(String omServiceId) {
+        return new MockOmTransport();
+      }
+
+      @Override
+      protected XceiverClientFactory createXceiverClientFactory(
+          ServiceInfoEx serviceInfo) {
+        return new MockXceiverClientFactory();
+      }
+    };
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15522. Make RpcClient close idempotent

Guard RpcClient cleanup so repeated close calls return before releasing ContainerClientMetrics again. This keeps the metrics acquire/release pairing per client instance and avoids shutdown warnings when ViewFS or filesystem cache cleanup closes the same client more than once.

## How was this patch tested?

We have built it and deployed it in our client nodes, and we can't see anymore the following warning when executing operations in an Ozone viewfs mount:

```
$ hdfs dfs -ls /ozone
...
26/06/10 10:06:13 WARN util.ShutdownHookManager: ShutdownHook 'ClientFinalizer' failed, java.util.concurrent.ExecutionException: java.lang.IllegalStateException: This metrics class is not used.
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: This metrics class is not used.
        at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
        at org.apache.hadoop.util.ShutdownHookManager.executeShutdown(ShutdownHookManager.java:124)
        at org.apache.hadoop.util.ShutdownHookManager$1.run(ShutdownHookManager.java:95)
Caused by: java.lang.IllegalStateException: This metrics class is not used.
        at org.apache.hadoop.hdds.scm.ContainerClientMetrics.release(ContainerClientMetrics.java:96)
        at org.apache.hadoop.ozone.client.rpc.RpcClient.close(RpcClient.java:1892)
        at org.apache.hadoop.ozone.client.OzoneClient.close(OzoneClient.java:122)
        at org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl.close(BasicRootedOzoneClientAdapterImpl.java:372)
        at org.apache.hadoop.fs.ozone.BasicRootedOzoneFileSystem.close(BasicRootedOzoneFileSystem.java:225)
        at org.apache.hadoop.fs.viewfs.ViewFileSystem$InnerCache.closeAll(ViewFileSystem.java:156)
        at org.apache.hadoop.fs.viewfs.ViewFileSystem.close(ViewFileSystem.java:1936)
        at org.apache.hadoop.fs.FileSystem$Cache.closeAll(FileSystem.java:3816)
        at org.apache.hadoop.fs.FileSystem$Cache$ClientFinalizer.run(FileSystem.java:3833)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```