### PR TITLE
HDDS-15524. [DiskBalancer] Container parallel moves can overwrite pending source replica deletions

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -38,8 +38,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -112,7 +114,8 @@ public class DiskBalancerService extends BackgroundService {
   private AtomicLong nextAvailableTime = new AtomicLong(Time.monotonicNow());
 
   private Set<ContainerID> inProgressContainers;
-  private ConcurrentSkipListMap<Long, Container> pendingDeletionContainers = new ConcurrentSkipListMap();
+  private final ConcurrentSkipListMap<Long, Queue<Container>> pendingDeletionContainers =
+      new ConcurrentSkipListMap<>();
   private static FaultInjector injector;
 
   /**
@@ -639,8 +642,10 @@ public class DiskBalancerService extends BackgroundService {
         }
         if (moveSucceeded && newContainer != null) {
           // Add current old container to pendingDeletionContainers.
-          pendingDeletionContainers.put(clock.millis() + replicaDeletionDelay,
-              container);
+          long deadline = clock.millis() + replicaDeletionDelay;
+          pendingDeletionContainers
+              .computeIfAbsent(deadline, ignored -> new ConcurrentLinkedQueue<>())
+              .add(container);
           ContainerLogger.logMoveSuccess(newContainer.getContainerData(), sourceVolume,
               destVolume, containerSize, Time.monotonicNow() - startTime);
         }
@@ -695,18 +700,18 @@ public class DiskBalancerService extends BackgroundService {
   }
 
   private boolean tryCleanupOnePendingDeletionContainer() {
-    Map.Entry<Long, Container> entry = pendingDeletionContainers.pollFirstEntry();
-    if (entry != null) {
-      if (entry.getKey() <= clock.millis()) {
-        // entry container is expired
-        deleteContainer(entry.getValue());
-        return true;
-      } else {
-        // put back the container
-        pendingDeletionContainers.put(entry.getKey(), entry.getValue());
-      }
+    // peek first, only remove when expired
+    Map.Entry<Long, Queue<Container>> entry = pendingDeletionContainers.firstEntry();
+    if (entry == null || entry.getKey() > clock.millis()) {
+      return false;
     }
-    return false;
+    if (!pendingDeletionContainers.remove(entry.getKey(), entry.getValue())) {
+      return false;
+    }
+    for (Container pending : entry.getValue()) {
+      deleteContainer(pending);
+    }
+    return true;
   }
 
   public DiskBalancerInfo getDiskBalancerInfo() {
@@ -886,5 +891,15 @@ public class DiskBalancerService extends BackgroundService {
   @VisibleForTesting
   public void setReplicaDeletionDelay(long durationMills) {
     this.replicaDeletionDelay = durationMills;
+  }
+
+  public int getPendingDeletionQueueSize() {
+    return pendingDeletionContainers.values().stream()
+        .mapToInt(Queue::size)
+        .sum();
+  }
+
+  public void drainPendingDeletionsForTest() {
+    cleanupPendingDeletionContainers();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -651,7 +651,7 @@ public class DiskBalancerService extends BackgroundService {
         }
         postCall(moveSucceeded && newContainer != null, startTime);
 
-        // pick one expired container from pendingDeletionContainers to delete
+        // Attempt to delete any pending-deletion buckets whose deadline has elapsed.
         tryCleanupOnePendingDeletionContainer();
       }
       return BackgroundTaskResult.EmptyTaskResult.newResult();
@@ -691,7 +691,8 @@ public class DiskBalancerService extends BackgroundService {
     }
   }
 
-  private void cleanupPendingDeletionContainers() {
+  @VisibleForTesting
+  public void cleanupPendingDeletionContainers() {
     // delete all pending deletion containers before stop the service
     boolean ret;
     do {
@@ -893,13 +894,15 @@ public class DiskBalancerService extends BackgroundService {
     this.replicaDeletionDelay = durationMills;
   }
 
+  @VisibleForTesting
+  public int getPendingDeletionDeadlineCount() {
+    return pendingDeletionContainers.size();
+  }
+
+  @VisibleForTesting
   public int getPendingDeletionQueueSize() {
     return pendingDeletionContainers.values().stream()
         .mapToInt(Queue::size)
         .sum();
-  }
-
-  public void drainPendingDeletionsForTest() {
-    cleanupPendingDeletionContainers();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -697,6 +697,7 @@ public class TestDiskBalancerTask {
 
     long id1 = CONTAINER_ID;
     long id2 = CONTAINER_ID + 1;
+    long initialSourceUsed = sourceVolume.getCurrentUsage().getUsedSpace();
 
     Container c1 = createContainer(id1, sourceVolume, State.CLOSED);
     Container c2 = createContainer(id2, sourceVolume, State.CLOSED);
@@ -735,21 +736,25 @@ public class TestDiskBalancerTask {
 
     assertEquals(2, diskBalancerService.getMetrics().getSuccessCount());
 
-    // With the bug: map size is 1; with fix: 2 queued replicas.
-    assertEquals(2, diskBalancerService.getPendingDeletionQueueSize());
+    assertEquals(1, diskBalancerService.getPendingDeletionDeadlineCount(),
+        "both moves should share one deadline key");
+    assertEquals(2, diskBalancerService.getPendingDeletionQueueSize(),
+        "both container replicas should be queued for deletion");
 
     // Not deleted yet — delay has not elapsed.
     assertTrue(oldDir1.exists());
     assertTrue(oldDir2.exists());
 
     clock.fastForward(delayMs);
-    diskBalancerService.drainPendingDeletionsForTest();
+    diskBalancerService.cleanupPendingDeletionContainers();
 
     assertEquals(0, diskBalancerService.getPendingDeletionQueueSize());
     assertFalse(oldDir1.exists());
     assertFalse(oldDir2.exists());
     assertFalse(sourceVolume.getContainerIterator().hasNext(),
         "source volume should have no containers after delayed deletion");
+    assertEquals(initialSourceUsed, sourceVolume.getCurrentUsage().getUsedSpace(),
+        "source volume used space should return to pre-move level after old replicas are deleted");
 
     // New replicas live on dest volume.
     assertTrue(new File(containerSet.getContainer(id1).getContainerData().getContainerPath()).exists());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -47,6 +48,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -58,6 +63,8 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerD
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.hdds.utils.FaultInjector;
 import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
@@ -677,6 +684,76 @@ public class TestDiskBalancerTask {
 
     // Verify delta sizes are restored
     assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testPendingDeletionDoesNotDropReplicasOnSameMillisecondKey(
+      ContainerTestVersionInfo versionInfo)
+      throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
+
+    long delayMs = 2_000L;
+    diskBalancerService.setReplicaDeletionDelay(delayMs);
+
+    long id1 = CONTAINER_ID;
+    long id2 = CONTAINER_ID + 1;
+
+    Container c1 = createContainer(id1, sourceVolume, State.CLOSED);
+    Container c2 = createContainer(id2, sourceVolume, State.CLOSED);
+
+    File oldDir1 = new File(c1.getContainerData().getContainerPath());
+    File oldDir2 = new File(c2.getContainerData().getContainerPath());
+    assertTrue(oldDir1.exists());
+    assertTrue(oldDir2.exists());
+
+    // Reserve dest space like the choosing policy would.
+    destVolume.incCommittedBytes(c1.getContainerData().getBytesUsed());
+    destVolume.incCommittedBytes(c2.getContainerData().getBytesUsed());
+
+    // Schedule two moves (parallelThread default is 5 in config).
+    BackgroundTaskQueue queue = diskBalancerService.getTasks();
+    assertEquals(2, queue.size());
+    DiskBalancerService.DiskBalancerTask task1 =
+        (DiskBalancerService.DiskBalancerTask) queue.poll();
+    DiskBalancerService.DiskBalancerTask task2 =
+        (DiskBalancerService.DiskBalancerTask) queue.poll();
+    assertNotNull(task1);
+    assertNotNull(task2);
+
+    // Run both moves concurrently; fixed TestClock => same deadline key.
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      List<Future<BackgroundTaskResult>> futures = pool.invokeAll(Arrays.asList(
+          task1::call,
+          task2::call));
+      for (Future<BackgroundTaskResult> future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertEquals(2, diskBalancerService.getMetrics().getSuccessCount());
+
+    // With the bug: map size is 1; with fix: 2 queued replicas.
+    assertEquals(2, diskBalancerService.getPendingDeletionQueueSize());
+
+    // Not deleted yet — delay has not elapsed.
+    assertTrue(oldDir1.exists());
+    assertTrue(oldDir2.exists());
+
+    clock.fastForward(delayMs);
+    diskBalancerService.drainPendingDeletionsForTest();
+
+    assertEquals(0, diskBalancerService.getPendingDeletionQueueSize());
+    assertFalse(oldDir1.exists());
+    assertFalse(oldDir2.exists());
+    assertFalse(sourceVolume.getContainerIterator().hasNext(),
+        "source volume should have no containers after delayed deletion");
+
+    // New replicas live on dest volume.
+    assertTrue(new File(containerSet.getContainer(id1).getContainerData().getContainerPath()).exists());
+    assertTrue(new File(containerSet.getContainer(id2).getContainerData().getContainerPath()).exists());
   }
 
   private KeyValueContainer createContainer(long containerId, HddsVolume vol, State state)


### PR DESCRIPTION
## What changes were proposed in this pull request?
In` DiskBalancerService.java` at **lines 642-643** :

`pendingDeletionContainers.put(clock.millis() + replicaDeletionDelay, container);`
After a successful container move, the old replica is queued for deletion in **pendingDeletionContainers**, keyed by `clock.millis() + replicaDeletionDelay`. That key has only millisecond precision, so if two moves finish in the same millisecond, they get the same key.
 Because the map stores one container per key, the second `put() `overwrites the first. The overwritten container is never scheduled for deletion, so its old replica stays on disk and wastes space. With `parallelThread > 1`, this is realistic under normal load.

The key is: **clock.millis() + replicaDeletionDelay**
Both parts are the same for every thread finishing at the same millisecond: 

1. **clock.millis()**— wall clock, millisecond resolution. All JVM threads share the same clock.
2. **replicaDeletionDelay**— a single constant (default 5 minutes = 300,000 ms) shared by the whole service.

**Step-by-step analysis**
Assume **replicaDeletionDelay = 300,000 ms** and **parallelThread = 5**.
Five container moves run in parallel. Moves for containers C-101 and C-202 both finish at clock.millis() = 1,000,000:
 
```
Thread-1 (moving C-101):
key = 1,000,000 + 300,000 = 1,300,000
pendingDeletionContainers.put(1_300_000, C-101_old_replica)
Map now: { 1_300_000 → C-101_old }
 
Thread-2 (moving C-202), same millisecond:
key = 1,000,000 + 300,000 = 1,300,000           <------ identical key! pendingDeletionContainers.put(1_300_000, C-202_old_replica)
Map now: { 1_300_000 → C-202_old }     <--------- C-101_old silently GONE
C-101's old replica has been permanently lost from the pending-deletion queue. It will never be scheduled for deletion. * C-202's old replica gets deleted correctly.

```

- C-101's old replica is never visited. It sits on the source disk forever.
- The container is marked DELETED in metadata (line 605), so it won't be served.
- But its data directory(chunks,container.db,.containerdescriptor) remains on the source disk.
- decrementUsedSpaceis only called insidedeleteContainer(), so the source volume'sused-space counter is never corrected.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15524

## How was this patch tested?

Added unit test in `TestDiskBalancerTask`:
**Before fix:** If two container moves completed at same time it has same key so one gets overridden and it left on the source volume until detected by RM to be deleted, leaving space unclaimed on source volume.
Added test failed with below error:
```
// With the bug: map size is 1; with fix: 2 queued replicas.
org.opentest4j.AssertionFailedError: 
Expected :2
Actual   :1
<Click to see difference>

	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:531)
	at org.apache.hadoop.ozone.container.diskbalancer.TestDiskBalancerTask.testPendingDeletionDoesNotDropReplicasOnSameMillisecondKey(TestDiskBalancerTask.java:739)
	at java.lang.reflect.Method.invoke(Method.java:498)	
...
```
**After fix :** both the containers completing move at the same time is correctly deleted from source volume. Test case passed.
