### PR TITLE
HDDS-15200. Refactor TestReconOmMetaManagerUtils to ReconOmMetaManagerTestUtils

### DIFF
--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/ReconOmMetaManagerTestUtils.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/ReconOmMetaManagerTestUtils.java
@@ -27,7 +27,7 @@ import org.apache.ozone.test.GenericTestUtils;
 /**
  * Utility methods for Recon OM metadata manager integration tests.
  */
-public final class ReconOmMetaManagerTestUtils {
+final class ReconOmMetaManagerTestUtils {
 
   private ReconOmMetaManagerTestUtils() {
   }
@@ -39,8 +39,7 @@ public final class ReconOmMetaManagerTestUtils {
    *
    * @return CompletableFuture that completes when buffer is empty
    */
-  public static CompletableFuture<Void> waitForEventBufferEmpty(
-      OMUpdateEventBuffer eventBuffer) {
+  static CompletableFuture<Void> waitForEventBufferEmpty(OMUpdateEventBuffer eventBuffer) {
     return CompletableFuture.runAsync(() -> {
       try {
         GenericTestUtils.waitFor(() -> eventBuffer.getQueueSize() == 0, 100, 30000);
@@ -64,7 +63,7 @@ public final class ReconOmMetaManagerTestUtils {
    * @param minimumCountPerContainer map of container ID to minimum inclusive key count
    * @throws Exception               if the condition is not met within the timeout or on interrupt
    */
-  public static void waitUntilReconKeyCounts(ReconContainerMetadataManager mgr,
+  static void waitUntilReconKeyCounts(ReconContainerMetadataManager mgr,
       Map<Long, Integer> minimumCountPerContainer) throws Exception {
     GenericTestUtils.waitFor(() -> {
       try {

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/ReconOmMetaManagerTestUtils.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/ReconOmMetaManagerTestUtils.java
@@ -30,7 +30,6 @@ import org.apache.ozone.test.GenericTestUtils;
 public final class ReconOmMetaManagerTestUtils {
 
   private ReconOmMetaManagerTestUtils() {
-    // no instances
   }
 
   /**

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/ReconOmMetaManagerTestUtils.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/ReconOmMetaManagerTestUtils.java
@@ -25,9 +25,13 @@ import org.apache.hadoop.ozone.recon.tasks.OMUpdateEventBuffer;
 import org.apache.ozone.test.GenericTestUtils;
 
 /**
- * Test Recon Utility methods.
+ * Utility methods for Recon OM metadata manager integration tests.
  */
-public class TestReconOmMetaManagerUtils {
+public final class ReconOmMetaManagerTestUtils {
+
+  private ReconOmMetaManagerTestUtils() {
+    // no instances
+  }
 
   /**
    * Wait for all currently buffered events to be processed asynchronously.
@@ -36,7 +40,8 @@ public class TestReconOmMetaManagerUtils {
    *
    * @return CompletableFuture that completes when buffer is empty
    */
-  public CompletableFuture<Void> waitForEventBufferEmpty(OMUpdateEventBuffer eventBuffer) {
+  public static CompletableFuture<Void> waitForEventBufferEmpty(
+      OMUpdateEventBuffer eventBuffer) {
     return CompletableFuture.runAsync(() -> {
       try {
         GenericTestUtils.waitFor(() -> eventBuffer.getQueueSize() == 0, 100, 30000);

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.recon;
 
+import static org.apache.hadoop.ozone.recon.ReconOmMetaManagerTestUtils.waitForEventBufferEmpty;
+import static org.apache.hadoop.ozone.recon.ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -120,7 +122,7 @@ public class TestReconContainerEndpoint {
     ReconTaskControllerImpl reconTaskController =
         (ReconTaskControllerImpl) recon.getReconServer().getReconTaskController();
     CompletableFuture<Void> completableFuture =
-        ReconOmMetaManagerTestUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
+        waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
     completableFuture.join();
     waitUntilReconIndexesKeysForPaths(volName, bucketName,
@@ -191,7 +193,7 @@ public class TestReconContainerEndpoint {
     ReconTaskControllerImpl reconTaskController =
         (ReconTaskControllerImpl) recon.getReconServer().getReconTaskController();
     CompletableFuture<Void> completableFuture =
-        ReconOmMetaManagerTestUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
+        waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
     completableFuture.join();
     waitUntilReconIndexesKeysForPaths(volumeName, obsBucketName, obsSingleFileKey);
@@ -251,7 +253,7 @@ public class TestReconContainerEndpoint {
     }
     ReconContainerMetadataManager mgr =
         recon.getReconServer().getReconContainerMetadataManager();
-    ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts(mgr, requiredCountByContainer);
+    waitUntilReconKeyCounts(mgr, requiredCountByContainer);
   }
 
   private long getContainerIdForKey(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconContainerEndpoint.java
@@ -63,7 +63,6 @@ public class TestReconContainerEndpoint {
   private OzoneClient client;
   private ObjectStore store;
   private ReconService recon;
-  private TestReconOmMetaManagerUtils omMetaManagerUtils = new TestReconOmMetaManagerUtils();
 
   @BeforeEach
   public void init() throws Exception {
@@ -121,7 +120,7 @@ public class TestReconContainerEndpoint {
     ReconTaskControllerImpl reconTaskController =
         (ReconTaskControllerImpl) recon.getReconServer().getReconTaskController();
     CompletableFuture<Void> completableFuture =
-        omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
+        ReconOmMetaManagerTestUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
     completableFuture.join();
     waitUntilReconIndexesKeysForPaths(volName, bucketName,
@@ -192,7 +191,7 @@ public class TestReconContainerEndpoint {
     ReconTaskControllerImpl reconTaskController =
         (ReconTaskControllerImpl) recon.getReconServer().getReconTaskController();
     CompletableFuture<Void> completableFuture =
-        omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
+        ReconOmMetaManagerTestUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
     completableFuture.join();
     waitUntilReconIndexesKeysForPaths(volumeName, obsBucketName, obsSingleFileKey);
@@ -252,7 +251,7 @@ public class TestReconContainerEndpoint {
     }
     ReconContainerMetadataManager mgr =
         recon.getReconServer().getReconContainerMetadataManager();
-    TestReconOmMetaManagerUtils.waitUntilReconKeyCounts(mgr, requiredCountByContainer);
+    ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts(mgr, requiredCountByContainer);
   }
 
   private long getContainerIdForKey(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.recon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.recon.ReconOmMetaManagerTestUtils.waitForEventBufferEmpty;
+import static org.apache.hadoop.ozone.recon.ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -143,7 +145,7 @@ public class TestReconWithOzoneManagerHA {
     ReconTaskControllerImpl reconTaskController =
         (ReconTaskControllerImpl) recon.getReconServer().getReconTaskController();
     CompletableFuture<Void> completableFuture =
-        ReconOmMetaManagerTestUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
+        waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
 
     final ReconContainerMetadataManagerImpl reconContainerMetadataManager =
@@ -151,7 +153,7 @@ public class TestReconWithOzoneManagerHA {
     long containerId = getContainerIdForKey(ozoneManager.get(), VOL_NAME, VOL_NAME, keyPrefix);
     Map<Long, Integer> requiredKeyCountByContainer =
         Collections.singletonMap(containerId, 1);
-    ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts(reconContainerMetadataManager,
+    waitUntilReconKeyCounts(reconContainerMetadataManager,
         requiredKeyCountByContainer);
     try (Table.KeyValueIterator<ContainerKeyPrefix, Integer> iterator
         = reconContainerMetadataManager.getContainerKeyTableForTesting().iterator()) {

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -66,7 +66,6 @@ public class TestReconWithOzoneManagerHA {
   private static final String VOL_NAME = "testrecon";
   private OzoneClient client;
   private ReconService recon;
-  private TestReconOmMetaManagerUtils omMetaManagerUtils = new TestReconOmMetaManagerUtils();
 
   @BeforeEach
   public void setup() throws Exception {
@@ -144,7 +143,7 @@ public class TestReconWithOzoneManagerHA {
     ReconTaskControllerImpl reconTaskController =
         (ReconTaskControllerImpl) recon.getReconServer().getReconTaskController();
     CompletableFuture<Void> completableFuture =
-        omMetaManagerUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
+        ReconOmMetaManagerTestUtils.waitForEventBufferEmpty(reconTaskController.getEventBuffer());
     GenericTestUtils.waitFor(completableFuture::isDone, 100, 30000);
 
     final ReconContainerMetadataManagerImpl reconContainerMetadataManager =
@@ -152,7 +151,7 @@ public class TestReconWithOzoneManagerHA {
     long containerId = getContainerIdForKey(ozoneManager.get(), VOL_NAME, VOL_NAME, keyPrefix);
     Map<Long, Integer> requiredKeyCountByContainer =
         Collections.singletonMap(containerId, 1);
-    TestReconOmMetaManagerUtils.waitUntilReconKeyCounts(reconContainerMetadataManager,
+    ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts(reconContainerMetadataManager,
         requiredKeyCountByContainer);
     try (Table.KeyValueIterator<ContainerKeyPrefix, Integer> iterator
         = reconContainerMetadataManager.getContainerKeyTableForTesting().iterator()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Refactor TestReconOmMetaManagerUtils to ReconOmMetaManagerTestUtils

Please describe your PR in detail:

- Rename TestReconOmMetaManagerUtils to ReconOmMetaManagerTestUtils
- Make waitForEventBufferEmpty a static method
- Make the utility class final with a private constructor
- Remove instance fields from TestReconContainerEndpoint and TestReconWithOzoneManagerHA


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15200

## How was this patch tested?

- Ran:

```
mvn -pl hadoop-ozone/integration-test-recon -am \
  -Dtest=TestReconContainerEndpoint,TestReconWithOzoneManagerHA \
  -DfailIfNoTests=false test

```
- Build passed successfully