### PR TITLE
HDDS-15268. Speed up TestUnhealthyContainersDerbyPerformance.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/DerbyDataSourceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/DerbyDataSourceProvider.java
@@ -51,7 +51,8 @@ public class DerbyDataSourceProvider implements Provider<DataSource> {
       LOG.error("Error creating Recon Derby DB.", e);
     }
     EmbeddedDataSource dataSource = new EmbeddedDataSource();
-    dataSource.setDatabaseName(jdbcUrl.split(":")[2]);
+    String dbName = jdbcUrl.replaceFirst("^jdbc:derby:", "");
+    dataSource.setDatabaseName(dbName);
     dataSource.setUser(RECON_SCHEMA_NAME);
     return dataSource;
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -318,8 +318,9 @@ public class TestUnhealthyContainersDerbyPerformance {
   @AfterAll
   public void tearDownDatabase() {
     if (inMemoryDbName != null) {
-      try {
-        java.sql.DriverManager.getConnection("jdbc:derby:memory:" + inMemoryDbName + ";drop=true");
+      try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
+          "jdbc:derby:memory:" + inMemoryDbName + ";drop=true")) {
+        // Database is dropped when this connection closes.
       } catch (java.sql.SQLException e) {
         if (!"08006".equals(e.getSQLState())) {
           LOG.warn("Unexpected SQLState while dropping in-memory Derby DB: {}", e.getSQLState(), e);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -46,6 +46,7 @@ import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContaine
 import org.apache.ozone.recon.schema.ReconSchemaGenerationModule;
 import org.apache.ozone.recon.schema.generated.tables.daos.UnhealthyContainersDao;
 import org.jooq.DSLContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -74,9 +75,9 @@ import org.slf4j.LoggerFactory;
  *
  * <h2>Performance settings applied in this test</h2>
  * <ul>
- *   <li><b>Page cache</b>: {@code derby.storage.pageCacheSize = 20000}
- *       (~80 MB of 4-KB pages) keeps hot B-tree nodes in memory, reducing
- *       filesystem reads even with the file-based Derby driver.</li>
+ *   <li><b>In-memory database</b>: The test uses an in-memory Derby database
+ *       ({@code jdbc:derby:memory:...}) to eliminate disk I/O and fsync overhead
+ *       during the 1-million-row benchmark.</li>
  *   <li><b>JDBC fetch size</b>: set to {@value #READ_PAGE_SIZE} on each query
  *       so Derby pre-buffers a full page of rows per JDBC round-trip instead
  *       of the default 1-row-at-a-time fetch.</li>
@@ -184,8 +185,8 @@ public class TestUnhealthyContainersDerbyPerformance {
   private static final int READ_PAGE_SIZE = 5_000;
 
   // -----------------------------------------------------------------------
-  // Performance thresholds (CI-safe; expected run times are 5–10× faster
-  // than the original file-based Derby baseline after the optimisations)
+  // Performance thresholds (CI-safe; expected run times are significantly faster
+  // than the original file-based Derby baseline after switching to in-memory)
   // -----------------------------------------------------------------------
 
   /** Maximum acceptable time to insert all TOTAL_RECORDS into Derby. */
@@ -220,6 +221,8 @@ public class TestUnhealthyContainersDerbyPerformance {
   // One-time setup: create Derby schema + insert 1 M records
   // -----------------------------------------------------------------------
 
+  private String inMemoryDbName;
+
   /**
    * Initialises the embedded Derby database and creates the Recon schema.
    * Data population is done in dedicated test methods.
@@ -233,30 +236,80 @@ public class TestUnhealthyContainersDerbyPerformance {
    *
    * <h3>Performance settings applied here</h3>
    * <ul>
-   *   <li><b>Page cache</b> ({@code derby.storage.pageCacheSize = 20000}):
-   *       ~80 MB of 4-KB B-tree pages resident in heap — covers the hot path
-   *       for index scans on a 1-M-row table even with the file-based
-   *       driver.</li>
+   *   <li><b>In-memory database</b>: The test uses an in-memory Derby database
+   *       ({@code jdbc:derby:memory:...}) to eliminate disk I/O and fsync overhead
+   *       during the 1-million-row benchmark.</li>
    * </ul>
    */
   @BeforeAll
   public void setUpDatabase(@TempDir Path tempDir) throws Exception {
+    inMemoryDbName = "reconPerf_" + java.util.UUID.randomUUID().toString();
     LOG.info("=== Derby Performance Benchmark — Setup ===");
     LOG.info("Dataset: {} states × {} container IDs = {} total records",
         TESTED_STATES.size(), CONTAINER_ID_RANGE, TOTAL_RECORDS);
 
-    // Derby engine property — must be set before the first connection.
-    //
-    // pageCacheSize: number of 4-KB pages Derby keeps in its buffer pool.
-    //   Default = 1,000 pages (4 MB) — far too small for a 1-M-row table.
-    //   20,000 pages = ~80 MB, enough to hold the full B-tree for both the
-    //   primary-key index and the composite (state, container_id) index.
-    System.setProperty("derby.storage.pageCacheSize", "20000");
-
     // ----- Guice wiring (mirrors AbstractReconSqlDBTest) -----
-    File configDir = Files.createDirectory(tempDir.resolve("Config")).toFile();
-    Provider<DataSourceConfiguration> configProvider =
-        new DerbyDataSourceConfigurationProvider(configDir);
+    Provider<DataSourceConfiguration> configProvider = () -> new DataSourceConfiguration() {
+      @Override
+      public String getDriverClass() {
+        return org.apache.ozone.recon.schema.SqlDbUtils.DERBY_DRIVER_CLASS;
+      }
+
+      @Override
+      public String getJdbcUrl() {
+        return "jdbc:derby:memory:" + inMemoryDbName;
+      }
+
+      @Override
+      public String getUserName() {
+        return null;
+      }
+
+      @Override
+      public String getPassword() {
+        return null;
+      }
+
+      @Override
+      public boolean setAutoCommit() {
+        return true;
+      }
+
+      @Override
+      public long getConnectionTimeout() {
+        return 10000;
+      }
+
+      @Override
+      public String getSqlDialect() {
+        return org.jooq.SQLDialect.DERBY.toString();
+      }
+
+      @Override
+      public Integer getMaxActiveConnections() {
+        return 2;
+      }
+
+      @Override
+      public long getMaxConnectionAge() {
+        return 120;
+      }
+
+      @Override
+      public long getMaxIdleConnectionAge() {
+        return 120;
+      }
+
+      @Override
+      public String getConnectionTestStatement() {
+        return "SELECT 1";
+      }
+
+      @Override
+      public long getIdleConnectionTestPeriod() {
+        return 30;
+      }
+    };
 
     Injector injector = Guice.createInjector(
         new JooqPersistenceModule(configProvider),
@@ -275,6 +328,19 @@ public class TestUnhealthyContainersDerbyPerformance {
     dao = injector.getInstance(UnhealthyContainersDao.class);
     schemaDefinition = injector.getInstance(ContainerSchemaDefinition.class);
     schemaManager = new ContainerHealthSchemaManager(schemaDefinition, new OzoneConfiguration());
+  }
+
+  @AfterAll
+  public void tearDownDatabase() {
+    if (inMemoryDbName != null) {
+      try {
+        java.sql.DriverManager.getConnection("jdbc:derby:memory:" + inMemoryDbName + ";drop=true");
+      } catch (java.sql.SQLException e) {
+        if (!"08006".equals(e.getSQLState())) {
+          LOG.warn("Unexpected SQLState while dropping in-memory Derby DB: {}", e.getSQLState(), e);
+        }
+      }
+    }
   }
 
   // -----------------------------------------------------------------------

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -48,12 +48,12 @@ import org.apache.ozone.recon.schema.generated.tables.daos.UnhealthyContainersDa
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -244,18 +244,65 @@ public class TestUnhealthyContainersDerbyPerformance {
 
     // Reuse DerbyDataSourceConfigurationProvider settings but point to an in-memory DB.
     Provider<DataSourceConfiguration> configProvider = () -> new DataSourceConfiguration() {
-      @Override public String getDriverClass() { return base.getDriverClass(); }
-      @Override public String getJdbcUrl() { return "jdbc:derby:memory:" + inMemoryDbName; }
-      @Override public String getUserName() { return base.getUserName(); }
-      @Override public String getPassword() { return base.getPassword(); }
-      @Override public boolean setAutoCommit() { return base.setAutoCommit(); }
-      @Override public long getConnectionTimeout() { return base.getConnectionTimeout(); }
-      @Override public String getSqlDialect() { return base.getSqlDialect(); }
-      @Override public Integer getMaxActiveConnections() { return base.getMaxActiveConnections(); }
-      @Override public long getMaxConnectionAge() { return base.getMaxConnectionAge(); }
-      @Override public long getMaxIdleConnectionAge() { return base.getMaxIdleConnectionAge(); }
-      @Override public String getConnectionTestStatement() { return base.getConnectionTestStatement(); }
-      @Override public long getIdleConnectionTestPeriod() { return base.getIdleConnectionTestPeriod(); }
+      @Override
+      public String getDriverClass() {
+        return base.getDriverClass();
+      }
+
+      @Override
+      public String getJdbcUrl() {
+        return "jdbc:derby:memory:" + inMemoryDbName;
+      }
+
+      @Override
+      public String getUserName() {
+        return base.getUserName();
+      }
+
+      @Override
+      public String getPassword() {
+        return base.getPassword();
+      }
+
+      @Override
+      public boolean setAutoCommit() {
+        return base.setAutoCommit();
+      }
+
+      @Override
+      public long getConnectionTimeout() {
+        return base.getConnectionTimeout();
+      }
+
+      @Override
+      public String getSqlDialect() {
+        return base.getSqlDialect();
+      }
+
+      @Override
+      public Integer getMaxActiveConnections() {
+        return base.getMaxActiveConnections();
+      }
+
+      @Override
+      public long getMaxConnectionAge() {
+        return base.getMaxConnectionAge();
+      }
+
+      @Override
+      public long getMaxIdleConnectionAge() {
+        return base.getMaxIdleConnectionAge();
+      }
+
+      @Override
+      public String getConnectionTestStatement() {
+        return base.getConnectionTestStatement();
+      }
+
+      @Override
+      public long getIdleConnectionTestPeriod() {
+        return base.getIdleConnectionTestPeriod();
+      }
     };
 
     Injector injector = Guice.createInjector(
@@ -282,7 +329,7 @@ public class TestUnhealthyContainersDerbyPerformance {
     if (inMemoryDbName != null) {
       try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
           "jdbc:derby:memory:" + inMemoryDbName + ";drop=true")) {
-        // Database is dropped when this connection closes.
+        conn.isValid(1);
       } catch (java.sql.SQLException e) {
         if (!"08006".equals(e.getSQLState())) {
           LOG.warn("Unexpected SQLState while dropping in-memory Derby DB: {}", e.getSQLState(), e);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -26,9 +26,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -38,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.recon.ReconControllerModule.ReconDaoBindingModule;
 import org.apache.hadoop.ozone.recon.ReconSchemaManager;
-import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest.DerbyDataSourceConfigurationProvider;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainerRecord;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainersSummary;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
@@ -53,7 +49,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -224,25 +219,15 @@ public class TestUnhealthyContainersDerbyPerformance {
   private String inMemoryDbName;
 
   /**
-   * Initialises the embedded Derby database and creates the Recon schema.
+   * Initialises the embedded in-memory Derby database and creates the Recon schema.
    * Data population is done in dedicated test methods.
    *
-   * <p>The {@code @TempDir} is injected as a <em>method parameter</em> rather
-   * than a class field.  With {@code @TestInstance(PER_CLASS)}, a field-level
-   * {@code @TempDir} is populated by JUnit's {@code TempDirExtension} in its
-   * own {@code beforeAll} callback, which may run <em>after</em> the user's
-   * {@code @BeforeAll} — leaving it null when needed here.  A method
-   * parameter is resolved by JUnit before the method body executes.</p>
-   *
-   * <h3>Performance settings applied here</h3>
-   * <ul>
-   *   <li><b>In-memory database</b>: The test uses an in-memory Derby database
-   *       ({@code jdbc:derby:memory:...}) to eliminate disk I/O and fsync overhead
-   *       during the 1-million-row benchmark.</li>
-   * </ul>
+   * <p>Uses {@code jdbc:derby:memory:...} to keep all 1M rows in RAM and eliminate
+   * disk I/O (fsync) overhead across the benchmark's insert, replace, and delete
+   * transactions.</p>
    */
   @BeforeAll
-  public void setUpDatabase(@TempDir Path tempDir) throws Exception {
+  public void setUpDatabase() throws Exception {
     inMemoryDbName = "reconPerf_" + java.util.UUID.randomUUID().toString();
     LOG.info("=== Derby Performance Benchmark — Setup ===");
     LOG.info("Dataset: {} states × {} container IDs = {} total records",

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -26,6 +26,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -35,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.recon.ReconControllerModule.ReconDaoBindingModule;
 import org.apache.hadoop.ozone.recon.ReconSchemaManager;
+import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest.DerbyDataSourceConfigurationProvider;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainerRecord;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainersSummary;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
@@ -44,6 +48,7 @@ import org.apache.ozone.recon.schema.generated.tables.daos.UnhealthyContainersDa
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -222,78 +227,35 @@ public class TestUnhealthyContainersDerbyPerformance {
    * Initialises the embedded in-memory Derby database and creates the Recon schema.
    * Data population is done in dedicated test methods.
    *
-   * <p>Uses {@code jdbc:derby:memory:...} to keep all 1M rows in RAM and eliminate
-   * disk I/O (fsync) overhead across the benchmark's insert, replace, and delete
-   * transactions.</p>
+   * <p>Reuses {@link DerbyDataSourceConfigurationProvider} for all connection settings
+   * and overrides only {@code getJdbcUrl()} to use an in-memory Derby database
+   * ({@code jdbc:derby:memory:...}), eliminating disk I/O and fsync overhead across
+   * the benchmark's insert, replace, and delete transactions.</p>
    */
   @BeforeAll
-  public void setUpDatabase() throws Exception {
+  public void setUpDatabase(@TempDir Path tempDir) throws Exception {
     inMemoryDbName = "reconPerf_" + java.util.UUID.randomUUID().toString();
     LOG.info("=== Derby Performance Benchmark — Setup ===");
     LOG.info("Dataset: {} states × {} container IDs = {} total records",
         TESTED_STATES.size(), CONTAINER_ID_RANGE, TOTAL_RECORDS);
 
-    // ----- Guice wiring (mirrors AbstractReconSqlDBTest) -----
+    File configDir = Files.createDirectory(tempDir.resolve("Config")).toFile();
+    DataSourceConfiguration base = new DerbyDataSourceConfigurationProvider(configDir).get();
+
+    // Reuse DerbyDataSourceConfigurationProvider settings but point to an in-memory DB.
     Provider<DataSourceConfiguration> configProvider = () -> new DataSourceConfiguration() {
-      @Override
-      public String getDriverClass() {
-        return org.apache.ozone.recon.schema.SqlDbUtils.DERBY_DRIVER_CLASS;
-      }
-
-      @Override
-      public String getJdbcUrl() {
-        return "jdbc:derby:memory:" + inMemoryDbName;
-      }
-
-      @Override
-      public String getUserName() {
-        return null;
-      }
-
-      @Override
-      public String getPassword() {
-        return null;
-      }
-
-      @Override
-      public boolean setAutoCommit() {
-        return true;
-      }
-
-      @Override
-      public long getConnectionTimeout() {
-        return 10000;
-      }
-
-      @Override
-      public String getSqlDialect() {
-        return org.jooq.SQLDialect.DERBY.toString();
-      }
-
-      @Override
-      public Integer getMaxActiveConnections() {
-        return 2;
-      }
-
-      @Override
-      public long getMaxConnectionAge() {
-        return 120;
-      }
-
-      @Override
-      public long getMaxIdleConnectionAge() {
-        return 120;
-      }
-
-      @Override
-      public String getConnectionTestStatement() {
-        return "SELECT 1";
-      }
-
-      @Override
-      public long getIdleConnectionTestPeriod() {
-        return 30;
-      }
+      @Override public String getDriverClass() { return base.getDriverClass(); }
+      @Override public String getJdbcUrl() { return "jdbc:derby:memory:" + inMemoryDbName; }
+      @Override public String getUserName() { return base.getUserName(); }
+      @Override public String getPassword() { return base.getPassword(); }
+      @Override public boolean setAutoCommit() { return base.setAutoCommit(); }
+      @Override public long getConnectionTimeout() { return base.getConnectionTimeout(); }
+      @Override public String getSqlDialect() { return base.getSqlDialect(); }
+      @Override public Integer getMaxActiveConnections() { return base.getMaxActiveConnections(); }
+      @Override public long getMaxConnectionAge() { return base.getMaxConnectionAge(); }
+      @Override public long getMaxIdleConnectionAge() { return base.getMaxIdleConnectionAge(); }
+      @Override public String getConnectionTestStatement() { return base.getConnectionTestStatement(); }
+      @Override public long getIdleConnectionTestPeriod() { return base.getIdleConnectionTestPeriod(); }
     };
 
     Injector injector = Guice.createInjector(


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TestUnhealthyContainersDerbyPerformance` was taking about **336.4 seconds** in CI because it used a file-based Derby database and paid disk I/O and fsync cost on large insert/replace/delete operations.

This PR speeds up the test without reducing coverage:

- Switches the test to an **in-memory Derby** database (`jdbc:derby:memory:<unique-name>`)
- Keeps the full **1,000,000-row** dataset and all existing assertions
- Adds `@AfterAll` cleanup to drop the in-memory database
- Fixes `DerbyDataSourceProvider` URL parsing so in-memory Derby URLs work, while file-based URLs remain unchanged

**Why:** The test validates Recon persistence behavior at scale, not disk fsync performance. In-memory Derby removes the main bottleneck without weakening the test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15268

## How was this patch tested?
- Ran:
```
mvn test -Dtest=TestUnhealthyContainersDerbyPerformance -pl hadoop-ozone/recon
```
- Result:
```
[INFO] Running org.apache.hadoop.ozone.recon.persistence.TestUnhealthyContainersDerbyPerformance
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 195.8 s -- in org.apache.hadoop.ozone.recon.persistence.TestUnhealthyContainersDerbyPerformance
```
- ### Baseline was about 336.4 s; optimised run is about 195.8 s (~42% faster)
