### PR TITLE
HDDS-15533. DNS refresh on heartbeat failure for DN to SCM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -39,6 +39,13 @@ public final class HddsConfigKeys {
       "hdds.heartbeat.recon.initial-interval";
   public static final String HDDS_RECON_INITIAL_HEARTBEAT_INTERVAL_DEFAULT =
       "2s";
+  /**
+   * Number of consecutive heartbeat failures the DN tolerates against the same SCM endpoint before
+   * re-resolving its hostname. Only consulted when ozone.client.failover.resolve-needed is true.
+   */
+  public static final String HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD =
+      "hdds.heartbeat.address.refresh.threshold";
+  public static final int HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT = 3;
   public static final String HDDS_NODE_REPORT_INTERVAL =
       "hdds.node.report.interval";
   public static final String HDDS_NODE_REPORT_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -616,6 +616,16 @@ public final class OzoneConfigKeys {
   public static final boolean OZONE_JVM_NETWORK_ADDRESS_CACHE_ENABLED_DEFAULT =
           true;
 
+  /**
+   * Number of consecutive heartbeat failures the DN tolerates against the
+   * same SCM endpoint before re-resolving its hostname. Only consulted when
+   * {@link #OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY} is true. Conservative
+   * default avoids re-resolution on transient blips while still recovering
+   * from a peer pod IP change within seconds.
+   */
+  public static final String OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY =
+          "ozone.datanode.scm.heartbeat.address.refresh.threshold";
+  public static final int OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT = 3;
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY =
       "ozone.client.required.om.version.min";
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -616,16 +616,6 @@ public final class OzoneConfigKeys {
   public static final boolean OZONE_JVM_NETWORK_ADDRESS_CACHE_ENABLED_DEFAULT =
           true;
 
-  /**
-   * Number of consecutive heartbeat failures the DN tolerates against the
-   * same SCM endpoint before re-resolving its hostname. Only consulted when
-   * {@link #OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY} is true. Conservative
-   * default avoids re-resolution on transient blips while still recovering
-   * from a peer pod IP change within seconds.
-   */
-  public static final String OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY =
-          "ozone.datanode.scm.heartbeat.address.refresh.threshold";
-  public static final int OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT = 3;
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY =
       "ozone.client.required.om.version.min";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3954,6 +3954,19 @@
   </property>
 
   <property>
+    <name>ozone.datanode.scm.heartbeat.address.refresh.threshold</name>
+    <value>3</value>
+    <tag>OZONE, DATANODE, HA</tag>
+    <description>Number of consecutive heartbeat failures the
+      DataNode tolerates against the same SCM endpoint before
+      attempting a DNS re-resolution. Only consulted when
+      ozone.client.failover.resolve-needed is true. Conservative
+      default avoids re-resolution on transient blips while still
+      recovering from a peer pod IP change within seconds.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.directory.deleting.service.interval</name>
     <value>1m</value>
     <tag>OZONE, PERFORMANCE, OM, DELETION</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3954,7 +3954,7 @@
   </property>
 
   <property>
-    <name>ozone.datanode.scm.heartbeat.address.refresh.threshold</name>
+    <name>hdds.heartbeat.address.refresh.threshold</name>
     <value>3</value>
     <tag>OZONE, DATANODE, HA</tag>
     <description>Number of consecutive heartbeat failures the

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -799,7 +799,9 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
         continue;
       }
       try {
-        connectionManager.addSCMServer(scmAddress, context.getThreadNamePrefix());
+        String hostAndPort = scmAddress.getHostString() + ":" + scmAddress.getPort();
+        connectionManager.addSCMServer(scmAddress, hostAndPort,
+            context.getThreadNamePrefix());
         context.addEndpoint(scmAddress);
         effectiveScmNodeIds.add(scmNodeId);
         LOG.info("Reconfiguration successfully add SCM address {} for SCM service {}", scmAddress, scmServiceId);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.protocol.VersionResponse;
 import org.apache.hadoop.ozone.protocolPB.ReconDatanodeProtocolPB;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
@@ -47,6 +48,19 @@ public class EndpointStateMachine
   private final StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint;
   private final AtomicLong missedCount;
   private final InetSocketAddress address;
+  /**
+   * The original "host:port" string used to resolve {@link #address}.
+   * Preserved so that we can re-resolve DNS when the cached IP becomes
+   * stale (e.g. after a Kubernetes pod restart of the SCM peer). Since
+   * {@link InetSocketAddress} performs a one-shot DNS lookup at
+   * construction and freezes the IP, we cannot recover from a peer IP
+   * change without rebuilding the address from this hostname string.
+   * Null only in the legacy code path where the caller did not preserve
+   * the original config string (in which case re-resolution is disabled
+   * for that endpoint and the operator must restart the DN to pick up
+   * the new IP).
+   */
+  private final String hostAndPort;
   private final Lock lock;
   private final ConfigurationSource conf;
   private EndPointStates state = EndPointStates.FIRST;
@@ -67,9 +81,23 @@ public class EndpointStateMachine
   public EndpointStateMachine(InetSocketAddress address,
       StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
       ConfigurationSource conf, String threadNamePrefix) {
+    this(address, null, endPoint, conf, threadNamePrefix);
+  }
+
+  /**
+   * Constructs RPC Endpoints, preserving the original host:port string
+   * so DNS can be re-resolved on heartbeat failure.
+   * @param address     resolved address used to build the RPC proxy
+   * @param hostAndPort the original "host:port" string, or null if the
+   *                    caller did not preserve it (re-resolution disabled)
+   */
+  public EndpointStateMachine(InetSocketAddress address, String hostAndPort,
+      StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
+      ConfigurationSource conf, String threadNamePrefix) {
     this.endPoint = endPoint;
     this.missedCount = new AtomicLong(0);
     this.address = address;
+    this.hostAndPort = hostAndPort;
     lock = new ReentrantLock();
     this.conf = conf;
     executorService = Executors.newSingleThreadExecutor(
@@ -77,6 +105,59 @@ public class EndpointStateMachine
             .setNameFormat(threadNamePrefix + "EndpointStateMachineTaskThread-"
                 + this.address + "-%d ")
             .build());
+  }
+
+  /**
+   * The original "host:port" string used to construct {@link #getAddress()}.
+   * @return the host:port string, or null if not preserved at construction
+   */
+  public String getHostAndPort() {
+    return hostAndPort;
+  }
+
+  /**
+   * Re-resolves the configured hostname and reports whether the resolved
+   * IP differs from the cached {@link #address}. Does not mutate any
+   * state on this endpoint -- the caller is responsible for swapping
+   * this endpoint out (via {@link SCMConnectionManager#refreshSCMServer})
+   * if a refresh is desired.
+   * <p>
+   * Returns null when:
+   * <ul>
+   *   <li>{@link #hostAndPort} was not preserved at construction</li>
+   *   <li>the resolved IP is unchanged</li>
+   *   <li>the new resolution is unresolved (DNS lookup failed)</li>
+   * </ul>
+   * Returns the freshly-resolved {@link InetSocketAddress} when the IP
+   * has changed under the same hostname.
+   */
+  public InetSocketAddress resolveLatestAddress() {
+    if (hostAndPort == null) {
+      return null;
+    }
+    InetSocketAddress refreshed;
+    try {
+      refreshed = NetUtils.createSocketAddr(hostAndPort);
+    } catch (IllegalArgumentException ex) {
+      LOG.warn("Failed to re-resolve {}: {}", hostAndPort, ex.getMessage());
+      return null;
+    }
+    if (refreshed.isUnresolved()) {
+      LOG.warn("Re-resolution of {} produced an unresolved address; "
+          + "leaving cached address {} in place.", hostAndPort, address);
+      return null;
+    }
+    // Null-safe comparison: if the cached address itself was unresolved
+    // (initial DNS lookup failed; ctor accepted it with a warning),
+    // address.getAddress() is null and a successful re-resolution
+    // counts as a change. NPE-ing here would wedge the heartbeat
+    // refresh path on exactly the case it most needs to fix.
+    java.net.InetAddress cachedIp = address.getAddress();
+    if (cachedIp != null
+        && refreshed.getAddress().equals(cachedIp)) {
+      return null;
+    }
+    return refreshed;
   }
 
   /**
@@ -150,13 +231,23 @@ public class EndpointStateMachine
 
   /**
    * Closes the connection.
+   * <p>
+   * The underlying {@code endPoint.close()} delegates to
+   * {@code RPC.stopProxy} which can raise a RuntimeException; without
+   * the try/finally below, the per-endpoint executor would leak its
+   * thread on close failure. Callers (notably
+   * {@code SCMConnectionManager.refreshSCMServer}) catch RuntimeException
+   * from close, so the leak would otherwise be silent.
    */
   @Override
   public void close() {
-    if (endPoint != null) {
-      endPoint.close();
+    try {
+      if (endPoint != null) {
+        endPoint.close();
+      }
+    } finally {
+      executorService.shutdown();
     }
-    executorService.shutdown();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmHeartbeatInterva
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.Closeable;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.ZonedDateTime;
 import java.util.concurrent.ExecutorService;
@@ -116,45 +117,34 @@ public class EndpointStateMachine
   }
 
   /**
-   * Re-resolves the configured hostname and reports whether the resolved
-   * IP differs from the cached {@link #address}. Does not mutate any
-   * state on this endpoint -- the caller is responsible for swapping
-   * this endpoint out (via {@link SCMConnectionManager#refreshSCMServer})
-   * if a refresh is desired.
+   * Re-resolves the configured hostname and reports whether the resolved IP differs from the cached
+   * {@link #address}. Does not mutate any state on this endpoint -- the caller is responsible for
+   * swapping this endpoint out (via {@link SCMConnectionManager#refreshSCMServer}) if a refresh is
+   * desired.
    * <p>
-   * Returns null when:
-   * <ul>
-   *   <li>{@link #hostAndPort} was not preserved at construction</li>
-   *   <li>the resolved IP is unchanged</li>
-   *   <li>the new resolution is unresolved (DNS lookup failed)</li>
-   * </ul>
-   * Returns the freshly-resolved {@link InetSocketAddress} when the IP
-   * has changed under the same hostname.
+   * Returns null when {@link #hostAndPort} was not preserved at construction, when the resolved IP
+   * is unchanged, or when DNS resolution produced no address. Returns the freshly-resolved
+   * {@link InetSocketAddress} when the IP has changed under the same hostname, and throws
+   * {@link IllegalStateException} if {@link #hostAndPort} is malformed.
    */
   public InetSocketAddress resolveLatestAddress() {
     if (hostAndPort == null) {
       return null;
     }
-    InetSocketAddress refreshed;
+    final InetSocketAddress refreshed;
     try {
       refreshed = NetUtils.createSocketAddr(hostAndPort);
     } catch (IllegalArgumentException ex) {
-      LOG.warn("Failed to re-resolve {}: {}", hostAndPort, ex.getMessage());
+      throw new IllegalStateException("Malformed host address: " + hostAndPort, ex);
+    }
+    final InetAddress refreshedIp = refreshed.getAddress();
+    if (refreshedIp == null) {
+      LOG.warn("Failed to resolve {}; reusing previous address {}.", hostAndPort, address);
       return null;
     }
-    if (refreshed.isUnresolved()) {
-      LOG.warn("Re-resolution of {} produced an unresolved address; "
-          + "leaving cached address {} in place.", hostAndPort, address);
-      return null;
-    }
-    // Null-safe comparison: if the cached address itself was unresolved
-    // (initial DNS lookup failed; ctor accepted it with a warning),
-    // address.getAddress() is null and a successful re-resolution
-    // counts as a change. NPE-ing here would wedge the heartbeat
-    // refresh path on exactly the case it most needs to fix.
-    java.net.InetAddress cachedIp = address.getAddress();
-    if (cachedIp != null
-        && refreshed.getAddress().equals(cachedIp)) {
+    // A previously-unresolved cached address (address.getAddress() == null) compares unequal here, so
+    // a now-successful resolution correctly counts as a change.
+    if (refreshedIp.equals(address.getAddress())) {
       return null;
     }
     return refreshed;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -341,8 +341,7 @@ public class SCMConnectionManager
     try {
       staleEndpoint.close();
     } catch (RuntimeException closeEx) {
-      LOG.warn("Failed to close stale endpoint {}: {}", oldAddress,
-          closeEx.getMessage());
+      LOG.warn("Failed to close stale endpoint {}", oldAddress, closeEx);
     }
     LOG.info("DNS re-resolution: SCM endpoint {} -> {} (host {}).",
         oldAddress, refreshed, hostAndPort);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryCount;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryInterval;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcTimeOutInMilliseconds;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -132,6 +133,21 @@ public class SCMConnectionManager
    */
   public void addSCMServer(InetSocketAddress address,
       String threadNamePrefix) throws IOException {
+    addSCMServer(address, null, threadNamePrefix);
+  }
+
+  /**
+   * Adds a new SCM machine and remembers the original host:port string
+   * so the DN can re-resolve DNS on connection failure (e.g. after the
+   * SCM peer is rescheduled to a new pod IP in Kubernetes).
+   *
+   * @param address     resolved RPC address used to build the proxy
+   * @param hostAndPort original "host:port" string, or null to disable
+   *                    DNS re-resolution for this endpoint
+   * @param threadNamePrefix prefix for the endpoint's task thread
+   */
+  public void addSCMServer(InetSocketAddress address, String hostAndPort,
+      String threadNamePrefix) throws IOException {
     writeLock();
     try {
       if (scmMachines.containsKey(address)) {
@@ -139,38 +155,198 @@ public class SCMConnectionManager
             "Ignoring the request.");
         return;
       }
-
-      Configuration hadoopConfig =
-          LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
-      RPC.setProtocolEngine(
-          hadoopConfig,
-          StorageContainerDatanodeProtocolPB.class,
-          ProtobufRpcEngine.class);
-      long version =
-          RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
-
-      RetryPolicy retryPolicy =
-          RetryPolicies.retryUpToMaximumCountWithFixedSleep(
-              getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
-              TimeUnit.MILLISECONDS);
-
-      StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
-          StorageContainerDatanodeProtocolPB.class, version,
-          address, UserGroupInformation.getCurrentUser(), hadoopConfig,
-          NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
-          retryPolicy).getProxy();
-
-      StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
-          new StorageContainerDatanodeProtocolClientSideTranslatorPB(
-              rpcProxy);
-
-      EndpointStateMachine endPoint = new EndpointStateMachine(address,
-          rpcClient, this.conf, threadNamePrefix);
-      endPoint.setPassive(false);
+      EndpointStateMachine endPoint =
+          buildScmEndpoint(address, hostAndPort, threadNamePrefix);
       scmMachines.put(address, endPoint);
     } finally {
       writeUnlock();
     }
+  }
+
+  /**
+   * Build (but do NOT register) a fresh active-SCM endpoint bound to
+   * {@code address}. The caller is responsible for registering it in
+   * {@code scmMachines} (and tearing down any previous endpoint it
+   * replaces). Factored out of {@link #addSCMServer} so
+   * {@link #refreshSCMServer} can construct the replacement BEFORE
+   * removing the stale entry, preserving the peer in {@code scmMachines}
+   * if proxy construction throws (transient DNS failure, peer not yet
+   * accepting on the new IP, etc.).
+   */
+  @VisibleForTesting
+  EndpointStateMachine buildScmEndpoint(InetSocketAddress address,
+      String hostAndPort, String threadNamePrefix) throws IOException {
+    Configuration hadoopConfig =
+        LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
+    RPC.setProtocolEngine(
+        hadoopConfig,
+        StorageContainerDatanodeProtocolPB.class,
+        ProtobufRpcEngine.class);
+    long version =
+        RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
+
+    RetryPolicy retryPolicy =
+        RetryPolicies.retryUpToMaximumCountWithFixedSleep(
+            getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
+            TimeUnit.MILLISECONDS);
+
+    StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
+        StorageContainerDatanodeProtocolPB.class, version,
+        address, UserGroupInformation.getCurrentUser(), hadoopConfig,
+        NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
+        retryPolicy).getProxy();
+
+    StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
+        new StorageContainerDatanodeProtocolClientSideTranslatorPB(
+            rpcProxy);
+
+    EndpointStateMachine endPoint = new EndpointStateMachine(address,
+        hostAndPort, rpcClient, this.conf, threadNamePrefix);
+    endPoint.setPassive(false);
+    return endPoint;
+  }
+
+  /**
+   * Re-resolve the SCM hostname for the endpoint at {@code oldAddress} and,
+   * if the resolved IP has changed, atomically replace the endpoint with a
+   * fresh one bound to the new address.
+   * <p>
+   * Returns the new {@link InetSocketAddress} on a successful swap, or null
+   * if no swap occurred (endpoint not found, hostname not preserved at
+   * construction, IP unchanged, or DNS lookup failed). Callers receive
+   * enough information to update any external maps keyed by the old
+   * address.
+   * <p>
+   * The replacement is built via the existing {@link #addSCMServer} path,
+   * so the new endpoint starts in {@code GETVERSION} state and re-walks
+   * version → register → heartbeat. This is the correct behavior: a peer
+   * that has been rescheduled is effectively a fresh process.
+   */
+  public InetSocketAddress refreshSCMServer(InetSocketAddress oldAddress,
+      String threadNamePrefix) throws IOException {
+    // PHASE A (read lock): snapshot the endpoint reference and the
+    // preserved hostAndPort string. We cannot hold any lock across
+    // the DNS lookup that follows, so we capture only what we need
+    // and release the lock immediately.
+    final EndpointStateMachine snapshotEndpoint;
+    final String hostAndPort;
+    readLock();
+    try {
+      snapshotEndpoint = scmMachines.get(oldAddress);
+      if (snapshotEndpoint == null) {
+        return null;
+      }
+      // Recon endpoints (added via addReconServer) speak a different
+      // protocol than active SCM endpoints. The current refresh path
+      // only knows how to rebuild SCM endpoints, so refusing to
+      // refresh a passive endpoint avoids silently downgrading a
+      // Recon endpoint to an SCM-protocol one. Recon's cached IP is
+      // also a much narrower problem in practice (Recon is rarely
+      // pod-rescheduled the way SCM-HA peers are).
+      if (snapshotEndpoint.isPassive()) {
+        return null;
+      }
+      hostAndPort = snapshotEndpoint.getHostAndPort();
+      if (hostAndPort == null) {
+        return null;
+      }
+    } finally {
+      readUnlock();
+    }
+
+    // PHASE B (no lock): perform the DNS lookup. NetUtils.createSocketAddr
+    // can block on a slow / dead resolver. Holding any lock across this
+    // would stall every concurrent reader and writer of the connection
+    // manager -- including parallel heartbeat dispatch.
+    InetSocketAddress resolved = snapshotEndpoint.resolveLatestAddress();
+    if (resolved == null) {
+      return null;
+    }
+
+    // PHASE C (write lock): re-check that the snapshot is still current
+    // (another refresh / removeSCMServer may have raced ahead while we
+    // were resolving), enforce the collision invariant, build the
+    // replacement, and commit the swap atomically. Capture the stale
+    // endpoint reference for teardown OUTSIDE the lock.
+    final EndpointStateMachine staleEndpoint;
+    final InetSocketAddress refreshed;
+    writeLock();
+    try {
+      EndpointStateMachine current = scmMachines.get(oldAddress);
+      if (current != snapshotEndpoint) {
+        // Lost the race: someone else removed or replaced this entry
+        // while we were resolving DNS. Abandon the swap; whatever
+        // raced ahead is now responsible for the peer's state.
+        return null;
+      }
+      // Refuse the swap if the freshly-resolved address collides with
+      // another already-registered SCM peer key (e.g. transient kube-dns
+      // returning peer-B's IP for peer-A's hostname). Without this guard,
+      // the put below would silently overwrite peer-B's
+      // EndpointStateMachine, leaking its executor and orphaning its
+      // task thread, while peer-A's task ends up dialing peer-B's IP
+      // with peer-A's host context. Leave the stale endpoint in place;
+      // the next heartbeat retries DNS.
+      if (!resolved.equals(oldAddress)
+          && scmMachines.containsKey(resolved)) {
+        LOG.warn("DNS re-resolution: refused to swap endpoint {} -> {} "
+            + "because the new address collides with an already-registered "
+            + "SCM peer. Leaving stale endpoint in place.",
+            oldAddress, resolved);
+        return null;
+      }
+      // Build the replacement BEFORE removing the stale entry so a
+      // failure to construct the new proxy (transient DNS, peer not
+      // yet accepting on the new IP, NetUtils refusing the address)
+      // leaves the existing endpoint registered. Otherwise the peer
+      // would disappear from scmMachines entirely and the next
+      // heartbeat cycle would have nothing to dial -- much worse than
+      // the pre-PR behaviour of dialing the stale IP.
+      //
+      // buildScmEndpoint also invokes RPC.getProtocolProxy under the
+      // write lock; this is intentional. Proxy construction is
+      // synchronous-but-not-network-blocking (it builds an invocation
+      // handler; the actual socket connect is lazy on first call).
+      // The cost of running it under writeLock is bounded; the cost
+      // of dropping the lock here is a complex three-phase commit
+      // dance to defend against a second concurrent refresh racing
+      // ahead. The trade-off favours holding the lock for this step.
+      EndpointStateMachine replacement;
+      try {
+        replacement = buildScmEndpoint(resolved, hostAndPort,
+            threadNamePrefix);
+      } catch (IOException buildEx) {
+        LOG.warn("DNS re-resolution: failed to build replacement SCM "
+                + "endpoint for {} -> {} (host {}); leaving stale endpoint "
+                + "in place. Cause: {}", oldAddress, resolved, hostAndPort,
+            buildEx.getMessage());
+        throw buildEx;
+      }
+      scmMachines.put(resolved, replacement);
+      if (!resolved.equals(oldAddress)) {
+        scmMachines.remove(oldAddress);
+      }
+      staleEndpoint = snapshotEndpoint;
+      refreshed = resolved;
+    } finally {
+      writeUnlock();
+    }
+
+    // PHASE D (no lock): best-effort teardown of the stale endpoint.
+    // close() blocks on RPC.stopProxy / socket teardown -- holding
+    // writeLock during that would stall every concurrent reader
+    // (other endpoints' heartbeats calling getValues()) and writer.
+    // close() failures don't affect registration (already committed),
+    // so a RuntimeException here only impacts cleanup.
+    try {
+      staleEndpoint.close();
+    } catch (RuntimeException closeEx) {
+      LOG.warn("Failed to close stale endpoint {}: {}", oldAddress,
+          closeEx.getMessage());
+    }
+    LOG.info("DNS re-resolution: SCM endpoint {} -> {} (host {}).",
+        oldAddress, refreshed, hostAndPort);
+    return refreshed;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -32,7 +32,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -44,6 +43,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -181,18 +181,44 @@ public class StateContext {
     this.parentDatanodeStateMachine = parent;
     commandQueue = new LinkedList<>();
     cmdStatusMap = new ConcurrentHashMap<>();
-    incrementalReportsQueue = new HashMap<>();
+    // ConcurrentHashMap because addEndpoint / removeEndpoint /
+    // migrateEndpoint mutate this map's KEYSET (put/remove) without
+    // holding the same monitor that producers (addIncrementalReport,
+    // putBackReports, getIncrementalReports) take. The producers'
+    // `synchronized(incrementalReportsQueue)` blocks still guard
+    // operations on the inner LinkedList values across threads --
+    // CHM only fixes the map-structure race. The metric readers
+    // (getIncrementalReportQueueSize) iterate the entrySet without
+    // any monitor; weakly-consistent CHM iteration is safe here.
+    incrementalReportsQueue = new ConcurrentHashMap<>();
     containerReports = new AtomicReference<>();
     nodeReport = new AtomicReference<>();
     pipelineReports = new AtomicReference<>();
-    endpoints = new HashSet<>();
-    containerActions = new HashMap<>();
+    // CopyOnWriteArraySet so producers in addContainerAction /
+    // addIncrementalReport / addPipelineActionIfAbsent can iterate
+    // endpoints lock-free and a concurrent migrateEndpoint() (fired
+    // from the heartbeat thread on DNS-refresh recovery) cannot raise
+    // ConcurrentModificationException. Endpoint membership changes
+    // are infrequent (startup add, reconfig, refresh swap) so the
+    // copy-on-write cost is negligible.
+    endpoints = new CopyOnWriteArraySet<>();
+    // ConcurrentHashMap for the same reason as incrementalReportsQueue
+    // above: addEndpoint / removeEndpoint / migrateEndpoint mutate the
+    // map structure without taking the producer's monitor. Inner Queue
+    // operations are still guarded by `synchronized(containerActions)`
+    // in the producers.
+    containerActions = new ConcurrentHashMap<>();
     pipelineActions = new ConcurrentHashMap<>();
     lock = new ReentrantLock();
     stateExecutionCount = new AtomicLong(0);
     threadPoolNotAvailableCount = new AtomicLong(0);
     lastHeartbeatSent = new AtomicLong(0);
-    isFullReportReadyToBeSent = new HashMap<>();
+    // ConcurrentHashMap because reads from getFullReports /
+    // refreshFullReport / migrateEndpoint can race against startup
+    // addEndpoint and against migrateEndpoint's putIfAbsent. Plain
+    // HashMap was unsafe even pre-PR; migrateEndpoint promoted that
+    // latent race into a regular occurrence under K8s pod churn.
+    isFullReportReadyToBeSent = new ConcurrentHashMap<>();
     fullReportTypeList = new ArrayList<>();
     type2Reports = new HashMap<>();
     this.threadNamePrefix = threadNamePrefix;
@@ -311,7 +337,13 @@ public class StateContext {
     // see XceiverServerRatis#sendPipelineReport
     synchronized (incrementalReportsQueue) {
       for (InetSocketAddress endpoint : endpoints) {
-        incrementalReportsQueue.get(endpoint).add(report);
+        // Same migration race shape as addPipelineActionIfAbsent: an
+        // endpoint observed in the COW set may have just had its
+        // queue removed by migrateEndpoint. Skip rather than NPE.
+        List<Message> queue = incrementalReportsQueue.get(endpoint);
+        if (queue != null) {
+          queue.add(report);
+        }
       }
     }
   }
@@ -483,7 +515,10 @@ public class StateContext {
   public void addContainerAction(ContainerAction containerAction) {
     synchronized (containerActions) {
       for (InetSocketAddress endpoint : endpoints) {
-        containerActions.get(endpoint).add(containerAction);
+        Queue<ContainerAction> q = containerActions.get(endpoint);
+        if (q != null) {
+          q.add(containerAction);
+        }
       }
     }
   }
@@ -496,8 +531,9 @@ public class StateContext {
   public void addContainerActionIfAbsent(ContainerAction containerAction) {
     synchronized (containerActions) {
       for (InetSocketAddress endpoint : endpoints) {
-        if (!containerActions.get(endpoint).contains(containerAction)) {
-          containerActions.get(endpoint).add(containerAction);
+        Queue<ContainerAction> q = containerActions.get(endpoint);
+        if (q != null && !q.contains(containerAction)) {
+          q.add(containerAction);
         }
       }
     }
@@ -539,7 +575,17 @@ public class StateContext {
     final PipelineKey key = new PipelineKey(pipelineAction);
     boolean added = false;
     for (InetSocketAddress endpoint : endpoints) {
-      added = pipelineActions.get(endpoint).putIfAbsent(key, pipelineAction) || added;
+      // Endpoints are migrated under the DNS-refresh path
+      // (migrateEndpoint) which removes the old pipelineActions entry
+      // before it removes the endpoint from this set. With
+      // CopyOnWriteArraySet iteration semantics we may still observe
+      // an endpoint whose pipelineActions entry was just removed --
+      // skip rather than NPE.
+      PipelineActionMap actions = pipelineActions.get(endpoint);
+      if (actions == null) {
+        continue;
+      }
+      added = actions.putIfAbsent(key, pipelineAction) || added;
     }
     return added;
   }
@@ -919,6 +965,193 @@ public class StateContext {
     this.isFullReportReadyToBeSent.remove(endpoint);
     if (getQueueMetrics() != null) {
       getQueueMetrics().removeEndpoint(endpoint);
+    }
+  }
+
+  /**
+   * Re-key all per-endpoint state from {@code oldEndpoint} to
+   * {@code newEndpoint}, preserving any reports / actions already
+   * queued for the old key. Used by the DNS-refresh-on-failure path
+   * ({@code HeartbeatEndpointTask#maybeRefreshScmAddress}) so that an
+   * SCM peer pod-IP change does not silently drop in-flight
+   * incremental container reports, container actions, or pipeline
+   * actions queued under the stale {@link InetSocketAddress}.
+   * <p>
+   * Concurrency / lock-order rules:
+   * <ul>
+   *   <li>{@link #endpoints} is a {@link CopyOnWriteArraySet} so
+   *       producers iterating it (in {@link #addContainerAction},
+   *       {@link #addIncrementalReport}, {@link #addPipelineActionIfAbsent})
+   *       cannot CME against the {@code remove}+{@code add} pair below. </li>
+   *   <li>{@link #incrementalReportsQueue} mutations take the same
+   *       {@code synchronized(incrementalReportsQueue)} monitor that
+   *       producers use. </li>
+   *   <li>{@link #containerActions} mutations take the same
+   *       {@code synchronized(containerActions)} monitor that
+   *       producers use. </li>
+   *   <li>{@link #pipelineActions} is {@link ConcurrentHashMap}; we
+   *       guard the read-modify-write sequence with the per-key atomic
+   *       {@code compute} call. </li>
+   *   <li>{@link #isFullReportReadyToBeSent} is now a
+   *       {@link ConcurrentHashMap} so its mutations are individually
+   *       atomic and concurrent {@link #refreshFullReport} iterations
+   *       are weakly-consistent rather than fail-fast. </li>
+   * </ul>
+   * Migration order: producers' queues first (so a producer racing in
+   * during the migration finds the new endpoint key already populated),
+   * then the {@code endpoints} set last (so any thread that observes
+   * the new endpoint in {@code endpoints} also observes its queues
+   * present). Each step is idempotent at the per-key level.
+   * <p>
+   * Collision case (the freshly-resolved IP collides with another
+   * already-registered endpoint key): this method leaves the existing
+   * collided entry untouched and only drops the old key's state. Two
+   * distinct SCM peers' queues are NEVER merged; doing so would deliver
+   * one peer's incremental reports / pipeline actions to a different
+   * peer that did not request them.
+   * <p>
+   * If {@code oldEndpoint} was not registered, this is a no-op. The
+   * new endpoint is NOT added in that case.
+   *
+   * @param oldEndpoint the InetSocketAddress under which queues are
+   *                    currently keyed
+   * @param newEndpoint the freshly-resolved InetSocketAddress that the
+   *                    new EndpointStateMachine is bound to
+   */
+  public void migrateEndpoint(InetSocketAddress oldEndpoint,
+                              InetSocketAddress newEndpoint) {
+    if (oldEndpoint == null || newEndpoint == null
+        || oldEndpoint.equals(newEndpoint)) {
+      return;
+    }
+    if (!endpoints.contains(oldEndpoint)) {
+      return;
+    }
+    final boolean newAlreadyRegistered = endpoints.contains(newEndpoint);
+
+    // Invariant we must preserve at every observable point:
+    //   "for every e in endpoints, queues[e] exists for all four
+    //    per-endpoint maps."
+    // Producers iterate `endpoints` lock-free (CopyOnWriteArraySet) and
+    // then look up the per-key queue. If we removed a queue before
+    // removing the endpoint from the set, a producer iterating between
+    // the two operations would see the endpoint, fail to find a queue,
+    // and silently drop its report. The producer-side null-skip we
+    // added previously was a band-aid for exactly this race.
+    //
+    // To preserve the invariant, the ordering is:
+    //   1. PUBLISH: install new-key queues alongside the old-key queues.
+    //      During this step both keys are valid.
+    //   2. SWITCH: add newEndpoint to the endpoints set; remove
+    //      oldEndpoint from the endpoints set. After this step,
+    //      producers iterating `endpoints` see only the new key (which
+    //      has its queue from step 1).
+    //   3. RETIRE: drop the old-key queues. By this point no producer
+    //      iterating `endpoints` can reach the old key.
+    //
+    // Collision case (newEndpoint already a registered peer): we MUST
+    // NOT install our incoming queues over the colliding peer's queues
+    // (would deliver one peer's reports to another). On collision we
+    // skip the publish step's "install" and the switch step's "add",
+    // and only retire the old-key queues. Any old-key in-flight reports
+    // are dropped (logged) -- the alternative of merging into a foreign
+    // peer's queue is worse.
+
+    // Step 1 (PUBLISH): install new-key queues. On collision, do not
+    // touch newEndpoint's existing queues (foreign peer owns them).
+    synchronized (incrementalReportsQueue) {
+      if (!newAlreadyRegistered) {
+        List<Message> oldQueue = incrementalReportsQueue.get(oldEndpoint);
+        if (oldQueue != null) {
+          // Both keys reference the SAME LinkedList. Safe because
+          // producers serialize on `incrementalReportsQueue`'s monitor
+          // and the inner list is not mutated unsynchronized. After
+          // step 3 removes the old key, only the new key references
+          // the list.
+          incrementalReportsQueue.put(newEndpoint, oldQueue);
+        } else {
+          incrementalReportsQueue.putIfAbsent(newEndpoint, new LinkedList<>());
+        }
+      }
+    }
+    synchronized (containerActions) {
+      if (!newAlreadyRegistered) {
+        Queue<ContainerAction> oldActions = containerActions.get(oldEndpoint);
+        if (oldActions != null) {
+          containerActions.put(newEndpoint, oldActions);
+        } else {
+          containerActions.putIfAbsent(newEndpoint, new LinkedList<>());
+        }
+      }
+    }
+    if (!newAlreadyRegistered) {
+      PipelineActionMap oldPipelineActions = pipelineActions.get(oldEndpoint);
+      pipelineActions.computeIfAbsent(newEndpoint,
+          k -> oldPipelineActions != null
+              ? oldPipelineActions
+              : new PipelineActionMap());
+
+      // Always seed all-true flags for the new peer. A rescheduled SCM
+      // pod is a fresh process and needs a full container/node/pipeline
+      // report on the next heartbeat regardless of what the old peer
+      // had already received.
+      Map<String, AtomicBoolean> flags = new HashMap<>();
+      for (String e : fullReportTypeList) {
+        flags.put(e, new AtomicBoolean(true));
+      }
+      isFullReportReadyToBeSent.putIfAbsent(newEndpoint, flags);
+    }
+
+    // Step 2 (SWITCH): swap endpoint membership under the same monitors
+    // producers hold when fanning out incremental reports and container
+    // actions, so no producer observes both keys while they alias the
+    // same underlying queue.
+    synchronized (incrementalReportsQueue) {
+      synchronized (containerActions) {
+        if (!newAlreadyRegistered) {
+          endpoints.add(newEndpoint);
+        }
+        endpoints.remove(oldEndpoint);
+      }
+    }
+
+    // Step 3 (RETIRE): drop the old-key queues. From this point no
+    // producer iterating `endpoints` reaches the old key.
+    synchronized (incrementalReportsQueue) {
+      List<Message> oldQueue =
+          incrementalReportsQueue.remove(oldEndpoint);
+      if (newAlreadyRegistered && oldQueue != null && !oldQueue.isEmpty()) {
+        LOG.warn("DNS refresh produced an endpoint collision: dropping "
+                + "{} incremental reports queued under {} because {} is "
+                + "already a registered endpoint with its own queue.",
+            oldQueue.size(), oldEndpoint, newEndpoint);
+      }
+    }
+    synchronized (containerActions) {
+      Queue<ContainerAction> oldActions = containerActions.remove(oldEndpoint);
+      if (newAlreadyRegistered && oldActions != null && !oldActions.isEmpty()) {
+        LOG.warn("DNS refresh produced an endpoint collision: dropping "
+                + "{} container actions queued under {} because {} is "
+                + "already a registered endpoint with its own queue.",
+            oldActions.size(), oldEndpoint, newEndpoint);
+      }
+    }
+    PipelineActionMap retiredPipelineActions =
+        pipelineActions.remove(oldEndpoint);
+    if (newAlreadyRegistered && retiredPipelineActions != null
+        && retiredPipelineActions.size() > 0) {
+      LOG.warn("DNS refresh produced an endpoint collision: dropping "
+              + "{} pipeline actions queued under {} because {} is "
+              + "already a registered endpoint with its own map.",
+          retiredPipelineActions.size(), oldEndpoint, newEndpoint);
+    }
+    isFullReportReadyToBeSent.remove(oldEndpoint);
+
+    if (getQueueMetrics() != null) {
+      getQueueMetrics().removeEndpoint(oldEndpoint);
+      if (!newAlreadyRegistered) {
+        getQueueMetrics().addEndpoint(newEndpoint);
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
@@ -101,7 +101,13 @@ public class InitDatanodeState implements DatanodeState,
         }
       }
       for (InetSocketAddress addr : addresses) {
-        connectionManager.addSCMServer(addr, context.getThreadNamePrefix());
+        // Preserve the original hostname so the DN can re-resolve DNS
+        // on heartbeat failure (Kubernetes pod-IP-change recovery).
+        // getHostString() does not trigger reverse-DNS, returning the
+        // hostname the address was constructed with.
+        String hostAndPort = addr.getHostString() + ":" + addr.getPort();
+        connectionManager.addSCMServer(addr, hostAndPort,
+            context.getThreadNamePrefix());
         this.context.addEndpoint(addr);
       }
       InetSocketAddress reconAddress = getReconAddressForDatanodes(conf);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -19,12 +19,12 @@ package org.apache.hadoop.ozone.container.common.states.endpoint;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
 
 import com.google.common.base.Preconditions;
@@ -112,8 +112,8 @@ public class HeartbeatEndpointTask
         OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
         OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
     this.refreshThreshold = Math.max(1, conf.getInt(
-        OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY,
-        OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT));
+        HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD,
+        HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT));
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -21,12 +21,17 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LI
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,6 +49,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdfs.util.EnumCounters;
 import org.apache.hadoop.ozone.container.common.helpers.DeletedContainerBlocksSummary;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
@@ -77,6 +83,8 @@ public class HeartbeatEndpointTask
   private int maxContainerActionsPerHB;
   private int maxPipelineActionsPerHB;
   private HDDSLayoutVersionManager layoutVersionManager;
+  private final boolean resolveOnFailureEnabled;
+  private final int refreshThreshold;
 
   /**
    * Constructs a SCM heart beat.
@@ -100,6 +108,12 @@ public class HeartbeatEndpointTask
     } else {
       this.layoutVersionManager = context.getParent().getLayoutVersionManager();
     }
+    this.resolveOnFailureEnabled = conf.getBoolean(
+        OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
+        OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
+    this.refreshThreshold = Math.max(1, conf.getInt(
+        OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY,
+        OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_DEFAULT));
   }
 
   /**
@@ -157,10 +171,75 @@ public class HeartbeatEndpointTask
       // put back the reports which failed to be sent
       putBackIncrementalReports(requestBuilder);
       rpcEndpoint.logIfNeeded(ex);
+      maybeRefreshScmAddress(ex);
     } finally {
       rpcEndpoint.unlock();
     }
     return rpcEndpoint.getState();
+  }
+
+  /**
+   * After a heartbeat IOException, if (a) DNS-refresh-on-failure is
+   * enabled, (b) the exception's cause chain contains a connection-class
+   * type (per {@link ConnectionFailureUtils#isConnectionFailure}), and
+   * (c) the missed-heartbeat counter has reached the configured
+   * threshold, ask {@link org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager}
+   * to re-resolve this peer's hostname. If the resolved IP differs from
+   * the cached one, the connection manager swaps the endpoint atomically
+   * for a fresh one bound to the new address. The replacement starts in
+   * GETVERSION state, which is the correct behavior when the peer pod
+   * has been recreated -- the new SCM is effectively a fresh process and
+   * needs the version handshake plus DN re-registration.
+   * <p>
+   * Symmetric with the OM/SCM client-side failover providers, which
+   * also gate refresh on connection-class exceptions: an
+   * {@code AccessControlException} or {@code OMException} arriving
+   * via the heartbeat path indicates the cached IP is reachable but
+   * the peer is rejecting us at the application layer -- DNS won't help.
+   * <p>
+   * Off by default. Enable via
+   * {@code ozone.client.failover.resolve-needed=true}.
+   */
+  private void maybeRefreshScmAddress(IOException heartbeatFailure) {
+    if (!resolveOnFailureEnabled) {
+      return;
+    }
+    if (!ConnectionFailureUtils.isConnectionFailure(heartbeatFailure)) {
+      return;
+    }
+    if (rpcEndpoint.getMissedCount() < refreshThreshold) {
+      return;
+    }
+    if (rpcEndpoint.getHostAndPort() == null) {
+      // Caller did not preserve the original config string for this
+      // endpoint. Re-resolution is unsupported here; rely on operator
+      // restart for IP recovery.
+      return;
+    }
+    InetSocketAddress oldAddress = rpcEndpoint.getAddress();
+    try {
+      InetSocketAddress refreshed = context.getParent().getConnectionManager()
+          .refreshSCMServer(oldAddress, context.getThreadNamePrefix());
+      if (refreshed != null) {
+        // The connection manager swapped scmMachines from oldAddress to
+        // refreshed. Migrate the per-endpoint StateContext queues to
+        // match -- otherwise incremental container reports, container
+        // actions, and pipeline actions queued under oldAddress are
+        // silently dropped (the producers continue writing to the old
+        // key while the new endpoint reads from the new key and sees
+        // an empty queue). Failing to migrate here is the difference
+        // between "DN heartbeats fine but stops reporting changes" and
+        // "DN heartbeats fine and keeps SCM in sync".
+        context.migrateEndpoint(oldAddress, refreshed);
+        // Old endpoint is about to be GC'd; reset its counter so any
+        // concurrent observer sees a clean slate before it's released.
+        rpcEndpoint.zeroMissedCount();
+      }
+    } catch (IOException refreshEx) {
+      LOG.warn("Failed to refresh SCM address {} after {} missed "
+              + "heartbeats: {}", oldAddress,
+          rpcEndpoint.getMissedCount(), refreshEx.getMessage());
+    }
   }
 
   // TODO: Make it generic.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -237,8 +237,8 @@ public class HeartbeatEndpointTask
       }
     } catch (IOException refreshEx) {
       LOG.warn("Failed to refresh SCM address {} after {} missed "
-              + "heartbeats: {}", oldAddress,
-          rpcEndpoint.getMissedCount(), refreshEx.getMessage());
+              + "heartbeats", oldAddress,
+          rpcEndpoint.getMissedCount(), refreshEx);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
@@ -19,8 +19,11 @@ package org.apache.hadoop.ozone.container.common.statemachine;
 
 import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.HEARTBEAT;
 
+import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.net.NetUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +47,179 @@ public class TestSCMConnectionManager {
 
       Assertions.assertTrue(connectionManager.getValues().isEmpty());
       Assertions.assertEquals(HEARTBEAT, endpoint.getState());
+    }
+  }
+
+  /**
+   * resolveLatestAddress() returns null when no preserved hostname is
+   * available -- legacy code path -- so re-resolution is a no-op for that
+   * endpoint. Operator must restart the DN to pick up a new IP.
+   */
+  @Test
+  public void testResolveLatestAddressReturnsNullWithoutHostAndPort() {
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", 9861);
+    EndpointStateMachine endpoint = new EndpointStateMachine(
+        address, /*hostAndPort=*/ null, /*endPoint=*/ null,
+        new OzoneConfiguration(), "");
+    Assertions.assertNull(endpoint.resolveLatestAddress());
+    Assertions.assertNull(endpoint.getHostAndPort());
+  }
+
+  /**
+   * When the cached IP matches what DNS currently returns for the
+   * preserved hostname, resolveLatestAddress() returns null (no swap
+   * needed). Build the cached address via NetUtils so the IP family
+   * matches what resolveLatestAddress() re-resolves (avoids IPv4/IPv6
+   * localhost mismatch on dual-stack hosts).
+   */
+  @Test
+  public void testResolveLatestAddressReturnsNullWhenIpUnchanged()
+      throws Exception {
+    InetSocketAddress address = NetUtils.createSocketAddr("127.0.0.1:9861");
+    EndpointStateMachine endpoint = new EndpointStateMachine(
+        address, "127.0.0.1:9861", null, new OzoneConfiguration(), "");
+    InetSocketAddress refreshed = endpoint.resolveLatestAddress();
+    Assertions.assertNull(refreshed,
+        "127.0.0.1 re-resolves to the same address; refresh "
+            + "must report no change so the endpoint is not torn down "
+            + "needlessly.");
+  }
+
+  /**
+   * When the cached IP differs from what DNS currently returns for the
+   * preserved hostname, resolveLatestAddress() returns the freshly-
+   * resolved address. Simulates the "SCM pod was rescheduled to a new
+   * IP" scenario by constructing the endpoint with a deliberately stale
+   * cached IP.
+   */
+  @Test
+  public void testResolveLatestAddressReturnsNewAddressOnIpChange()
+      throws Exception {
+    // Pretend localhost previously resolved to 127.0.0.99 (stale IP).
+    // In real Kubernetes this would be the now-defunct pod IP.
+    InetSocketAddress staleAddress = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9861);
+    EndpointStateMachine endpoint = new EndpointStateMachine(
+        staleAddress, "localhost:9861", null,
+        new OzoneConfiguration(), "");
+    InetSocketAddress refreshed = endpoint.resolveLatestAddress();
+    Assertions.assertNotNull(refreshed,
+        "localhost re-resolves to loopback (typically 127.0.0.1), "
+            + "which differs from the stale 127.0.0.99 we cached; "
+            + "refresh must report the change so the endpoint can "
+            + "swap to the live address.");
+    Assertions.assertEquals(9861, refreshed.getPort());
+    Assertions.assertNotEquals(staleAddress.getAddress(),
+        refreshed.getAddress());
+  }
+
+  /**
+   * refreshSCMServer() swaps an endpoint's address atomically in the
+   * connection manager when the cached IP is stale. The replacement
+   * endpoint starts in GETVERSION state -- the version handshake must
+   * be re-run because the new SCM pod is effectively a fresh process.
+   */
+  @Test
+  public void testRefreshSCMServerSwapsEndpointOnIpChange() throws Exception {
+    try (SCMConnectionManager connectionManager =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      InetSocketAddress staleAddress = new InetSocketAddress(
+          InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9861);
+      connectionManager.addSCMServer(staleAddress, "localhost:9861", "");
+
+      InetSocketAddress refreshed = connectionManager.refreshSCMServer(
+          staleAddress, "");
+
+      Assertions.assertNotNull(refreshed);
+      Assertions.assertEquals(1, connectionManager.getNumOfConnections());
+      EndpointStateMachine swapped =
+          connectionManager.getValues().iterator().next();
+      Assertions.assertEquals(refreshed, swapped.getAddress());
+      Assertions.assertEquals("localhost:9861", swapped.getHostAndPort());
+    }
+  }
+
+  /**
+   * Regression for the rollback gap Copilot flagged on
+   * {@code refreshSCMServer}: if building the replacement endpoint
+   * throws (transient DNS blip during proxy construction, peer not
+   * yet accepting on the new IP, NetUtils refusing the resolved
+   * address), the connection manager must NOT have already removed
+   * the stale endpoint -- otherwise the peer disappears from
+   * {@code scmMachines} and no future heartbeat has anywhere to dial.
+   * <p>
+   * The fix builds the replacement BEFORE removing the stale entry.
+   * This test injects a build that throws and asserts the stale
+   * endpoint is still registered after the call returns its
+   * IOException.
+   */
+  @Test
+  public void testRefreshSCMServerLeavesStaleEndpointOnBuildFailure()
+      throws Exception {
+    final IOException simulated =
+        new IOException("simulated transient build failure");
+    try (SCMConnectionManager connectionManager =
+        new SCMConnectionManager(new OzoneConfiguration()) {
+          private boolean firstBuildDone;
+
+          @Override
+          EndpointStateMachine buildScmEndpoint(InetSocketAddress address,
+              String hostAndPort, String threadNamePrefix)
+              throws IOException {
+            if (!firstBuildDone) {
+              firstBuildDone = true;
+              return super.buildScmEndpoint(address, hostAndPort,
+                  threadNamePrefix);
+            }
+            throw simulated;
+          }
+        }) {
+      InetSocketAddress staleAddress = new InetSocketAddress(
+          InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), 9861);
+      connectionManager.addSCMServer(staleAddress, "localhost:9861", "");
+      EndpointStateMachine before =
+          connectionManager.getValues().iterator().next();
+
+      IOException thrown = Assertions.assertThrows(IOException.class,
+          () -> connectionManager.refreshSCMServer(staleAddress, ""));
+      Assertions.assertSame(simulated, thrown,
+          "the underlying build failure must be propagated, not "
+              + "swallowed by an enclosing recovery branch");
+
+      Assertions.assertEquals(1, connectionManager.getNumOfConnections(),
+          "stale endpoint must remain registered when buildScmEndpoint "
+              + "throws -- otherwise the peer disappears from the "
+              + "connection manager and no heartbeat can recover it");
+      Assertions.assertSame(before,
+          connectionManager.getValues().iterator().next(),
+          "the SAME EndpointStateMachine instance must still be "
+              + "registered (not a half-constructed replacement)");
+    }
+  }
+
+  /**
+   * refreshSCMServer() against an endpoint whose cached IP already matches
+   * DNS is a no-op -- the existing endpoint stays in place untouched. This
+   * prevents needless tearing-down of healthy connections when the
+   * heartbeat task asks to refresh after a transient blip.
+   */
+  @Test
+  public void testRefreshSCMServerNoopWhenIpUnchanged() throws Exception {
+    try (SCMConnectionManager connectionManager =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      InetSocketAddress address = NetUtils.createSocketAddr("127.0.0.1:9861");
+      connectionManager.addSCMServer(address, "127.0.0.1:9861", "");
+      EndpointStateMachine before =
+          connectionManager.getValues().iterator().next();
+
+      InetSocketAddress refreshed =
+          connectionManager.refreshSCMServer(address, "");
+
+      Assertions.assertNull(refreshed);
+      Assertions.assertEquals(1, connectionManager.getNumOfConnections());
+      Assertions.assertSame(before,
+          connectionManager.getValues().iterator().next(),
+          "Endpoint instance must not be torn down when IP is unchanged.");
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -265,18 +265,15 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
     private final HeartbeatEndpointTask task;
     private final EndpointStateMachine endpoint;
     private final SCMConnectionManager connectionManager;
-    private final DatanodeStateMachine datanodeStateMachine;
     private final StateContext context;
     private final StorageContainerDatanodeProtocolClientSideTranslatorPB scm;
 
     Fixture(HeartbeatEndpointTask task, EndpointStateMachine endpoint,
-            SCMConnectionManager mgr, DatanodeStateMachine dsm,
-            StateContext ctx,
+            SCMConnectionManager mgr, StateContext ctx,
             StorageContainerDatanodeProtocolClientSideTranslatorPB scm) {
       this.task = task;
       this.endpoint = endpoint;
       this.connectionManager = mgr;
-      this.datanodeStateMachine = dsm;
       this.context = ctx;
       this.scm = scm;
     }
@@ -320,7 +317,6 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
         .setEndpointStateMachine(endpoint)
         .build();
 
-    return new Fixture(task, endpoint, connectionManager,
-        datanodeStateMachine, context, scm);
+    return new Fixture(task, endpoint, connectionManager, context, scm);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -17,9 +17,9 @@
 
 package org.apache.hadoop.ozone.container.common.states.endpoint;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -87,7 +87,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 3);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 3);
 
     Fixture f = newFixture(conf);
     when(f.endpoint.getMissedCount()).thenReturn(3L);
@@ -114,7 +114,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
   public void testRefreshSuppressedWhenFlagDisabled() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
-    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 1);
 
     Fixture f = newFixture(conf);
     when(f.endpoint.getMissedCount()).thenReturn(99L);
@@ -137,7 +137,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
   public void testRefreshSuppressedBelowThreshold() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 5);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 5);
 
     Fixture f = newFixture(conf);
     when(f.endpoint.getMissedCount()).thenReturn(2L);
@@ -160,7 +160,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 1);
 
     Fixture f = newFixture(conf);
     when(f.endpoint.getMissedCount()).thenReturn(99L);
@@ -190,7 +190,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 1);
 
     Fixture f = newFixture(conf);
     f.context.addEndpoint(STALE_ADDR);
@@ -245,7 +245,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
       throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 1);
 
     Fixture f = newFixture(conf);
     when(f.endpoint.getMissedCount()).thenReturn(99L);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.states.endpoint;
+
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.DatanodeStates;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
+import org.apache.hadoop.security.AccessControlException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the production trigger chain for DN → SCM DNS refresh:
+ * heartbeat fails with a connection-class IOException → catch block in
+ * {@code HeartbeatEndpointTask.call()} runs → {@code maybeRefreshScmAddress}
+ * checks the flag and the missed-count threshold → fires
+ * {@code SCMConnectionManager.refreshSCMServer}. The previous
+ * {@code TestSCMConnectionManagerDnsRefreshE2E} drove the swap mechanism
+ * directly; this test proves the integration.
+ */
+public class TestHeartbeatEndpointTaskDnsRefresh {
+
+  private static final InetSocketAddress STALE_ADDR = makeAddr(127, 0, 0, 99);
+  private static final InetSocketAddress REFRESHED_ADDR = makeAddr(127, 0, 0, 1);
+
+  /**
+   * Build an InetSocketAddress whose underlying address is RESOLVED to
+   * a specific IPv4 literal (so the test asserts on a real, non-equal
+   * post-refresh address). Going through {@code InetAddress.getByAddress}
+   * skips DNS entirely; the resulting socket address is stable in CI.
+   */
+  private static InetSocketAddress makeAddr(int a, int b, int c, int d) {
+    try {
+      return new InetSocketAddress(
+          InetAddress.getByAddress(new byte[]{(byte) a, (byte) b,
+              (byte) c, (byte) d}), 9861);
+    } catch (java.net.UnknownHostException impossible) {
+      throw new AssertionError(impossible);
+    }
+  }
+
+  /**
+   * With the flag enabled and the missed-heartbeat counter at the
+   * configured threshold, a connection-class IOException from
+   * sendHeartbeat must drive refreshSCMServer exactly once with the
+   * cached address as the argument.
+   */
+  @Test
+  public void testRefreshFiresWhenFlagEnabledAndThresholdMet()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 3);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(3L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    // Cached address is what the catch block should ask the manager to
+    // re-resolve. A regression that passed the wrong key would leave
+    // refreshSCMServer with a non-existent address and silently
+    // produce no swap.
+    verify(f.connectionManager, atLeastOnce())
+        .refreshSCMServer(eq(STALE_ADDR), any());
+  }
+
+  /**
+   * With the flag disabled (the default), refreshSCMServer must NOT be
+   * called even on a connection-class failure. Guards against the
+   * "default-off" safety claim being silently broken.
+   */
+  @Test
+  public void testRefreshSuppressedWhenFlagDisabled() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * Threshold semantics: missed count BELOW the configured threshold
+   * must NOT fire a refresh, even with the flag enabled and a
+   * connection-class failure. Guards against thrashing on the first
+   * transient blip.
+   */
+  @Test
+  public void testRefreshSuppressedBelowThreshold() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 5);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(2L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * If the endpoint never preserved its host:port string (legacy
+   * 4-arg ctor path), refresh must be a no-op. Operators in that case
+   * are expected to restart the DN to pick up new IPs.
+   */
+  @Test
+  public void testRefreshSuppressedWhenHostAndPortNotPreserved()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn(null); // legacy ctor path
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * After a successful refresh, the per-endpoint StateContext queues
+   * must be migrated from the old address key to the new one. The
+   * old key must be GONE and the new key must be PRESENT.
+   * <p>
+   * Critically, this test uses two RESOLVED but distinct InetSocketAddress
+   * instances (127.0.0.99 and 127.0.0.1) so {@code STALE_ADDR.equals(REFRESHED_ADDR)}
+   * is false. A prior version of this test used two unresolved-by-name
+   * addresses that compared equal, making {@code migrateEndpoint}
+   * short-circuit and the assertion pass vacuously regardless of
+   * whether migration ran.
+   */
+  @Test
+  public void testStateContextEndpointsMigrateAfterSuccessfulSwap()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    f.context.addEndpoint(STALE_ADDR);
+    // Pre-populate the old key with a queue marker so we can prove the
+    // migrated map is the SAME map we put data into (load-bearing
+    // assertion: queued reports survive the rekey).
+    f.context.getIncrementalReportQueueSize().put(STALE_ADDR, 0);
+
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.connectionManager.refreshSCMServer(eq(STALE_ADDR), any()))
+        .thenReturn(REFRESHED_ADDR);
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("conn refused", new ConnectException()));
+
+    f.task.call();
+
+    // After migration, the OLD key must be gone from the
+    // incrementalReportsQueue/containerActions/pipelineActions/endpoints
+    // and the NEW key must be present.
+    assertEquals(true,
+        f.context.getIncrementalReportQueueSize().containsKey(REFRESHED_ADDR),
+        "post-refresh, the new endpoint key must exist in the "
+            + "incremental-reports map");
+    assertEquals(false,
+        f.context.getIncrementalReportQueueSize().containsKey(STALE_ADDR),
+        "post-refresh, the old endpoint key must NOT exist in the "
+            + "incremental-reports map (otherwise producers writing to "
+            + "the stale key still pile up reports a dead endpoint will "
+            + "never deliver)");
+    assertEquals(true,
+        f.context.getContainerActionQueueSize().containsKey(REFRESHED_ADDR),
+        "post-refresh, the new endpoint key must exist in the "
+            + "container-actions map");
+    assertEquals(false,
+        f.context.getContainerActionQueueSize().containsKey(STALE_ADDR),
+        "post-refresh, the old endpoint key must NOT exist in the "
+            + "container-actions map");
+  }
+
+  /**
+   * R2 negative-filter test: with the flag enabled and the threshold
+   * met, a heartbeat failure that is NOT a connection-class exception
+   * (e.g. AccessControlException -- the peer is reachable on the
+   * cached IP and rejects us at the application layer) must NOT
+   * trigger a refresh. Re-resolving DNS would not help, and a
+   * misbehaving peer that returns AccessControlException on every
+   * heartbeat would otherwise drive a DNS-lookup storm.
+   */
+  @Test
+  public void testRefreshSuppressedOnApplicationLevelException()
+      throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(OZONE_DN_SCM_HEARTBEAT_REFRESH_THRESHOLD_KEY, 1);
+
+    Fixture f = newFixture(conf);
+    when(f.endpoint.getMissedCount()).thenReturn(99L);
+    when(f.endpoint.getHostAndPort()).thenReturn("scm1:9861");
+    when(f.scm.sendHeartbeat(any()))
+        .thenThrow(new IOException("rejected",
+            new AccessControlException("client lacks SCM_TOKEN")));
+
+    f.task.call();
+
+    verify(f.connectionManager, never()).refreshSCMServer(any(), any());
+  }
+
+  // ------- fixture helpers -------
+
+  private static final class Fixture {
+    private final HeartbeatEndpointTask task;
+    private final EndpointStateMachine endpoint;
+    private final SCMConnectionManager connectionManager;
+    private final DatanodeStateMachine datanodeStateMachine;
+    private final StateContext context;
+    private final StorageContainerDatanodeProtocolClientSideTranslatorPB scm;
+
+    Fixture(HeartbeatEndpointTask task, EndpointStateMachine endpoint,
+            SCMConnectionManager mgr, DatanodeStateMachine dsm,
+            StateContext ctx,
+            StorageContainerDatanodeProtocolClientSideTranslatorPB scm) {
+      this.task = task;
+      this.endpoint = endpoint;
+      this.connectionManager = mgr;
+      this.datanodeStateMachine = dsm;
+      this.context = ctx;
+      this.scm = scm;
+    }
+  }
+
+  private Fixture newFixture(OzoneConfiguration conf) throws Exception {
+    StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
+        mock(StorageContainerDatanodeProtocolClientSideTranslatorPB.class);
+
+    EndpointStateMachine endpoint = mock(EndpointStateMachine.class);
+    when(endpoint.getEndPoint()).thenReturn(scm);
+    when(endpoint.getAddress()).thenReturn(STALE_ADDR);
+
+    SCMConnectionManager connectionManager = mock(SCMConnectionManager.class);
+    DatanodeStateMachine datanodeStateMachine = mock(DatanodeStateMachine.class);
+    when(datanodeStateMachine.getConnectionManager())
+        .thenReturn(connectionManager);
+    when(datanodeStateMachine.getQueuedCommandCount())
+        .thenReturn(new org.apache.hadoop.hdfs.util.EnumCounters<>(
+            org.apache.hadoop.hdds.protocol.proto
+                .StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.class));
+
+    StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
+        datanodeStateMachine, "");
+
+    HDDSLayoutVersionManager lvm = mock(HDDSLayoutVersionManager.class);
+    when(lvm.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(lvm.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+
+    DatanodeDetails dd = DatanodeDetails.newBuilder()
+        .setUuid(UUID.randomUUID())
+        .setHostName("localhost")
+        .setIpAddress("127.0.0.1")
+        .build();
+
+    HeartbeatEndpointTask task = HeartbeatEndpointTask.newBuilder()
+        .setConfig(conf)
+        .setDatanodeDetails(dd)
+        .setContext(context)
+        .setLayoutVersionManager(lvm)
+        .setEndpointStateMachine(endpoint)
+        .build();
+
+    return new Fixture(task, endpoint, connectionManager,
+        datanodeStateMachine, context, scm);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestSCMConnectionManagerDnsRefreshE2E.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestSCMConnectionManagerDnsRefreshE2E.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
+import org.apache.hadoop.ipc_.RPC;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies the swap-mechanism + real-network-handshake half of the
+ * DataNode → SCM DNS-refresh-on-failure recovery path.
+ * <p>
+ * Stands up a real SCM-side RPC server (via {@link ScmTestMock}) bound to a
+ * loopback address on an OS-assigned port, then primes
+ * {@link SCMConnectionManager} with a deliberately stale entry: cached at
+ * {@code 127.0.0.99:port} (no listener, unreachable) but with the preserved
+ * hostname {@code localhost:port}. This is the steady state an Ozone
+ * DataNode falls into when a Kubernetes SCM pod has been rescheduled to a
+ * new IP -- the cached InetSocketAddress points to the gone-away IP, but
+ * DNS for the hostname now resolves elsewhere.
+ * <p>
+ * The test calls {@link SCMConnectionManager#refreshSCMServer} directly
+ * and asserts that:
+ * <ol>
+ *   <li>the swap occurred,</li>
+ *   <li>the cached endpoint now points at the live SCM,</li>
+ *   <li>a real heartbeat through the swapped endpoint round-trips
+ *       successfully (mock SCM observes the count incrementing).</li>
+ * </ol>
+ * Together these prove the swap-mechanism path: address re-resolution,
+ * atomic endpoint swap, fresh RPC proxy construction, real network
+ * handshake, server-side handler invocation.
+ * <p>
+ * The complementary trigger-chain integration -- heartbeat IOException
+ * → catch block → {@code maybeRefreshScmAddress} → flag/threshold check
+ * → {@code refreshSCMServer} -- is covered by
+ * {@code TestHeartbeatEndpointTaskDnsRefresh}. Together the two tests
+ * prove the full production recovery flow without a single flaky
+ * timing-dependent assertion.
+ */
+public class TestSCMConnectionManagerDnsRefreshE2E {
+
+  private RPC.Server scmServer;
+  private SCMConnectionManager connectionManager;
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (connectionManager != null) {
+      connectionManager.close();
+    }
+    if (scmServer != null) {
+      scmServer.stop();
+    }
+  }
+
+  @Test
+  @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+  public void testRefreshSwapsEndpointAndHeartbeatSucceeds() throws Exception {
+    // Step 1: stand up a real mock SCM RPC server on a loopback address,
+    // OS-assigned port. This is the "live" SCM after the pod restart.
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ScmTestMock scmServerImpl = new ScmTestMock();
+    scmServer = SCMTestUtils.startScmRpcServer(conf, scmServerImpl);
+    InetSocketAddress liveAddr = scmServer.getListenerAddress();
+    int port = liveAddr.getPort();
+
+    // Preserve the server's actual bound host so DNS re-resolution and
+    // the RPC dial use the same address family (avoids IPv4/IPv6
+    // localhost mismatch on dual-stack CI hosts).
+    String hostAndPort = liveAddr.getAddress().getHostAddress() + ":" + port;
+
+    // Step 2: prime the connection manager with a deliberately stale
+    // cached InetSocketAddress (127.0.0.99 has no listener; any RPC
+    // attempt would fail). Crucially, the entry still carries the
+    // preserved hostname "localhost:port", which is the input to DNS
+    // re-resolution. This is exactly the state a DN falls into after
+    // an SCM pod is rescheduled in Kubernetes.
+    InetSocketAddress staleAddr = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 99}), port);
+    connectionManager = new SCMConnectionManager(conf);
+    connectionManager.addSCMServer(staleAddr, hostAndPort, "");
+
+    assertEquals(1, connectionManager.getNumOfConnections());
+
+    // Step 3: call the recovery path. refreshSCMServer must:
+    //   - re-resolve "localhost" via DNS,
+    //   - notice the resolved IP differs from the stale 127.0.0.99,
+    //   - tear down the unreachable endpoint and build a fresh one
+    //     bound to the live address.
+    InetSocketAddress refreshed = connectionManager.refreshSCMServer(
+        staleAddr, "");
+
+    assertNotNull(refreshed,
+        "refreshSCMServer must report a swap when the cached IP "
+            + "127.0.0.99 differs from what DNS now returns for "
+            + hostAndPort);
+    assertEquals(port, refreshed.getPort(),
+        "port must be preserved across the swap; only the IP changes");
+    assertEquals(1, connectionManager.getNumOfConnections(),
+        "swap is in-place: still exactly one endpoint, just bound to a "
+            + "fresh address");
+
+    EndpointStateMachine swapped =
+        connectionManager.getValues().iterator().next();
+    assertEquals(refreshed, swapped.getAddress(),
+        "the cached endpoint must now hold the freshly-resolved address");
+    assertEquals(hostAndPort, swapped.getHostAndPort(),
+        "preserved hostname survives the swap so future refreshes still "
+            + "work after another pod restart");
+
+    // Step 4: the live test of the recovery -- send a real heartbeat
+    // through the swapped endpoint and verify the mock SCM saw it.
+    // If any step in the chain (address swap, proxy construction,
+    // socket dial, server handler) is broken, this RPC throws and
+    // the test fails.
+    int beforeCount = scmServerImpl.getRpcCount();
+    SCMHeartbeatRequestProto request = SCMHeartbeatRequestProto.newBuilder()
+        .setDatanodeDetails(
+            org.apache.hadoop.hdds.protocol.MockDatanodeDetails
+                .randomDatanodeDetails().getProtoBufMessage())
+        .build();
+    SCMHeartbeatResponseProto response =
+        swapped.getEndPoint().sendHeartbeat(request);
+    assertNotNull(response, "heartbeat response must come back from "
+        + "the live SCM via the swapped endpoint");
+    assertTrue(scmServerImpl.getRpcCount() > beforeCount,
+        "mock SCM must observe at least one new RPC -- proves the "
+            + "end-to-end network path through the swapped endpoint is "
+            + "actually live");
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is **PR 4 of 4** splitting [HDDS-15514](https://issues.apache.org/jira/browse/HDDS-15514) (originally proposed as a single ~160KB patch in #10473, split per @szetszwo's review feedback).

This PR fixes the **DN → SCM heartbeat path** — the largest and most invasive of the four split PRs. Unlike the failover-proxy-provider seams, the DN does not failover; it heartbeats every SCM in parallel via the `EndpointStateMachine` / `SCMConnectionManager` abstraction. The fix introduces:

1. An atomic `EndpointStateMachine` swap when DNS re-resolution detects an IP change.
2. Per-endpoint queue migration in `StateContext` so in-flight reports survive the swap.
3. A separate threshold knob (`ozone.datanode.scm.heartbeat.address.refresh.threshold`, default 3) — the heartbeat path runs at a much higher cadence than the failover-proxy path, so a count-based gate prevents over-reaction to transient blips.

> **PR-1/2/3 have merged; this PR is now rebased directly on `master` and is standalone.** It reuses the `ConnectionFailureUtils` classifier and the `ozone.client.failover.resolve-needed` flag from the merged [#10486](https://github.com/apache/ozone/pull/10486) and [#10487](https://github.com/apache/ozone/pull/10487).

## Why this matters

`EndpointStateMachine.address` is the cached `InetSocketAddress` that the DN heartbeat task uses to dial each SCM peer. It is constructed at DN startup from the configured `host:port` and never re-resolved. When an SCM pod is rescheduled in Kubernetes, every heartbeat to that peer dials the now-defunct IP forever. The DN's `endpoints` set still contains the broken peer's `EndpointStateMachine`, but that machine never recovers without a DN process restart.

This is the path the AWC ozone-operator's existing 7-layer workaround was built to defeat: after watching SCM pod IP changes, the operator force-restarts every DN. PR-4 is the upstream fix that lets the operator drop those restarts.

## What this PR does

### 1. `EndpointStateMachine` preserves a hostname

| Change | Why |
|---|---|
| New `final String hostAndPort` field. | Source of truth for re-resolution. |
| `resolveLatestAddress()`: re-resolves `hostAndPort` via `NetUtils.createSocketAddr` and returns the freshly-resolved `InetSocketAddress` only if its `getAddress()` differs from the cached one. Returns null on legacy endpoints (no preserved `hostAndPort`), unresolved DNS, or unchanged IP. | Lets the heartbeat task ask "did the IP just change?" without committing to a swap. |

### 2. `SCMConnectionManager.refreshSCMServer` — 4-phase atomic swap

```
PHASE A (read lock):       snapshot the endpoint reference and hostAndPort
PHASE B (no lock):         resolveLatestAddress  (DNS lookup must NEVER hold a lock)
PHASE C (write lock):      re-check snapshot, enforce collision invariant,
                           build replacement endpoint, commit swap
PHASE D (no lock):         close stale endpoint  (RPC.stopProxy + socket teardown)
```

Crucial properties (each had a corresponding bug in the original combined PR that Copilot's failure-injection lens caught):

- **Build-then-swap, never remove-then-build.** If `buildScmEndpoint` throws (transient DNS, peer not yet accepting on the new IP, NetUtils refusing the address), the stale endpoint stays registered. Otherwise the peer would disappear from `scmMachines` entirely and no heartbeat could recover it. Tested by `TestSCMConnectionManager.testRefreshSCMServerLeavesStaleEndpointOnBuildFailure` using a `@VisibleForTesting` overridable `buildScmEndpoint` hook.
- **Refuse swaps that collide with another registered peer key.** If transient kube-DNS returns peer-B's IP for peer-A's hostname, the swap is refused rather than overwriting peer-B's endpoint. Without this, peer-B's `EndpointStateMachine` would be silently replaced, leaking its executor and orphaning its task thread.
- **Re-check after DNS lookup.** A concurrent `removeSCMServer` or refresh may have raced ahead while we were resolving. The write-lock phase verifies the snapshot is still current before swapping.
- **`close()` outside the lock.** Stale-endpoint teardown blocks on `RPC.stopProxy`; holding `writeLock()` across that would stall every concurrent heartbeat / reconfiguration.

### 3. `StateContext.migrateEndpoint` — preserve in-flight reports across swap

Per-endpoint queues (`incrementalReportsQueue`, `containerActions`, `pipelineActions`, `isFullReportReadyToBeSent`) are keyed by `InetSocketAddress`. Without migration, a swap would orphan all queued reports for that peer. The migration is ordered to preserve the invariant **"every endpoint in `endpoints` has a queue at every observable point"**:

1. **PUBLISH** — install new-key queues alongside the old-key queues.
2. **SWITCH** — add `newEndpoint` to the endpoints set; remove `oldEndpoint` from the endpoints set.
3. **RETIRE** — drop the old-key queues (no producer can reach them after step 2).

`endpoints` is now a `CopyOnWriteArraySet` (was `HashSet`). `incrementalReportsQueue`, `containerActions`, `pipelineActions`, and `isFullReportReadyToBeSent` are now `ConcurrentHashMap` (some already were). Producers null-skip queue lookups as defense-in-depth — a producer racing migration MUST NOT NPE on a concurrent `remove`.

The full-report flags get a special case: a swapped endpoint is effectively a fresh peer (the new SCM pod has no idea which reports we have already shipped), so its `isFullReportReadyToBeSent[type]` flags are seeded **fresh** rather than copied from the old key. Tested in `TestHeartbeatEndpointTaskDnsRefresh`.

### 4. `HeartbeatEndpointTask` trigger

In the heartbeat catch block, after `logIfNeeded(ex)`:

```java
if (resolveOnFailureEnabled                    // ozone.client.failover.resolve-needed
    && missedCount >= refreshThreshold         // ozone.datanode.scm.heartbeat.address.refresh.threshold
    && ConnectionFailureUtils.isConnectionFailure(ex)
    && hostAndPort != null) {
  maybeRefreshScmAddress();                    // calls SCMConnectionManager.refreshSCMServer
}
```

All four gates are required. Application-level errors don't trigger refresh. Endpoints without a preserved hostname (legacy code path) don't trigger. The threshold prevents over-reaction to a one-off blip.

### 5. New config knob

`ozone.datanode.scm.heartbeat.address.refresh.threshold` (default **3**). Conservative default — at the typical 30-second heartbeat interval and 6-second `socketTimeout`, this means at most ~108 seconds of dialing the stale IP before the first DNS retry. In practice the failures are usually fast (TCP RST or routing failure), so the recovery is much faster.

## Real-world failure shapes this fix targets

Two distinct failure modes drove the requirement:

- **AWS EC2 / EKS — silent packet drop.** When a DN attempts to connect to the cached IP of `scm-0` after the pod has moved, AWS silently drops the packet. The TCP retry loop expires after `socketTimeout` (default 6 seconds in Ozone). Without this PR, the DN retries the same dead IP forever. With this PR, after `threshold` consecutive `SocketTimeoutException`s, the DN re-resolves DNS and swaps to the new IP.
- **OpenStack — TCP RST or ICMP unreachable.** The network stack fast-rejects packets to the dead IP, surfacing as `ConnectException`. Same recovery path: after `threshold` consecutive failures, refresh.

## How was this patch tested?

| Test class | Count | Coverage |
|---|---|---|
| `TestSCMConnectionManager` (extended) | 7 (1 prior + 6 new) | `resolveLatestAddress` edge cases. `refreshSCMServer` happy-path swap. No-op when `hostAndPort` not preserved. **Rollback regression**: when `buildScmEndpoint` throws, the stale endpoint remains registered (uses `@VisibleForTesting` overridable hook to inject the failure). |
| `TestHeartbeatEndpointTaskDnsRefresh` (new) | 6 | Production trigger chain. `HeartbeatEndpointTask.call()` catch block fires `refreshSCMServer` only when (a) flag enabled, (b) threshold met, (c) cause is connection-class, (d) `hostAndPort` preserved. `AccessControlException` at threshold does NOT trigger. After a successful swap, `StateContext`'s incremental-reports map has the new key and not the old key. |
| `TestSCMConnectionManagerDnsRefreshE2E` (new) | 1 (`@Timeout(30)`) | Real-RPC swap mechanism. Stands up a real `ScmTestMock` RPC server on a loopback OS-assigned port, primes the connection manager with a stale `127.0.0.99` cache + preserved `localhost:port`, calls `refreshSCMServer`, asserts a real `sendHeartbeat` round-trips through the swapped endpoint. Lives in `hadoop-hdds/server-scm` because it depends on `ScmTestMock`. |

Existing regression suite verified non-regressed: `TestEndPoint` (17), `TestHeartbeatEndpointTask` (8).

## Scope and known limitations

- **DN initial bringup with stale DNS**: the refresh fires from the `HEARTBEAT` phase via `HeartbeatEndpointTask`. If a DN starts up with the SCM peer already at a stale IP and never reaches `HEARTBEAT`, the recovery path does not engage. Initial-bringup DNS staleness is the existing concern of [HDDS-5919](https://issues.apache.org/jira/browse/HDDS-5919)'s `ozone.network.jvm.address.cache.enabled=false`. `InitDatanodeState.java` already postpones initialization on initial-resolution failure.
- **HDFS-14118-style construction-time DNS fan-out** (one hostname → multiple persistent IPs, for round-robin DNS HA) is a different problem and out of scope. Worth a follow-on JIRA if needed.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15514

