### PR TITLE
HDDS-15531. DNS refresh on connection failure for Client to OM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import java.io.EOFException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+/**
+ * Shared classifier for exceptions where the cached peer IP is no longer
+ * reachable and DNS re-resolution is the only plausible recovery path.
+ * <p>
+ * Used by both {@code SCMFailoverProxyProviderBase} and
+ * {@code OMFailoverProxyProviderBase} to gate the DNS-refresh-on-failure
+ * code path so that application-level errors (NotLeader, AccessControl,
+ * OMException, RetryAction) do not trigger spurious DNS lookups.
+ * <p>
+ * The classifier must match the failure shapes seen in production
+ * Kubernetes deployments where the peer pod has been rescheduled to a
+ * new IP under a stable hostname:
+ * <ul>
+ *   <li>{@link ConnectException} -- the TCP SYN was refused. Seen on
+ *       OpenStack / fast-RST environments. </li>
+ *   <li>{@link SocketTimeoutException} (and its IPC subclass
+ *       {@code ConnectTimeoutException}) -- the SYN was dropped silently.
+ *       This is the dominant failure shape on AWS EC2 / EKS where the
+ *       network silently drops packets to a defunct pod IP. The PR that
+ *       introduced this helper (HDDS-15514) is sold on this case; it
+ *       must be in the filter. </li>
+ *   <li>{@link NoRouteToHostException} -- routing table no longer
+ *       reaches the cached IP. </li>
+ *   <li>{@link UnknownHostException} -- the hostname itself failed to
+ *       resolve at the time the IPC layer reconstructed the address. </li>
+ *   <li>{@link EOFException} -- a load balancer or iptables RST closed
+ *       the half-open connection cleanly. Common in Kubernetes when an
+ *       IP is reassigned to an unrelated pod that rejects the RPC
+ *       handshake. </li>
+ *   <li>{@link SocketException} (e.g. "Connection reset") -- the peer
+ *       sent RST mid-stream. </li>
+ * </ul>
+ * The walk is bounded to {@value #MAX_CAUSE_DEPTH} levels to defend
+ * against cause chains that have been constructed (in violation of
+ * {@code Throwable.initCause}'s contract) into a cycle of length > 1.
+ */
+public final class ConnectionFailureUtils {
+
+  /**
+   * Maximum depth of the {@code Throwable.getCause()} chain we walk
+   * before giving up. Matches Hadoop's own walkers in
+   * {@code RemoteException} handling.
+   */
+  static final int MAX_CAUSE_DEPTH = 16;
+
+  private ConnectionFailureUtils() {
+  }
+
+  /**
+   * Returns true when any link in {@code t}'s cause chain (up to
+   * {@link #MAX_CAUSE_DEPTH} levels) is one of the connection-class
+   * exceptions documented on this class.
+   *
+   * @param t the throwable to classify. {@code null} returns false.
+   */
+  public static boolean isConnectionFailure(Throwable t) {
+    Throwable cause = t;
+    for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++) {
+      if (cause instanceof ConnectException
+          || cause instanceof SocketTimeoutException
+          || cause instanceof NoRouteToHostException
+          || cause instanceof UnknownHostException
+          || cause instanceof EOFException
+          || cause instanceof SocketException) {
+        return true;
+      }
+      Throwable next = cause.getCause();
+      if (next == cause) {
+        break;
+      }
+      cause = next;
+    }
+    return false;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
@@ -58,7 +58,7 @@ import java.net.UnknownHostException;
  * </ul>
  * The walk is bounded to {@value #MAX_CAUSE_DEPTH} levels to defend
  * against cause chains that have been constructed (in violation of
- * {@code Throwable.initCause}'s contract) into a cycle of length > 1.
+ * {@code Throwable.initCause}'s contract) into a cycle of length &gt; 1.
  */
 public final class ConnectionFailureUtils {
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -604,6 +604,19 @@ public final class OzoneConfigKeys {
   public static final boolean OZONE_JVM_NETWORK_ADDRESS_CACHE_ENABLED_DEFAULT =
           true;
 
+  /**
+   * When true, RPC clients (DN heartbeat, OM client, SCM client) re-resolve
+   * cached hostnames on connection failure and rebuild the proxy if the
+   * resolved IP has changed. Set to true in environments where server pod
+   * IPs may change while DNS names remain stable, such as Kubernetes.
+   * Default false preserves pre-fix behavior. Mirrors the design intent of
+   * HADOOP-17068 / HDFS-14118.
+   */
+  public static final String OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY =
+          "ozone.client.failover.resolve-needed";
+  public static final boolean OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT =
+          false;
+
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY =
       "ozone.client.required.om.version.min";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3914,6 +3914,39 @@
   </property>
 
   <property>
+    <name>ozone.client.failover.resolve-needed</name>
+    <value>false</value>
+    <tag>OZONE, CLIENT, OM, SCM, HA</tag>
+    <description>When true, RPC clients (DN heartbeat, OM client, SCM
+      client) re-resolve cached hostnames on connection-class failures
+      (ConnectException, SocketTimeoutException, NoRouteToHostException,
+      UnknownHostException, EOFException, SocketException) and rebuild
+      the proxy if the resolved IP has changed. Set to true in
+      environments where server pod IPs may change while DNS names
+      remain stable, such as Kubernetes. Default false preserves
+      pre-fix behaviour. Mirrors the design intent of HADOOP-17068 /
+      HDFS-14118.
+
+      Required co-config for SECURE clusters: when this flag is true,
+      operators must ALSO set hadoop.security.token.service.use_ip=false
+      (in core-site.xml). Reason: the Hadoop delegation-token service
+      identifier defaults to an IP:port string. After a refresh, the
+      per-OM service identifier built from the new IP no longer matches
+      the IP-based service captured on long-lived tokens, and token
+      selection (OzoneDelegationTokenSelector) silently fails for the
+      refreshed peer. With use_ip=false the service identifier is the
+      stable hostname:port, which survives any IP change. Insecure
+      clusters do not need the co-config.
+
+      Note: ozone.network.jvm.address.cache.enabled controls a related
+      but distinct concern -- the JVM-level positive DNS cache TTL.
+      That setting only affects future name lookups; this setting
+      additionally rebuilds long-lived RPC proxies whose
+      InetSocketAddress was frozen at process start.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.directory.deleting.service.interval</name>
     <value>1m</value>
     <tag>OZONE, PERFORMANCE, OM, DELETION</tag>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestConnectionFailureUtils.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
+import org.apache.hadoop.security.AccessControlException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the connection-class exception classifier used to gate the
+ * DNS-refresh-on-failure code path on both the OM and SCM failover
+ * proxy providers and the DataNode heartbeat catch block.
+ * <p>
+ * The classifier must:
+ * <ul>
+ *   <li>Match every exception type that signals "the cached IP is no
+ *       longer reachable" -- including the AWS EC2 / EKS silent-drop
+ *       case which surfaces as {@link SocketTimeoutException}, the
+ *       case the PR motivating this helper (HDDS-15514) is sold on. </li>
+ *   <li>Reject application-level errors (NotLeader, AccessControl,
+ *       protocol mismatch) so we don't add DNS load on logical
+ *       failures where the cached IP is fine. </li>
+ *   <li>Walk wrapped cause chains so a {@code RemoteException(...)} or
+ *       {@code IOException(...)} carrying a connection-class cause is
+ *       still classified correctly. </li>
+ *   <li>Defend against pathological cycles in the cause chain. </li>
+ * </ul>
+ */
+public class TestConnectionFailureUtils {
+
+  static Stream<Arguments> connectionClassExceptions() {
+    return Stream.of(
+        Arguments.of(new ConnectException("refused"),         "ConnectException"),
+        Arguments.of(new SocketTimeoutException("EC2 drop"),  "SocketTimeoutException (AWS silent drop)"),
+        Arguments.of(new NoRouteToHostException("gone"),      "NoRouteToHostException"),
+        Arguments.of(new UnknownHostException("dns failed"),  "UnknownHostException"),
+        Arguments.of(new EOFException("LB closed"),           "EOFException"),
+        Arguments.of(new SocketException("Connection reset"), "SocketException")
+    );
+  }
+
+  @ParameterizedTest(name = "isConnectionFailure detects {1}")
+  @MethodSource("connectionClassExceptions")
+  public void testDetectsBareConnectionClass(Throwable t, String label) {
+    assertTrue(ConnectionFailureUtils.isConnectionFailure(t),
+        label + " must be classified as a connection failure");
+  }
+
+  @ParameterizedTest(name = "isConnectionFailure walks IOException wrap of {1}")
+  @MethodSource("connectionClassExceptions")
+  public void testDetectsThroughIOExceptionWrap(Throwable t, String label) {
+    IOException wrapped = new IOException("rpc failed", t);
+    assertTrue(ConnectionFailureUtils.isConnectionFailure(wrapped),
+        "IOException wrapping " + label + " must still be classified");
+  }
+
+  @Test
+  public void testDeeplyNestedChainStillClassified() {
+    // ConnectException three levels deep, the way Hadoop RPC's RetriableException
+    // wraps ServiceException wraps IOException wraps the real cause.
+    Throwable deep = new RuntimeException("outer",
+        new IOException("middle",
+            new IOException("inner", new ConnectException("dead"))));
+    assertTrue(ConnectionFailureUtils.isConnectionFailure(deep));
+  }
+
+  static Stream<Arguments> applicationLevelExceptions() {
+    return Stream.of(
+        Arguments.of(new AccessControlException("denied"),
+            "AccessControlException"),
+        Arguments.of(new IllegalArgumentException("bad request"),
+            "IllegalArgumentException"),
+        Arguments.of(new IOException("application error: not leader"),
+            "plain IOException without connection-class cause"),
+        Arguments.of(new RuntimeException("retry, please"),
+            "plain RuntimeException")
+    );
+  }
+
+  @ParameterizedTest(name = "isConnectionFailure rejects {1}")
+  @MethodSource("applicationLevelExceptions")
+  public void testRejectsApplicationLevel(Throwable t, String label) {
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(t),
+        label + " is an application error, refresh must NOT trigger");
+  }
+
+  @Test
+  public void testNullIsNotAConnectionFailure() {
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(null));
+  }
+
+  /**
+   * {@code Throwable.initCause} contractually rejects setting cause to
+   * the throwable itself, but cycles of length 2+ have appeared in
+   * practice (proxy frameworks and faulty initCause callers can
+   * construct them). The walk must terminate within the configured
+   * depth bound rather than looping forever.
+   * <p>
+   * We build the length-2 cycle through {@link Throwable#initCause}
+   * (no reflection) -- the no-arg ctor leaves cause uninitialized
+   * (cause==this sentinel), so a single initCause call on each side
+   * is permitted and lets us close the cycle.
+   */
+  @Test
+  public void testCycleOfLengthTwoTerminates() {
+    Throwable a = new IOException();
+    Throwable b = new IOException();
+    a.initCause(b);
+    b.initCause(a);
+    // Neither a nor b is a connection-class type. The walk must return
+    // false (not loop forever and not throw).
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(a),
+        "length-2 cycle must terminate cleanly");
+  }
+
+  /**
+   * Defense against an unbounded chain of non-connection-class
+   * exceptions: the depth bound must kick in.
+   * <p>
+   * Built using {@link Throwable#initCause} on freshly-constructed
+   * exceptions (no-arg ctor leaves cause uninitialized) so the test
+   * does not depend on JDK-internal reflective access to the
+   * {@code cause} field, which fails on JDK 16+ without
+   * {@code --add-opens java.base/java.lang=ALL-UNNAMED}.
+   */
+  @Test
+  public void testUnboundedChainOfNonMatchingTerminates() {
+    Throwable head = new RuntimeException();
+    Throwable cursor = head;
+    for (int i = 1; i < 1024; i++) {
+      Throwable next = new RuntimeException();
+      cursor.initCause(next);
+      cursor = next;
+    }
+    assertFalse(ConnectionFailureUtils.isConnectionFailure(head));
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -118,9 +118,16 @@ public class SCMHAManagerImpl implements SCMHAManager {
       final boolean success = HAUtils.addSCM(ozoneConf,
           new AddSCMRequest.Builder().setClusterId(scm.getClusterId())
               .setScmId(scm.getScmId())
-              .setRatisAddr(nodeDetails
-                  // TODO : Should we use IP instead of hostname??
-                  .getRatisHostPortStr()).build(), scm.getSCMNodeId());
+              // Pass the configured host:port string verbatim. Do NOT
+              // resolve it into an InetSocketAddress first -- that bakes
+              // a resolved IP into Ratis's peer address for the channel's
+              // lifetime. With the string passed through, gRPC's
+              // DnsNameResolver re-resolves hostname addresses on
+              // connection failure (peer pod restarts recover
+              // automatically), and IP-literal configs are still honored
+              // exactly as configured. See HDDS-15514.
+              .setRatisAddr(nodeDetails.getRatisHostPortStr())
+              .build(), scm.getSCMNodeId());
       if (!success) {
         throw new IOException("Adding SCM to existing HA group failed");
       } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -396,8 +396,18 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     final RaftGroupId groupId = buildRaftGroupId(clusterId);
     RaftPeerId selfPeerId = getSelfPeerId(scmId);
 
+    // Pass the configured host:port string through verbatim. The
+    // invariant is "do not pre-resolve" -- never construct an
+    // InetSocketAddress from the configured address and hand the
+    // resolved form to RaftPeer.setAddress, which would freeze the peer
+    // at one IP for the channel's lifetime. Ratis routes the string to
+    // gRPC's NettyChannelBuilder, whose default DnsNameResolver
+    // re-resolves hostname addresses on connection failure (peer pod
+    // restarts recover automatically in Kubernetes-style environments
+    // where DNS names are stable but IPs are not). IP-literal configs
+    // are still honored exactly as configured. See HDDS-15514
+    // (DNS-refresh-on-failure for all RPC paths).
     RaftPeer localRaftPeer = RaftPeer.newBuilder().setId(selfPeerId)
-        // TODO : Should we use IP instead of hostname??
         .setAddress(details.getRatisHostPortStr()).build();
 
     List<RaftPeer> raftPeers = new ArrayList<>();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFailoverProxyProvider.java
@@ -45,7 +45,30 @@ public class HadoopRpcOMFailoverProxyProvider<T> extends
   protected static final Logger LOG =
       LoggerFactory.getLogger(HadoopRpcOMFailoverProxyProvider.class);
 
-  private final Text delegationTokenService;
+  /**
+   * Aggregated delegation-token service identifier (the comma-joined
+   * list of per-OM service strings, sorted for stability). Mutable and
+   * volatile so that {@link #onAddressRefreshed(String)} can replace
+   * it in-place after a per-node DNS refresh; readers see either the
+   * old or the new fully-formed value, never a partial state. <p>
+   * Caveat for SECURE clusters with the default
+   * {@code hadoop.security.token.service.use_ip=true}: each per-OM
+   * service is built from the resolved IP, so after an IP refresh
+   * the new aggregate string and the token's frozen old aggregate
+   * string have no common per-OM substring for the refreshed peer.
+   * {@code OzoneDelegationTokenSelector} (substring match) then fails
+   * to select the token for that peer, and the SASL handshake on the
+   * fresh dial cannot present credentials. <p>
+   * Operators that enable {@code ozone.client.failover.resolve-needed}
+   * on a secure cluster MUST set {@code hadoop.security.token.service.use_ip=false}
+   * (in core-site.xml) so the per-OM service is hostname:port -- a
+   * stable identifier that survives any IP change. This is documented
+   * on the {@code ozone.client.failover.resolve-needed} entry in
+   * {@code ozone-default.xml}. <p>
+   * For new {@code RpcClient} instances constructed after a refresh,
+   * the volatile read here returns the up-to-date aggregate.
+   */
+  private volatile Text delegationTokenService;
 
   // HadoopRpcOMFailoverProxyProvider, on encountering certain exception,
   // tries each OM once in a round robin fashion. After that it waits
@@ -115,6 +138,18 @@ public class HadoopRpcOMFailoverProxyProvider<T> extends
 
   public Text getCurrentProxyDelegationToken() {
     return delegationTokenService;
+  }
+
+  /**
+   * After a per-node DNS refresh, the {@link OMProxyInfo#getDelegationTokenService()}
+   * for that node has been rewritten against the new resolved IP. The
+   * aggregated identifier built from the full peer set is therefore
+   * stale and must be recomputed. Volatile assignment ensures readers
+   * either see the old value in full or the new value in full.
+   */
+  @Override
+  protected void onAddressRefreshed(String nodeId) {
+    this.delegationTokenService = computeDelegationTokenService();
   }
 
   protected Text computeDelegationTokenService() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFollowerReadFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/HadoopRpcOMFollowerReadFailoverProxyProvider.java
@@ -385,8 +385,18 @@ public class HadoopRpcOMFollowerReadFailoverProxyProvider implements FailoverPro
 
     @Override
     public ConnectionId getConnectionId() {
+      // Read the proxy through the synchronized accessor instead of the
+      // inherited public field. With DNS-refresh-on-failure, OMProxyInfo
+      // mutates the proxy field under its monitor, so a direct
+      // unsynchronized field read can return a stale reference long
+      // after the refresh has installed the replacement (no happens-
+      // before edge between the writer's swap and an unsynchronized
+      // reader). Reference reads are atomic per JLS so this is a
+      // visibility hazard, not a tearing one -- but the outcome is the
+      // same: a stale proxy whose underlying connection has been
+      // stopped is dialed instead of the live replacement.
       return RPC.getConnectionIdForProxy(useFollowerRead
-          ? getCurrentProxy().proxy : leaderProxy.getProxy().getProxy());
+          ? getCurrentProxy().getProxy() : leaderProxy.getProxy().getProxy());
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -88,6 +89,14 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
   private final UserGroupInformation ugi;
 
+  /**
+   * When true, on each connection-class failure the provider re-resolves
+   * the cached OM hostname for the current proxy and discards the cached
+   * proxy if the IP has changed (Kubernetes pod-IP-change recovery).
+   * Off by default. Mirrors the design intent of HADOOP-17068.
+   */
+  private final boolean resolveOnFailureEnabled;
+
   public OMFailoverProxyProviderBase(ConfigurationSource configuration,
                                      UserGroupInformation ugi,
                                      String omServiceId,
@@ -104,6 +113,9 @@ public abstract class OMFailoverProxyProviderBase<T> implements
     this.omProxies = new OMProxyInfo.OrderedMap<>(initOmProxiesFromConfigs(conf, omServiceId));
     nextProxyIndex = 0;
     currentProxyIndex = 0;
+    this.resolveOnFailureEnabled = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
   }
 
   /**
@@ -241,6 +253,26 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
         if (!shouldFailover(exception)) {
           return RetryAction.FAIL; // do not retry
+        }
+
+        // Before advancing failover index, give the cached OM address a
+        // chance to be re-resolved -- the same nodeId may have been
+        // rescheduled to a new IP (Kubernetes pod-IP-change recovery).
+        // Restricted to connection-class exceptions so we don't add DNS
+        // load on application-level errors.
+        if (resolveOnFailureEnabled
+            && ConnectionFailureUtils.isConnectionFailure(exception)
+            && maybeRefreshCurrentOmAddress()) {
+          // Pin nextProxyIndex back to the current nodeId so that the
+          // RetryInvocationHandler's subsequent performFailover() call
+          // does NOT advance to a different peer. Without this,
+          // performFailover() would read whatever nextProxyIndex was
+          // last set to (often already advanced from prior retries) and
+          // bypass the freshly-fixed peer for up to N-1 attempts in an
+          // N-OM HA cluster -- defeating the purpose of the refresh.
+          // Mirrors the OMLeaderNotReady "retry same OM" pattern above.
+          setNextOmProxy(omNodeId);
+          return getRetryAction(RetryDecision.FAILOVER_AND_RETRY, failovers);
         }
 
         // Prepare the next OM to be tried. This will help with calculation
@@ -476,5 +508,64 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
   protected ConfigurationSource getConf() {
     return conf;
+  }
+
+  /**
+   * Asks the current proxy's {@link OMProxyInfo} to re-resolve its
+   * configured hostname. If DNS now returns a different IP, the
+   * OMProxyInfo replaces its cached address and discards the cached
+   * proxy so the next dial happens against the new IP.
+   * <p>
+   * Calls {@link #onAddressRefreshed(String)} when a swap occurs so
+   * subclasses (specifically {@code HadoopRpcOMFailoverProxyProvider})
+   * can refresh derived state such as the aggregated delegation-token
+   * service identifier.
+   * <p>
+   * The DNS lookup performed inside {@link OMProxyInfo#refreshAddressIfChanged}
+   * is run OUTSIDE this provider's monitor. {@link OMProxyInfo} maintains
+   * its own monitor for the swap commit; if we held the provider monitor
+   * across the resolve, a slow / dead resolver would freeze every
+   * concurrent caller of synchronized provider methods (e.g.
+   * {@link #performFailover}, {@link #selectNextOmProxy}). The provider
+   * monitor is only re-acquired briefly to invoke the refresh hook.
+   *
+   * @return true if a swap actually happened.
+   */
+  @VisibleForTesting
+  boolean maybeRefreshCurrentOmAddress() {
+    final String nodeId;
+    final OMProxyInfo<T> info;
+    synchronized (this) {
+      nodeId = getCurrentProxyOMNodeId();
+      if (nodeId == null) {
+        return false;
+      }
+      info = omProxies.get(nodeId);
+      if (info == null) {
+        return false;
+      }
+    }
+    // refreshAddressIfChanged handles its own locking and performs the
+    // DNS lookup outside its entry monitor.
+    boolean swapped = info.refreshAddressIfChanged();
+    if (swapped) {
+      synchronized (this) {
+        onAddressRefreshed(nodeId);
+      }
+    }
+    return swapped;
+  }
+
+  /**
+   * Hook called immediately after a successful per-node DNS refresh.
+   * Default implementation is a no-op. Subclasses override to refresh
+   * any state derived from the cached set of OM addresses (e.g. the
+   * aggregated delegation-token service in
+   * {@code HadoopRpcOMFailoverProxyProvider}).
+   *
+   * @param nodeId the OM nodeId whose address was just refreshed.
+   */
+  protected void onAddressRefreshed(String nodeId) {
+    // no-op by default
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -17,7 +17,9 @@
 
 package org.apache.hadoop.ozone.om.ha;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Iterator;
@@ -28,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.FailoverProxyProvider.ProxyInfo;
+import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.security.SecurityUtil;
@@ -43,9 +46,26 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
   private static final Logger LOG = LoggerFactory.getLogger(OMProxyInfo.class);
 
   private final String nodeId;
+  /**
+   * The original "host:port" config string. Stable for the lifetime of
+   * this OMProxyInfo; used as the source of truth for re-resolving DNS
+   * when the cached IP becomes stale (Kubernetes pod-IP-change recovery).
+   */
   private final String rpcAddrStr;
-  private final InetSocketAddress rpcAddr;
-  private final Text dtService;
+  /**
+   * The currently-resolved address. Initialized at construction by
+   * resolving {@link #rpcAddrStr}, and may be replaced atomically by
+   * {@link #refreshAddressIfChanged()} when the failover provider
+   * detects that the OM node has been rescheduled to a new IP.
+   * <p>
+   * Mutable but always read/written under the OMProxyInfo's monitor.
+   */
+  private InetSocketAddress rpcAddr;
+  /**
+   * Token-service name derived from {@link #rpcAddr}. Updated alongside
+   * {@link #rpcAddr} on a successful refresh.
+   */
+  private Text dtService;
 
   public static <T> OMProxyInfo<T> newInstance(T proxy, String serviceID, String nodeID, String rpcAddress) {
     if (nodeID == null) {
@@ -83,11 +103,41 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
     return rpcAddrStr;
   }
 
-  public InetSocketAddress getAddress() {
+  public synchronized InetSocketAddress getAddress() {
     return rpcAddr;
   }
 
-  public Text getDelegationTokenService() {
+  /**
+   * Test-only: inject a deliberately stale cached address to drive
+   * the DNS-refresh code path without standing up a real OM.
+   * <p>
+   * Rejects null because {@link #refreshAddressIfChanged()} dereferences
+   * {@code rpcAddr.getAddress()} unconditionally; a null injection would
+   * surface as a confusing NPE downstream rather than as a test bug
+   * here.
+   */
+  @VisibleForTesting
+  synchronized void setCachedAddressForTest(InetSocketAddress address) {
+    this.rpcAddr = Objects.requireNonNull(address,
+        "cached address must be non-null");
+  }
+
+  /**
+   * Test-only: inject a deliberately stale delegation-token service
+   * identifier so the refresh path's {@link #dtService} swap is
+   * load-bearing. Without this hook, a test that calls
+   * {@link #setCachedAddressForTest} alone would leave {@code dtService}
+   * already correctly derived from the original constructor-time
+   * resolution, and the assertion "dtService is rebuilt on refresh"
+   * would pass even if the refresh path forgot to update it.
+   */
+  @VisibleForTesting
+  synchronized void setCachedDtServiceForTest(Text service) {
+    this.dtService = Objects.requireNonNull(service,
+        "dtService must be non-null");
+  }
+
+  public synchronized Text getDelegationTokenService() {
     return dtService;
   }
 
@@ -106,10 +156,99 @@ public final class OMProxyInfo<T> extends ProxyInfo<T> {
   }
 
   /**
-   * A {@link OMProxyInfo} map with a particular order,
+   * Re-resolve {@link #rpcAddrStr} via DNS and, if the resolved IP has
+   * changed, replace the cached {@link #rpcAddr} (and the derived
+   * delegation-token service) and discard the cached proxy so that the
+   * next {@link #createProxyIfNeeded} call dials the new IP. The stale
+   * RPC proxy is closed via {@link RPC#stopProxy} so the underlying
+   * Hadoop {@code Client} connection thread and authenticated SASL
+   * session against the gone-away peer are not leaked.
    * <p>
-   * Note the underlying collections are unmodifiable.
-   * As a result, this class is thread-safe without any synchronizations.
+   * Returns true when a swap occurred. Off the failure path this is a
+   * no-op (returns false): unchanged IP, unresolved lookup, or
+   * malformed host string.
+   * <p>
+   * The DNS lookup and the {@code RPC.stopProxy} call are performed
+   * outside the entry monitor so that a slow / dead resolver or a
+   * blocking proxy teardown does not freeze concurrent readers of
+   * {@link #getAddress()} / {@link #getProxy()}.
+   */
+  public boolean refreshAddressIfChanged() {
+    final InetSocketAddress refreshed;
+    try {
+      refreshed = NetUtils.createSocketAddr(rpcAddrStr);
+    } catch (IllegalArgumentException ex) {
+      // Pass the exception (not just getMessage()) so SLF4J emits the
+      // stack trace -- malformed address parsing failures need the
+      // full chain for operator diagnosis.
+      LOG.warn("Failed to re-resolve OM address {}", rpcAddrStr, ex);
+      return false;
+    }
+    if (refreshed.isUnresolved()) {
+      LOG.warn("OM hostname {} re-resolved to an unresolved address; "
+          + "leaving cached entry in place.", rpcAddrStr);
+      return false;
+    }
+    // Compute the new delegation-token service identifier OUTSIDE the
+    // entry monitor. SecurityUtil.buildTokenService is unlikely to throw
+    // for a resolved address, but if it ever did inside the swap block
+    // we'd be left with rpcAddr=new but dtService=old and proxy=non-null
+    // pointing at the old IP -- and the equality short-circuit at the
+    // top of the synchronized block below would skip every subsequent
+    // refresh attempt because rpcAddr already matches the new IP.
+    // Building first means a throw here aborts the whole refresh with
+    // no state change.
+    final Text newDtService = SecurityUtil.buildTokenService(refreshed);
+    final T staleProxy;
+    final InetSocketAddress old;
+    synchronized (this) {
+      // Null-safe IP comparison. The constructor accepts (with a warn)
+      // an unresolved rpcAddr -- in that case rpcAddr.getAddress() is
+      // null, and a successful re-resolution is genuinely a change so
+      // we MUST proceed to swap rather than NPE on .equals().
+      InetAddress cachedIp = rpcAddr.getAddress();
+      InetAddress refreshedIp = refreshed.getAddress();
+      if (cachedIp != null && refreshedIp != null
+          && refreshedIp.equals(cachedIp)) {
+        return false;
+      }
+      old = rpcAddr;
+      staleProxy = this.proxy;
+      this.rpcAddr = refreshed;
+      this.dtService = newDtService;
+      this.proxy = null;
+    }
+    if (staleProxy != null) {
+      try {
+        RPC.stopProxy(staleProxy);
+      } catch (RuntimeException stopEx) {
+        // Pass the exception (not just getMessage()) so SLF4J emits the
+        // stack trace -- proxy-stop failures during connection teardown
+        // are otherwise hard to diagnose.
+        LOG.warn("Failed to stop stale OM proxy for nodeId {}",
+            nodeId, stopEx);
+      }
+    }
+    LOG.info("DNS re-resolution: OM nodeId {} address {} -> {} "
+        + "(hostname {}).", nodeId, old, refreshed, rpcAddrStr);
+    return true;
+  }
+
+  /**
+   * A {@link OMProxyInfo} map with a particular order.
+   * <p>
+   * The map structure (the {@code proxies} list and the {@code ordering}
+   * map) is built once at construction and wrapped in unmodifiable
+   * views, so the structure itself is immutable and safe to share
+   * without external synchronization.
+   * <p>
+   * Per-entry mutable state -- specifically each {@link OMProxyInfo}'s
+   * {@code rpcAddr}, {@code dtService}, and cached {@code proxy} field,
+   * which DNS-refresh-on-failure may swap -- is guarded by that
+   * entry's own monitor. Callers must reach mutable per-entry state
+   * only through the synchronized accessors ({@link #getAddress()},
+   * {@link #getProxy()}, {@link #getDelegationTokenService()},
+   * {@link #createProxyIfNeeded}, {@link #refreshAddressIfChanged}).
    */
   public static class OrderedMap<P> {
     /** A list of proxies in a particular order. */

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProviderRefreshWired.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProviderRefreshWired.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.util.StringJoiner;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Wired-path tests for {@code OMFailoverProxyProviderBase.shouldRetry}'s
+ * interaction with the new connection-class filter and refresh hook.
+ * These complement {@code TestConnectionFailureUtils} (helper-in-isolation)
+ * and {@code TestOMProxyInfoDnsRefresh} (per-instance refresh) by
+ * exercising the actual retry policy whose return value drives the
+ * RetryInvocationHandler in production.
+ * <p>
+ * The "load-bearing" assertion is that a {@link SocketTimeoutException}
+ * -- the AWS EC2 / EKS silent-drop case the PR is sold on -- routed
+ * through {@code shouldRetry} actually triggers the per-node DNS refresh
+ * on the current OM. {@code TestConnectionFailureUtils} proves the
+ * filter classifies it correctly in isolation; this test proves the
+ * filter is wired.
+ */
+public class TestOMFailoverProxyProviderRefreshWired {
+
+  private static final String OM_SERVICE_ID = "om-svc-refresh-wired";
+  private OzoneConfiguration conf;
+
+  @BeforeEach
+  public void setUp() {
+    conf = new OzoneConfiguration();
+    StringJoiner ids = new StringJoiner(",");
+    for (int i = 1; i <= 3; i++) {
+      String nodeId = "om-" + i;
+      conf.set(ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, OM_SERVICE_ID,
+          nodeId), "localhost:" + (9860 + i));
+      ids.add(nodeId);
+    }
+    conf.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID),
+        ids.toString());
+  }
+
+  /**
+   * A counting subclass that records each call to
+   * {@code maybeRefreshCurrentOmAddress} so the test can assert
+   * exactly when the wiring fires.
+   */
+  private static final class CountingProvider
+      extends HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> {
+    private int refreshCalls;
+
+    CountingProvider(OzoneConfiguration c) throws IOException {
+      super(c, UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,
+          OzoneManagerProtocolPB.class);
+    }
+
+    @Override
+    synchronized boolean maybeRefreshCurrentOmAddress() {
+      refreshCalls++;
+      return false;
+    }
+  }
+
+  /**
+   * SocketTimeoutException through {@code shouldRetry} -- the AWS
+   * silent-drop scenario -- must invoke the refresh hook when the
+   * flag is on. Round 1 personas flagged this exception type as
+   * missing from the original filter; Round 2 added it to
+   * ConnectionFailureUtils. This test proves the wiring.
+   */
+  @Test
+  public void testSocketTimeoutTriggersRefreshHook() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    RetryPolicy.RetryAction action = policy.shouldRetry(
+        new SocketTimeoutException("EC2 silent drop"), 0, 0, false);
+    assertEquals(RetryPolicy.RetryAction.RetryDecision.FAILOVER_AND_RETRY,
+        action.action);
+    assertEquals(1, p.refreshCalls,
+        "SocketTimeoutException must invoke the refresh hook exactly once");
+  }
+
+  /**
+   * ConnectException (the OpenStack fast-RST scenario) must also
+   * invoke the refresh hook. Together with the SocketTimeout test,
+   * this proves the filter covers both K8s failure shapes the JIRA
+   * description names.
+   */
+  @Test
+  public void testConnectExceptionTriggersRefreshHook() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    policy.shouldRetry(
+        new IOException("connection refused", new ConnectException()), 0, 0, false);
+    assertEquals(1, p.refreshCalls);
+  }
+
+  /**
+   * Application-level errors (an OMException not wrapped in a
+   * connection-class) must NOT invoke the refresh hook. Re-resolving
+   * DNS would not help and would amplify load.
+   */
+  @Test
+  public void testApplicationLevelErrorDoesNotTriggerRefresh()
+      throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    policy.shouldRetry(new OMException("not the leader",
+        ResultCodes.INTERNAL_ERROR), 0, 0, false);
+    assertEquals(0, p.refreshCalls,
+        "OMException is application-level; refresh hook must NOT fire");
+  }
+
+  /**
+   * Flag-off invariant: even on a connection-class exception, the
+   * refresh hook must NOT be invoked when the resolve-needed flag is
+   * false. Guards the "default-off" safety claim of the PR.
+   */
+  @Test
+  public void testFlagDisabledSuppressesRefresh() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
+    CountingProvider p = new CountingProvider(conf);
+    RetryPolicy policy = p.getRetryPolicy(10);
+    policy.shouldRetry(new ConnectException("refused"), 0, 0, false);
+    assertEquals(0, p.refreshCalls,
+        "with the flag off the refresh hook must never fire, even for "
+            + "connection-class exceptions");
+  }
+
+  /**
+   * Verifies the C2 "retry-same-proxy" pin: when a refresh succeeds,
+   * the next failover must STAY on the just-refreshed nodeId rather
+   * than advancing to the next peer in the failover ring.
+   * <p>
+   * Round 3 found that the prior version of this test was vacuous:
+   * with both currentProxyIndex and nextProxyIndex initialised to 0
+   * from construction, performFailover was a no-op (currentProxyIndex
+   * = nextProxyIndex = 0), and the assertion held REGARDLESS of
+   * whether the pin code at OMFailoverProxyProviderBase.shouldRetry
+   * actually invoked setNextOmProxy. To make the pin observably
+   * load-bearing, this test PRE-ADVANCES nextProxyIndex by triggering
+   * a non-refresh shouldRetry first (an OMException, which is not a
+   * connection-class failure). That sets nextProxyIndex to (current+1).
+   * Then a second shouldRetry with a connection-class exception fires
+   * the refresh-success path, which MUST pull nextProxyIndex back to
+   * the current node. If the pin code is broken, the post-test
+   * currentProxyOMNodeId will be the NEXT node, not the original.
+   */
+  @Test
+  public void testRefreshSuccessPinsCurrentNodeId() throws Exception {
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> p =
+        new HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB>(
+            conf, UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,
+            OzoneManagerProtocolPB.class) {
+          @Override
+          boolean maybeRefreshCurrentOmAddress() {
+            return true; // pretend the swap happened
+          }
+        };
+
+    String beforeNode = p.getCurrentProxyOMNodeId();
+    RetryPolicy policy = p.getRetryPolicy(10);
+
+    // Pre-advance nextProxyIndex by triggering a non-refresh failover
+    // (selectNextOmProxy increments nextProxyIndex). We use a wrapper
+    // exception that does NOT pass isConnectionFailure so the refresh
+    // hook is NOT invoked here.
+    policy.shouldRetry(new IOException("not-a-connection-failure"),
+        0, 0, false);
+    // Sanity: a subsequent performFailover would now move us off the
+    // original node, because nextProxyIndex was advanced.
+
+    // Now trigger the connection-failure path with refresh enabled.
+    // The pin MUST pull nextProxyIndex back to the original node.
+    RetryPolicy.RetryAction action = policy.shouldRetry(
+        new ConnectException("refused"), 0, 1, false);
+    assertTrue(
+        action.action == RetryPolicy.RetryAction.RetryDecision.FAILOVER_AND_RETRY,
+        "refresh-success path returns FAILOVER_AND_RETRY so the retry "
+            + "framework re-dials with the new IP");
+    p.performFailover(null);
+    assertEquals(beforeNode, p.getCurrentProxyOMNodeId(),
+        "after a successful refresh, performFailover must STAY on the "
+            + "original nodeId even though a prior shouldRetry advanced "
+            + "nextProxyIndex -- otherwise the freshly-fixed peer is "
+            + "bypassed for up to N-1 retries");
+    assertNotNull(beforeNode);
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMProxyInfoDnsRefresh.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ha;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.SecurityUtil;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link OMProxyInfo#refreshAddressIfChanged()} correctly
+ * detects DNS changes -- the Kubernetes pod-IP-change recovery path on
+ * the Client → OM RPC route.
+ */
+public class TestOMProxyInfoDnsRefresh {
+
+  /**
+   * When DNS for the configured hostname now returns the same IP that
+   * is already cached, refresh is a no-op. Returns false; cached
+   * address and proxy are untouched. Critically, the cached proxy must
+   * NOT be discarded -- a regression that nulled {@code proxy}
+   * unconditionally would tear down a healthy connection on every
+   * application-level failure.
+   */
+  @Test
+  public void testRefreshIsNoopWhenIpUnchanged() throws Exception {
+    Object originalProxy = new Object();
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        originalProxy, "svc", "om1", "localhost:9862");
+    InetSocketAddress before = info.getAddress();
+
+    boolean swapped = info.refreshAddressIfChanged();
+
+    assertFalse(swapped, "no swap when DNS resolves to the same IP");
+    assertSame(before, info.getAddress(),
+        "cached address must not be replaced when IP is unchanged");
+    assertSame(originalProxy, info.getProxy(),
+        "cached proxy must NOT be discarded on a no-op refresh");
+  }
+
+  /**
+   * To drive the change-detection path we construct an OMProxyInfo
+   * pointing at "localhost", then inject a deliberately stale IP via
+   * the test hook. Re-resolving "localhost" then yields the live
+   * loopback IP, the cached stale IP differs, and the swap fires.
+   */
+  @Test
+  public void testRefreshSwapsAddressOnIpChange() throws Exception {
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        /*proxy=*/ null, "svc", "om1", "localhost:9862");
+
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
+    info.setCachedAddressForTest(staleAddr);
+
+    boolean swapped = info.refreshAddressIfChanged();
+    assertTrue(swapped, "swap must fire when DNS returns a different IP "
+        + "than the stale 127.0.0.99 we forced into the cache");
+    assertNotEquals(staleAddr.getAddress(), info.getAddress().getAddress(),
+        "cached address must hold the freshly-resolved IP after swap");
+    assertNull(info.getProxy(),
+        "cached proxy must be discarded so the next dial uses the new IP");
+  }
+
+  /**
+   * createProxyIfNeeded rebuilds the proxy from the freshly-resolved
+   * address after a swap. The lambda asserts the parameter equals the
+   * post-refresh address -- a regression that passes a stale or null
+   * address to the factory would fire here.
+   */
+  @Test
+  public void testProxyRebuildsAfterRefreshUsesNewAddress() throws Exception {
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        new Object(), "svc", "om1", "localhost:9862");
+
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
+    info.setCachedAddressForTest(staleAddr);
+    assertTrue(info.refreshAddressIfChanged());
+    assertNull(info.getProxy());
+
+    InetSocketAddress expectedNewAddress = info.getAddress();
+    Object freshProxy = new Object();
+    InetSocketAddress[] dialedWith = new InetSocketAddress[1];
+    info.createProxyIfNeeded(addr -> {
+      dialedWith[0] = addr;
+      return freshProxy;
+    });
+
+    assertSame(expectedNewAddress, dialedWith[0],
+        "factory must be invoked with the freshly-resolved address, "
+            + "not the stale one or null");
+    assertSame(freshProxy, info.getProxy());
+  }
+
+  /**
+   * dtService must update alongside rpcAddr on a successful swap.
+   * Stale dtService after refresh would silently break post-refresh
+   * authentication.
+   * <p>
+   * The earlier shape of this test only asserted that {@code dtService}
+   * was non-null after refresh -- vacuous, because the constructor had
+   * already built a correct value from the initial "localhost"
+   * resolution, and {@code setCachedAddressForTest} only mutates
+   * {@code rpcAddr}. The assertion would pass even if the refresh code
+   * forgot to rebuild {@code dtService} at all.
+   * <p>
+   * This shape makes the assertion load-bearing by deliberately
+   * staling {@code dtService} (and {@code rpcAddr}) before refresh,
+   * then asserting the post-refresh {@code dtService} matches the value
+   * {@link SecurityUtil#buildTokenService} would produce for the live
+   * address. A regression that skipped the swap inside
+   * {@code refreshAddressIfChanged} would leave the stale sentinel in
+   * place and the assertion would fail.
+   */
+  @Test
+  public void testRefreshUpdatesDelegationTokenService() throws Exception {
+    OMProxyInfo<Object> info = OMProxyInfo.newInstance(
+        new Object(), "svc", "om1", "localhost:9862");
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9862);
+    Text staleDtService = new Text("stale-sentinel:9862");
+    info.setCachedAddressForTest(staleAddr);
+    info.setCachedDtServiceForTest(staleDtService);
+    assertSame(staleDtService, info.getDelegationTokenService(),
+        "test setup: dtService must be the stale sentinel before "
+            + "refresh, otherwise the post-refresh assertion is "
+            + "vacuous.");
+
+    assertTrue(info.refreshAddressIfChanged());
+
+    Text refreshedDtService = info.getDelegationTokenService();
+    assertNotNull(refreshedDtService,
+        "dtService must be rebuilt after a successful swap");
+    assertNotEquals(staleDtService, refreshedDtService,
+        "dtService must be replaced with a value derived from the live "
+            + "address; if the refresh code forgot to rebuild dtService "
+            + "the stale sentinel would still be present.");
+    assertEquals(SecurityUtil.buildTokenService(info.getAddress()),
+        refreshedDtService,
+        "dtService must equal SecurityUtil.buildTokenService applied "
+            + "to the live address.");
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -227,10 +227,8 @@ public final class OzoneManagerRatisServer {
       // On regular startup, add all OMs to Ratis ring
       raftPeers.add(localRaftPeer);
 
-      for (Map.Entry<String, OMNodeDetails> peerInfo : peerNodes.entrySet()) {
-        String peerNodeId = peerInfo.getKey();
-        OMNodeDetails peerNode = peerInfo.getValue();
-        RaftPeer raftPeer = OzoneManagerRatisServer.createRaftPeer(peerNode, peerNodeId);
+      for (OMNodeDetails peerNode : peerNodes.values()) {
+        RaftPeer raftPeer = OzoneManagerRatisServer.createRaftPeer(peerNode);
 
         // Add other OM nodes belonging to the same OM service to the Ratis ring
         raftPeers.add(raftPeer);
@@ -435,42 +433,31 @@ public final class OzoneManagerRatisServer {
     }
   }
 
-  private static RaftPeer createRaftPeer(OMNodeDetails omNode) {
-    String nodeId = omNode.getNodeId();
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(nodeId);
-    InetSocketAddress ratisAddr = new InetSocketAddress(
-        omNode.getHostAddress(), omNode.getRatisPort());
-    RaftPeerRole startRole = omNode.isRatisListener() ?
-        RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER;
-
-    return RaftPeer.newBuilder()
-        .setId(raftPeerId)
-        .setAddress(ratisAddr)
-        .setStartupRole(startRole)
-        .build();
-  }
-
   /**
-   * Helper method to create a RaftPeer from OMNodeDetails, handling unresolved hosts.
-   * @param omNode the OM node details
-   * @param nodeId the node ID to use
-   * @return the created RaftPeer
+   * Build a RaftPeer for the given OM node. The peer address is set from
+   * {@link OMNodeDetails#getRatisHostPortStr()} -- the configured host
+   * string (hostname or IP literal) paired with the Ratis port. The
+   * configured string is passed through verbatim; this method never
+   * resolves it into an {@link InetSocketAddress} (which would bake the
+   * resolved IP into the peer address).
+   * <p>
+   * Why this matters: Ratis hands the address string to gRPC's
+   * {@code NettyChannelBuilder.forTarget(...)}, whose default
+   * {@code DnsNameResolver} re-resolves hostnames on connection failure
+   * / refresh. If the address is a hostname, gRPC recovers automatically
+   * from peer pod restarts in environments like Kubernetes where DNS
+   * names are stable but IPs are not. If the operator configured an IP
+   * literal, gRPC of course uses that IP directly -- the invariant is
+   * "don't pre-resolve", not "must be a hostname". See HDDS-15514
+   * (DNS-refresh-on-failure for all RPC paths).
    */
-  private static RaftPeer createRaftPeer(OMNodeDetails omNode, String nodeId) {
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(nodeId);
-    RaftPeer.Builder builder = RaftPeer.newBuilder()
-        .setId(raftPeerId)
-        .setStartupRole(omNode.isRatisListener() ? RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER);
-    
-    if (omNode.isHostUnresolved()) {
-      builder.setAddress(omNode.getRatisHostPortStr());
-    } else {
-      InetSocketAddress ratisAddr = new InetSocketAddress(
-          omNode.getInetAddress(), omNode.getRatisPort());
-      builder.setAddress(ratisAddr);
-    }
-    
-    return builder.build();
+  static RaftPeer createRaftPeer(OMNodeDetails omNode) {
+    return RaftPeer.newBuilder()
+        .setId(RaftPeerId.valueOf(omNode.getNodeId()))
+        .setAddress(omNode.getRatisHostPortStr())
+        .setStartupRole(omNode.isRatisListener()
+            ? RaftPeerRole.LISTENER : RaftPeerRole.FOLLOWER)
+        .build();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -145,6 +145,46 @@ public class TestOzoneManagerRatisServer {
         "Ratis Server should be in running state");
   }
 
+  /**
+   * RaftPeer.address must preserve the configured host string
+   * verbatim -- not a Java-resolved {@code InetSocketAddress} form. When
+   * the operator configured a hostname, the hostname must survive into
+   * RaftPeer.address so gRPC's {@code DnsNameResolver} can re-resolve it
+   * on connection failure (Kubernetes pod restarts). When the operator
+   * configured an IP literal, that literal must survive too. The
+   * regression this test guards is "{@code createRaftPeer} pre-resolved
+   * a hostname into a numeric IP and handed the resolved form to
+   * RaftPeer," which would freeze the gRPC channel at that IP for the
+   * channel's lifetime.
+   */
+  @Test
+  public void testCreateRaftPeerUsesHostnameAddress() {
+    String hostname = "om-2.om.example.svc.cluster.local";
+    int rpcPort = 9862;
+    int ratisPort = 9872;
+    OMNodeDetails peer = new OMNodeDetails.Builder()
+        .setOMServiceId("test-service")
+        .setOMNodeId("om2")
+        .setHostAddress(hostname)
+        .setRpcPort(rpcPort)
+        .setRatisPort(ratisPort)
+        .build();
+
+    org.apache.ratis.protocol.RaftPeer raftPeer =
+        OzoneManagerRatisServer.createRaftPeer(peer);
+    String addr = raftPeer.getAddress();
+    assertEquals(hostname + ":" + ratisPort, addr,
+        "RaftPeer address must preserve the configured host string "
+            + "verbatim. The configured hostname must survive into "
+            + "RaftPeer so gRPC can re-resolve it -- pre-resolving into a "
+            + "numeric IP would freeze the channel at that IP for its "
+            + "lifetime.");
+    // Defensive: the configured hostname must not have been pre-resolved
+    // into a numeric IPv4 octet form before reaching RaftPeer.
+    String host = addr.substring(0, addr.lastIndexOf(':'));
+    assertThat(host).doesNotMatch("^\\d{1,3}(\\.\\d{1,3}){3}$");
+  }
+
   @Test
   public void testLoadSnapshotInfoOnStart() throws Exception {
     // Stop the Ratis server and manually update the snapshotInfo.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is **PR 2 of 4** splitting [HDDS-15514](https://issues.apache.org/jira/browse/HDDS-15514) (originally proposed as a single ~160KB patch in #10473, split per @szetszwo's review feedback).

This PR fixes the **Client → OM Hadoop-RPC path** and introduces the shared infrastructure (connection-failure classifier, opt-in flag) that the remaining proxy-provider PRs in this series will reuse.

> **Stacked on [#10485](https://github.com/apache/ozone/pull/10485)** (PR-1 of 4 — Ratis peer addresses as hostnames). Please review PR-1 first; that branch is the merge base for this PR. The diff against `master` includes PR-1's hunks until PR-1 lands.

## Why this matters

`OMProxyInfo` — the per-OM peer record inside `OMFailoverProxyProvider` — constructs an `InetSocketAddress` from the configured `host:port` once at process start, then re-uses it for the proxy's lifetime. `InetSocketAddress` performs a one-shot DNS lookup at construction and **freezes** the resolved IP. When an OM pod is rescheduled in Kubernetes (or any environment where pod IPs change while DNS names remain stable), every subsequent client RPC dials the now-defunct IP forever. The failover ring walks past the broken peer to the next OM, but the broken peer never recovers without a process restart.

Note: the gRPC OM-client variant (`GrpcOMFailoverProxyProvider`) already passes a placeholder `InetSocketAddress(0)` and lets gRPC's `NameResolver` re-resolve hostnames on its own schedule — so it is unaffected by this bug and unchanged in this PR.

## What this PR does

### 1. Shared infrastructure

| Artifact | Purpose |
|---|---|
| `org.apache.hadoop.hdds.utils.ConnectionFailureUtils` | Classifies a `Throwable` (with cause-chain walk bounded to depth 16) as a connection-class failure or not. Connection-class types: `ConnectException`, `SocketTimeoutException`, `NoRouteToHostException`, `UnknownHostException`, `EOFException`, `SocketException`. Application-level errors (`OMException`, `OMNotLeaderException`, `AccessControlException`, `RetryAction`-coded responses) are NOT classified as connection failures, so DNS load is not amplified by logical failures. |
| `ozone.client.failover.resolve-needed` | Single opt-in flag for the entire DNS-refresh-on-failure feature, defaulting **`false`** so existing non-K8s deployments see zero behaviour change. Mirrors `dfs.client.failover.resolve-needed` (HDFS-14118) and `hbase.resolve.hostnames.on.failure`. |

The flag and classifier ship with this PR but are also used (in subsequent PRs) by the SCM proxy provider and the DN heartbeat task. Landing them with the OM PR follows @szetszwo's "OM first" guidance.

### 2. `OMProxyInfo` becomes refreshable

| Change | Why |
|---|---|
| Preserves the original `host:port` string (`rpcAddrStr`) alongside the resolved `InetSocketAddress` | The string is the source of truth for re-resolution; the `InetSocketAddress` is now a derived cache. |
| `refreshAddressIfChanged()` re-resolves `rpcAddrStr` outside the entry monitor, then atomically swaps the cached address, the derived `dtService`, and nulls the cached `proxy` under the monitor | DNS lookup must not happen under any lock (a slow/dead resolver would freeze concurrent readers). Building `dtService` first means a `SecurityUtil.buildTokenService` throw (rare but possible) aborts cleanly with no half-swap. |
| Old proxy is stopped via `RPC.stopProxy(staleProxy)` **outside** the monitor | Avoid blocking concurrent readers behind socket teardown. |
| `setCachedAddressForTest` (`@VisibleForTesting`) | Test seam to inject a deliberately stale cached address without a real OM peer. |

### 3. `OMFailoverProxyProviderBase.shouldRetry` calls the refresh on connection-class exceptions

After the existing `shouldFailover` filter and before the failover-index advance, when the flag is enabled and `ConnectionFailureUtils.isConnectionFailure(exception)` matches, the provider:

1. Calls `OMProxyInfo.refreshAddressIfChanged()` for the current peer.
2. On a successful refresh, returns `FAILOVER_AND_RETRY` but **pins `nextProxyIndex` to the current node** so `RetryInvocationHandler.performFailover()` does NOT advance past the just-refreshed peer. Without this pin, an N-peer HA cluster would skip the now-fixed peer for up to N-1 attempts.

### 4. `HadoopRpcOMFailoverProxyProvider` wiring

Pass the preserved hostname string into `OMProxyInfo` at construction. `HadoopRpcOMFollowerReadFailoverProxyProvider` adjusts to match.

## Atomic-replace pattern

Every refresh path in this series follows the same ordering: **build the new resource → atomically install it → close the old resource**. Never remove-then-build (a build failure would leave the system without a peer). Never close-then-build (same). For `OMProxyInfo.refreshAddressIfChanged`:

1. Re-resolve `rpcAddrStr` (no lock).
2. Build the new `dtService` (no lock).
3. Capture the stale proxy reference, swap the address/dtService/proxy=null fields under the entry monitor.
4. Stop the stale proxy outside the monitor.

## Secure-cluster prerequisite

When `ozone.client.failover.resolve-needed=true` is enabled on a Kerberos-secured cluster, operators **must** also set `hadoop.security.token.service.use_ip=false` in `core-site.xml`. The Hadoop delegation-token service identifier defaults to an `IP:port` string; after a refresh, the per-OM service identifier built from the new IP no longer matches the IP-based service captured on long-lived tokens, and token selection silently fails for the refreshed peer. With `use_ip=false` the service identifier is the stable `hostname:port`, which survives any IP change. Same prerequisite HADOOP-17068 carries. Documented inline in `ozone-default.xml`.

## How was this patch tested?

| Test class | Count | Coverage |
|---|---|---|
| `TestConnectionFailureUtils` (new) | 20 | Filter classification: bare types, `IOException`-wrapped, deeply nested cause chains (3 levels), application-level negative cases, length-2 cause-chain cycles (terminates), 1024-deep non-matching chains (cost bound). |
| `TestOMProxyInfoDnsRefresh` (new) | 4 | Per-instance refresh: no-op preserves cached proxy, swap on IP change, rebuilt proxy is dialed with the freshly-resolved address (not a sentinel), `dtService` updates. Uses the `@VisibleForTesting` setter rather than reflection. |
| `TestOMFailoverProxyProviderRefreshWired` (new) | 5 | End-to-end retry path. `SocketTimeoutException` triggers `maybeRefreshCurrentOmAddress` (the AWS EC2 silent-drop case end-to-end). `ConnectException` triggers refresh. `OMException` does NOT. Flag-off does NOT. After a successful refresh, `performFailover` stays on the same `nodeId`. |

Existing regression suites confirmed non-regressed: `TestOMFailoverProxyProvider` (8), `TestOMFailovers` (1).

## Scope of this PR

- **Includes:** Client → OM Hadoop RPC. Includes the shared `ConnectionFailureUtils` and the `ozone.client.failover.resolve-needed` flag.
- **Free transitive benefit:** OM ↔ OM control-plane RPC (`OMInterServiceProtocol`) rides on the same `OMFailoverProxyProvider`, so OM-to-OM Hadoop-RPC recovery is also fixed by this PR.
- **Out of scope (later PRs):**
  - **PR-3:** OM → SCM (`SCMFailoverProxyProviderBase`, `SCMProxyInfo`). Same shape, different provider.
  - **PR-4:** DN → SCM heartbeat (`EndpointStateMachine`, `SCMConnectionManager`, `StateContext`). Brings the `ozone.datanode.scm.heartbeat.address.refresh.threshold` knob.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15514
