### PR TITLE
HDDS-15528. Adjust upgrade finalize command to call OM instread of SCM

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -42,7 +42,7 @@ public class FinalizeSubCommand extends AbstractSubcommand implements Callable<V
   public Void call() throws Exception {
     try (OzoneManagerProtocol client = getClient()) {
       client.finalizeUpgrade();
-      out().println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status");
+      out().println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status`");
     }
     return null;
   }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.admin.upgrade;
 
 import java.util.concurrent.Callable;
+import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.admin.om.OmAddressOptions;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
@@ -32,7 +33,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
-public class FinalizeSubCommand implements Callable<Void> {
+public class FinalizeSubCommand extends AbstractSubcommand implements Callable<Void> {
 
   @CommandLine.Mixin
   private OmAddressOptions.OptionalServiceIdOrHostMixin omAddressOptions;
@@ -41,7 +42,7 @@ public class FinalizeSubCommand implements Callable<Void> {
   public Void call() throws Exception {
     try (OzoneManagerProtocol client = getClient()) {
       client.finalizeUpgrade();
-      System.out.println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status`");
+      out().println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status");
     }
     return null;
   }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import picocli.CommandLine;
 
 /**
- * Handler for the ozone admin upgrade finalize command
+ * Handler for the ozone admin upgrade finalize command.
  */
 @CommandLine.Command(
     name = "finalize",

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -17,27 +17,36 @@
 
 package org.apache.hadoop.ozone.admin.upgrade;
 
-import java.io.IOException;
+import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
-import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.hadoop.ozone.admin.om.OmAddressOptions;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import picocli.CommandLine;
 
 /**
- * Sub command to finalize a cluster upgrade.
+ * Handler for the ozone admin upgrade finalize command
  */
 @CommandLine.Command(
     name = "finalize",
-    description = "Finalize a cluster upgrade",
+    description = "Initiates the the process to finalize a cluster upgrade.",
     mixinStandardHelpOptions = true,
-    versionProvider = HddsVersionProvider.class)
-public class FinalizeSubCommand extends ScmSubcommand {
+    versionProvider = HddsVersionProvider.class
+)
+public class FinalizeSubCommand implements Callable<Void> {
+
+  @CommandLine.Mixin
+  private OmAddressOptions.OptionalServiceIdOrHostMixin omAddressOptions;
 
   @Override
-  public void execute(ScmClient client) throws IOException {
-    client.finalizeUpgrade();
+  public Void call() throws Exception {
+    try (OzoneManagerProtocol client = getClient()) {
+      client.finalizeUpgrade();
+      System.out.println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status`");
+    }
+    return null;
+  }
 
-    out().println("Cluster finalization has been started. Monitor progress with `ozone admin upgrade status`");
+  protected OzoneManagerProtocol getClient() throws Exception {
+    return omAddressOptions.newClient();
   }
 }
-

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -17,8 +17,10 @@
 
 package org.apache.hadoop.ozone.admin.upgrade;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -67,12 +69,30 @@ public class TestFinalizeSubCommand {
 
   @Test
   public void testCommandRunsAndPrintsOutput() throws Exception {
-
     new CommandLine(cmd).parseArgs();
     cmd.call();
 
     String output = outContent.toString(DEFAULT_ENCODING);
     assertTrue(output.contains("Cluster finalization has been started"));
     verify(omClient).finalizeUpgrade();
+  }
+
+  @Test
+  public void testClientIsClosedAfterSuccessfulCall() throws Exception {
+    new CommandLine(cmd).parseArgs();
+    cmd.call();
+
+    verify(omClient).close();
+  }
+
+  @Test
+  public void testExceptionFromServerIsPropagated() throws Exception {
+    doThrow(new IOException("OM unavailable")).when(omClient).finalizeUpgrade();
+
+    new CommandLine(cmd).parseArgs();
+    assertThrows(IOException.class, cmd::call);
+
+    // Client must still be closed even when finalizeUpgrade() throws.
+    verify(omClient).close();
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -18,15 +18,15 @@
 package org.apache.hadoop.ozone.admin.upgrade;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,10 +42,21 @@ public class TestFinalizeSubCommand {
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   private final PrintStream originalOut = System.out;
   private FinalizeSubCommand cmd;
+  private OzoneManagerProtocol omClient;
 
   @BeforeEach
-  public void setup() throws UnsupportedEncodingException {
-    cmd = new FinalizeSubCommand();
+  public void setup() throws IOException {
+    omClient = mock(OzoneManagerProtocol.class);
+
+    // Mock close() to do nothing - needed for try-with-resources
+    doNothing().when(omClient).close();
+
+    cmd = new FinalizeSubCommand() {
+      @Override
+      protected OzoneManagerProtocol getClient() throws Exception {
+        return omClient;
+      }
+    };
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
   }
 
@@ -55,14 +66,13 @@ public class TestFinalizeSubCommand {
   }
 
   @Test
-  public void testCommandRunsAndPrintsOutput() throws IOException {
-    ScmClient scmClient = mock(ScmClient.class);
+  public void testCommandRunsAndPrintsOutput() throws Exception {
 
     new CommandLine(cmd).parseArgs();
-    cmd.execute(scmClient);
+    cmd.call();
 
     String output = outContent.toString(DEFAULT_ENCODING);
     assertTrue(output.contains("Cluster finalization has been started"));
-    verify(scmClient).finalizeUpgrade();
+    verify(omClient).finalizeUpgrade();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -295,6 +295,7 @@ public final class OmUtils {
       // TODO: Remove once migrated to proto3 and mark fields in proto
       // as deprecated
     case FinalizeUpgrade:
+    case StartFinalizeUpgrade:
     case Prepare:
     case CancelPrepare:
     case DeleteOpenKeys:
@@ -410,6 +411,7 @@ public final class OmUtils {
       // TODO: Remove once migrated to proto3 and mark fields in proto
       // as deprecated
     case FinalizeUpgrade:
+    case StartFinalizeUpgrade:
     case Prepare:
     case CancelPrepare:
     case DeleteOpenKeys:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -497,7 +497,7 @@ public interface OzoneManagerProtocol
    * finalizing the HDDS layer. After that call completes successfully, the HDDS finalization will be in progress.
    * Second, a key will be written to the OM database to persist the fact that OM finalization is pending. It will
    * complete once the HDDS layer has completed. OM will poll SCM periodically to check the status of the SCM
-   * finaliaztion progress, and OM will only finalize when SCM indicates it is OK for it to do so.
+   * finalization progress, and OM will only finalize when SCM indicates it is OK for it to do so.
    *
    * This command is async, and will return before finalization is complete. The caller must issue a Query Finalization
    * Progress command to monitor the progress.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -492,6 +492,22 @@ public interface OzoneManagerProtocol
   UpgradeFinalization.StatusAndMessages finalizeUpgrade(String upgradeClientID) throws IOException;
 
   /**
+   * Initiate metadata upgrade finalization.
+   * This method when called, performs two actions. First, it will result in OM making a call to SCM to start
+   * finalizing the HDDS layer. After that call completes successfully, the HDDS finaliztion will be in progress.
+   * Second, a key will be written to the OM database to persist the fact that OM finalization is pending. It will
+   * complete once the HDDS layer has completed. OM will poll SCM periodically to check the status of the SCM
+   * finaliztion progress, and OM will only finalize when SCM indicates it is OK for it to do so.
+   *
+   * This command is async, and will return before finalization is complete. The caller must issue a Query Finalzation
+   * Progress command to monitor the progress.
+   *
+   * @throws IOException If any error occurs. If this happens finalization is not in progress and the command must be
+   *                     retried.
+   */
+  void finalizeUpgrade() throws IOException;
+
+  /**
    * Queries the current status of finalization.
    * This method when called, returns the status messages from the finalization
    * progress, if any. The status returned is

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -494,12 +494,12 @@ public interface OzoneManagerProtocol
   /**
    * Initiate metadata upgrade finalization.
    * This method when called, performs two actions. First, it will result in OM making a call to SCM to start
-   * finalizing the HDDS layer. After that call completes successfully, the HDDS finaliztion will be in progress.
+   * finalizing the HDDS layer. After that call completes successfully, the HDDS finalization will be in progress.
    * Second, a key will be written to the OM database to persist the fact that OM finalization is pending. It will
    * complete once the HDDS layer has completed. OM will poll SCM periodically to check the status of the SCM
-   * finaliztion progress, and OM will only finalize when SCM indicates it is OK for it to do so.
+   * finaliaztion progress, and OM will only finalize when SCM indicates it is OK for it to do so.
    *
-   * This command is async, and will return before finalization is complete. The caller must issue a Query Finalzation
+   * This command is async, and will return before finalization is complete. The caller must issue a Query Finalization
    * Progress command to monitor the progress.
    *
    * @throws IOException If any error occurs. If this happens finalization is not in progress and the command must be

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2043,7 +2043,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setStartFinalizeUpgradeRequest(req)
         .build();
 
-    handleError(submitRequest(omRequest)).getStartFinalizeUpgradeResponse();
+    handleError(submitRequest(omRequest));
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -210,8 +210,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RevokeS
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Secret;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SafeMode;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StartFinalizeUpgradeRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StartFinalizeUpgradeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclRequest;
@@ -226,6 +224,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetTime
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetVolumePropertyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetVolumePropertyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotInfoRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StartFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantAssignAdminRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantAssignUserAccessIdRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantAssignUserAccessIdResponse;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -210,6 +210,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RevokeS
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Secret;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SafeMode;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StartFinalizeUpgradeRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StartFinalizeUpgradeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclRequest;
@@ -2031,6 +2033,18 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         UpgradeFinalization.Status.valueOf(status.getStatus().name()),
         status.getMessagesList()
     );
+  }
+
+  @Override
+  public void finalizeUpgrade() throws IOException {
+    StartFinalizeUpgradeRequest req = StartFinalizeUpgradeRequest.newBuilder()
+        .build();
+
+    OMRequest omRequest = createOMRequest(Type.StartFinalizeUpgrade)
+        .setStartFinalizeUpgradeRequest(req)
+        .build();
+
+    handleError(submitRequest(omRequest)).getStartFinalizeUpgradeResponse();
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSyncUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSyncUpgrade.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.ClientConfigForTesting;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -212,11 +211,7 @@ public class TestHSyncUpgrade {
     // Trigger OM upgrade finalization. Ref: FinalizeUpgradeSubCommand#call
     final OzoneManagerProtocol omClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
-    // TODO - OZONE_FINAL_COMMAND - change to sending command when it is ready. This will trigger OM finalization
-    cluster.getOzoneManager().getMetadataManager().getMetaTable()
-        .addCacheEntry(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore", 1);
-    cluster.getOzoneManager().getMetadataManager().getMetaTable()
-        .put(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore");
+    omClient.finalizeUpgrade();
     OMUpgradeTestUtils.waitForFinalization(omClient);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
@@ -33,11 +33,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.ComponentVersion;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.hdds.utils.db.CodecException;
-import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -155,16 +152,7 @@ class TestOMBucketLayoutUpgrade {
   @Test
   @Order(DURING_UPGRADE)
   void finalizeUpgrade() throws Exception {
-    // TODO - OZONE_FINAL_COMMAND - change to sending command when it is ready. This will trigger OM finalization
-    cluster.getOzoneManagersList().forEach(om -> {
-      try {
-        om.getMetadataManager().getMetaTable().addCacheEntry(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore", 1);
-        om.getMetadataManager().getMetaTable()
-            .put(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore");
-      } catch (RocksDatabaseException | CodecException e) {
-        throw new RuntimeException(e);
-      }
-    });
+    omClient.finalizeUpgrade();
     waitForFinalization(omClient);
 
     final String expectedVersion =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
@@ -32,8 +32,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.utils.db.CodecException;
-import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -100,18 +98,7 @@ class TestOMUpgradeFinalization {
         AuditLogTestUtils.verifyAuditLog(OMAction.UPGRADE_PREPARE, AuditEventStatus.SUCCESS);
         omClient.cancelOzoneManagerPrepare();
         AuditLogTestUtils.verifyAuditLog(OMAction.UPGRADE_CANCEL, AuditEventStatus.SUCCESS);
-        // TODO - OZONE_FINAL_COMMAND - change to sending command when it is ready. This will trigger OM finalization
-        cluster.getOzoneManagersList().forEach(om -> {
-          try {
-            om.getMetadataManager().getMetaTable()
-                .addCacheEntry(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore", 1);
-            om.getMetadataManager().getMetaTable()
-                .put(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore");
-          } catch (RocksDatabaseException | CodecException e) {
-            throw new RuntimeException(e);
-          }
-        });
-
+        omClient.finalizeUpgrade();
         waitForFinalization(omClient);
         AuditLogTestUtils.verifySystemAuditLog(OMAction.UPGRADE_FINALIZE, AuditEventStatus.SUCCESS);
         // Ensure the finalization in progress key has been removed.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -143,11 +143,7 @@ public class TestMultiTenantVolume {
     // Trigger OM upgrade finalization. Ref: FinalizeUpgradeSubCommand#call
     final OzoneManagerProtocol omClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
-    // TODO - OZONE_FINAL_COMMAND - change to sending command when it is ready. This will trigger OM finalization
-    cluster.getOzoneManager().getMetadataManager().getMetaTable()
-        .addCacheEntry(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore", 1);
-    cluster.getOzoneManager().getMetadataManager().getMetaTable()
-        .put(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore");
+    omClient.finalizeUpgrade();
     OMUpgradeTestUtils.waitForFinalization(omClient);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -325,11 +325,7 @@ public abstract class TestOmSnapshot {
   private void finalizeOMUpgrade() throws Exception {
     final OzoneManagerProtocol omClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
-    // TODO - OZONE_FINAL_COMMAND - change to sending command when it is ready. This will trigger OM finalization
-    cluster.getOzoneManager().getMetadataManager().getMetaTable()
-        .addCacheEntry(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore", 1);
-    cluster.getOzoneManager().getMetadataManager().getMetaTable()
-        .put(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignore");
+    omClient.finalizeUpgrade();
     OMUpgradeTestUtils.waitForFinalization(omClient);
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -157,6 +157,7 @@ enum Type {
   GetObjectTagging = 141;
   DeleteObjectTagging = 142;
   SubmitSnapshotDiff = 143;
+  StartFinalizeUpgrade = 144;
 }
 
 enum SafeMode {
@@ -309,6 +310,7 @@ message OMRequest {
   repeated SetSnapshotPropertyRequest       SetSnapshotPropertyRequests    = 143;
 
   optional SubmitSnapshotDiffRequest        submitSnapshotDiffRequest       = 144;
+  optional StartFinalizeUpgradeRequest      startFinalizeUpgradeRequest     = 145;
 }
 
 message OMResponse {
@@ -444,6 +446,7 @@ message OMResponse {
   optional DeleteObjectTaggingResponse       deleteObjectTaggingResponse   = 142;
 
   optional SubmitSnapshotDiffResponse        submitSnapshotDiffResponse    = 143;
+  optional StartFinalizeUpgradeResponse      startFinalizeUpgradeResponse  = 144;
 }
 
 enum Status {
@@ -1629,6 +1632,12 @@ message FinalizeUpgradeRequest {
 
 message FinalizeUpgradeResponse {
   required hadoop.hdds.UpgradeFinalizationStatus status = 1;
+}
+
+message StartFinalizeUpgradeRequest {
+}
+
+message StartFinalizeUpgradeResponse {
 }
 
 message FinalizeUpgradeProgressRequest {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -73,7 +73,7 @@ enum Type {
 
   ServiceList = 51;
   DBUpdates = 53;
-  FinalizeUpgrade = 54;
+  FinalizeUpgrade = 54; // [deprecated = true]
   FinalizeUpgradeProgress = 55;
   Prepare = 56;
   PrepareStatus = 57;
@@ -216,7 +216,7 @@ message OMRequest {
 
   optional ServiceListRequest               serviceListRequest             = 51;
   optional DBUpdatesRequest                  dbUpdatesRequest              = 53;
-  optional FinalizeUpgradeRequest           finalizeUpgradeRequest         = 54;
+  optional FinalizeUpgradeRequest           finalizeUpgradeRequest         = 54 [deprecated = true];
   optional FinalizeUpgradeProgressRequest   finalizeUpgradeProgressRequest = 55;
   optional PrepareRequest                   prepareRequest                 = 56;
   optional PrepareStatusRequest             prepareStatusRequest           = 57;
@@ -360,7 +360,7 @@ message OMResponse {
 
   optional ServiceListResponse               ServiceListResponse           = 51;
   optional DBUpdatesResponse                 dbUpdatesResponse             = 52;
-  optional FinalizeUpgradeResponse           finalizeUpgradeResponse       = 54;
+  optional FinalizeUpgradeResponse           finalizeUpgradeResponse       = 54 [deprecated = true];
   optional FinalizeUpgradeProgressResponse finalizeUpgradeProgressResponse = 55;
   optional PrepareResponse                 prepareResponse                 = 56;
   optional PrepareStatusResponse           prepareStatusResponse           = 57;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3643,7 +3643,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public void finalizeUpgrade() throws IOException {
-    // unused, but must be defined for the interface
+    // Server-side stub; the real implementation is handled via the Ratis request path through
+    // OMStartFinalizeUpgradeRequest
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3642,6 +3642,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
+  public void finalizeUpgrade() throws IOException {
+    // unused, but must be defined for the interface
+  }
+
+  @Override
   public StatusAndMessages queryUpgradeFinalizationProgress(
       String unusedUpgradeClientId, boolean unusedTakeover, boolean unusedReadonly)
       throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -87,6 +87,7 @@ import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotSetPropertyRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMCancelPrepareRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMPrepareRequest;
+import org.apache.hadoop.ozone.om.request.upgrade.OMStartFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.om.request.util.OMEchoRPCWriteRequest;
 import org.apache.hadoop.ozone.om.request.volume.OMQuotaRepairRequest;
 import org.apache.hadoop.ozone.om.request.volume.OMVolumeCreateRequest;
@@ -185,6 +186,8 @@ public final class OzoneManagerRatisUtils {
       return new S3GetSecretRequest(omRequest);
     case FinalizeUpgrade:
       return new OMFinalizeUpgradeRequest(omRequest);
+    case StartFinalizeUpgrade:
+      return new OMStartFinalizeUpgradeRequest(omRequest);
     case Prepare:
       return new OMPrepareRequest(omRequest);
     case CancelPrepare:

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMStartFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMStartFinalizeUpgradeRequest.java
@@ -55,7 +55,7 @@ public class OMStartFinalizeUpgradeRequest extends OMClientRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     ozoneManager.getScmClient().getContainerClient().finalizeUpgrade();
-    LOG.info("Successfully trigger the finalize upgrade process in SCM");
+    LOG.info("Successfully triggered the finalize upgrade process in SCM");
     return super.preExecute(ozoneManager);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMStartFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMStartFinalizeUpgradeRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.upgrade;
+
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.StartFinalizeUpgrade;
+
+import java.io.IOException;
+import java.util.HashMap;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.upgrade.OMFinalizeUpgradeResponse;
+import org.apache.hadoop.ozone.om.response.upgrade.OMStartFinalizeUpgradeResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Starts the cluster upgrade finalization process.
+ */
+public class OMStartFinalizeUpgradeRequest extends OMClientRequest {
+  private static final Logger LOG = LoggerFactory.getLogger(OMStartFinalizeUpgradeRequest.class);
+
+  public OMStartFinalizeUpgradeRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    ozoneManager.getScmClient().getContainerClient().finalizeUpgrade();
+    LOG.info("Successfully trigger the finalize upgrade process in SCM");
+    return super.preExecute(ozoneManager);
+  }
+
+  @Override
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, ExecutionContext context) {
+    LOG.trace("Request: {}", getOmRequest());
+    AuditLogger auditLogger = ozoneManager.getSystemAuditLogger();
+    OzoneManagerProtocolProtos.UserInfo userInfo = getOmRequest().getUserInfo();
+    OMResponse.Builder responseBuilder = OmResponseUtil.getOMResponseBuilder(getOmRequest());
+    responseBuilder.setCmdType(StartFinalizeUpgrade);
+    OMClientResponse response = null;
+    Exception exception = null;
+
+    try {
+      if (ozoneManager.isAdminAuthorizationEnabled()) {
+        UserGroupInformation ugi = createUGIForApi();
+        if (!ozoneManager.isAdmin(ugi)) {
+          throw new OMException("Access denied for user " + ugi + ". "
+              + "Superuser privilege is required to start finalize upgrade.", OMException.ResultCodes.ACCESS_DENIED);
+        }
+      }
+
+      OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+      omMetadataManager.getMetaTable().addCacheEntry(
+          new CacheKey<>(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY), CacheValue.get(context.getIndex(), "ignored"));
+
+
+      OzoneManagerProtocolProtos.StartFinalizeUpgradeResponse omResponse =
+          OzoneManagerProtocolProtos.StartFinalizeUpgradeResponse.newBuilder()
+              .build();
+      responseBuilder.setStartFinalizeUpgradeResponse(omResponse);
+      response = new OMStartFinalizeUpgradeResponse(responseBuilder.build());
+      LOG.trace("Returning response: {}", response);
+    } catch (IOException e) {
+      exception = e;
+      response = new OMFinalizeUpgradeResponse(
+          createErrorOMResponse(responseBuilder, e), -1);
+    }
+
+    markForAudit(auditLogger, buildAuditMessage(OMAction.UPGRADE_FINALIZE, new HashMap<>(), exception, userInfo));
+    return response;
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMStartFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMStartFinalizeUpgradeRequest.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.om.response.upgrade.OMFinalizeUpgradeResponse;
 import org.apache.hadoop.ozone.om.response.upgrade.OMStartFinalizeUpgradeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -54,9 +53,17 @@ public class OMStartFinalizeUpgradeRequest extends OMClientRequest {
 
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    OMRequest omRequest = super.preExecute(ozoneManager);
+    if (ozoneManager.isAdminAuthorizationEnabled()) {
+      UserGroupInformation ugi = createUGIForApi();
+      if (!ozoneManager.isAdmin(ugi)) {
+        throw new OMException("Access denied for user " + ugi + ". "
+            + "Superuser privilege is required to start finalize upgrade.", OMException.ResultCodes.ACCESS_DENIED);
+      }
+    }
     ozoneManager.getScmClient().getContainerClient().finalizeUpgrade();
     LOG.info("Successfully triggered the finalize upgrade process in SCM");
-    return super.preExecute(ozoneManager);
+    return omRequest;
   }
 
   @Override
@@ -70,14 +77,6 @@ public class OMStartFinalizeUpgradeRequest extends OMClientRequest {
     Exception exception = null;
 
     try {
-      if (ozoneManager.isAdminAuthorizationEnabled()) {
-        UserGroupInformation ugi = createUGIForApi();
-        if (!ozoneManager.isAdmin(ugi)) {
-          throw new OMException("Access denied for user " + ugi + ". "
-              + "Superuser privilege is required to start finalize upgrade.", OMException.ResultCodes.ACCESS_DENIED);
-        }
-      }
-
       OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
       omMetadataManager.getMetaTable().addCacheEntry(
           new CacheKey<>(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY), CacheValue.get(context.getIndex(), "ignored"));
@@ -89,10 +88,9 @@ public class OMStartFinalizeUpgradeRequest extends OMClientRequest {
       responseBuilder.setStartFinalizeUpgradeResponse(omResponse);
       response = new OMStartFinalizeUpgradeResponse(responseBuilder.build());
       LOG.trace("Returning response: {}", response);
-    } catch (IOException e) {
+    } catch (Exception e) {
       exception = e;
-      response = new OMFinalizeUpgradeResponse(
-          createErrorOMResponse(responseBuilder, e), -1);
+      response = new OMStartFinalizeUpgradeResponse(createErrorOMResponse(responseBuilder, e));
     }
 
     markForAudit(auditLogger, buildAuditMessage(OMAction.UPGRADE_FINALIZE, new HashMap<>(), exception, userInfo));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMStartFinalizeUpgradeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMStartFinalizeUpgradeResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.upgrade;
+
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.META_TABLE;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Response for finalizeUpgrade request.
+ */
+@CleanupTableInfo(cleanupTables = {META_TABLE})
+public class OMStartFinalizeUpgradeResponse extends OMClientResponse {
+  private static final Logger LOG = LoggerFactory.getLogger(OMStartFinalizeUpgradeResponse.class);
+
+  public OMStartFinalizeUpgradeResponse(OzoneManagerProtocolProtos.OMResponse omResponse) {
+    super(omResponse);
+  }
+
+  @Override
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    LOG.info("Persisting Finalization In Progress Key to the Meta DB table");
+    omMetadataManager.getMetaTable().putWithBatch(batchOperation, OzoneConsts.FINALIZATION_IN_PROGRESS_KEY, "ignored");
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.ratis;
 
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.INVALID_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,7 @@ import org.apache.hadoop.ozone.om.execution.OMExecutionFlow;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.request.upgrade.OMStartFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
 import org.junit.jupiter.api.Test;
@@ -88,6 +90,19 @@ public class TestOzoneManagerRatisRequest {
             ozoneManager));
     assertEquals(OMException.ResultCodes.BUCKET_NOT_FOUND,
         omException.getResult());
+  }
+
+  @Test
+  public void testStartFinalizeUpgradeRequestIsDispatched() throws IOException {
+    OzoneManagerProtocolProtos.OMRequest omRequest =
+        OzoneManagerProtocolProtos.OMRequest.newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.StartFinalizeUpgrade)
+            .setClientId("test-client-id")
+            .build();
+
+    OzoneManager mockOm = mock(OzoneManager.class);
+    assertInstanceOf(OMStartFinalizeUpgradeRequest.class,
+        OzoneManagerRatisUtils.createClientRequest(omRequest, mockOm));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMStartFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMStartFinalizeUpgradeRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
+import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for OMStartFinalizeUpgradeRequest.
+ */
+public class TestOMStartFinalizeUpgradeRequest extends TestOMKeyRequest {
+
+  @Test
+  public void testPreExecuteCallsScmFinalizeUpgrade() throws IOException {
+    doNothing().when(scmContainerLocationProtocol).finalizeUpgrade();
+
+    OzoneManagerProtocolProtos.OMRequest original = buildRequest();
+    OMStartFinalizeUpgradeRequest request = new OMStartFinalizeUpgradeRequest(original);
+
+    OzoneManagerProtocolProtos.OMRequest modified = request.preExecute(ozoneManager);
+
+    // UserInfo must have been added by the base class preExecute.
+    assertNotEquals(original, modified);
+    assertNotNull(modified.getUserInfo());
+
+    // SCM must have been asked to begin finalization.
+    verify(scmContainerLocationProtocol).finalizeUpgrade();
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheAddsFinalizationInProgressKey() throws IOException {
+    doNothing().when(scmContainerLocationProtocol).finalizeUpgrade();
+
+    assertNull(omMetadataManager.getMetaTable().get(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY),
+        "key should not exist before the request");
+
+    submitRequest();
+
+    assertNotNull(omMetadataManager.getMetaTable().get(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY),
+        "key should be present in the cache after validateAndUpdateCache");
+  }
+
+  @Test
+  public void testAccessDeniedWhenUserIsNotAdmin() throws IOException {
+    doNothing().when(scmContainerLocationProtocol).finalizeUpgrade();
+    when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(true);
+    when(ozoneManager.isAdmin(any())).thenReturn(false);
+
+    OMClientResponse response = submitRequest();
+
+    // ResultCodes.ACCESS_DENIED maps to Status.UNAUTHORIZED via the ordinal-based
+    // exceptionToResponseStatus conversion used by createErrorOMResponse.
+    assertEquals(OzoneManagerProtocolProtos.Status.UNAUTHORIZED,
+        response.getOMResponse().getStatus(),
+        "non-admin user should receive an authorization-failure status");
+  }
+
+  private OMClientResponse submitRequest() throws IOException {
+    OzoneManagerProtocolProtos.OMRequest original = buildRequest();
+    OMStartFinalizeUpgradeRequest request = new OMStartFinalizeUpgradeRequest(original);
+    ExecutionContext context = ExecutionContext.of(1, TermIndex.INITIAL_VALUE);
+
+    OzoneManagerProtocolProtos.OMRequest modified = request.preExecute(ozoneManager);
+    assertNotEquals(original, modified);
+
+    return request.validateAndUpdateCache(ozoneManager, context);
+  }
+
+  private OzoneManagerProtocolProtos.OMRequest buildRequest() {
+    return OzoneManagerProtocolProtos.OMRequest.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.StartFinalizeUpgrade)
+        .setClientId(ClientId.randomId().toString())
+        .build();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMStartFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMStartFinalizeUpgradeRequest.java
@@ -21,17 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.jupiter.api.Test;
@@ -40,7 +44,7 @@ import org.junit.jupiter.api.Test;
  * Tests for OMStartFinalizeUpgradeRequest.
  */
 public class TestOMStartFinalizeUpgradeRequest extends TestOMKeyRequest {
-
+  
   @Test
   public void testPreExecuteCallsScmFinalizeUpgrade() throws IOException {
     doNothing().when(scmContainerLocationProtocol).finalizeUpgrade();
@@ -73,17 +77,26 @@ public class TestOMStartFinalizeUpgradeRequest extends TestOMKeyRequest {
 
   @Test
   public void testAccessDeniedWhenUserIsNotAdmin() throws IOException {
-    doNothing().when(scmContainerLocationProtocol).finalizeUpgrade();
     when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(true);
     when(ozoneManager.isAdmin(any())).thenReturn(false);
 
-    OMClientResponse response = submitRequest();
+    OzoneManagerProtocolProtos.OMRequest original = buildRequest();
+    OMStartFinalizeUpgradeRequest request = new OMStartFinalizeUpgradeRequest(original);
+    // In the test environment there is no live RPC thread, so
+    // ProtobufRpcEngine.Server.getRemoteUser() returns null and super.preExecute()
+    // cannot resolve a username. setUGI() pre-seeds the identity so that
+    // createUGIForApi() succeeds without needing the RPC thread-local.
+    request.setUGI(UserGroupInformation.createRemoteUser("testuser"));
 
-    // ResultCodes.ACCESS_DENIED maps to Status.UNAUTHORIZED via the ordinal-based
-    // exceptionToResponseStatus conversion used by createErrorOMResponse.
-    assertEquals(OzoneManagerProtocolProtos.Status.UNAUTHORIZED,
-        response.getOMResponse().getStatus(),
-        "non-admin user should receive an authorization-failure status");
+    // With auth in preExecute(), a non-admin is rejected before the request
+    // reaches Raft or touches SCM.
+    OMException ex = assertThrows(OMException.class,
+        () -> request.preExecute(ozoneManager));
+    assertEquals(OMException.ResultCodes.ACCESS_DENIED, ex.getResult(),
+        "non-admin user should receive ACCESS_DENIED from preExecute");
+
+    // SCM must NOT have been called — auth is checked before the SCM call.
+    verify(scmContainerLocationProtocol, never()).finalizeUpgrade();
   }
 
   private OMClientResponse submitRequest() throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/upgrade/TestOMStartFinalizeUpgradeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/upgrade/TestOMStartFinalizeUpgradeResponse.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for OMStartFinalizeUpgradeResponse.
+ */
+public class TestOMStartFinalizeUpgradeResponse {
+
+  @TempDir
+  private Path folder;
+  private OMMetadataManager omMetadataManager;
+  private BatchOperation batchOperation;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
+        folder.toAbsolutePath().toString());
+    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
+    batchOperation = omMetadataManager.getStore().initBatchOperation();
+  }
+
+  @Test
+  public void testAddToDBBatchPersistsFinalizationInProgressKey() throws IOException {
+    assertNull(omMetadataManager.getMetaTable().get(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY),
+        "key should not exist before the response is applied");
+
+    OMStartFinalizeUpgradeResponse response = new OMStartFinalizeUpgradeResponse(buildOkResponse());
+    response.addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    assertEquals("ignored",
+        omMetadataManager.getMetaTable().get(OzoneConsts.FINALIZATION_IN_PROGRESS_KEY),
+        "key should be persisted to the meta table after the response is committed");
+  }
+
+  private OzoneManagerProtocolProtos.OMResponse buildOkResponse() {
+    return OzoneManagerProtocolProtos.OMResponse.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.StartFinalizeUpgrade)
+        .setStatus(OzoneManagerProtocolProtos.Status.OK)
+        .build();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

We created the new `ozone admin upgrade finalize` command to go to SCM. However after discovering that OM needs to trigger the upgrade flow, we need to make the command go to OM instead. Upon receiving the command, OM will call SCM using the API added in previous PRs for the upgrade finalize command and then store a key in the meta table to let OM know finalize has started.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15528

## How was this patch tested?

New unit tests added
