### PR TITLE
HDDS-15514. Pass Ratis peer addresses as hostnames

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -118,9 +118,16 @@ public class SCMHAManagerImpl implements SCMHAManager {
       final boolean success = HAUtils.addSCM(ozoneConf,
           new AddSCMRequest.Builder().setClusterId(scm.getClusterId())
               .setScmId(scm.getScmId())
-              .setRatisAddr(nodeDetails
-                  // TODO : Should we use IP instead of hostname??
-                  .getRatisHostPortStr()).build(), scm.getSCMNodeId());
+              // Pass the configured host:port string verbatim. Do NOT
+              // resolve it into an InetSocketAddress first -- that bakes
+              // a resolved IP into Ratis's peer address for the channel's
+              // lifetime. With the string passed through, gRPC's
+              // DnsNameResolver re-resolves hostname addresses on
+              // connection failure (peer pod restarts recover
+              // automatically), and IP-literal configs are still honored
+              // exactly as configured. See HDDS-15514.
+              .setRatisAddr(nodeDetails.getRatisHostPortStr())
+              .build(), scm.getSCMNodeId());
       if (!success) {
         throw new IOException("Adding SCM to existing HA group failed");
       } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -396,8 +396,18 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     final RaftGroupId groupId = buildRaftGroupId(clusterId);
     RaftPeerId selfPeerId = getSelfPeerId(scmId);
 
+    // Pass the configured host:port string through verbatim. The
+    // invariant is "do not pre-resolve" -- never construct an
+    // InetSocketAddress from the configured address and hand the
+    // resolved form to RaftPeer.setAddress, which would freeze the peer
+    // at one IP for the channel's lifetime. Ratis routes the string to
+    // gRPC's NettyChannelBuilder, whose default DnsNameResolver
+    // re-resolves hostname addresses on connection failure (peer pod
+    // restarts recover automatically in Kubernetes-style environments
+    // where DNS names are stable but IPs are not). IP-literal configs
+    // are still honored exactly as configured. See HDDS-15514
+    // (DNS-refresh-on-failure for all RPC paths).
     RaftPeer localRaftPeer = RaftPeer.newBuilder().setId(selfPeerId)
-        // TODO : Should we use IP instead of hostname??
         .setAddress(details.getRatisHostPortStr()).build();
 
     List<RaftPeer> raftPeers = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -227,10 +227,8 @@ public final class OzoneManagerRatisServer {
       // On regular startup, add all OMs to Ratis ring
       raftPeers.add(localRaftPeer);
 
-      for (Map.Entry<String, OMNodeDetails> peerInfo : peerNodes.entrySet()) {
-        String peerNodeId = peerInfo.getKey();
-        OMNodeDetails peerNode = peerInfo.getValue();
-        RaftPeer raftPeer = OzoneManagerRatisServer.createRaftPeer(peerNode, peerNodeId);
+      for (OMNodeDetails peerNode : peerNodes.values()) {
+        RaftPeer raftPeer = OzoneManagerRatisServer.createRaftPeer(peerNode);
 
         // Add other OM nodes belonging to the same OM service to the Ratis ring
         raftPeers.add(raftPeer);
@@ -435,42 +433,31 @@ public final class OzoneManagerRatisServer {
     }
   }
 
-  private static RaftPeer createRaftPeer(OMNodeDetails omNode) {
-    String nodeId = omNode.getNodeId();
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(nodeId);
-    InetSocketAddress ratisAddr = new InetSocketAddress(
-        omNode.getHostAddress(), omNode.getRatisPort());
-    RaftPeerRole startRole = omNode.isRatisListener() ?
-        RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER;
-
-    return RaftPeer.newBuilder()
-        .setId(raftPeerId)
-        .setAddress(ratisAddr)
-        .setStartupRole(startRole)
-        .build();
-  }
-
   /**
-   * Helper method to create a RaftPeer from OMNodeDetails, handling unresolved hosts.
-   * @param omNode the OM node details
-   * @param nodeId the node ID to use
-   * @return the created RaftPeer
+   * Build a RaftPeer for the given OM node. The peer address is set from
+   * {@link OMNodeDetails#getRatisHostPortStr()} -- the configured host
+   * string (hostname or IP literal) paired with the Ratis port. The
+   * configured string is passed through verbatim; this method never
+   * resolves it into an {@link InetSocketAddress} (which would bake the
+   * resolved IP into the peer address).
+   * <p>
+   * Why this matters: Ratis hands the address string to gRPC's
+   * {@code NettyChannelBuilder.forTarget(...)}, whose default
+   * {@code DnsNameResolver} re-resolves hostnames on connection failure
+   * / refresh. If the address is a hostname, gRPC recovers automatically
+   * from peer pod restarts in environments like Kubernetes where DNS
+   * names are stable but IPs are not. If the operator configured an IP
+   * literal, gRPC of course uses that IP directly -- the invariant is
+   * "don't pre-resolve", not "must be a hostname". See HDDS-15514
+   * (DNS-refresh-on-failure for all RPC paths).
    */
-  private static RaftPeer createRaftPeer(OMNodeDetails omNode, String nodeId) {
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(nodeId);
-    RaftPeer.Builder builder = RaftPeer.newBuilder()
-        .setId(raftPeerId)
-        .setStartupRole(omNode.isRatisListener() ? RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER);
-    
-    if (omNode.isHostUnresolved()) {
-      builder.setAddress(omNode.getRatisHostPortStr());
-    } else {
-      InetSocketAddress ratisAddr = new InetSocketAddress(
-          omNode.getInetAddress(), omNode.getRatisPort());
-      builder.setAddress(ratisAddr);
-    }
-    
-    return builder.build();
+  static RaftPeer createRaftPeer(OMNodeDetails omNode) {
+    return RaftPeer.newBuilder()
+        .setId(RaftPeerId.valueOf(omNode.getNodeId()))
+        .setAddress(omNode.getRatisHostPortStr())
+        .setStartupRole(omNode.isRatisListener()
+            ? RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER)
+        .build();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -145,6 +145,46 @@ public class TestOzoneManagerRatisServer {
         "Ratis Server should be in running state");
   }
 
+  /**
+   * RaftPeer.address must preserve the configured host string
+   * verbatim -- not a Java-resolved {@code InetSocketAddress} form. When
+   * the operator configured a hostname, the hostname must survive into
+   * RaftPeer.address so gRPC's {@code DnsNameResolver} can re-resolve it
+   * on connection failure (Kubernetes pod restarts). When the operator
+   * configured an IP literal, that literal must survive too. The
+   * regression this test guards is "{@code createRaftPeer} pre-resolved
+   * a hostname into a numeric IP and handed the resolved form to
+   * RaftPeer," which would freeze the gRPC channel at that IP for the
+   * channel's lifetime.
+   */
+  @Test
+  public void testCreateRaftPeerUsesHostnameAddress() {
+    String hostname = "om-2.om.example.svc.cluster.local";
+    int rpcPort = 9862;
+    int ratisPort = 9872;
+    OMNodeDetails peer = new OMNodeDetails.Builder()
+        .setOMServiceId("test-service")
+        .setOMNodeId("om2")
+        .setHostAddress(hostname)
+        .setRpcPort(rpcPort)
+        .setRatisPort(ratisPort)
+        .build();
+
+    org.apache.ratis.protocol.RaftPeer raftPeer =
+        OzoneManagerRatisServer.createRaftPeer(peer);
+    String addr = raftPeer.getAddress();
+    assertEquals(hostname + ":" + ratisPort, addr,
+        "RaftPeer address must preserve the configured host string "
+            + "verbatim. The configured hostname must survive into "
+            + "RaftPeer so gRPC can re-resolve it -- pre-resolving into a "
+            + "numeric IP would freeze the channel at that IP for its "
+            + "lifetime.");
+    // Defensive: the configured hostname must not have been pre-resolved
+    // into a numeric IPv4 octet form before reaching RaftPeer.
+    String host = addr.substring(0, addr.lastIndexOf(':'));
+    assertThat(host).doesNotMatch("^\\d{1,3}(\\.\\d{1,3}){3}$");
+  }
+
   @Test
   public void testLoadSnapshotInfoOnStart() throws Exception {
     // Stop the Ratis server and manually update the snapshotInfo.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is **PR 1 of 4** splitting [HDDS-15514](https://issues.apache.org/jira/browse/HDDS-15514) (originally proposed as a single ~160KB patch in #10473, split per @szetszwo's review feedback).

This PR fixes the Ratis-replication paths only:

- **OM ↔ OM Ratis replication**: `OzoneManagerRatisServer.createRaftPeer` now always passes a `hostname:port` string to `RaftPeer.setAddress(...)`, never a resolved `InetSocketAddress`. Two of the three pre-existing `createRaftPeer` branches called `new InetSocketAddress(omNode.getInetAddress(), ratisPort)`, baking the resolved IP into `RaftPeer.address`. The two overloads collapse into one.
- **SCM ↔ SCM Ratis replication**: comment-only — replaces the misleading `// TODO : Should we use IP instead of hostname??` markers in `SCMRatisServerImpl.buildRaftGroup` and `SCMHAManagerImpl#start` with explanatory comments citing HDDS-15514. Both call sites already passed `getRatisHostPortStr()`; the TODO falsely implied IPs would be a fine alternative.

## Why this matters

Ratis builds gRPC channels via `NettyChannelBuilder.forTarget(address)`. The default `DnsNameResolver` re-resolves hostnames on connection failure, so a peer-pod restart in Kubernetes (where the pod's IP changes but the DNS name stays stable) is recovered automatically — **as long as `RaftPeer.address` is a hostname**. If the address is a numeric IP (because Ozone resolved it at construction and passed the resolved form to Ratis), the channel stays bound to the now-defunct IP forever and the only recovery is a parent-process restart.

## How was this patch tested?

- Unit test: `TestOzoneManagerRatisServer.testCreateRaftPeerUsesHostnameAddress` — asserts that `RaftPeer.getAddress()` for an OM peer is the literal `hostname:port` string and is not an IPv4 numeric form. This guards the invariant against future regressions that re-introduce `InetSocketAddress` at this seam.
- Existing `TestOzoneManagerRatisServer` tests (5 prior + 1 new) all pass.
- `mvn clean install` of `hadoop-ozone/ozone-manager` and `hadoop-hdds/server-scm` modules.

## Scope of this PR

- Pure hostname-string discipline. No new flags, no new exception classifier, no atomic-replace machinery, no `RPC.stopProxy` calls. Those arrive with the next three PRs.
- Zero behavior change in non-K8s deployments where DNS-to-IP is stable for the process lifetime.

## Follow-up PRs

Per the [4-PR split](https://github.com/apache/ozone/pull/10473#issuecomment-4677191510):

2. **HDDS-15514. DNS refresh on connection failure for Client → OM** — introduces `ConnectionFailureUtils`, `ozone.client.failover.resolve-needed` flag, `OMProxyInfo.refreshAddressIfChanged`, and the `OMFailoverProxyProviderBase.shouldRetry` hook.
3. **HDDS-15514. DNS refresh on connection failure for OM → SCM** — same shape against `SCMFailoverProxyProviderBase` / `SCMProxyInfo`.
4. **HDDS-15514. DNS refresh on heartbeat failure for DN → SCM** — `EndpointStateMachine.resolveLatestAddress`, `SCMConnectionManager.refreshSCMServer` (4-phase atomic-replace), `StateContext.migrateEndpoint`, and the `ozone.datanode.scm.heartbeat.address.refresh.threshold` knob.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15514
